### PR TITLE
Revert "add new dependencies to intellij plugin and set infinity until version"

### DIFF
--- a/integration/schema-language-server/clients/intellij/build.gradle.kts
+++ b/integration/schema-language-server/clients/intellij/build.gradle.kts
@@ -31,11 +31,10 @@ dependencies {
   implementation("com.yahoo.vespa:config-model-api:8-SNAPSHOT")
   implementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
   implementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
-  implementation("org.jsoup:jsoup:1.17.2")
-  implementation("com.vladsch.flexmark:flexmark-html2md-converter:0.64.8")
 
   intellijPlatform {
     intellijIdeaUltimate("2024.1")
+    //local("/Applications/IntelliJ IDEA.app")
     instrumentationTools()
   }
 }
@@ -81,6 +80,7 @@ tasks {
 
   patchPluginXml {
     sinceBuild.set("232")
+    untilBuild.set("242.*")
   }
 
   signPlugin {


### PR DESCRIPTION
Reverts vespa-engine/vespa#32440

Build fails with:
`invalid major version: lsp-v2`

so I assume this is caused by this change
 