### PR TITLE
feat(ci): update release tag detection logic

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -60,7 +60,7 @@ jobs:
 
           # Checks for changes since the last release.
           new_tag="v${{ steps.meta.outputs.version }}"
-          previous_tag=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName' | grep -E "${VERSION_PATTERN}" | head -n 1)
+          previous_tag=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --jq '.[] | .tagName' | grep -E "${VERSION_PATTERN}" | head -n 1)
 
           # If the previous tag and the current tag are the same, there are no changes.
           if [[ "${previous_tag}" == "${new_tag}" ]]; then


### PR DESCRIPTION
## What

Update the logic used to detect the previous release tag in the CI workflow.

## Why

Previously, the workflow was using the first release tag, but this could lead to incorrect results, if _for example_ the "Language Server" was released.

The updated code now retrieves all the release tags and selects _the most recent one that matches the pattern_.

## Additional info

The previous change (PR #32433) was tested in another repo, but that repo only had 1 type of releases, so this was not seen.