### PR TITLE
Support building a supplied vespa version first when building config models

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -249,6 +249,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
             PrepareParams.Builder params = new PrepareParams.Builder()
                     .applicationId(session.getApplicationId())
                     .vespaVersion(session.getVespaVersion().toString())
+                    .vespaVersionToBuildFirst(session.getVersionToBuildFirst())
                     .timeoutBudget(timeoutBudget)
                     .ignoreValidationErrors(ignoreValidationErrors)
                     .isBootstrap(isBootstrap)

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -19,7 +19,6 @@ import com.yahoo.config.model.api.ModelFactory;
 import com.yahoo.config.model.api.OnnxModelCost;
 import com.yahoo.config.model.api.Provisioned;
 import com.yahoo.config.model.api.ValidationParameters;
-import com.yahoo.config.model.api.ValidationParameters.IgnoreValidationErrors;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.AllocatedHosts;
@@ -49,6 +48,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.yahoo.config.model.api.ValidationParameters.IgnoreValidationErrors.FALSE;
+import static com.yahoo.config.model.api.ValidationParameters.IgnoreValidationErrors.TRUE;
 import static com.yahoo.yolean.Exceptions.toMessageString;
 import static java.util.logging.Level.FINE;
 
@@ -142,9 +143,8 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
                                                      ModelContext modelContext) {
         log.log(FINE, () -> "Create and validate model " + modelVersion + " for " + applicationId +
                 ", previous model " + (modelOf(modelVersion).isPresent() ? " exists" : "does not exist"));
-        ValidationParameters validationParameters =
-                new ValidationParameters(params.ignoreValidationErrors() ? IgnoreValidationErrors.TRUE : IgnoreValidationErrors.FALSE);
-        ModelCreateResult result = modelFactory.createAndValidateModel(modelContext, validationParameters);
+        var validationParameters = new ValidationParameters(params.ignoreValidationErrors() ? TRUE : FALSE);
+        var result = modelFactory.createAndValidateModel(modelContext, validationParameters);
         validateModelHosts(hostValidator, applicationId, result.getModel());
         log.log(FINE, () -> "Done building model " + modelVersion + " for " + applicationId);
         params.getTimeoutBudget().assertNotTimedOut(() -> "prepare timed out after building model " + modelVersion +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
@@ -132,6 +132,8 @@ public abstract class Session implements Comparable<Session>  {
 
     public Version getVespaVersion() { return sessionZooKeeperClient.readVespaVersion(); }
 
+    public Optional<Version> getVersionToBuildFirst() { return sessionZooKeeperClient.readVersionToBuildFirst(); }
+
     public Optional<AthenzDomain> getAthenzDomain() { return sessionZooKeeperClient.readAthenzDomain(); }
 
     public Optional<Quota> getQuota() { return sessionZooKeeperClient.readQuota(); }
@@ -194,7 +196,7 @@ public abstract class Session implements Comparable<Session>  {
         return getApplicationPackage().getFile(relativePath);
     }
 
-    Optional<ApplicationVersions> applicationVersions() { return Optional.empty(); }
+    public Optional<ApplicationVersions> applicationVersions() { return Optional.empty(); }
 
     private void markSessionEdited() {
         setStatus(Session.Status.NEW);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionData.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionData.java
@@ -36,6 +36,7 @@ import static com.yahoo.slime.SlimeUtils.optionalString;
 public record SessionData(ApplicationId applicationId,
                           Optional<FileReference> applicationPackageReference,
                           Version version,
+                          Optional<Version> versionToBuildFirst,
                           Instant created,
                           Optional<DockerImage> dockerImageRepository,
                           Optional<AthenzDomain> athenzDomain,
@@ -51,6 +52,7 @@ public record SessionData(ApplicationId applicationId,
     static final String APPLICATION_ID_PATH = "applicationId";
     static final String APPLICATION_PACKAGE_REFERENCE_PATH = "applicationPackageReference";
     static final String VERSION_PATH = "version";
+    static final String VERSION_TO_BUILD_FIRST_PATH = "versionToBuildFirst";
     static final String CREATE_TIME_PATH = "createTime";
     static final String DOCKER_IMAGE_REPOSITORY_PATH = "dockerImageRepository";
     static final String ATHENZ_DOMAIN = "athenzDomain";
@@ -78,6 +80,7 @@ public record SessionData(ApplicationId applicationId,
         object.setString(APPLICATION_ID_PATH, applicationId.serializedForm());
         applicationPackageReference.ifPresent(ref -> object.setString(APPLICATION_PACKAGE_REFERENCE_PATH, ref.value()));
         object.setString(VERSION_PATH, version.toString());
+        versionToBuildFirst.ifPresent(v -> object.setString(VERSION_TO_BUILD_FIRST_PATH, v.toString()));
         object.setLong(CREATE_TIME_PATH, created.toEpochMilli());
         dockerImageRepository.ifPresent(image -> object.setString(DOCKER_IMAGE_REPOSITORY_PATH, image.asString()));
         athenzDomain.ifPresent(domain -> object.setString(ATHENZ_DOMAIN, domain.value()));
@@ -105,6 +108,9 @@ public record SessionData(ApplicationId applicationId,
         return new SessionData(ApplicationId.fromSerializedForm(cursor.field(APPLICATION_ID_PATH).asString()),
                                optionalString(cursor.field(APPLICATION_PACKAGE_REFERENCE_PATH)).map(FileReference::new),
                                Version.fromString(cursor.field(VERSION_PATH).asString()),
+                               SlimeUtils.isPresent(cursor.field(VERSION_TO_BUILD_FIRST_PATH))
+                                       ? Optional.of(Version.fromString(cursor.field(VERSION_TO_BUILD_FIRST_PATH).asString()))
+                                       : Optional.empty(),
                                Instant.ofEpochMilli(cursor.field(CREATE_TIME_PATH).asLong()),
                                optionalString(cursor.field(DOCKER_IMAGE_REPOSITORY_PATH)).map(DockerImage::fromString),
                                optionalString(cursor.field(ATHENZ_DOMAIN)).map(AthenzDomain::from),

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -178,6 +178,8 @@ public class SessionPreparer {
 
         /** The version of Vespa the application to be prepared specifies for its nodes */
         final Version vespaVersion;
+        /** The version of Vespa to build first when there are several config models, empty if latest version should be built first */
+        final Optional<Version> vespaVersionToBuildFirst;
 
         final ContainerEndpointsCache containerEndpointsCache;
         final List<ContainerEndpoint> containerEndpoints;
@@ -206,6 +208,7 @@ public class SessionPreparer {
             this.applicationId = params.getApplicationId();
             this.dockerImageRepository = params.dockerImageRepository();
             this.vespaVersion = params.vespaVersion().orElse(Vtag.currentVersion);
+            this.vespaVersionToBuildFirst = params.vespaVersionToBuildFirst();
             this.containerEndpointsCache = new ContainerEndpointsCache(tenantPath, curator);
             this.endpointCertificateMetadataStore = new EndpointCertificateMetadataStore(curator, tenantPath);
             EndpointCertificateRetriever endpointCertificateRetriever = new EndpointCertificateRetriever(endpointCertificateSecretStores);
@@ -337,7 +340,8 @@ public class SessionPreparer {
         AllocatedHosts buildModels(Instant now) {
             var allocatedHosts = new AllocatedHostsFromAllModels();
             this.modelResultList = preparedModelsBuilder.buildModels(applicationId, dockerImageRepository, vespaVersion,
-                                                                     preprocessedApplicationPackage, allocatedHosts, now);
+                                                                     vespaVersionToBuildFirst, preprocessedApplicationPackage,
+                                                                     allocatedHosts, now);
             checkTimeout("build models");
             return allocatedHosts.toAllocatedHosts();
         }
@@ -357,6 +361,7 @@ public class SessionPreparer {
                                   Optional.of(filereference),
                                   dockerImageRepository,
                                   vespaVersion,
+                                  vespaVersionToBuildFirst,
                                   logger,
                                   prepareResult.getFileRegistries(),
                                   prepareResult.allocatedHosts(),
@@ -402,6 +407,7 @@ public class SessionPreparer {
                                        Optional<FileReference> fileReference,
                                        Optional<DockerImage> dockerImageRepository,
                                        Version vespaVersion,
+                                       Optional<Version> versionToBuildFirst,
                                        DeployLogger deployLogger,
                                        Map<Version, FileRegistry> fileRegistryMap,
                                        AllocatedHosts allocatedHosts,
@@ -422,6 +428,7 @@ public class SessionPreparer {
                                           fileReference,
                                           dockerImageRepository,
                                           vespaVersion,
+                                          versionToBuildFirst,
                                           athenzDomain,
                                           quota,
                                           tenantVaults,

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -547,6 +547,7 @@ public class SessionRepository {
         return ApplicationVersions.fromList(builder.buildModels(session.getApplicationId(),
                                                                 session.getDockerImageRepository(),
                                                                 session.getVespaVersion(),
+                                                                session.getVersionToBuildFirst(),
                                                                 sessionZooKeeperClient.loadApplicationPackage(),
                                                                 new AllocatedHostsFromAllModels(),
                                                                 clock.instant()));
@@ -584,6 +585,7 @@ public class SessionRepository {
                                 existingSession.getApplicationPackageReference(),
                                 existingSession.getDockerImageRepository(),
                                 existingSession.getVespaVersion(),
+                                existingSession.getVersionToBuildFirst(),
                                 existingSession.getAthenzDomain(),
                                 existingSession.getQuota(),
                                 existingSession.getTenantVaults(),

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionSerializer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionSerializer.java
@@ -32,7 +32,8 @@ public class SessionSerializer {
 
     void write(SessionZooKeeperClient zooKeeperClient, ApplicationId applicationId,
                Instant created, Optional<FileReference> fileReference, Optional<DockerImage> dockerImageRepository,
-               Version vespaVersion, Optional<AthenzDomain> athenzDomain, Optional<Quota> quota,
+               Version vespaVersion, Optional<Version> versionToBuildFirst,
+               Optional<AthenzDomain> athenzDomain, Optional<Quota> quota,
                List<TenantVault> tenantVaults, List<TenantSecretStore> tenantSecretStores,
                List<X509Certificate> operatorCertificates, Optional<CloudAccount> cloudAccount,
                List<DataplaneToken> dataplaneTokens, ActivationTriggers activationTriggers,
@@ -40,6 +41,7 @@ public class SessionSerializer {
         zooKeeperClient.writeApplicationId(applicationId);
         zooKeeperClient.writeApplicationPackageReference(fileReference);
         zooKeeperClient.writeVespaVersion(vespaVersion);
+        zooKeeperClient.writeVersionToBuildFirst(versionToBuildFirst);
         zooKeeperClient.writeDockerImageRepository(dockerImageRepository);
         zooKeeperClient.writeAthenzDomain(athenzDomain);
         zooKeeperClient.writeQuota(quota);
@@ -53,6 +55,7 @@ public class SessionSerializer {
             zooKeeperClient.writeSessionData(new SessionData(applicationId,
                                                              fileReference,
                                                              vespaVersion,
+                                                             versionToBuildFirst,
                                                              created,
                                                              dockerImageRepository,
                                                              athenzDomain,
@@ -81,6 +84,7 @@ public class SessionSerializer {
         return new SessionData(zooKeeperClient.readApplicationId(),
                                zooKeeperClient.readApplicationPackageReference(),
                                zooKeeperClient.readVespaVersion(),
+                               zooKeeperClient.readVersionToBuildFirst(),
                                zooKeeperClient.readCreateTime(),
                                zooKeeperClient.readDockerImageRepository(),
                                zooKeeperClient.readAthenzDomain(),

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.session;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.model.api.ApplicationClusterEndpoint;
 import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.EndpointCertificateMetadata;
@@ -66,6 +67,7 @@ public class PrepareParamsTest {
         assertFalse(prepareParams.isVerbose());
         assertFalse(prepareParams.ignoreValidationErrors());
         assertTrue(prepareParams.vespaVersion().isEmpty());
+        assertTrue(prepareParams.vespaVersionToBuildFirst().isEmpty());
         assertTrue(prepareParams.getTimeoutBudget().hasTimeLeft());
         assertTrue(prepareParams.containerEndpoints().isEmpty());
         assertTrue(prepareParams.cloudAccount().isEmpty());
@@ -229,6 +231,13 @@ public class PrepareParamsTest {
         assertEquals(CloudAccount.from("012345678912"), params.cloudAccount().get());
     }
 
+    @Test
+    public void testFirstVespaVersionToBuild() {
+        String json = "{\"vespaVersionToBuildFirst\": \"8.3.0\"}";
+        PrepareParams params = PrepareParams.fromJson(json.getBytes(StandardCharsets.UTF_8), TenantName.defaultName(), Duration.ZERO);
+        assertEquals(Version.fromString("8.3.0"), params.vespaVersionToBuildFirst().get());
+    }
+
     private void assertPrepareParamsEqual(PrepareParams urlParams, PrepareParams jsonParams) {
         assertEquals(urlParams.ignoreValidationErrors(), jsonParams.ignoreValidationErrors());
         assertEquals(urlParams.isDryRun(), jsonParams.isDryRun());
@@ -239,6 +248,7 @@ public class PrepareParamsTest {
         assertEquals(urlParams.getApplicationId(), jsonParams.getApplicationId());
         assertEquals(urlParams.getTimeoutBudget().timeout(), jsonParams.getTimeoutBudget().timeout());
         assertEquals(urlParams.vespaVersion(), jsonParams.vespaVersion());
+        assertEquals(urlParams.vespaVersionToBuildFirst(), jsonParams.vespaVersionToBuildFirst());
         assertEquals(urlParams.containerEndpoints(), jsonParams.containerEndpoints());
         assertEquals(urlParams.endpointCertificateMetadata(), jsonParams.endpointCertificateMetadata());
         assertEquals(urlParams.dockerImageRepository(), jsonParams.dockerImageRepository());

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClientTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClientTest.java
@@ -180,6 +180,7 @@ public class SessionZooKeeperClientTest {
         zkc.writeSessionData(new SessionData(ApplicationId.defaultId(),
                                              Optional.of(new FileReference("foo")),
                                              Version.fromString("8.195.1"),
+                                             Optional.empty(),
                                              Instant.now(),
                                              Optional.empty(),
                                              Optional.empty(),


### PR DESCRIPTION
To support building only specified version, e.g. when an application is
pinned to an older version because the latest one has a config model change
that prevents it from working.