### PR TITLE
Glebashnik/fix tensor adress hash code

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelCache.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelCache.java
@@ -20,7 +20,7 @@ import java.util.concurrent.locks.Lock;
  */
 public class LabelCache {
     // Global cache used as default.
-    public static final LabelCache GLOBAL = new LabelCache(128, 2000);
+    public static final LabelCache GLOBAL = new LabelCache(32, 1000);
     // Label for invalid index.
     public static final Label INVALID_INDEX_LABEL = new LabelImpl(Tensor.invalidIndex, null);
     

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelCache.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelCache.java
@@ -20,7 +20,7 @@ import java.util.concurrent.locks.Lock;
  */
 public class LabelCache {
     // Global cache used as default.
-    public static final LabelCache GLOBAL = new LabelCache(32, 1000);
+    public static final LabelCache GLOBAL = new LabelCache(128, 2000);
     // Label for invalid index.
     public static final Label INVALID_INDEX_LABEL = new LabelImpl(Tensor.invalidIndex, null);
     

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
@@ -13,7 +13,7 @@ import com.yahoo.tensor.Tensor;
  * @author glebashnik
  */
 class LabelImpl implements Label {
-    // Using caching function with avalanche effect to avoid too many hash bucket collisions.
+    // Hash function with avalanche effect to avoid too many hash bucket collisions.
     private static final HashFunction hashFunction = Hashing.murmur3_32_fixed();
     
     private final long numeric;

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
@@ -6,13 +6,13 @@ import com.yahoo.tensor.Tensor;
 
 /**
  * {@link Label} implementation used by {@link LabelCache}.
- *
+ * 
  * @author glebashnik
  */
 class LabelImpl implements Label {
     private final long numeric;
     private final String string;
-
+    
     LabelImpl(long numeric) {
         this.numeric = numeric;
         this.string = null;
@@ -33,12 +33,12 @@ class LabelImpl implements Label {
         if (numeric == Tensor.invalidIndex) {
             return null;
         }
-
+        
         // String label for indexed dimension are created at runtime to reduce memory usage.
         if (string == null) {
             return String.valueOf(numeric);
         }
-
+        
         return string;
     }
 
@@ -54,7 +54,7 @@ class LabelImpl implements Label {
         var label = (LabelImpl) object;
         return isEqualTo(label);
     }
-
+    
     @Override
     public int hashCode() {
         return Long.hashCode(numeric);

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
@@ -1,6 +1,9 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.tensor.impl;
 
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.Tensor;
 
@@ -10,17 +13,25 @@ import com.yahoo.tensor.Tensor;
  * @author glebashnik
  */
 class LabelImpl implements Label {
+    // Using caching function with avalanche effect to avoid too many hash bucket collisions.
+    private static final HashFunction hashFunction = Hashing.murmur3_32_fixed();
+    
     private final long numeric;
     private final String string;
+    
+    // Caching the hash code to avoid recalculating it when cached labels are reused in multiple tensors.
+    private final int hashCode;
     
     LabelImpl(long numeric) {
         this.numeric = numeric;
         this.string = null;
+        this.hashCode = hashFunction.hashLong(numeric).asInt();
     }
 
     LabelImpl(long numeric, String string) {
         this.numeric = numeric;
         this.string = string;
+        this.hashCode = hashFunction.hashLong(numeric).asInt();
     }
 
     @Override
@@ -57,6 +68,6 @@ class LabelImpl implements Label {
     
     @Override
     public int hashCode() {
-        return Long.hashCode(numeric);
+        return hashCode;
     }
 }

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/LabelImpl.java
@@ -6,13 +6,13 @@ import com.yahoo.tensor.Tensor;
 
 /**
  * {@link Label} implementation used by {@link LabelCache}.
- * 
+ *
  * @author glebashnik
  */
 class LabelImpl implements Label {
     private final long numeric;
     private final String string;
-    
+
     LabelImpl(long numeric) {
         this.numeric = numeric;
         this.string = null;
@@ -33,12 +33,12 @@ class LabelImpl implements Label {
         if (numeric == Tensor.invalidIndex) {
             return null;
         }
-        
+
         // String label for indexed dimension are created at runtime to reduce memory usage.
         if (string == null) {
             return String.valueOf(numeric);
         }
-        
+
         return string;
     }
 
@@ -54,7 +54,7 @@ class LabelImpl implements Label {
         var label = (LabelImpl) object;
         return isEqualTo(label);
     }
-    
+
     @Override
     public int hashCode() {
         return Long.hashCode(numeric);

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
@@ -16,7 +16,7 @@ final class TensorAddressAny1 extends TensorAddressAny {
     TensorAddressAny1(Label label) { this.label = label; }
 
     @Override public int size() { return 1; }
-    
+
     @Override
     public Label objectLabel(int i) {
         if (i == 0) {
@@ -31,7 +31,10 @@ final class TensorAddressAny1 extends TensorAddressAny {
         throw new IllegalArgumentException("No label " + labelIndex);
     }
 
-    @Override public int hashCode() { return (int)Math.abs(label.asNumeric()); }
+    // Added 32 to be consistent with the multi-label addresses
+    @Override public int hashCode() { 
+        return 31 + label.hashCode(); 
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
@@ -16,7 +16,7 @@ final class TensorAddressAny1 extends TensorAddressAny {
     TensorAddressAny1(Label label) { this.label = label; }
 
     @Override public int size() { return 1; }
-
+    
     @Override
     public Label objectLabel(int i) {
         if (i == 0) {
@@ -30,10 +30,9 @@ final class TensorAddressAny1 extends TensorAddressAny {
         if (labelIndex == 0) return new TensorAddressAny1(LabelCache.GLOBAL.getOrCreateLabel(label));
         throw new IllegalArgumentException("No label " + labelIndex);
     }
-
-    // Added 32 to be consistent with the multi-label addresses
+    
     @Override public int hashCode() { 
-        return 31 + label.hashCode(); 
+        return label.hashCode(); 
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
@@ -32,7 +32,7 @@ final class TensorAddressAny1 extends TensorAddressAny {
     }
     
     @Override public int hashCode() { 
-        return label.hashCode(); 
+        return 31 + label.hashCode(); 
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
@@ -5,10 +5,6 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.TensorAddress;
 
-import java.util.Objects;
-
-import static java.lang.Math.abs;
-
 /**
  * A two-dimensional address.
  *

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
@@ -5,6 +5,8 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.TensorAddress;
 
+import java.util.Objects;
+
 import static java.lang.Math.abs;
 
 /**
@@ -40,11 +42,13 @@ final class TensorAddressAny2 extends TensorAddressAny {
         };
     }
 
+    // Same as Objects.hash(label1, label0) but a little faster since it avoids creating an array, loop and null checks.
+    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
     @Override
     public int hashCode() {
-        long hash =  abs(label0.asNumeric()) |
-                (abs(label1.asNumeric()) << (64 - Long.numberOfLeadingZeros(abs(label0.asNumeric()))));
-        return (int) hash;
+        return 31 * 31 
+                + 31 * label1.hashCode() 
+                + label0.hashCode();
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
@@ -38,13 +38,12 @@ final class TensorAddressAny2 extends TensorAddressAny {
         };
     }
 
-    // Same as Objects.hash(label1, label0) but a little faster since it avoids creating an array, loop and null checks.
-    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
+    // Same as Objects.hash(...) but a little faster since it avoids creating an array, loop and null checks.
     @Override
     public int hashCode() {
-        return 31 * 31 
-                + 31 * label1.hashCode() 
-                + label0.hashCode();
+        return 31 * 31
+                + 31 * label0.hashCode() 
+                + label1.hashCode();
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
@@ -5,10 +5,6 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.TensorAddress;
 
-import java.util.Objects;
-
-import static java.lang.Math.abs;
-
 /**
  * A three-dimensional address.
  *

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
@@ -5,6 +5,8 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.TensorAddress;
 
+import java.util.Objects;
+
 import static java.lang.Math.abs;
 
 /**
@@ -43,12 +45,14 @@ final class TensorAddressAny3 extends TensorAddressAny {
         };
     }
 
+    // Same as Objects.hash(label1, label0) but a little faster since it avoids creating an array, loop and null checks.
+    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
     @Override
     public int hashCode() {
-        long hash =  abs(label0.asNumeric()) |
-                (abs(label1.asNumeric()) << (64 - Long.numberOfLeadingZeros(abs(label0.asNumeric())))) |
-                (abs(label2.asNumeric()) << (2*64 - (Long.numberOfLeadingZeros(abs(label0.asNumeric())) + Long.numberOfLeadingZeros(abs(label1.asNumeric())))));
-        return (int) hash;
+        return 31 * 31 * 31 
+                + 31 * 31 * label2.hashCode() 
+                + 31 * label1.hashCode() 
+                + label0.hashCode();
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
@@ -41,14 +41,13 @@ final class TensorAddressAny3 extends TensorAddressAny {
         };
     }
 
-    // Same as Objects.hash(label1, label0) but a little faster since it avoids creating an array, loop and null checks.
-    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
+    // Same as Objects.hash(...) but a little faster since it avoids creating an array, loop and null checks.
     @Override
     public int hashCode() {
         return 31 * 31 * 31 
-                + 31 * 31 * label2.hashCode() 
+                + 31 * 31 * label0.hashCode() 
                 + 31 * label1.hashCode() 
-                + label0.hashCode();
+                + label2.hashCode();
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
@@ -5,10 +5,6 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.TensorAddress;
 
-import java.util.Objects;
-
-import static java.lang.Math.abs;
-
 /**
  * A four-dimensional address.
  *

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
@@ -5,6 +5,8 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Label;
 import com.yahoo.tensor.TensorAddress;
 
+import java.util.Objects;
+
 import static java.lang.Math.abs;
 
 /**
@@ -46,13 +48,15 @@ final class TensorAddressAny4 extends TensorAddressAny {
         };
     }
 
+    // Same as Objects.hash(label1, label0) but a little faster since it avoids creating an array, loop and null checks.
+    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
     @Override
     public int hashCode() {
-        long hash =  abs(label0.asNumeric()) |
-                (abs(label1.asNumeric()) << (64 - Long.numberOfLeadingZeros(abs(label0.asNumeric())))) |
-                (abs(label2.asNumeric()) << (2*64 - (Long.numberOfLeadingZeros(abs(label0.asNumeric())) + Long.numberOfLeadingZeros(abs(label1.asNumeric()))))) |
-                (abs(label3.asNumeric()) << (3*64 - (Long.numberOfLeadingZeros(abs(label0.asNumeric())) + Long.numberOfLeadingZeros(abs(label1.asNumeric())) + Long.numberOfLeadingZeros(abs(label1.asNumeric())))));
-        return (int) hash;
+        return 31 * 31 * 31 * 31 
+                + 31 * 31 * 31 * label3.hashCode() 
+                + 31 * 31 * label2.hashCode() 
+                + 31 * label1.hashCode() 
+                + label0.hashCode();
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
@@ -44,15 +44,14 @@ final class TensorAddressAny4 extends TensorAddressAny {
         };
     }
 
-    // Same as Objects.hash(label1, label0) but a little faster since it avoids creating an array, loop and null checks.
-    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
+    // Same as Objects.hash(...) but a little faster since it avoids creating an array, loop and null checks.
     @Override
     public int hashCode() {
-        return 31 * 31 * 31 * 31 
-                + 31 * 31 * 31 * label3.hashCode() 
-                + 31 * 31 * label2.hashCode() 
-                + 31 * label1.hashCode() 
-                + label0.hashCode();
+        return 31 * 31 * 31 * 31    
+                + 31 * 31 * 31 * label0.hashCode() 
+                + 31 * 31 * label1.hashCode() 
+                + 31 * label2.hashCode() 
+                + label3.hashCode();
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
@@ -23,16 +23,16 @@ final class TensorAddressAnyN extends TensorAddressAny {
         this.labels = labels;
     }
 
-    @Override public int size() { 
-        return labels.length; 
+    @Override public int size() {
+        return labels.length;
     }
 
     @Override
     public Label objectLabel(int i) {
-        if (i < 0 || i >= size()) 
+        if (i < 0 || i >= size())
             throw new IndexOutOfBoundsException("Index is not in [0," + (size() - 1) + "]: " + i);
-        
-        return labels[i]; 
+
+        return labels[i];
     }
 
     @Override
@@ -42,13 +42,16 @@ final class TensorAddressAnyN extends TensorAddressAny {
         return new TensorAddressAnyN(copy);
     }
 
+    // Same as Arrays.hashCode(labels) but labels are iterated in reverse order. 
+    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
     @Override public int hashCode() {
-        long hash = abs(labels[0].asNumeric());
-        for (int i = 0; i < size(); i++) {
-            hash = hash | (abs(labels[i].asNumeric()) << (32 - Long.numberOfLeadingZeros(hash)));
-        }
-        return (int) hash;
-    }
+        int result = 1;
+
+        for (int i = labels.length - 1; i >= 0; i--)
+            result = 31 * result +  labels[i].hashCode();
+
+        return result;
+     }
 
     @Override
     public boolean equals(Object o) {

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
@@ -7,8 +7,6 @@ import com.yahoo.tensor.TensorAddress;
 
 import java.util.Arrays;
 
-import static java.lang.Math.abs;
-
 /**
  * An n-dimensional address.
  *

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
@@ -40,13 +40,12 @@ final class TensorAddressAnyN extends TensorAddressAny {
         return new TensorAddressAnyN(copy);
     }
 
-    // Same as Arrays.hashCode(labels) but labels are iterated in reverse order. 
-    // The order of labels is important - it has a big impact on the performance of mapped tensors in a dot product.
+    // Same as Arrays.hashCode(labels) but without null checks.
     @Override public int hashCode() {
         int result = 1;
 
-        for (int i = labels.length - 1; i >= 0; i--)
-            result = 31 * result +  labels[i].hashCode();
+        for (var label : labels)
+            result = 31 * result + label.hashCode();
 
         return result;
      }

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
@@ -21,16 +21,16 @@ final class TensorAddressAnyN extends TensorAddressAny {
         this.labels = labels;
     }
 
-    @Override public int size() {
-        return labels.length;
+    @Override public int size() { 
+        return labels.length; 
     }
 
     @Override
     public Label objectLabel(int i) {
-        if (i < 0 || i >= size())
+        if (i < 0 || i >= size()) 
             throw new IndexOutOfBoundsException("Index is not in [0," + (size() - 1) + "]: " + i);
-
-        return labels[i];
+        
+        return labels[i]; 
     }
 
     @Override

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorAddressTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorAddressTestCase.java
@@ -40,8 +40,8 @@ public class TensorAddressTestCase {
     void testInEquality() {
         notEqual(ofLabels("1"), ofLabels("2"));
         notEqual(of(1), of(2));
-        notEqual(ofLabels("1"), ofLabels("01"));
         notEqual(ofLabels("0"), ofLabels("00"));
+        notEqual(ofLabels("1"), ofLabels("01"));
     }
     @Test
     void testDimensionsEffectsEqualityAndHash() {
@@ -79,5 +79,19 @@ public class TensorAddressTestCase {
         int[] o_1_3_2 = {1,3,2};
         equal(ofLabels("b", "d", "c"), abcd.partialCopy(o_1_3_2));
     }
+    
+    @Test
+    void testHashCodeForLowEntropy() {
+        var e = TensorAddress.ofLabels("1", "4", "5", "6", "x", "y", "z");
+        var f = TensorAddress.ofLabels("1", "4", "5", "6", "x", "y", "z");
+        assertEquals(e.hashCode(), f.hashCode());
+        
+        var a = TensorAddress.ofLabels("a", "b", "c", "d", "e", "f", "g");
+        var b = TensorAddress.ofLabels("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
+        assertNotEquals(a.hashCode(), b.hashCode());
 
+        var c = TensorAddress.ofLabels("1", "4", "5", "6", "x", "y", "z");
+        var d = TensorAddress.ofLabels("1", "3", "5", "7", "z", "b", "c", "d", "e", "f");
+        assertNotEquals(c.hashCode(), d.hashCode());
+    }
 }

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorAddressTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorAddressTestCase.java
@@ -80,6 +80,9 @@ public class TensorAddressTestCase {
         equal(ofLabels("b", "d", "c"), abcd.partialCopy(o_1_3_2));
     }
     
+    // This test was designed for a previous version of the hashCode to produce collisions, see:
+    // https://github.com/vespa-engine/vespa/blob/073cb004ce0c26da9eff4b8f4745e0174bc85424/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java#L45
+    // Current implementation of the hashCode shouldn't produce collisions for this test.
     @Test
     void testHashCodeForLowEntropy() {
         var e = TensorAddress.ofLabels("1", "4", "5", "6", "x", "y", "z");


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Replaced custom hash code implementation with the one that is similar to a Java standart library.
The order of labels is reversed when generating hash codes for multi-label addresses.
For some reason this increased performance 8x for matrices with string labels.
Benchmarked with TensorFunctionBenchmark.java.
