### PR TITLE
Revert "Log warning (shown in console) when using admin version 2.0 on cloud"

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
+++ b/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
@@ -78,7 +78,9 @@ public class AdminModel extends ConfigModel {
 
         @Override
         public void doBuild(AdminModel model, Element adminElement, ConfigModelContext modelContext) {
-            if (modelContext.getDeployState().isHosted()) { // admin v4 is used on hosted: Build a default V4 instead
+            // admin v4 is used on hosted: Build a default V4 instead. We want to allow version 2.0 so
+            // that self-hosted apps deploy without changes. TODO: Warn if tags from version 2.0 are used (and ignored)
+            if (modelContext.getDeployState().isHosted()) {
                 new BuilderV4().doBuild(model, adminElement, modelContext);
                 return;
             }

--- a/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
+++ b/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
@@ -20,8 +20,7 @@ import org.w3c.dom.Element;
 
 import java.util.Collection;
 import java.util.List;
-
-import static java.util.logging.Level.WARNING;
+import java.util.logging.Level;
 
 /**
  * Config model adaptor of the Admin class.
@@ -79,10 +78,7 @@ public class AdminModel extends ConfigModel {
 
         @Override
         public void doBuild(AdminModel model, Element adminElement, ConfigModelContext modelContext) {
-            // admin v4 is used on hosted: Build a default V4 instead
-            if (modelContext.getDeployState().isHosted()) {
-                modelContext.getDeployLogger().logApplicationPackage(WARNING, "<admin> version 2.0 is deprecated" +
-                        " and will be ignored, please use <admin> version 4.0 instead");
+            if (modelContext.getDeployState().isHosted()) { // admin v4 is used on hosted: Build a default V4 instead
                 new BuilderV4().doBuild(model, adminElement, modelContext);
                 return;
             }
@@ -118,7 +114,7 @@ public class AdminModel extends ConfigModel {
             // TODO: Remove in Vespa 9
             if ("3.0".equals(adminElement.getAttribute("version")))
                 modelContext.getDeployState().getDeployLogger()
-                            .logApplicationPackage(WARNING, "admin model version 3.0 is deprecated and support will removed in Vespa 9, " +
+                            .logApplicationPackage(Level.WARNING, "admin model version 3.0 is deprecated and support will removed in Vespa 9, " +
                                     "please use version 4.0 or remove the element completely. See https://cloud.vespa.ai/en/reference/services#ignored-elements");
 
             TreeConfigProducer<AnyConfigProducer> parent = modelContext.getParentProducer();


### PR DESCRIPTION
Reverts vespa-engine/vespa#32872

Reverting, based on offline discussion, we want self-hosted apps to deploy on cloud without warning where possible. We want to warn instead if tags that only are valid for version 2.0 are used (work coming in a later PR)