### PR TITLE
fix: remove rm statement from vscode langserver-install

### DIFF
--- a/integration/schema-language-server/clients/vscode/package.json
+++ b/integration/schema-language-server/clients/vscode/package.json
@@ -65,7 +65,7 @@
     "test": "vscode-test",
     "check-types": "tsc --noEmit",
     "copy-images": "cp ../../resources/* ./images",
-    "langserver-install": "mkdir -p server && rm -r server/* && cp ../../language-server/target/schema-language-server-jar-with-dependencies.jar ./server/",
+    "langserver-install": "mkdir -p server && cp ../../language-server/target/schema-language-server-jar-with-dependencies.jar ./server/",
     "publish": "npm run compile && node out/publish.js"
   },
   "devDependencies": {


### PR DESCRIPTION
There was an rm statement in package.json preventing the lspDeploy action from running correctly.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
