### PR TITLE
Disable creation of '._' files in tarball on mac os

### DIFF
--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/CompressedApplicationInputStreamTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/CompressedApplicationInputStreamTest.java
@@ -142,7 +142,7 @@ public class CompressedApplicationInputStreamTest {
 
     private File createTarGz(String appDir) throws IOException, InterruptedException {
         File tmpTar = Files.createTempFile(temporaryFolder.getRoot().toPath(), "myapp", ".tar").toFile();
-        Process p = new ProcessBuilder("tar", "-C", appDir, "-cvf", tmpTar.getAbsolutePath(), ".").start();
+        Process p = new ProcessBuilder("tar", "--disable-copyfile", "-C", appDir, "-cvf", tmpTar.getAbsolutePath(), ".").start();
         p.waitFor();
         p = new ProcessBuilder("gzip", tmpTar.getAbsolutePath()).start();
         p.waitFor();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/CompressedApplicationInputStreamTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/CompressedApplicationInputStreamTest.java
@@ -141,8 +141,10 @@ public class CompressedApplicationInputStreamTest {
     }
 
     private File createTarGz(String appDir) throws IOException, InterruptedException {
+        var noMacMetadataOption = System.getProperty("os.name").startsWith("Mac OS X") ? "--no-mac-metadata" : "";
+
         File tmpTar = Files.createTempFile(temporaryFolder.getRoot().toPath(), "myapp", ".tar").toFile();
-        Process p = new ProcessBuilder("tar", "--disable-copyfile", "-C", appDir, "-cvf", tmpTar.getAbsolutePath(), ".").start();
+        Process p = new ProcessBuilder("tar", noMacMetadataOption, "-C", appDir, "-cvf", tmpTar.getAbsolutePath(), ".").start();
         p.waitFor();
         p = new ProcessBuilder("gzip", tmpTar.getAbsolutePath()).start();
         p.waitFor();


### PR DESCRIPTION
See:
https://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x

I got the problem with dot-underscore files in the unpacked application packages again after wiping the mac. This time, the 'com.apple.quarantine' xattr was not set, but instead 'com.apple.provenance'. The latter seems impossible to remove. Hence, this solution.
