### PR TITLE
Integrate optional LFU frequency sketch into (S)LRU cache

### DIFF
--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -661,7 +661,7 @@ TEST_F(LogDataStoreTest, Control_static_memory_usage)
     // FIXME this is very, very implementation-specific... :I
     constexpr size_t mutex_size = sizeof(std::mutex) * 2 * (113 + 1); // sizeof(std::mutex) is platform dependent
     constexpr size_t string_size = sizeof(std::string);
-    constexpr size_t lru_segment_overhead = 304;
+    constexpr size_t lru_segment_overhead = 352;
     EXPECT_EQ(74476 + mutex_size + 3 * string_size + lru_segment_overhead, usage.allocatedBytes());
     EXPECT_EQ(752u + mutex_size + 3 * string_size + lru_segment_overhead, usage.usedBytes());
 }

--- a/vespalib/src/vespa/vespalib/stllike/cache.h
+++ b/vespalib/src/vespa/vespalib/stllike/cache.h
@@ -276,7 +276,9 @@ public:
      * Setting the size to >0 will always create a new sketch. The sketch will be
      * initialized with the cache keys that are currently present in the cache segments,
      * giving each existing entry an estimated frequency of 1. All preexisting frequency
-     * information about entries _not_ currently in the cache will be lost.
+     * information about entries _not_ currently in the cache will be lost. To avoid
+     * pathological frequency estimates for existing entries, the sketch has a lower
+     * bound size of max(existing cache element count, cache_max_elem_count).
      */
     void set_frequency_sketch_size(size_t cache_max_elem_count);
 

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.h
@@ -116,6 +116,12 @@ public:
     const V & get(const K & key) const { return HashTable::find(key)->second._value; }
 
     /**
+     * Returns an iterator to the tail of the LRU, i.e. the oldest element, or end()
+     * iff the mapping is empty. Note: this is not a reverse iterator.
+     */
+    iterator iter_to_last() noexcept;
+
+    /**
      * This simply erases the object.
      */
     void erase(const K & key);

--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
@@ -108,6 +108,12 @@ lrucache_map<P>::move(next_t from, next_t to) {
     }
 }
 
+template <typename P>
+typename lrucache_map<P>::iterator
+lrucache_map<P>::iter_to_last() noexcept {
+    return iterator(this, _tail); // If _tail is npos, this is implicitly == end()
+}
+
 template< typename P >
 void
 lrucache_map<P>::erase(const K & key) {


### PR DESCRIPTION
@havardpe please review today's advent of cache 🎅 oh ho ho ho! Most added lines are tests or comments.

Allows a cache to be configured to use a probabilistic LFU frequency sketch for gating insertions to its segments. An element that is a candidate for insertion will only be allowed into a segment if it is estimated to be more frequently accessed than the element it would displace (note that if the cache is below max capacity the insertion would not displace any element(s), so it is always allowed).

LFU gating works in both LRU and SLRU modes. In both modes, initial insertion into the probationary segment is gated (for cache read-through and write-through). In SLRU mode, promotion from probationary to protected is _also_ gated. In the case that promotion is denied, the candidate element is placed at the LRU head of the probationary segment instead, giving it another chance.

The configured sketch element count should be at least as large as the maximum _expected_ number of elements that the cache can hold at once.

The default size is 0, i.e. LFU functionality is disabled.

Setting the size to >0 will always create a new sketch. The sketch will be initialized with the cache keys that are currently present in the cache segments, giving each existing entry an estimated frequency of 1. All preexisting frequency information about entries _not_ currently in the cache will be lost.

