### PR TITLE
Support setting zookeeper preAllocSize with feature flag

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -758,10 +758,10 @@
       "public static final enum com.yahoo.config.application.api.ValidationId accessControl",
       "public static final enum com.yahoo.config.application.api.ValidationId globalEndpointChange",
       "public static final enum com.yahoo.config.application.api.ValidationId zoneEndpointChange",
-      "public static final enum com.yahoo.config.application.api.ValidationId redundancyIncrease",
       "public static final enum com.yahoo.config.application.api.ValidationId redundancyOne",
       "public static final enum com.yahoo.config.application.api.ValidationId pagedSettingRemoval",
-      "public static final enum com.yahoo.config.application.api.ValidationId certificateRemoval"
+      "public static final enum com.yahoo.config.application.api.ValidationId certificateRemoval",
+      "public static final enum com.yahoo.config.application.api.ValidationId redundancyIncrease"
     ]
   },
   "com.yahoo.config.application.api.ValidationOverrides$Allow" : {
@@ -1341,7 +1341,8 @@
       "public boolean enforceStrictlyIncreasingClusterStateVersions()",
       "public boolean distributionConfigFromClusterController()",
       "public boolean useLegacyWandQueryParsing()",
-      "public boolean forwardAllLogLevels()"
+      "public boolean forwardAllLogLevels()",
+      "public long zookeeperPreAllocSize()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -123,6 +123,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"vekterli"}) default boolean distributionConfigFromClusterController() { return false; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean useLegacyWandQueryParsing() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean forwardAllLogLevels() { return true; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.container.configserver;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.cloud.config.CuratorConfig;
 import com.yahoo.cloud.config.ZookeeperServerConfig;
+
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
@@ -20,6 +21,8 @@ import com.yahoo.vespa.model.container.configserver.option.ConfigOptions.ConfigS
 import java.util.Optional;
 import java.util.stream.IntStream;
 
+import static com.yahoo.config.model.api.ModelContext.FeatureFlags;
+
 /**
  * Represents a config server cluster.
  *
@@ -34,11 +37,13 @@ public class ConfigserverCluster extends TreeConfigProducer
         ZookeeperServerConfig.Producer {
 
     private final ConfigOptions options;
+    private final FeatureFlags featureFlags;
     private ContainerCluster<?> containerCluster;
 
-    public ConfigserverCluster(TreeConfigProducer<?> parent, String subId, ConfigOptions options) {
+    public ConfigserverCluster(TreeConfigProducer<?> parent, String subId, ConfigOptions options, FeatureFlags featureFlags) {
         super(parent, subId);
         this.options = options;
+        this.featureFlags = featureFlags;
     }
 
     public void setContainerCluster(ContainerCluster<?> containerCluster) {
@@ -87,6 +92,7 @@ public class ConfigserverCluster extends TreeConfigProducer
         builder.reconfigureEnsemble(!isHostedVespa);
         builder.snapshotMethod(options.zooKeeperSnapshotMethod());
         builder.juteMaxBuffer(options.zookeeperJuteMaxBuffer());
+        builder.preAllocSizeKb(featureFlags.zookeeperPreAllocSize());
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ConfigServerContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ConfigServerContainerModelBuilder.java
@@ -28,7 +28,7 @@ public class ConfigServerContainerModelBuilder extends ContainerModelBuilder {
     @Override
     public void doBuild(ContainerModel model, Element spec, ConfigModelContext modelContext) {
         ConfigserverCluster cluster = new ConfigserverCluster(modelContext.getParentProducer(), "configserver",
-                                                              options);
+                                                              options, modelContext.featureFlags());
         super.doBuild(model, spec, modelContext.withParent(cluster));
         cluster.setContainerCluster(model.getCluster());
     }

--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -61,3 +61,7 @@ learnerAsyncSending bool default=false
 # Whether the ZooKeeper ensemble should be reconfigured automatically if servers change. This only has an effect if
 # dynamicReconfiguration=true.
 reconfigureEnsemble bool default=true
+
+# To avoid seeks ZooKeeper allocates space in the transaction log file in blocks of preAllocSize kilobytes. The default block size is 64M
+# Can/should be reduced for tests
+preAllocSizeKb long default=65536

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -215,6 +215,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean distributionConfigFromClusterController;
         private final boolean useLegacyWandQueryParsing;
         private final boolean forwardAllLogLevels;
+        private final long zookeeperPreAllocSize;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
             this.defaultTermwiseLimit = Flags.DEFAULT_TERM_WISE_LIMIT.bindTo(source).with(appId).with(version).value();
@@ -258,7 +259,7 @@ public class ModelContextImpl implements ModelContext {
             this.sortBlueprintsByCost = Flags.SORT_BLUEPRINTS_BY_COST.bindTo(source).with(appId).with(version).value();
             this.persistenceThreadMaxFeedOpBatchSize = Flags.PERSISTENCE_THREAD_MAX_FEED_OP_BATCH_SIZE.bindTo(source).with(appId).with(version).value();
             this.logserverOtelCol = Flags.LOGSERVER_OTELCOL_AGENT.bindTo(source).with(appId).with(version).value();
-            this.sharedHosts = PermanentFlags.SHARED_HOST.bindTo(source).with( appId).with(version).value();
+            this.sharedHosts = PermanentFlags.SHARED_HOST.bindTo(source).with(appId).with(version).value();
             this.adminClusterArchitecture = Architecture.valueOf(PermanentFlags.ADMIN_CLUSTER_NODE_ARCHITECTURE.bindTo(source).with(appId).with(version).value());
             this.logserverNodeMemory = PermanentFlags.LOGSERVER_NODE_MEMORY.bindTo(source).with(appId).with(version).value();
             this.symmetricPutAndActivateReplicaSelection = Flags.SYMMETRIC_PUT_AND_ACTIVATE_REPLICA_SELECTION.bindTo(source).with(appId).with(version).value();
@@ -267,6 +268,7 @@ public class ModelContextImpl implements ModelContext {
             this.distributionConfigFromClusterController = Flags.DISTRIBUTION_CONFIG_FROM_CLUSTER_CONTROLLER.bindTo(source).with(appId).with(version).value();
             this.useLegacyWandQueryParsing = Flags.USE_LEGACY_WAND_QUERY_PARSING.bindTo(source).with(appId).with(version).value();
             this.forwardAllLogLevels = PermanentFlags.FORWARD_ALL_LOG_LEVELS.bindTo(source).with(appId).with(version).value();
+            this.zookeeperPreAllocSize = Flags.ZOOKEEPER_PRE_ALLOC_SIZE.bindTo(source).value();
         }
 
         @Override public int heapSizePercentage() { return heapPercentage; }
@@ -324,6 +326,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean distributionConfigFromClusterController() { return distributionConfigFromClusterController; }
         @Override public boolean useLegacyWandQueryParsing() { return useLegacyWandQueryParsing; }
         @Override public boolean forwardAllLogLevels() { return forwardAllLogLevels; }
+        @Override public long zookeeperPreAllocSize() { return zookeeperPreAllocSize; }
     }
 
     public static class Properties implements ModelContext.Properties {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -268,7 +268,7 @@ public class ModelContextImpl implements ModelContext {
             this.distributionConfigFromClusterController = Flags.DISTRIBUTION_CONFIG_FROM_CLUSTER_CONTROLLER.bindTo(source).with(appId).with(version).value();
             this.useLegacyWandQueryParsing = Flags.USE_LEGACY_WAND_QUERY_PARSING.bindTo(source).with(appId).with(version).value();
             this.forwardAllLogLevels = PermanentFlags.FORWARD_ALL_LOG_LEVELS.bindTo(source).with(appId).with(version).value();
-            this.zookeeperPreAllocSize = Flags.ZOOKEEPER_PRE_ALLOC_SIZE.bindTo(source).value();
+            this.zookeeperPreAllocSize = Flags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB.bindTo(source).value();
         }
 
         @Override public int heapSizePercentage() { return heapPercentage; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -484,6 +484,13 @@ public class Flags {
             "Whether node snapshots should be created when host storage is discarded",
             "Takes effect immediately");
 
+    public static final UnboundLongFlag ZOOKEEPER_PRE_ALLOC_SIZE = defineLongFlag(
+            "zookeeper-pre-alloc-size", 65536,
+            List.of("hmusum"), "2024-11-11", "2025-01-11",
+            "Setting for zookeeper.preAllocSize flag, can be reduced from default value "
+            + "e.g. when running tests to avoid writing a large, sparse, mostly unused file",
+            "Takes effect on restart of Docker container");
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -484,10 +484,10 @@ public class Flags {
             "Whether node snapshots should be created when host storage is discarded",
             "Takes effect immediately");
 
-    public static final UnboundLongFlag ZOOKEEPER_PRE_ALLOC_SIZE = defineLongFlag(
+    public static final UnboundLongFlag ZOOKEEPER_PRE_ALLOC_SIZE_KIB = defineLongFlag(
             "zookeeper-pre-alloc-size", 65536,
             List.of("hmusum"), "2024-11-11", "2025-01-11",
-            "Setting for zookeeper.preAllocSize flag, can be reduced from default value "
+            "Setting for zookeeper.preAllocSize flag in KiB, can be reduced from default value "
             + "e.g. when running tests to avoid writing a large, sparse, mostly unused file",
             "Takes effect on restart of Docker container");
 

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -56,6 +56,8 @@ public class Configurator {
         System.setProperty("zookeeper.learner.asyncSending", String.valueOf(zookeeperServerConfig.learnerAsyncSending()));
         // Enable creation of TTL Nodes.
         System.setProperty("zookeeper.extendedTypesEnabled", "true");
+        // Space in the transaction log file in kilobytes.
+        System.setProperty("zookeeper.preAllocSize", String.valueOf(zookeeperServerConfig.preAllocSizeKb()));
     }
 
     void writeConfigToDisk() {

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -64,12 +64,12 @@ public class ConfiguratorTest {
     }
 
     @Test
-    public void config_is_written_correctly_with_multiple_servers() throws IOException {
+    public void config_is_written_correctly_with_multiple_servers() {
         three_config_servers(false);
     }
 
     @Test
-    public void config_is_written_correctly_with_multiple_servers_on_hosted_vespa() throws IOException {
+    public void config_is_written_correctly_with_multiple_servers_on_hosted_vespa() {
         three_config_servers(true);
     }
 
@@ -155,7 +155,7 @@ public class ConfiguratorTest {
                      Files.readString(cfgFile.toPath()));
     }
 
-    private void three_config_servers(boolean hosted) throws IOException {
+    private void three_config_servers(boolean hosted) {
         ZookeeperServerConfig.Builder builder = new ZookeeperServerConfig.Builder();
         builder.zooKeeperConfigFile(cfgFile.getAbsolutePath());
         builder.server(newServer(0, "foo", 123, 321, false));


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This will make it possible to reduce this setting significantly, to avoid writing an unnecessarily huge amount of data in e.g. system tests