### PR TITLE
Feature flag for max tenants per user

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -202,6 +202,12 @@ public class PermanentFlags {
             "Takes effect immediately"
     );
 
+    public static final UnboundIntFlag MAX_TENANTS_PER_USER = defineIntFlag(
+            "max-tenants-per-user", 3,
+            "The maximum nr. of tenants a user can create",
+            "Takes effect immediately"
+    );
+
     public static final UnboundBooleanFlag ALLOW_DISABLE_MTLS = defineFeatureFlag(
             "allow-disable-mtls", true,
             "Allow application to disable client authentication",


### PR DESCRIPTION
This is currently hard-coded to 3 in our code.  Making this configurable in feature flags so that we can have some flexibility in publiccd when running playwright tests.

Default value is still 3.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
