### PR TITLE
Don't log warning when no master cluster-controller and when request times out in cluster-controller 

### DIFF
--- a/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/server/RestApiHandler.java
+++ b/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/server/RestApiHandler.java
@@ -106,13 +106,13 @@ public class RestApiHandler implements HttpRequestHandler {
             result.setJson(jsonWriter.createErrorJson(exception.getMessage()));
             return result;
         } catch (UnknownMasterException exception) {
-            logRequestException(request, exception, Level.WARNING);
+            logRequestException(request, exception, Level.INFO);
             JsonHttpResult result = new JsonHttpResult();
             result.setHttpCode(503, "Service Unavailable");
             result.setJson(jsonWriter.createErrorJson(exception.getMessage()));
             return result;
         } catch (DeadlineExceededException | UncheckedTimeoutException exception) {
-            logRequestException(request, exception, Level.WARNING);
+            logRequestException(request, exception, Level.INFO);
             JsonHttpResult result = new JsonHttpResult();
             result.setHttpCode(504, "Gateway Timeout");
             result.setJson(jsonWriter.createErrorJson(exception.getMessage()));


### PR DESCRIPTION
I don't think anyone looks at the log for this, metrics and/or http response from this are more important, so this is mostly removing noise.
