### PR TITLE
unsupported operation should give a nice error

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -401,6 +401,11 @@ public class SearchHandler extends LoggingRequestHandler {
                                                                + Exceptions.toMessageString(e));
             log.log(Level.FINE, error::getDetailedMessage);
             return new Result(query, error);
+        } catch (UnsupportedOperationException e) {
+            ErrorMessage error = ErrorMessage.createBadRequest("Unsupported operation in [" + request + "]: "
+                                                               + Exceptions.toMessageString(e));
+            log.log(Level.FINE, error::getDetailedMessage);
+            return new Result(query, error);
         } catch (Exception e) {
             log(request, query, e);
             return new Result(query, ErrorMessage.createUnspecifiedError("Failed: " +

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -318,7 +318,8 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
     }
 
     protected boolean shouldRenderStacktraceOf(Throwable cause) {
-        return  ! (cause instanceof IllegalArgumentException);
+        return  ! (cause instanceof IllegalArgumentException ||
+                   cause instanceof UnsupportedOperationException);
     }
 
     protected void renderCoverage() throws IOException {


### PR DESCRIPTION
@bratseth please review
@geirst @bjorncs FYI

it looks like we throw UnsupportedOperation various places, I triggered one when trying to make some grouping requests and the result was pretty unreadable (and useless for normal users):
               
                "summary": "Unspecified error",
                "message": "Failed: Can not order single group content.",
                "stackTrace": "java.lang.UnsupportedOperationException: Can not order single group content.\n\tat com.yahoo.search.grouping.vespa.RequestBuilder.resolveOrderBy(RequestBuilder.java:293)\n\tat com.yahoo.search.grouping.vespa.RequestBuilder.resolveState(RequestBuilder.java:237)\n\tat com.yahoo.search.grouping.vespa.RequestBuilder.processRequestNode(RequestBuilder.java:184)\n\tat com.yahoo.search.grouping.vespa.RequestBuilder.build(RequestBuilder.java:134)\n\tat com.yahoo.search.grouping.vespa.GroupingExecutor.convertRequest(GroupingExecutor.java:166)\n\tat com.yahoo.search.grouping.vespa.GroupingExecutor.search(GroupingExecutor.java:86)\n\tat com.yahoo.search.Searcher.process(Searcher.java:134)\n\tat com.yahoo.processing.execution.Execution.process(Execution.java:112)\n\tat com.yahoo.search.searchchain.Execution.search(Execution.java:499)\n\tat com.yahoo.search.querytransform.BooleanSearcher.search(BooleanSearcher.java:46) ...

with the change we get instead
                "summary": "Bad request.",
                "message": "Unsupported operation in [/search/?timeout=10s&yql=select+%2A+from+sources+%2A+where+true+limit+1+%7C+all%28group%28item%29+each%28order%28price%29+each%28output%28summary%28%29%29%29%29%29]: Can not order single group content."
