### PR TITLE
Add support for explicit trimming of LRU cache

### DIFF
--- a/vespalib/src/tests/stllike/lrucache.cpp
+++ b/vespalib/src/tests/stllike/lrucache.cpp
@@ -11,29 +11,29 @@ TEST(LruCacheMapTest, cache_basics) {
     // Verify start conditions.
     EXPECT_EQ(cache.size(), 0);
     cache.insert(1, "First inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 1);
     EXPECT_TRUE(cache.hasKey(1));
     cache.insert(2, "Second inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 2);
     EXPECT_TRUE(cache.hasKey(1));
     EXPECT_TRUE(cache.hasKey(2));
     cache.insert(3, "Third inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 3);
     EXPECT_TRUE(cache.hasKey(1));
     EXPECT_TRUE(cache.hasKey(2));
     EXPECT_TRUE(cache.hasKey(3));
     cache.insert(4, "Fourth inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 4);
     EXPECT_TRUE(cache.hasKey(1));
     EXPECT_TRUE(cache.hasKey(2));
     EXPECT_TRUE(cache.hasKey(3));
     EXPECT_TRUE(cache.hasKey(4));
     cache.insert(5, "Fifth inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 5);
     EXPECT_TRUE(cache.hasKey(1));
     EXPECT_TRUE(cache.hasKey(2));
@@ -41,7 +41,7 @@ TEST(LruCacheMapTest, cache_basics) {
     EXPECT_TRUE(cache.hasKey(4));
     EXPECT_TRUE(cache.hasKey(5));
     cache.insert(6, "Sixt inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 6);
     EXPECT_TRUE(cache.hasKey(1));
     EXPECT_TRUE(cache.hasKey(2));
@@ -50,7 +50,7 @@ TEST(LruCacheMapTest, cache_basics) {
     EXPECT_TRUE(cache.hasKey(5));
     EXPECT_TRUE(cache.hasKey(6));
     cache.insert(7, "Seventh inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 7);
     EXPECT_TRUE(cache.hasKey(1));
     EXPECT_TRUE(cache.hasKey(2));
@@ -60,7 +60,7 @@ TEST(LruCacheMapTest, cache_basics) {
     EXPECT_TRUE(cache.hasKey(6));
     EXPECT_TRUE(cache.hasKey(7));
     cache.insert(8, "Eighth inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 7);
     EXPECT_TRUE(cache.hasKey(2));
     EXPECT_TRUE(cache.hasKey(3));
@@ -70,7 +70,7 @@ TEST(LruCacheMapTest, cache_basics) {
     EXPECT_TRUE(cache.hasKey(7));
     EXPECT_TRUE(cache.hasKey(8));
     cache.insert(15, "Eighth inserted string");
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_EQ(cache.size(), 7);
     EXPECT_TRUE(cache.hasKey(3));
     EXPECT_TRUE(cache.hasKey(4));
@@ -81,9 +81,9 @@ TEST(LruCacheMapTest, cache_basics) {
     EXPECT_TRUE(cache.hasKey(15));
     // Test get and erase
     (void)cache.get(3);
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     cache.erase(3);
-    EXPECT_TRUE(cache.verifyInternals());
+    cache.verifyInternals();
     EXPECT_TRUE(!cache.hasKey(3));
 }
 
@@ -204,6 +204,7 @@ TEST(LruCacheMapTest, cache_erase_by_iterator) {
     ASSERT_EQ("third", *it);
     cache.erase(it);
     EXPECT_EQ(lru_key_order(cache), "1");
+    cache.verifyInternals();
 }
 
 TEST(LruCacheMapTest, find_no_ref_returns_iterator_if_present_and_does_not_update_lru) {

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -125,7 +125,7 @@ class cache {
 
         // Trims the cache segment so that after the call the following holds:
         //   size_bytes() <= capacity() && size() <= maxElements()
-        void trim();
+        using Lru::trim;
 
         [[nodiscard]] std::vector<KeyT> dump_segment_keys_in_lru_order();
 

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -123,9 +123,9 @@ class cache {
         // Otherwise, `val_out` is not modified and false is returned.
         [[nodiscard]] bool try_get_and_ref(const KeyT& key, ValueT& val_out);
 
-        // Clears the entire cache segment. removeOldest() is not invoked for any entries.
-        // _size_bytes will be reset to zero after invocation.
-        void evict_all();
+        // Trims the cache segment so that after the call the following holds:
+        //   size_bytes() <= capacity() && size() <= maxElements()
+        void trim();
 
         [[nodiscard]] std::vector<KeyT> dump_segment_keys_in_lru_order();
 
@@ -325,7 +325,7 @@ private:
     [[nodiscard]] bool try_fill_from_cache(const K& key, V& val_out);
 
     [[nodiscard]] bool multi_segment() const noexcept { return _protected_segment.capacity_bytes() != 0; }
-    void disable_slru();
+    void trim_segments();
     void verifyHashLock(const UniqueLock& guard) const;
     [[nodiscard]] size_t calcSize(const K& k, const V& v) const noexcept {
         return per_element_fixed_overhead() + _sizeK(k) + _sizeV(v);

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -92,12 +92,6 @@ cache<P>::SizeConstrainedLru::try_get_and_ref(const KeyT& key, ValueT& val_out) 
 }
 
 template <typename P>
-void
-cache<P>::SizeConstrainedLru::trim() {
-    Lru::trim();
-}
-
-template <typename P>
 std::vector<typename P::Key>
 cache<P>::SizeConstrainedLru::dump_segment_keys_in_lru_order() {
     std::vector<KeyT> lru_keys;

--- a/vespalib/src/vespa/vespalib/stllike/cache.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/cache.hpp
@@ -46,7 +46,6 @@ cache<P>::SizeConstrainedLru::insert_and_update_size(const KeyT& key, ValueT val
     add_size_bytes(_owner.calcSize(key, value));
     auto insert_res = Lru::insert(key, std::move(value));
     assert(insert_res.second);
-
 }
 
 template <typename P>
@@ -94,16 +93,8 @@ cache<P>::SizeConstrainedLru::try_get_and_ref(const KeyT& key, ValueT& val_out) 
 
 template <typename P>
 void
-cache<P>::SizeConstrainedLru::evict_all() {
-    // There's no `clear()` on lrucache_map, so do it the hard way.
-    auto iter = Lru::begin();
-    while (iter != Lru::end()) {
-        // Entries will not be transitioned out of the cache via the probationary segment,
-        // so invoke the removal callback directly.
-        _owner.onRemove(iter.key());
-        iter = Lru::erase(iter); // This does _not_ invoke `removeOldest()`
-    }
-    set_size_bytes(0);
+cache<P>::SizeConstrainedLru::trim() {
+    Lru::trim();
 }
 
 template <typename P>
@@ -166,9 +157,7 @@ cache<P>::maxElements(size_t probationary_elems, size_t protected_elems) {
     std::lock_guard guard(_hashLock);
     _probationary_segment.set_max_elements(probationary_elems);
     _protected_segment.set_max_elements(protected_elems);
-    if (protected_elems == 0) { // If max protected elems == 0, this disables SLRU semantics
-        disable_slru();
-    }
+    trim_segments();
     return *this;
 }
 
@@ -185,9 +174,7 @@ cache<P>::setCapacityBytes(size_t probationary_sz, size_t protected_sz) {
     std::lock_guard guard(_hashLock);
     _probationary_segment.set_capacity_bytes(probationary_sz);
     _protected_segment.set_capacity_bytes(protected_sz);
-    if (protected_sz == 0) { // If max protected size == 0, this disables SLRU semantics
-        disable_slru();
-    }
+    trim_segments();
     return *this;
 }
 
@@ -200,15 +187,13 @@ cache<P>::setCapacityBytes(size_t sz) {
 
 template <typename P>
 void
-cache<P>::disable_slru() {
-    _protected_segment.set_max_elements(0);
-    _protected_segment.set_capacity_bytes(0);
-    // This has the not-entirely-optimal(tm) side effect of evicting the elements
-    // we consider the most important (i.e. the protected ones), but this exists
-    // only so that live-disabling SLRU entirely will be _correct_, not that it
-    // will be objectively _efficient_.
-    // TODO expose lrucache_map trimming and use this here instead.
-    _protected_segment.evict_all();
+cache<P>::trim_segments() {
+    // First trim the protected segment. This will transfer trimmed elements into the
+    // probationary segment, preserving the presumed most "important" elements.
+    _protected_segment.trim();
+    // Now trim the probationary segment. This will not transfer elements to the
+    // protected segment, but will send them to the great cache in the sky.
+    _probationary_segment.trim();
 }
 
 template <typename P>

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -126,6 +126,18 @@ public:
     iterator erase(const iterator & it);
 
     /**
+     * Trims the cache size so that it is within its capacity limits. Since
+     * the cache itself will normally do this during inserts, this can be
+     * used to explicitly trim the cache when higher-level capacities (used
+     * via removeOldest()) change, which are not picked up directly by the
+     * cache itself.
+     *
+     * Note that this does not use soft limits; if the cache has only a single
+     * element, and it is over-sized, trimming will remove the entry.
+     */
+    void trim();
+
+    /**
      * Object is inserted in cache with given key.
      * Object is then put at head of LRU list.
      */
@@ -204,6 +216,14 @@ private:
     void ref(const internal_iterator & it);
     insert_result insert(value_type && value);
     void removeOld();
+    /**
+     * Trims the cache by removing elements in an old-to-new order, stopping as
+     * soon as either removeOldest() returns false, or:
+     *   - if PreserveHead == true, the current element is the LRU head element
+     *   - if PreserveHead == false, if the LRU list is empty
+     */
+    template <bool PreserveHead> void trim_impl();
+
     class RecordMoves {
     public:
         RecordMoves(const RecordMoves &) = delete;

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -197,7 +197,7 @@ public:
     /**
      * Method for testing that internal consistency is good.
      */
-    bool verifyInternals();
+    void verifyInternals();
 
     /**
      * Implements the move callback from the hashtable

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
@@ -146,16 +146,15 @@ lrucache_map<P>::erase(const iterator & it)
 }
 
 template< typename P >
-bool
+void
 lrucache_map<P>::verifyInternals()
 {
-    bool retval(true);
     if (_head == LinkedValueBase::npos || _tail == LinkedValueBase::npos) {
         // If _either_ head or tail is invalid, they must both be.
         assert(_head == LinkedValueBase::npos);
         assert(_tail == LinkedValueBase::npos);
         assert(size() == 0);
-        return true;
+        return;
     }
     assert(HashTable::getByInternalIndex(_head).second._prev == LinkedValueBase::npos);
     assert(HashTable::getByInternalIndex(_tail).second._next == LinkedValueBase::npos);
@@ -181,7 +180,6 @@ lrucache_map<P>::verifyInternals()
         assert(i == size());
         assert(c == LinkedValueBase::npos);
     }
-    return retval;
 }
 
 template< typename P >


### PR DESCRIPTION
@havardpe please review. Last one... <sup>for now...</sup> 😼

`lrucache_map`: add a `trim()` function which evicts elements in old-to-new order until the LRU policy stays stop. Note that this does not use soft limits; if the cache has only a single element, and it is over-sized, trimming will remove the entry and leave the cache empty.

`cache`: always use the trimming functionality (for both segments) when reconfiguring capacities instead of special-casing eviction. Trim protected before probationary to ensure spillover to probationary segment.