### PR TITLE
ZtsClient: Support getting Azure temporary credentials

### DIFF
--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/api/AwsTemporaryCredentials.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/api/AwsTemporaryCredentials.java
@@ -6,32 +6,8 @@ import java.time.Instant;
 /**
  * @author mortent
  */
-public class AwsTemporaryCredentials {
-    private final String accessKeyId;
-    private final String secretAccessKey;
-    private final String sessionToken;
-    private final Instant expiration;
-
-    public AwsTemporaryCredentials(String accessKeyId, String secretAccessKey, String sessionToken, Instant expiration) {
-        this.accessKeyId = accessKeyId;
-        this.secretAccessKey = secretAccessKey;
-        this.sessionToken = sessionToken;
-        this.expiration = expiration;
-    }
-
-    public String accessKeyId() {
-        return accessKeyId;
-    }
-
-    public String secretAccessKey() {
-        return secretAccessKey;
-    }
-
-    public String sessionToken() {
-        return sessionToken;
-    }
-
-    public Instant expiration() {
-        return expiration;
-    }
+public record AwsTemporaryCredentials(String accessKeyId,
+                                      String secretAccessKey,
+                                      String sessionToken,
+                                      Instant expiration) {
 }

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/api/AzureTemporaryCredentials.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/api/AzureTemporaryCredentials.java
@@ -1,0 +1,13 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.athenz.api;
+
+import java.time.Instant;
+
+/**
+ * @author freva
+ */
+public record AzureTemporaryCredentials(String azureSubscription,
+                                        String azureTenant,
+                                        String accessToken,
+                                        Instant expiration) {
+}

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zms/DefaultZmsClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zms/DefaultZmsClient.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.athenz.client.zms;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.vespa.athenz.api.AthenzAssertion;
@@ -51,8 +50,6 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static com.yahoo.yolean.Exceptions.uncheck;
 
 
 /**
@@ -231,10 +228,9 @@ public class DefaultZmsClient extends ClientBase implements ZmsClient {
 
     @Override
     public void updateDomain(AthenzDomain domain, String mainKey, Map<String, Object> attributes) {
-        String domainMeta = uncheck(() -> new ObjectMapper().writeValueAsString(attributes));
         HttpUriRequest request = RequestBuilder.put()
                                                .setUri(zmsUrl.resolve("domain/%s/meta/system/%s".formatted(domain.getName(), mainKey)))
-                                               .setEntity(new StringEntity(domainMeta, ContentType.APPLICATION_JSON))
+                                               .setEntity(toJsonStringEntity(attributes))
                                                .build();
         execute(request, response -> readEntity(response, Void.class));
     }

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/ZtsClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/ZtsClient.java
@@ -9,6 +9,7 @@ import com.yahoo.vespa.athenz.api.AthenzResourceName;
 import com.yahoo.vespa.athenz.api.AthenzRole;
 import com.yahoo.vespa.athenz.api.AwsRole;
 import com.yahoo.vespa.athenz.api.AwsTemporaryCredentials;
+import com.yahoo.vespa.athenz.api.AzureTemporaryCredentials;
 import com.yahoo.vespa.athenz.api.ZToken;
 
 import java.security.KeyPair;
@@ -167,7 +168,7 @@ public interface ZtsClient extends AutoCloseable {
     List<AthenzDomain> getTenantDomains(AthenzIdentity providerIdentity, AthenzIdentity userIdentity, String roleName);
 
     /**
-     * Get aws temporary credentials
+     * Get AWS temporary credentials
      *
      * @param awsRole AWS role to get credentials for
      * @param externalId External Id to get credentials, or <code>null</code> if not required
@@ -178,7 +179,7 @@ public interface ZtsClient extends AutoCloseable {
     }
 
     /**
-     * Get aws temporary credentials
+     * Get AWS temporary credentials
      *
      * @param awsRole AWS role to get credentials for
      * @param duration Duration for which the credentials should be valid, or <code>null</code> to use default
@@ -186,6 +187,21 @@ public interface ZtsClient extends AutoCloseable {
      * @return AWS temporary credentials
      */
     AwsTemporaryCredentials getAwsTemporaryCredentials(AthenzDomain athenzDomain, AwsRole awsRole, Duration duration, String externalId);
+
+    /**
+     * @param athenzRole Athenz role to use when assuming credentials
+     * @param azureIdentityId Client ID of the Azure identity to assume
+     * @return Azure temporary credentials
+     */
+    AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId);
+
+    /**
+     * @param athenzRole Athenz role to use when assuming credentials
+     * @param azureResourceGroup Azure resource group that contains the target identity
+     * @param azureIdentityName Name of the Azure Identity to assume
+     * @return Azure temporary credentials
+     */
+    AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName);
 
     /**
      * Check access to resource for a given principal

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/bindings/AwsTemporaryCredentialsResponseEntity.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/bindings/AwsTemporaryCredentialsResponseEntity.java
@@ -11,8 +11,8 @@ import java.time.Instant;
  * @author mortent
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AwsTemporaryCredentialsResponseEntity {
-    private AwsTemporaryCredentials credentials;
+public class AwsTemporaryCredentialsResponseEntity implements TemporaryCredentialsResponse<AwsTemporaryCredentials> {
+    private final AwsTemporaryCredentials credentials;
 
     public AwsTemporaryCredentialsResponseEntity(
             @JsonProperty("accessKeyId") String accessKeyId,

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/bindings/AzureTemporaryCredentialsResponseEntity.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/bindings/AzureTemporaryCredentialsResponseEntity.java
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.athenz.client.zts.bindings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.vespa.athenz.api.AzureTemporaryCredentials;
+
+import java.time.Instant;
+
+/**
+ * @author freva
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AzureTemporaryCredentialsResponseEntity implements TemporaryCredentialsResponse<AzureTemporaryCredentials> {
+    private final AzureTemporaryCredentials credentials;
+
+    public AzureTemporaryCredentialsResponseEntity(
+            @JsonProperty("attributes") Attributes attributes,
+            @JsonProperty("expiration") Instant expiration) {
+        this.credentials = new AzureTemporaryCredentials(
+                attributes.azureSubscription(),
+                attributes.azureTenant(),
+                attributes.accessToken(),
+                expiration);
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Attributes(@JsonProperty("azureSubscription") String azureSubscription,
+                             @JsonProperty("azureTenant") String azureTenant,
+                             @JsonProperty("accessToken") String accessToken) { }
+
+    public AzureTemporaryCredentials credentials() {
+        return credentials;
+    }
+}

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/bindings/TemporaryCredentialsResponse.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/bindings/TemporaryCredentialsResponse.java
@@ -1,0 +1,9 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.athenz.client.zts.bindings;
+
+/**
+ * @author freva
+ */
+public interface TemporaryCredentialsResponse<T> {
+    T credentials();
+}


### PR DESCRIPTION
Reason for generics in `TemporaryCredentialsResponse` and `DefaultZtsClient::getExternalTemporaryCredentials` is that GCP temporary credentials has similar flow, will reuse these when adding support for GCP.