### PR TITLE
Move SnapshotId to config-provisioning

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SnapshotId.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SnapshotId.java
@@ -1,4 +1,4 @@
-package com.yahoo.vespa.hosted.provision.backup;
+package com.yahoo.config.provision;
 
 import java.util.Objects;
 import java.util.UUID;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshot.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshot.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.node.ClusterId;
 
 import java.time.Duration;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/SnapshotStoreMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/SnapshotStoreMock.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.provision.backup;
 
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.HostName;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.provisioning.SnapshotStore;
 
 import java.util.Collections;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshots.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/backup/Snapshots.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Lock;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializer.java
@@ -12,7 +12,7 @@ import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.vespa.hosted.provision.backup.Snapshot;
-import com.yahoo.vespa.hosted.provision.backup.SnapshotId;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.node.ClusterId;
 
 import java.time.Instant;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/SnapshotStore.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/SnapshotStore.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.hosted.provision.provisioning;
 
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.HostName;
-import com.yahoo.vespa.hosted.provision.backup.SnapshotId;
+import com.yahoo.config.provision.SnapshotId;
 
 /**
  * A service that stores the actual files of a {@link com.yahoo.vespa.hosted.provision.backup.Snapshot}.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -37,7 +37,7 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.applications.Application;
 import com.yahoo.vespa.hosted.provision.autoscale.Load;
 import com.yahoo.vespa.hosted.provision.backup.Snapshot;
-import com.yahoo.vespa.hosted.provision.backup.SnapshotId;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.maintenance.InfraApplicationRedeployer;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.IP;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/SnapshotResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/SnapshotResponse.java
@@ -5,7 +5,7 @@ import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.backup.Snapshot;
-import com.yahoo.vespa.hosted.provision.backup.SnapshotId;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.persistence.SnapshotSerializer;
 
 import java.time.Instant;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/SnapshotExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/SnapshotExpirerTest.java
@@ -10,7 +10,7 @@ import com.yahoo.jdisc.test.MockMetric;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.backup.Snapshot;
-import com.yahoo.vespa.hosted.provision.backup.SnapshotId;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
 import org.junit.jupiter.api.Test;
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/SnapshotSerializerTest.java
@@ -5,7 +5,7 @@ import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.vespa.hosted.provision.backup.Snapshot;
-import com.yahoo.vespa.hosted.provision.backup.SnapshotId;
+import com.yahoo.config.provision.SnapshotId;
 import com.yahoo.vespa.hosted.provision.node.ClusterId;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Because this class is also used in internal code. Merge with internal PR.

@hakonhall