### PR TITLE
Make tests more realistic

### DIFF
--- a/jdisc-cloud-aws/src/main/java/ai/vespa/secret/aws/testutil/AsmSecretTesterBase.java
+++ b/jdisc-cloud-aws/src/main/java/ai/vespa/secret/aws/testutil/AsmSecretTesterBase.java
@@ -87,7 +87,8 @@ public class AsmSecretTesterBase {
 
         protected List<String> toAwsStages(SecretVersionState state) {
             return switch (state) {
-                case CURRENT -> List.of("AWSCURRENT");
+                // We don't remove the AWSPENDING label when setting AWSCURRENT
+                case CURRENT -> List.of("AWSPENDING", "AWSCURRENT");
                 case PENDING -> List.of("AWSPENDING");
                 case PREVIOUS, DEPRECATED -> List.of();
             };


### PR DESCRIPTION
- AWSCURRENT versions will also have AWSPENDING in our case.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
