### PR TITLE
Don't log deployment warning for high distribution keys on Cloud

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -299,7 +299,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
             var aggr = new HighestDistributionKeyAggregator();
             aggr.aggregateNodeStats(rootGroup);
             int warnThreshold = 100; // ... Not scientifically chosen
-            if ((aggr.highestNodeDistributionKey - aggr.nodeCount) >= warnThreshold) {
+            if (!deployState.isHosted() && (aggr.highestNodeDistributionKey - aggr.nodeCount) >= warnThreshold) {
                 deployState.getDeployLogger().logApplicationPackage(WARNING,
                         ("Content cluster '%s' has %d node(s), but the highest distribution key is %d. " +
                          "Having much higher distribution keys than the number of nodes is not recommended, " +


### PR DESCRIPTION
@hmusum please review. The _presence_ of this log warning for self-hosted is already explicitly unit-tested.

Assigned distribution keys are an internal detail in Cloud, so it does not make any sense to log a warning that the user can't do anything about.

