### PR TITLE
Separate bit vector lookup from bit vector read.

### DIFF
--- a/searchlib/src/tests/diskindex/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/diskindex/bitvector/bitvector_test.cpp
@@ -118,8 +118,8 @@ TEST_P(BitVectorTest, require_that_dictionary_handles_no_entries)
     EXPECT_TRUE(dict.open("dump/1/", tuneFileRead, bvScope));
     EXPECT_EQ(5u, dict.getDocIdLimit());
     EXPECT_EQ(0u, dict.getEntries().size());
-    EXPECT_FALSE(dict.lookup(1));
-    EXPECT_FALSE(dict.lookup(2));
+    EXPECT_FALSE(dict.lookup(1).valid());
+    EXPECT_FALSE(dict.lookup(2).valid());
 }
 
 TEST_P(BitVectorTest, require_that_dictionary_handles_multiple_entries)
@@ -176,16 +176,20 @@ TEST_P(BitVectorTest, require_that_dictionary_handles_multiple_entries)
     EXPECT_EQ(5u, e._wordNum);
     EXPECT_EQ(23u, e._numDocs);
 
-    EXPECT_FALSE(dict.lookup(2));
-    EXPECT_FALSE(dict.lookup(3));
-    EXPECT_FALSE(dict.lookup(4));
-    EXPECT_FALSE(dict.lookup(6));
+    EXPECT_FALSE(dict.lookup(2).valid());
+    EXPECT_FALSE(dict.lookup(3).valid());
+    EXPECT_FALSE(dict.lookup(4).valid());
+    EXPECT_FALSE(dict.lookup(6).valid());
 
-    BitVector::UP bv1act = dict.lookup(1);
+    auto bv1lr = dict.lookup(1);
+    EXPECT_TRUE(bv1lr.valid());
+    auto bv1act = dict.read_bitvector(bv1lr);
     EXPECT_TRUE(bv1act);
     EXPECT_TRUE(*bv1exp == *bv1act);
 
-    BitVector::UP bv5act = dict.lookup(5);
+    auto bv5lr = dict.lookup(5);
+    EXPECT_TRUE(bv5lr.valid());
+    auto bv5act = dict.read_bitvector(bv5lr);
     EXPECT_TRUE(bv5act);
     EXPECT_TRUE(*bv5exp == *bv5act);
 }

