### PR TITLE
Revert "add progress reporting when rebuilding HNSW index"

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute_loader.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute_loader.cpp
@@ -13,12 +13,10 @@
 #include <vespa/searchlib/attribute/load_utils.h>
 #include <vespa/searchlib/attribute/readerbase.h>
 #include <vespa/searchlib/util/disk_space_calculator.h>
-#include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/arrayqueue.hpp>
 #include <vespa/vespalib/util/cpu_usage.h>
-#include <vespa/vespalib/util/jsonwriter.h>
 #include <vespa/vespalib/util/lambdatask.h>
-#include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/objects/nbostream.h>
 #include <condition_variable>
 #include <filesystem>
 #include <mutex>
@@ -43,15 +41,12 @@ bool
 can_use_index_save_file(const search::attribute::Config &config, const AttributeHeader& header)
 {
     if (!config.hnsw_index_params().has_value() || !header.get_hnsw_index_params().has_value()) {
-        LOG(warning, "Cannot use saved HNSW index for ANN, missing index parameters");
         return false;
     }
     const auto &config_params = config.hnsw_index_params().value();
     const auto &header_params = header.get_hnsw_index_params().value();
     if ((config_params.max_links_per_node() != header_params.max_links_per_node()) ||
-        (config_params.distance_metric() != header_params.distance_metric()))
-    {
-        LOG(warning, "Cannot use saved HNSW index for ANN, index parameters have changed");
+        (config_params.distance_metric() != header_params.distance_metric())) {
         return false;
     }
     return true;
@@ -263,28 +258,16 @@ TensorAttributeLoader::build_index(vespalib::Executor* executor, uint32_t docid_
     std::unique_ptr<IndexBuilder> builder;
     if (executor != nullptr) {
         builder = std::make_unique<ThreadedIndexBuilder>(_attr, _generation_handler, _store, *_index, *executor);
-        log_event("hnsw.index.rebuild.start", "execution", "multi-threaded");
     } else {
         builder = std::make_unique<ForegroundIndexBuilder>(_attr, *_index);
-        log_event("hnsw.index.rebuild.start", "execution", "single-threaded");
     }
-    constexpr vespalib::duration report_interval = 60s;
-    auto beforeStamp = vespalib::steady_clock::now();
-    auto last_report = beforeStamp;
     for (uint32_t lid = 0; lid < docid_limit; ++lid) {
         auto ref = _ref_vector[lid].load_relaxed();
         if (ref.valid()) {
             builder->add(lid);
-            auto now = vespalib::steady_clock::now();
-            if (last_report + report_interval < now) {
-                log_event("hnsw.index.rebuild.progress", "percent", (lid * 100.0 / docid_limit));
-                last_report = now;
-            }
         }
     }
     builder->wait_complete();
-    vespalib::duration elapsedTime = vespalib::steady_clock::now() - beforeStamp;
-    log_event("hnsw.index.rebuild.complete", "time.elapsed.ms", vespalib::count_ms(elapsedTime));
     _attr.commit();
 }
 
@@ -374,37 +357,4 @@ TensorAttributeLoader::check_consistency(uint32_t docid_limit)
         inconsistencies, _attr.getName().c_str(), elapsed);
 }
 
-
-namespace {
-struct EventValue {
-    vespalib::JSONStringer jstr;
-    EventValue(const TensorAttribute& attr) : jstr() {
-        jstr.beginObject();
-        jstr.appendKey("name").appendString(attr.getName());
-    }
-    void addKV(const char* key, const char* value) { jstr.appendKey(key).appendString(value); }
-    void addKV(const char* key, double value) { jstr.appendKey(key).appendDouble(value); }
-    const char* message() {
-        jstr.endObject();
-        return jstr.str().c_str();
-     }
-};
-} // namespace
-
-void TensorAttributeLoader::log_event(const char* eventName) {
-    EV_STATE(eventName, EventValue(_attr).message());
 }
-
-void TensorAttributeLoader::log_event(const char* eventName, const char* key, const char* value) {
-    EventValue ev(_attr);
-    ev.addKV(key, value);
-    EV_STATE(eventName, ev.message());
-}
-
-void TensorAttributeLoader::log_event(const char* eventName, const char* key, double value) {
-    EventValue ev(_attr);
-    ev.addKV(key, value);
-    EV_STATE(eventName, ev.message());
-}
-
-} // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute_loader.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute_loader.h
@@ -36,9 +36,6 @@ class TensorAttributeLoader {
     bool load_index();
     uint64_t get_index_size_on_disk();
     void check_consistency(uint32_t docid_limit);
-    void log_event(const char *eventName);
-    void log_event(const char *eventName, const char *key, const char *value);
-    void log_event(const char *eventName, const char *key, double value);
 
 public:
     TensorAttributeLoader(TensorAttribute& attr, GenerationHandler& generation_handler, RefVector& ref_vector, TensorStore& store, NearestNeighborIndex* index);
@@ -47,3 +44,4 @@ public:
 };
 
 }
