### PR TITLE
Add snapshot model and REST API

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -22,6 +22,7 @@ import com.yahoo.vespa.hosted.provision.Node.State;
 import com.yahoo.vespa.hosted.provision.applications.Applications;
 import com.yahoo.vespa.hosted.provision.archive.ArchiveUriManager;
 import com.yahoo.vespa.hosted.provision.autoscale.MetricsDb;
+import com.yahoo.vespa.hosted.provision.backup.Snapshots;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancers;
 import com.yahoo.vespa.hosted.provision.maintenance.InfrastructureVersions;
@@ -75,6 +76,7 @@ public class NodeRepository extends AbstractComponent implements HealthCheckerPr
     private final Orchestrator orchestrator;
     private final int spareCount;
     private final ProtoHealthChecker healthChecker;
+    private final Snapshots snapshots;
 
     /**
      * Creates a node repository from a zookeeper provider.
@@ -149,6 +151,7 @@ public class NodeRepository extends AbstractComponent implements HealthCheckerPr
         this.orchestrator = orchestrator;
         this.spareCount = spareCount;
         this.healthChecker = provisionServiceProvider.getHealthChecker();
+        this.snapshots = new Snapshots(this);
         nodes.rewrite();
     }
 
@@ -260,6 +263,11 @@ public class NodeRepository extends AbstractComponent implements HealthCheckerPr
                                                               .first()
                                                               .map(LoadBalancer::idSeed)
                                                               .orElseThrow(() -> new IllegalArgumentException("no load balancer for '" + endpoint + "'")));
+    }
+
+    /** Manage backup snapshots for nodes in this */
+    public Snapshots snapshots() {
+        return snapshots;
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshot.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshot.java
@@ -1,0 +1,64 @@
+package com.yahoo.vespa.hosted.provision.backup;
+
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostName;
+import com.yahoo.vespa.hosted.provision.node.ClusterId;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A backup snapshot of a node's local data. Only {@link ClusterSpec.Type#content} nodes support snapshots.
+ *
+ * @author mpolden
+ */
+public record Snapshot(String id, HostName hostname, State state, Instant createdAt, ClusterId cluster, int clusterIndex) {
+
+    public Snapshot {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(state);
+        Objects.requireNonNull(hostname);
+        Objects.requireNonNull(createdAt);
+        Objects.requireNonNull(cluster);
+        if (clusterIndex < 0) {
+            throw new IllegalArgumentException("clusterIndex cannot be negative, got " + cluster);
+        }
+    }
+
+    public Snapshot with(State state) {
+        if (state.compareTo(this.state) < 0) {
+            throw new IllegalArgumentException("Cannot change state of " + this + " to " + state);
+        }
+        return new Snapshot(id, hostname, state, createdAt, cluster, clusterIndex);
+    }
+
+    public enum State {
+        /** Snapshot is being created by the node */
+        creating,
+        /** The node failed to create a snapshot */
+        failed,
+        /** The node successfully created a snapshot */
+        created,
+        /** Snapshot is being restored by the node */
+        restoring,
+        /** The node failed to restore the snapshot */
+        restoreFailed,
+        /** The node successfully created a snapshot */
+        restored;
+
+        /** Returns whether this state indicates that we're awaiting and action from the node */
+        public boolean busy() {
+            return switch (this) {
+                case creating, restoring -> true;
+                case failed, created, restoreFailed, restored -> false;
+            };
+        }
+
+    }
+
+    public static Snapshot create(HostName hostname, ClusterId cluster, int clusterIndex, Instant at) {
+        return new Snapshot(UUID.randomUUID().toString(), hostname, State.creating, at, cluster, clusterIndex);
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshots.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshots.java
@@ -1,0 +1,107 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.backup;
+
+import com.yahoo.config.provision.ClusterMembership;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.transaction.Mutex;
+import com.yahoo.transaction.NestedTransaction;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.node.Allocation;
+import com.yahoo.vespa.hosted.provision.node.ClusterId;
+import com.yahoo.vespa.hosted.provision.persistence.CuratorDb;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Manage {@link Snapshot}s for nodes in this repository.
+ *
+ * @author mpolden
+ */
+public class Snapshots {
+
+    private final NodeRepository nodeRepository;
+    private final CuratorDb db;
+
+    public Snapshots(NodeRepository nodeRepository) {
+        this.nodeRepository = Objects.requireNonNull(nodeRepository);
+        this.db = nodeRepository.database();
+    }
+
+    /** Read known backup snapshots, for all hosts */
+    public List<Snapshot> read() {
+        return db.readSnapshots();
+    }
+
+    /** Return backup snapshots for given hostname */
+    public List<Snapshot> read(String hostname) {
+        return db.readSnapshots(hostname);
+    }
+
+    /** Read given snapshot or throw */
+    public Snapshot require(String id, String hostname) {
+        return read(hostname).stream()
+                             .filter(s -> s.id().equals(id))
+                             .findFirst()
+                             .orElseThrow(() -> new IllegalArgumentException("No snapshot found with ID '" + id + "' and hostname '" + hostname + "'"));
+    }
+
+    /** Trigger a new snapshot for node of given hostname */
+    public Snapshot create(String hostname, Instant instant) {
+        try (var lock = db.lockSnapshots(hostname)) {
+            Optional<Snapshot> busySnapshot = read(hostname).stream().filter(s -> s.state().busy()).findFirst();
+            if (busySnapshot.isPresent()) {
+                throw new IllegalArgumentException("Cannot write snapshot " +
+                                                   ": Node " + hostname + " is busy with snapshot " +
+                                                   busySnapshot.get().id() + " in state " + busySnapshot.get().state());
+            }
+            return writeSnapshot(hostname, (node) -> {
+                ClusterId cluster = new ClusterId(node.allocation().get().owner(), node.allocation().get().membership().cluster().id());
+                return Snapshot.create(com.yahoo.config.provision.HostName.of(hostname), cluster, node.allocation().get().membership().index(), instant);
+            }, lock);
+        }
+    }
+
+    /** Move snapshot to given state */
+    public Snapshot move(Snapshot snapshot, Snapshot.State newState) {
+        try (var lock = db.lockSnapshots(snapshot.hostname().value())) {
+            Snapshot updated = require(snapshot.id(), snapshot.hostname().value());
+            return writeSnapshot(snapshot.hostname().value(), node -> updated.with(newState), lock);
+        }
+    }
+
+    private Snapshot writeSnapshot(String hostname, Function<Node, Snapshot> snapshotFunction, @SuppressWarnings("unused") Mutex snapshotLock) {
+        List<Snapshot> snapshots = read(hostname);
+        try (var nodeMutex = nodeRepository.nodes().lockAndGetRequired(hostname)) {
+            Node node = nodeMutex.node();
+            if (node.state() != Node.State.active) throw new IllegalArgumentException("Node " + node + " must be " + Node.State.active + ", but is " + node.status());
+            if (node.type() != NodeType.tenant) throw new IllegalArgumentException("Node " + node + " has unexpected type " + node.type());
+            Optional<ClusterSpec> clusterSpec = node.allocation().map(Allocation::membership).map(ClusterMembership::cluster);
+            if (clusterSpec.isEmpty() || clusterSpec.get().type() != ClusterSpec.Type.content) {
+                throw new IllegalArgumentException("Node " + node + " is not a member of a content cluster: Refusing to write snapshot");
+            }
+            Snapshot snapshot = snapshotFunction.apply(node);
+            try (var transaction = new NestedTransaction()) {
+                Node updatedNode = node.with(node.status().withSnapshot(snapshot));
+                db.writeTo(updatedNode.state(),
+                           List.of(updatedNode),
+                           Agent.system,
+                           Optional.empty(),
+                           transaction);
+                List<Snapshot> updated = new ArrayList<>(snapshots);
+                updated.add(snapshot);
+                db.writeSnapshots(snapshot.hostname().value(), updated, transaction);
+                transaction.commit();
+            }
+            return snapshot;
+        }
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshots.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshots.java
@@ -70,10 +70,10 @@ public class Snapshots {
     }
 
     /** Move snapshot to given state */
-    public Snapshot move(Snapshot snapshot, Snapshot.State newState) {
-        try (var lock = db.lockSnapshots(snapshot.hostname().value())) {
-            Snapshot updated = require(snapshot.id(), snapshot.hostname().value());
-            return writeSnapshot(snapshot.hostname().value(), node -> updated.with(newState), lock);
+    public Snapshot move(String snapshotId, String hostname, Snapshot.State newState) {
+        try (var lock = db.lockSnapshots(hostname)) {
+            Snapshot updated = require(snapshotId, hostname);
+            return writeSnapshot(hostname, node -> updated.with(newState), lock);
         }
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -101,6 +101,7 @@ public class NodeSerializer {
     private static final String cloudAccountKey = "cloudAccount";
     private static final String wireguardPubKeyKey = "wireguardPubkey";
     private static final String wireguardKeyTimestampKey = "wireguardKeyTimestamp";
+    private static final String snapshotKey = "snapshot";
 
     // Node resource fields
     private static final String flavorKey = "flavor";
@@ -178,6 +179,7 @@ public class NodeSerializer {
         node.status().osVersion().current().ifPresent(version -> object.setString(osVersionKey, version.toString()));
         node.status().osVersion().wanted().ifPresent(version -> object.setString(wantedOsVersionKey, version.toFullString()));
         node.status().firmwareVerifiedAt().ifPresent(instant -> object.setLong(firmwareCheckKey, instant.toEpochMilli()));
+        node.status().snapshot().ifPresent(snapshot -> SnapshotSerializer.toSlime(snapshot, object.setObject(snapshotKey)));
         node.switchHostname().ifPresent(switchHostname -> object.setString(switchHostnameKey, switchHostname));
         node.reports().toSlime(object, reportsKey);
         node.modelName().ifPresent(modelName -> object.setString(modelNameKey, modelName));
@@ -305,8 +307,8 @@ public class NodeSerializer {
                           object.field(wantToFailKey).asBool(),
                           object.field(wantToUpgradeFlavorKey).asBool(),
                           new OsVersion(versionFromSlime(object.field(osVersionKey)),
-                                                       versionFromSlime(object.field(wantedOsVersionKey))),
-                          SlimeUtils.optionalInstant(object.field(firmwareCheckKey)));
+                                                       versionFromSlime(object.field(wantedOsVersionKey))), SlimeUtils.optionalInstant(object.field(firmwareCheckKey)),
+                          SlimeUtils.optional(object.field(snapshotKey), SnapshotSerializer::fromInspector));
     }
 
     private Flavor flavorFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializer.java
@@ -1,0 +1,103 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.persistence;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostName;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Inspector;
+import com.yahoo.slime.Slime;
+import com.yahoo.slime.SlimeUtils;
+import com.yahoo.vespa.hosted.provision.backup.Snapshot;
+import com.yahoo.vespa.hosted.provision.node.ClusterId;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * @author mpolden
+ */
+public class SnapshotSerializer {
+
+    private static final String SNAPSHOTS_FIELD = "snapshots";
+    private static final String ID_FIELD = "id";
+    private static final String HOSTNAME_FIELD = "hostname";
+    private static final String STATE_FIELD = "state";
+    private static final String CREATED_AT_FIELD = "createdAt";
+    private static final String INSTANCE_FIELD = "instance";
+    private static final String CLUSTER_FIELD = "cluster";
+    private static final String CLUSTER_INDEX_FIELD = "clusterIndex";
+
+    private SnapshotSerializer() {}
+
+    public static Snapshot fromInspector(Inspector object) {
+        return new Snapshot(object.field(ID_FIELD).asString(),
+                            HostName.of(object.field(HOSTNAME_FIELD).asString()),
+                            stateFromSlime(object.field(STATE_FIELD).asString()),
+                            Instant.ofEpochMilli(object.field(CREATED_AT_FIELD).asLong()),
+                            new ClusterId(ApplicationId.fromSerializedForm(object.field(INSTANCE_FIELD).asString()),
+                                          ClusterSpec.Id.from(object.field(CLUSTER_FIELD).asString())),
+                            (int) object.field(CLUSTER_INDEX_FIELD).asLong());
+    }
+
+    public static Snapshot fromSlime(Slime slime) {
+        return fromInspector(slime.get());
+    }
+
+    public static Slime toSlime(Snapshot snapshot) {
+        Slime slime = new Slime();
+        toSlime(snapshot, slime.setObject());
+        return slime;
+    }
+
+    public static List<Snapshot> listFromSlime(Slime slime) {
+        Cursor root = slime.get();
+        return SlimeUtils.entriesStream(root.field(SNAPSHOTS_FIELD))
+                         .map(SnapshotSerializer::fromInspector)
+                         .toList();
+    }
+
+    public static Slime toSlime(List<Snapshot> snapshots) {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+        Cursor array = root.setArray(SNAPSHOTS_FIELD);
+        for (var snapshot : snapshots) {
+            toSlime(snapshot, array.addObject());
+        }
+        return slime;
+    }
+
+    public static void toSlime(Snapshot snapshot, Cursor object) {
+        object.setString(ID_FIELD, snapshot.id());
+        object.setString(HOSTNAME_FIELD, snapshot.hostname().value());
+        object.setString(STATE_FIELD, asString(snapshot.state()));
+        object.setLong(CREATED_AT_FIELD, snapshot.createdAt().toEpochMilli());
+        object.setString(INSTANCE_FIELD, snapshot.cluster().application().serializedForm());
+        object.setString(CLUSTER_FIELD, snapshot.cluster().cluster().value());
+        object.setLong(CLUSTER_INDEX_FIELD, snapshot.clusterIndex());
+    }
+
+    public static String asString(Snapshot.State state) {
+        return switch (state) {
+            case creating -> "creating";
+            case failed -> "failed";
+            case created -> "created";
+            case restoring -> "restoring";
+            case restoreFailed -> "restoreFailed";
+            case restored -> "restored";
+        };
+    }
+
+    private static Snapshot.State stateFromSlime(String value) {
+        return switch (value) {
+            case "creating" -> Snapshot.State.creating;
+            case "failed" -> Snapshot.State.failed;
+            case "created" -> Snapshot.State.created;
+            case "restoring" -> Snapshot.State.restoring;
+            case "restoreFailed" -> Snapshot.State.restoreFailed;
+            case "restored" -> Snapshot.State.restored;
+            default -> throw new IllegalArgumentException("Unknown snapshot state '" + value + "'");
+        };
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -18,10 +18,12 @@ import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.flags.StringFlag;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.backup.Snapshot;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.node.TrustStoreItem;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeFilter;
+import com.yahoo.vespa.hosted.provision.persistence.SnapshotSerializer;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.orchestrator.status.HostInfo;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
@@ -194,6 +196,7 @@ class NodesResponse extends SlimeJsonResponse {
             object.setString("cloudAccount", node.cloudAccount().value());
         }
         node.wireguardPubKey().ifPresent(key -> toSlime(key, object.setObject("wireguard")));
+        node.status().snapshot().ifPresent(snapshot -> toSlime(snapshot, object.setObject("snapshot")));
     }
 
     private Version resolveVersionFlag(StringFlag flag, Node node, Allocation allocation) {
@@ -240,6 +243,11 @@ class NodesResponse extends SlimeJsonResponse {
     static void toSlime(WireguardKeyWithTimestamp keyWithTimestamp, Cursor object) {
         object.setString("key", keyWithTimestamp.key().value());
         object.setLong("timestamp", keyWithTimestamp.timestamp().toEpochMilli());
+    }
+
+    private void toSlime(Snapshot snapshot, Cursor object) {
+        object.setString("id", snapshot.id());
+        object.setString("state", SnapshotSerializer.asString(snapshot.state()));
     }
 
     private Optional<DockerImage> currentContainerImage(Node node) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -36,6 +36,8 @@ import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.applications.Application;
 import com.yahoo.vespa.hosted.provision.autoscale.Load;
+import com.yahoo.vespa.hosted.provision.backup.Snapshot;
+import com.yahoo.vespa.hosted.provision.maintenance.InfraApplicationRedeployer;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.IP;
 import com.yahoo.vespa.hosted.provision.node.filter.ApplicationFilter;
@@ -45,7 +47,6 @@ import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeOsVersionFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeTypeFilter;
 import com.yahoo.vespa.hosted.provision.node.filter.ParentHostFilter;
-import com.yahoo.vespa.hosted.provision.maintenance.InfraApplicationRedeployer;
 import com.yahoo.vespa.hosted.provision.restapi.NodesResponse.ResponseType;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.yolean.Exceptions;
@@ -120,7 +121,7 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
     private HttpResponse handleGET(HttpRequest request) {
         Path path = new Path(request.getUri());
         String pathS = request.getUri().getPath();
-        if (path.matches(    "/nodes/v2")) return new ResourceResponse(request.getUri(), "node", "state", "acl", "command", "archive", "locks", "maintenance", "upgrade", "capacity", "application", "stats", "wireguard");
+        if (path.matches(    "/nodes/v2")) return new ResourceResponse(request.getUri(), "node", "state", "acl", "command", "archive", "locks", "maintenance", "upgrade", "capacity", "application", "stats", "wireguard", "snapshot");
         if (path.matches(    "/nodes/v2/node")) return new NodesResponse(ResponseType.nodeList, request, orchestrator, nodeRepository);
         if (pathS.startsWith("/nodes/v2/node/")) return new NodesResponse(ResponseType.singleNode, request, orchestrator, nodeRepository);
         if (path.matches(    "/nodes/v2/state")) return new NodesResponse(ResponseType.stateList, request, orchestrator, nodeRepository);
@@ -136,6 +137,9 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
         if (path.matches(    "/nodes/v2/application/{applicationId}")) return application(path.get("applicationId"), request.getUri());
         if (path.matches(    "/nodes/v2/stats")) return stats();
         if (path.matches(    "/nodes/v2/wireguard")) return new WireguardResponse(nodeRepository);
+        if (path.matches(    "/nodes/v2/snapshot")) return new SnapshotResponse(nodeRepository);
+        if (path.matches(    "/nodes/v2/snapshot/{hostname}")) return new SnapshotResponse(nodeRepository, path.get("hostname"));
+        if (path.matches(    "/nodes/v2/snapshot/{hostname}/{snapshotId}")) return new SnapshotResponse(nodeRepository, path.get("hostname"), path.get("snapshotId"));
         throw new NotFoundException("Nothing at " + path);
     }
 
@@ -199,6 +203,9 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
         else if (path.matches("/nodes/v2/upgrade/{nodeType}")) {
             return setTargetVersions(path.get("nodeType"), toSlime(request));
         }
+        else if (path.matches("/nodes/v2/snapshot/{hostname}/{snapshot}")) {
+            return updateSnapshot(path.get("hostname"), path.get("snapshot"), toSlime(request));
+        }
 
         throw new NotFoundException("Nothing at '" + path + "'");
     }
@@ -233,8 +240,34 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
                     Optional.ofNullable(request.getProperty("clusterId")).map(ClusterSpec.Id::from)).size();
             return new MessageResponse("Triggered dropping of documents on " + count + " nodes");
         }
+        if (path.matches("/nodes/v2/snapshot/{hostname}")) return snapshot(path.get("hostname"));
 
         throw new NotFoundException("Nothing at path '" + request.getUri().getPath() + "'");
+    }
+
+    private HttpResponse snapshot(String hostname) {
+        Snapshot snapshot = nodeRepository.snapshots().create(hostname, nodeRepository.clock().instant());
+        return new MessageResponse("Triggered a new snapshot of " + hostname + ": " + snapshot.id());
+    }
+
+    private HttpResponse updateSnapshot(String hostname, String id, Inspector body) {
+        Snapshot snapshot = nodeRepository.snapshots().require(id, hostname);
+        Inspector stateField = body.field("state");
+        if (!stateField.valid()) {
+            throw new IllegalArgumentException("No 'state' field present in request body");
+        }
+        String value = stateField.asString();
+        Snapshot.State newState = switch (value) {
+            case "creating" -> Snapshot.State.creating;
+            case "failed" -> Snapshot.State.failed;
+            case "created" -> Snapshot.State.created;
+            case "restoring" -> Snapshot.State.restoring;
+            case "restoreFailed" -> Snapshot.State.restoreFailed;
+            case "restored" -> Snapshot.State.restored;
+            default -> throw new IllegalArgumentException("Invalid snapshot state '" + value + "'");
+        };
+        nodeRepository.snapshots().move(snapshot, newState);
+        return new MessageResponse("Updated snapshot '" + id + "' for node " + hostname);
     }
 
     private HttpResponse handleDELETE(HttpRequest request) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -251,7 +251,6 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
     }
 
     private HttpResponse updateSnapshot(String hostname, String id, Inspector body) {
-        Snapshot snapshot = nodeRepository.snapshots().require(id, hostname);
         Inspector stateField = body.field("state");
         if (!stateField.valid()) {
             throw new IllegalArgumentException("No 'state' field present in request body");
@@ -266,7 +265,7 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
             case "restored" -> Snapshot.State.restored;
             default -> throw new IllegalArgumentException("Invalid snapshot state '" + value + "'");
         };
-        nodeRepository.snapshots().move(snapshot, newState);
+        nodeRepository.snapshots().move(id, hostname, newState);
         return new MessageResponse("Updated snapshot '" + id + "' for node " + hostname);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/SnapshotResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/SnapshotResponse.java
@@ -1,0 +1,53 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.restapi;
+
+import com.yahoo.restapi.SlimeJsonResponse;
+import com.yahoo.slime.Cursor;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.backup.Snapshot;
+import com.yahoo.vespa.hosted.provision.persistence.SnapshotSerializer;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author mpolden
+ */
+public class SnapshotResponse extends SlimeJsonResponse {
+
+    public SnapshotResponse(NodeRepository nodeRepository) {
+        this(nodeRepository, Optional.empty(), Optional.empty());
+    }
+
+    public SnapshotResponse(NodeRepository nodeRepository, String hostname) {
+        this(nodeRepository, Optional.of(hostname), Optional.empty());
+    }
+
+    public SnapshotResponse(NodeRepository nodeRepository, String hostname, String snapshotId) {
+        this(nodeRepository, Optional.of(hostname), Optional.of(snapshotId));
+    }
+
+    private SnapshotResponse(NodeRepository nodeRepository, Optional<String> hostname, Optional<String> snapshotId) {
+        if (snapshotId.isPresent() && hostname.isEmpty()) {
+            throw new IllegalArgumentException("Must specify hostname when snapshotId is given");
+        }
+        Cursor root = slime.setObject();
+        if (snapshotId.isPresent()) {
+            SnapshotSerializer.toSlime(nodeRepository.snapshots().require(snapshotId.get(), hostname.get()), root);
+        } else {
+            final List<Snapshot> snapshots;
+            if (hostname.isPresent()) {
+                snapshots = nodeRepository.snapshots().read(hostname.get());
+            } else {
+                snapshots = nodeRepository.snapshots().read();
+            }
+            Cursor snapshotsArray = root.setArray("snapshots");
+            snapshots.stream()
+                     .sorted(Comparator.comparing(Snapshot::hostname)
+                                       .thenComparing(Snapshot::createdAt))
+                     .forEach(snapshot -> SnapshotSerializer.toSlime(snapshot, snapshotsArray.addObject()));
+        }
+    }
+
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializerTest.java
@@ -1,0 +1,41 @@
+package com.yahoo.vespa.hosted.provision.persistence;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostName;
+import com.yahoo.vespa.hosted.provision.backup.Snapshot;
+import com.yahoo.vespa.hosted.provision.node.ClusterId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author mpolden
+ */
+class SnapshotSerializerTest {
+
+    @Test
+    void serialization() {
+        Snapshot snapshot0 = new Snapshot("id0",
+                                          HostName.of("host0.example.com"),
+                                          Snapshot.State.creating,
+                                          Instant.ofEpochMilli(123),
+                                          new ClusterId(ApplicationId.from("t1", "a1", "i1"),
+                                                        ClusterSpec.Id.from("c1")),
+                                          1);
+        Snapshot snapshot1 = new Snapshot("id1",
+                                          HostName.of("host1.example.com"),
+                                          Snapshot.State.restored,
+                                          Instant.ofEpochMilli(456),
+                                          new ClusterId(ApplicationId.from("t2", "a2", "i2"),
+                                                        ClusterSpec.Id.from("c2")),
+                                          2);
+        assertEquals(snapshot0, SnapshotSerializer.fromSlime(SnapshotSerializer.toSlime(snapshot0)));
+        List<Snapshot> snapshots = List.of(snapshot0, snapshot1);
+        assertEquals(snapshots, SnapshotSerializer.listFromSlime(SnapshotSerializer.toSlime(snapshots)));
+    }
+
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/root.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/root.json
@@ -35,5 +35,9 @@
     },
     {
       "url":"http://localhost:8080/nodes/v2/wireguard/"
-    }  ]
+    },
+    {
+      "url":"http://localhost:8080/nodes/v2/snapshot/"
+    }
+  ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/list-host.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/list-host.json
@@ -1,0 +1,13 @@
+{
+  "snapshots": [
+    {
+      "cluster": "id3",
+      "clusterIndex": 0,
+      "createdAt": 123,
+      "hostname": "host4.yahoo.com",
+      "id": "(ignore)",
+      "instance": "tenant3:application3:instance3",
+      "state": "creating"
+    }
+  ]
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/list.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/list.json
@@ -1,0 +1,22 @@
+{
+  "snapshots": [
+    {
+      "cluster": "id2",
+      "clusterIndex": 0,
+      "createdAt": 123,
+      "hostname": "host2.yahoo.com",
+      "id": "(ignore)",
+      "instance": "tenant2:application2:instance2",
+      "state": "creating"
+    },
+    {
+      "cluster": "id3",
+      "clusterIndex": 0,
+      "createdAt": 123,
+      "hostname": "host4.yahoo.com",
+      "id": "(ignore)",
+      "instance": "tenant3:application3:instance3",
+      "state": "creating"
+    }
+  ]
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/node4.json
@@ -1,0 +1,128 @@
+{
+  "url": "http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+  "id": "node4",
+  "state": "active",
+  "type": "tenant",
+  "hostname": "host4.yahoo.com",
+  "parentHostname": "dockerhost1.yahoo.com",
+  "flavor": "[vcpu: 1.0, memory: 4.0 Gb, disk: 100.0 Gb, bandwidth: 1.0 Gbps, storage type: local, architecture: x86_64]",
+  "resources": {
+    "vcpu": 1.0,
+    "memoryGb": 4.0,
+    "diskGb": 100.0,
+    "bandwidthGbps": 1.0,
+    "diskSpeed": "fast",
+    "storageType": "local",
+    "architecture": "x86_64"
+  },
+  "realResources": {
+    "vcpu": 1.0,
+    "memoryGb": 4.0,
+    "diskGb": 100.0,
+    "bandwidthGbps": 1.0,
+    "diskSpeed": "fast",
+    "storageType": "local",
+    "architecture": "x86_64"
+  },
+  "environment": "DOCKER_CONTAINER",
+  "owner": {
+    "tenant": "tenant3",
+    "application": "application3",
+    "instance": "instance3"
+  },
+  "membership": {
+    "clustertype": "content",
+    "clusterid": "id3",
+    "group": "0",
+    "index": 0,
+    "retired": false
+  },
+  "restartGeneration": 0,
+  "currentRestartGeneration": 0,
+  "wantedDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.42.0",
+  "wantedVespaVersion": "6.42.0",
+  "requestedResources": {
+    "vcpu": 1.0,
+    "memoryGb": 4.0,
+    "diskGb": 100.0,
+    "bandwidthGbps": 1.0,
+    "diskSpeed": "fast",
+    "storageType": "any",
+    "architecture": "any"
+  },
+  "rebootGeneration": 0,
+  "currentRebootGeneration": 0,
+  "vespaVersion": "6.41.0",
+  "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.41.0",
+  "failCount": 0,
+  "wantToRetire": false,
+  "preferToRetire": false,
+  "wantToDeprovision": false,
+  "wantToRebuild": false,
+  "wantToUpgradeFlavor": false,
+  "down": false,
+  "history": [
+    {
+      "event": "provisioned",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "readied",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "reserved",
+      "at": 123,
+      "agent": "application"
+    },
+    {
+      "event": "activated",
+      "at": 123,
+      "agent": "application"
+    }
+  ],
+  "log": [
+    {
+      "event": "provisioned",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "deallocated",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "readied",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "reserved",
+      "at": 123,
+      "agent": "application"
+    },
+    {
+      "event": "reserved",
+      "at": 123,
+      "agent": "application"
+    },
+    {
+      "event": "activated",
+      "at": 123,
+      "agent": "application"
+    }
+  ],
+  "ipAddresses": [
+    "::4:1",
+    "127.0.4.1"
+  ],
+  "additionalIpAddresses": [],
+  "cloudAccount": "aws:111222333444",
+  "snapshot": {
+    "id": "(ignore)",
+    "state": "created"
+  }
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/single.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/single.json
@@ -1,0 +1,9 @@
+{
+  "cluster": "id3",
+  "clusterIndex": 0,
+  "createdAt": 123,
+  "hostname": "host4.yahoo.com",
+  "id": "(ignore)",
+  "instance": "tenant3:application3:instance3",
+  "state": "creating"
+}

--- a/vespajlib/src/main/java/com/yahoo/slime/SlimeUtils.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/SlimeUtils.java
@@ -14,6 +14,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -131,7 +132,7 @@ public class SlimeUtils {
     }
 
     public static Optional<String> optionalString(Inspector inspector) {
-        return isPresent(inspector) ? Optional.of(inspector.asString()) : Optional.empty();
+        return optional(inspector, Inspector::asString);
     }
 
     public static OptionalLong optionalLong(Inspector field) {
@@ -147,11 +148,15 @@ public class SlimeUtils {
     }
 
     public static Optional<Instant> optionalInstant(Inspector field) {
-        return isPresent(field) ? Optional.of(Instant.ofEpochMilli(field.asLong())) : Optional.empty();
+        return optional(field, f -> Instant.ofEpochMilli(f.asLong()));
     }
 
     public static Optional<Duration> optionalDuration(Inspector field) {
-        return isPresent(field) ? Optional.of(Duration.ofMillis(field.asLong())) : Optional.empty();
+        return optional(field, f -> Duration.ofMillis(f.asLong()));
+    }
+
+    public static <T> Optional<T> optional(Inspector field, Function<Inspector, T> factory) {
+        return isPresent(field) ? Optional.of(factory.apply(field)) : Optional.empty();
     }
 
     public static Iterator<Inspector> entriesIterator(Inspector inspector) {


### PR DESCRIPTION
Many requirements were piled on to this feature. Implementation-wise I'm
thinking we do it roughly in these steps:

1. Make it possible to create node-level snapshots
2. Wire node-level snapshots into OS upgrades
3. Implement a user-facing backup/restore feature

This PR can be considered 1a), which adds a data model and REST API for node
snapshots. The current model is only concerned with backups at the _node-level_,
but building cluster- or application-level backups on top of this later should
be straight-forward.

Snapshots are stored separately from the nodes in ZooKeeper, as they may outlive
individual nodes.

When a new snapshot is triggered, the node object will be updated to contain the
snapshot ID and state. Once set, the node will act on the snapshot and update
the state. The next step is to implement this part.

@hakonhall