### PR TITLE
The documentation says no label matches the "default" index

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/Condition.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/Condition.java
@@ -231,6 +231,7 @@ public abstract class Condition {
         if (label == null)
             label = e.getCurrentLabel();
         if ("".equals(indexName) && label == null) return true;
+        if ("default".equals(indexName) && label == null) return true;
         if (indexName.equals(label)) return true;
         if (e.getTraceLevel() >= 4)
             e.trace(4, "'" + this + "' does not match, label of " + e.currentItem() + " was required to be " + label);

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExactMatchTrickTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExactMatchTrickTestCase.java
@@ -17,18 +17,35 @@ public class ExactMatchTrickTestCase extends RuleBaseAbstractTestCase {
     @Test
     void testCompleteMatch() {
         assertSemantics("AND default:primetime default:in default:no default:time", "primetime notime");
+        assertSemantics("AND default:primetime default:in default:no default:time", "primetime");
+        assertSemantics("AND default:primetime default:in default:no default:time", "prime time in no time");
+        assertSemantics("AND default:primetime default:in default:no default:time", "prime time");
+        assertSemantics("AND default:primetime default:in default:no default:time", "pint");
+        assertSemantics("AND default:primetime default:in default:no default:time", "default:primetime notime");
+        assertSemantics("AND default:primetime default:in default:no default:time", "default:primetime");
+        assertSemantics("AND default:primetime default:in default:no default:time", "default:prime time in no time");
+        assertSemantics("AND default:primetime default:in default:no default:time", "default:prime time");
+        assertSemantics("AND default:primetime default:in default:no default:time", "default:pint");
     }
 
     @Test
-    void testCompleteMatchWithNegative() { // Notice ordering bug
-        assertSemantics("+(AND default:primetime default:in default:time default:no TRUE) -regionexcl:us",
+    void testCompleteMatchWithNegative() {
+        assertSemantics("+(AND default:primetime default:in default:no default:time TRUE) -regionexcl:us",
                 new Query(QueryTestCase.httpEncode("?query=primetime ANDNOT regionexcl:us&type=adv")));
     }
 
     @Test
     void testCompleteMatchWithFilterAndNegative() {
-        assertSemantics("AND (+(AND default:primetime default:in default:time default:no TRUE) -regionexcl:us) |lang:en",
+        assertSemantics("AND (+(AND default:primetime default:in default:no default:time TRUE) -regionexcl:us) |lang:en",
                 new Query(QueryTestCase.httpEncode("?query=primetime ANDNOT regionexcl:us&type=adv&filter=+lang:en")));
     }
 
+    @Test
+    void testInnerMatch() {
+        assertSemantics("AND foo default:primetime default:in default:no default:time bar", "foo primetime notime bar");
+        assertSemantics("AND foo default:primetime default:in default:no default:time bar", "foo primetime bar");
+        assertSemantics("AND foo default:primetime default:in default:no default:time bar", "foo prime time in no time bar");
+        assertSemantics("AND foo default:primetime default:in default:no default:time bar", "foo prime time bar");
+        assertSemantics("AND foo default:primetime default:in default:no default:time bar", "foo pint bar");
+    }
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/exactmatchtrick.sr
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/exactmatchtrick.sr
@@ -1,6 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-primetime notime -> default:primetime default:in default:no default:time;
-primetime -> default:primetime default:in default:no default:time;
-prime time in no time -> default:primetime default:in default:no default:time;
-prime time -> default:primetime default:in default:no default:time;
-pint -> default:primetime default:in default:no default:time;
+primetime notime -> replacemarker:pint;
+primetime -> replacemarker:pint;
+prime time in no time -> replacemarker:pint;
+prime time -> replacemarker:pint;
+pint -> replacemarker:pint;
+replacemarker:pint -> default:primetime default:in default:no default:time;


### PR DESCRIPTION
 -- make it so.

The "exactmatchtrick" rulebase depended on explicit "default" not matching the un-labeled conditions; changed to use a two-step replacement.