--- a/searchlib/src/tests/diskindex/fusion/fusion_test.cpp
+++ b/searchlib/src/tests/diskindex/fusion/fusion_test.cpp
@@ -159,12 +159,13 @@ assert_interleaved_features(DiskIndex &d, const std::string &field, const std::s
 {
     const Schema &schema = d.getSchema();
     uint32_t field_id(schema.getIndexFieldId(field));
+    auto& field_index = d.get_field_index(field_id);
     auto lookup_result(d.lookup(field_id, term));
-    auto handle(d.readPostingList(lookup_result));
+    auto handle(field_index.read_posting_list(lookup_result));
     TermFieldMatchData tfmd;
     TermFieldMatchDataArray tfmda;
     tfmda.add(&tfmd);
-    auto sbap(d.create_iterator(lookup_result, handle, tfmda));
+    auto sbap(field_index.create_iterator(lookup_result, handle, tfmda));
     sbap->initFullRange();
     EXPECT_TRUE(sbap->seek(doc_id));
     sbap->unpack(doc_id);
@@ -179,12 +180,13 @@ validateDiskIndex(DiskIndex &dw, bool f2HasElements, bool f3HasWeights)
 
     {
         uint32_t id1(schema.getIndexFieldId("f0"));
+        auto& field_index = dw.get_field_index(id1);
         auto lr1(dw.lookup(id1, "c"));
-        auto wh1(dw.readPostingList(lr1));
+        auto wh1(field_index.read_posting_list(lr1));
         TermFieldMatchData f0;
         TermFieldMatchDataArray a;
         a.add(&f0);
-        auto sbap(dw.create_iterator(lr1, wh1, a));
+        auto sbap(field_index.create_iterator(lr1, wh1, a));
         sbap->initFullRange();
         EXPECT_EQ(std::string("{1000000:}"), toString(f0.getIterator()));
         EXPECT_TRUE(sbap->seek(10));
@@ -193,12 +195,13 @@ validateDiskIndex(DiskIndex &dw, bool f2HasElements, bool f3HasWeights)
     }
     {
         uint32_t id1(schema.getIndexFieldId("f2"));
+        auto& field_index = dw.get_field_index(id1);
         auto lr1(dw.lookup(id1, "ax"));
-        auto wh1(dw.readPostingList(lr1));
+        auto wh1(field_index.read_posting_list(lr1));
         TermFieldMatchData f2;
         TermFieldMatchDataArray a;
         a.add(&f2);
-        auto sbap(dw.create_iterator(lr1, wh1, a));
+        auto sbap(field_index.create_iterator(lr1, wh1, a));
         sbap->initFullRange();
         EXPECT_EQ(std::string("{1000000:}"), toString(f2.getIterator()));
         EXPECT_TRUE(sbap->seek(10));
@@ -213,12 +216,13 @@ validateDiskIndex(DiskIndex &dw, bool f2HasElements, bool f3HasWeights)
     }
     {
         uint32_t id1(schema.getIndexFieldId("f3"));
+        auto& field_index = dw.get_field_index(id1);
         auto lr1(dw.lookup(id1, "wx"));
-        auto wh1(dw.readPostingList(lr1));
+        auto wh1(field_index.read_posting_list(lr1));
         TermFieldMatchData f3;
         TermFieldMatchDataArray a;
         a.add(&f3);
-        auto sbap(dw.create_iterator(lr1, wh1, a));
+        auto sbap(field_index.create_iterator(lr1, wh1, a));
         sbap->initFullRange();
         EXPECT_EQ(std::string("{1000000:}"), toString(f3.getIterator()));
         EXPECT_TRUE(sbap->seek(10));
@@ -233,12 +237,13 @@ validateDiskIndex(DiskIndex &dw, bool f2HasElements, bool f3HasWeights)
     }
     {
         uint32_t id1(schema.getIndexFieldId("f3"));;
+        auto& field_index = dw.get_field_index(id1);
         auto lr1(dw.lookup(id1, "zz"));
-        auto wh1(dw.readPostingList(lr1));
+        auto wh1(field_index.read_posting_list(lr1));
         TermFieldMatchData f3;
         TermFieldMatchDataArray a;
         a.add(&f3);
-        auto sbap(dw.create_iterator(lr1, wh1, a));
+        auto sbap(field_index.create_iterator(lr1, wh1, a));
         sbap->initFullRange();
         EXPECT_EQ(std::string("{1000000:}"), toString(f3.getIterator()));
         EXPECT_TRUE(sbap->seek(11));
@@ -253,12 +258,13 @@ validateDiskIndex(DiskIndex &dw, bool f2HasElements, bool f3HasWeights)
     }
     {
         uint32_t id1(schema.getIndexFieldId("f3"));;
+        auto& field_index = dw.get_field_index(id1);
         auto lr1(dw.lookup(id1, "zz0"));
-        auto wh1(dw.readPostingList(lr1));
+        auto wh1(field_index.read_posting_list(lr1));
         TermFieldMatchData f3;
         TermFieldMatchDataArray a;
         a.add(&f3);
-        auto sbap(dw.create_iterator(lr1, wh1, a));
+        auto sbap(field_index.create_iterator(lr1, wh1, a));
         sbap->initFullRange();
         EXPECT_EQ(std::string("{1000000:}"), toString(f3.getIterator()));
         EXPECT_TRUE(sbap->seek(12));

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectordictionary.h
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectordictionary.h
@@ -2,11 +2,16 @@
 #pragma once
 
 #include "bitvectorkeyscope.h"
-#include <vespa/searchlib/common/bitvector.h>
+//#include <vespa/searchlib/common/bitvector.h>
+#include <vespa/searchlib/index/bitvector_dictionary_lookup_result.h>
 #include <vespa/searchlib/index/bitvectorkeys.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <string>
 #include <vector>
+
+class FastOS_FileInterface;
+
+namespace search { class BitVector; }
 
 namespace search::diskindex {
 
@@ -48,13 +53,19 @@ public:
          BitVectorKeyScope scope);
 
     /**
-     * Lookup the given word number and load and return the associated
-     * bit vector if found.
+     * Lookup the given word number.
      *
-     * @param wordNum the word number to lookup a bit vector for.
-     * @return the loaded bit vector or nullptr if not found.
+     * @param word_num the word number to lookup a bit vector for.
+     * @return a bitvector dictionary lookup result that can be passed to read_bitvector member function.
      **/
-    BitVector::UP lookup(uint64_t wordNum);
+    index::BitVectorDictionaryLookupResult lookup(uint64_t word_num);
+    /**
+     * load and return the associated bit vector if lookup result is valid.
+     *
+     * @param lookup_result the result returned from lookup.
+     * @return the loaded bit vector or empty if lookup result was invalid.
+     **/
+    std::unique_ptr<BitVector> read_bitvector(index::BitVectorDictionaryLookupResult lookup_result);
 
     uint32_t getDocIdLimit() const { return _docIdLimit; }
 

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectordictionary.h
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectordictionary.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "bitvectorkeyscope.h"
-//#include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/index/bitvector_dictionary_lookup_result.h>
 #include <vespa/searchlib/index/bitvectorkeys.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
@@ -60,7 +59,7 @@ public:
      **/
     index::BitVectorDictionaryLookupResult lookup(uint64_t word_num);
     /**
-     * load and return the associated bit vector if lookup result is valid.
+     * Load and return the associated bit vector if lookup result is valid.
      *
      * @param lookup_result the result returned from lookup.
      * @return the loaded bit vector or empty if lookup result was invalid.

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.h
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.h
@@ -99,28 +99,6 @@ public:
 
     LookupResultVector lookup(const std::vector<uint32_t> & indexes, std::string_view word);
 
-    /**
-     * Read the posting list corresponding to the given lookup result.
-     *
-     * @param lookupRes the result of the previous dictionary lookup.
-     * @return a handle for the posting list in memory.
-     */
-    index::PostingListHandle readPostingList(const LookupResult &lookupRes) const;
-
-    std::unique_ptr<search::queryeval::SearchIterator>
-    create_iterator(const LookupResult& lookup_result,
-                    const index::PostingListHandle& handle,
-                    const search::fef::TermFieldMatchDataArray& tfmda) const;
-
-    /**
-     * Read the bit vector corresponding to the given lookup result.
-     *
-     * @param lookupRes the result of the previous dictionary lookup.
-     * @return the bit vector or nullptr if no bit vector exists for the
-     *         word in the lookup result.
-     */
-    BitVector::UP readBitVector(const LookupResult &lookupRes) const;
-
     std::unique_ptr<queryeval::Blueprint> createBlueprint(const queryeval::IRequestContext & requestContext,
                                                           const queryeval::FieldSpec &field,
                                                           const query::Node &term) override;
@@ -143,6 +121,7 @@ public:
 
     index::FieldLengthInfo get_field_length_info(const std::string& field_name) const;
     const std::shared_ptr<IPostingListCache>& get_posting_list_cache() const noexcept { return _posting_list_cache; }
+    const FieldIndex& get_field_index(uint32_t field_id) const noexcept { return _field_indexes[field_id]; }
 };
 
 void swap(DiskIndex::LookupResult & a, DiskIndex::LookupResult & b);

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
@@ -14,6 +14,7 @@ LOG_SETUP(".diskindex.disktermblueprint");
 
 using search::BitVectorIterator;
 using search::fef::TermFieldMatchDataArray;
+using search::index::DictionaryLookupResult;
 using search::index::Schema;
 using search::queryeval::Blueprint;
 using search::queryeval::BooleanMatchIteratorWrapper;
@@ -37,19 +38,20 @@ getName(uint32_t indexId)
 }
 
 DiskTermBlueprint::DiskTermBlueprint(const FieldSpec & field,
-                                     const DiskIndex & diskIndex,
+                                     const FieldIndex& field_index,
                                      const std::string& query_term,
-                                     DiskIndex::LookupResult lookupRes,
-                                     bool useBitVector) :
-    SimpleLeafBlueprint(field),
-    _field(field),
-    _diskIndex(diskIndex),
-    _query_term(query_term),
-    _lookupRes(std::move(lookupRes)),
-    _useBitVector(useBitVector),
-    _fetchPostingsDone(false),
-    _postingHandle(),
-    _bitVector()
+                                     DictionaryLookupResult lookupRes,
+                                     bool useBitVector)
+    : SimpleLeafBlueprint(field),
+      _field(field),
+      _field_index(field_index),
+      _query_term(query_term),
+      _lookupRes(std::move(lookupRes)),
+      _bitvector_lookup_result(_field_index.lookup_bit_vector(_lookupRes)),
+      _useBitVector(useBitVector),
+      _fetchPostingsDone(false),
+      _postingHandle(),
+      _bitVector()
 {
     setEstimate(HitEstimate(_lookupRes.counts._numDocs,
                             _lookupRes.counts._numDocs == 0));
@@ -60,9 +62,9 @@ DiskTermBlueprint::fetchPostings(const queryeval::ExecuteInfo &execInfo)
 {
     (void) execInfo;
     if (!_fetchPostingsDone) {
-        _bitVector = _diskIndex.readBitVector(_lookupRes);
+        _bitVector = _field_index.read_bit_vector(_bitvector_lookup_result);
         if (!_useBitVector || !_bitVector) {
-            _postingHandle = _diskIndex.readPostingList(_lookupRes);
+            _postingHandle = _field_index.read_posting_list(_lookupRes);
         }
     }
     _fetchPostingsDone = true;
@@ -80,17 +82,17 @@ DiskTermBlueprint::createLeafSearch(const TermFieldMatchDataArray & tfmda) const
 {
     if (_bitVector && (_useBitVector || tfmda[0]->isNotNeeded())) {
         LOG(debug, "Return BitVectorIterator: %s, wordNum(%" PRIu64 "), docCount(%" PRIu64 ")",
-            getName(_lookupRes.indexId).c_str(), _lookupRes.wordNum, _lookupRes.counts._numDocs);
+            getName(_field_index.get_field_id()).c_str(), _lookupRes.wordNum, _lookupRes.counts._numDocs);
         return BitVectorIterator::create(_bitVector.get(), *tfmda[0], strict());
     }
-    auto search(_diskIndex.create_iterator(_lookupRes, _postingHandle, tfmda));
+    auto search(_field_index.create_iterator(_lookupRes, _postingHandle, tfmda));
     if (_useBitVector) {
         LOG(debug, "Return BooleanMatchIteratorWrapper: %s, wordNum(%" PRIu64 "), docCount(%" PRIu64 ")",
-            getName(_lookupRes.indexId).c_str(), _lookupRes.wordNum, _lookupRes.counts._numDocs);
+            getName(_field_index.get_field_id()).c_str(), _lookupRes.wordNum, _lookupRes.counts._numDocs);
         return std::make_unique<BooleanMatchIteratorWrapper>(std::move(search), tfmda);
     }
     LOG(debug, "Return posting list iterator: %s, wordNum(%" PRIu64 "), docCount(%" PRIu64 ")",
-        getName(_lookupRes.indexId).c_str(), _lookupRes.wordNum, _lookupRes.counts._numDocs);
+        getName(_field_index.get_field_id()).c_str(), _lookupRes.wordNum, _lookupRes.counts._numDocs);
     return search;
 }
 
