### PR TITLE
Fixed hardcoded doc ids in significance model generator

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/ClientParameters.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/ClientParameters.java
@@ -23,9 +23,6 @@ public class ClientParameters {
     // Language for the program
     public final String language;
 
-    // Document type identifier
-    public final String docType;
-
     // Zstandard compression
     public final boolean zstCompression;
 
@@ -35,14 +32,12 @@ public class ClientParameters {
             String outputFile,
             String field,
             String language,
-            String docType,
             boolean zstCompression) {
         this.help = help;
         this.inputFile = inputFile;
         this.outputFile = outputFile;
         this.field = field;
         this.language = language;
-        this.docType = docType;
         this.zstCompression = zstCompression;
     }
 
@@ -52,7 +47,6 @@ public class ClientParameters {
         private String outputFile;
         private String field;
         private String language;
-        private String docType;
         private boolean zstCompression;
 
         public Builder setHelp(boolean help) {
@@ -79,18 +73,13 @@ public class ClientParameters {
             return this;
         }
 
-        public Builder setDocType(String docType) {
-            this.docType = docType;
-            return this;
-        }
-
         public Builder setZstCompression(String useZstCompression) {
             this.zstCompression = Boolean.parseBoolean(useZstCompression);
             return this;
         }
 
         public ClientParameters build() {
-            return new ClientParameters(help, inputFile, outputFile, field, language, docType, zstCompression);
+            return new ClientParameters(help, inputFile, outputFile, field, language, zstCompression);
         }
     }
 }

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -25,7 +25,6 @@ public class CommandLineOptions {
     public static final String OUTPUT_OPTION = "out";
     public static final String FIELD_OPTION = "field";
     public static final String LANGUAGE_OPTION = "language";
-    public static final String DOC_TYPE_OPTION = "doc-type";
     public static final String ZST_COMPRESSION = "zst-compression";
 
     private final Options options = createOptions();
@@ -68,13 +67,6 @@ public class CommandLineOptions {
                 .longOpt(LANGUAGE_OPTION)
                 .build());
 
-        options.addOption(Option.builder("d")
-                .required()
-                .hasArg(true)
-                .desc("Document type identifier")
-                .longOpt(DOC_TYPE_OPTION)
-                .build());
-
         options.addOption(Option.builder("zst")
                 .hasArg(true)
                 .desc("Use Zstandard compression")
@@ -104,7 +96,6 @@ public class CommandLineOptions {
             builder.setOutputFile(cl.getOptionValue(OUTPUT_OPTION));
             builder.setField(cl.getOptionValue(FIELD_OPTION));
             builder.setLanguage(cl.getOptionValue(LANGUAGE_OPTION));
-            builder.setDocType(cl.getOptionValue(DOC_TYPE_OPTION));
             builder.setZstCompression(cl.hasOption(ZST_COMPRESSION) ? cl.getOptionValue(ZST_COMPRESSION) : "true");
 
             return builder.build();

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/SignificanceModelGenerator.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/SignificanceModelGenerator.java
@@ -72,6 +72,9 @@ public class SignificanceModelGenerator {
     private final static String SIGNIFICANCE_DESCRIPTION = "Significance model for input file";
     private final static String DOC_FREQ_DESCRIPTION = "Document frequency for language";
 
+    private final static String DUMMY_DOC_TYPE = "dummy";
+    private final static String DUMMY_DOC_ID = "id:dummy:" + DUMMY_DOC_TYPE + "::dummy";
+
     public SignificanceModelGenerator(ClientParameters clientParameters) {
         this.clientParameters = clientParameters;
 
@@ -93,7 +96,7 @@ public class SignificanceModelGenerator {
         tokenizer = openNlpLinguistics.getTokenizer();
         objectMapper = new ObjectMapper();
 
-        docType = new DocumentType(clientParameters.docType);
+        docType = new DocumentType(DUMMY_DOC_TYPE);
         docType.addField(new Field(clientParameters.field, DataType.STRING));
         useZstCompression = clientParameters.zstCompression;
 
@@ -112,10 +115,16 @@ public class SignificanceModelGenerator {
         long i = 1;
         while (reader.ready()) {
             String line = reader.readLine();
-            JsonReader jsonReader = new JsonReader(types, new ByteArrayInputStream(Utf8.toBytes(line)), parserFactory);
-            String wikimediaId = "id:wikimedia:" + languageTag.languageCode() + "::" + i;
 
-            ParsedDocumentOperation operation = jsonReader.readSingleDocumentStreaming(DocumentOperationType.PUT, wikimediaId);
+            // Avoid failing on empty lines
+            if (line.isBlank())
+                continue;
+
+            JsonReader jsonReader = new JsonReader(types, new ByteArrayInputStream(Utf8.toBytes(line)), parserFactory);
+
+            // Using DUMMY_DOC_ID since we are only interested in content.
+            ParsedDocumentOperation operation = jsonReader.readSingleDocumentStreaming(DocumentOperationType.PUT, DUMMY_DOC_ID);
+
             DocumentPut put = (DocumentPut) operation.operation();
             Document document = put.getDocument();
             FieldValue fieldValue = document.getFieldValue(clientParameters.field);

--- a/vespaclient-java/src/test/files/en.jsonl
+++ b/vespaclient-java/src/test/files/en.jsonl
@@ -1,3 +1,3 @@
-{"put": "id:wikimedia:en::1", "fields": {"text": "Some english wiki dump"}}
-{"put": "id:wikimedia:en::2", "fields": {"text": "Some english wiki dump"}}
-{"put": "id:wikimedia:en::3", "fields": {"text": "Some english wiki dump"}}
+{"put": "id:wikimedia:en::1", "fields": {"text": "[[English]]"}}
+{"put": "id:wikimedia:en::2", "fields": {"text": "[[English Wiki]]"}}
+{"put": "id:wikimedia:en::3", "fields": {"text": "[[English]] wiki pages"}}

--- a/vespaclient-java/src/test/files/no.jsonl
+++ b/vespaclient-java/src/test/files/no.jsonl
@@ -1,3 +1,0 @@
-{"put": "id:wikimedia:nb::1", "fields": {"text": "[[Arbeiderpartiet]][[Kategori:Omdirigeringer fra eldre skriveform]]"}}
-{"put": "id:wikimedia:nb::2", "fields": {"text": "[[Arbeiderpartiet]][[Kategori:Omdirigeringer fra eldre skriveform]]"}}
-{"put": "id:wikimedia:nb::3", "fields": {"text": "[[Arbeiderpartiet]][[Kategori:Omdirigeringer fra eldre skriveform]]"}}

--- a/vespaclient-java/src/test/files/no_1.jsonl
+++ b/vespaclient-java/src/test/files/no_1.jsonl
@@ -1,0 +1,3 @@
+{"put": "id:wikimedia:nb::1", "fields": {"text": "Norske"}}
+{"put": "id:wikimedia:nb::2", "fields": {"text": "Norske wiki"}}
+{"put": "id:wikimedia:nb::3", "fields": {"text": "Norske wiki sider"}}

--- a/vespaclient-java/src/test/files/no_2.jsonl
+++ b/vespaclient-java/src/test/files/no_2.jsonl
@@ -1,3 +1,3 @@
-{"put": "id:wikimedia:nb::1", "fields": {"text": "[[Arbeiderpartiet]][[Kategori:Omdirigeringer fra eldre eldre skriveform]]"}}
-{"put": "id:wikimedia:nb::2", "fields": {"text": "[[Arbeiderpartiet]][[Kategori:Omdirigeringer fra eldre skriveform nytt]]"}}
-{"put": "id:wikimedia:nb::3", "fields": {"text": "[[Arbeiderpartiet]][[Kategori:Omdirigeringer frå eldre skriveform nytt]]"}}
+{"put": "id:wikimedia:nb::1", "fields": {"text": "[[Norske]]"}}
+{"put": "id:wikimedia:nb::2", "fields": {"text": "[Norske wikipedia]"}}
+{"put": "id:wikimedia:nb::3", "fields": {"text": "Norske [[wikipedia]] sider"}}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

- Fixed mismatch between doc type registered for parsing and the one in doc id.
- Removed doc type as parameter, a dummy doc type is used instead since we are only interested in content.