### PR TITLE
Support tensor field presence checks as part of document selection evaluation

### DIFF
--- a/document/src/main/java/com/yahoo/document/select/rule/ComparisonNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/ComparisonNode.java
@@ -7,6 +7,7 @@ import com.yahoo.document.DocumentId;
 import com.yahoo.document.datatypes.BoolFieldValue;
 import com.yahoo.document.datatypes.FieldPathIteratorHandler;
 import com.yahoo.document.datatypes.NumericFieldValue;
+import com.yahoo.document.datatypes.TensorFieldValue;
 import com.yahoo.document.idstring.IdIdString;
 import com.yahoo.document.select.BucketSet;
 import com.yahoo.document.select.Context;
@@ -179,6 +180,9 @@ public class ComparisonNode implements ExpressionNode {
             if (!lhs.get(i).getVariables().equals(rhs.get(i).getVariables())) {
                 return new ResultList(Result.FALSE);
             }
+            if (lhs.get(i).getValue() instanceof TensorFieldValue || rhs.get(i).getValue() instanceof TensorFieldValue) {
+                return new ResultList(Result.INVALID);
+            }
 
             if (evaluateEquals(lhs.get(i).getValue(), rhs.get(i).getValue()) == Result.FALSE) {
                 return new ResultList(Result.FALSE);
@@ -214,6 +218,9 @@ public class ComparisonNode implements ExpressionNode {
         }
         if (list == null || other == null) {
             return new ResultList(Result.FALSE);
+        }
+        if (other instanceof TensorFieldValue) {
+            return new ResultList(Result.INVALID);
         }
 
         var results = new ResultList();
@@ -267,6 +274,10 @@ public class ComparisonNode implements ExpressionNode {
     private Result evaluateEquals(Object lhs, Object rhs) {
         if (lhs == null || rhs == null) {
             return Result.toResult(lhs == rhs);
+        }
+        // If either side is a tensor field, the result is Invalid (no peeking inside tensors)
+        if (lhs instanceof TensorFieldValue || rhs instanceof TensorFieldValue) {
+            return Result.INVALID;
         }
 
         double a = getAsNumber(lhs);

--- a/document/src/vespa/document/select/compare.cpp
+++ b/document/src/vespa/document/select/compare.cpp
@@ -41,12 +41,12 @@ namespace {
     {
         std::unique_ptr<Value> left(l.getValue(value));
         std::unique_ptr<Value> right(r.getValue(value));
-        if (left->getType() == Value::Bucket
-            || right->getType() == Value::Bucket)
+        if (left->getType() == Value::Type::Bucket
+            || right->getType() == Value::Type::Bucket)
         {
-            Value& bVal(left->getType() == Value::Bucket ? *left : *right);
-            Value& nVal(left->getType() == Value::Bucket ? *right : *left);
-            if (nVal.getType() == Value::Integer
+            Value& bVal(left->getType() == Value::Type::Bucket ? *left : *right);
+            Value& nVal(left->getType() == Value::Type::Bucket ? *right : *left);
+            if (nVal.getType() == Value::Type::Integer
                 && (op == FunctionOperator::EQ || op == FunctionOperator::NE
                     || op == GlobOperator::GLOB))
             {
@@ -70,12 +70,12 @@ namespace {
     {
         std::unique_ptr<Value> left(l.traceValue(value, out));
         std::unique_ptr<Value> right(r.traceValue(value, out));
-        if (left->getType() == Value::Bucket
-            || right->getType() == Value::Bucket)
+        if (left->getType() == Value::Type::Bucket
+            || right->getType() == Value::Type::Bucket)
         {
-            Value& bVal(left->getType() == Value::Bucket ? *left : *right);
-            Value& nVal(left->getType() == Value::Bucket ? *right : *left);
-            if (nVal.getType() == Value::Integer
+            Value& bVal(left->getType() == Value::Type::Bucket ? *left : *right);
+            Value& nVal(left->getType() == Value::Type::Bucket ? *right : *left);
+            if (nVal.getType() == Value::Type::Integer
                 && (op == FunctionOperator::EQ || op == FunctionOperator::NE
                     || op == GlobOperator::GLOB))
             {

--- a/document/src/vespa/document/select/value.cpp
+++ b/document/src/vespa/document/select/value.cpp
@@ -9,6 +9,22 @@
 
 namespace document::select {
 
+std::ostream& operator<<(std::ostream& os, Value::Type t) {
+    using Type = Value::Type;
+    switch (t) {
+    case Type::Invalid: os << "Invalid"; break;
+    case Type::Null:    os << "Null";    break;
+    case Type::String:  os << "String";  break;
+    case Type::Integer: os << "Integer"; break;
+    case Type::Float:   os << "Float";   break;
+    case Type::Array:   os << "Array";   break;
+    case Type::Struct:  os << "Struct";  break;
+    case Type::Bucket:  os << "Bucket";  break;
+    case Type::Tensor:  os << "Tensor";  break;
+    }
+    return os;
+}
+
 ResultList
 Value::globCompare(const Value& value) const
 {
@@ -100,7 +116,7 @@ NullValue::print(std::ostream& out, bool verbose,
 }
 
 StringValue::StringValue(std::string_view val)
-    : Value(String),
+    : Value(Type::String),
       _value(val)
 {
 }
@@ -134,7 +150,7 @@ StringValue::print(std::ostream& out, bool verbose, const std::string& indent) c
 }
 
 IntegerValue::IntegerValue(int64_t val, bool isBucketValue)
-    : NumberValue(isBucketValue ? Bucket : Integer),
+    : NumberValue(isBucketValue ? Type::Bucket : Type::Integer),
       _value(val)
 {
 }
@@ -168,7 +184,7 @@ IntegerValue::print(std::ostream& out, bool verbose, const std::string& indent) 
 }
 
 FloatValue::FloatValue(double val)
-    : NumberValue(Float),
+    : NumberValue(Type::Float),
       _value(val)
 {
 }
@@ -202,7 +218,7 @@ FloatValue::print(std::ostream& out, bool verbose, const std::string& indent) co
 }
 
 ArrayValue::ArrayValue(std::vector<VariableValue> values)
-    : Value(Array),
+    : Value(Type::Array),
       _values(std::move(values))
 {
 }
@@ -324,7 +340,7 @@ ArrayValue::print(std::ostream& out, bool verbose, const std::string& indent) co
 }
 
 StructValue::StructValue(ValueMap values)
-    : Value(Struct),
+    : Value(Type::Struct),
       _values(std::move(values))
 {
 }
@@ -411,7 +427,7 @@ template <typename Predicate>
 ResultList
 ArrayValue::doCompare(const Value& value, const Predicate& cmp) const
 {
-    if (value.getType() == Array) {
+    if (value.getType() == Type::Array) {
         // If comparing with an array, must match all.
         const ArrayValue* val(static_cast<const ArrayValue*>(&value));
         if (_values.size() != val->_values.size()) {
@@ -447,7 +463,7 @@ ArrayValue::doCompare(const Value& value, const Predicate& cmp) const
     }
 }
 
-TensorValue::TensorValue() : Value(Tensor) {}
+TensorValue::TensorValue() : Value(Type::Tensor) {}
 TensorValue::~TensorValue() = default;
 
 ResultList

--- a/document/src/vespa/document/select/value.h
+++ b/document/src/vespa/document/select/value.h
@@ -30,7 +30,7 @@ class Value : public document::Printable
 public:
     using SP = std::shared_ptr<Value>;
     using UP = std::unique_ptr<Value>;
-    enum Type { Invalid, Null, String, Integer, Float, Array, Struct, Bucket };
+    enum Type { Invalid, Null, String, Integer, Float, Array, Struct, Bucket, Tensor };
 
     Value(Type t) : _type(t) {}
     virtual ~Value() = default;
@@ -239,6 +239,20 @@ public:
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 private:
     ValueMap _values;
+};
+
+// We currently only support checking for tensor field _presence_ as part of
+// document selections (i.e. via null-checks). All other interactions with tensor
+// fields will yield Invalid.
+class TensorValue : public Value {
+public:
+    TensorValue();
+    ~TensorValue() override;
+
+    ResultList operator<(const Value&) const override;
+    ResultList operator==(const Value&) const override;
+    ResultList operator!=(const Value&) const override;
+    void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 };
 
 }

--- a/document/src/vespa/document/select/value.h
+++ b/document/src/vespa/document/select/value.h
@@ -30,10 +30,10 @@ class Value : public document::Printable
 public:
     using SP = std::shared_ptr<Value>;
     using UP = std::unique_ptr<Value>;
-    enum Type { Invalid, Null, String, Integer, Float, Array, Struct, Bucket, Tensor };
+    enum class Type { Invalid, Null, String, Integer, Float, Array, Struct, Bucket, Tensor };
 
-    Value(Type t) : _type(t) {}
-    virtual ~Value() = default;
+    explicit Value(Type t) : _type(t) {}
+    ~Value() override = default;
 
     Type getType() const { return _type; }
 
@@ -61,10 +61,12 @@ private:
     Type _type;
 };
 
+std::ostream& operator<<(std::ostream&, Value::Type);
+
 class InvalidValue : public Value
 {
 public:
-    InvalidValue() : Value(Invalid) {}
+    InvalidValue() : Value(Type::Invalid) {}
 
     ResultList operator<(const Value&) const override;
     ResultList operator==(const Value&) const override;
@@ -74,7 +76,7 @@ public:
 class NullValue : public Value
 {
 public:
-    NullValue() : Value(Null) {}
+    NullValue() : Value(Type::Null) {}
 
     ResultList operator<(const Value&) const override;
     ResultList operator==(const Value&) const override;

--- a/document/src/vespa/document/select/valuenodes.cpp
+++ b/document/src/vespa/document/select/valuenodes.cpp
@@ -371,6 +371,15 @@ IteratorHandler::getInternalValue(const FieldValue& fval) const
                 return std::make_unique<ArrayValue>(std::vector<ArrayValue::VariableValue>());
             }
         }
+        case FieldValue::Type::TENSOR:
+        {
+            const auto& tensor_val(static_cast<const TensorFieldValue&>(fval));
+            if (tensor_val.getAsTensorPtr() == nullptr) {
+                return std::make_unique<NullValue>();
+            }
+            // TODO consider adding tensor cell inspection to document selection language?
+            return std::make_unique<TensorValue>();
+        }
         default:
             break;
     }
@@ -797,6 +806,7 @@ FunctionValueNode::getValue(std::unique_ptr<Value> val) const
 
         case Value::Array: break;
         case Value::Struct: break;
+        case Value::Tensor: break;
         case Value::Invalid: break;
         case Value::Null: break;
     }
@@ -862,6 +872,7 @@ FunctionValueNode::traceValue(std::unique_ptr<Value> val, std::ostream& out) con
         case Value::Bucket: break;
         case Value::Array: break;
         case Value::Struct: break;
+        case Value::Tensor: break;
         case Value::Invalid: break;
         case Value::Null: break;
     }

--- a/document/src/vespa/document/select/valuenodes.cpp
+++ b/document/src/vespa/document/select/valuenodes.cpp
@@ -760,7 +760,7 @@ std::unique_ptr<Value>
 FunctionValueNode::getValue(std::unique_ptr<Value> val) const
 {
     switch (val->getType()) {
-        case Value::String:
+        case Value::Type::String:
         {
             StringValue& sval(static_cast<StringValue&>(*val));
             if (_function == LOWERCASE) {
@@ -770,7 +770,7 @@ FunctionValueNode::getValue(std::unique_ptr<Value> val) const
             }
             break;
         }
-        case Value::Float:
+        case Value::Type::Float:
         {
             FloatValue& fval(static_cast<FloatValue&>(*val));
             if (_function == HASH) {
@@ -783,7 +783,7 @@ FunctionValueNode::getValue(std::unique_ptr<Value> val) const
             }
             break;
         }
-        case Value::Integer:
+        case Value::Type::Integer:
         {
             IntegerValue& ival(static_cast<IntegerValue&>(*val));
             if (_function == HASH) {
@@ -796,7 +796,7 @@ FunctionValueNode::getValue(std::unique_ptr<Value> val) const
             }
             break;
         }
-        case Value::Bucket:
+        case Value::Type::Bucket:
         {
             throw ParsingFailedException(
                     "No function calls are allowed on value of type bucket",
@@ -804,11 +804,11 @@ FunctionValueNode::getValue(std::unique_ptr<Value> val) const
             break;
         }
 
-        case Value::Array: break;
-        case Value::Struct: break;
-        case Value::Tensor: break;
-        case Value::Invalid: break;
-        case Value::Null: break;
+        case Value::Type::Array: break;
+        case Value::Type::Struct: break;
+        case Value::Type::Tensor: break;
+        case Value::Type::Invalid: break;
+        case Value::Type::Null: break;
     }
     return std::make_unique<InvalidValue>();
 }
@@ -817,7 +817,7 @@ std::unique_ptr<Value>
 FunctionValueNode::traceValue(std::unique_ptr<Value> val, std::ostream& out) const
 {
     switch (val->getType()) {
-        case Value::String:
+        case Value::Type::String:
         {
             StringValue& sval(static_cast<StringValue&>(*val));
             if (_function == LOWERCASE) {
@@ -833,7 +833,7 @@ FunctionValueNode::traceValue(std::unique_ptr<Value> val, std::ostream& out) con
             }
             break;
         }
-        case Value::Float:
+        case Value::Type::Float:
         {
             FloatValue& fval(static_cast<FloatValue&>(*val));
             if (_function == HASH) {
@@ -851,7 +851,7 @@ FunctionValueNode::traceValue(std::unique_ptr<Value> val, std::ostream& out) con
             }
             break;
         }
-        case Value::Integer:
+        case Value::Type::Integer:
         {
             IntegerValue& ival(static_cast<IntegerValue&>(*val));
             if (_function == HASH) {
@@ -869,12 +869,12 @@ FunctionValueNode::traceValue(std::unique_ptr<Value> val, std::ostream& out) con
             }
             break;
         }
-        case Value::Bucket: break;
-        case Value::Array: break;
-        case Value::Struct: break;
-        case Value::Tensor: break;
-        case Value::Invalid: break;
-        case Value::Null: break;
+        case Value::Type::Bucket: break;
+        case Value::Type::Array: break;
+        case Value::Type::Struct: break;
+        case Value::Type::Tensor: break;
+        case Value::Type::Invalid: break;
+        case Value::Type::Null: break;
     }
     out << "Cannot use function " << _function << " on a value of type "
         << val->getType() << ". Resolving invalid.\n";
@@ -940,8 +940,8 @@ ArithmeticValueNode::getValue(std::unique_ptr<Value> lval,
     switch (_operator) {
         case ADD:
         {
-            if (lval->getType() == Value::String &&
-                rval->getType() == Value::String)
+            if (lval->getType() == Value::Type::String &&
+                rval->getType() == Value::Type::String)
             {
                 StringValue& slval(static_cast<StringValue&>(*lval));
                 StringValue& srval(static_cast<StringValue&>(*rval));
@@ -953,8 +953,8 @@ ArithmeticValueNode::getValue(std::unique_ptr<Value> lval,
         case MUL:
         case DIV:
         {
-            if (lval->getType() == Value::Integer &&
-                rval->getType() == Value::Integer)
+            if (lval->getType() == Value::Type::Integer &&
+                rval->getType() == Value::Type::Integer)
             {
                 IntegerValue& ilval(static_cast<IntegerValue&>(*lval));
                 IntegerValue& irval(static_cast<IntegerValue&>(*rval));
@@ -1001,8 +1001,8 @@ ArithmeticValueNode::getValue(std::unique_ptr<Value> lval,
         break;
         case MOD:
         {
-            if (lval->getType() == Value::Integer &&
-                rval->getType() == Value::Integer)
+            if (lval->getType() == Value::Type::Integer &&
+                rval->getType() == Value::Type::Integer)
             {
                 IntegerValue& ilval(static_cast<IntegerValue&>(*lval));
                 IntegerValue& irval(static_cast<IntegerValue&>(*rval));
@@ -1026,8 +1026,8 @@ ArithmeticValueNode::traceValue(std::unique_ptr<Value> lval,
     switch (_operator) {
         case ADD:
         {
-            if (lval->getType() == Value::String &&
-                rval->getType() == Value::String)
+            if (lval->getType() == Value::Type::String &&
+                rval->getType() == Value::Type::String)
             {
                 StringValue& slval(static_cast<StringValue&>(*lval));
                 StringValue& srval(static_cast<StringValue&>(*rval));
@@ -1042,8 +1042,8 @@ ArithmeticValueNode::traceValue(std::unique_ptr<Value> lval,
         case MUL:
         case DIV:
         {
-            if (lval->getType() == Value::Integer &&
-                rval->getType() == Value::Integer)
+            if (lval->getType() == Value::Type::Integer &&
+                rval->getType() == Value::Type::Integer)
             {
                 IntegerValue& ilval(static_cast<IntegerValue&>(*lval));
                 IntegerValue& irval(static_cast<IntegerValue&>(*rval));
@@ -1086,8 +1086,8 @@ ArithmeticValueNode::traceValue(std::unique_ptr<Value> lval,
         break;
         case MOD:
         {
-            if (lval->getType() == Value::Integer &&
-                rval->getType() == Value::Integer)
+            if (lval->getType() == Value::Type::Integer &&
+                rval->getType() == Value::Type::Integer)
             {
                 IntegerValue& ilval(static_cast<IntegerValue&>(*lval));
                 IntegerValue& irval(static_cast<IntegerValue&>(*rval));

--- a/searchcore/src/vespa/searchcore/proton/common/cachedselect.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/cachedselect.cpp
@@ -80,7 +80,7 @@ AttrVisitor::AttrVisitor(const search::IAttributeManager &amgr,
 AttrVisitor::~AttrVisitor() = default;
 
 bool isSingleValueThatWeHandle(BasicType type) {
-    return (type != BasicType::PREDICATE) && (type != BasicType::TENSOR) && (type != BasicType::REFERENCE) && (type != BasicType::RAW);
+    return (type != BasicType::PREDICATE) && (type != BasicType::REFERENCE) && (type != BasicType::RAW);
 }
 
 void


### PR DESCRIPTION
@geirst @toregge please review. Can be reviewed per commit, if desired.

For the C++ implementation, adds a sentinel `TensorValue` selection-internal type which is instantiated iff a field is a tensor, and which only allows for comparing against (explicit or implicit) `null` values. All other comparisons poison the expression with `Invalid` results. In other words, tensor _contents_ cannot be inspected as part of selection evaluation.

This sentinel is also instantiated by the search core tensor attribute wiring.

The Java implementation has very different evaluation semantics, so the changes are mostly about enforcing `Invalid` results when using tensors in ways that are not supported.

Also doing some casual code cleanup.