### PR TITLE
fix: overriding/extending rank-profile default in schema LS

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/InheritanceResolver.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/InheritanceResolver.java
@@ -155,16 +155,17 @@ public class InheritanceResolver {
         if (myRankProfileDefinitionNode == null) return;
         if (!myRankProfileDefinitionNode.hasSymbol() || myRankProfileDefinitionNode.getSymbol().getStatus() != SymbolStatus.DEFINITION) return;
 
-        if (inheritedIdentifier.equals("default")) {
-            inheritanceNode.setSymbolStatus(SymbolStatus.BUILTIN_REFERENCE);
-            return;
-        }
-
-
         List<Symbol> parentSymbols = context.schemaIndex().findSymbols(inheritanceNode.getSymbol());
 
-        if (parentSymbols.isEmpty()) {
-            // Handled in resolve symbol ref
+        if (parentSymbols.isEmpty() || 
+            // prevents rank-profile default inherits default from causing cyclic inheritance
+            (inheritedIdentifier.equals("default") && myRankProfileDefinitionNode.getSymbol().getShortIdentifier().equals("default"))
+        ) {
+            if (inheritedIdentifier.equals("default")) {
+                inheritanceNode.setSymbolStatus(SymbolStatus.BUILTIN_REFERENCE);
+                return;
+            }
+            // Otherwise handled in resolve symbol ref
             return;
         }
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -334,7 +334,7 @@ public class BuiltInFunctions {
         // === ML Model features ===
         put("onnx", new GenericFunction("onnx", new FunctionSignature(new SymbolArgument(SymbolType.ONNX_MODEL, "onnx-model"))));
         put("onnxModel", new GenericFunction("onnxModel", new FunctionSignature(new SymbolArgument(SymbolType.ONNX_MODEL, "onnx-model"))));
-        put("lightbgm", new GenericFunction("lightbgm", new FunctionSignature(new StringArgument("\"/path/to/lightbgm-model.json\""))));
+        put("lightgbm", new GenericFunction("lightgbm", new FunctionSignature(new StringArgument("\"/path/to/lightgbm-model.json\""))));
         put("xgboost", new GenericFunction("xgboost", new FunctionSignature(new StringArgument("\"/path/to/xgboost-model.json\""))));
     }};
 

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -262,6 +262,7 @@ public class SchemaParserTest {
              * */
             "src/test/sdfiles/single/structinfieldset.sd",
             "src/test/sdfiles/single/attributeposition.sd",
+            "src/test/sdfiles/single/defaultdefault.sd",
         };
 
         return Arrays.stream(filePaths)

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/defaultdefault.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/defaultdefault.sd
@@ -1,0 +1,32 @@
+# This file tests if overriding/extending the rank-profile default works
+schema defaultdefault {
+    document defaultdefault {
+        field title type string {
+            indexing: index | summary
+        }
+
+        field chunk type string {
+            indexing: index | summary
+        }
+    }
+    
+    field embedding type tensor<bfloat16>(x[384]) {
+        indexing: (input title || "") . " " . (input chunk || "") | embed e5 | attribute | index 
+	    attribute {
+	        distance-metric: angular
+	    }
+    }
+
+    rank-profile default inherits default {
+        function cos_sim() {
+            expression: cos(distance(field, embedding))
+        }
+    }
+
+    rank-profile custom inherits default {
+        function foo() {
+            expression: cos_sim()
+        }
+        
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/onnxmodel.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/onnxmodel.sd
@@ -20,7 +20,7 @@ schema onnxmodel {
         }
 
         function func_b() {
-            expression: sum(lightbgm("/path/to/lightbgm-model.json"))
+            expression: sum(lightgbm("/path/to/lightbgm-model.json"))
         }
     }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
