### PR TITLE
more hex support in mixed tensor parsing

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/query/RankProfileInputTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/RankProfileInputTest.java
@@ -36,7 +36,7 @@ public class RankProfileInputTest {
 
     @Test
     void testTensorRankFeatureInRequest() {
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
 
         {
             Query query = createTensor1Query(tensorString, "commonProfile", "");
@@ -57,19 +57,19 @@ public class RankProfileInputTest {
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
-            assertEquals("Could not set 'ranking.features.query(myTensor1)' to '{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}': No profile named 'bOnly' exists in schemas [a]", Exceptions.toMessageString(e));
+            assertEquals("Could not set 'ranking.features.query(myTensor1)' to '{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}': No profile named 'bOnly' exists in schemas [a]", Exceptions.toMessageString(e));
         }
     }
 
     @Test
     void testTensorRankFeatureInRequestInconsistentInput() {
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
         try {
             createTensor1Query(tensorString, "inconsistent", "");
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
-            assertEquals("Could not set 'ranking.features.query(myTensor1)' to '{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}': " +
+            assertEquals("Could not set 'ranking.features.query(myTensor1)' to '{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}': " +
                          "Conflicting input type declarations for 'query(myTensor1)': " +
                          "Declared as tensor(a{},b{}) in rank profile 'inconsistent' in schema 'a', " +
                          "and as tensor(x[10]) in rank profile 'inconsistent' in schema 'b'",
@@ -79,7 +79,7 @@ public class RankProfileInputTest {
 
     @Test
     void testTensorRankFeatureWithSourceResolution() {
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
 
         {
             createTensor1Query(tensorString, "inconsistent", "sources=a");
@@ -102,7 +102,7 @@ public class RankProfileInputTest {
 
     @Test
     void testTensorRankFeatureSetProgrammatically() {
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
         Query query = new Query.Builder()
                 .setSchemaInfo(createSchemaInfo())
                 .setQueryProfile(createQueryProfile()) // Use the instantiation path with query profiles

--- a/container-search/src/test/java/com/yahoo/search/query/profile/types/test/QueryProfileTypeTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/types/test/QueryProfileTypeTestCase.java
@@ -110,11 +110,11 @@ public class QueryProfileTypeTestCase {
         profile.set("myDouble", 2.18, registry);
         profile.set("myBoolean", true, registry);
 
-        String tensorString1 = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString1 = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
         profile.set("ranking.features.query(myTensor1)", tensorString1, registry);
-        String tensorString2 = "{{x:0, y:0}:1.0, {x:0, y:1}:2.0}}";
+        String tensorString2 = "{{x:0, y:0}:1.0, {x:0, y:1}:2.0}";
         profile.set("ranking.features.query(myTensor2)", tensorString2, registry);
-        String tensorString3 = "{{x:x1}:1.0, {x:x2}:2.0}}";
+        String tensorString3 = "{{x:x1}:1.0, {x:x2}:2.0}";
         profile.set("ranking.features.query(myTensor3)", tensorString3, registry);
 
         profile.set("myQuery", "...", registry); // TODO
@@ -409,7 +409,7 @@ public class QueryProfileTypeTestCase {
         registry.register(profile);
 
         CompiledQueryProfileRegistry cRegistry = registry.compile();
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
         Query query = new Query(HttpRequest.createTestRequest("?" + urlEncode("ranking.features.query(myTensor1)") +
                         "=" + urlEncode(tensorString),
                         com.yahoo.jdisc.http.HttpRequest.Method.GET),
@@ -426,7 +426,7 @@ public class QueryProfileTypeTestCase {
         registry.register(profile);
 
         CompiledQueryProfileRegistry cRegistry = registry.compile();
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
         Query query = new Query(HttpRequest.createTestRequest("?", com.yahoo.jdisc.http.HttpRequest.Method.GET),
                 cRegistry.getComponent("test"));
         query.properties().set("ranking.features.query(myTensor1)", Tensor.from(tensorString));
@@ -471,7 +471,7 @@ public class QueryProfileTypeTestCase {
         registry.register(profile);
 
         CompiledQueryProfileRegistry cRegistry = registry.compile();
-        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}}";
+        String tensorString = "{{a:a1, b:b1}:1.0, {a:a2, b:b1}:2.0}";
         Query query = new Query(HttpRequest.createTestRequest("?" + urlEncode("ranking.features.query(myTensor1)") +
                         "=" + urlEncode(tensorString),
                         com.yahoo.jdisc.http.HttpRequest.Method.GET),

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -1934,7 +1934,7 @@ public class JsonReaderTestCase {
 
     @Test
     public void testParsingOfSparseTensorWithCells() {
-        Tensor tensor = assertSparseTensorField("{{x:a,y:b}:2.0,{x:c,y:b}:3.0}}",
+        Tensor tensor = assertSparseTensorField("{{x:a,y:b}:2.0,{x:c,y:b}:3.0}",
                                 createPutWithSparseTensor("""
                                                           {
                                                             "type": "tensor(x{},y{})",
@@ -1949,7 +1949,7 @@ public class JsonReaderTestCase {
 
     @Test
     public void testParsingOfDenseTensorWithCells() {
-        Tensor tensor = assertTensorField("{{x:0,y:0}:2.0,{x:1,y:0}:3.0}}",
+        Tensor tensor = assertTensorField("{{x:0,y:0}:2.0,{x:1,y:0}:3.0}",
                                           createPutWithTensor("""
                                                               {
                                                                 "cells": [
@@ -2183,7 +2183,7 @@ public class JsonReaderTestCase {
 
     @Test
     public void testAssignUpdateOfTensorWithCells() {
-        assertTensorAssignUpdateSparseField("{{x:a,y:b}:2.0,{x:c,y:b}:3.0}}",
+        assertTensorAssignUpdateSparseField("{{x:a,y:b}:2.0,{x:c,y:b}:3.0}",
                                             createAssignUpdateWithSparseTensor("""
                                                                                {
                                                                                 "cells": [

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -372,7 +372,7 @@ public class EvaluationTestCase {
         tester.assertEvaluates("{ {x:0,y:0,z:0}:7, {x:0,y:0,z:1}:13, {x:1,y:0,z:0}:21, {x:1,y:0,z:1}:39, {x:0,y:1,z:0}:55, {x:0,y:1,z:1}:0, {x:1,y:1,z:0}:0, {x:1,y:1,z:1}:0 }",
                                "tensor0 * tensor1", "{ {x:0,y:0}:1, {x:1,y:0}:3, {x:0,y:1}:5, {x:1,y:1}:0 }", "{ {y:0,z:0}:7, {y:1,z:0}:11, {y:0,z:1}:13, {y:1,z:1}:0 }");
         tester.assertEvaluates("{ {x:0,y:1,z:0}:35, {x:0,y:1,z:1}:65 }",
-                               "tensor0 * tensor1", "tensor(x{},y{}):{ {x:0,y:0}:1, {x:1,y:0}:3, {x:0,y:1}:5 }", "tensor(y{},z{}):{ {y:1,z:0}:7, {y:2,z:0}:11, {y:1,z:1}:13 })");
+                               "tensor0 * tensor1", "tensor(x{},y{}):{ {x:0,y:0}:1, {x:1,y:0}:3, {x:0,y:1}:5 }", "tensor(y{},z{}):{ {y:1,z:0}:7, {y:2,z:0}:11, {y:1,z:1}:13 }");
         tester.assertEvaluates("{{x:0,y:0}:0.0}","tensor1 * tensor2 * tensor3", "{ {x:0}:1 }", "{ {x:1,y:0}:1, {x:0,y:0}:1 }", "{ {x:0,y:0}:1 }");
         tester.assertEvaluates("{ {d1:0}:50, {d1:1}:500, {d1:2}:5000 }",
                                "5 * tensor0", "{ {d1:0}:10, {d1:1}:100, {d1:2}:1000 }");
@@ -455,8 +455,8 @@ public class EvaluationTestCase {
         tester.assertEvaluates("{ {x:0}:0, {x:1}:0, {x:2}:1, {x:3}:0 }", "argmin(tensor0, x)", "{ {x:0}:15, {x:1}:12, {x:2}:7, {x:3}:15 }");
 
         // expressions combining functions
-        tester.assertEvaluates("tensor(y{}):{{y:6}:0}}", "matmul(tensor0, diag(x[5],y[7]), x)", "tensor(x{},y{}):{{x:4,y:6}:1})");
-        tester.assertEvaluates("tensor(y{}):{{y:6}:10}}", "matmul(tensor0, range(x[5],y[7]), x)", "tensor(x{},y{}):{{x:4,y:6}:1})");
+        tester.assertEvaluates("tensor(y{}):{{y:6}:0}", "matmul(tensor0, diag(x[5],y[7]), x)", "tensor(x{},y{}):{{x:4,y:6}:1}");
+        tester.assertEvaluates("tensor(y{}):{{y:6}:10}", "matmul(tensor0, range(x[5],y[7]), x)", "tensor(x{},y{}):{{x:4,y:6}:1}");
         tester.assertEvaluates(String.valueOf(7.5 + 45 + 1.7),
                                "sum( " +               // model computation:
                                "      tensor0 * tensor1 * tensor2 " + // - feature combinations

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/NeuralNetEvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/NeuralNetEvaluationTestCase.java
@@ -22,7 +22,7 @@ public class NeuralNetEvaluationTestCase {
         String firstLayerBias = "{ {h:1}:-0.5, {h:2}:-1.5 }"; // tensor2
         String firstLayerInput = "sum(tensor0 * tensor1, x) + tensor2";
         String firstLayerOutput = "min(1.0, max(0.0, 0.5 + " + firstLayerInput + "))"; // non-linearity, "poor man's sigmoid"
-        assertEvaluates("{ {h:1}:1.0, {h:2}:0.0} }", firstLayerOutput, input, firstLayerWeights, firstLayerBias);
+        assertEvaluates("{ {h:1}:1.0, {h:2}:0.0 }", firstLayerOutput, input, firstLayerWeights, firstLayerBias);
         String secondLayerWeights = "{ {h:1,y:1}:1, {h:2,y:1}:-1 }"; // tensor3
         String secondLayerBias = "{ {y:1}:-0.5 }"; // tensor4
         String secondLayerInput = "sum(" + firstLayerOutput + "* tensor3, h) + tensor4";

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorParser.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorParser.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.tensor;
 
+import java.util.function.Consumer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -104,20 +105,23 @@ class TensorParser {
         if (type.isEmpty())
             throw new IllegalArgumentException("The mixed tensor form requires an explicit tensor type " +
                                                "on the form 'tensor(dimensions):...");
-        if (type.get().dimensions().stream().filter(d -> d.isMapped()).count() > 1)
-            throw new IllegalArgumentException("The mixed tensor form requires a type with a single mapped dimension, " +
-                                               "but got " + type.get());
-        if (! MixedValueParser.findMappedDimension(type.get()).isPresent())
-            throw new IllegalArgumentException("No suitable dimension in " + type.get() + " for parsing a tensor on " +
-                                               "the mixed form: Should have one mapped dimension");
-
+        long numMappedDims = type.get().dimensions().stream().filter(d -> d.isMapped()).count();
         try {
             valueString = valueString.trim();
             if ( ! valueString.startsWith("{") && valueString.endsWith("}"))
                 throw new IllegalArgumentException("A mixed tensor must be enclosed in {}");
             Tensor.Builder builder = Tensor.Builder.of(type.get());
-            MixedValueParser parser = new MixedValueParser(valueString, dimensionOrder, builder);
-            parser.parse();
+            if (numMappedDims == 0) {
+                if (! SingleUnboundParser.canHandle(type.get())) {
+                    throw new IllegalArgumentException("No suitable dimension in " + type.get() + " for parsing a tensor on " +
+                                                       "the mixed form: Should have one mapped dimension");
+                }
+                var parser = new SingleUnboundParser(valueString, builder);
+                parser.parse();
+            } else {
+                var parser = new GenericMixedValueParser(valueString, dimensionOrder, builder);
+                parser.parse();
+            }
             return builder.build();
         }
         catch (NumberFormatException e) {
@@ -125,31 +129,10 @@ class TensorParser {
         }
     }
 
-    private static Optional<Tensor> maybeFromBinaryValueString(
-            String valueString,
-            Optional<TensorType> optType,
-            List<String> dimensionOrder)
-    {
-        if (optType.isEmpty() || dimensionOrder != null) {
-            return Optional.empty();
-        }
-        var type = optType.get();
-        var builder = IndexedTensor.Builder.of(type);
-        if (builder instanceof IndexedTensor.DirectIndexBuilder dib) {
-            if (fillFromBinaryValueString(dib, valueString)) {
-                return Optional.of(builder.build());
-            }
-        }
-        return Optional.empty();
-    }
-
-    private static boolean fillFromBinaryValueString(IndexedTensor.DirectIndexBuilder builder,
-                                                 String valueString)
-    {
-        var type = builder.type();
+    private static boolean validHexString(TensorType type, String valueString) {
         long sz = 1;
         for (var d : type.dimensions()) {
-                sz *= d.size().orElse(0L);
+            sz *= d.size().orElse(0L);
         }
         int numHexDigits = (int)(sz * 2 * type.valueType().sizeOfCell());
         if (sz == 0
@@ -159,18 +142,23 @@ class TensorParser {
         {
             return false;
         }
-        try {
-            double[] values = decodeHexString(valueString, type.valueType());
-            if (values.length != sz) {
-                return false;
-            }
-            for (int i = 0; i < sz; ++i) {
-                builder.cellByDirectIndex(i, values[i]);
-            }
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
+        return true;
+    }
+
+    private static Optional<Tensor> maybeFromBinaryValueString(
+            String valueString,
+            Optional<TensorType> optType,
+            List<String> dimensionOrder)
+    {
+        if (optType.isEmpty()) {
+            return Optional.empty();
         }
+        var type = optType.get();
+        if (validHexString(type, valueString)) {
+            var tensor = tensorFromDenseValueString(valueString, optType, dimensionOrder);
+            return Optional.of(tensor);
+        }
+        return Optional.empty();
     }
 
     private static Tensor tensorFromDenseValueString(String valueString,
@@ -260,23 +248,21 @@ class TensorParser {
             }
         }
 
-        protected Number consumeNumber(TensorType.Value cellValueType) {
+        protected void consumeNumber(TensorType.Value cellValueType,
+                                     Consumer<Float> consumeFloat,
+                                     Consumer<Double> consumeDouble) {
             skipSpace();
             int nextNumberEnd = requiredNextStopCharIndex(position);
+            String cellValueString = string.substring(position, nextNumberEnd);
             try {
-                String cellValueString = string.substring(position, nextNumberEnd);
-                try {
-                    return switch (cellValueType) {
-                        case DOUBLE -> Double.parseDouble(cellValueString);
-                        case FLOAT -> Float.parseFloat(cellValueString);
-                        case BFLOAT16 -> Float.parseFloat(cellValueString);
-                        case INT8 -> Float.parseFloat(cellValueString);
-                        default -> throw new IllegalArgumentException(cellValueType + " is not supported");
-                    };
-                } catch (NumberFormatException e) {
-                    throw new IllegalArgumentException("At value position " + position + ": '" +
-                                                       cellValueString + "' is not a valid " + cellValueType);
-                }
+                switch (cellValueType) {
+                    case DOUBLE -> consumeDouble.accept(Double.parseDouble(cellValueString));
+                    case FLOAT, BFLOAT16, INT8 -> consumeFloat.accept(Float.parseFloat(cellValueString));
+                    default -> throw new IllegalArgumentException(cellValueType + " is not supported");
+                };
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("At value position " + position + ": '" +
+                                                   cellValueString + "' is not a valid " + cellValueType);
             }
             finally {
                 position = nextNumberEnd;
@@ -339,7 +325,17 @@ class TensorParser {
             skipSpace();
             if (string.charAt(position) != '[') {
                 int stopPos = stopCharIndex(position);
-                if (fillFromBinaryValueString(builder, string.substring(position, stopPos))) {
+                String hexToken = string.substring(position, stopPos);
+                if (validHexString(builder.type(), hexToken)) {
+                    double[] values = decodeHexString(hexToken, builder.type().valueType());
+                    int i = 0;
+                    while (indexes.hasNext()) {
+                        indexes.next();
+                        builder.cellByDirectIndex(indexes.toSourceValueIndex(), values[i++]);
+                    }
+                    if (i != values.length) {
+                        throw new IllegalStateException("consume " + i + " values out of " + values.length);
+                    }
                     position = stopPos;
                     return;
                 }
@@ -373,13 +369,9 @@ class TensorParser {
         }
 
         protected void consumeNumber() {
-            Number number = consumeNumber(builder.type().valueType());
-            switch (builder.type().valueType()) {
-                case DOUBLE -> builder.cellByDirectIndex(indexes.toSourceValueIndex(), (Double) number);
-                case FLOAT -> builder.cellByDirectIndex(indexes.toSourceValueIndex(), (Float) number);
-                case BFLOAT16 -> builder.cellByDirectIndex(indexes.toSourceValueIndex(), (Float) number);
-                case INT8 -> builder.cellByDirectIndex(indexes.toSourceValueIndex(), (Float) number);
-            }
+            consumeNumber(builder.type().valueType(),
+                          f -> builder.cellByDirectIndex(indexes.toSourceValueIndex(), f),
+                          d -> builder.cellByDirectIndex(indexes.toSourceValueIndex(), d));
         }
     }
 
@@ -417,13 +409,9 @@ class TensorParser {
         }
 
         private void consumeNumber() {
-            Number number = consumeNumber(builder.type().valueType());
-            switch (builder.type().valueType()) {
-                case DOUBLE -> builder.cell((Double) number, indexes);
-                case FLOAT -> builder.cell((Float) number, indexes);
-                case BFLOAT16 -> builder.cell((Float) number, indexes);
-                case INT8 -> builder.cell((Float) number, indexes);
-            }
+            consumeNumber(builder.type().valueType(),
+                          f -> builder.cell(f, indexes),
+                          d -> builder.cell(d, indexes));
         }
 
         private boolean isInnerMostDimension(int dimension) {
@@ -442,52 +430,124 @@ class TensorParser {
     }
 
     /**
-     * Parses mixed tensor short forms {a:[1,2], ...} AND 1d mapped tensor short form {a:b, ...}.
+     * Parses mixed tensor short form {0:17.0, 1:42.0, ...} used for single unbound dimension
      */
-    private static class MixedValueParser extends ValueParser {
+    private static class SingleUnboundParser extends ValueParser {
 
         private final Tensor.Builder builder;
-        private final List<String> dimensionOrder;
 
-        public MixedValueParser(String string, List<String> dimensionOrder, Tensor.Builder builder) {
+        public SingleUnboundParser(String string, Tensor.Builder builder) {
             super(string);
-            this.dimensionOrder = dimensionOrder;
             this.builder = builder;
         }
 
         private void parse() {
-            TensorType.Dimension mappedDimension = findMappedDimension().get();
-            TensorType mappedSubtype = MixedTensor.createPartialType(builder.type().valueType(), List.of(mappedDimension));
-            if (dimensionOrder != null)
-                dimensionOrder.remove(mappedDimension.name());
-
+            var type = builder.type();
+            String dimName = type.dimensions().get(0).name();
             skipSpace();
             consume('{');
             skipSpace();
             while (position + 1 < string.length()) {
                 String label = consumeLabel();
                 consume(':');
-                TensorAddress mappedAddress = new TensorAddress.Builder(mappedSubtype).add(mappedDimension.name(), label).build();
-                if (builder.type().rank() > 1)
-                    parseDenseSubspace(mappedAddress, dimensionOrder);
-                else
-                    consumeNumber(mappedAddress);
+                TensorAddress mappedAddress = new TensorAddress.Builder(type).add(dimName, label).build();
+                consumeNumber(mappedAddress);
                 if ( ! consumeOptional(','))
                     consume('}');
                 skipSpace();
             }
         }
 
-        private Optional<TensorType.Dimension> findMappedDimension() {
-            return findMappedDimension(builder.type());
+        static boolean canHandle(TensorType type) {
+            if (type.rank() != 1) return false;
+            var dim = type.dimensions().get(0);
+            return (dim.isIndexed() && dim.size().isEmpty());
         }
 
-        static Optional<TensorType.Dimension> findMappedDimension(TensorType type) {
-            Optional<TensorType.Dimension> mappedDimension = type.dimensions().stream().filter(TensorType.Dimension::isMapped).findAny();
-            if (mappedDimension.isPresent()) return Optional.of(mappedDimension.get());
-            if (type.rank() == 1 && type.dimensions().get(0).size().isEmpty())
-                return Optional.of(type.dimensions().get(0));
-            return Optional.empty();
+        private void consumeNumber(TensorAddress address) {
+            consumeNumber(builder.type().valueType(),
+                          f -> builder.cell(address, f),
+                          d -> builder.cell(address, d));
+        }
+    }
+
+    /**
+     * Parses mixed tensor short form {a:{b1:[1,2], b2:[2,3]}, ...}
+     */
+    private static class GenericMixedValueParser extends ValueParser {
+
+        private final Tensor.Builder builder;
+        private final TensorType type;
+        private final List<TensorType.Dimension> mappedDimensions;
+        private final TensorType mappedSubtype;
+        private final List<String> denseDimensionOrder;
+
+        public GenericMixedValueParser(String string, List<String> dimensionOrder, Tensor.Builder builder) {
+            super(string);
+            this.builder = builder;
+            this.type = builder.type();
+            var allDims = findOrder(dimensionOrder, type);
+            this.mappedDimensions = findMapped(allDims, type);
+            this.mappedSubtype = MixedTensor.createPartialType(type.valueType(), mappedDimensions);
+            this.denseDimensionOrder = new ArrayList<>(allDims);
+            for (var mapped : this.mappedDimensions) {
+                denseDimensionOrder.remove(mapped.name());
+            }
+        }
+
+        private static final List<String> findOrder(List<String> dimensionOrder, TensorType type) {
+            if (dimensionOrder == null) {
+                return type.dimensions().stream().map(d -> d.name()).toList();
+            } else {
+                return dimensionOrder;
+            }
+        }
+
+        private static final List<TensorType.Dimension> findMapped(List<String> dimensionOrder, TensorType type) {
+            List<TensorType.Dimension> result = new ArrayList<>();
+            for (var name : dimensionOrder) {
+                var dim = type.dimension(name).orElseThrow(() -> new IllegalArgumentException("bad dimension " + name));
+                if (dim.isMapped()) {
+                    result.add(dim);
+                }
+            }
+            return result;
+        }
+
+        private void parse() {
+            consume('{');
+            skipSpace();
+            while (position + 1 < string.length()) {
+                var addrBuilder = new TensorAddress.Builder(mappedSubtype);
+                parseSubspace(addrBuilder, 0);
+                if ( ! consumeOptional(',')) {
+                    break;
+                }
+            }
+            consume('}');
+        }
+
+        private void parseSubspace(TensorAddress.Builder addrBuilder, int level) {
+            if (level >= mappedDimensions.size()) {
+                throw new IllegalArgumentException("Too many nested {label:...} levels");
+            }
+            String label = consumeLabel();
+            addrBuilder.add(mappedDimensions.get(level).name(), label);
+            consume(':');
+            ++level;
+            if (consumeOptional('{')) {
+                parseSubspace(addrBuilder, level);
+                consume('}');
+            } else {
+                if (level < mappedDimensions.size()) {
+                    throw new IllegalArgumentException("Not enough nested {label:...} levels");
+                }
+                var mappedAddress = addrBuilder.build();
+                if (builder.type().rank() > level)
+                    parseDenseSubspace(mappedAddress, denseDimensionOrder);
+                else
+                    consumeNumber(mappedAddress);
+            }
         }
 
         private void parseDenseSubspace(TensorAddress mappedAddress, List<String> denseDimensionOrder) {
@@ -501,13 +561,9 @@ class TensorParser {
         }
 
         private void consumeNumber(TensorAddress address) {
-            Number number = consumeNumber(builder.type().valueType());
-            switch (builder.type().valueType()) {
-                case DOUBLE -> builder.cell(address, (Double) number);
-                case FLOAT -> builder.cell(address, (Float) number);
-                case BFLOAT16 -> builder.cell(address, (Float) number);
-                case INT8 -> builder.cell(address, (Float) number);
-            }
+            consumeNumber(builder.type().valueType(),
+                          f -> builder.cell(address, f),
+                          d -> builder.cell(address, d));
         }
     }
 
@@ -522,39 +578,29 @@ class TensorParser {
 
         private void parse() {
             consume('{');
-            skipSpace();
-            while (position + 1 < string.length()) {
+            while (position < string.length()) {
+                skipSpace();
+                if (string.charAt(position) == '}') {
+                    break;
+                }
                 TensorAddress address = consumeLabels();
                 if ( ! address.isEmpty())
                     consume(':');
                 else
                     consumeOptional(':');
-
-                int valueEnd = string.indexOf(',', position);
-                if (valueEnd < 0) { // last value
-                    valueEnd = string.indexOf('}', position);
-                    if (valueEnd < 0)
-                        throw new IllegalArgumentException("A mapped tensor string must end by '}'");
+                consumeNumber(builder.type().valueType(),
+                              f -> builder.cell(address, f),
+                              d -> builder.cell(address, d));
+                if (! consumeOptional(',')) {
+                    break;
                 }
-
-                TensorType.Value cellValueType = builder.type().valueType();
-                String cellValueString = string.substring(position, valueEnd).trim();
-                try {
-                    switch (cellValueType) {
-                        case DOUBLE -> builder.cell(address, Double.parseDouble(cellValueString));
-                        case FLOAT -> builder.cell(address, Float.parseFloat(cellValueString));
-                        case BFLOAT16 -> builder.cell(address, Float.parseFloat(cellValueString));
-                        case INT8 -> builder.cell(address, Float.parseFloat(cellValueString));
-                        default -> throw new IllegalArgumentException(cellValueType + " is not supported");
-                    }
-                }
-                catch (NumberFormatException e) {
-                    throw new IllegalArgumentException("At " + address.toString(builder.type()) + ": '" +
-                                                       cellValueString + "' is not a valid " + cellValueType);
-                }
-
-                position = valueEnd+1;
-                skipSpace();
+            }
+            if (! consumeOptional('}')) {
+                throw new IllegalArgumentException("A mapped tensor string must end by '}'");
+            }
+            skipSpace();
+            if (position < string.length()) {
+                throw new IllegalArgumentException("Garbage after mapped tensor string: " + string.substring(position));
             }
         }
 
@@ -572,6 +618,15 @@ class TensorParser {
             return addressBuilder.build();
         }
 
+        private void parseDenseSubspace(TensorAddress mappedAddress, List<String> denseDimensionOrder) {
+            var subBuilder = ((MixedTensor.BoundBuilder)builder).denseSubspaceBuilder(mappedAddress);
+            var rest = string.substring(position);
+            DenseValueParser denseParser = new DenseValueParser(rest,
+                                                                denseDimensionOrder,
+                                                                subBuilder);
+            denseParser.parse();
+            position += denseParser.position();
+        }
     }
 
     /** Parses a tensor *value* into a type */


### PR DESCRIPTION
* now also handles hex input with out-of-order dimensions
* also, add support for short-form mixed tensors with several mapped dimensions, using basically the same syntax as C++ implementation
* refactor and consolidate the various places handling different cell types
* detect garbage after ending brace
* fix various unit tests that had tensors with extra ending brace

@bratseth please review
@lesters @havardpe FYI
