### PR TITLE
Make it tuneable when to use bitvector when searching a disk index

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -356,6 +356,7 @@ MatchToolsFactory::extract_create_blueprint_params(const RankSetup& rank_setup, 
     double weakand_range = temporary::WeakAndRange::lookup(rank_properties, rank_setup.get_weakand_range());
     double weakand_stop_word_adjust_limit = WeakAndStopWordAdjustLimit::lookup(rank_properties, rank_setup.get_weakand_stop_word_adjust_limit());
     double weakand_stop_word_drop_limit = WeakAndStopWordDropLimit::lookup(rank_properties, rank_setup.get_weakand_stop_word_drop_limit());
+    double disk_index_bitvector_limit = DiskIndexBitvectorLimit::lookup(rank_properties, rank_setup.get_disk_index_bitvector_limit());
 
     // Note that we count the reserved docid 0 as active.
     // This ensures that when searchable-copies=1, the ratio is 1.0.
@@ -367,7 +368,8 @@ MatchToolsFactory::extract_create_blueprint_params(const RankSetup& rank_setup, 
             fuzzy_matching_algorithm,
             weakand_range,
             StopWordStrategy(weakand_stop_word_adjust_limit,
-                                                      weakand_stop_word_drop_limit, docid_limit)};
+                                                      weakand_stop_word_drop_limit, docid_limit),
+            disk_index_bitvector_limit};
 }
 
 AttributeOperationTask::AttributeOperationTask(const RequestContext & requestContext,

--- a/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
+++ b/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
@@ -142,6 +142,7 @@ protected:
     void test_io_settings(const IOSettings& io_settings);
     SimpleResult search(const FieldIndex& field_index, const DictionaryLookupResult& lookup_result,
                         const PostingListHandle& handle);
+    Blueprint::UP create_blueprint(const FieldSpec& field, const search::query::Node& term, uint32_t docid_limit=1000);
 };
 
 DiskIndexTest::DiskIndexTest() = default;
@@ -256,6 +257,14 @@ DiskIndexTest::search(const FieldIndex& field_index, const DictionaryLookupResul
     return SimpleResult().search(*sb);
 }
 
+Blueprint::UP
+DiskIndexTest::create_blueprint(const FieldSpec& field, const search::query::Node& term, uint32_t docid_limit)
+{
+    auto b = _index->createBlueprint(_requestContext, field, term);
+    b->basic_plan(true, docid_limit);
+    b->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+    return b;
+}
 
 void
 DiskIndexTest::requireThatWeCanReadPostingList(const IOSettings& io_settings)
@@ -327,28 +336,23 @@ void
 DiskIndexTest::requireThatBlueprintIsCreated()
 {
     { // unknown field
-        Blueprint::UP b =
-            _index->createBlueprint(_requestContext, FieldSpec("none", 0, 0), makeTerm("w1"));
-        EXPECT_TRUE(dynamic_cast<EmptyBlueprint *>(b.get()) != NULL);
+        auto b = _index->createBlueprint(_requestContext, FieldSpec("none", 0, 0), makeTerm("w1"));
+        EXPECT_TRUE(dynamic_cast<EmptyBlueprint *>(b.get()) != nullptr);
     }
     { // unknown word
-        Blueprint::UP b =
-            _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("none"));
-        EXPECT_TRUE(dynamic_cast<EmptyBlueprint *>(b.get()) != NULL);
+        auto b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("none"));
+        EXPECT_TRUE(dynamic_cast<EmptyBlueprint *>(b.get()) != nullptr);
     }
     { // known field & word with hits
-        Blueprint::UP b =
-            _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("w1"));
-        EXPECT_TRUE(dynamic_cast<DiskTermBlueprint *>(b.get()) != NULL);
+        auto b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("w1"));
+        EXPECT_TRUE(dynamic_cast<DiskTermBlueprint *>(b.get()) != nullptr);
         EXPECT_EQ(2u, b->getState().estimate().estHits);
         EXPECT_TRUE(!b->getState().estimate().empty);
     }
     { // known field & word without hits
-        Blueprint::UP b =
-            _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("w2"));
-//        std::cerr << "BP = " << typeid(*b).name() << std::endl;
-        EXPECT_TRUE((dynamic_cast<DiskTermBlueprint *>(b.get()) != NULL) ||
-                    (dynamic_cast<EmptyBlueprint *>(b.get()) != NULL));
+        auto b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("w2"));
+        EXPECT_TRUE((dynamic_cast<DiskTermBlueprint *>(b.get()) != nullptr) ||
+                    (dynamic_cast<EmptyBlueprint *>(b.get()) != nullptr));
         EXPECT_EQ(0u, b->getState().estimate().estHits);
         EXPECT_TRUE(b->getState().estimate().empty);
     }
