### PR TITLE
Improve startup logging

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -116,7 +116,7 @@ public final class ConfiguredApplication implements Application {
     private volatile boolean shutdownReconfiguration = false;
 
     static {
-        log.log(Level.FINE, "Starting jdisc" + (Vtag.currentVersion.isEmpty() ? "" : " at version " + Vtag.currentVersion));
+        log.log(Level.INFO, "Starting jdisc" + (Vtag.currentVersion.isEmpty() ? "" : " at version " + Vtag.currentVersion));
         installBouncyCastleSecurityProvider();
     }
 

--- a/container-llama/src/main/java/ai/vespa/llama/LlamaBundleActivator.java
+++ b/container-llama/src/main/java/ai/vespa/llama/LlamaBundleActivator.java
@@ -23,7 +23,7 @@ public class LlamaBundleActivator implements BundleActivator {
         log.fine("start bundle");
         String skipAll = LlamaBundleActivator.class.getSimpleName() + SKIP_SUFFIX;
         if (SKIP_VALUE.equals(System.getProperty(skipAll))) {
-            log.info("skip loading of native libraries");
+            log.fine("skip loading of native libraries");
             return;
         }
         if (checkFilenames(

--- a/container-onnxruntime/src/main/java/ai/vespa/onnxruntime/OnnxBundleActivator.java
+++ b/container-onnxruntime/src/main/java/ai/vespa/onnxruntime/OnnxBundleActivator.java
@@ -26,7 +26,7 @@ public class OnnxBundleActivator implements BundleActivator {
     public void start(BundleContext ctx) {
         String skipAll = OnnxBundleActivator.class.getSimpleName() + SKIP_SUFFIX;
         if (SKIP_VALUE.equals(System.getProperty(skipAll))) {
-            log.info("skip loading of native libraries");
+            log.fine("skip loading of native libraries");
             return;
         }
         System.setProperty(ONNX_PREFIX + PATH_SUFFIX, "/opt/vespa-deps/lib64");

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -191,6 +191,7 @@ StartCommand() {
         --add-opens=java.base/java.nio=ALL-UNNAMED \
         --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
         --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
+        -Dconfig_model.ip_check=false \
         -Djava.library.path="${VESPA_HOME}/lib64" \
         -Djava.security.properties=${VESPA_HOME}/conf/vespa/java.security.override \
         -Djava.awt.headless=true \


### PR DESCRIPTION
Host admin gets  `config_model.ip_check=false`  to avoid a log line on hostname-to-IP-to-hostname verification.