### PR TITLE
fix(cli): only publish if changes detected since last release

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -53,11 +53,21 @@ jobs:
       - name: Check for Changes
         id: check-diff
         env:
-          VERSION_PREFIX: 'v8*' # We need the 8 or else "vespa-7." will match and sort before "v8.x.y"
+          VERSION_PATTERN: '^v8\.' # We need the 8 prefix or else "vespa-7." will match and sort before "v8.x.y"
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -x
+
           # Checks for changes since the last release.
           new_tag="v${{ steps.meta.outputs.version }}"
-          previous_tag=$(git tag --list "${VERSION_PREFIX}" --sort="-version:refname" | grep -v "${new_tag}" | head -n 1)
+          previous_tag=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName' | grep -E "${VERSION_PATTERN}" | head -n 1)
+
+          # If the previous tag and the current tag are the same, there are no changes.
+          if [[ "${previous_tag}" == "${new_tag}" ]]; then
+            echo "No changes detected between ${previous_tag} and ${new_tag}."
+            echo "has-changes=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
 
           # Detect if we are using a dev version (starts with "0.0.0-dev").
           if [[ "${new_tag:0:}" == "0.0.0-dev" ]]; then
@@ -88,14 +98,16 @@ jobs:
         # This workflow only interacts with the client/go directory, so we can set the working directory here.
         working-directory: client/go
 
+    env:
+      VERSION: ${{ needs.prepare.outputs.build-version }}
+      HAS_CHANGES: ${{ needs.prepare.outputs.changes-detected }}
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
 
       - name: build
-        env:
-          VERSION: ${{ needs.prepare.outputs.build-version }}
         run: |
           make clean dist
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -112,8 +112,8 @@ jobs:
   publish:
     runs-on: macos-latest
 
-    # Publish the CLI only if changes were detected and the event was a push or workflow_dispatch.
-    if: needs.prepare.outputs.changes-detected == 'true' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+    # Publish if there are changes detected or if the workflow was manually triggered.
+    if: (github.event_name == 'push' && needs.prepare.outputs.changes-detected == 'true') || (github.event_name == 'workflow_dispatch')
     needs:
       - prepare
       - build-test
@@ -130,9 +130,12 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.build-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository at tagged version
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Prefix the version with "v" to checkout the tag.
+          ref: "v${{ needs.prepare.outputs.build-version }}"
 
       - uses: actions/download-artifact@v4
         with:
@@ -151,13 +154,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          make clean dist-github
+          # Release to Github directly, bypassing the diff check as we already perform this check in the "prepare" job.
+          make -- --dist-github
 
       - name: Publish to Homebrew
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
-          make clean dist-homebrew
+          # Release to Homebrew directly, bypassing the diff check as we already perform this check in the "prepare" job.
+          make -- --dist-homebrew
 
       - name: Install via Homebrew
         run: |

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -151,13 +151,17 @@ jobs:
           brew install --quiet coreutils gh zip go
 
       - name: Publish to GitHub Releases
+        id: github-release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Release to Github directly, bypassing the diff check as we already perform this check in the "prepare" job.
           make -- --dist-github
+          release_url="$(cat /tmp/vespa-cli-release-url.txt || true)"
+          echo "release-url=${release_url}" > "${GITHUB_OUTPUT}"
 
       - name: Publish to Homebrew
+        if: steps.github-release.outputs.release-url != ''
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
@@ -165,5 +169,6 @@ jobs:
           make -- --dist-homebrew
 
       - name: Install via Homebrew
+        if: steps.github-release.outputs.release-url != ''
         run: |
           make install-brew

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -28,9 +28,14 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
+      changes-detected: ${{ steps.check-diff.outputs.has-changes }}
       build-version: ${{ steps.meta.outputs.version }}
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for git operations.
+
       - name: Define Build Version
         id: meta
         run: |
@@ -43,7 +48,34 @@ jobs:
             BUILD_VERSION="0.0.0-dev_${{ github.run_number }}"
           fi
 
