### PR TITLE
fix: improve handling of failed dnf list command

### DIFF
--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -54,10 +54,7 @@ done
 
 echo
 if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-    echo '\033[1;33mDeleting the following RPMs:\033[0m'
-    echo
-    cat "${RPMS_TO_DELETE}"
-    echo
+    printf '\033[1;33mDeleting the following RPMs:\033[0m\n\n' "${RPMS_TO_DELETE}"
 
     while IFS= read -r RPMID
     do
@@ -68,8 +65,7 @@ if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflo
         "https://api.cloudsmith.io/v1/packages/vespa/open-source-rpms/${RPMID}/"
     done < "${RPMS_TO_DELETE}"
 else
-    echo '\033[1;32m#### Dry-run mode ####\033[0m'
-    echo '\033[0;32mWould have deleted the following RPMs:\033[0m'
-    echo
+    printf '\033[1;32m#### Dry-run mode ####\033[0m\n'
+    printf '\033[0;32mWould have deleted the following RPMs:\033[0m\n\n'
     cat "${RPMS_TO_DELETE}"
 fi

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -19,9 +19,10 @@ curl  --silent --show-error --location --fail \
   --tlsv1 --output /tmp/vespa-open-source-rpms.repo \
   'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.txt?distro=el&codename=8'
 dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
+dnf makecache -y --quiet --repo=vespa-open-source-rpms
 rm -f /tmp/vespa-open-source-rpms.repo
 
-dnf list -y --quiet --showduplicates --disablerepo='*' --enablerepo=vespa-open-source-rpms vespa >/tmp/dnf-stdout 2>/tmp/dnf-stderr || true
+dnf list -y --quiet --showduplicates --repo=vespa-open-source-rpms vespa >/tmp/dnf-stdout 2>/tmp/dnf-stderr || true
 DNF_STDERR="$(cat /tmp/dnf-stderr)"
 DNF_STDOUT="$(cat /tmp/dnf-stdout)"
 if [[ "${DNF_STDERR}" == "Error: No matching Packages to list" ]]; then


### PR DESCRIPTION
## What

Updates the script to delete old artifacts in Cloudsmith:

- Add a `|| true` after the `dnf list` command to ensure that the script continues to execute even if the `dnf list` command returns non-zero status code.
- Adds the standard set of bash options at the beginning of the script.

## Why

- fixes an issue where if there are no artifacts to remove the Workflow would be marked as failed

## Additional info

Failed workflows: https://github.com/vespa-engine/vespa/actions/workflows/delete-old-versions-in-archive.yml?query=is%3Afailure+branch%3Amaster


---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
