### PR TITLE
Implement Segmented LRU (SLRU) caching

### DIFF
--- a/messagebus/src/vespa/messagebus/network/rpcservicepool.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcservicepool.cpp
@@ -26,7 +26,10 @@ RPCServicePool::resolve(const string &pattern)
     {
         LockGuard guard(_lock);
         handleMirrorUpdates(guard);
-        std::shared_ptr<RPCService> *found = _lru->findAndRef(pattern);
+        // The address pool has a capacity of 4K and is likely to contain many fewer elements
+        // than this; use lazy findAndRef which only updates the LRU if the cache is more than
+        // 50% full. Prevents LRU reordering in the common case.
+        std::shared_ptr<RPCService> *found = _lru->find_and_lazy_ref(pattern);
         if (found) {
             service = *found;
         }

--- a/searchlib/src/tests/diskindex/posting_list_cache/posting_list_cache_test.cpp
+++ b/searchlib/src/tests/diskindex/posting_list_cache/posting_list_cache_test.cpp
@@ -97,7 +97,7 @@ TEST_F(PostingListCacheTest, repeated_lookups_gives_hit)
     EXPECT_EQ(PostingListCache::element_size() + 24, stats.memory_used);
 }
 
-TEST_F(PostingListCacheTest, large_elements_kills_cache_on_next_read)
+TEST_F(PostingListCacheTest, large_elements_immediately_evicts_from_cache)
 {
     _key.bit_length = 24 * 8;
     (void) read();
@@ -107,10 +107,10 @@ TEST_F(PostingListCacheTest, large_elements_kills_cache_on_next_read)
     EXPECT_EQ(2, stats.elements);
     _key.bit_length = 512_Ki * 8;
     _key.bit_offset = 16_Ki;
-    auto handle = read(); // stats for memory usage updated after eviction check => no eviction
+    auto handle = read(); // stats for memory usage updated before eviction check => eviction
     EXPECT_EQ(512_Ki, handle._allocSize);
     stats = _cache.get_stats();
-    EXPECT_EQ(3, stats.elements);
+    EXPECT_EQ(1, stats.elements);
     EXPECT_LT(512_Ki, stats.memory_used);
     _key.bit_length = 25 * 8;
     _key.bit_offset = 2000;

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -658,10 +658,12 @@ TEST_F(LogDataStoreTest, Control_static_memory_usage)
     VisitCacheStore vcs(DocumentStore::Config::UpdateStrategy::UPDATE);
     IDocumentStore &ds = vcs.getStore();
     vespalib::MemoryUsage usage = ds.getMemoryUsage();
+    // FIXME this is very, very implementation-specific... :I
     constexpr size_t mutex_size = sizeof(std::mutex) * 2 * (113 + 1); // sizeof(std::mutex) is platform dependent
     constexpr size_t string_size = sizeof(std::string);
-    EXPECT_EQ(74476 + mutex_size + 3 * string_size, usage.allocatedBytes());
-    EXPECT_EQ(752u + mutex_size + 3 * string_size, usage.usedBytes());
+    constexpr size_t lru_segment_overhead = 304;
+    EXPECT_EQ(74476 + mutex_size + 3 * string_size + lru_segment_overhead, usage.allocatedBytes());
+    EXPECT_EQ(752u + mutex_size + 3 * string_size + lru_segment_overhead, usage.usedBytes());
 }
 
 TEST_F(LogDataStoreTest, test_the_update_cache_strategy)

--- a/searchlib/src/vespa/searchlib/docstore/value.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/value.cpp
@@ -28,6 +28,7 @@ Value::Value(uint64_t syncToken)
 {}
 
 Value::Value(const Value &rhs) = default;
+Value& Value::operator=(const Value&) = default;
 
 Value::~Value() = default;
 

--- a/searchlib/src/vespa/searchlib/docstore/value.h
+++ b/searchlib/src/vespa/searchlib/docstore/value.h
@@ -25,6 +25,7 @@ public:
     Value &operator=(Value &&rhs) = default;
 
     Value(const Value &rhs);
+    Value& operator=(const Value&);
     ~Value();
 
     uint64_t getSyncToken() const { return _syncToken; }

--- a/vespalib/src/tests/stllike/CMakeLists.txt
+++ b/vespalib/src/tests/stllike/CMakeLists.txt
@@ -68,5 +68,6 @@ vespa_add_executable(vespalib_cache_test_app TEST
     cache_test.cpp
     DEPENDS
     vespalib
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_cache_test_app COMMAND vespalib_cache_test_app)

--- a/vespalib/src/tests/stllike/cache_test.cpp
+++ b/vespalib/src/tests/stllike/cache_test.cpp
@@ -447,8 +447,7 @@ TEST_F(SlruCacheTest, assigning_zero_capacity_of_protected_segment_evicts_all_se
     EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 0, 90));
 }
 
