### PR TITLE
fix(CI): use almalinux instead of fedora for container image

### DIFF
--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-        image: fedora:latest
+        image: almalinux:8
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           CLOUDSMITH_API_TOKEN: ${{ secrets.CLOUDSMITH_API_TOKEN }}


### PR DESCRIPTION
## What

Replace `fedora:latest` with `almalinux:8` as container image for CI.

## Why

- `fedora:latest` switched from 40 to 41 which updated `dnf` which in turn is missing the `--add-repo` and this caused [the job to fail](https://github.com/vespa-engine/vespa/actions/runs/11698141451/job/32577960781#step:4:177).
- `almalinux:8` is the stable default image we use in all other CI jobs

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
