### PR TITLE
fix(ci): github release creation in makefile

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -169,12 +169,13 @@ jobs:
         run: |
           # Release to Github directly, bypassing the diff check as we already perform this check in the "prepare" job.
           make -- --dist-github
-          release_url="$(cat /tmp/vespa-cli-release-url.txt || true)"
+          release_url="$(cat /tmp/vespa-cli-release-url.txt)"
           echo "release-url=${release_url}" > "${GITHUB_OUTPUT}"
 
       - name: Publish to Homebrew
         if: steps.github-release.outputs.release-url != ''
         env:
+          GITHUB_RELEASE_URL: ${{ steps.github-release.outputs.release-url }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
           # Release to Homebrew directly, bypassing the diff check as we already perform this check in the "prepare" job.

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -52,16 +52,14 @@ dist-homebrew:
 #
 # $ make dist-github
 --dist-github: dist
-	RELEASE_URL="$(gh release create v$(VERSION) \
+	gh release create v$(VERSION) \
 		--verify-tag \
 		--repo vespa-engine/vespa \
 		--notes-file $(CURDIR)/README.md \
 		--title "Vespa CLI $(VERSION)" \
 		$(DIST)/vespa-cli_$(VERSION)_sha256sums.txt \
 		$(DIST)/vespa-cli_$(VERSION)_*.zip \
-		$(DIST)/vespa-cli_$(VERSION)_*.tar.gz)"
-
-		echo $RELEASE_URL > /tmp/vespa-cli-release-url.txt
+		$(DIST)/vespa-cli_$(VERSION)_*.tar.gz | tee /tmp/vespa-cli-release-url.txt
 
 dist-github:
 	go run cond_make.go --dist-github


### PR DESCRIPTION
## What

The release URL is now written to a temporary file using "tee" instead of capturing the output in variable.

## Why

The script in the Makefile would not run as expected and the Release would be created.