### PR TITLE
Revert "Reduce max vault name length from 64 to 24"

### DIFF
--- a/container-disc/src/main/java/ai/vespa/secret/model/VaultName.java
+++ b/container-disc/src/main/java/ai/vespa/secret/model/VaultName.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
  */
 public class VaultName extends PatternedStringWrapper<VaultName> {
 
-        private static final Pattern namePattern = Pattern.compile("[.a-zA-Z0-9_-]{1,24}");
+        private static final Pattern namePattern = Pattern.compile("[.a-zA-Z0-9_-]{1,64}");
 
         private VaultName(String name) {
             super(name, namePattern, "Vault name");


### PR DESCRIPTION
Reverts vespa-engine/vespa#32717

Broke some unit tests in internal repo