### PR TITLE
feat: setting to set java path in IntelliJ plugin

### DIFF
--- a/integration/schema-language-server/clients/intellij/src/main/java/ai/vespa/schemals/intellij/settings/SchemaSettings.java
+++ b/integration/schema-language-server/clients/intellij/src/main/java/ai/vespa/schemals/intellij/settings/SchemaSettings.java
@@ -1,0 +1,41 @@
+package ai.vespa.schemals.intellij.settings;
+
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This is the 'Model' part of the Settings interface per MVC.
+ * It simply contains the current settings state.
+ */
+@State(
+        name = "ai.vespa.schemals.intellij.settings.SchemaLspSettings",
+        storages = @Storage("VespaSchemaSettings.xml")
+)
+public final class SchemaSettings implements PersistentStateComponent<SchemaSettings.State> {
+    public static class State {
+        @NonNls
+        public String javaPath = "";
+    }
+
+    private State state = new State();
+
+    public static SchemaSettings getInstance() {
+        return ApplicationManager.getApplication()
+                .getService(SchemaSettings.class);
+    }
+
+    @Override
+    public State getState() {
+        return state;
+    }
+
+    @Override
+    public void loadState(@NotNull State state) {
+        this.state = state;
+    }
+}

--- a/integration/schema-language-server/clients/intellij/src/main/java/ai/vespa/schemals/intellij/settings/SchemaSettingsComponent.java
+++ b/integration/schema-language-server/clients/intellij/src/main/java/ai/vespa/schemals/intellij/settings/SchemaSettingsComponent.java
@@ -1,0 +1,56 @@
+package ai.vespa.schemals.intellij.settings;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.fileChooser.FileChooserPanel;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.FormBuilder;
+import com.jetbrains.JBRFileDialog;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * This is the 'View' part of the Settings interface per MVC
+ * It defines the settings ui for the plugin.
+ */
+public class SchemaSettingsComponent {
+    private final JPanel mainPanel;
+    private final TextFieldWithBrowseButton javaPathTextField = new TextFieldWithBrowseButton();
+
+    public SchemaSettingsComponent() {
+        FileChooserDescriptor fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor();
+        fileChooserDescriptor.setTitle("Select Path to Java Home");
+        javaPathTextField.addBrowseFolderListener("Java Path", "Select path to java home", null, fileChooserDescriptor);
+        javaPathTextField.setToolTipText("Path to Java Home or directory containing a java executable. Will use the system installed version of java if not set.");
+
+        mainPanel = FormBuilder.createFormBuilder()
+                .addLabeledComponent(new JBLabel("Path to java home:"), javaPathTextField, 1, false)
+                .addComponentFillVertically(new JPanel(), 0)
+                .getPanel();
+    }
+
+    public JPanel getPanel() {
+        return mainPanel;
+    }
+
+    public JComponent getPreferredFocusedComponent() {
+        return javaPathTextField;
+    }
+
+    @NotNull
+    public String getJavaPathText() {
+        return javaPathTextField.getText();
+    }
+
+    public void setJavaPathText(@NotNull String javaPath) {
+        javaPathTextField.setText(javaPath);
+    }
+}

--- a/integration/schema-language-server/clients/intellij/src/main/java/ai/vespa/schemals/intellij/settings/SchemaSettingsConfigurable.java
+++ b/integration/schema-language-server/clients/intellij/src/main/java/ai/vespa/schemals/intellij/settings/SchemaSettingsConfigurable.java
@@ -1,0 +1,61 @@
+package ai.vespa.schemals.intellij.settings;
+
+import com.intellij.openapi.options.Configurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Objects;
+
+/**
+ * This is the 'Controller' part of the Settings interface per MVC
+ * It glues the ui and the state together and interacts with the IntelliJ platform.
+ */
+public class SchemaSettingsConfigurable implements Configurable {
+    private SchemaSettingsComponent settingsComponent;
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "Vespa Schema Settings";
+    }
+
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return settingsComponent.getPreferredFocusedComponent();
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        settingsComponent = new SchemaSettingsComponent();
+        return settingsComponent.getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        SchemaSettings.State state =
+                Objects.requireNonNull(SchemaSettings.getInstance().getState());
+        return !settingsComponent.getJavaPathText().equals(state.javaPath);
+    }
+
+    @Override
+    public void apply() {
+        SchemaSettings.State state =
+                Objects.requireNonNull(SchemaSettings.getInstance().getState());
+        state.javaPath = settingsComponent.getJavaPathText();
+    }
+
+    @Override
+    public void reset() {
+        SchemaSettings.State state =
+                Objects.requireNonNull(SchemaSettings.getInstance().getState());
+        settingsComponent.setJavaPathText(state.javaPath);
+    }
+
+    @Override
+    public void disposeUIResources() {
+        settingsComponent = null;
+    }
+}

--- a/integration/schema-language-server/clients/intellij/src/main/resources/META-INF/plugin.xml
+++ b/integration/schema-language-server/clients/intellij/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,10 @@
     <li>Syntax highlighting</li>
 </ul>
 
+<h2>Settings:</h2>
+<p>If you encounter issues running the language server, you can supply a custom path to java by changing the setting under "Languages & Frameworks": "Vespa Schema Language Server"</p>
+<p>The language server requires Java 17 or higher. The supplied path should contain a java binary or a subdirectory "bin" containing the java binary.</p>
+
   ]]></description>
   <change-notes><![CDATA[
 <h2>Rewritten from scratch to include LSP support</h2>
@@ -36,5 +40,17 @@
 
     <platform.lsp.serverSupportProvider implementation="ai.vespa.schemals.intellij.SchemaLspServerSupportProvider"/>
     <lang.syntaxHighlighter language="Schema" implementationClass="ai.vespa.schemals.intellij.SchemaSyntaxHighlighter" />
+  </extensions>
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationService
+            serviceImplementation="ai.vespa.schemals.intellij.settings.SchemaSettings"/>
+  </extensions>
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationConfigurable
+      parentId="language"
+      instance="ai.vespa.schemals.intellij.settings.SchemaSettingsConfigurable"
+      id="ai.vespa.schemals.intellij.settings.SchemaSettingsConfigurable"
+      displayName="Vespa Schema Language Server"
+      />
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
This makes it possible to set a custom path to the java installation used for running the language server in intellij.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
