### PR TITLE
allow JSON format tensors as query input

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorParser.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorParser.java
@@ -5,7 +5,9 @@ import java.util.function.Consumer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.yahoo.tensor.serialization.JsonFormat;
 import static com.yahoo.tensor.serialization.JsonFormat.decodeHexString;
 
 /**
@@ -17,6 +19,14 @@ class TensorParser {
         try {
             return tensorFromBody(tensorString, explicitType);
         } catch (IllegalArgumentException e) {
+            if (explicitType.isPresent()) {
+                // handle legal JSON-based tensor formats as well:
+                try {
+                    return JsonFormat.decode(explicitType.get(), tensorString.getBytes(UTF_8));
+                } catch (RuntimeException ignored) {
+                    // return error from exception above
+                }
+            }
             throw new IllegalArgumentException("Could not parse '" + tensorString + "' as a tensor" +
                                                (explicitType.isPresent() ? " of type " + explicitType.get() : ""),
                                                e);

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -294,7 +294,7 @@ public class JsonFormat {
     }
 
     private static void decodeSingleDimensionBlock(String key, Inspector value, MixedTensor.BoundBuilder mixedBuilder) {
-        if (value.type() != Type.ARRAY)
+        if (value.type() != Type.ARRAY && value.type() != Type.STRING)
             throw new IllegalArgumentException("Expected an item in a blocks array to be an array, not " + value.type());
         mixedBuilder.block(asAddress(key, mixedBuilder.type().mappedSubtype()),
                            decodeValuesInBlock(value, mixedBuilder));

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorParserTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorParserTestCase.java
@@ -400,4 +400,18 @@ public class TensorParserTestCase {
         }
     }
 
+    @Test
+    public void testJsonFormatInside() {
+        var type = TensorType.fromSpec("tensor<int8>(key{}, x[2])");
+        var expected = Tensor.Builder.of(type)
+                .cell(TensorAddress.ofLabels("a", "0"), (byte)0xa1)
+                .cell(TensorAddress.ofLabels("a", "1"), 2)
+                .cell(TensorAddress.ofLabels("b", "0"), (byte)0xA3)
+                .cell(TensorAddress.ofLabels("b", "1"), 4)
+                .build();
+        assertEquals(expected, Tensor.from(type, "{'a': 'a102', 'b': 'A304'}"));
+        assertEquals(expected, Tensor.from(type, "{'blocks': {'a': 'a102', 'b': 'A304'}}"));
+        assertEquals(expected, Tensor.from(type, "{'blocks': [{'address': {'key': 'a'}, 'values': 'a102'}, {'address':{'key': 'b'}, 'values': 'A304'}]}"));
+    }
+
 }

--- a/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
@@ -464,19 +464,22 @@ public class JsonFormatTestCase {
     @Test
     public void testMixedInt8TensorWithHexForm() {
         Tensor.Builder builder = Tensor.Builder.of(TensorType.fromSpec("tensor<int8>(x{},y[3])"));
-        builder.cell().label("x", 0).label("y", 0).value(2.0);
-        builder.cell().label("x", 0).label("y", 1).value(3.0);
-        builder.cell().label("x", 0).label("y", 2).value(4.0);
-        builder.cell().label("x", 1).label("y", 0).value(5.0);
-        builder.cell().label("x", 1).label("y", 1).value(6.0);
-        builder.cell().label("x", 1).label("y", 2).value(7.0);
+        builder.cell().label("x", "a").label("y", 0).value(2.0);
+        builder.cell().label("x", "a").label("y", 1).value(3.0);
+        builder.cell().label("x", "a").label("y", 2).value(4.0);
+        builder.cell().label("x", "b").label("y", 0).value(5.0);
+        builder.cell().label("x", "b").label("y", 1).value(6.0);
+        builder.cell().label("x", "b").label("y", 2).value(7.0);
         Tensor expected = builder.build();
 
         String mixedJson = "{\"blocks\":[" +
-                           "{\"address\":{\"x\":\"0\"},\"values\":\"020304\"}," +
-                           "{\"address\":{\"x\":\"1\"},\"values\":\"050607\"}" +
+                           "{\"address\":{\"x\":\"a\"},\"values\":\"020304\"}," +
+                           "{\"address\":{\"x\":\"b\"},\"values\":\"050607\"}" +
                            "]}";
         Tensor decoded = JsonFormat.decode(expected.type(), mixedJson.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, decoded);
+        String shortJson = "{\"a\": \"020304\", \"b\": \"050607\"}";
+        decoded = JsonFormat.decode(expected.type(), shortJson.getBytes(StandardCharsets.UTF_8));
         assertEquals(expected, decoded);
     }
 


### PR DESCRIPTION
* if non-JSON-format parsing fails, try JSON as well
* also, handle another hex-encoded dense block case

@bratseth please review
@havardpe @lesters @jobergum FYI
