### PR TITLE
Revert "unsupported operation should give a nice error"

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -401,11 +401,6 @@ public class SearchHandler extends LoggingRequestHandler {
                                                                + Exceptions.toMessageString(e));
             log.log(Level.FINE, error::getDetailedMessage);
             return new Result(query, error);
-        } catch (UnsupportedOperationException e) {
-            ErrorMessage error = ErrorMessage.createBadRequest("Unsupported operation in [" + request + "]: "
-                                                               + Exceptions.toMessageString(e));
-            log.log(Level.FINE, error::getDetailedMessage);
-            return new Result(query, error);
         } catch (Exception e) {
             log(request, query, e);
             return new Result(query, ErrorMessage.createUnspecifiedError("Failed: " +

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -318,8 +318,7 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
     }
 
     protected boolean shouldRenderStacktraceOf(Throwable cause) {
-        return  ! (cause instanceof IllegalArgumentException ||
-                   cause instanceof UnsupportedOperationException);
+        return  ! (cause instanceof IllegalArgumentException);
     }
 
     protected void renderCoverage() throws IOException {


### PR DESCRIPTION
Reverts vespa-engine/vespa#32572

after discussion with @bratseth we will instead change to throwing IllegalInputException in those places where the query does something we don't accept, and use UnsupportedOperation only for cases where it indicates a bug in Java code (our own or plugins).  If we see stack traces in search results we should ideally investigate and make some sort of fix.

@bjorncs @hmusum FYI
@bratseth review and merge
