### PR TITLE
Make vespa-zkflw work with fewer arguments

### DIFF
--- a/zookeeper-command-line-client/src/main/sh/vespa-zkflw
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkflw
@@ -77,6 +77,24 @@ export ROOT
 
 # END environment bootstrap section
 
+# Defaults
+server="localhost"
+port="2181"
+command="stat"
+
+if [ "$#" -eq 1 ]; then
+    command=$1
+elif [ "$#" -eq 2 ] || [ "$#" -gt 3 ]; then
+    echo "Need 0, 1 (command) or 3 arguments (host, port, command)"
+    exit 1
+elif [ "$#" -eq 3 ]; then
+    server=$1
+    port=$2
+    command=$3
+fi
+
+args="$server $port $command"
+
 java -cp ${VESPA_HOME}/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
      -Dlogback.configurationFile="logback-vespa.xml" -Xms32m -Xmx512m \
-     com.yahoo.vespa.zookeeper.cli.FourLetterWordMain "$@"
+     com.yahoo.vespa.zookeeper.cli.FourLetterWordMain $args

--- a/zookeeper-command-line-client/src/main/sh/vespa-zkflw
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkflw
@@ -93,8 +93,8 @@ elif [ "$#" -eq 3 ]; then
     command=$3
 fi
 
-args="$server $port $command"
+args=("$server" "$port" "$command")
 
 java -cp ${VESPA_HOME}/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
      -Dlogback.configurationFile="logback-vespa.xml" -Xms32m -Xmx512m \
-     com.yahoo.vespa.zookeeper.cli.FourLetterWordMain $args
+     com.yahoo.vespa.zookeeper.cli.FourLetterWordMain ${args[@]}

--- a/zookeeper-command-line-client/src/main/sh/vespa-zkflw
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkflw
@@ -88,13 +88,13 @@ elif [ "$#" -eq 2 ] || [ "$#" -gt 3 ]; then
     echo "Need 0, 1 (command) or 3 arguments (host, port, command)"
     exit 1
 elif [ "$#" -eq 3 ]; then
-    server=$1
-    port=$2
-    command=$3
+    server="$1"
+    port="$2"
+    command="$3"
 fi
 
 args=("$server" "$port" "$command")
 
 java -cp ${VESPA_HOME}/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
      -Dlogback.configurationFile="logback-vespa.xml" -Xms32m -Xmx512m \
-     com.yahoo.vespa.zookeeper.cli.FourLetterWordMain ${args[@]}
+     com.yahoo.vespa.zookeeper.cli.FourLetterWordMain "${args[@]}"


### PR DESCRIPTION
Use defaults for hostname, port and command
Require 0, 1 or 3 arguments to script