### PR TITLE
Don't use significance model when it set in a query

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
@@ -160,6 +160,9 @@ public class SignificanceSearcher extends Searcher {
         if (root == null || root instanceof NullItem) return;
 
         if (root instanceof WordItem wi) {
+            if (wi.getDocumentFrequency().isPresent() || wi.hasExplicitSignificance())
+                return;
+
             var word = wi.getWord();
             var documentFrequency = significanceModel.documentFrequency(word.toLowerCase());
             long N                = documentFrequency.corpusSize();


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Added logic to not use significance model when document frequency or significance is set in a query.
In addition to adding new unit test, made minor refactoring of existing ones, mostly naming.
