### PR TITLE
Use a lower log level when there is no master cluster controller

### DIFF
--- a/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/server/RestApiHandler.java
+++ b/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/server/RestApiHandler.java
@@ -106,7 +106,7 @@ public class RestApiHandler implements HttpRequestHandler {
             result.setJson(jsonWriter.createErrorJson(exception.getMessage()));
             return result;
         } catch (UnknownMasterException exception) {
-            logRequestException(request, exception, Level.WARNING);
+            logRequestException(request, exception, Level.INFO);
             JsonHttpResult result = new JsonHttpResult();
             result.setHttpCode(503, "Service Unavailable");
             result.setJson(jsonWriter.createErrorJson(exception.getMessage()));


### PR DESCRIPTION
When a request fails with master cluster controller the client will get that response, I don't think we need to log it as a warning, response and metrics shuold be enough.