### PR TITLE
Add a Count-Min-based probabilistic relative frequency sketch

### DIFF
--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -25,6 +25,7 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     random_test.cpp
     rcuvector_test.cpp
     ref_counted_test.cpp
+    relative_frequency_sketch_test.cpp
     require_test.cpp
     size_literals_test.cpp
     small_vector_test.cpp

--- a/vespalib/src/tests/util/relative_frequency_sketch_test.cpp
+++ b/vespalib/src/tests/util/relative_frequency_sketch_test.cpp
@@ -1,0 +1,90 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include <vespa/vespalib/util/relative_frequency_sketch.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+namespace vespalib {
+
+using namespace ::testing;
+
+namespace {
+
+struct Identity {
+    template <typename T>
+    constexpr T operator()(T v) const noexcept { return v; }
+};
+
+}
+
+struct RelativeFrequencySketchTest : Test {
+    // Note: although the sketch is inherently _probabilistic_, the below tests are fully
+    // deterministic as long as the underlying hash function remains the same. This is also why
+    // we explicitly do _not_ use std::hash here, but defer entirely to (deterministic) XXH3.
+    using U32FrequencySketch = RelativeFrequencySketch<uint32_t, Identity>;
+};
+
+TEST_F(RelativeFrequencySketchTest, frequency_estimates_are_initially_zero) {
+    U32FrequencySketch sketch(2);
+    EXPECT_EQ(sketch.count_min(0), 0);
+    EXPECT_EQ(sketch.count_min(12345), 0);
+    EXPECT_EQ(sketch.estimate_relative_frequency(123, 456), std::weak_ordering::equivalent);
+}
+
+TEST_F(RelativeFrequencySketchTest, frequency_is_counted_up_to_and_saturated_at_15) {
+    U32FrequencySketch sketch(1);
+    for (uint32_t i = 1; i <= 20; ++i) {
+        sketch.add(7);
+        // With only one entry we're guaranteed to be exact up to the saturation point
+        if (i < 15) {
+            EXPECT_EQ(sketch.count_min(7), i);
+        } else {
+            EXPECT_EQ(sketch.count_min(7), 15);
+        }
+    }
+}
+
+TEST_F(RelativeFrequencySketchTest, can_track_frequency_of_multiple_elements) {
+    U32FrequencySketch sketch(3);
+    sketch.add(100);
+    sketch.add(200);
+    sketch.add(300);
+    sketch.add(200);
+
+    EXPECT_EQ(sketch.count_min(100), 1);
+    EXPECT_EQ(sketch.count_min(200), 2);
+    EXPECT_EQ(sketch.count_min(300), 1);
+    EXPECT_EQ(sketch.count_min(400), 0);
+
+    EXPECT_EQ(sketch.estimate_relative_frequency(0, 100),   std::weak_ordering::less);
+    EXPECT_EQ(sketch.estimate_relative_frequency(100, 0),   std::weak_ordering::greater);
+    EXPECT_EQ(sketch.estimate_relative_frequency(100, 100), std::weak_ordering::equivalent);
+    EXPECT_EQ(sketch.estimate_relative_frequency(100, 300), std::weak_ordering::equivalent);
+    EXPECT_EQ(sketch.estimate_relative_frequency(300, 100), std::weak_ordering::equivalent);
+    EXPECT_EQ(sketch.estimate_relative_frequency(100, 200), std::weak_ordering::less);
+    EXPECT_EQ(sketch.estimate_relative_frequency(200, 100), std::weak_ordering::greater);
+}
+
+TEST_F(RelativeFrequencySketchTest, counters_are_divided_by_2_once_window_size_reached) {
+    U32FrequencySketch sketch(8);
+    const auto ws = sketch.window_size();
+    std::vector<uint32_t> truth(8);
+    ASSERT_GT(ws, 0);
+    for (size_t i = 0; i < ws - 1; ++i) { // don't trigger decay just yet
+        uint32_t elem = i % 8;
+        sketch.add(elem);
+        truth[elem]++;
+    }
+    std::vector<uint32_t> c_before(8);
+    for (uint32_t i = 0; i < 8; ++i) {
+        c_before[i] = sketch.count_min(i);
+        EXPECT_GE(c_before[i], truth[i]);
+        // No counters should be saturated yet
+        EXPECT_LT(c_before[i], 15);
+    }
+    // Edge triggered sample ==> should divide all counters
+    sketch.add(9);
+    for (uint32_t i = 0; i < 8; ++i) {
+        EXPECT_EQ(sketch.count_min(i), c_before[i] / 2);
+    }
+}
+
+}

