### PR TITLE
Revert ""match: cased" should imply "dictionary: cased"" MERGEOK

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/document/Dictionary.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/Dictionary.java
@@ -26,7 +26,7 @@ public class Dictionary {
         }
     }
     public void updateMatch(Case casing) {
-        if (this.casing != null && this.casing != casing) {
+        if (this.casing != null) {
             throw new IllegalArgumentException("dictionary match mode has already been set to " + this.casing);
         }
         this.casing = casing;

--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
@@ -38,17 +38,9 @@ public class ConvertParsedFields {
         this.structProxies = structProxies;
     }
 
-    static void caseHandling(SDField field, Case casing) {
-        field.setMatchingCase(casing);
-        if (casing == Case.CASED) {
-            var dictionary = field.getOrSetDictionary();
-            dictionary.updateMatch(casing);
-        }
-    }
-
     static void convertMatchSettings(SDField field, ParsedMatchSettings parsed) {
         parsed.getMatchType().ifPresent(matchingType -> field.setMatchingType(matchingType));
-        parsed.getMatchCase().ifPresent(casing -> caseHandling(field, casing));
+        parsed.getMatchCase().ifPresent(casing -> field.setMatchingCase(casing));
         parsed.getGramSize().ifPresent(gramSize -> field.getMatching().setGramSize(gramSize));
         parsed.getMaxLength().ifPresent(maxLength -> field.getMatching().maxLength(maxLength));
         parsed.getMaxTermOccurrences().ifPresent(maxTermOccurrences -> field.getMatching().maxTermOccurrences(maxTermOccurrences));
@@ -298,29 +290,21 @@ public class ConvertParsedFields {
 
     SDField convertDocumentField(Schema schema, SDDocumentType document, ParsedField parsed) {
         String name = parsed.name();
-        try {
-            DataType dataType = context.resolveType(parsed.getType());
-            var field = new SDField(document, name, dataType);
-            convertCommonFieldSettings(schema, field, parsed);
-            convertExtraFieldSettings(schema, field, parsed);
-            document.addField(field);
-            return field;
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("For schema '" + schema.getName() + "', field '" + name + "': " + e.getMessage());
-        }
+        DataType dataType = context.resolveType(parsed.getType());
+        var field = new SDField(document, name, dataType);
+        convertCommonFieldSettings(schema, field, parsed);
+        convertExtraFieldSettings(schema, field, parsed);
+        document.addField(field);
+        return field;
     }
 
     void convertExtraField(Schema schema, ParsedField parsed) {
         String name = parsed.name();
-        try {
-            DataType dataType = context.resolveType(parsed.getType());
-            var field = new SDField(schema.getDocument(), name, dataType);
-            convertCommonFieldSettings(schema, field, parsed);
-            convertExtraFieldSettings(schema, field, parsed);
-            schema.addExtraField(field);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("For schema '" + schema.getName() + "', field '" + name + "': " + e.getMessage());
-        }
+        DataType dataType = context.resolveType(parsed.getType());
+        var field = new SDField(schema.getDocument(), name, dataType);
+        convertCommonFieldSettings(schema, field, parsed);
+        convertExtraFieldSettings(schema, field, parsed);
+        schema.addExtraField(field);
     }
 
     void convertExtraIndex(Schema schema, ParsedIndex parsed) {

--- a/config-model/src/test/java/com/yahoo/schema/processing/DictionaryTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/DictionaryTestCase.java
@@ -144,12 +144,6 @@ public class DictionaryTestCase {
     @Test
     void testStringBtreeCasedSettings() throws ParseException {
         verifyStringDictionaryControl(Dictionary.Type.BTREE, Case.CASED, Case.CASED, "dictionary { btree\ncased\n}", "match:cased");
-        verifyStringDictionaryControl(Dictionary.Type.BTREE, Case.CASED, Case.CASED, "dictionary: btree", "match: cased");
-        try {
-            verifyStringDictionaryControl(Dictionary.Type.BTREE, Case.UNCASED, Case.CASED, "dictionary { hash\nuncased\n}", "match: cased");
-        } catch (IllegalArgumentException e) {
-            assertEquals("For schema 'test', field 'n1': dictionary match mode has already been set to CASED", e.getMessage());
-        }
     }
 
     @Test


### PR DESCRIPTION
Reverts vespa-engine/vespa#32655

Unit test failures:

[ERROR] Failures:
[ERROR]   RankProfileTestCase.requireThatDenseDimensionsMustBeBound:385 expected: <Illegal type in field a type tensor(x[]): Dense tensor dimensions must have a size> but was: <For schema 'test', field 'a': Illegal type in field a type tensor(x[]): Dense tensor dimensions must have a size>
[ERROR]   AttributeListTestCase.bad_array_of_struct_attribute:137->run_bad_struct_or_map_attribute:141->run_bad_struct_or_map_attribute:159 expected: <For schema 'test': Field 'metadata' of type 'array<s>' cannot be an attribute. Instead specify the struct fields to be searchable as attribute> but was: <For schema 'test', field 'metadata': For schema 'test': Field 'metadata' of type 'array<s>' cannot be an attribute. Instead specify the struct fields to be searchable as attribute>
[ERROR]   AttributeListTestCase.bad_map_attribute:132->run_bad_struct_or_map_attribute:141->run_bad_struct_or_map_attribute:159 expected: <For schema 'test': Field 'metadata' of type 'map<string,string>' cannot be an attribute. Instead specify the struct fields to be searchable as attribute> but was: <For schema 'test', field 'metadata': For schema 'test': Field 'metadata' of type 'map<string,string>' cannot be an attribute. Instead specify the struct fields to be searchable as attribute>
[ERROR]   TensorFieldTestCase.requireThatIndexedTensorAttributeCannotBeFastRank:61 expected: <The attribute 'f1' (tensor(x[3])) does not support 'fast-rank'. Only supported for tensor types with at least one mapped dimension> but was: <For schema 'test', field 'f1': The attribute 'f1' (tensor(x[3])) does not support 'fast-rank'. Only supported for tensor types with at least one mapped dimension>
[ERROR]   ComplexFieldsValidatorTestCase.throws_exception_when_nested_struct_array_is_specified_as_struct_field_attribute:71 expected: <For schema 'test': Field 'docTopics.topics' of type 'array<topic>' cannot be an attribute. Instead specify the struct fields to be searchable as attribute> but was: <For schema 'test', field 'docTopics': For schema 'test': Field 'docTopics.topics' of type 'array<topic>' cannot be an attribute. Instead specify the struct fields to be searchable as attribute>