### PR TITLE
fix ringbuffer expand() code

### DIFF
--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/JsonFeeder.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/JsonFeeder.java
@@ -302,9 +302,11 @@ public class JsonFeeder implements Closeable {
             int offset = (int) (tail % size);
             int newOffset = (int) (tail % newSize);
             int toWrite = size - offset;
+            // exactly doubling the buffer size ensures there is room in the new buffer
             System.arraycopy(data, offset, newData, newOffset, toWrite);
-            if (toWrite < size)
-                System.arraycopy(data, 0, newData, newOffset + toWrite, size - toWrite);
+            // the wrapped data ends up either after the first part, or at the start of the new buffer
+            newOffset = (newOffset + toWrite) % newSize;
+            System.arraycopy(data, 0, newData, newOffset, offset);
             size = newSize;
             data = newData;
             lock.notify();

--- a/vespa-feed-client-api/src/test/java/ai/vespa/feed/client/JsonFeederTest.java
+++ b/vespa-feed-client-api/src/test/java/ai/vespa/feed/client/JsonFeederTest.java
@@ -34,16 +34,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonFeederTest {
 
+    static String lulVal(int i) {
+        var buf = new StringBuilder();
+        while (i-- > 0) {
+            buf.append("lal");
+            i = (int) (i/1.005);
+        }
+        return buf.toString();
+    }
+
     @Test
     void test() throws IOException {
-        int docs = 1 << 14;
+        int docs = 1 << 12;
         String json = "[\n" +
 
                       IntStream.range(0, docs).mapToObj(i ->
                                                                 "  {\n" +
                                                                 "    \"id\": \"id:ns:type::abc" + i + "\",\n" +
                                                                 "    \"fields\": {\n" +
-                                                                "      \"lul\":\"lal\"\n" +
+                                                                "      \"lul\":\"" + lulVal(i) + "\"\n" +
                                                                 "    }\n" +
                                                                 "  },\n"
                       ).collect(joining()) +
@@ -64,7 +73,7 @@ class JsonFeederTest {
             long startNanos = System.nanoTime();
             MockClient feedClient = new MockClient();
             JsonFeeder.builder(feedClient).build()
-                    .feedMany(in, 1 << 10,
+                    .feedMany(in, 1 << 7,
                             new JsonFeeder.ResultCallback() {
                                 @Override
                                 public void onNextResult(Result result, FeedException error) { resultsReceived.incrementAndGet(); }


### PR DESCRIPTION
@jonmv please review
the issue here was: only one of two cases was handled
case A) `newOffSet == offset`; enough room for second arraycopy after newOffset + toWrite
case B) `newOffset == offset + size`; `newOffset + toWrite == newSize`; triggered exception in second arrraycopy.
removed `if (toWrite < size)` because it seems unlikely and arraycopy handles copying 0 bytes.