### PR TITLE
fix: correctly unset untilBuild in intellij

### DIFF
--- a/integration/schema-language-server/clients/intellij/build.gradle.kts
+++ b/integration/schema-language-server/clients/intellij/build.gradle.kts
@@ -82,6 +82,7 @@ tasks {
 
   patchPluginXml {
     sinceBuild.set("232")
+    untilBuild.set(provider { null })
   }
 
   signPlugin {


### PR DESCRIPTION
Due to reasons explained [here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/18554337303186-How-can-we-declare-a-plugin-compatible-with-future-versions) we need to explicitly set untilBuild to null to make the intellij plugin compatible with all future versions of IntelliJ.