### PR TITLE
keep original index name if uncertain

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/IndexFacts.java
+++ b/container-search/src/main/java/com/yahoo/prelude/IndexFacts.java
@@ -87,14 +87,27 @@ public class IndexFacts {
 
     private String getCanonicNameFromDocumentTypes(String indexName, List<String> documentTypes) {
         if (documentTypes.isEmpty()) {
-            Index index = unionSearchDefinition.getIndexByLowerCase(toLowerCase(indexName));
+            Index index = unionSearchDefinition.getIndex(indexName);
+            if (index == null) {
+                index = unionSearchDefinition.getIndexByLowerCase(toLowerCase(indexName));
+            }
             return index == null ? indexName : index.getName();
         }
-        DocumentTypeListOffset sd = chooseSearchDefinition(documentTypes, 0);
-        while (sd != null) {
-            Index index = sd.searchDefinition.getIndexByLowerCase(toLowerCase(indexName));
-            if (index != null) return index.getName();
-            sd = chooseSearchDefinition(documentTypes, sd.offset);
+        Set<String> gotNames = new TreeSet<>();
+        for (String dt : documentTypes) {
+            var sd = searchDefinitions.get(dt);
+            if (sd != null) {
+                Index index = sd.getIndex(indexName);
+                if (index == null) {
+                    index = sd.getIndexByLowerCase(toLowerCase(indexName));
+                }
+                if (index != null) {
+                    gotNames.add(index.getName());
+                }
+            }
+        }
+        if (gotNames.size() == 1) {
+            return gotNames.iterator().next();
         }
         return indexName;
     }

--- a/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
@@ -204,6 +204,31 @@ public class IndexFactsTestCase {
         assertFalse(session.getIndex("b").isUriIndex());
         assertFalse(session.getIndex("b").isHostIndex());
         assertEquals(StemMode.NONE, session.getIndex("b").getStemMode());
+        assertEquals("NAME", session.getCanonicName("name"));
+        assertEquals("NAME", session.getCanonicName("Name"));
+        assertEquals("NAME", session.getCanonicName("NAME"));
+        assertEquals("NAME", session.getCanonicName("nAmE"));
+        query = new Query();
+        session = indexFacts.newSession(query);
+        assertEquals("name", session.getCanonicName("name"));
+        assertEquals("NAME", session.getCanonicName("NAME"));
+        // no way to choose among the valid names:
+        assertEquals("nAmE", session.getCanonicName("nAmE"));
+        query = new Query();
+        query.getModel().getRestrict().add("one");
+        query.getModel().getRestrict().add("two");
+        session = indexFacts.newSession(query);
+        assertEquals("name", session.getCanonicName("nAmE"));
+        query = new Query();
+        query.getModel().getRestrict().add("two");
+        query.getModel().getRestrict().add("three");
+        session = indexFacts.newSession(query);
+        assertEquals("NAME", session.getCanonicName("nAmE"));
+        query = new Query();
+        query.getModel().getRestrict().add("one");
+        query.getModel().getRestrict().add("three");
+        session = indexFacts.newSession(query);
+        assertEquals("nAmE", session.getCanonicName("nAmE"));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/test/indexfactstesting.cfg
+++ b/container-search/src/test/java/com/yahoo/prelude/test/indexfactstesting.cfg
@@ -1,8 +1,10 @@
 indexinfo[3]
 indexinfo[0].name one
-indexinfo[0].command[1]
+indexinfo[0].command[2]
 indexinfo[0].command[0].indexname a
 indexinfo[0].command[0].command index
+indexinfo[0].command[1].indexname name
+indexinfo[0].command[1].command index
 indexinfo[1].name two
 indexinfo[1].command[3]
 indexinfo[1].command[0].indexname d
@@ -12,7 +14,7 @@ indexinfo[1].command[1].command fullurl
 indexinfo[1].command[2].indexname e
 indexinfo[1].command[2].command exact kj(/&
 indexinfo[2].name three
-indexinfo[2].command[7]
+indexinfo[2].command[8]
 indexinfo[2].command[0].indexname a
 indexinfo[2].command[0].command index
 indexinfo[2].command[1].indexname a
@@ -27,3 +29,5 @@ indexinfo[2].command[5].indexname d
 indexinfo[2].command[5].command exact
 indexinfo[2].command[6].indexname twewm
 indexinfo[2].command[6].command word
+indexinfo[2].command[7].indexname NAME
+indexinfo[2].command[7].command index


### PR DESCRIPTION
* if there are several index names differing only in casing, keep the original from the request.

@hmusum please review
@geirst @bratseth FYI
