### PR TITLE
Interns/magnus/tensorexpressions

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/SchemaIndex.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/SchemaIndex.java
@@ -210,6 +210,7 @@ public class SchemaIndex {
     public List<Symbol> findSymbols(Symbol scope, SymbolType type, String shortIdentifier) {
         // First candidates are all symbols with correct type and correct short identifier
 
+        // Special case for schema and document because a schema can sometimes refer to a document and vice versa
         if (type == SymbolType.SCHEMA || type == SymbolType.DOCUMENT) {
             SymbolType firstCheck = (type == SymbolType.SCHEMA ? SymbolType.SCHEMA : SymbolType.DOCUMENT);
             List<Symbol> schemaDefinitions = 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
@@ -110,9 +110,9 @@ public class SchemaDocument implements DocumentManager {
             this.CST = parsingResult.CST().get();
             lexer.setCST(CST);
 
-            //logger.info("======== CST for file: " + fileURI + " ========");
+            logger.info("======== CST for file: " + fileURI + " ========");
      
-            //CSTUtils.printTree(logger, CST);
+            CSTUtils.printTree(logger, CST);
         }
 
 
@@ -234,6 +234,8 @@ public class SchemaDocument implements DocumentManager {
 
             diagnostics.addAll(ResolverTraversal.traverse(context, tolerantResult.CST().get()));
 
+            // Unresolved field arguments (type and indexing settings) need to be resolved after 'ResolverTraversal'
+            // because the indexing language is traversed in the ResolverTraversal
             for (UnresolvedFieldArgument fieldArg : context.unresolvedFieldArguments()) {
                 Optional<Diagnostic> diagnostic = FieldArgumentResolver.resolveFieldArgument(context, fieldArg);
                 if (diagnostic.isPresent()) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
@@ -110,9 +110,9 @@ public class SchemaDocument implements DocumentManager {
             this.CST = parsingResult.CST().get();
             lexer.setCST(CST);
 
-            logger.info("======== CST for file: " + fileURI + " ========");
+            //logger.info("======== CST for file: " + fileURI + " ========");
      
-            CSTUtils.printTree(logger, CST);
+            //CSTUtils.printTree(logger, CST);
         }
 
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/IdentifySymbolDefinition.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/IdentifySymbolDefinition.java
@@ -350,8 +350,6 @@ public class IdentifySymbolDefinition extends Identifier {
         Optional<Symbol> existingSymbolMapped = context.schemaIndex().findSymbolInScope(scope, SymbolType.TENSOR_DIMENSION_MAPPED, identifierNode.getText());
         Optional<Symbol> existingSymbolIndexed = context.schemaIndex().findSymbolInScope(scope, SymbolType.TENSOR_DIMENSION_INDEXED, identifierNode.getText());
 
-        // I want to keep this check here to give a message,
-        // but we have to change some stuff in the CongoCC parser for it to take effect.
         if (existingSymbolMapped.isPresent() || existingSymbolIndexed.isPresent()) {
             identifierNode.setSymbolStatus(SymbolStatus.INVALID);
             diagnostics.add(new SchemaDiagnostic.Builder()
@@ -363,6 +361,7 @@ public class IdentifySymbolDefinition extends Identifier {
         }
 
         identifierNode.setSymbolStatus(SymbolStatus.DEFINITION);
+        context.schemaIndex().insertSymbolDefinition(identifierNode.getSymbol());
     }
 
     private static final Set<String> reservedFunctionNames = ReservedFunctionNames.getReservedNames();

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/FieldArgumentResolver.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/FieldArgumentResolver.java
@@ -14,9 +14,14 @@ import ai.vespa.schemals.index.Symbol;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.FieldArgument.UnresolvedFieldArgument;
 import ai.vespa.schemals.tree.SchemaNode;
 
+/**
+ * This checks that the type or indexing settings for a referenced field are correct.
+ * For instance, some uses require that a field has indexing 'attribute'. Other uses require that a field is of a certain type 
+ * or set of types.
+ * The information about the required data is in class {@link ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.FieldArgument.UnresolvedFieldArgument}
+ * The resolver then looks up the field definition and chcks if the registered indexing settings are correct.
+ */
 public class FieldArgumentResolver {
-    
-
     public static Optional<Diagnostic> resolveFieldArgument(ParseContext context, UnresolvedFieldArgument fieldArgument) {
 
         if (fieldArgument.indexingTypes().size() == 0) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpressionSymbolResolver.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpressionSymbolResolver.java
@@ -68,7 +68,7 @@ public class RankExpressionSymbolResolver {
             diagnostics.addAll(traverseRankExpressionTree(child, context));
         }
 
-        // All feature nodes has a symbol before the parse
+        // All feature nodes has a symbol before the traversal
         if (node.hasSymbol()) {
 
             if (node.getSymbolStatus() == SymbolStatus.UNRESOLVED) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpressionSymbolResolver.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpressionSymbolResolver.java
@@ -144,6 +144,8 @@ public class RankExpressionSymbolResolver {
         // add(SymbolType.PARAMETER); // This is a special case
         add(SymbolType.FUNCTION);
         add(SymbolType.RANK_CONSTANT);
+        add(SymbolType.TENSOR_DIMENSION_MAPPED);
+        add(SymbolType.TENSOR_DIMENSION_INDEXED);
     }};
 
     private static void resolveReference(RankNode referenceNode, ParseContext context, List<Diagnostic> diagnostics) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/tree/CSTUtils.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/tree/CSTUtils.java
@@ -12,12 +12,15 @@ import ai.vespa.schemals.common.ClientLogger;
 import ai.vespa.schemals.index.SchemaIndex;
 import ai.vespa.schemals.index.Symbol;
 import ai.vespa.schemals.index.Symbol.SymbolStatus;
+import ai.vespa.schemals.index.Symbol.SymbolType;
 import ai.vespa.schemals.parser.Node;
 import ai.vespa.schemals.parser.TokenSource;
 import ai.vespa.schemals.parser.ast.documentElm;
 import ai.vespa.schemals.parser.ast.functionElm;
 import ai.vespa.schemals.parser.rankingexpression.ast.BaseNode;
 import ai.vespa.schemals.parser.rankingexpression.ast.lambdaFunction;
+import ai.vespa.schemals.parser.rankingexpression.ast.tensorGenerateBody;
+import ai.vespa.schemals.parser.rankingexpression.ast.tensorType;
 import ai.vespa.schemals.tree.SchemaNode.LanguageType;
 import ai.vespa.schemals.tree.indexinglanguage.ILUtils;
 import ai.vespa.schemals.tree.rankingexpression.RankingExpressionUtils;
@@ -194,13 +197,18 @@ public class CSTUtils {
                 if (currentNode.isASTInstance(lambdaFunction.class)) {
                     indexGuess = 0;
                 }
-
                 if (indexGuess < currentNode.size()) {
                     SchemaNode potentialDefinition = currentNode.get(indexGuess);
                     if (potentialDefinition.hasSymbol() && potentialDefinition.getSymbol().getStatus() == SymbolStatus.DEFINITION) {
                         return Optional.of(potentialDefinition.getSymbol());
                     }
                 }
+            } else if (currentNode.isASTInstance(tensorGenerateBody.class) && 
+                       currentNode.getPreviousSibling() != null && 
+                       currentNode.getPreviousSibling().hasSymbol() &&
+                       currentNode.getPreviousSibling().getSymbol().getType() == SymbolType.TENSOR) {
+                // Edge case for tensor type in rank expression
+                return Optional.of(currentNode.getPreviousSibling().getSymbol());
             }
 
             currentNode = currentNode.getParent();

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -338,6 +338,7 @@ public class SchemaParserTest {
 
             new BadFileTestCase("src/test/sdfiles/single/rankprofilefuncs.sd", 2),
             new BadFileTestCase("src/test/sdfiles/single/onnxmodel.sd", 1),
+            new BadFileTestCase("src/test/sdfiles/single/tensorGenerate.sd", 2)
         };
 
         return Arrays.stream(tests)

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/tensorGenerate.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/tensorGenerate.sd
@@ -1,0 +1,18 @@
+schema tensorGenerate {
+    document tensorGenerate {
+    }
+
+    rank-profile myprofile {
+        first-phase {
+            expression: tensor<float>(d0[100], d1{})(d0)
+        }
+
+        function func() {
+            expression: tensor<bfloat16>(d0[10], d1[20], d3[30])(d4) # error
+        }
+
+        function complicated() {
+            expression: tensor<float>(d0[1],d1[1],d2[2])(d2) + tensor<float>(d1[1])(d2) # also error, d2 exists in other tensor.
+        }
+    }
+}


### PR DESCRIPTION
### Language server
This PR specifically fixes the case:

expression: tensor<float>(d0[1],d1[10])(d1)
where d1 is a reference to the tensor dimension in the tensor expression body.

Earlier the d1 was correctly marked as a reference in the body, but the dimensions were not marked as definitions in the type definition.