### PR TITLE
Use vaultId for aws role names

### DIFF
--- a/jdisc-cloud-aws/src/main/java/ai/vespa/secret/aws/AsmTenantSecretReader.java
+++ b/jdisc-cloud-aws/src/main/java/ai/vespa/secret/aws/AsmTenantSecretReader.java
@@ -53,7 +53,10 @@ public final class AsmTenantSecretReader extends AsmSecretReader {
 
     @Override
     protected AwsRolePath awsRole(VaultName vault) {
-        return AthenzUtil.awsReaderRole(system, tenant, vault);
+        if ( ! vaultIds.containsKey(vault)) {
+            throw new IllegalArgumentException("No vault id found for " + vault);
+        }
+        return AthenzUtil.awsReaderRole(system, tenant, vaultIds.get(vault));
     }
 
     @Override

--- a/jdisc-cloud-aws/src/main/java/ai/vespa/secret/aws/AthenzUtil.java
+++ b/jdisc-cloud-aws/src/main/java/ai/vespa/secret/aws/AthenzUtil.java
@@ -2,6 +2,7 @@
 package ai.vespa.secret.aws;
 
 import ai.vespa.secret.model.Role;
+import ai.vespa.secret.model.VaultId;
 import ai.vespa.secret.model.VaultName;
 import com.yahoo.vespa.athenz.api.AwsRole;
 
@@ -32,6 +33,11 @@ public class AthenzUtil {
                 .toLowerCase();
     }
 
+    /* <vaultName>.reader */
+    public static String athenzReaderRoleName(VaultName vault) {
+        return "%s.%s".formatted(vault.value(), Role.READER.value());
+    }
+
     /* Path: /tenant-secret/<system>/<tenant>/ */
     public static AwsPath awsPath(String systemName, String tenantName) {
         return AwsPath.of(PREFIX, systemName, tenantName);
@@ -43,13 +49,13 @@ public class AthenzUtil {
      * We use vaultId instead of vaultName because vaultName is not unique across tenants,
      * and role names must be unique across paths within an account.
      */
-    public static AwsRolePath awsReaderRole(String systemName, String tenantName, VaultName vault) {
-        return new AwsRolePath(awsPath(systemName, tenantName), new AwsRole(athenzReaderRoleName(vault)));
+    public static AwsRolePath awsReaderRole(String systemName, String tenantName, VaultId vaultId) {
+        return new AwsRolePath(awsPath(systemName, tenantName), new AwsRole(awsReaderRoleName(vaultId)));
     }
 
     /* <vaultName>.reader */
-    private static String athenzReaderRoleName(VaultName vault) {
-        return "%s.%s".formatted(vault.value(), Role.READER.value());
+    private static String awsReaderRoleName(VaultId vaultId) {
+        return "%s.%s".formatted(vaultId.value(), Role.READER.value());
     }
 
 }

--- a/jdisc-cloud-aws/src/test/java/ai/vespa/secret/aws/AsmTenantSecretReaderTest.java
+++ b/jdisc-cloud-aws/src/test/java/ai/vespa/secret/aws/AsmTenantSecretReaderTest.java
@@ -43,15 +43,17 @@ public class AsmTenantSecretReaderTest {
     }
 
     AsmTenantSecretReader secretReader() {
-        return new AsmTenantSecretReader(tester::newClient, system, tenant, Map.of());
+        return new AsmTenantSecretReader(tester::newClient, system, tenant,
+                                         Map.of(VaultName.of("vault1"), VaultId.of("vaultId1"),
+                                                VaultName.of("vault2"), VaultId.of("vaultId2")));
     }
 
     @Test
     void it_creates_one_credentials_and_client_per_vault_and_closes_them() {
         var vault1 = VaultName.of("vault1");
-        var awsRole1 = AwsRolePath.fromStrings("/tenant-secret/publiccd/tenant1/", "vault1.reader");
+        var awsRole1 = AwsRolePath.fromStrings("/tenant-secret/publiccd/tenant1/", "vaultId1.reader");
         var vault2 = VaultName.of("vault2");
-        var awsRole2 = AwsRolePath.fromStrings("/tenant-secret/publiccd/tenant1/", "vault2.reader");
+        var awsRole2 = AwsRolePath.fromStrings("/tenant-secret/publiccd/tenant1/", "vaultId2.reader");
 
         var secret1 = new SecretVersion("1", SecretVersionState.CURRENT, "secret1");
         var secret2 = new SecretVersion("2", SecretVersionState.CURRENT, "secret2");


### PR DESCRIPTION
- Athenz role names still use vaultName

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