@@ -366,53 +370,64 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
     SimpleResult result_f1_w2;
     SimpleResult result_f2_w2({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17});
     auto upper_bound = Blueprint::FilterConstraint::UPPER_BOUND;
-    { // bit vector due to isFilter
-        b = _index->createBlueprint(_requestContext, FieldSpec("f2", 0, 0, true), makeTerm("w2"));
-        b->basic_plan(true, 1000);
-        b->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+    { // bitvector due to is_filter_field=true
+        b = create_blueprint(FieldSpec("f2", 0, 0, true), makeTerm("w2"));
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
-        EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != NULL);
+        EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
         EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
         EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
-    { // bit vector due to no ranking needed
-        b = _index->createBlueprint(_requestContext, FieldSpec("f2", 0, 0, false), makeTerm("w2"));
-        b->basic_plan(true, 1000);
-        b->fetchPostings(ExecuteInfo::FULL);
+    { // bitvector due to no ranking needed
+        b = create_blueprint(FieldSpec("f2", 0, 0, false), makeTerm("w2"));
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
-        EXPECT_FALSE(dynamic_cast<BitVectorIterator *>(s.get()) != NULL);
+        EXPECT_FALSE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
         TermFieldMatchData md2;
         md2.tagAsNotNeeded();
         TermFieldMatchDataArray mda2;
         mda2.add(&md2);
         EXPECT_TRUE(mda2[0]->isNotNeeded());
         s = (dynamic_cast<LeafBlueprint *>(b.get()))->createLeafSearch(mda2);
-        EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != NULL);
+        EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
         EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
         EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
-    { // fake bit vector
-        b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0, true), makeTerm("w2"));
-//        std::cerr << "BP = " << typeid(*b).name() << std::endl;
-        b->basic_plan(true, 1000);
-        b->fetchPostings(ExecuteInfo::FULL);
+    { // fake bitvector (wrapping posocc iterator)
+        b = create_blueprint(FieldSpec("f1", 0, 0, true), makeTerm("w1"));
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
-//        std::cerr << "SI = " << typeid(*s).name() << std::endl;
-        EXPECT_TRUE((dynamic_cast<BooleanMatchIteratorWrapper *>(s.get()) != NULL) ||
-                    dynamic_cast<EmptySearch *>(s.get()));
-        EXPECT_EQ(result_f1_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f1_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_TRUE(dynamic_cast<BooleanMatchIteratorWrapper *>(s.get()) != nullptr);
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
     { // posting list iterator
-        b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("w1"));
-        b->basic_plan(true, 1000);
-        b->fetchPostings(ExecuteInfo::FULL);
+        b = create_blueprint(FieldSpec("f1", 0, 0), makeTerm("w1"));
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
-        ASSERT_TRUE((dynamic_cast<ZcRareWordPosOccIterator<true, false> *>(s.get()) != NULL));
+        ASSERT_TRUE((dynamic_cast<ZcRareWordPosOccIterator<true, false> *>(s.get()) != nullptr));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+    }
+    { // bitvector used due to bitvector_limit set.
+        // The term 'w2' hits 17 docs in field 'f2' (bitvector for term exists).
+        double bitvector_limit = 16.0 / 100.0;
+        _requestContext.get_create_blueprint_params().disk_index_bitvector_limit = bitvector_limit;
+        b = create_blueprint(FieldSpec("f2", 0, 0, false), makeTerm("w2"), 100);
+        auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
+        s = leaf_b.createLeafSearch(mda);
+        EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+    }
+    { // fake bitvector (wrapping posocc iterator) used due to bitvector_limit set.
+        // The term 'w1' hits 2 docs in field 'f1' (bitvector for term doesn't exist).
+        double bitvector_limit = 1.0 / 100.0;
+        _requestContext.get_create_blueprint_params().disk_index_bitvector_limit = bitvector_limit;
+        b = create_blueprint(FieldSpec("f1", 0, 0, false), makeTerm("w1"), 100);
+        auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
+        s = leaf_b.createLeafSearch(mda);
+        EXPECT_TRUE((dynamic_cast<BooleanMatchIteratorWrapper *>(s.get()) != nullptr));
         EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
         EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
@@ -490,7 +505,7 @@ DiskIndexTest::test_io_settings(const IOSettings& io_settings)
         ASSERT_TRUE(posting_list_cache);
         auto stats = posting_list_cache->get_stats();
         EXPECT_EQ(2, stats.misses);
-        EXPECT_EQ(1, stats.hits);
+        EXPECT_EQ(3, stats.hits);
     } else {
         ASSERT_FALSE(posting_list_cache);
     }

--- a/searchlib/src/tests/ranksetup/ranksetup_test.cpp
+++ b/searchlib/src/tests/ranksetup/ranksetup_test.cpp
@@ -563,6 +563,7 @@ TEST_F(RankSetupTest, rank_setup)
     env.getProperties().add(matching::FuzzyAlgorithm::NAME, "dfa_implicit");
     env.getProperties().add(matching::WeakAndStopWordAdjustLimit::NAME, "0.05");
     env.getProperties().add(matching::WeakAndStopWordDropLimit::NAME, "0.5");
+    env.getProperties().add(matching::DiskIndexBitvectorLimit::NAME, "0.04");
 
     RankSetup rs(_factory, env);
     EXPECT_FALSE(rs.has_match_features());
@@ -608,6 +609,7 @@ TEST_F(RankSetupTest, rank_setup)
     EXPECT_EQ(rs.get_fuzzy_matching_algorithm(), vespalib::FuzzyMatchingAlgorithm::DfaImplicit);
     EXPECT_EQ(rs.get_weakand_stop_word_adjust_limit(), 0.05);
     EXPECT_EQ(rs.get_weakand_stop_word_drop_limit(), 0.5);
+    EXPECT_EQ(rs.get_disk_index_bitvector_limit(), 0.04);
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
@@ -15,16 +15,18 @@ class DiskTermBlueprint : public queryeval::SimpleLeafBlueprint
 private:
     queryeval::FieldSpec             _field;
     const FieldIndex&                _field_index;
-    std::string                 _query_term;
-    index::DictionaryLookupResult          _lookupRes;
+    std::string                      _query_term;
+    index::DictionaryLookupResult    _lookupRes;
     index::BitVectorDictionaryLookupResult _bitvector_lookup_result;
-    bool                             _useBitVector;
+    bool                             _is_filter_field;
+    double                           _bitvector_limit;
     bool                             _fetchPostingsDone;
     index::PostingListHandle         _postingHandle;
     std::shared_ptr<BitVector>       _bitVector;
     mutable std::mutex               _mutex;
     mutable std::shared_ptr<BitVector> _late_bitvector;
 
+    bool use_bitvector() const;
     const BitVector* get_bitvector() const;
     void log_bitvector_read() const __attribute__((noinline));
     void log_posting_list_read() const __attribute__((noinline));
@@ -32,16 +34,20 @@ public:
     /**
      * Create a new blueprint.
      *
-     * @param field        the field to search in.
-     * @param field_index    the field index used to read the bit vector or posting list.
-     * @param lookupRes    the result after disk dictionary lookup.
-     * @param useBitVector whether or not we should use bit vector.
+     * @param field           The field to search in.
+     * @param field_index     The field index used to read the bit vector or posting list.
+     * @param lookupRes       The result after disk dictionary lookup.
+     * @param is_filter_field Whether this field is filter and we should force use of bit vector.
+     * @param bitvector_limit The hit estimate limit for whether bitvector should be used for searching this term.
+                              This can be used to tune performance at the cost of quality.
+                              If no bitvector exists for the term, a fake bitvector wrapping the posocc iterator is used.
      **/
     DiskTermBlueprint(const queryeval::FieldSpec & field,
                       const FieldIndex& field_index,
                       const std::string& query_term,
                       index::DictionaryLookupResult lookupRes,
-                      bool useBitVector);
+                      bool is_filter_field,
+                      double bitvector_limit);
 
     queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
@@ -458,6 +458,13 @@ double WeakAndStopWordDropLimit::lookup(const Properties &props, double defaultV
     return lookupDouble(props, NAME, defaultValue);
 }
 
+const std::string DiskIndexBitvectorLimit::NAME("vespa.matching.diskindex.bitvector_limit");
+const double DiskIndexBitvectorLimit::DEFAULT_VALUE(1.0);
+double DiskIndexBitvectorLimit::lookup(const Properties& props) { return lookup(props, DEFAULT_VALUE); }
+double DiskIndexBitvectorLimit::lookup(const Properties& props, double default_value) {
+    return lookupDouble(props, NAME, default_value);
+}
+
 const std::string TargetHitsMaxAdjustmentFactor::NAME("vespa.matching.nns.target_hits_max_adjustment_factor");
 
 const double TargetHitsMaxAdjustmentFactor::DEFAULT_VALUE(20.0);

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.h
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.h
@@ -364,6 +364,17 @@ namespace matching {
     };
 
     /**
+     * Use bitvector posting list for terms searching in disk indexes that match more than this limit of the corpus.
+     * If a bitvector is not available for the term, mask the posocc posting list as a bitvector iterator.
+     **/
+    struct DiskIndexBitvectorLimit {
+        static const std::string NAME;
+        static const double DEFAULT_VALUE;
+        static double lookup(const Properties& props);
+        static double lookup(const Properties& props, double default_value);
+    };
+
+    /**
      * Property to control the algorithm using for fuzzy matching.
      **/
     struct FuzzyAlgorithm {

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -77,6 +77,7 @@ RankSetup::RankSetup(const BlueprintFactory &factory, const IIndexEnvironment &i
       _weakand_range(0.0),
       _weakand_stop_word_adjust_limit(matching::WeakAndStopWordAdjustLimit::DEFAULT_VALUE),
       _weakand_stop_word_drop_limit(matching::WeakAndStopWordDropLimit::DEFAULT_VALUE),
+      _disk_index_bitvector_limit(matching::DiskIndexBitvectorLimit::DEFAULT_VALUE),
       _fuzzy_matching_algorithm(vespalib::FuzzyMatchingAlgorithm::DfaTable),
       _mutateOnMatch(),
       _mutateOnFirstPhase(),
@@ -136,6 +137,7 @@ RankSetup::configure()
     set_weakand_range(temporary::WeakAndRange::lookup(_indexEnv.getProperties()));
     set_weakand_stop_word_adjust_limit(matching::WeakAndStopWordAdjustLimit::lookup(_indexEnv.getProperties()));
     set_weakand_stop_word_drop_limit(matching::WeakAndStopWordDropLimit::lookup(_indexEnv.getProperties()));
+    set_disk_index_bitvector_limit(matching::DiskIndexBitvectorLimit::lookup(_indexEnv.getProperties()));
     _mutateOnMatch._attribute = mutate::on_match::Attribute::lookup(_indexEnv.getProperties());
     _mutateOnMatch._operation = mutate::on_match::Operation::lookup(_indexEnv.getProperties());
     _mutateOnFirstPhase._attribute = mutate::on_first_phase::Attribute::lookup(_indexEnv.getProperties());

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -86,6 +86,7 @@ private:
     double                   _weakand_range;
     double                   _weakand_stop_word_adjust_limit;
     double                   _weakand_stop_word_drop_limit;
+    double                   _disk_index_bitvector_limit;
     vespalib::FuzzyMatchingAlgorithm _fuzzy_matching_algorithm;
     MutateOperation          _mutateOnMatch;
     MutateOperation          _mutateOnFirstPhase;
@@ -418,6 +419,8 @@ public:
     double get_weakand_stop_word_adjust_limit() const { return _weakand_stop_word_adjust_limit; }
     void set_weakand_stop_word_drop_limit(double v) { _weakand_stop_word_drop_limit = v; }
     double get_weakand_stop_word_drop_limit() const { return _weakand_stop_word_drop_limit; }
+    void set_disk_index_bitvector_limit(double v) { _disk_index_bitvector_limit = v; }
+    double get_disk_index_bitvector_limit() const { return _disk_index_bitvector_limit; }
 
     /**
      * This method may be used to indicate that certain features

--- a/searchlib/src/vespa/searchlib/queryeval/create_blueprint_params.h
+++ b/searchlib/src/vespa/searchlib/queryeval/create_blueprint_params.h
@@ -19,19 +19,22 @@ struct CreateBlueprintParams
     vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm;
     double weakand_range;
     queryeval::wand::StopWordStrategy weakand_stop_word_strategy;
+    double disk_index_bitvector_limit;
 
     CreateBlueprintParams(double global_filter_lower_limit_in,
                           double global_filter_upper_limit_in,
                           double target_hits_max_adjustment_factor_in,
                           vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm_in,
                           double weakand_range_in,
-                          queryeval::wand::StopWordStrategy weakand_stop_word_strategy_in)
+                          queryeval::wand::StopWordStrategy weakand_stop_word_strategy_in,
+                          double disk_index_bitvector_limit_in)
         : global_filter_lower_limit(global_filter_lower_limit_in),
           global_filter_upper_limit(global_filter_upper_limit_in),
           target_hits_max_adjustment_factor(target_hits_max_adjustment_factor_in),
           fuzzy_matching_algorithm(fuzzy_matching_algorithm_in),
           weakand_range(weakand_range_in),
-          weakand_stop_word_strategy(weakand_stop_word_strategy_in)
+          weakand_stop_word_strategy(weakand_stop_word_strategy_in),
+          disk_index_bitvector_limit(disk_index_bitvector_limit_in)
     {
     }
 
@@ -41,7 +44,8 @@ struct CreateBlueprintParams
                                 fef::indexproperties::matching::TargetHitsMaxAdjustmentFactor::DEFAULT_VALUE,
                                 fef::indexproperties::matching::FuzzyAlgorithm::DEFAULT_VALUE,
                                 fef::indexproperties::temporary::WeakAndRange::DEFAULT_VALUE,
-                                queryeval::wand::StopWordStrategy::none())
+                                queryeval::wand::StopWordStrategy::none(),
+                                fef::indexproperties::matching::DiskIndexBitvectorLimit::DEFAULT_VALUE)
     {
     }
 };

--- a/searchlib/src/vespa/searchlib/queryeval/fake_requestcontext.h
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_requestcontext.h
@@ -50,6 +50,8 @@ public:
 
     const CreateBlueprintParams& get_create_blueprint_params() const override;
     const MetaStoreReadGuardSP * getMetaStoreReadGuard() const override { return nullptr; }
+
+    CreateBlueprintParams& get_create_blueprint_params() { return _create_blueprint_params; }
 private:
     std::unique_ptr<vespalib::TestClock> _clock;
     const vespalib::Doom _doom;


### PR DESCRIPTION
The bitvector hit estimate limit can be used to tune performance at the cost of quality,
by not reading the large posocc posting lists for common words from disk.
The posocc posting list for the most common words are typically more than 100x larger than the bitvector.

@toregge please review