-          echo "version=${BUILD_VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${BUILD_VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check for Changes
+        id: check-diff
+        env:
+          VERSION_PREFIX: 'v8*' # We need the 8 or else "vespa-7." will match and sort before "v8.x.y"
+        run: |
+          # Checks for changes since the last release.
+          new_tag="v${{ steps.meta.outputs.version }}"
+          previous_tag=$(git tag --list "${VERSION_PREFIX}" --sort="-version:refname" | grep -v "${new_tag}" | head -n 1)
+
+          # Detect if we are using a dev version (starts with "0.0.0-dev").
+          if [[ "${new_tag:0:}" == "0.0.0-dev" ]]; then
+            echo "Dev version being used, skipping check for changes."
+            echo "has-changes=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Git will return a non-zero exit code if there are changes.
+          if git diff --quiet "${previous_tag}" "${new_tag}" -- client/go; then
+              echo "No changes detected between ${previous_tag} and ${new_tag}."
+              echo "has-changes=false" >> "${GITHUB_OUTPUT}"
+              exit 0
+          fi
+
+          echo "Changes detected between ${previous_tag} and ${new_tag}."
+          echo "has-changes=true" >> "${GITHUB_OUTPUT}"
+
 
   build-test:
     runs-on: ubuntu-latest
@@ -80,8 +112,8 @@ jobs:
   publish:
     runs-on: macos-latest
 
-    # Publish the CLI when a tag is pushed or a workflow is triggered manually.
-    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+    # Publish the CLI only if changes were detected and the event was a push or workflow_dispatch.
+    if: needs.prepare.outputs.changes-detected == 'true' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs:
       - prepare
       - build-test

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -52,10 +52,16 @@ dist-homebrew:
 #
 # $ make dist-github
 --dist-github: dist
-	gh release create v$(VERSION) --repo vespa-engine/vespa --notes-file $(CURDIR)/README.md --title "Vespa CLI $(VERSION)" \
-		$(DIST)/vespa-cli_$(VERSION)_sha256sums.txt \
-		$(DIST)/vespa-cli_$(VERSION)_*.zip \
-		$(DIST)/vespa-cli_$(VERSION)_*.tar.gz
+	RELEASE_URL="$(gh release create v$(VERSION)
+		--verify-tag
+		--repo vespa-engine/vespa
+		--notes-file $(CURDIR)/README.md
+		--title "Vespa CLI $(VERSION)"
+		$(DIST)/vespa-cli_$(VERSION)_sha256sums.txt
+		$(DIST)/vespa-cli_$(VERSION)_*.zip
+		$(DIST)/vespa-cli_$(VERSION)_*.tar.gz)"
+
+		echo $RELEASE_URL > /tmp/vespa-cli-release-url.txt
 
 dist-github:
 	go run cond_make.go --dist-github

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -52,13 +52,13 @@ dist-homebrew:
 #
 # $ make dist-github
 --dist-github: dist
-	RELEASE_URL="$(gh release create v$(VERSION)
-		--verify-tag
-		--repo vespa-engine/vespa
-		--notes-file $(CURDIR)/README.md
-		--title "Vespa CLI $(VERSION)"
-		$(DIST)/vespa-cli_$(VERSION)_sha256sums.txt
-		$(DIST)/vespa-cli_$(VERSION)_*.zip
+	RELEASE_URL="$(gh release create v$(VERSION) \
+		--verify-tag \
+		--repo vespa-engine/vespa \
+		--notes-file $(CURDIR)/README.md \
+		--title "Vespa CLI $(VERSION)" \
+		$(DIST)/vespa-cli_$(VERSION)_sha256sums.txt \
+		$(DIST)/vespa-cli_$(VERSION)_*.zip \
 		$(DIST)/vespa-cli_$(VERSION)_*.tar.gz)"
 
 		echo $RELEASE_URL > /tmp/vespa-cli-release-url.txt


### PR DESCRIPTION
## What

Changes on the "Publish Vespa CLI" Github workflow:

1. The publish job now checks if there are any changes between the last release tag and the new version being published. This is done by using the `git diff` command to compare the changes in the `client/go` directory.
2. If no changes are detected, the workflow will skip the publish step.
3. The workflow also handles the case where a dev version (starting with "0.0.0-dev") is being used, in which case the changes check is skipped.

## Why

This ensures that the CLI is only published when there are actual changes, preventing unnecessary releases.

A further reason is that we had 2 separate systems checking for changes, one for the Github Releases and another one for Homebrew, this leads to inconsistencies, so this PR merges the validation into an initial check.


## Additional info

- Fixes #32365 