--- a/vespalib/src/tests/util/relative_frequency_sketch_test.cpp
+++ b/vespalib/src/tests/util/relative_frequency_sketch_test.cpp
@@ -8,9 +8,9 @@ using namespace ::testing;
 
 namespace {
 
-struct Identity {
+struct IdentityHash {
     template <typename T>
-    constexpr T operator()(T v) const noexcept { return v; }
+    constexpr size_t operator()(T v) const noexcept { return v; }
 };
 
 }
@@ -19,7 +19,7 @@ struct RelativeFrequencySketchTest : Test {
     // Note: although the sketch is inherently _probabilistic_, the below tests are fully
     // deterministic as long as the underlying hash function remains the same. This is also why
     // we explicitly do _not_ use std::hash here, but defer entirely to (deterministic) XXH3.
-    using U32FrequencySketch = RelativeFrequencySketch<uint32_t, Identity>;
+    using U32FrequencySketch = RelativeFrequencySketch<uint32_t, IdentityHash>;
 };
 
 TEST_F(RelativeFrequencySketchTest, frequency_estimates_are_initially_zero) {
@@ -40,6 +40,14 @@ TEST_F(RelativeFrequencySketchTest, frequency_is_counted_up_to_and_saturated_at_
             EXPECT_EQ(sketch.count_min(7), 15);
         }
     }
+}
+
+TEST_F(RelativeFrequencySketchTest, add_and_count_returns_min_count_after_add) {
+    U32FrequencySketch sketch(2);
+    EXPECT_EQ(sketch.add_and_count(123), 1);
+    EXPECT_EQ(sketch.add_and_count(123), 2);
+    EXPECT_EQ(sketch.add_and_count(123), 3);
+    EXPECT_EQ(sketch.add_and_count(456), 1);
 }
 
 TEST_F(RelativeFrequencySketchTest, can_track_frequency_of_multiple_elements) {

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -68,6 +68,7 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     rcuvector.cpp
     ref_counted.cpp
     regexp.cpp
+    relative_frequency_sketch.cpp
     require.cpp
     resource_limits.cpp
     round_up_to_page_size.cpp

--- a/vespalib/src/vespa/vespalib/util/relative_frequency_sketch.cpp
+++ b/vespalib/src/vespa/vespalib/util/relative_frequency_sketch.cpp
@@ -1,0 +1,161 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "relative_frequency_sketch.h"
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+namespace vespalib {
+
+/**
+ * Cf. the description of the Caffeine sketch in [2][3] we use 8 bytes per cache entry and
+ * a sample (window) size W that is 10x the cache size (C). It is not immediately clear why
+ * W/C = 10 rather than 16 since we use 4 bits and log2(10) = 3.321..., but surely the
+ * underlying reason must be very exciting.
+ *
+ * Note: `Alloc` currently does not support < 512 byte alignment, which is suboptimal if
+ * the allocation is small enough to end up on the heap (FIXME).
+ */
+RawRelativeFrequencySketch::RawRelativeFrequencySketch(size_t count)
+    : _buf(alloc::Alloc::alloc_aligned(roundUp2inN(std::max(size_t(64U), count * 8)), 512)),
+      _samples_since_decay(0),
+      _window_size((_buf.size() / 8) * 10),
+      _block_mask_bits(_buf.size() > 64 ? Optimized::msbIdx(_buf.size() / 64) : 0)
+{
+    assert(_block_mask_bits <= 48); // Will always be the case in practice, but it's an invariant...
+    memset(_buf.get(), 0, _buf.size());
+}
+
+RawRelativeFrequencySketch::~RawRelativeFrequencySketch() = default;
+
+/**
+ * Add an element by its hash. This involves incrementing 4 distinct counters based on the hash.
+ *
+ * Our sketch buffer is logically divided into buf_size/64 distinct 64-byte blocks. Each
+ * block is in turn logically divided into 4 rows x 32 4-bit counters, laid out sequentially.
+ * Each counter is saturated at 15, i.e. there is no overflow.
+ *
+ * We first select the block based on the B LSBs of the hash, where B is log2(buffer_size/64)
+ * and buffer_size is always a power of two. These B bits are considered consumed and are not
+ * used for anything else.
+ *
+ * Within the block we always update exactly 1 counter in each logical row. Use 5 distinct
+ * bits from the hash for each of the 4 row updates (4 bits to select a byte out of 16, 1 for
+ * selecting either the high or low in-byte nibble). To make a nice round number, round up to
+ * consuming 8 bits per row (the 3 remaining bits are unused).
+ *
+ * We use the same conditional decay trigger as the Caffeine sketch, in that we only bump
+ * the observed sample count (and possibly decay the counters) iff we actually increment at
+ * least one counter (i.e. not all counters are pre-saturated). The rationale for this is not
+ * stated outright in the code, but it makes sense as a way to gracefully handle repeated
+ * insertions of a small set of very high frequency elements. If we always counted these as
+ * distinct samples we would eventually decay the counters until we have forgotten _all_
+ * elements that are not similarly frequent.
+ */
+void RawRelativeFrequencySketch::add_by_hash(uint64_t hash) noexcept {
+    const uint64_t block = hash & ((1u << _block_mask_bits) - 1);
+    hash >>= _block_mask_bits;
+    assert(block*64 + 64 <= _buf.size());
+    auto* block_ptr = static_cast<uint8_t*>(_buf.get()) + (block * 64);
+    uint16_t old_counter_bits = 0;
+    // The compiler will happily and easily unroll this loop.
+    for (uint8_t i = 0; i < 4; ++i) {
+        uint8_t h = hash >> (i*8); // Note: we only use 5 out of the 8 bits
+        uint8_t* vp = block_ptr + (i * 16) + (h & 0xf); // row #i byte select
+        const uint8_t v = *vp;
+        h >>= 4;
+        const uint8_t nib_shift = (h & 1) * 4; // High or low nibble shift factor (4 or 0)
+        const uint8_t nib_mask  = 0xf << nib_shift;
+        const uint8_t nib_old   = (v & nib_mask) >> nib_shift;
+        const uint8_t nib_new   = nib_old < 15 ? nib_old + 1 : 15; // Saturated add
+        const uint8_t nib_rem   = v & ~nib_mask; // Untouched nibble that should be preserved
+        old_counter_bits       |= nib_old << (i * 4);
+        *vp = (nib_new << nib_shift) | nib_rem;
+    }
+    if (old_counter_bits != 0xffff && (++_samples_since_decay >= _window_size)) [[unlikely]] {
+        div_all_by_2();
+        _samples_since_decay /= 2;
+    }
+}
+
+/**
+ * Estimates the count associated with the given hash. This uses the exact same counter
+ * addressing as `add_by_hash()`, so refer to that function for a description on the
+ * semantics. As the name Count-Min implies we take the _minimum_ of the observed counters
+ * and return this value to the caller.
+ *
+ * This will over-estimate the true frequency iff _all_ counters overlap with at least one
+ * other element, but it will never under-estimate (here casually ignoring the effects of
+ * counter decaying).
+ */
+uint8_t RawRelativeFrequencySketch::count_min_by_hash(uint64_t hash) const noexcept {
+    const uint64_t block = hash & ((1u << _block_mask_bits) - 1);
+    hash >>= _block_mask_bits;
+    const uint8_t* block_ptr = static_cast<const uint8_t*>(_buf.get()) + (block * 64);
+    uint8_t cm[4];
+    for (uint8_t i = 0; i < 4; ++i) {
+        uint8_t h = hash >> (i*8);
+        const uint8_t* vp = block_ptr + (i * 16) + (h & 0xf); // row #i byte select
+        h >>= 4;
+        const uint8_t nib_shift = (h & 1) * 4; // 4 or 0
+        const uint8_t nib_mask = 0xf << nib_shift;
+        cm[i] = (*vp & nib_mask) >> nib_shift;
+    }
+    return std::min(std::min(cm[0], cm[1]), std::min(cm[2], cm[3]));
+}
+
+std::weak_ordering
+RawRelativeFrequencySketch::estimate_relative_frequency_by_hash(uint64_t lhs_hash, uint64_t rhs_hash) const noexcept {
+    return count_min_by_hash(lhs_hash) <=> count_min_by_hash(rhs_hash);
+}
+
+/**
+ * Divides all the 4-bit counters in the sketch by 2. Since this integral division, we
+ * inherently lose some precision for odd-numbered counter values.
+ *
+ * We speed up the division by treating each 64-byte block as 8x u64 values that can
+ * logically be processed in parallel. The compiler will unroll and auto-vectorize the u64
+ * fixed-count inner-loop as expected (verified via Godbolt).
+ *
+ * Each u64 value is right-shifted by 1. This shifts the LSB of all 16 4-bit nibbles (except
+ * the last one) into the MSB of the next nibble. We want the semantics as-if each nibble
+ * were in its own register, which would mean shifting in a zero bit in the MSB instead.
+ * We emulate this by explicitly clearing all nibble MSBs. This effectively divides all
+ * nibbles by 2. This should be entirely endian-agnostic.
+ *
+ * Example:
+ *
+ * Before:
+ *  nibble#: [ 15 ][ 14 ][ 13 ][ 12 ][ ...
+ *  bits:     1111  0011  0000  1100   ...
+ *  value:      15     3     0    12   ...
+ *
+ * After shift (_uncorrected_ prior to masking)
+ *  nibble#: [ 15 ][ 14 ][ 13 ][ 12 ][ ...
+ *  bits:     0111  1001  1000  0110  0...
+ *  value:       7     9     8     6   ...
+ *
+ * We will then apply the following per-nibble mask:
+ *  mask:     0111  0111  0111  0111  0...
+ *
+ * After shift (corrected by masking off nibble MSBs)
+ *  nibble#: [ 15 ][ 14 ][ 13 ][ 12 ][ ...
+ *  bits:     0111  0001  0000  0110  0...
+ *  value:       7     1     0     6   ...
+ */
+void RawRelativeFrequencySketch::div_all_by_2() noexcept {
+    const uint64_t n_blocks = _buf.size() / 64;
+    auto* block_ptr = static_cast<uint8_t*>(_buf.get());
+    for (uint64_t i = 0; i < n_blocks; ++i) {
+        for (uint32_t j = 0; j < 8; ++j) {
+            uint64_t chunk;
+            // Compiler will optimize away memcpys (avoids aliasing).
+            memcpy(&chunk, block_ptr + (sizeof(uint64_t) * j), sizeof(uint64_t));
+            chunk >>= 1;
+            chunk &= 0x7777777777777777ULL; // nibble ~MSB mask
+            memcpy(block_ptr + (sizeof(uint64_t) * j), &chunk, sizeof(uint64_t));
+        }
+        block_ptr += 64;
+    }
+}
+
+} // vespalib

--- a/vespalib/src/vespa/vespalib/util/relative_frequency_sketch.h
+++ b/vespalib/src/vespa/vespalib/util/relative_frequency_sketch.h
@@ -1,0 +1,134 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "alloc.h"
+#include <vespa/vespalib/stllike/hash_fun.h>
+#include <compare>
+
+namespace vespalib {
+
+/**
+ * Adds an implementation of a probabilistic frequency sketch that allows for estimating the
+ * relative frequency of of elements from a stream of events. That is, the sketch does not
+ * capture the _absolute_ frequency of a given element over time.
+ *
+ * To reduce the requirement for the number of bits used for the sketch's underlying counters,
+ * this sketch uses automatic decaying of counter values once the number of recorded samples
+ * reaches a certain point (relative to the sketch's size). Decaying divides all counters by 2.
+ *
+ * The underlying data structure is a Count-Min sketch [0][1] with automatic decaying of
+ * counters based on TinyLFU [2].
+ *
+ * This implementation has certain changes from a "textbook" CM sketch, inspired by the
+ * approach used in [3]. In particular, instead of having `d` logical rows each with width `w`
+ * that are accessed with hash-derived indexes (and thus likely triggering `d` cache misses
+ * for large values of `w`) we subdivide into w/64 blocks each with fixed number d=4 rows of
+ * 32 4-bit counters, i.e. each block is exactly 64 bytes. Counter updates or reads always
+ * happen within the scope of a single block. We also ensure the block array is allocated with
+ * at least a 64-byte alignment. This ensures that a given sketch access will touch exactly 1
+ * cache line of the underlying sketch buffer (not counting cache lines occupied by the sketch
+ * object itself, as we assume these are already present in the cache).
+ * Similarly, comparing the frequency of two elements will always touch at most 2 cache lines.
+ *
+ * Unlike [3] we use byte-wise counter accesses and only using a single hash computation per
+ * distinct sketch lookup instead of explicitly re-mixing hash bits. We also always divide the
+ * decay counter by 2 instead of subtracting the number of odd counters found (TODO reconsider?).
+ *
+ * The Count-Min sketch (and its cousin, the Counting Bloom Filter) using `k` counters is
+ * usually described as requiring k pairwise independent hash functions. This implementation
+ * assumes this requirement is unnecessary assuming a hash function with good entropy; we
+ * instead extract non-overlapping subsets of bits of a single hash value and use these as
+ * indices into our data structure components.
+ *
+ * Important: this frequency sketch _requires_ a good hash function, i.e. high entropy.
+ * Use `RelativeFrequencySketch` with HasGoodEntropyHash=false (default) if this is not the
+ * case for the type being counted, as it implicitly mixes the hash bits using XXH3.
+ *
+ * Thread safety: as thread safe as a std::vector.
+ *
+ * References:
+ *  [0]: The Count-Min Sketch and its Applications (2003)
+ *  [1]: https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch
+ *  [2]: TinyLFU: A Highly Efficient Cache Admission Policy (2015)
+ *  [3]: https://github.com/ben-manes/caffeine/blob/master/caffeine/
+ *       src/main/java/com/github/benmanes/caffeine/cache/FrequencySketch.java
+ */
+class RawRelativeFrequencySketch {
+    alloc::Alloc _buf;
+    size_t       _samples_since_decay;
+    size_t       _window_size;
+    uint32_t     _block_mask_bits;
+public:
+    explicit RawRelativeFrequencySketch(size_t count);
+    ~RawRelativeFrequencySketch();
+
+    void add_by_hash(uint64_t hash) noexcept;
+    [[nodiscard]] std::weak_ordering estimate_relative_frequency_by_hash(uint64_t lhs_hash, uint64_t rhs_hash) const noexcept;
+
+    // Gets the raw underlying counter value saturated in [0, 15] for a given hash.
+    [[nodiscard]] uint8_t count_min_by_hash(uint64_t hash) const noexcept;
+
+    void div_all_by_2() noexcept;
+
+    [[nodiscard]] size_t window_size() const noexcept { return _window_size; }
+};
+
+/**
+ * Wrapper of RawRelativeFrequencySketch for an arbitrary hashable type.
+ *
+ * Only set HasGoodEntropyHash=true if you know that the underlying hash function is
+ * of good quality. This _excludes_ std::hash<> hashes, especially those for integers,
+ * as the hash function for those is more often than not the identity function.
+ *
+ * See `RawRelativeFrequencySketch` for algorithm details.
+ */
+template <typename T, typename Hash = std::hash<T>, bool HasGoodEntropyHash = false>
+requires requires(Hash h, T t) { noexcept(noexcept(h(t))); }
+class RelativeFrequencySketch {
+    RawRelativeFrequencySketch _impl;
+    Hash                       _hash;
+public:
+    // Initializes a sketch used for estimating frequencies for an underlying cache
+    // (or similar datastructure) that can hold a maximum of `count` entries.
+    explicit RelativeFrequencySketch(size_t count, Hash hash = Hash{})
+        : _impl(count),
+          _hash(hash)
+    {}
+    ~RelativeFrequencySketch() = default;
+private:
+    [[nodiscard]] uint64_t hash_elem(const T& elem) const noexcept {
+        uint64_t hash = _hash(elem);
+        if constexpr (!HasGoodEntropyHash) {
+            hash = xxhash::xxh3_64(hash); // Mix it up!
+        }
+        return hash;
+    }
+public:
+    // Increments the estimated frequency for the given element, identified by its hash.
+    // Frequency is saturated at 15.
+    void add(const T& elem) noexcept {
+        _impl.add_by_hash(hash_elem(elem));
+    }
+    // Returns a frequency estimate for the given element, saturated at 15. Since this is
+    // a probabilistic sketch, the frequency may be overestimated. Note that automatic counter
+    // decaying will over time reduce the reported frequency of elements that are no longer
+    // added to the sketch.
+    [[nodiscard]] uint8_t count_min(const T& elem) const noexcept {
+        return _impl.count_min_by_hash(hash_elem(elem));
+    }
+    [[nodiscard]] std::weak_ordering estimate_relative_frequency(const T& lhs, const T& rhs) const noexcept {
+        const uint64_t lhs_hash = hash_elem(lhs);
+        const uint64_t rhs_hash = hash_elem(rhs);
+        return _impl.estimate_relative_frequency_by_hash(lhs_hash, rhs_hash);
+    }
+    // Manually trigger counter decay; divides all count estimates by 2
+    void div_all_by_2() {
+        _impl.div_all_by_2();
+    }
+    // Sample count required before all counters are automatically divided by 2.
+    // Note that invoking `add(v)` for an element `v` whose counters are _all_ fully
+    // saturated prior to the invocation will _not_ count towards the sample count.
+    [[nodiscard]] size_t window_size() const noexcept { return _impl.window_size(); }
+};
+
+} // vespalib


### PR DESCRIPTION
@havardpe please review. This is arguably a rather experimental addition (that is currently not wired to anything), but it could come in handy for gluing into the caching subsystem as part of a cache admission controller (or something else shiny) 😳👉👈

Adds an implementation of a probabilistic frequency sketch that allows for estimating the relative frequency of of elements from a stream of events. That is, the sketch does not capture the _absolute_ frequency of a given element over time.

To reduce the requirement for the number of bits used for the sketch's underlying counters, this sketch uses automatic decaying of counter values once the number of recorded samples reaches a certain point (relative to the sketch's size). Decaying divides all counters by 2.