@@ -102,7 +104,7 @@ DiskTermBlueprint::createFilterSearch(FilterConstraint) const
     if (_bitVector) {
         wrapper->wrap(BitVectorIterator::create(_bitVector.get(), *tfmda[0], strict()));
     } else {
-        wrapper->wrap(_diskIndex.create_iterator(_lookupRes, _postingHandle, tfmda));
+        wrapper->wrap(_field_index.create_iterator(_lookupRes, _postingHandle, tfmda));
     }
     return wrapper;
 }

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "diskindex.h"
+#include "field_index.h"
 #include <vespa/searchlib/queryeval/blueprint.h>
 
 namespace search::diskindex {
@@ -14,9 +14,10 @@ class DiskTermBlueprint : public queryeval::SimpleLeafBlueprint
 {
 private:
     queryeval::FieldSpec             _field;
-    const DiskIndex               &  _diskIndex;
+    const FieldIndex&                _field_index;
     std::string                 _query_term;
-    DiskIndex::LookupResult          _lookupRes;
+    index::DictionaryLookupResult          _lookupRes;
+    index::BitVectorDictionaryLookupResult _bitvector_lookup_result;
     bool                             _useBitVector;
     bool                             _fetchPostingsDone;
     index::PostingListHandle         _postingHandle;
@@ -27,14 +28,14 @@ public:
      * Create a new blueprint.
      *
      * @param field        the field to search in.
-     * @param diskIndex    the disk index used to read the bit vector or posting list.
+     * @param field_index    the field index used to read the bit vector or posting list.
      * @param lookupRes    the result after disk dictionary lookup.
      * @param useBitVector whether or not we should use bit vector.
      **/
     DiskTermBlueprint(const queryeval::FieldSpec & field,
-                      const DiskIndex & diskIndex,
+                      const FieldIndex& field_index,
                       const std::string& query_term,
-                      DiskIndex::LookupResult lookupRes,
+                      index::DictionaryLookupResult lookupRes,
                       bool useBitVector);
 
     queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override;

--- a/searchlib/src/vespa/searchlib/diskindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/field_index.cpp
@@ -3,6 +3,7 @@
 #include "field_index.h"
 #include "fileheader.h"
 #include "pagedict4randread.h"
+#include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/searchlib/util/disk_space_calculator.h>
 #include <filesystem>
@@ -10,6 +11,7 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".diskindex.field_index");
 
+using search::index::BitVectorDictionaryLookupResult;
 using search::index::DictionaryLookupResult;
 using search::index::PostingListHandle;
 
@@ -45,13 +47,15 @@ FieldIndex::FieldIndex()
       _file_id(0),
       _size_on_disk(0),
       _cache_disk_io_stats(std::make_shared<LockedCacheDiskIoStats>()),
-      _posting_list_cache()
+      _posting_list_cache(),
+      _field_id(0)
 {
 }
 
-FieldIndex::FieldIndex(std::shared_ptr<IPostingListCache> posting_list_cache)
+FieldIndex::FieldIndex(uint32_t field_id, std::shared_ptr<IPostingListCache> posting_list_cache)
     : FieldIndex()
 {
+    _field_id = field_id;
     _posting_list_cache = std::move(posting_list_cache);
 }
 
@@ -203,8 +207,8 @@ FieldIndex::read_posting_list(const DictionaryLookupResult& lookup_result) const
     return result;
 }
 
