### PR TITLE
Decrease default value for file-download-backoff-initial-time-ms to 1000

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -43,7 +43,7 @@ public class FileDownloader implements AutoCloseable {
     static {
         // Undocumented on purpose, might change or be removed at any time
         var backOff = System.getenv("VESPA_FILE_DOWNLOAD_BACKOFF_INITIAL_TIME_MS");
-        backoffInitialTime = Duration.ofMillis(backOff == null ? 2000 : Long.parseLong(backOff));
+        backoffInitialTime = Duration.ofMillis(backOff == null ? 1000 : Long.parseLong(backOff));
     }
 
     public FileDownloader(ConnectionPool connectionPool, Supervisor supervisor, Duration timeout) {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -529,7 +529,7 @@ public class Flags {
             TENANT_ID, APPLICATION, INSTANCE_ID);
 
     public static final UnboundLongFlag FILE_DOWNLOAD_BACKOFF_INITIAL_TIME_MS = defineLongFlag(
-            "file-download-backoff-initial-time-ms", 2000,
+            "file-download-backoff-initial-time-ms", 1000,
             List.of("hmusum"), "2024-08-16", "2024-11-01",
             "Initial backoff time in milliseconds when failing to download a file reference",
             "Takes effect on restart of Docker container");


### PR DESCRIPTION
Decrease fallback value for file download backoff time.

Please review only, will merge later this week.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