The underlying data structure is a Count-Min sketch [^0][^1] with automatic decaying of counters based on TinyLFU [^2].

This implementation has certain changes from a "textbook" CM sketch, inspired by the approach used in [^3]. In particular, instead of having `d` logical rows each with width `w` that are accessed with hash-derived indexes (and thus likely triggering `d` cache misses for large values of `w`) we subdivide into `w/64` blocks each with fixed number d=4 rows of 32 4-bit counters, i.e. each block is exactly 64 bytes. Counter updates or reads always happen within the scope of a single block. We also ensure the block array is allocated with at least a 64-byte alignment. This ensures that a given sketch update will touch exactly 1 cache line of the underlying sketch buffer (not counting cache lines occupied by the sketch object itself, as we assume these are already present in the CPU cache). Similarly, comparing the frequency of two elements will always touch at most 2 cache lines.

The Count-Min sketch (and its cousin, the Counting Bloom Filter) using `k` counters is usually described as requiring `k` pairwise independent hash functions. This implementation assumes this requirement is unnecessary assuming a hash function with good entropy; we instead extract non-overlapping subsets of bits of a single 64-bit hash value and use these as indices into our data structure components.

 [^0]: The Count-Min Sketch and its Applications (2003)
 [^1]: https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch
 [^2]: TinyLFU: A Highly Efficient Cache Admission Policy (2015)
 [^3]: [Caffeine FrequencySketch](https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/FrequencySketch.java)
