### PR TITLE
libc++ 19 still lacks std::from_chars overloads.

### DIFF
--- a/document/src/vespa/document/select/parse_utils.cpp
+++ b/document/src/vespa/document/select/parse_utils.cpp
@@ -25,7 +25,7 @@ parse_i64(const char* str, size_t len, int64_t& out) {
 
 bool
 parse_double(const char* str, size_t len, double& out) {
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 190000
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 200000
     // Temporary workaround that also handles underflow (cf. issue 3081)
     // until libc++ supports std::from_chars for double
     char *str_end = const_cast<char*>(str) + len;

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
@@ -49,7 +49,7 @@ template <typename T>
 struct FloatDecoder {
     static T fromstr(const char * q, const char * qend, const char ** end) noexcept {
         T v(0);
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 190000
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 200000
         std::string tmp(q, qend - q);
         char* tmp_end = nullptr;
         const char *tmp_cstring = tmp.c_str();


### PR DESCRIPTION
@geirst : please review
