### PR TITLE
vespa-logfmt now shows all levels by default;

### DIFF
--- a/client/go/internal/admin/vespa-wrapper/logfmt/levelflags.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/levelflags.go
@@ -21,10 +21,10 @@ func defaultLevelFlags() map[string]bool {
 		"error":   true,
 		"warning": true,
 		"info":    true,
-		"config":  false,
-		"event":   false,
-		"debug":   false,
-		"spam":    false,
+		"config":  true,
+		"event":   true,
+		"debug":   true,
+		"spam":    true,
 	}
 }
 
@@ -68,5 +68,7 @@ func (v *flagValueForLevel) unchanged() bool {
 }
 
 func (v *flagValueForLevel) Set(val string) error {
-	return applyPlusMinus(val, v)
+	err := applyPlusMinus(val, v)
+	v.changed = true
+	return err
 }

--- a/client/go/internal/admin/vespa-wrapper/logfmt/levelflags_test.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/levelflags_test.go
@@ -37,18 +37,19 @@ func TestLevelFlags(t *testing.T) {
 			t.Fail()
 		}
 	}
-	check(" +fatal +error +warning +info -config -event -debug -spam")
+	check(" +fatal +error +warning +info +config +event +debug +spam")
 	check(" -fatal -error -warning -info -config -event -debug -spam", "-all")
 	check(" +fatal +error +warning +info +config +event +debug +spam", "all")
 	check(" +fatal +error +warning +info +config +event +debug +spam", "+all")
 	check(" -fatal -error -warning -info -config -event +debug -spam", "debug")
 	check(" +fatal +error +warning +info +config +event +debug -spam", "all-spam")
 	check(" +fatal +error +warning +info +config +event +debug -spam", "all", "-spam")
-	check(" +fatal +error +warning -info -config +event -debug -spam", "+event", "-info")
-	check(" +fatal +error -warning -info -config +event -debug -spam", "+event,-info,-warning,config")
-	check(" +fatal +error -warning -info +config +event -debug -spam", "+event,-info,-warning,+config")
-	check(" +fatal +error -warning -info +config +event -debug -spam", "+event,-info", "-warning,+config")
-	check(" -fatal -error -warning -info +config -event -debug -spam", "+event", "-info", "-warning", "config")
+	check(" +fatal +error +warning -info +config +event +debug +spam", "+event", "-info")
+	check(" +fatal +error -warning -info -config +event +debug +spam", "+event,-info,-warning,config")
+	check(" +fatal +error -warning -info +config +event +debug +spam", "+event,-info,-warning,+config")
+	check(" +fatal +error -warning -info +config +event +debug +spam", "+event,-info", "-warning,+config")
+	check(" +fatal +error -warning -info +config +event +debug +spam", "+event", "-info", "-warning", "config")
+	check(" -fatal +error -warning +info -config -event +debug -spam", "info", "debug", "error")
 	check = func(expectErr string, texts ...string) {
 		var target flagValueForLevel
 		target.levels = defaultLevelFlags()

--- a/client/go/internal/admin/vespa-wrapper/logfmt/showflags.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/showflags.go
@@ -72,5 +72,7 @@ func (v *flagValueForShow) unchanged() bool {
 }
 
 func (v *flagValueForShow) Set(val string) error {
-	return applyPlusMinus(val, v)
+	err := applyPlusMinus(val, v)
+	v.changed = true
+	return err
 }

--- a/client/go/internal/admin/vespa-wrapper/logfmt/showflags_test.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/showflags_test.go
@@ -37,7 +37,8 @@ func TestShowFlags(t *testing.T) {
 	check(" +time -fmttime +msecs -usecs +host +level -pid -service +component +message", "+host,-fmttime,-service,pid")
 	check(" +time -fmttime +msecs -usecs +host +level +pid -service +component +message", "+host,-fmttime,-service,+pid")
 	check(" +time -fmttime +msecs -usecs +host +level +pid -service +component +message", "+host,-fmttime", "-service,+pid")
-	check(" -time -fmttime -msecs -usecs -host -level +pid -service -component -message", "+host", "-fmttime", "-service", "pid")
+	check(" +time -fmttime +msecs -usecs +host +level +pid -service +component +message", "+host", "-fmttime", "-service", "pid")
+	check(" -time -fmttime -msecs -usecs +host -level +pid -service +component -message", "host", "component", "pid")
 	check = func(expectErr string, texts ...string) {
 		var target flagValueForShow
 		target.shown = defaultShowFlags()


### PR DESCRIPTION
also extend unit tests and fix a corner case

@hmusum please review
