### PR TITLE
Interns/magnus/model features

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/SchemaIndex.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/SchemaIndex.java
@@ -21,6 +21,8 @@ import ai.vespa.schemals.parser.ast.fieldSetElm;
 import ai.vespa.schemals.parser.ast.functionElm;
 import ai.vespa.schemals.parser.ast.inputName;
 import ai.vespa.schemals.parser.ast.namedDocument;
+import ai.vespa.schemals.parser.ast.onnxModel;
+import ai.vespa.schemals.parser.ast.onnxModelInProfile;
 import ai.vespa.schemals.parser.ast.rankProfile;
 import ai.vespa.schemals.parser.ast.rootSchema;
 import ai.vespa.schemals.parser.ast.structDefinitionElm;
@@ -40,6 +42,7 @@ public class SchemaIndex {
         put(functionElm.class, SymbolType.FUNCTION);
         put(inputName.class, SymbolType.QUERY_INPUT);
         put(constantName.class, SymbolType.RANK_CONSTANT);
+        put(onnxModel.class, SymbolType.ONNX_MODEL);
     }};
 
     public static final HashMap<Class<?>, SymbolType> IDENTIFIER_WITH_DASH_TYPE_MAP = new HashMap<>() {{

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/Symbol.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/Symbol.java
@@ -153,6 +153,7 @@ public class Symbol {
         LAMBDA_FUNCTION,
         MAP_KEY,
         MAP_VALUE,
+        ONNX_MODEL,
         PARAMETER,
         PROPERTY,
         QUERY_INPUT,

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
@@ -110,9 +110,9 @@ public class SchemaDocument implements DocumentManager {
             this.CST = parsingResult.CST().get();
             lexer.setCST(CST);
 
-            // logger.info("======== CST for file: " + fileURI + " ========");
+            logger.info("======== CST for file: " + fileURI + " ========");
      
-            //CSTUtils.printTree(logger, CST);
+            CSTUtils.printTree(logger, CST);
         }
 
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
@@ -110,9 +110,9 @@ public class SchemaDocument implements DocumentManager {
             this.CST = parsingResult.CST().get();
             lexer.setCST(CST);
 
-            logger.info("======== CST for file: " + fileURI + " ========");
+            //logger.info("======== CST for file: " + fileURI + " ========");
      
-            CSTUtils.printTree(logger, CST);
+            //CSTUtils.printTree(logger, CST);
         }
 
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -330,6 +330,12 @@ public class BuiltInFunctions {
                 new EnumArgument("operation", List.of("sum", "product", "average", "min", "max", "count"))
             ))
         )));
+
+        // === ML Model features ===
+        put("onnx", new GenericFunction("onnx", new FunctionSignature(new SymbolArgument(SymbolType.ONNX_MODEL, "onnx-model"))));
+        put("onnxModel", new GenericFunction("onnxModel", new FunctionSignature(new SymbolArgument(SymbolType.ONNX_MODEL, "onnx-model"))));
+        put("lightbgm", new GenericFunction("lightbgm", new FunctionSignature(new StringArgument("\"/path/to/lightbgm-model.json\""))));
+        put("xgboost", new GenericFunction("xgboost", new FunctionSignature(new StringArgument("\"/path/to/xgboost-model.json\""))));
     }};
 
     // Some features that have not gotten a signature for various reasons

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -337,6 +337,7 @@ public class SchemaParserTest {
             new BadFileTestCase("../../../config-model/src/test/examples/simple.sd", 5), // TODO: unused rank-profile functions should throw errors? Also rank-type doesntexist: ... in field?
 
             new BadFileTestCase("src/test/sdfiles/single/rankprofilefuncs.sd", 2),
+            new BadFileTestCase("src/test/sdfiles/single/onnxmodel.sd", 1),
         };
 
         return Arrays.stream(tests)

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/onnxmodel.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/onnxmodel.sd
@@ -1,0 +1,26 @@
+schema onnxmodel {
+    document onnxmodel {
+    }
+
+    rank-profile profile {
+        first-phase {
+            expression: sum( onnxModel(mymodel).output_name )
+        }
+
+        second-phase {
+            expression: sum( onnx(noexist).nooutput ) # should give error
+        }
+
+        onnx-model mymodel {
+            file: files/something.onnx
+        }
+
+        function func_a() {
+            expression: sum(xgboost("xgboost.json"))
+        }
+
+        function func_b() {
+            expression: sum(lightbgm("/path/to/lightbgm-model.json"))
+        }
+    }
+}


### PR DESCRIPTION
Add onnx, onnxModel, xgboost and lightbgm rank features to the builtin feature set.
onnx model contain symbol references to the onnx-model definition in the schema or rank-profile.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.