### PR TITLE
refactor(zookeeper-common): make TLS config path public for broader access

### DIFF
--- a/zookeeper-common/src/main/java/com/yahoo/vespa/zookeeper/tls/VespaZookeeperTlsContextUtils.java
+++ b/zookeeper-common/src/main/java/com/yahoo/vespa/zookeeper/tls/VespaZookeeperTlsContextUtils.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  */
 public class VespaZookeeperTlsContextUtils {
 
-    private static final Path ZOOKEEPER_TLS_CONFIG_FILE = Path.of(Defaults.getDefaults().underVespaHome("var/zookeeper/conf/tls.conf.json"));
+    public static final Path ZOOKEEPER_TLS_CONFIG_FILE = Path.of(Defaults.getDefaults().underVespaHome("var/zookeeper/conf/tls.conf.json"));
     private static final TlsContext tlsContext = Files.exists(ZOOKEEPER_TLS_CONFIG_FILE)
                                                  ? new ConfigFileBasedTlsContext(ZOOKEEPER_TLS_CONFIG_FILE, TransportSecurityUtils.getInsecureAuthorizationMode())
                                                  : TransportSecurityUtils.getSystemTlsContext().orElse(null);


### PR DESCRIPTION
## What

- update ZOOKEEPER_TLS_CONFIG_FILE access to public

## Why

- Allow usage in host-admin instead of hardcoding the path.