-std::unique_ptr<BitVector>
-FieldIndex::read_bit_vector(const DictionaryLookupResult& lookup_result) const
+BitVectorDictionaryLookupResult
+FieldIndex::lookup_bit_vector(const DictionaryLookupResult& lookup_result) const
 {
     if (!_bit_vector_dict) {
         return {};
@@ -212,8 +216,17 @@ FieldIndex::read_bit_vector(const DictionaryLookupResult& lookup_result) const
     return _bit_vector_dict->lookup(lookup_result.wordNum);
 }
 
+std::unique_ptr<BitVector>
+FieldIndex::read_bit_vector(BitVectorDictionaryLookupResult lookup_result) const
+{
+    if (!_bit_vector_dict) {
+        return {};
+    }
+    return _bit_vector_dict->read_bitvector(lookup_result);
+}
+
 std::unique_ptr<search::queryeval::SearchIterator>
-FieldIndex::create_iterator(const search::index::DictionaryLookupResult& lookup_result,
+FieldIndex::create_iterator(const DictionaryLookupResult& lookup_result,
                             const index::PostingListHandle& handle,
                             const search::fef::TermFieldMatchDataArray& tfmda) const
 {

--- a/searchlib/src/vespa/searchlib/diskindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/field_index.cpp
@@ -210,7 +210,7 @@ FieldIndex::read_posting_list(const DictionaryLookupResult& lookup_result) const
 BitVectorDictionaryLookupResult
 FieldIndex::lookup_bit_vector(const DictionaryLookupResult& lookup_result) const
 {
-    if (!_bit_vector_dict) {
+    if (!_bit_vector_dict || !lookup_result.valid()) {
         return {};
     }
     return _bit_vector_dict->lookup(lookup_result.wordNum);

--- a/searchlib/src/vespa/searchlib/index/bitvector_dictionary_lookup_result.h
+++ b/searchlib/src/vespa/searchlib/index/bitvector_dictionary_lookup_result.h
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace search::index {
+
+/**
+ * The result after performing a disk bitvector dictionary lookup.
+ **/
+class BitVectorDictionaryLookupResult {
+public:
+    static constexpr uint32_t invalid = std::numeric_limits<uint32_t>::max();
+    uint64_t idx;
+
+    explicit BitVectorDictionaryLookupResult(uint32_t idx_in) noexcept
+        : idx(idx_in)
+    {
+    }
+    BitVectorDictionaryLookupResult() noexcept
+        : BitVectorDictionaryLookupResult(invalid)
+    {
+    }
+    bool valid() const noexcept { return idx != invalid; }
+};
+
+}


### PR DESCRIPTION
Reduce proxying from DiskIndex to FieldIndex.

@geirst : please review
