### PR TITLE
Do not reduce number of distribution bits in a running system

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/test/TestRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/TestRoot.java
@@ -21,6 +21,8 @@ public class TestRoot {
         this.model = model;
     }
 
+    public VespaModel getModel() { return model; }
+
     /**
      * Get a list of all config models of a particular type.
      *


### PR DESCRIPTION
Reducing distribution bits may not always be safe, as previously disjoint bucket subtrees are joined back into the same subtrees which will be problematic, as we assume unique timestamps per unique document in a given bucket.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
