### PR TITLE
Ensure TaS fieldset enumeration descends below binary arithmetic AST nodes

### DIFF
--- a/storage/src/tests/persistence/CMakeLists.txt
+++ b/storage/src/tests/persistence/CMakeLists.txt
@@ -5,6 +5,7 @@ vespa_add_executable(storage_persistence_gtest_runner_app TEST
     active_operations_stats_test.cpp
     apply_bucket_diff_state_test.cpp
     bucketownershipnotifiertest.cpp
+    field_visitor_test.cpp
     has_mask_remapper_test.cpp
     mergehandlertest.cpp
     persistencequeuetest.cpp

--- a/storage/src/tests/persistence/field_visitor_test.cpp
+++ b/storage/src/tests/persistence/field_visitor_test.cpp
@@ -1,0 +1,56 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/document/base/testdocman.h>
+#include <vespa/document/select/parser.h>
+#include <vespa/storage/persistence/fieldvisitor.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace ::testing;
+using document::Document;
+
+namespace storage {
+
+struct FieldVisitorTest : Test {
+    document::TestDocMan _test_doc_mgr;
+
+    [[nodiscard]] std::vector<std::string> fields_in_selection(const std::string& selection) const {
+        document::BucketIdFactory id_factory;
+        document::select::Parser parser(_test_doc_mgr.getTypeRepo(), id_factory);
+        auto* doc_type = _test_doc_mgr.getTypeRepo().getDocumentType("testdoctype1");
+        assert(doc_type);
+        FieldVisitor visitor(*doc_type);
+
+        auto sel_ast = parser.parse(selection);
+        sel_ast->visit(visitor);
+        auto field_set = visitor.steal_field_set();
+
+        std::vector<std::string> field_names;
+        for (const auto& f : field_set.getFields()) {
+            field_names.emplace_back(f->getName());
+        }
+        std::sort(field_names.begin(), field_names.end());
+        return field_names;
+    }
+};
+
+TEST_F(FieldVisitorTest, fields_are_resolved_below_binary_operators) {
+    EXPECT_THAT(fields_in_selection("testdoctype1.headerval == 0"), ElementsAre("headerval"));
+    EXPECT_THAT(fields_in_selection("testdoctype1.headerval % 100 != 0"), ElementsAre("headerval"));
+    EXPECT_THAT(fields_in_selection("testdoctype1.headerval % testdoctype1.headerlongval != testdoctype1.boolfield"),
+                ElementsAre("boolfield", "headerlongval", "headerval"));
+    EXPECT_THAT(fields_in_selection("testdoctype1.boolfield and (testdoctype1.headerval > 0)"),
+                ElementsAre("boolfield", "headerval"));
+    EXPECT_THAT(fields_in_selection("testdoctype1.boolfield or (testdoctype1.headerval > 0)"),
+                ElementsAre("boolfield", "headerval"));
+}
+
+TEST_F(FieldVisitorTest, fields_are_resolved_below_unary_operators) {
+    EXPECT_THAT(fields_in_selection("not testdoctype1.boolfield"), ElementsAre("boolfield"));
+}
+
+} // storage

--- a/storage/src/vespa/storage/persistence/fieldvisitor.cpp
+++ b/storage/src/vespa/storage/persistence/fieldvisitor.cpp
@@ -28,4 +28,8 @@ void FieldVisitor::visitNotBranch(const document::select::Not & node) {
     node.getChild().visit(*this);
 }
 
+void FieldVisitor::visitArithmeticValueNode(const document::select::ArithmeticValueNode& node) {
+    visitBothBranches(node);
+}
+
 } // storage

--- a/storage/src/vespa/storage/persistence/fieldvisitor.h
+++ b/storage/src/vespa/storage/persistence/fieldvisitor.h
@@ -25,7 +25,8 @@ public:
     {}
     ~FieldVisitor() override;
 
-    document::FieldCollection getFieldSet() {
+    // Postcondition: `this` is invalidated. I.e. must only be called once.
+    [[nodiscard]] document::FieldCollection steal_field_set() {
         return document::FieldCollection(_docType, _fields.build());
     }
 
@@ -34,12 +35,12 @@ public:
     void visitAndBranch(const document::select::And &) override;
     void visitOrBranch(const document::select::Or &) override;
     void visitNotBranch(const document::select::Not &) override;
+    void visitArithmeticValueNode(const document::select::ArithmeticValueNode &) override;
 
     // Ignored node types 
     void visitConstant(const document::select::Constant &) override {}
     void visitInvalidConstant(const document::select::InvalidConstant &) override {}
     void visitDocumentType(const document::select::DocType &) override {}
-    void visitArithmeticValueNode(const document::select::ArithmeticValueNode &) override {}
     void visitFunctionValueNode(const document::select::FunctionValueNode &) override {}
     void visitIdValueNode(const document::select::IdValueNode &) override {}
     void visitFloatValueNode(const document::select::FloatValueNode &) override {}

--- a/storage/src/vespa/storage/persistence/testandsethelper.cpp
+++ b/storage/src/vespa/storage/persistence/testandsethelper.cpp
@@ -80,7 +80,7 @@ TestAndSetHelper::fetch_and_match_selection(spi::Context& context) {
                                       "Imported fields are not supported in conditional mutations.",
                                       e.getFieldName().c_str())));
     }
-    auto result = fetch_document(fieldVisitor.getFieldSet(), context);
+    auto result = fetch_document(fieldVisitor.steal_field_set(), context);
     // If document exists, match it with selection
     if (result.hasDocument()) {
         auto docPtr = result.getDocumentPtr();


### PR DESCRIPTION
@geirst please review
@hmusum FYI

This resolves a long-standing (but not discovered before now) bug where the AST visitor responsible for determining the minimal set of fields to fetch from the backend in order to evaluate a test-and-set condition did not descend into the children of a binary arithmetic operator node. This meant that if an expression only mentioned a particular field once and this happened as part of a binary arithmetic sub-expression, the field would not be fetched and the condition evaluation would fail.

The fact that no one has observed this thus far means that this seems to be a very rare use-case in practice... 😬
