### PR TITLE
Wire SLRU segment size ratio into Proton config

### DIFF
--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -548,6 +548,19 @@ index.cache.size long default=0 restart
 index.cache.postinglist.maxbytes long default=0 restart
 index.cache.bitvector.maxbytes long default=0 restart
 
+## Configure a size ratio between the probationary and protected segment in
+## the posting list and bitvector caches. A value of zero means that segmented
+## (SLRU) behavior is entirely disabled, and the cache works as a regular
+## LRU. Any other value (0, 1] will scale the cache so that the protected
+## segment will receive `maxbytes` * ratio bytes, and the probationary segment
+## will receive `maxbytes` * (1 - ratio) bytes.
+##
+## Note that it never makes sense with a ratio of 1, as elements must be able
+## to first enter the probationary segment before being allowed a promotion into
+## the protected segment.
+index.cache.postinglist.slru_protected_segment_ratio double default=0.0 restart
+index.cache.bitvector.slru_protected_segment_ratio double default=0.0 restart
+
 ## Specifies which tensor implementation to use for all backend code.
 ##
 ## TENSOR_ENGINE (default) uses DefaultTensorEngine, which has been the production implementation for years.

--- a/searchlib/src/vespa/searchlib/diskindex/posting_list_cache.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/posting_list_cache.cpp
@@ -55,13 +55,13 @@ using CacheParams = vespalib::CacheParam<
 class PostingListCache::Cache : public vespalib::cache<CacheParams> {
 public:
     using Parent = vespalib::cache<CacheParams>;
-    Cache(BackingStore& backing_store, size_t max_bytes);
+    Cache(BackingStore& backing_store, size_t max_bytes, size_t max_protected_bytes);
     ~Cache();
     static size_t element_size() { return sizeof(value_type); }
 };
 
-PostingListCache::Cache::Cache(BackingStore& backing_store, size_t max_bytes)
-    : Parent(backing_store, max_bytes)
+PostingListCache::Cache::Cache(BackingStore& backing_store, size_t max_bytes, size_t max_protected_bytes)
+    : Parent(backing_store, max_bytes, max_protected_bytes)
 {
 }
 
@@ -81,25 +81,33 @@ using BitVectorCacheParams = vespalib::CacheParam<
 class PostingListCache::BitVectorCache : public vespalib::cache<BitVectorCacheParams> {
 public:
     using Parent = vespalib::cache<BitVectorCacheParams>;
-    BitVectorCache(BackingStore& backing_store, size_t max_bytes);
+    BitVectorCache(BackingStore& backing_store, size_t max_bytes, size_t max_protected_bytes);
     ~BitVectorCache();
     static size_t element_size() { return sizeof(value_type); }
 };
 
-PostingListCache::BitVectorCache::BitVectorCache(BackingStore& backing_store, size_t max_bytes)
-    : Parent(backing_store, max_bytes)
+PostingListCache::BitVectorCache::BitVectorCache(BackingStore& backing_store, size_t max_bytes, size_t max_protected_bytes)
+    : Parent(backing_store, max_bytes, max_protected_bytes)
 {
 }
 
 PostingListCache::BitVectorCache::~BitVectorCache() = default;
 
-PostingListCache::PostingListCache(size_t max_bytes, size_t bitvector_max_bytes)
+PostingListCache::PostingListCache(const CacheSizingParams& params)
     : IPostingListCache(),
       _backing_store(std::make_unique<BackingStore>()),
-      _cache(std::make_unique<Cache>(*_backing_store, max_bytes)),
-      _bitvector_cache(std::make_unique<BitVectorCache>(*_backing_store, bitvector_max_bytes))
+      _cache(std::make_unique<Cache>(*_backing_store,
+                                     params.posting_slru_probationary_bytes(),
+                                     params.posting_slru_protected_bytes())),
+      _bitvector_cache(std::make_unique<BitVectorCache>(*_backing_store,
+                                                        params.bitvector_slru_probationary_bytes(),
+                                                        params.bitvector_slru_protected_bytes()))
 {
 }
+
+PostingListCache::PostingListCache(size_t max_bytes, size_t bitvector_max_bytes)
+    : PostingListCache(CacheSizingParams(max_bytes, bitvector_max_bytes, 0.0, 0.0))
+{}
 
 PostingListCache::~PostingListCache() = default;
 

--- a/searchlib/src/vespa/searchlib/diskindex/posting_list_cache.h
+++ b/searchlib/src/vespa/searchlib/diskindex/posting_list_cache.h
@@ -20,6 +20,44 @@ private:
     std::unique_ptr<Cache> _cache;
     std::unique_ptr<BitVectorCache> _bitvector_cache;
 public:
+    class CacheSizingParams {
+        size_t _posting_max_bytes   = 0;
+        size_t _bitvector_max_bytes = 0;
+        double _posting_slru_protected_ratio   = 0.0; // [0, 1]
+        double _bitvector_slru_protected_ratio = 0.0; // [0, 1]
+    public:
+        constexpr CacheSizingParams() noexcept = default;
+        CacheSizingParams(size_t posting_max_bytes, size_t bitvector_max_bytes,
+                          double posting_slru_protected_ratio, double bitvector_slru_protected_ratio) noexcept
+            : _posting_max_bytes(posting_max_bytes),
+              _bitvector_max_bytes(bitvector_max_bytes),
+              _posting_slru_protected_ratio(std::min(std::max(posting_slru_protected_ratio, 0.0), 1.0)),
+              _bitvector_slru_protected_ratio(std::min(std::max(bitvector_slru_protected_ratio, 0.0), 1.0))
+        {
+        }
+
+        [[nodiscard]] size_t posting_slru_protected_bytes() const noexcept {
+            if (_posting_slru_protected_ratio <= 0) {
+                return 0;
+            }
+            return static_cast<size_t>(static_cast<double>(_posting_max_bytes) * _posting_slru_protected_ratio);
+        }
+        [[nodiscard]] size_t posting_slru_probationary_bytes() const noexcept {
+            return _posting_max_bytes - posting_slru_protected_bytes();
+        }
+
+        [[nodiscard]] size_t bitvector_slru_protected_bytes() const noexcept {
+            if (_bitvector_slru_protected_ratio <= 0) {
+                return 0;
+            }
+            return static_cast<size_t>(static_cast<double>(_bitvector_max_bytes) * _bitvector_slru_protected_ratio);
+        }
+        [[nodiscard]] size_t bitvector_slru_probationary_bytes() const noexcept {
+            return _bitvector_max_bytes - posting_slru_protected_bytes();
+        }
+    };
+
+    explicit PostingListCache(const CacheSizingParams& params);
     PostingListCache(size_t max_bytes, size_t bitvector_max_bytes);
     ~PostingListCache() override;
     search::index::PostingListHandle read(const Key& key, Context& ctx) const override;

--- a/searchlib/src/vespa/searchlib/diskindex/posting_list_cache.h
+++ b/searchlib/src/vespa/searchlib/diskindex/posting_list_cache.h
@@ -53,7 +53,7 @@ public:
             return static_cast<size_t>(static_cast<double>(_bitvector_max_bytes) * _bitvector_slru_protected_ratio);
         }
         [[nodiscard]] size_t bitvector_slru_probationary_bytes() const noexcept {
-            return _bitvector_max_bytes - posting_slru_protected_bytes();
+            return _bitvector_max_bytes - bitvector_slru_protected_bytes();
         }
     };
 


### PR DESCRIPTION
@geirst please review

By default SLRU semantics are disabled, but a segment ratio greater than 0 will enable it implicitly.

Also add a guard against negative values in config, since we don't support auto-adjusting based on available memory yet.