+


### PR DESCRIPTION
Reverts vespa-engine/vespa#32886

@arnej27959 : please review

```
 RUN      ] TensorAttributeTest.onLoad_reconstructs_nearest_neighbor_index_if_save_file_does_not_exists
==37119== Invalid read of size 1
==37119==    at 0x4C421E6: strlen (vg_replace_strmem.c:502)
==37119==    by 0x1420029C: vfprintf (vfprintf.c:1599)
==37119==    by 0x142269C3: vsnprintf (vsnprintf.c:114)
==37119==    by 0x1192B9D4: ns_log::Logger::tryLog(int, ns_log::Logger::LogLevel, char const*, int, char const*, __va_list_tag*) (log.cpp:220)
==37119==    by 0x1192BAFA: ns_log::Logger::doLog(ns_log::Logger::LogLevel, char const*, int, char const*, ...) (log.cpp:238)
==37119==    by 0x1192C3E7: ns_log::Logger::doEventState(char const*, char const*) (log.cpp:391)
==37119==    by 0x5AF8212: search::tensor::TensorAttributeLoader::log_event(char const*, char const*, char const*) (tensor_attribute_loader.cpp:401)
==37119==    by 0x5AF8596: search::tensor::TensorAttributeLoader::build_index(vespalib::Executor*, unsigned int) (tensor_attribute_loader.cpp:269)
==37119==    by 0x5AF9619: search::tensor::TensorAttributeLoader::on_load(vespalib::Executor*) (tensor_attribute_loader.cpp:360)
==37119==    by 0x5AF6373: search::tensor::TensorAttribute::onLoad(vespalib::Executor*) (tensor_attribute.cpp:352)
==37119==    by 0x54A9FC1: search::AttributeVector::load(vespalib::Executor*) (attributevector.cpp:357)
==37119==    by 0x442E52: Fixture::load() (tensorattribute_test.cpp:603)
==37119==  Address 0x176bbea0 is 0 bytes inside a block of size 49 free'd
==37119==    at 0x4C3D2F8: operator delete(void*, unsigned long) (vg_replace_malloc.c:1101)
==37119==    by 0x5AF8200: deallocate (new_allocator.h:172)
==37119==    by 0x5AF8200: deallocate (allocator.h:210)
==37119==    by 0x5AF8200: deallocate (alloc_traits.h:517)
==37119==    by 0x5AF8200: _M_destroy (basic_string.h:289)
==37119==    by 0x5AF8200: _M_dispose (basic_string.h:283)
==37119==    by 0x5AF8200: ~basic_string (basic_string.h:804)
==37119==    by 0x5AF8200: message (tensor_attribute_loader.cpp:389)
==37119==    by 0x5AF8200: search::tensor::TensorAttributeLoader::log_event(char const*, char const*, char const*) (tensor_attribute_loader.cpp:401)
==37119==    by 0x5AF8596: search::tensor::TensorAttributeLoader::build_index(vespalib::Executor*, unsigned int) (tensor_attribute_loader.cpp:269)
==37119==    by 0x5AF9619: search::tensor::TensorAttributeLoader::on_load(vespalib::Executor*) (tensor_attribute_loader.cpp:360)
==37119==    by 0x5AF6373: search::tensor::TensorAttribute::onLoad(vespalib::Executor*) (tensor_attribute.cpp:352)
==37119==    by 0x54A9FC1: search::AttributeVector::load(vespalib::Executor*) (attributevector.cpp:357)
==37119==    by 0x442E52: Fixture::load() (tensorattribute_test.cpp:603)
==37119==    by 0x42D4F9: TensorAttributeTest_onLoad_reconstructs_nearest_neighbor_index_if_save_file_does_not_exists_Test::TestBody() (tensorattribute_test.cpp:1327)
==37119==    by 0x4096A9E: HandleSehExceptionsInMethodIfSupported<testing::Test, void> (gtest.cc:2612)
==37119==    by 0x4096A9E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2648)
==37119==    by 0x4084555: Run (gtest.cc:2687)
==37119==    by 0x4084555: testing::Test::Run() (gtest.cc:2677)
==37119==    by 0x4084714: testing::TestInfo::Run() (gtest.cc:2836)
==37119==    by 0x40848FE: Run (gtest.cc:3015)
==37119==    by 0x40848FE: testing::TestSuite::Run() (gtest.cc:2968)

```