### PR TITLE
Deinline frequency sketch counter division

### DIFF
--- a/vespalib/src/vespa/vespalib/util/relative_frequency_sketch.h
+++ b/vespalib/src/vespa/vespalib/util/relative_frequency_sketch.h
@@ -72,7 +72,7 @@ public:
 
     [[nodiscard]] size_t window_size() const noexcept { return _window_size; }
 private:
-    void div_all_by_2() noexcept;
+    void div_all_by_2() noexcept __attribute__((noinline));
 
     template <bool ReturnMinCount>
     uint8_t add_by_hash_impl(uint64_t hash) noexcept;


### PR DESCRIPTION
@havardpe please review. At least GCC on ARM64 thinks this is a neat thing to inline, while I don't particularly. Presumably because the NEON-vectorized inner loop is quite a bit more terse than the equivalent x64 AVX2 code.

This by definition happens very rarely relative to how often the caller is invoked, so don't inline it.