-// FIXME LRU must be LRU first!
-TEST_F(SlruCacheTest, DISABLED_accessing_element_in_protected_segment_moves_to_segment_head) {
+TEST_F(SlruCacheTest, accessing_element_in_protected_segment_moves_to_segment_head) {
     cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, -1, -1);
     cache.write(1, "a");
     cache.write(2, "b");

--- a/vespalib/src/tests/stllike/cache_test.cpp
+++ b/vespalib/src/tests/stllike/cache_test.cpp
@@ -1,22 +1,22 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/stllike/small_string.h>
 #include <vespa/vespalib/stllike/cache.hpp>
+#include <vespa/vespalib/gtest/gtest.h>
 #include <map>
 
 using namespace vespalib;
+using namespace ::testing;
 
-template<typename K, typename V>
+template <typename K, typename V>
 class Map : public std::map<K, V> {
-    using const_iterator = typename std::map<K, V>::const_iterator;
     using M = std::map<K, V>;
 public:
     mutable std::string _forwarded_arg;
 
     bool read(const K& k, V& v) const {
-        const_iterator found = M::find(k);
-        bool ok(found != this->end());
+        auto found = M::find(k);
+        bool ok = (found != this->end());
         if (ok) {
             v = found->second;
         }
@@ -26,10 +26,10 @@ public:
         _forwarded_arg = arg;
         return read(k, v);
     }
-    void write(const K & k, const V & v) {
+    void write(const K& k, const V& v) {
         (*this)[k] = v;
     }
-    void erase(const K & k) {
+    void erase(const K& k) {
         M::erase(k);
     }
 };
@@ -37,87 +37,84 @@ public:
 using P = LruParam<uint32_t, vespa_string>;
 using B = Map<uint32_t, vespa_string>;
 
-TEST("testCache") {
+struct CacheTest : Test {
     B m;
-    cache< CacheParam<P, B> > cache(m, -1);
-    // Verfify start conditions.
+};
+
+TEST_F(CacheTest, basic) {
+    cache<CacheParam<P, B>> cache(m, -1);
+    // Verify start conditions.
     EXPECT_TRUE(cache.size() == 0);
-    EXPECT_TRUE( ! cache.hasKey(1) );
+    EXPECT_TRUE(cache.empty());
+    EXPECT_FALSE(cache.hasKey(1));
     cache.write(1, "First inserted string");
-    EXPECT_TRUE( cache.hasKey(1) );
+    EXPECT_TRUE(cache.hasKey(1) );
     m[2] = "String inserted beneath";
-    EXPECT_TRUE( ! cache.hasKey(2) );
-    EXPECT_EQUAL( cache.read(2), "String inserted beneath");
-    EXPECT_TRUE( cache.hasKey(2) );
+    EXPECT_FALSE(cache.hasKey(2));
+    EXPECT_EQ(cache.read(2), "String inserted beneath");
+    EXPECT_TRUE(cache.hasKey(2));
     cache.erase(1);
-    EXPECT_TRUE( ! cache.hasKey(1) );
+    EXPECT_FALSE(cache.hasKey(1));
     EXPECT_TRUE(cache.size() == 1);
 }
 
-TEST("testCacheSize")
-{
-    B m;
-    cache< CacheParam<P, B> > cache(m, -1);
+TEST_F(CacheTest, cache_size) {
+    cache<CacheParam<P, B>> cache(m, -1);
     cache.write(1, "10 bytes string");
-    EXPECT_EQUAL(80u, cache.sizeBytes());
+    EXPECT_EQ(80u, cache.sizeBytes());
     cache.write(1, "10 bytes string"); // Still the same size
-    EXPECT_EQUAL(80u, cache.sizeBytes());
+    EXPECT_EQ(80u, cache.sizeBytes());
 }
 
-TEST("testCacheSizeDeep")
-{
-    B m;
-    cache< CacheParam<P, B, zero<uint32_t>, size<std::string> > > cache(m, -1);
+TEST_F(CacheTest, cache_size_deep) {
+    cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, -1);
     cache.write(1, "15 bytes string");
-    EXPECT_EQUAL(95u, cache.sizeBytes());
+    EXPECT_EQ(95u, cache.sizeBytes());
     cache.write(1, "10 bytes s");
-    EXPECT_EQUAL(90u, cache.sizeBytes());
+    EXPECT_EQ(90u, cache.sizeBytes());
     cache.write(1, "20 bytes string ssss");
-    EXPECT_EQUAL(100u, cache.sizeBytes());
+    EXPECT_EQ(100u, cache.sizeBytes());
 }
 
-TEST("testCacheEntriesHonoured") {
-    B m;
-    cache< CacheParam<P, B, zero<uint32_t>, size<std::string> > > cache(m, -1);
+TEST_F(CacheTest, max_elements_is_honored) {
+    cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, -1);
     cache.maxElements(1);
     cache.write(1, "15 bytes string");
-    EXPECT_EQUAL(1u, cache.size());
-    EXPECT_EQUAL(95u, cache.sizeBytes());
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_EQ(95u, cache.sizeBytes());
     cache.write(2, "16 bytes stringg");
-    EXPECT_EQUAL(1u, cache.size());
-    EXPECT_TRUE( cache.hasKey(2) );
-    EXPECT_FALSE( cache.hasKey(1) );
-    EXPECT_EQUAL(96u, cache.sizeBytes());
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_TRUE(cache.hasKey(2));
+    EXPECT_FALSE(cache.hasKey(1));
+    EXPECT_EQ(96u, cache.sizeBytes());
 }
 
-TEST("testCacheMaxSizeHonoured") {
-    B m;
-    cache< CacheParam<P, B, zero<uint32_t>, size<std::string> > > cache(m, 200);
+TEST_F(CacheTest, max_cache_size_is_honored) {
+    cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, 200);
     cache.write(1, "15 bytes string");
-    EXPECT_EQUAL(1u, cache.size());
-    EXPECT_EQUAL(95u, cache.sizeBytes());
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_EQ(95u, cache.sizeBytes());
     cache.write(2, "16 bytes stringg");
-    EXPECT_EQUAL(2u, cache.size());
-    EXPECT_EQUAL(191u, cache.sizeBytes());
+    EXPECT_EQ(2u, cache.size());
+    EXPECT_EQ(191u, cache.sizeBytes());
     cache.write(3, "17 bytes stringgg");
-    EXPECT_EQUAL(3u, cache.size());
-    EXPECT_EQUAL(288u, cache.sizeBytes());
+    EXPECT_EQ(3u, cache.size());
+    EXPECT_EQ(288u, cache.sizeBytes());
     cache.write(4, "18 bytes stringggg");
-    EXPECT_EQUAL(3u, cache.size());
-    EXPECT_EQUAL(291u, cache.sizeBytes());
+    EXPECT_EQ(3u, cache.size());
+    EXPECT_EQ(291u, cache.sizeBytes());
 }
 
-TEST("testThatMultipleRemoveOnOverflowIsFine") {
-    B m;
-    cache< CacheParam<P, B, zero<uint32_t>, size<std::string> > > cache(m, 2000);
+TEST_F(CacheTest, overflow_can_remove_multiple_elements) {
+    cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, 2000);
     
     for (size_t j(0); j < 5; j++) {
         for (size_t i(0); cache.size() == i; i++) {
             cache.write(j*53+i, "a");
         }
     }
-    EXPECT_EQUAL(25u, cache.size());
-    EXPECT_EQUAL(2025u, cache.sizeBytes());
+    EXPECT_EQ(25u, cache.size());
+    EXPECT_EQ(2025u, cache.sizeBytes());
     EXPECT_FALSE( cache.hasKey(0) );
     std::string ls("long string aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -127,92 +124,316 @@ TEST("testThatMultipleRemoveOnOverflowIsFine") {
               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     std::string vls=ls+ls+ls+ls+ls+ls;
     cache.write(53+5, ls);
-    EXPECT_EQUAL(25u, cache.size());
-    EXPECT_EQUAL(2498u, cache.sizeBytes());
-    EXPECT_FALSE( cache.hasKey(1) );
+    EXPECT_EQ(25u, cache.size());
+    EXPECT_EQ(2498u, cache.sizeBytes());
+    EXPECT_FALSE(cache.hasKey(1));
     cache.write(53*7+5, ls);
-    EXPECT_EQUAL(19u, cache.size());
-    EXPECT_EQUAL(2485u, cache.sizeBytes());
-    EXPECT_FALSE( cache.hasKey(2) );
+    EXPECT_EQ(19u, cache.size());
+    EXPECT_EQ(2485u, cache.sizeBytes());
+    EXPECT_FALSE(cache.hasKey(2));
     cache.write(53*8+5, vls);
-    EXPECT_EQUAL(14u, cache.size());
-    EXPECT_EQUAL(4923u, cache.sizeBytes());
+    EXPECT_EQ(14u, cache.size());
+    EXPECT_EQ(4923u, cache.sizeBytes());
     cache.write(53*9+6, vls);
-    EXPECT_EQUAL(1u, cache.size());
-    EXPECT_EQUAL(2924u, cache.sizeBytes());
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_EQ(2924u, cache.sizeBytes());
 }
 
-class ExtendedCache : public cache< CacheParam<P, B> > {
+class ExtendedCache : public cache<CacheParam<P, B>> {
 public:
-    ExtendedCache(BackingStore & b, size_t maxBytes)
-        : cache<CacheParam<P, B>>(b, maxBytes),
+    ExtendedCache(BackingStore& b, size_t maxBytes)
+        : cache(b, maxBytes),
           _insert_count(0),
           _remove_count(0)
     {}
     size_t _insert_count;
     size_t _remove_count;
 private:
-    void onRemove(const K &) override {
+    void onRemove(const K&) override {
         _remove_count++;
     }
 
-    void onInsert(const K &) override {
+    void onInsert(const K&) override {
         _insert_count++;
     }
 };
 
-TEST("testOnInsertonRemoveCalledWhenFull") {
-    B m;
+TEST_F(CacheTest, insert_and_remove_callbacks_invoked_when_full) {
     ExtendedCache cache(m, 200);
-    EXPECT_EQUAL(0u, cache._insert_count);
-    EXPECT_EQUAL(0u, cache._remove_count);
+    EXPECT_EQ(0u, cache._insert_count);
+    EXPECT_EQ(0u, cache._remove_count);
     cache.write(1, "15 bytes string");
-    EXPECT_EQUAL(1u, cache.size());
-    EXPECT_EQUAL(80u, cache.sizeBytes());
-    EXPECT_EQUAL(1u, cache._insert_count);
-    EXPECT_EQUAL(0u, cache._remove_count);
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_EQ(80u, cache.sizeBytes());
+    EXPECT_EQ(1u, cache._insert_count);
+    EXPECT_EQ(0u, cache._remove_count);
     cache.write(2, "16 bytes stringg");
-    EXPECT_EQUAL(2u, cache.size());
-    EXPECT_EQUAL(160u, cache.sizeBytes());
-    EXPECT_EQUAL(2u, cache._insert_count);
-    EXPECT_EQUAL(0u, cache._remove_count);
+    EXPECT_EQ(2u, cache.size());
+    EXPECT_EQ(160u, cache.sizeBytes());
+    EXPECT_EQ(2u, cache._insert_count);
+    EXPECT_EQ(0u, cache._remove_count);
     cache.write(3, "17 bytes stringgg");
-    EXPECT_EQUAL(3u, cache.size());
-    EXPECT_EQUAL(240u, cache.sizeBytes());
-    EXPECT_EQUAL(3u, cache._insert_count);
-    EXPECT_EQUAL(0u, cache._remove_count);
+    EXPECT_EQ(3u, cache.size());
+    EXPECT_EQ(240u, cache.sizeBytes());
+    EXPECT_EQ(3u, cache._insert_count);
+    EXPECT_EQ(0u, cache._remove_count);
     EXPECT_TRUE(cache.hasKey(1));
     cache.write(4, "18 bytes stringggg");
-    EXPECT_EQUAL(3u, cache.size());
-    EXPECT_EQUAL(240u, cache.sizeBytes());
-    EXPECT_EQUAL(4u, cache._insert_count);
-    EXPECT_EQUAL(1u, cache._remove_count);
+    EXPECT_EQ(3u, cache.size());
+    EXPECT_EQ(240u, cache.sizeBytes());
+    EXPECT_EQ(4u, cache._insert_count);
+    EXPECT_EQ(1u, cache._remove_count);
     EXPECT_FALSE(cache.hasKey(1));
     cache.invalidate(2);
-    EXPECT_EQUAL(2u, cache.size());
-    EXPECT_EQUAL(160u, cache.sizeBytes());
-    EXPECT_EQUAL(4u, cache._insert_count);
-    EXPECT_EQUAL(2u, cache._remove_count);
+    EXPECT_EQ(2u, cache.size());
+    EXPECT_EQ(160u, cache.sizeBytes());
+    EXPECT_EQ(4u, cache._insert_count);
+    EXPECT_EQ(2u, cache._remove_count);
     EXPECT_FALSE(cache.hasKey(2));
     cache.invalidate(3);
-    EXPECT_EQUAL(1u, cache.size());
-    EXPECT_EQUAL(80u, cache.sizeBytes());
-    EXPECT_EQUAL(4u, cache._insert_count);
-    EXPECT_EQUAL(3u, cache._remove_count);
+    EXPECT_EQ(1u, cache.size());
+    EXPECT_EQ(80u, cache.sizeBytes());
+    EXPECT_EQ(4u, cache._insert_count);
+    EXPECT_EQ(3u, cache._remove_count);
     EXPECT_FALSE(cache.hasKey(3));
 }
 
-TEST("Can forward arguments to backing store on cache miss") {
-    B m;
+TEST_F(CacheTest, can_forward_arguments_to_backing_store_on_cache_miss) {
     cache<CacheParam<P, B>> cache(m, -1);
     m[123] = "foo";
-    EXPECT_EQUAL(cache.read(123, "hello cache world"), "foo");
-    EXPECT_EQUAL(m._forwarded_arg, "hello cache world");
+    EXPECT_EQ(cache.read(123, "hello cache world"), "foo");
+    EXPECT_EQ(m._forwarded_arg, "hello cache world");
 
     // Already cached; no forwarding.
     m._forwarded_arg.clear();
-    EXPECT_EQUAL(cache.read(123, "goodbye cache moon"), "foo");
-    EXPECT_EQUAL(m._forwarded_arg, "");
+    EXPECT_EQ(cache.read(123, "goodbye cache moon"), "foo");
+    EXPECT_EQ(m._forwarded_arg, "");
 }
 
-TEST_MAIN() { TEST_RUN_ALL(); }
+TEST_F(CacheTest, fetching_element_moves_it_to_head_of_lru_list) {
+    cache<CacheParam<P, B>> cache(m, -1);
+    cache.maxElements(3);
+    cache.write(1, "foo");
+    cache.write(2, "bar");
+    cache.write(3, "baz");
+    EXPECT_EQ(cache.size(), 3);
+    // Cache now in LIFO order <3, 2, 1>. Bring 1 to the front.
+    EXPECT_EQ(cache.read(1), "foo");
+    // 2 is now last in line, evict it.
+    cache.write(4, "zoid");
+    EXPECT_EQ(cache.size(), 3);
+    EXPECT_FALSE(cache.hasKey(2));
+    EXPECT_TRUE(cache.hasKey(4));
+    EXPECT_TRUE(cache.hasKey(1));
+    EXPECT_TRUE(cache.hasKey(3));
+    // Cache now in order <4, 1, 3>. Bring 3 to the front.
+    EXPECT_EQ(cache.read(3), "baz");
+    // 1 is now last in line, throw it to the electric wolves!
+    cache.write(5, "winner winner chicken dinner");
+    EXPECT_FALSE(cache.hasKey(1));
+    EXPECT_TRUE(cache.hasKey(5));
+    EXPECT_TRUE(cache.hasKey(3));
+    EXPECT_TRUE(cache.hasKey(4));
+}
+
+struct SlruCacheTest : CacheTest {
+    template <typename C>
+    void assert_segment_capacity_bytes(const C& cache, size_t exp_probationary, size_t exp_protected) {
+        ASSERT_EQ(cache.segment_capacity_bytes(CacheSegment::Probationary), exp_probationary);
+        ASSERT_EQ(cache.segment_capacity_bytes(CacheSegment::Protected), exp_protected);
+    }
+
+    template <typename C>
+    void assert_segment_capacities(const C& cache, size_t exp_probationary, size_t exp_protected) {
+        ASSERT_EQ(cache.segment_capacity(CacheSegment::Probationary), exp_probationary);
+        ASSERT_EQ(cache.segment_capacity(CacheSegment::Protected), exp_protected);
+    }
+
+    template <typename C>
+    void assert_segment_sizes(const C& cache, size_t exp_probationary, size_t exp_protected) {
+        ASSERT_EQ(cache.segment_size(CacheSegment::Probationary), exp_probationary);
+        ASSERT_EQ(cache.segment_size(CacheSegment::Protected), exp_protected);
+    }
+
+    template <typename C>
+    void assert_segment_size_bytes(const C& cache, size_t exp_probationary, size_t exp_protected) {
+        ASSERT_EQ(cache.segment_size_bytes(CacheSegment::Probationary), exp_probationary);
+        ASSERT_EQ(cache.segment_size_bytes(CacheSegment::Protected), exp_protected);
+    }
+};
+
+namespace {
+struct SelfAsSize {
+    template <typename T>
+    constexpr size_t operator()(const T& v) const noexcept {
+        return static_cast<size_t>(v);
+    }
+};
+}
+
+TEST_F(SlruCacheTest, zero_sized_protected_segment_implies_lru_semantics) {
+    cache<CacheParam<P, B, SelfAsSize, zero<std::string>>> cache(m, 200, 0);
+
+    ASSERT_NO_FATAL_FAILURE(assert_segment_capacity_bytes(cache, 200, 0));
+
+    cache.write(20, "foo");
+    EXPECT_EQ(cache.size(), 1);
+    EXPECT_EQ(cache.sizeBytes(), 100);
+    cache.write(18, "bar");
+    EXPECT_EQ(cache.size(), 2);
+    EXPECT_EQ(cache.sizeBytes(), 198);
+    cache.write(10, "baz");
+    // Soft limit
+    EXPECT_EQ(cache.size(), 3);
+    EXPECT_EQ(cache.sizeBytes(), 288);
+    cache.write(11, "zoid");
+    EXPECT_EQ(cache.sizeBytes(), 279);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 279, 0));
+    ASSERT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 3, 0));
+    EXPECT_TRUE(cache.hasKey(11));
+    EXPECT_TRUE(cache.hasKey(10));
+    EXPECT_TRUE(cache.hasKey(18));
+    EXPECT_FALSE(cache.hasKey(20));
+    // Reading a cached entry does not promote it to protected
+    EXPECT_EQ(cache.read(10), "baz");
+    ASSERT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 3, 0));
+}
+
+TEST_F(SlruCacheTest, cache_elements_are_transitioned_between_segments) {
+    cache<CacheParam<P, B, zero<uint32_t>, zero<std::string>>> cache(m, -1, -1); // no size restrictions
+    cache.maxElements(2, 1);
+
+    ASSERT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 0, 0));
+    ASSERT_NO_FATAL_FAILURE(assert_segment_capacities(cache, 2, 1));
+    ASSERT_NO_FATAL_FAILURE(assert_segment_capacity_bytes(cache, -1, -1));
+
+    cache.write(1, "foo");
+    cache.write(2, "bar");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 2, 0));
+    // Evicting an entry from probationary does not push it into protected
+    cache.write(3, "baz");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 2, 0));
+    // {2, 3} in probationary. Access 2; it should be placed in protected
+    EXPECT_EQ(cache.read(2), "bar");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    // Reading it again fetches from protected
+    m[2] = "backing store should not be consulted for cached entry";
+    EXPECT_EQ(cache.read(2), "bar");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    // Room for one more in probationary
+    cache.write(4, "zoid");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 2, 1));
+    EXPECT_TRUE(cache.hasKey(2));
+    EXPECT_TRUE(cache.hasKey(3));
+    EXPECT_TRUE(cache.hasKey(4));
+    // Read 4; it should be placed in protected. This evicts 2 from protected,
+    // placing it back at the head of the LRU in probationary for a second chance.
+    EXPECT_EQ(cache.read(4), "zoid");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 2, 1));
+    EXPECT_TRUE(cache.hasKey(2));
+    EXPECT_TRUE(cache.hasKey(3));
+    EXPECT_TRUE(cache.hasKey(4));
+    // 3 should be the oldest probationary element, and will be kicked out on a new
+    // write (_not_ 2, which has been given a new lease on life).
+    cache.write(5, "zoid");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 2, 1));
+    EXPECT_TRUE(cache.hasKey(2));
+    EXPECT_FALSE(cache.hasKey(3));
+    EXPECT_TRUE(cache.hasKey(4));
+    EXPECT_TRUE(cache.hasKey(5));
+}
+
+TEST_F(SlruCacheTest, write_through_updates_correct_segment) {
+    cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, -1, -1);
+
+    cache.write(1, "foo");
+    cache.write(2, "zoid");
+    EXPECT_EQ(cache.read(1), "foo"); // --> protected
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 84, 83));
+    cache.write(1, "a string that takes more memory yes"); // in protected
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 84, 115));
+    EXPECT_EQ(m[1], "a string that takes more memory yes"); // Backing store has been updated
+
+    cache.write(2, "un petit string"); // in probationary
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 95, 115));
+    EXPECT_EQ(m[2], "un petit string");
+
+    cache.erase(1);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 0));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 95, 0));
+    EXPECT_FALSE(m.contains(1));
+
+    cache.erase(2);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 0, 0));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 0, 0));
+    EXPECT_FALSE(m.contains(2));
+}
+
+TEST_F(SlruCacheTest, cache_invalidations_update_correct_segment) {
+    cache<CacheParam<P, B, zero<uint32_t>, size<std::string>>> cache(m, -1, -1);
+
+    cache.write(1, "foo");
+    cache.write(2, "zoid");
+    EXPECT_EQ(cache.read(1), "foo"); // --> protected
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 84, 83));
+    cache.invalidate(2);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 0, 1));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 0, 83));
+    cache.invalidate(1);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 0, 0));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 0, 0));
+    // Backing store remains untouched
+    EXPECT_EQ(m[1], "foo");
+    EXPECT_EQ(m[2], "zoid");
+}
+
+TEST_F(SlruCacheTest, capacity_bytes_change_is_propagated_to_segments) {
+    cache<CacheParam<P, B, zero<uint32_t>, zero<std::string>>> cache(m, 200, 400);
+
+    EXPECT_NO_FATAL_FAILURE(assert_segment_capacity_bytes(cache, 200, 400));
+    cache.setCapacityBytes(300);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_capacity_bytes(cache, 300, 0));
+    cache.setCapacityBytes(500, 700);
+    EXPECT_NO_FATAL_FAILURE(assert_segment_capacity_bytes(cache, 500, 700));
+}
+
+TEST_F(SlruCacheTest, assigning_zero_capacity_of_protected_segment_evicts_all_segment_entries) {
+    cache<CacheParam<P, B, SelfAsSize, zero<std::string>>> cache(m, 400, 500);
+
+    cache.write(10, "foo");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 90, 0));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_capacities(cache, -1, -1)); // Unlimited cardinality for both
+    cache.write(20, "bar");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 2, 0));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 190, 0));
+    EXPECT_EQ(cache.read(20), "bar");
+    // 20 is now in protected segment
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 1));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 90, 100));
+    cache.setCapacityBytes(400, 0);
+    // Evicting the protected segment drops them on the floor without bringing them
+    // back into the probationary segment (at least with the current semantics).
+    // Setting byte capacity to zero also implicitly sets max elements to zero.
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 0));
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 90, 0));
+    ASSERT_NO_FATAL_FAILURE(assert_segment_capacities(cache, -1, 0));
+    EXPECT_TRUE(cache.hasKey(10));
+    EXPECT_FALSE(cache.hasKey(20));
+    // Backing store is untouched by evictions
+    EXPECT_EQ(m[20], "bar");
+    // Accessing key 10 does not move it to protected
+    EXPECT_EQ(cache.read(10), "foo");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 1, 0));
+
+    // We can turn segmenting back on again
+    cache.setCapacityBytes(400, 500);
+    EXPECT_EQ(cache.read(10), "foo");
+    EXPECT_NO_FATAL_FAILURE(assert_segment_sizes(cache, 0, 1)); // key 10 now moved to protected
+    EXPECT_NO_FATAL_FAILURE(assert_segment_size_bytes(cache, 0, 90));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -223,7 +223,7 @@ public:
     }
     // Thread safe
     [[nodiscard]] size_t sizeBytes() const noexcept {
-        return _size_bytes.load(std::memory_order_relaxed);
+        return _probationary_segment.size_bytes() + _protected_segment.size_bytes();
     }
     // _Not_ thread safe
     [[nodiscard]] bool empty() const noexcept {
@@ -312,7 +312,6 @@ private:
 
     [[nodiscard]] bool multi_segment() const noexcept { return _protected_segment.capacity_bytes() != 0; }
     void disable_slru();
-    void update_size_bytes() noexcept;
     void verifyHashLock(const UniqueLock& guard) const;
     [[nodiscard]] size_t calcSize(const K& k, const V& v) const noexcept {
         return per_element_fixed_overhead() + _sizeK(k) + _sizeV(v);

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -10,85 +10,253 @@ namespace vespalib {
 
 struct CacheStats;
 
-template<typename K, typename V>
+template <typename K, typename V>
 class NullStore {
 public:
-    bool read(const K &, V &) const { return false; }
-    void write(const K &, const V &) { }
-    void erase(const K &) { }
+    bool read(const K&, V&) const { return false; }
+    void write(const K&, const V&) { }
+    void erase(const K&) { }
 };
 
 /**
  * These are the parameters needed for setting up the cache.
  * @param P is the set of parameters needed for setting up the underlying lrucache. See @ref LruParam
  * @param B is the backing store. That is where the real data is backed up if there are any.
- *          If there are no backing store or you mix and match yourself, you can give it the @ref NullStore.
+ *          If there is no backing store, or you mix and match yourself, you can give it the @ref NullStore.
  * @param SizeK is the method to get the space needed by the key in addition to what you get with sizeof.
  * @param SizeV is the method to get the space needed by the value in addition to what you get with sizeof.
  */
-template<typename P, typename B, typename sizeK = vespalib::zero<typename P::Key>, typename sizeV = vespalib::zero<typename P::Value> >
-struct CacheParam : public P
-{
+template <
+    typename P,
+    typename B,
+    typename sizeK = zero<typename P::Key>,
+    typename sizeV = zero<typename P::Value>
+>
+struct CacheParam : P {
     using BackingStore = B;
     using SizeK = sizeK;
     using SizeV = sizeV;
 };
 
+enum class CacheSegment {
+    Probationary,
+    Protected
+};
+
 /**
- * This is a cache using the underlying lru implementation as the store. It is modelled as a pure cache
- * with an backing store underneath it. That backing store is given to the constructor and must of course have
- * proper lifetime. The store must implement the same 3 methods as the @ref NullStore above.
- * Stuff is evicted from the cache if either number of elements or the accounted size passes the limits given.
- * The cache is thread safe by a single lock for accessing the underlying Lru. In addition a striped locking with
- * 64 locks chosen by the hash of the key to enable a single fetch for any element required by multiple readers.
+ * This is a cache using the underlying LRU implementation as the store. It is modelled as a
+ * pure cache with a backing store underneath it. That backing store is given to the constructor
+ * and must of course have proper lifetime. The store must implement the same 3 methods as the
+ * @ref NullStore above.
+ *
+ * Stuff is evicted from the cache if either number of elements or the accounted size passes the
+ * limits given. The cache is thread safe by a single lock for accessing the underlying LRU.
+ * In addition, a striped locking with 113 locks chosen by the hash of the key to enable a single
+ * fetch for any element required by multiple readers.
+ *
+ * The cache can optionally be constructed (or configured) with a secondary cache capacity; this
+ * automatically enables Segmented LRU (SLRU) semantics. When SLRU is enabled, cached elements
+ * are present in exactly one out of two segments; probationary or protected.
+ *
+ * The probationary segment is where all newly cached entries are placed. Entries evicted from
+ * this segment are lost to the sands of time. If a probationary element is explicitly fetched
+ * it is moved to the protected segment. This may cause the capacity of the protected segment
+ * to be exceeded, causing one or more protected entries to be evicted. Entries evicted from the
+ * protected segment are reinserted into the probationary segment, giving them a second chance.
+ * This reinsertion may in turn evict entries from the probationary segment.
+ *
+ * Promotion from probationary to protected can be seen as an analogue of a GC algorithm with
+ * automatic aging (young gen vs old gen).
+ *
+ * SLRU involves juggling entries between two separate LRUs, which has higher overhead than a
+ * simple single LRU. This means that cache performance will likely _decrease_ slightly if the
+ * cache is already large enough to fit all data (in which case eviction policies do not matter
+ * because they will not be used in practice). The opposite is expected to be the case if the
+ * cache is substantially smaller than the size of all cacheable objects.
+ *
+ * Note that the regular non-SLRU cache is implemented to reside entirely within the probationary
+ * segment.
  */
-template< typename P >
-class cache : private lrucache_map<P>
-{
+template <typename P>
+class cache {
     using Lru = lrucache_map<P>;
+    friend class SizeConstrainedLru;
+    friend class ProbationarySegmentLru;
+
+    // Shared parent LRU type used by both probationary and protected segments. In particular,
+    // it overrides the `removeOldest` LRU callback function to provide segment-specific
+    // capacity limits. Since the entry size calculation may be stateful, there's a slightly
+    // awkward back-reference to the owning cache object that holds the calculator.
+    class SizeConstrainedLru : protected Lru {
+    protected:
+        cache&              _owner;
+        std::atomic<size_t> _size_bytes;
+        std::atomic<size_t> _capacity_bytes;
+    public:
+        using KeyT   = typename P::Key;
+        using ValueT = typename P::Value; // Not to be confused with P::value_type, which is a std::pair
+
+        SizeConstrainedLru(cache& owner, size_t capacity_bytes);
+        ~SizeConstrainedLru() override;
+
+        // Callback from `lrucache_map` invoked when an element `kv` is a candidate for eviction.
+        bool removeOldest(const typename P::value_type& kv) override;
+
+        [[nodiscard]] bool has_key(const KeyT& key) const noexcept;
+        // Precondition: key does not already exist in the mapping
+        void insert_and_update_size(const KeyT& key, ValueT value);
+        // Precondition: key must exist in the mapping
+        void erase_and_update_size(const KeyT& key);
+        void replace_and_update_size(const KeyT& key, ValueT value);
+        // Fetches an existing key from the cache _without_ updating the LRU ordering.
+        [[nodiscard]] const typename P::Value& get_existing(const KeyT& key) const;
+
+        // Iff element exists in cache, assigns `val_out` the stored value and returns true.
+        // This also updates the underlying LRU order.
+        // Otherwise, `val_out` is not modified and false is returned.
+        [[nodiscard]] bool try_get_and_ref(const KeyT& key, ValueT& val_out);
+
+        // Clears the entire cache segment. removeOldest() is not invoked for any entries.
+        // _size_bytes will be reset to zero after invocation.
+        void evict_all();
+
+        using Lru::empty;
+        using Lru::size;
+        using Lru::capacity;
+
+        void set_max_elements(size_t max_elems) { Lru::maxElements(max_elems); }
+        void set_capacity_bytes(size_t capacity_bytes) noexcept { _capacity_bytes = capacity_bytes; }
+
+        [[nodiscard]] size_t size_bytes() const noexcept {
+            return _size_bytes.load(std::memory_order_relaxed);
+        }
+        [[nodiscard]] size_t capacity_bytes() const noexcept {
+            return _capacity_bytes.load(std::memory_order_relaxed);
+        }
+    private:
+        void set_size_bytes(size_t new_sz) noexcept {
+            _size_bytes.store(new_sz, std::memory_order_relaxed);
+        }
+        void add_size_bytes(size_t pos_delta) noexcept {
+            set_size_bytes(size_bytes() + pos_delta);
+        }
+        void sub_size_bytes(size_t neg_delta) noexcept {
+            set_size_bytes(size_bytes() - neg_delta);
+        }
+    };
+
+    class ProbationarySegmentLru final : public SizeConstrainedLru {
+    public:
+        using KeyT = typename SizeConstrainedLru::KeyT;
+
+        ProbationarySegmentLru(cache& owner, size_t capacity_bytes);
+        ~ProbationarySegmentLru() override;
+        // Elements are always inserted into the probationary segment first, and
+        // removed from the probationary segment last. Forward these events to any
+        // subclass of the owner cache, as they represent an object either freshly
+        // entering or finally leaving the cache.
+        void onRemove(const KeyT&) override;
+        void onInsert(const KeyT&) override;
+    };
+
+    class ProtectedSegmentLru final : public SizeConstrainedLru {
+    public:
+        ProtectedSegmentLru(cache& owner, size_t capacity_bytes);
+        ~ProtectedSegmentLru() override;
+        // Reinserts element evicted from protected segment back into probationary segment.
+        bool removeOldest(const typename P::value_type& kv) override;
+    };
+
 protected:
     using BackingStore = typename P::BackingStore;
-    using Hash = typename P::Hash;
-    using K = typename P::Key;
-    using V = typename P::Value;
-    using SizeK = typename P::SizeK;
-    using SizeV = typename P::SizeV;
-    using value_type = typename P::value_type;
+    using Hash         = typename P::Hash;
+    using K            = typename P::Key;
+    using V            = typename P::Value;
+    using SizeK        = typename P::SizeK;
+    using SizeV        = typename P::SizeV;
+    using value_type   = typename P::value_type;
 public:
+    cache(BackingStore& backing_store, size_t max_probationary_bytes, size_t max_protected_bytes);
+
     /**
      * Will create a cache that populates on demand from the backing store.
-     * The cache uses LRU and evicts whne its size in bytes or elements is reached.
+     * The cache uses LRU and evicts when its size in bytes or elements is reached.
      * By max elements is initialized to max bytes.
      *
-     * @param backingStore is the store for populating the cache on a cache miss.
-     * @maxBytes is the maximum limit of bytes the store can hold, before eviction starts.
+     * @param backing_store is the store for populating the cache on a cache miss.
+     * @param max_bytes is the maximum limit of bytes the store can hold, before eviction starts.
      */
-    cache(BackingStore & b, size_t maxBytes);
-    ~cache() override;
+    cache(BackingStore& backing_store, size_t max_bytes);
+    virtual ~cache();
     /**
      * Can be used for controlling max number of elements.
+     *
+     * Note that explicitly (or implicitly) configuring the protected segment to zero
+     * entries triggers a full eviction of all entries cached within it.
      */
-    cache & maxElements(size_t elems);
+    cache& maxElements(size_t elems);
+    cache& maxElements(size_t probationary_elems, size_t protected_elems);
 
-    cache & setCapacityBytes(size_t sz);
+    /**
+     * Sets a soft max capacity of bytes used by the underlying LRU cache.
+     * If used when in SLRU mode, the protected segment is cleared and the cache
+     * enters single LRU mode.
+     */
+    cache& setCapacityBytes(size_t sz);
+    /**
+     * Sets a soft max capacity of bytes used by the underlying LRU cache segments
+     * individually. A `protected_sz` of 0 implicitly disables SLRU mode, any higher
+     * values enable it.
+     */
+    cache& setCapacityBytes(size_t probationary_sz, size_t protected_sz);
 
-    size_t capacity()                  const { return Lru::capacity(); }
-    size_t capacityBytes()             const { return _maxBytes.load(std::memory_order_relaxed); }
-    size_t size()                      const { return Lru::size(); }
-    size_t sizeBytes()                 const { return _sizeBytes.load(std::memory_order_relaxed); }
-    bool empty()                       const { return Lru::empty(); }
+    // Thread safe
+    [[nodiscard]] size_t capacity() const noexcept {
+        return _probationary_segment.capacity() + _protected_segment.capacity();
+    }
+    // Thread safe
+    [[nodiscard]] size_t capacityBytes() const noexcept {
+        return _probationary_segment.capacity_bytes() + _protected_segment.capacity_bytes();
+    }
+    // Thread safe
+    [[nodiscard]] size_t size() const noexcept {
+        return _probationary_segment.size() + _protected_segment.size();
+    }
+    // Thread safe
+    [[nodiscard]] size_t sizeBytes() const noexcept {
+        return _size_bytes.load(std::memory_order_relaxed);
+    }
+    // _Not_ thread safe
+    [[nodiscard]] bool empty() const noexcept {
+        return _probationary_segment.empty() && _protected_segment.empty();
+    }
 
-    virtual MemoryUsage getStaticMemoryUsage() const;
+    [[nodiscard]] size_t segment_size(CacheSegment seg) const noexcept;
+    [[nodiscard]] size_t segment_size_bytes(CacheSegment seg) const noexcept;
+    [[nodiscard]] size_t segment_capacity(CacheSegment seg) const noexcept;
+    [[nodiscard]] size_t segment_capacity_bytes(CacheSegment seg) const noexcept;
+
+    [[nodiscard]] virtual MemoryUsage getStaticMemoryUsage() const;
+
+    /**
+     * Listeners for insertion and removal events that may be overridden by a subclass.
+     * Important: implementations should never directly or indirectly modify the cache
+     * from a listener, or they risk triggering an "uncontrolled" recursion chain.
+     */
+    virtual void onRemove(const K&) {}
+    virtual void onInsert(const K&) {}
 
     /**
      * This simply erases the object.
      * This will also erase from backing store.
      */
-    void erase(const K & key);
+    void erase(const K& key);
     /**
      * This simply erases the object from the cache.
      */
-    void invalidate(const K & key);
+    void invalidate(const K& key);
+
+    // TODO predicate invalidation?
 
     /**
      * Return the object with the given key. If it does not exist, the backing store will be consulted.
@@ -100,77 +268,90 @@ public:
      * backing store in case of a cache miss. They are entirely ignored if there is a cache hit.
      */
     template <typename... BackingStoreArgs>
-    V read(const K& key, BackingStoreArgs&&... backing_store_args);
+    [[nodiscard]] V read(const K& key, BackingStoreArgs&&... backing_store_args);
 
     /**
      * Update the cache and write through to backing store.
      * Object is then put at head of LRU list.
      */
-    void write(const K & key, V value);
+    void write(const K& key, V value);
 
     /**
      * Tell if an object with given key exists in the cache.
      * Does not alter the LRU list.
      */
-    bool hasKey(const K & key) const;
+    [[nodiscard]] bool hasKey(const K& key) const;
 
-    virtual CacheStats get_stats() const;
+    [[nodiscard]] virtual CacheStats get_stats() const;
 
-    size_t          getHit() const { return _hit.load(std::memory_order_relaxed); }
-    size_t         getMiss() const { return _miss.load(std::memory_order_relaxed); }
-    size_t getNoneExisting() const { return _noneExisting.load(std::memory_order_relaxed); }
-    size_t         getRace() const { return _race.load(std::memory_order_relaxed); }
-    size_t       getInsert() const { return _insert.load(std::memory_order_relaxed); }
-    size_t        getWrite() const { return _write.load(std::memory_order_relaxed); }
-    size_t   getInvalidate() const { return _invalidate.load(std::memory_order_relaxed); }
-    size_t       getlookup() const { return _lookup.load(std::memory_order_relaxed); }
+    size_t         getHit() const noexcept { return _hit.load(std::memory_order_relaxed); }
+    size_t        getMiss() const noexcept { return _miss.load(std::memory_order_relaxed); }
+    size_t getNonExisting() const noexcept { return _non_existing.load(std::memory_order_relaxed); }
+    size_t        getRace() const noexcept { return _race.load(std::memory_order_relaxed); }
+    size_t      getInsert() const noexcept { return _insert.load(std::memory_order_relaxed); }
+    size_t       getWrite() const noexcept { return _write.load(std::memory_order_relaxed); }
+    size_t  getInvalidate() const noexcept { return _invalidate.load(std::memory_order_relaxed); }
+    size_t      getLookup() const noexcept { return _lookup.load(std::memory_order_relaxed); }
+
+    /**
+     * Returns the number of bytes that are always implicitly added for each element
+     * present in the cache.
+    */
+    [[nodiscard]] constexpr static size_t per_element_fixed_overhead() noexcept {
+        return sizeof(value_type);
+    }
 
 protected:
     using UniqueLock = std::unique_lock<std::mutex>;
-    UniqueLock getGuard() const;
-    void invalidate(const UniqueLock & guard, const K & key);
-    bool hasKey(const UniqueLock & guard, const K & key) const;
+    [[nodiscard]] UniqueLock getGuard() const;
+    void invalidate(const UniqueLock& guard, const K& key);
+    [[nodiscard]] bool hasKey(const UniqueLock& guard, const K& key) const;
 private:
-    void verifyHashLock(const UniqueLock & guard) const;
-    /**
-     * Called when an object is inserted, to see if the LRU should be removed.
-     * Default is to obey the maxsize given in constructor.
-     * The obvious extension is when you are storing pointers and want to cap
-     * on the real size of the object pointed to.
-     */
-    bool removeOldest(const value_type & v) override;
-    size_t calcSize(const K & k, const V & v) const { return sizeof(value_type) + _sizeK(k) + _sizeV(v); }
-    std::mutex & getLock(const K & k) {
+    // Implicitly updates LRU segment(s) on hit.
+    // Precondition: _hashLock is held.
+    [[nodiscard]] bool try_fill_from_cache(const K& key, V& val_out);
+
+    [[nodiscard]] bool multi_segment() const noexcept { return _protected_segment.capacity_bytes() != 0; }
+    void disable_slru();
+    void update_size_bytes() noexcept;
+    void verifyHashLock(const UniqueLock& guard) const;
+    [[nodiscard]] size_t calcSize(const K& k, const V& v) const noexcept {
+        return per_element_fixed_overhead() + _sizeK(k) + _sizeV(v);
+    }
+    [[nodiscard]] std::mutex& getLock(const K& k) noexcept {
         size_t h(_hasher(k));
         return _addLocks[h%(sizeof(_addLocks)/sizeof(_addLocks[0]))];
     }
 
     template <typename V>
-    static void increment_stat(std::atomic<V>& v, const std::lock_guard<std::mutex>&) {
+    static void increment_stat(std::atomic<V>& v, const std::lock_guard<std::mutex>&) noexcept {
         v.store(v.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
     }
     template <typename V>
-    static void increment_stat(std::atomic<V>& v, const std::unique_lock<std::mutex>&) {
+    static void increment_stat(std::atomic<V>& v, const std::unique_lock<std::mutex>&) noexcept {
         v.store(v.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
     }
 
-    Hash                        _hasher;
-    SizeK                       _sizeK;
-    SizeV                       _sizeV;
-    std::atomic<size_t>         _maxBytes;
-    std::atomic<size_t>         _sizeBytes;
+    [[no_unique_address]] Hash  _hasher;
+    [[no_unique_address]] SizeK _sizeK;
+    [[no_unique_address]] SizeV _sizeV;
+    std::atomic<size_t>         _size_bytes;
     mutable std::atomic<size_t> _hit;
     mutable std::atomic<size_t> _miss;
-    std::atomic<size_t>         _noneExisting;
+    std::atomic<size_t>         _non_existing;
     mutable std::atomic<size_t> _race;
     mutable std::atomic<size_t> _insert;
     mutable std::atomic<size_t> _write;
     mutable std::atomic<size_t> _update;
     mutable std::atomic<size_t> _invalidate;
     mutable std::atomic<size_t> _lookup;
-    BackingStore              & _store;
+    BackingStore&               _store;
+
+    ProbationarySegmentLru      _probationary_segment;
+    ProtectedSegmentLru         _protected_segment;
+
     mutable std::mutex          _hashLock;
-    /// Striped locks that can be used for having a locked access to the backing store.
+    // Striped locks that can be used for having locked access to the backing store.
     std::mutex                  _addLocks[113];
 };
 

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -151,12 +151,11 @@ class cache {
 
         ProbationarySegmentLru(cache& owner, size_t capacity_bytes);
         ~ProbationarySegmentLru() override;
+
         // Elements are always inserted into the probationary segment first, and
-        // removed from the probationary segment last. Forward these events to any
-        // subclass of the owner cache, as they represent an object either freshly
-        // entering or finally leaving the cache.
-        void onRemove(const KeyT&) override;
-        void onInsert(const KeyT&) override;
+        // removed from the probationary segment last. Forward final removal events
+        // to the owner.
+        bool removeOldest(const typename P::value_type& kv) override;
     };
 
     class ProtectedSegmentLru final : public SizeConstrainedLru {

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/util/memoryusage.h>
 #include <atomic>
 #include <mutex>
+#include <vector>
 
 namespace vespalib {
 
@@ -120,6 +121,8 @@ class cache {
         // _size_bytes will be reset to zero after invocation.
         void evict_all();
 
+        [[nodiscard]] std::vector<KeyT> dump_segment_keys_in_lru_order();
+
         using Lru::empty;
         using Lru::size;
         using Lru::capacity;
@@ -175,6 +178,8 @@ protected:
     using SizeV        = typename P::SizeV;
     using value_type   = typename P::value_type;
 public:
+    using key_type     = K;
+
     cache(BackingStore& backing_store, size_t max_probationary_bytes, size_t max_protected_bytes);
 
     /**
@@ -299,6 +304,9 @@ public:
     [[nodiscard]] constexpr static size_t per_element_fixed_overhead() noexcept {
         return sizeof(value_type);
     }
+
+    // For testing. Not const since backing lrucache_map does not have const_iterator
+    [[nodiscard]] std::vector<K> dump_segment_keys_in_lru_order(CacheSegment segment);
 
 protected:
     using UniqueLock = std::unique_lock<std::mutex>;

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -179,6 +179,11 @@ void
 cache<P>::disable_slru() {
     _protected_segment.set_max_elements(0);
     _protected_segment.set_capacity_bytes(0);
+    // This has the not-entirely-optimal(tm) side effect of evicting the elements
+    // we consider the most important (i.e. the protected ones), but this exists
+    // only so that live-disabling SLRU entirely will be _correct_, not that it
+    // will be objectively _efficient_.
+    // TODO expose lrucache_map trimming and use this here instead.
     _protected_segment.evict_all();
 }
 

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -74,7 +74,7 @@ cache<P>::SizeConstrainedLru::get_existing(const KeyT& key) const {
 template <typename P>
 bool
 cache<P>::SizeConstrainedLru::try_get_and_ref(const KeyT& key, ValueT& val_out) {
-    const auto* maybe_val = Lru::findAndRef(key);
+    const auto* maybe_val = Lru::find_and_ref(key);
     if (maybe_val) {
         val_out = *maybe_val;
         return true;

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -88,6 +88,9 @@ cache<P>::SizeConstrainedLru::evict_all() {
     // There's no `clear()` on lrucache_map, so do it the hard way.
     auto iter = Lru::begin();
     while (iter != Lru::end()) {
+        // Entries will not be transitioned out of the cache via the probationary segment,
+        // so invoke the removal callback directly.
+        _owner.onRemove(iter.key());
         iter = Lru::erase(iter); // This does _not_ invoke `removeOldest()`
     }
     set_size_bytes(0);

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -40,12 +40,13 @@ cache<P>::SizeConstrainedLru::has_key(const KeyT& key) const noexcept {
 template <typename P>
 void
 cache<P>::SizeConstrainedLru::insert_and_update_size(const KeyT& key, ValueT value) {
-    const auto kv_size = _owner.calcSize(key, value);
+    // Account for added size _prior_ to inserting into the LRU so that we'll trigger
+    // an eviction of existing entries that would otherwise cause the segment to get
+    // overfull once the insertion has been completed.
+    add_size_bytes(_owner.calcSize(key, value));
     auto insert_res = Lru::insert(key, std::move(value));
     assert(insert_res.second);
-    // Must be updated _after_ insert, since the underlying eviction policy (removeOldest)
-    // transitively consults this value as part of the insertion itself.
-    add_size_bytes(kv_size);
+
 }
 
 template <typename P>

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -264,7 +264,6 @@ cache<P>::read(const K& key, BackingStoreArgs&&... backing_store_args)
     {
         std::lock_guard guard(_hashLock);
         if (try_fill_from_cache(key, value)) {
-            increment_stat(_hit, guard);
             increment_stat(_race, guard); // Somebody else just fetched it ahead of me.
             return value;
         }

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -7,55 +7,224 @@
 
 namespace vespalib {
 
-template< typename P >
-cache<P> &
-cache<P>::maxElements(size_t elems) {
-    Lru::maxElements(elems);
-    return *this;
+template <typename P>
+cache<P>::SizeConstrainedLru::SizeConstrainedLru(cache& owner, size_t capacity_bytes)
+    : Lru(Lru::UNLIMITED),
+      _owner(owner),
+      _size_bytes(0),
+      _capacity_bytes(capacity_bytes)
+{
 }
 
-template< typename P >
-cache<P> &
-cache<P>::setCapacityBytes(size_t sz) {
-    _maxBytes.store(sz, std::memory_order_relaxed);
-    return *this;
+template <typename P>
+cache<P>::SizeConstrainedLru::~SizeConstrainedLru() = default;
+
+template <typename P>
+bool
+cache<P>::SizeConstrainedLru::removeOldest(const typename P::value_type& kv) {
+    const size_t sz_now = size_bytes();
+    // TODO shouldn't this be size > capacity, not >= ? Not touching it for now...
+    bool remove(Lru::removeOldest(kv) || (sz_now >= capacity_bytes()));
+    if (remove) {
+        sub_size_bytes(_owner.calcSize(kv.first, kv.second._value));
+    }
+    return remove;
 }
 
-template< typename P >
+template <typename P>
+bool
+cache<P>::SizeConstrainedLru::has_key(const KeyT& key) const noexcept {
+    return Lru::hasKey(key);
+}
+
+template <typename P>
 void
-cache<P>::invalidate(const K & key) {
+cache<P>::SizeConstrainedLru::insert_and_update_size(const KeyT& key, ValueT value) {
+    const auto kv_size = _owner.calcSize(key, value);
+    auto insert_res = Lru::insert(key, std::move(value));
+    assert(insert_res.second);
+    // Must be updated _after_ insert, since the underlying eviction policy (removeOldest)
+    // transitively consults this value as part of the insertion itself.
+    add_size_bytes(kv_size);
+}
+
+template <typename P>
+void
+cache<P>::SizeConstrainedLru::erase_and_update_size(const KeyT& key) {
+    sub_size_bytes(_owner.calcSize(key, Lru::get(key)));
+    Lru::erase(key);
+}
+
+template <typename P>
+void
+cache<P>::SizeConstrainedLru::replace_and_update_size(const KeyT& key, ValueT value) {
+    const auto kv_size = _owner.calcSize(key, value);
+    sub_size_bytes(_owner.calcSize(key, Lru::get(key))); // get() does not update LRU
+    (*this)[key] = std::move(value); // operator[] _does_ update LRU; `key` will be placed at head
+    add_size_bytes(kv_size);
+}
+
+template <typename P>
+const typename P::Value&
+cache<P>::SizeConstrainedLru::get_existing(const KeyT& key) const {
+    return Lru::get(key);
+}
+
+template <typename P>
+bool
+cache<P>::SizeConstrainedLru::try_get_and_ref(const KeyT& key, ValueT& val_out) {
+    const auto* maybe_val = Lru::findAndRef(key);
+    if (maybe_val) {
+        val_out = *maybe_val;
+        return true;
+    }
+    return false;
+}
+
+template <typename P>
+void
+cache<P>::SizeConstrainedLru::evict_all() {
+    // There's no `clear()` on lrucache_map, so do it the hard way.
+    auto iter = Lru::begin();
+    while (iter != Lru::end()) {
+        iter = Lru::erase(iter); // This does _not_ invoke `removeOldest()`
+    }
+    set_size_bytes(0);
+}
+
+template <typename P>
+cache<P>::ProbationarySegmentLru::ProbationarySegmentLru(cache& owner, size_t capacity_bytes)
+    : SizeConstrainedLru(owner, capacity_bytes)
+{
+}
+
+template <typename P>
+cache<P>::ProbationarySegmentLru::~ProbationarySegmentLru() = default;
+
+template <typename P>
+void
+cache<P>::ProbationarySegmentLru::onRemove(const KeyT& k) {
+    SizeConstrainedLru::_owner.onRemove(k);
+}
+
+template <typename P>
+void
+cache<P>::ProbationarySegmentLru::onInsert(const KeyT& k) {
+    SizeConstrainedLru::_owner.onInsert(k);
+}
+
+template <typename P>
+cache<P>::ProtectedSegmentLru::ProtectedSegmentLru(cache& owner, size_t capacity_bytes)
+    : SizeConstrainedLru(owner, capacity_bytes)
+{
+}
+
+template <typename P>
+cache<P>::ProtectedSegmentLru::~ProtectedSegmentLru() = default;
+
+template <typename P>
+bool
+cache<P>::ProtectedSegmentLru::removeOldest(const typename P::value_type& kv) {
+    bool remove = SizeConstrainedLru::removeOldest(kv); // Updates own size if `remove == true`
+    if (remove) {
+        // Move back into probationary segment. This may shove the oldest entry out of it,
+        // which evicts it from the cache completely (no second chances for probationary elements).
+        // Note that we intercept this in removeOldest() and _not_ onRemove() since the latter
+        // only provides the _key_ of the element being removed, while removeOldest provides both
+        // the key and value. It is not obviously safe to resolve the key -> value from onRemove().
+        SizeConstrainedLru::_owner._probationary_segment.insert_and_update_size(kv.first, kv.second._value);
+    }
+    return remove;
+}
+
+template <typename P>
+cache<P>&
+cache<P>::maxElements(size_t probationary_elems, size_t protected_elems) {
+    std::lock_guard guard(_hashLock);
+    _probationary_segment.set_max_elements(probationary_elems);
+    _protected_segment.set_max_elements(protected_elems);
+    if (protected_elems == 0) { // If max protected elems == 0, this disables SLRU semantics
+        disable_slru();
+    }
+    return *this;
+}
+
+template <typename P>
+cache<P>&
+cache<P>::maxElements(size_t elems) {
+    maxElements(elems, 0);
+    return *this;
+}
+
+template <typename P>
+cache<P>&
+cache<P>::setCapacityBytes(size_t probationary_sz, size_t protected_sz) {
+    std::lock_guard guard(_hashLock);
+    _probationary_segment.set_capacity_bytes(probationary_sz);
+    _protected_segment.set_capacity_bytes(protected_sz);
+    if (protected_sz == 0) { // If max protected size == 0, this disables SLRU semantics
+        disable_slru();
+    }
+    return *this;
+}
+
+template <typename P>
+cache<P>&
+cache<P>::setCapacityBytes(size_t sz) {
+    setCapacityBytes(sz, 0);
+    return *this;
+}
+
+template <typename P>
+void
+cache<P>::disable_slru() {
+    _protected_segment.set_max_elements(0);
+    _protected_segment.set_capacity_bytes(0);
+    _protected_segment.evict_all();
+}
+
+template <typename P>
+void
+cache<P>::invalidate(const K& key) {
     UniqueLock guard(_hashLock);
     invalidate(guard, key);
 }
 
-template< typename P >
+template <typename P>
 bool
-cache<P>::hasKey(const K & key) const {
+cache<P>::hasKey(const K& key) const {
     UniqueLock guard(_hashLock);
     return hasKey(guard, key);
 }
 
-template< typename P >
+template <typename P>
 cache<P>::~cache() = default;
 
-template< typename P >
-cache<P>::cache(BackingStore & b, size_t maxBytes) :
-    Lru(Lru::UNLIMITED),
-    _maxBytes(maxBytes),
-    _sizeBytes(0),
+template <typename P>
+cache<P>::cache(BackingStore& backing_store,
+                size_t max_probationary_bytes,
+                size_t max_protected_bytes) :
+    _size_bytes(0),
     _hit(0),
     _miss(0),
-    _noneExisting(0),
+    _non_existing(0),
     _race(0),
     _insert(0),
     _write(0),
     _update(0),
     _invalidate(0),
     _lookup(0),
-    _store(b)
-{ }
+    _store(backing_store),
+    _probationary_segment(*this, max_probationary_bytes),
+    _protected_segment(*this, max_protected_bytes)
+{}
 
-template< typename P >
+template <typename P>
+cache<P>::cache(BackingStore& backing_store, size_t max_bytes)
+    : cache(backing_store, max_bytes, 0)
+{}
+
+template <typename P>
 MemoryUsage
 cache<P>::getStaticMemoryUsage() const {
     MemoryUsage usage;
@@ -65,17 +234,7 @@ cache<P>::getStaticMemoryUsage() const {
     return usage;
 }
 
-template< typename P >
-bool
-cache<P>::removeOldest(const value_type & v) {
-    bool remove(Lru::removeOldest(v) || (sizeBytes() >= capacityBytes()));
-    if (remove) {
-        _sizeBytes.store(sizeBytes() - calcSize(v.first, v.second._value), std::memory_order_relaxed);
-    }
-    return remove;
-}
-
-template< typename P >
+template <typename P>
 std::unique_lock<std::mutex>
 cache<P>::getGuard() const {
     return UniqueLock(_hashLock);
@@ -86,94 +245,119 @@ template <typename... BackingStoreArgs>
 typename P::Value
 cache<P>::read(const K& key, BackingStoreArgs&&... backing_store_args)
 {
+    V value;
     {
         std::lock_guard guard(_hashLock);
-        if (Lru::hasKey(key)) {
+        if (try_fill_from_cache(key, value)) {
             increment_stat(_hit, guard);
-            return (*this)[key];
+            return value;
         } else {
             increment_stat(_miss, guard);
         }
     }
 
-    std::lock_guard storeGuard(getLock(key));
+    std::lock_guard store_guard(getLock(key));
     {
         std::lock_guard guard(_hashLock);
-        if (Lru::hasKey(key)) {
-            // Somebody else just fetched it ahead of me.
-            increment_stat(_race, guard);
-            return (*this)[key];
+        if (try_fill_from_cache(key, value)) {
+            increment_stat(_hit, guard);
+            increment_stat(_race, guard); // Somebody else just fetched it ahead of me.
+            return value;
         }
     }
-    V value;
     if (_store.read(key, value, std::forward<BackingStoreArgs>(backing_store_args)...)) {
         std::lock_guard guard(_hashLock);
-        Lru::insert(key, value);
-        _sizeBytes.store(sizeBytes() + calcSize(key, value), std::memory_order_relaxed);
+        _probationary_segment.insert_and_update_size(key, value);
+        update_size_bytes();
         increment_stat(_insert, guard);
     } else {
-        _noneExisting.fetch_add(1);
+        _non_existing.fetch_add(1, std::memory_order_relaxed);
     }
     return value;
 }
 
-template< typename P >
-void
-cache<P>::write(const K & key, V value)
-{
-    size_t newSize = calcSize(key, value);
-    std::lock_guard storeGuard(getLock(key));
-    {
-        std::lock_guard guard(_hashLock);
-        if (Lru::hasKey(key)) {
-            _sizeBytes.store(sizeBytes() - calcSize(key, (*this)[key]), std::memory_order_relaxed);
-            increment_stat(_update, guard);
+template <typename P>
+bool
+cache<P>::try_fill_from_cache(const K& key, V& val_out) {
+    if (_probationary_segment.try_get_and_ref(key, val_out)) {
+        if (multi_segment()) {
+            // Hit on probationary item; move to protected segment
+            _probationary_segment.erase_and_update_size(key);
+            _protected_segment.insert_and_update_size(key, val_out);
         }
+        return true;
+    } else if (multi_segment() && _protected_segment.try_get_and_ref(key, val_out)) {
+        return true;
     }
+    return false;
+}
 
+template <typename P>
+void
+cache<P>::write(const K& key, V value)
+{
+    std::lock_guard storeGuard(getLock(key));
     _store.write(key, value);
     {
         std::lock_guard guard(_hashLock);
-        (*this)[key] = std::move(value);
-        _sizeBytes.store(sizeBytes() + newSize, std::memory_order_relaxed);
-        increment_stat(_write, guard);
+        if (_probationary_segment.has_key(key)) {
+            increment_stat(_update, guard);
+            _probationary_segment.replace_and_update_size(key, std::move(value));
+        } else if (multi_segment() && _protected_segment.has_key(key)) {
+            increment_stat(_update, guard);
+            _protected_segment.replace_and_update_size(key, std::move(value));
+        } else {
+            // Always insert into probationary first
+            _probationary_segment.insert_and_update_size(key, std::move(value));
+        }
+        update_size_bytes();
+        increment_stat(_write, guard); // TODO only increment when not updating?
     }
 }
 
-template< typename P >
+template <typename P>
 void
-cache<P>::erase(const K & key)
+cache<P>::erase(const K& key)
 {
     std::lock_guard storeGuard(getLock(key));
     invalidate(key);
     _store.erase(key);
 }
 
-template< typename P >
+template <typename P>
 void
-cache<P>::invalidate(const UniqueLock & guard, const K & key)
+cache<P>::invalidate(const UniqueLock& guard, const K& key)
 {
     verifyHashLock(guard);
-    if (Lru::hasKey(key)) {
-        _sizeBytes.store(sizeBytes() - calcSize(key, (*this)[key]), std::memory_order_relaxed);
-        increment_stat(_invalidate, guard);
-        Lru::erase(key);
+    // TODO lrucache_map should have a `bool erase(key)` function so that we could
+    //  do this in one lookup instead of two...
+    if (_probationary_segment.has_key(key)) {
+        _probationary_segment.erase_and_update_size(key);
+    } else if (multi_segment() && _protected_segment.has_key(key)) {
+        _protected_segment.erase_and_update_size(key);
+    } else {
+        return;
     }
+    update_size_bytes();
+    increment_stat(_invalidate, guard);
 }
 
-template< typename P >
+template <typename P>
 bool
-cache<P>::hasKey(const UniqueLock & guard, const K & key) const
+cache<P>::hasKey(const UniqueLock& guard, const K& key) const
 {
     verifyHashLock(guard);
     increment_stat(_lookup, guard);
-    return Lru::hasKey(key);
+    if (_probationary_segment.has_key(key)) {
+        return true;
+    }
+    return multi_segment() && _protected_segment.has_key(key);
 }
 
-template< typename P >
+template <typename P>
 void
-cache<P>::verifyHashLock(const UniqueLock & guard) const {
-    assert(guard.mutex() == & _hashLock);
+cache<P>::verifyHashLock(const UniqueLock& guard) const {
+    assert(guard.mutex() == &_hashLock);
     assert(guard.owns_lock());
 }
 
@@ -182,7 +366,46 @@ CacheStats
 cache<P>::get_stats() const
 {
     std::lock_guard guard(_hashLock);
-    return CacheStats(getHit(), getMiss(), Lru::size(), sizeBytes(), getInvalidate());
+    return CacheStats(getHit(), getMiss(), size(), sizeBytes(), getInvalidate());
+}
+
+template <typename P>
+void
+cache<P>::update_size_bytes() noexcept {
+    _size_bytes.store(_probationary_segment.size_bytes() + _protected_segment.size_bytes(),
+                      std::memory_order_relaxed);
+}
+
+template <typename P>
+size_t
+cache<P>::segment_size(CacheSegment seg) const noexcept {
+    std::lock_guard guard(_hashLock);
+    return (seg == CacheSegment::Probationary) ? _probationary_segment.size()
+                                               : _protected_segment.size();
+}
+
+template <typename P>
+size_t
+cache<P>::segment_size_bytes(CacheSegment seg) const noexcept {
+    std::lock_guard guard(_hashLock);
+    return (seg == CacheSegment::Probationary) ? _probationary_segment.size_bytes()
+                                               : _protected_segment.size_bytes();
+}
+
+template <typename P>
+size_t
+cache<P>::segment_capacity(CacheSegment seg) const noexcept {
+    std::lock_guard guard(_hashLock);
+    return (seg == CacheSegment::Probationary) ? _probationary_segment.capacity()
+                                               : _protected_segment.capacity();
+}
+
+template <typename P>
+size_t
+cache<P>::segment_capacity_bytes(CacheSegment seg) const noexcept {
+    std::lock_guard guard(_hashLock);
+    return (seg == CacheSegment::Probationary) ? _probationary_segment.capacity_bytes()
+                                               : _protected_segment.capacity_bytes();
 }
 
 }

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -61,8 +61,8 @@ void
 cache<P>::SizeConstrainedLru::replace_and_update_size(const KeyT& key, ValueT value) {
     const auto kv_size = _owner.calcSize(key, value);
     sub_size_bytes(_owner.calcSize(key, Lru::get(key))); // get() does not update LRU
-    (*this)[key] = std::move(value); // operator[] _does_ update LRU; `key` will be placed at head
     add_size_bytes(kv_size);
+    (*this)[key] = std::move(value); // operator[] _does_ update LRU; `key` will be placed at head
 }
 
 template <typename P>

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -94,6 +94,17 @@ cache<P>::SizeConstrainedLru::evict_all() {
 }
 
 template <typename P>
+std::vector<typename P::Key>
+cache<P>::SizeConstrainedLru::dump_segment_keys_in_lru_order() {
+    std::vector<KeyT> lru_keys;
+    lru_keys.reserve(size());
+    for (auto it = Lru::begin(); it != Lru::end(); ++it) {
+        lru_keys.emplace_back(it.key());
+    }
+    return lru_keys;
+}
+
+template <typename P>
 cache<P>::ProbationarySegmentLru::ProbationarySegmentLru(cache& owner, size_t capacity_bytes)
     : SizeConstrainedLru(owner, capacity_bytes)
 {
@@ -369,6 +380,14 @@ cache<P>::get_stats() const
 {
     std::lock_guard guard(_hashLock);
     return CacheStats(getHit(), getMiss(), size(), sizeBytes(), getInvalidate());
+}
+
+template <typename P>
+std::vector<typename P::Key>
+cache<P>::dump_segment_keys_in_lru_order(CacheSegment seg) {
+    std::lock_guard guard(_hashLock);
+    return (seg == CacheSegment::Probationary) ? _probationary_segment.dump_segment_keys_in_lru_order()
+                                               : _protected_segment.dump_segment_keys_in_lru_order();
 }
 
 template <typename P>

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -75,6 +75,10 @@ public:
         }
         bool operator==(const iterator& rhs) const { return (_current == rhs._current); }
         bool operator!=(const iterator& rhs) const { return (_current != rhs._current); }
+
+        [[nodiscard]] const K& key() const noexcept {
+            return _cache->getByInternalIndex(_current).first;
+        }
     private:
         lrucache_map * _cache;
         uint32_t _current;

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -143,7 +143,16 @@ public:
      * Object is then put at head of LRU list if found.
      * If not found nullptr is returned.
      */
-    V * findAndRef(const K & key);
+    [[nodiscard]] V* find_and_ref(const K& key);
+
+    /**
+     * Return pointer to the object with the given key. Object is then put at
+     * head of LRU list if found and the size of the cache is more than half
+     * its capacity. Otherwise, the LRU is not updated.
+     *
+     * If not found nullptr is returned.
+     */
+    [[nodiscard]] V* find_and_lazy_ref(const K& key);
 
     /**
      * Return the object with the given key. If it does not exist an empty one will be created.

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -86,7 +86,7 @@ public:
      * Will create a lrucache with max elements. Use the chained setter
      * @ref reserve to control initial size.
      *
-     * @param maxElements in cache unless you override @ref removeOldest.
+     * @param maxElems in cache unless you override @ref removeOldest.
      */
     lrucache_map(size_t maxElems);
     virtual ~lrucache_map();
@@ -165,7 +165,7 @@ public:
     virtual void onInsert(const K & key);
 
     /**
-     * Method for testing that internal consitency is good.
+     * Method for testing that internal consistency is good.
      */
     bool verifyInternals();
 

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
@@ -270,8 +270,20 @@ lrucache_map<P>::hasKey(const K & key) const {
 }
 
 template< typename P >
-typename P::Value *
-lrucache_map<P>::findAndRef(const K & key)
+typename P::Value*
+lrucache_map<P>::find_and_ref(const K& key)
+{
+    internal_iterator found = HashTable::find(key);
+    if (found != HashTable::end()) {
+        ref(found);
+        return &found->second._value;
+    }
+    return nullptr;
+}
+
+template< typename P >
+typename P::Value*
+lrucache_map<P>::find_and_lazy_ref(const K& key)
 {
     internal_iterator found = HashTable::find(key);
     if (found != HashTable::end()) {


### PR DESCRIPTION
@havardpe please review 👀

This extends the behavior of the current `vespalib::cache` class to support 2-segment caching. Default behavior is non-segmented LRU, maintaining current cache semantics and expected run-time overhead.

The cache can optionally be constructed (or configured) with a secondary cache capacity; this automatically enables SLRU semantics. When SLRU is enabled, cached elements are present in exactly one out of two segments; _probationary_ or _protected_.

Newly cached entries (from write-throughs or reads) are placed at the head of the probationary segment. Tail entries evicted from this segment are lost to the sands of time. If a probationary element is explicitly read it is moved to the head of the protected segment. This may cause the capacity of the protected segment to be exceeded, causing one or more protected tail entries to be evicted. Entries evicted from the protected segment are reinserted at the head of the probationary segment, giving them a second chance. This reinsertion may in turn evict entries from the probationary segment tail. _The circle of life._ 🦁

SLRU involves juggling entries between two separate LRUs, which has higher overhead than a simple single LRU. This means that cache performance will likely _decrease_ slightly if the cache is already large enough to fit all data (in which case eviction policies do not matter because they will not be used in practice). The opposite is expected to be the case if the cache is substantially smaller than the size of all cacheable objects.

Note that the regular non-SLRU cache is implemented to reside entirely within the probationary segment.

