### PR TITLE
Revert "Bratseth/remove static type inference"

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/IndexingInputs.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/IndexingInputs.java
@@ -75,7 +75,7 @@ public class IndexingInputs extends Processor {
 
         @Override
         protected Expression doConvert(Expression exp) {
-            if (exp.requiresInput()) {
+            if (exp.requiredInputType() != null) {
                 return new StatementExpression(new InputExpression(field.getName()), exp);
             } else {
                 return exp;

--- a/config-model/src/test/java/com/yahoo/schema/processing/IndexingInputsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/IndexingInputsTestCase.java
@@ -57,7 +57,7 @@ public class IndexingInputsTestCase {
         }
         catch (IllegalArgumentException e) {
             assertEquals("For schema 'indexing_extra_field_input_implicit', field 'foo': " +
-                         "Invalid expression 'tokenize normalize stem:\"BEST\"': Expected string input, but no input is provided",
+                         "Invalid expression '{ tokenize normalize stem:\"BEST\" | index foo; }': Expected string input, but no input is specified",
                          Exceptions.toMessageString(e));
         }
     }
@@ -156,8 +156,8 @@ public class IndexingInputsTestCase {
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
-            assertEquals("For schema 'test', field 'derived1': Invalid expression 'attribute derived1': " +
-                         "Expected int input, but no input is provided",
+            assertEquals("For schema 'test', field 'derived1': Invalid expression '{ attribute derived1; }': " +
+                         "Expected any input, but no input is specified",
                          Exceptions.toMessageString(e));
         }
     }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/Base64DecodeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/Base64DecodeExpression.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
+import com.yahoo.document.TensorDataType;
 import com.yahoo.document.datatypes.LongFieldValue;
 
 import java.util.Base64;
@@ -10,6 +11,10 @@ import java.util.Base64;
  * @author Simon Thoresen Hult
  */
 public final class Base64DecodeExpression extends Expression {
+
+    public Base64DecodeExpression() {
+        super(DataType.STRING);
+    }
 
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/Base64EncodeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/Base64EncodeExpression.java
@@ -12,6 +12,10 @@ import java.util.Base64;
  */
 public final class Base64EncodeExpression extends Expression {
 
+    public Base64EncodeExpression() {
+        super(DataType.LONG);
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, DataType.LONG, context);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/BinarizeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/BinarizeExpression.java
@@ -27,6 +27,7 @@ public class BinarizeExpression extends Expression  {
      * @param threshold the value which the tensor cell value must be larger than to be set to 1 and not 0.
      */
     public BinarizeExpression(double threshold) {
+        super(TensorDataType.any());
         this.threshold = threshold;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/BusyWaitExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/BusyWaitExpression.java
@@ -12,6 +12,10 @@ import com.yahoo.document.datatypes.NumericFieldValue;
  */
 public final class BusyWaitExpression extends Expression {
 
+    public BusyWaitExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     protected void doExecute(ExecutionContext context) {
         FieldValue value = context.getCurrentValue();

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/CatExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/CatExpression.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 import com.yahoo.document.ArrayDataType;
 import com.yahoo.document.CollectionDataType;
 import com.yahoo.document.DataType;
+import com.yahoo.document.TensorDataType;
 import com.yahoo.document.WeightedSetDataType;
 import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.FieldValue;
@@ -11,16 +12,13 @@ import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.document.datatypes.WeightedSet;
 import com.yahoo.vespa.indexinglanguage.ExpressionConverter;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.*;
 import java.util.List;
 
 /**
  * @author Simon Thoresen Hult
  */
-// TODO: Support Map in addition to Array and Weghted Set (doc just says "collection type")
+// TODO: Support Map in addition to Array and Wighted Set (doc just says "collection type")
 public final class CatExpression extends ExpressionList<Expression> {
 
     public CatExpression(Expression... expressions) {
@@ -28,11 +26,8 @@ public final class CatExpression extends ExpressionList<Expression> {
     }
 
     public CatExpression(Collection<? extends Expression> expressions) {
-        super(expressions);
+        super(expressions, resolveInputType(expressions));
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     @Override
     public CatExpression convertChildren(ExpressionConverter converter) {
@@ -47,14 +42,11 @@ public final class CatExpression extends ExpressionList<Expression> {
         for (var expression : expressions())
             outputTypes.add(expression.setInputType(inputType, context));
         DataType outputType = resolveOutputType(outputTypes);
-        if (outputType == null) outputType = getOutputType(context); // TODO: Remove this line
-        super.setOutputType(outputType, context);
-        return outputType;
+        return outputType != null ? outputType : getOutputType(context);
     }
 
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
-        if (outputType == null) return null;
         if (outputType != DataType.STRING && ! (outputType instanceof CollectionDataType))
             throw new VerificationException(this, "Required to produce " + outputType.getName() +
                                                   ", but this produces a string or collection");
@@ -84,13 +76,41 @@ public final class CatExpression extends ExpressionList<Expression> {
     @Override
     protected void doExecute(ExecutionContext context) {
         FieldValue input = context.getCurrentValue();
+        DataType inputType = input != null ? input.getDataType() : null;
+        VerificationContext verificationContext = new VerificationContext(context.getFieldValue());
+        context.fillVariableTypes(verificationContext);
         List<FieldValue> values = new LinkedList<>();
-        for (Expression expression : this)
-            values.add(context.setCurrentValue(input).execute(expression).getCurrentValue());
-        DataType type = getOutputType();
-        if (type == null)
-            throw new RuntimeException("Output type is not resolved in " + this);
+        List<DataType> types = new LinkedList<>();
+        for (Expression expression : this) {
+            FieldValue val = context.setCurrentValue(input).execute(expression).getCurrentValue();
+            values.add(val);
+
+            DataType type;
+            if (val != null) {
+                type = val.getDataType();
+            } else {
+                type = verificationContext.setCurrentType(inputType).verify(this).getCurrentType();
+            }
+            types.add(type);
+        }
+        DataType type = resolveOutputType(types);
         context.setCurrentValue(type == DataType.STRING ? asString(values) : asCollection(type, values));
+    }
+
+    private static DataType resolveInputType(Collection<? extends Expression> list) {
+        DataType prev = null;
+        for (Expression exp : list) {
+            DataType next = exp.requiredInputType();
+            if (next == null) {
+                // ignore
+            } else if (prev == null) {
+                prev = next;
+            } else if (!prev.isAssignableFrom(next)) {
+                throw new VerificationException(CatExpression.class, "Operands require conflicting input types, " +
+                                                                      prev.getName() + " vs " + next.getName());
+            }
+        }
+        return prev;
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ClearStateExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ClearStateExpression.java
@@ -8,8 +8,9 @@ import com.yahoo.document.DataType;
  */
 public final class ClearStateExpression extends Expression {
 
-    @Override
-    public boolean requiresInput() { return false; }
+    public ClearStateExpression() {
+        super(null);
+    }
 
     @Override
     protected void doVerify(VerificationContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/CompositeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/CompositeExpression.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
+import com.yahoo.document.DataType;
 import com.yahoo.vespa.indexinglanguage.ExpressionConverter;
 
 /**
@@ -10,6 +11,10 @@ public abstract class CompositeExpression extends Expression {
 
     @Override
     public abstract CompositeExpression convertChildren(ExpressionConverter converter);
+
+    protected CompositeExpression(DataType inputType) {
+        super(inputType);
+    }
 
     protected static String toScriptBlock(Expression exp) {
         if (exp instanceof ScriptExpression)

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ConstantExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ConstantExpression.java
@@ -17,11 +17,9 @@ public final class ConstantExpression extends Expression {
     private final FieldValue value;
 
     public ConstantExpression(FieldValue value) {
+        super(null);
         this.value = Objects.requireNonNull(value);
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     public FieldValue getValue() { return value; }
 
@@ -33,11 +31,10 @@ public final class ConstantExpression extends Expression {
 
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
-        if (outputType != null && ! value.getDataType().isAssignableTo(outputType))
+        if ( ! value.getDataType().isAssignableTo(outputType))
             throw new VerificationException(this, "Produces type " + value.getDataType().getName() + ", but type " +
                                             outputType.getName() + " is required");
-        super.setOutputType(outputType, context);
-        return null;
+        return super.setOutputType(outputType, context);
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EchoExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EchoExpression.java
@@ -17,6 +17,7 @@ public final class EchoExpression extends Expression {
     }
 
     public EchoExpression(PrintStream out) {
+        super(UnresolvedDataType.INSTANCE);
         this.out = out;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
@@ -39,6 +39,7 @@ public class EmbedExpression extends Expression  {
     private TensorType targetType;
 
     public EmbedExpression(Linguistics linguistics, Map<String, Embedder> embedders, String embedderId, List<String> embedderArguments) {
+        super(null);
         this.linguistics = linguistics;
         this.embedderId = embedderId;
         this.embedderArguments = List.copyOf(embedderArguments);
@@ -64,13 +65,12 @@ public class EmbedExpression extends Expression  {
     }
 
     @Override
-    public DataType setInputType(DataType inputType, VerificationContext context) {
-        super.setInputType(inputType, context);
-        if ( inputType != null &&
-             ! (inputType == DataType.STRING) &&
-             ! (inputType instanceof ArrayDataType array && array.getNestedType() == DataType.STRING))
+    public DataType setInputType(DataType type, VerificationContext context) {
+        super.setInputType(type, context);
+        if ( ! (type == DataType.STRING) &&
+             ! (type instanceof ArrayDataType array && array.getNestedType() == DataType.STRING))
             throw new VerificationException(this, "This requires either a string or array<string> input type, but got " +
-                                                  inputType.getName());
+                                                  type.getName());
         return getOutputType(context); // embed cannot determine the output type from the input
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExactExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExactExpression.java
@@ -26,6 +26,7 @@ public final class ExactExpression extends Expression {
     private final int maxTokenLength;
 
     private ExactExpression(OptionalInt maxTokenLength) {
+        super(DataType.STRING);
         this.maxTokenLength = maxTokenLength.isPresent() ? maxTokenLength.getAsInt() : AnnotatorConfig.getDefaultMaxTokenLength();
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionValueExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionValueExpression.java
@@ -2,6 +2,14 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.FieldPath;
+import com.yahoo.vespa.objects.ObjectOperation;
+import com.yahoo.vespa.objects.ObjectPredicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Returns the current execution value, that is the value passed to this expression.
@@ -11,6 +19,10 @@ import com.yahoo.document.DataType;
  * @author bratseth
  */
 public final class ExecutionValueExpression extends Expression {
+
+    public ExecutionValueExpression() {
+        super(null);
+    }
 
     @Override
     protected void doExecute(ExecutionContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/Expression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/Expression.java
@@ -10,14 +10,7 @@ import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.simple.SimpleLinguistics;
-import com.yahoo.vespa.indexinglanguage.AdapterFactory;
-import com.yahoo.vespa.indexinglanguage.DocumentAdapter;
-import com.yahoo.vespa.indexinglanguage.DocumentTypeAdapter;
-import com.yahoo.vespa.indexinglanguage.ExpressionConverter;
-import com.yahoo.vespa.indexinglanguage.ScriptParser;
-import com.yahoo.vespa.indexinglanguage.ScriptParserContext;
-import com.yahoo.vespa.indexinglanguage.SimpleAdapterFactory;
-import com.yahoo.vespa.indexinglanguage.UpdateAdapter;
+import com.yahoo.vespa.indexinglanguage.*;
 import com.yahoo.vespa.indexinglanguage.parser.IndexingInput;
 import com.yahoo.vespa.indexinglanguage.parser.ParseException;
 import com.yahoo.vespa.objects.Selectable;
@@ -25,23 +18,26 @@ import com.yahoo.vespa.objects.Selectable;
 import java.util.Map;
 
 /**
- * Superclass of expressions.
- *
- * Rules:
- * - All expressions produce an output.
- * - Expressions that does not require an input overrides requiresInput() to return false
- *
  * @author Simon Thoresen Hult
- * @author bratseth
  */
 public abstract class Expression extends Selectable {
+
+    private final DataType requiredInputType;
 
     // Input and output types resolved during verification
     private DataType inputType;
     private DataType outputType;
 
-    /** Returns whether this expression requires an input value. */
-    public boolean requiresInput() { return true; }
+    /**
+     * Creates an expression
+     *
+     * @param requiredInputType the type of the input this expression can work with.
+     *                          UnresolvedDataType.INSTANCE if it works with any type,
+     *                          and null if it does not consume any input.
+     */
+    protected Expression(DataType requiredInputType) {
+        this.requiredInputType = requiredInputType;
+    }
 
     /**
      * Returns an expression where the children of this has been converted using the given converter.
@@ -51,6 +47,8 @@ public abstract class Expression extends Selectable {
 
     /** Sets the document type and field the statement this expression is part of will write to */
     public void setStatementOutput(DocumentType documentType, Field field) {}
+
+    public final DataType requiredInputType() { return requiredInputType; }
 
     public DataType getInputType(VerificationContext context) { return inputType; }
 
@@ -66,10 +64,8 @@ public abstract class Expression extends Selectable {
      * @throws IllegalArgumentException if inputType isn't assignable to requiredType
      */
     protected final DataType setInputType(DataType inputType, DataType requiredType, VerificationContext context) {
-        if (requiredType != null && inputType == null)
-            throw new VerificationException(this, "Expected " + requiredType.getName() + " input, but no input is provided");
-        if (requiredType != null && ! (inputType.isAssignableTo(requiredType)))
-            throw new VerificationException(this, "Expected " + requiredType.getName() + " input, got " + inputType.getName());
+        if ( ! (inputType.isAssignableTo(requiredType)))
+            throw new VerificationException(this, "This requires type " + requiredType.getName() + ", but gets " + inputType.getName());
         return assignInputType(inputType);
     }
 
@@ -147,8 +143,19 @@ public abstract class Expression extends Selectable {
 
     public abstract DataType createdOutputType();
 
+    /** Implementations that don't change the type should implement this to do verification. */
+    protected void doVerify(VerificationContext context) {}
+
+    public final DataType verify() {
+        return verify(new VerificationContext());
+    }
+
     public final void verify(DocumentType type) {
         verify(new DocumentTypeAdapter(type));
+    }
+
+    public final DataType verify(DataType val) {
+        return verify(new VerificationContext().setCurrentType(val));
     }
 
     public final Document verify(Document doc) {
@@ -193,11 +200,35 @@ public abstract class Expression extends Selectable {
     }
 
     public final DataType verify(VerificationContext context) {
+        if (requiredInputType != null) {
+            DataType input = context.getCurrentType();
+            if (input == null) {
+                throw new VerificationException(this, "Expected " + requiredInputType.getName() + " input, but no input is specified");
+            }
+            if (input.getPrimitiveType() == UnresolvedDataType.INSTANCE) {
+                throw new VerificationException(this, "Failed to resolve input type");
+            }
+            if (!requiredInputType.isAssignableFrom(input)) {
+                throw new VerificationException(this, "Expected " + requiredInputType.getName() + " input, got " +
+                                                      input.getName());
+            }
+        }
         doVerify(context);
+        DataType outputType = createdOutputType();
+        if (outputType != null) {
+            DataType output = context.getCurrentType();
+            if (output == null) {
+                throw new VerificationException(this, "Expected " + outputType.getName() + " output, but no output is specified");
+            }
+            if (output.getPrimitiveType() == UnresolvedDataType.INSTANCE) {
+                throw new VerificationException(this, "Failed to resolve output type");
+            }
+            if (!outputType.isAssignableFrom(output)) {
+                throw new VerificationException(this, "Expected " + outputType.getName() + " output, got " + output.getName());
+            }
+        }
         return context.getCurrentType();
     }
-
-    protected void doVerify(VerificationContext context) {}
 
     public final FieldValue execute(FieldValue val) {
         return execute(new ExecutionContext().setCurrentValue(val));
@@ -240,9 +271,15 @@ public abstract class Expression extends Selectable {
     }
 
     public final FieldValue execute(ExecutionContext context) {
-        if (requiresInput()) {
+        DataType inputType = requiredInputType();
+        if (inputType != null) {
             FieldValue input = context.getCurrentValue();
             if (input == null) return null;
+
+            if (!inputType.isValueCompatible(input)) {
+                throw new IllegalArgumentException("Expression '" + this + "' expected " + inputType.getName() +
+                                                   " input, got " + input.getDataType().getName());
+            }
         }
         doExecute(context);
         DataType outputType = createdOutputType();
@@ -284,7 +321,6 @@ public abstract class Expression extends Selectable {
 
     // Convenience For testing
     public static Document execute(Expression expression, Document doc) {
-        expression.verify(doc);
         return expression.execute(new SimpleAdapterFactory(), doc);
     }
 
@@ -298,18 +334,12 @@ public abstract class Expression extends Selectable {
 
     protected DataType mostGeneralOf(DataType left, DataType right) {
         if (left == null || right == null) return null;
-        if (left.isAssignableTo(right)) return right;
-        if (right.isAssignableTo(left)) return left;
-        throw new VerificationException(this, "Argument types are incompatible. " +
-                                              "First " + left.getName() + ", second: " + right.getName());
+        return left.isAssignableTo(right) ? right : left;
     }
 
     protected DataType leastGeneralOf(DataType left, DataType right) {
         if (left == null || right == null) return null;
-        if (left.isAssignableTo(right)) return left;
-        if (right.isAssignableTo(left)) return right;
-        throw new VerificationException(this, "Argument types are incompatible. " +
-                                              "First " + left.getName() + ", second: " + right.getName());
+        return left.isAssignableTo(right) ? left : right;
     }
 
 }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExpressionList.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExpressionList.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
+import com.yahoo.document.DataType;
 import com.yahoo.document.DocumentType;
 import com.yahoo.document.Field;
 import com.yahoo.vespa.indexinglanguage.ExpressionConverter;
@@ -20,13 +21,12 @@ public abstract class ExpressionList<T extends Expression> extends CompositeExpr
 
     private final List<T> expressions = new ArrayList<T>();
 
-    protected ExpressionList(Iterable<? extends T> expressions) {
-        for (T exp : expressions)
+    protected ExpressionList(Iterable<? extends T> expressions, DataType inputType) {
+        super(inputType);
+        for (T exp : expressions) {
             this.expressions.add(exp);
+        }
     }
-
-    @Override
-    public boolean requiresInput() { return !expressions.isEmpty() && expressions.get(0).requiresInput(); }
 
     public List<T> expressions() { return expressions; }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/FlattenExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/FlattenExpression.java
@@ -24,6 +24,10 @@ import java.util.Map;
 // TODO: Remove on Vespa 9
 public final class FlattenExpression extends Expression {
 
+    public FlattenExpression() {
+        super(DataType.STRING);
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         return super.setInputType(inputType, DataType.STRING, context);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ForEachExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ForEachExpression.java
@@ -1,13 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
-import com.yahoo.document.ArrayDataType;
-import com.yahoo.document.DataType;
-import com.yahoo.document.DocumentType;
-import com.yahoo.document.Field;
-import com.yahoo.document.MapDataType;
-import com.yahoo.document.StructDataType;
-import com.yahoo.document.WeightedSetDataType;
+import com.yahoo.document.*;
 import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.MapFieldValue;
@@ -29,6 +23,7 @@ public final class ForEachExpression extends CompositeExpression {
     private final Expression expression;
 
     public ForEachExpression(Expression expression) {
+        super(UnresolvedDataType.INSTANCE);
         this.expression = Objects.requireNonNull(expression);
     }
 
@@ -48,7 +43,6 @@ public final class ForEachExpression extends CompositeExpression {
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, context);
-        if (inputType == null) return null;
 
         if (inputType instanceof ArrayDataType || inputType instanceof WeightedSetDataType) {
             // Value type outside block becomes the collection type having the block output type as argument
@@ -71,7 +65,6 @@ public final class ForEachExpression extends CompositeExpression {
 
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
-        if (outputType == null) return null;
         super.setOutputType(outputType, context);
 
         if (outputType instanceof ArrayDataType || outputType instanceof WeightedSetDataType) {
@@ -111,12 +104,12 @@ public final class ForEachExpression extends CompositeExpression {
             DataType fieldType = field.getDataType();
             DataType fieldOutputType = expression.setInputType(fieldType, context);
             if (fieldOutputType != null && ! fieldOutputType.isAssignableTo(fieldType))
-                throw new VerificationException(this, "Struct field '" + field.getName() + "' has type " + fieldType.getName() +
-                                                      " but expression produces " + fieldOutputType.getName());
+                throw new VerificationException(this, "Struct field " + field.getName() + " has type " + fieldType.getName() +
+                                                      " but expression produces " + fieldOutputType);
             DataType fieldInputType = expression.setOutputType(fieldType, context);
             if (fieldOutputType != null && ! fieldType.isAssignableTo(fieldInputType))
-                throw new VerificationException(this, "Struct field '" + field.getName() + "' has type " + fieldType.getName() +
-                                                      " but expression requires " + fieldInputType.getName());
+                throw new VerificationException(this, "Struct field " + field.getName() + " has type " + fieldType.getName() +
+                                                      " but expression requires " + fieldInputType);
             if (fieldOutputType == null && fieldInputType == null)
                 return null; // Neither direction could be inferred
         }
@@ -158,7 +151,7 @@ public final class ForEachExpression extends CompositeExpression {
         }
         else {
             throw new VerificationException(this, "Expected Array, Struct, WeightedSet or Map input, got " +
-                                                  (valueType == null ? "no value" : valueType.getName()));
+                                                  valueType.getName());
         }
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GetFieldExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GetFieldExpression.java
@@ -22,6 +22,7 @@ public final class GetFieldExpression extends Expression {
     private final String structFieldName;
 
     public GetFieldExpression(String structFieldName) {
+        super(UnresolvedDataType.INSTANCE);
         this.structFieldName = structFieldName;
     }
 
@@ -30,7 +31,6 @@ public final class GetFieldExpression extends Expression {
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, context);
-        if (inputType == null) return null;
         return getFieldType(inputType, context);
     }
 
@@ -57,7 +57,7 @@ public final class GetFieldExpression extends Expression {
         else if (input instanceof StructuredDataType structInput) {
             return getStructFieldType(structInput);
         }
-        throw new VerificationException(this, "Expected a struct or map, but got " + (input == null ? "no value": input.getName()));
+        throw new VerificationException(this, "Expected a struct or map, but got an " + input.getName());
     }
 
     private DataType getStructFieldType(StructuredDataType structInput) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GetVarExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GetVarExpression.java
@@ -11,11 +11,9 @@ public final class GetVarExpression extends Expression {
     private final String variableName;
 
     public GetVarExpression(String variableName) {
+        super(null);
         this.variableName = variableName;
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     public String getVariableName() { return variableName; }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GuardExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GuardExpression.java
@@ -15,39 +15,37 @@ import com.yahoo.vespa.objects.ObjectPredicate;
  */
 public final class GuardExpression extends CompositeExpression {
 
-    private final Expression innerExpression;
+    private final Expression expression;
     private final boolean shouldExecute;
 
-    public GuardExpression(Expression innerExpression) {
-        this.innerExpression = innerExpression;
-        shouldExecute = shouldExecute(innerExpression);
+    public GuardExpression(Expression expression) {
+        super(expression.requiredInputType());
+        this.expression = expression;
+        shouldExecute = shouldExecute(expression);
     }
 
-    @Override
-    public boolean requiresInput() { return innerExpression.requiresInput(); }
-
-    public Expression getInnerExpression() { return innerExpression; }
+    public Expression getInnerExpression() { return expression; }
 
     @Override
     public GuardExpression convertChildren(ExpressionConverter converter) {
-        return new GuardExpression(converter.convert(innerExpression));
+        return new GuardExpression(converter.convert(expression));
     }
 
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, context);
-        return innerExpression.setInputType(inputType, context);
+        return expression.setInputType(inputType, context);
     }
 
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
         super.setOutputType(outputType, context);
-        return innerExpression.setOutputType(outputType, context);
+        return expression.setOutputType(outputType, context);
     }
 
     @Override
     protected void doVerify(VerificationContext context) {
-        innerExpression.verify(context);
+        expression.verify(context);
     }
 
     @Override
@@ -55,40 +53,40 @@ public final class GuardExpression extends CompositeExpression {
         if (!shouldExecute && context.getFieldValue() instanceof UpdateAdapter) {
             context.setCurrentValue(null);
         } else {
-            innerExpression.execute(context);
+            expression.execute(context);
         }
     }
 
     @Override
     public void setStatementOutput(DocumentType documentType, Field field) {
-        innerExpression.setStatementOutput(documentType, field);
+        expression.setStatementOutput(documentType, field);
     }
 
     @Override
     public DataType createdOutputType() {
-        return innerExpression.createdOutputType();
+        return expression.createdOutputType();
     }
 
     @Override
     public String toString() {
-        return "guard " + toScriptBlock(innerExpression);
+        return "guard " + toScriptBlock(expression);
     }
 
     @Override
     public void selectMembers(ObjectPredicate predicate, ObjectOperation operation) {
-         select(innerExpression, predicate, operation);
+         select(expression, predicate, operation);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof GuardExpression rhs)) return false;
-        if (!innerExpression.equals(rhs.innerExpression)) return false;
+        if (!expression.equals(rhs.expression)) return false;
         return true;
     }
 
     @Override
     public int hashCode() {
-        return getClass().hashCode() + innerExpression.hashCode();
+        return getClass().hashCode() + expression.hashCode();
     }
 
     private static boolean shouldExecute(Expression exp) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HashExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HashExpression.java
@@ -23,6 +23,10 @@ public class HashExpression extends Expression  {
 
     private DataType targetType;
 
+    public HashExpression() {
+        super(DataType.STRING);
+    }
+
     @Override
     public void setStatementOutput(DocumentType documentType, Field field) {
         targetType = field.getDataType();
@@ -37,7 +41,7 @@ public class HashExpression extends Expression  {
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
         super.setOutputType(outputType, context);
-        if (outputType != null && ! isHashCompatible(outputType))
+        if ( ! isHashCompatible(outputType))
             throw new VerificationException(this, "An " + outputType.getName() +
                                                   " output is required, but this produces int or long");
         return DataType.STRING;

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HexDecodeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HexDecodeExpression.java
@@ -13,6 +13,10 @@ public final class HexDecodeExpression extends Expression {
 
     private static final BigInteger ULONG_MAX = new BigInteger("18446744073709551616");
 
+    public HexDecodeExpression() {
+        super(DataType.STRING);
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, DataType.STRING, context);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HexEncodeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HexEncodeExpression.java
@@ -10,6 +10,10 @@ import com.yahoo.document.datatypes.StringFieldValue;
  */
 public final class HexEncodeExpression extends Expression {
 
+    public HexEncodeExpression() {
+        super(DataType.LONG);
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, DataType.LONG, context);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HostNameExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/HostNameExpression.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.StringFieldValue;
-
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
 /**
@@ -11,8 +10,9 @@ import static com.yahoo.vespa.defaults.Defaults.getDefaults;
  */
 public final class HostNameExpression extends Expression {
 
-    @Override
-    public boolean requiresInput() { return false; }
+    public HostNameExpression() {
+        super(null);
+    }
 
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/InputExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/InputExpression.java
@@ -19,13 +19,11 @@ public final class InputExpression extends Expression {
     private FieldPath fieldPath;
 
     public InputExpression(String fieldName) {
+        super(null);
         if (fieldName == null)
             throw new IllegalArgumentException("'input' must be given a field name as argument");
         this.fieldName = fieldName;
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     public String getFieldName() { return fieldName; }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/JoinExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/JoinExpression.java
@@ -18,6 +18,7 @@ public final class JoinExpression extends Expression {
     private final String delimiter;
 
     public JoinExpression(String delimiter) {
+        super(UnresolvedDataType.INSTANCE);
         this.delimiter = delimiter;
     }
 
@@ -26,7 +27,6 @@ public final class JoinExpression extends Expression {
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, context);
-        if (inputType == null) return null;
         if ( ! (inputType instanceof ArrayDataType))
             throw new VerificationException(this, "Expected Array input, got type " + inputType.getName());
         return DataType.STRING;
@@ -41,8 +41,9 @@ public final class JoinExpression extends Expression {
     @Override
     protected void doVerify(VerificationContext context) {
         DataType input = context.getCurrentType();
-        if (!(input instanceof ArrayDataType))
-            throw new VerificationException(this, "Expected Array input, got " + (input == null ? "no value" : input.getName()));
+        if (!(input instanceof ArrayDataType)) {
+            throw new VerificationException(this, "Expected Array input, got type " + input.getName());
+        }
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/LiteralBoolExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/LiteralBoolExpression.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
+import com.yahoo.document.ArrayDataType;
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.BoolFieldValue;
 
@@ -14,11 +15,9 @@ public class LiteralBoolExpression extends Expression {
     private final boolean value;
 
     public LiteralBoolExpression(boolean value) {
+        super(null);
         this.value = value;
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/LowerCaseExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/LowerCaseExpression.java
@@ -11,6 +11,10 @@ import static com.yahoo.language.LinguisticsCase.toLowerCase;
  */
 public final class LowerCaseExpression extends Expression {
 
+    public LowerCaseExpression() {
+        super(DataType.STRING);
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         return super.setInputType(inputType, DataType.STRING, context);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NGramExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NGramExpression.java
@@ -34,6 +34,7 @@ public final class NGramExpression extends Expression {
      * @param gramSize the gram size
      */
     public NGramExpression(Linguistics linguistics, int gramSize) {
+        super(DataType.STRING);
         this.linguistics = linguistics;
         this.gramSize = gramSize;
     }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeExpression.java
@@ -6,8 +6,8 @@ import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.Transformer;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.logging.Level;
 
 /**
  * @author Simon Thoresen Hult
@@ -18,6 +18,7 @@ public final class NormalizeExpression extends Expression {
     private static final Logger logger = Logger.getLogger(NormalizeExpression.class.getName());
 
     public NormalizeExpression(Linguistics linguistics) {
+        super(DataType.STRING);
         this.linguistics = linguistics;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NowExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NowExpression.java
@@ -16,11 +16,9 @@ public final class NowExpression extends Expression {
     }
 
     public NowExpression(Timer timer) {
+        super(null);
         this.timer = timer;
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     public Timer getTimer() { return timer; }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/OptimizePredicateExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/OptimizePredicateExpression.java
@@ -25,6 +25,7 @@ public final class OptimizePredicateExpression extends Expression {
     }
 
     OptimizePredicateExpression(PredicateProcessor optimizer) {
+        super(DataType.PREDICATE);
         this.optimizer = optimizer;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/OutputExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/OutputExpression.java
@@ -17,6 +17,7 @@ public abstract class OutputExpression extends Expression {
     private final String fieldName;
 
     public OutputExpression(String image, String fieldName) {
+        super(UnresolvedDataType.INSTANCE);
         this.image = image;
         this.fieldName = fieldName;
     }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/PackBitsExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/PackBitsExpression.java
@@ -21,9 +21,13 @@ public class PackBitsExpression extends Expression  {
 
     private TensorType outputTensorType;
 
+    /** Creates a pack_bits expression. */
+    public PackBitsExpression() {
+        super(TensorDataType.any());
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
-        if (inputType == null) return null;
         super.setInputType(inputType, context);
         if ( ! validType(inputType))
             throw new VerificationException(this, "Require a tensor with one dense dimension, but got " + inputType.getName());
@@ -34,7 +38,7 @@ public class PackBitsExpression extends Expression  {
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
         super.setOutputType(outputType, context);
-        if (outputType != null && ! validType(outputType))
+        if ( ! validType(outputType))
             throw new VerificationException(this, "Required to produce " + outputType.getName() +
                                                   " but this produces a tensor with one dense dimension");
         outputTensorType = ((TensorDataType)outputType).getTensorType();

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ParenthesisExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ParenthesisExpression.java
@@ -13,74 +13,72 @@ import com.yahoo.vespa.objects.ObjectPredicate;
  */
 public class ParenthesisExpression extends CompositeExpression {
 
-    private final Expression innerExpression;
+    private final Expression innerExp;
 
-    public ParenthesisExpression(Expression innerExpression) {
-        this.innerExpression = innerExpression;
+    public ParenthesisExpression(Expression innerExp) {
+        super(innerExp.requiredInputType());
+        this.innerExp = innerExp;
     }
 
-    @Override
-    public boolean requiresInput() { return innerExpression.requiresInput(); }
-
-    public Expression getInnerExpression() { return innerExpression; }
+    public Expression getInnerExpression() { return innerExp; }
 
     @Override
     public ParenthesisExpression convertChildren(ExpressionConverter converter) {
-        return new ParenthesisExpression(converter.convert(innerExpression));
+        return new ParenthesisExpression(converter.convert(innerExp));
     }
 
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         super.setInputType(inputType, context);
-        return innerExpression.setInputType(inputType, context);
+        return innerExp.setInputType(inputType, context);
     }
 
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
         super.setOutputType(outputType, context);
-        return innerExpression.setInputType(outputType, context);
+        return innerExp.setInputType(outputType, context);
     }
 
     @Override
     public void setStatementOutput(DocumentType documentType, Field field) {
-        innerExpression.setStatementOutput(documentType, field);
+        innerExp.setStatementOutput(documentType, field);
     }
 
     @Override
     protected void doVerify(VerificationContext context) {
-        innerExpression.verify(context);
+        innerExp.verify(context);
     }
 
     @Override
     protected void doExecute(ExecutionContext context) {
-        innerExpression.execute(context);
+        innerExp.execute(context);
     }
 
     @Override
     public DataType createdOutputType() {
-        return innerExpression.createdOutputType();
+        return innerExp.createdOutputType();
     }
 
     @Override
     public String toString() {
-        return "(" + innerExpression + ")";
+        return "(" + innerExp + ")";
     }
 
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof ParenthesisExpression rhs)) return false;
-        if (!innerExpression.equals(rhs.innerExpression)) return false;
+        if (!innerExp.equals(rhs.innerExp)) return false;
         return true;
     }
 
     @Override
     public int hashCode() {
-        return getClass().hashCode() + innerExpression.hashCode();
+        return getClass().hashCode() + innerExp.hashCode();
     }
 
     @Override
     public void selectMembers(ObjectPredicate predicate, ObjectOperation operation) {
-        select(innerExpression, predicate, operation);
+        select(innerExp, predicate, operation);
     }
 
 }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/RandomExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/RandomExpression.java
@@ -19,11 +19,9 @@ public final class RandomExpression extends Expression {
     }
 
     public RandomExpression(Integer max) {
+        super(null);
         this.max = max;
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     public Integer getMaxValue() { return max; }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ScriptExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ScriptExpression.java
@@ -32,7 +32,7 @@ public final class ScriptExpression extends ExpressionList<StatementExpression> 
     }
 
     public ScriptExpression(Collection<? extends StatementExpression> statements) {
-        super(statements);
+        super(statements, resolveInputType(statements));
     }
 
     @Override
@@ -86,6 +86,20 @@ public final class ScriptExpression extends ExpressionList<StatementExpression> 
             if (context.getFieldValue(inputField) != null)
                 return true;
         return false;
+    }
+
+    private static DataType resolveInputType(Collection<? extends StatementExpression> list) {
+        DataType prev = null;
+        for (Expression exp : list) {
+            DataType next = exp.requiredInputType();
+            if (prev == null) {
+                prev = next;
+            } else if (next != null && !prev.isAssignableFrom(next)) {
+                throw new VerificationException(ScriptExpression.class, "Statements require conflicting input types, " +
+                                                                        prev.getName() + " vs " + next.getName());
+            }
+        }
+        return prev;
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SelectInputExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SelectInputExpression.java
@@ -27,11 +27,9 @@ public final class SelectInputExpression extends CompositeExpression {
     }
 
     public SelectInputExpression(List<Pair<String, Expression>> cases) {
+        super(null);
         this.cases = cases;
     }
-
-    @Override
-    public boolean requiresInput() { return false; }
 
     @Override
     public SelectInputExpression convertChildren(ExpressionConverter converter) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SetLanguageExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SetLanguageExpression.java
@@ -11,6 +11,10 @@ import com.yahoo.language.Language;
  */
 public final class SetLanguageExpression extends Expression {
 
+    public SetLanguageExpression() {
+        super(DataType.STRING);
+    }
+
     @Override
     public DataType setInputType(DataType inputType, VerificationContext context) {
         return super.setInputType(inputType, DataType.STRING, context);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SetVarExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SetVarExpression.java
@@ -11,6 +11,7 @@ public final class SetVarExpression extends Expression {
     private final String varName;
 
     public SetVarExpression(String varName) {
+        super(UnresolvedDataType.INSTANCE);
         this.varName = varName;
     }
 
@@ -24,15 +25,12 @@ public final class SetVarExpression extends Expression {
 
     @Override
     public DataType setOutputType(DataType outputType, VerificationContext context) {
-        if (outputType == null) return null;
         setVariableType(outputType, context);
         return super.setOutputType(outputType, context);
     }
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         setVariableType(context.getCurrentType(), context);
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SleepExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SleepExpression.java
@@ -12,6 +12,10 @@ import com.yahoo.document.datatypes.NumericFieldValue;
  */
 public final class SleepExpression extends Expression {
 
+    public SleepExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     protected void doVerify(VerificationContext context) { }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SplitExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SplitExpression.java
@@ -17,6 +17,7 @@ public final class SplitExpression extends Expression {
     private final Pattern splitPattern;
 
     public SplitExpression(String splitString) {
+        super(DataType.STRING);
         this.splitPattern = Pattern.compile(splitString);
     }
 
@@ -29,10 +30,10 @@ public final class SplitExpression extends Expression {
     }
 
     @Override
-    public DataType setOutputType(DataType outputType, VerificationContext context) {
-        super.setOutputType(outputType, context);
-        if (outputType != null && ! (outputType instanceof ArrayDataType) && outputType.getNestedType() == DataType.STRING)
-            throw new VerificationException(this, "This produces a string array, but " + outputType.getName() + " is required");
+    public DataType setOutputType(DataType output, VerificationContext context) {
+        super.setOutputType(output, context);
+        if ( ! (output instanceof ArrayDataType) && output.getNestedType() == DataType.STRING)
+            throw new VerificationException(this, "This produces a string array, but " + output.getName() + " is required");
         return DataType.STRING;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SubstringExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SubstringExpression.java
@@ -14,6 +14,7 @@ public final class SubstringExpression extends Expression {
     private final int to;
 
     public SubstringExpression(int from, int to) {
+        super(DataType.STRING);
         if (from < 0 || to < 0 || to < from) {
             throw new IndexOutOfBoundsException();
         }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SwitchExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/SwitchExpression.java
@@ -30,6 +30,7 @@ public final class SwitchExpression extends CompositeExpression {
     }
 
     public <T extends Expression> SwitchExpression(Map<String, T> cases, Expression defaultExp) {
+        super(null);
         this.defaultExp = defaultExp;
         this.cases.putAll(cases);
     }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ThisExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ThisExpression.java
@@ -8,10 +8,13 @@ import com.yahoo.document.DataType;
  */
 public final class ThisExpression extends Expression {
 
+    public ThisExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
+        // empty
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToArrayExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToArrayExpression.java
@@ -11,29 +11,29 @@ import com.yahoo.document.datatypes.FieldValue;
  */
 public final class ToArrayExpression extends Expression {
 
+    public ToArrayExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
-        if (input == null) return null;
         return new ArrayDataType(input);
     }
 
     @Override
-    public DataType setOutputType(DataType outputType, VerificationContext context) {
-        if (outputType == null) return null;
-        super.setOutputType(outputType, context);
-        if (outputType instanceof ArrayDataType arrayType)
+    public DataType setOutputType(DataType output, VerificationContext context) {
+        super.setOutputType(output, context);
+        if (output instanceof ArrayDataType arrayType)
             return arrayType.getNestedType();
-        if (outputType instanceof AnyDataType)
+        if (output instanceof AnyDataType)
             return AnyDataType.instance;
         else
-            throw new VerificationException(this, "Produces an array,  but " + outputType + " is required");
+            throw new VerificationException(this, "Produces an array,  but " + output + " is required");
     }
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(DataType.getArray(context.getCurrentType()));
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToBoolExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToBoolExpression.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
+import com.yahoo.document.ArrayDataType;
 import com.yahoo.document.DataType;
 import com.yahoo.document.NumericDataType;
 import com.yahoo.document.datatypes.BoolFieldValue;
@@ -13,10 +14,13 @@ import com.yahoo.document.datatypes.StringFieldValue;
  */
 public final class ToBoolExpression extends Expression {
 
+    public ToBoolExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
-        if (input == null) return null;
         if ( ! (input.isAssignableTo(DataType.STRING) && ! (input instanceof NumericDataType)))
             throw new VerificationException(this, "Input must be a string or number, but got " + input.getName());
         return DataType.BOOL;
@@ -30,8 +34,6 @@ public final class ToBoolExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToByteExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToByteExpression.java
@@ -2,12 +2,17 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
+import com.yahoo.document.NumericDataType;
 import com.yahoo.document.datatypes.ByteFieldValue;
 
 /**
  * @author Simon Thoresen Hult
  */
 public final class ToByteExpression extends Expression {
+
+    public ToByteExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
 
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
@@ -23,8 +28,6 @@ public final class ToByteExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToDoubleExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToDoubleExpression.java
@@ -9,6 +9,10 @@ import com.yahoo.document.datatypes.DoubleFieldValue;
  */
 public final class ToDoubleExpression extends Expression {
 
+    public ToDoubleExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
@@ -23,8 +27,6 @@ public final class ToDoubleExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToEpochSecondExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToEpochSecondExpression.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.LongFieldValue;
-
 import java.time.Instant;
 
 /**
@@ -12,6 +11,10 @@ import java.time.Instant;
  * @author bergum
  */
 public class ToEpochSecondExpression extends Expression {
+
+    public ToEpochSecondExpression() {
+        super(DataType.STRING); //only accept string input
+    }
 
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToFloatExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToFloatExpression.java
@@ -9,6 +9,10 @@ import com.yahoo.document.datatypes.FloatFieldValue;
  */
 public final class ToFloatExpression extends Expression {
 
+    public ToFloatExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
@@ -23,8 +27,6 @@ public final class ToFloatExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToIntegerExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToIntegerExpression.java
@@ -9,6 +9,10 @@ import com.yahoo.document.datatypes.IntegerFieldValue;
  */
 public final class ToIntegerExpression extends Expression {
 
+    public ToIntegerExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
@@ -23,8 +27,6 @@ public final class ToIntegerExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToLongExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToLongExpression.java
@@ -9,6 +9,10 @@ import com.yahoo.document.datatypes.LongFieldValue;
  */
 public final class ToLongExpression extends Expression {
 
+    public ToLongExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
@@ -23,8 +27,6 @@ public final class ToLongExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToPositionExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToPositionExpression.java
@@ -3,11 +3,16 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.PositionDataType;
+import com.yahoo.document.PrimitiveDataType;
 
 /**
  * @author Simon Thoresen Hult
  */
 public final class ToPositionExpression extends Expression {
+
+    public ToPositionExpression() {
+        super(DataType.STRING);
+    }
 
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToStringExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToStringExpression.java
@@ -9,6 +9,10 @@ import com.yahoo.document.datatypes.StringFieldValue;
  */
 public final class ToStringExpression extends Expression {
 
+    public ToStringExpression() {
+        super(UnresolvedDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
@@ -23,8 +27,6 @@ public final class ToStringExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToWsetExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ToWsetExpression.java
@@ -15,6 +15,7 @@ public final class ToWsetExpression extends Expression {
     private final Boolean removeIfZero;
 
     public ToWsetExpression(boolean createIfNonExistent, boolean removeIfZero) {
+        super(UnresolvedDataType.INSTANCE);
         this.createIfNonExistent = createIfNonExistent;
         this.removeIfZero = removeIfZero;
     }
@@ -26,7 +27,6 @@ public final class ToWsetExpression extends Expression {
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
         super.setInputType(input, context);
-        if (input == null) return null;
         return outputType(input);
     }
 
@@ -40,8 +40,6 @@ public final class ToWsetExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(outputType(context.getCurrentType()));
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/TokenizeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/TokenizeExpression.java
@@ -18,6 +18,7 @@ public final class TokenizeExpression extends Expression {
     private final AnnotatorConfig config;
 
     public TokenizeExpression(Linguistics linguistics, AnnotatorConfig config) {
+        super(DataType.STRING);
         this.linguistics = linguistics;
         this.config = config;
     }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/TrimExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/TrimExpression.java
@@ -9,6 +9,10 @@ import com.yahoo.document.datatypes.StringFieldValue;
  */
 public final class TrimExpression extends Expression {
 
+    public TrimExpression() {
+        super(DataType.STRING);
+    }
+
     @Override
     protected void doVerify(VerificationContext context) {
         context.setCurrentType(createdOutputType());

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/UnresolvedDataType.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/UnresolvedDataType.java
@@ -12,7 +12,7 @@ final class UnresolvedDataType extends PrimitiveDataType {
     public static final UnresolvedDataType INSTANCE = new UnresolvedDataType();
 
     private UnresolvedDataType() {
-        super("unresolved", -69, UnresolvedFieldValue.class, UnresolvedFieldValue.getFactory());
+        super("any", -69, UnresolvedFieldValue.class, UnresolvedFieldValue.getFactory());
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/VerificationContext.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/VerificationContext.java
@@ -5,7 +5,6 @@ import com.yahoo.document.DataType;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author Simon Thoresen Hult
@@ -17,8 +16,12 @@ public class VerificationContext {
     private DataType currentType;
     private String outputField;
 
+    public VerificationContext() {
+        this(null);
+    }
+
     public VerificationContext(FieldTypeAdapter fieldTypes) {
-        this.fieldTypes = Objects.requireNonNull(fieldTypes);
+        this.fieldTypes = fieldTypes;
     }
 
     public VerificationContext verify(Expression expression) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveExpression.java
@@ -14,9 +14,12 @@ import com.yahoo.geo.ZCurve;
  */
 public final class ZCurveExpression extends Expression {
 
+    public ZCurveExpression() {
+        super(PositionDataType.INSTANCE);
+    }
+
     @Override
     public DataType setInputType(DataType input, VerificationContext context) {
-        if (input == null) return null;
         if ( ! (input instanceof StructDataType struct))
             throw new VerificationException(this, "This requires a struct as input, but got " + input.getName());
         requireIntegerField(PositionDataType.FIELD_X, struct);
@@ -41,8 +44,6 @@ public final class ZCurveExpression extends Expression {
 
     @Override
     protected void doVerify(VerificationContext context) {
-        if (context.getCurrentType() == null)
-            throw new VerificationException(this, "Expected input, but no input is provided");
         context.setCurrentType(createdOutputType());
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ScriptTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ScriptTestCase.java
@@ -11,22 +11,14 @@ import com.yahoo.document.datatypes.BoolFieldValue;
 import com.yahoo.document.datatypes.FloatFieldValue;
 import com.yahoo.document.datatypes.IntegerFieldValue;
 import com.yahoo.document.datatypes.LongFieldValue;
+import com.yahoo.document.datatypes.MapFieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
-import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
-import com.yahoo.vespa.indexinglanguage.expressions.ExecutionContext;
-import com.yahoo.vespa.indexinglanguage.expressions.Expression;
-import com.yahoo.vespa.indexinglanguage.expressions.InputExpression;
-import com.yahoo.vespa.indexinglanguage.expressions.ScriptExpression;
-import com.yahoo.vespa.indexinglanguage.expressions.StatementExpression;
-import com.yahoo.vespa.indexinglanguage.expressions.VerificationContext;
-import com.yahoo.vespa.indexinglanguage.expressions.VerificationException;
+import com.yahoo.document.datatypes.Struct;
+import com.yahoo.vespa.indexinglanguage.expressions.*;
 import com.yahoo.vespa.indexinglanguage.parser.ParseException;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -60,7 +52,7 @@ public class ScriptTestCase {
     }
 
     @Test
-    public void failsWhenOneStatementIsMissingInput() {
+    public void requireThatEachStatementHasEmptyInput() {
         Document input = new Document(type, "id:scheme:mytype::");
         input.setFieldValue(input.getField("in-1"), new StringFieldValue("69"));
 
@@ -69,36 +61,11 @@ public class ScriptTestCase {
                 new StatementExpression(new AttributeExpression("out-2")));
         try {
             exp.verify(input);
-            fail("Expected exception");
+            fail();
         } catch (VerificationException e) {
-            assertEquals("Invalid expression 'attribute out-2': Expected string input, but no input is provided", e.getMessage());
+            assertEquals(e.getExpressionType(), ScriptExpression.class);
+            assertEquals("Invalid expression '{ input in-1 | attribute out-1; attribute out-2; }': Expected any input, but no input is specified", e.getMessage());
         }
-    }
-
-    @Test
-    public void failsWhenAllStatementIsMissingInput() {
-        Document input = new Document(type, "id:scheme:mytype::");
-        input.setFieldValue(input.getField("in-1"), new StringFieldValue("69"));
-
-        Expression exp = new ScriptExpression(
-                new StatementExpression(new AttributeExpression("out-2")));
-        try {
-            exp.verify(input);
-            fail("Expected exception");
-        } catch (VerificationException e) {
-            assertEquals(AttributeExpression.class, e.getExpressionType());
-            assertEquals("Invalid expression 'attribute out-2': Expected string input, but no input is provided", e.getMessage());
-        }
-    }
-
-    @Test
-    public void succeedsWhenAllStatementsHaveInput() {
-        Document input = new Document(type, "id:scheme:mytype::");
-        input.setFieldValue(input.getField("in-1"), new StringFieldValue("69"));
-
-        Expression exp = new ScriptExpression(
-                new StatementExpression(new InputExpression("in-1"), new AttributeExpression("out-1")));
-        exp.verify(input);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ArithmeticTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ArithmeticTestCase.java
@@ -10,10 +10,8 @@ import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ArithmeticExpression.Operator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Simon Thoresen Hult
@@ -65,12 +63,40 @@ public class ArithmeticTestCase {
     public void requireThatVerifyCallsAreForwarded() {
         assertVerify(SimpleExpression.newOutput(DataType.INT), Operator.ADD,
                      SimpleExpression.newOutput(DataType.INT), null);
+        assertVerifyThrows(SimpleExpression.newOutput(null), Operator.ADD,
+                           SimpleExpression.newOutput(DataType.INT), null,
+                           "Expected any output, but no output is specified");
+        assertVerifyThrows(SimpleExpression.newOutput(DataType.INT), Operator.ADD,
+                           SimpleExpression.newOutput(null), null,
+                           "Expected any output, but no output is specified");
+        assertVerifyThrows(SimpleExpression.newOutput(null), Operator.ADD,
+                           SimpleExpression.newOutput(null), null,
+                           "Expected any output, but no output is specified");
         assertVerifyThrows(SimpleExpression.newOutput(DataType.INT), Operator.ADD,
                            SimpleExpression.newOutput(DataType.STRING), null,
                            "The second argument must be a number, but has type string");
         assertVerifyThrows(SimpleExpression.newOutput(DataType.STRING), Operator.ADD,
                            SimpleExpression.newOutput(DataType.STRING), null,
                            "The first argument must be a number, but has type string");
+    }
+
+    @Test
+    public void requireThatOperandInputCanBeNull() {
+        SimpleExpression reqNull = new SimpleExpression();
+        SimpleExpression reqInt = new SimpleExpression(DataType.INT);
+        assertNull(newArithmetic(reqNull, Operator.ADD, reqNull).requiredInputType());
+        assertEquals(DataType.INT, newArithmetic(reqInt, Operator.ADD, reqNull).requiredInputType());
+        assertEquals(DataType.INT, newArithmetic(reqInt, Operator.ADD, reqInt).requiredInputType());
+        assertEquals(DataType.INT, newArithmetic(reqNull, Operator.ADD, reqInt).requiredInputType());
+    }
+
+    @Test
+    public void requireThatOperandsAreInputCompatible() {
+        assertVerify(new SimpleExpression(DataType.INT), Operator.ADD,
+                     new SimpleExpression(DataType.INT), DataType.INT);
+        assertVerifyThrows(new SimpleExpression(DataType.INT), Operator.ADD,
+                           new SimpleExpression(DataType.STRING), null,
+                           "Operands require conflicting input types, int vs string");
     }
 
     @Test
@@ -137,7 +163,7 @@ public class ArithmeticTestCase {
 
     private void assertType(DataType lhs, Operator op, DataType rhs, DataType expected) {
         assertEquals(expected, newArithmetic(SimpleExpression.newOutput(lhs), op,
-                                             SimpleExpression.newOutput(rhs)).verify(new VerificationContext(new SimpleTestAdapter())));
+                                             SimpleExpression.newOutput(rhs)).verify());
         assertEquals(expected, newArithmetic(lhs.createFieldValue(6), op,
                                              rhs.createFieldValue(9)).execute().getDataType());
     }
@@ -157,14 +183,7 @@ public class ArithmeticTestCase {
     }
 
     private static ArithmeticExpression newArithmetic(Expression lhs, Operator op, Expression rhs) {
-        return newArithmetic(lhs, op, rhs, null);
-    }
-
-    private static ArithmeticExpression newArithmetic(Expression lhs, Operator op, Expression rhs, VerificationContext context) {
-        var expression = new ArithmeticExpression(lhs, op, rhs);
-        if (context != null)
-            expression.verify(context);
-        return expression;
+        return new ArithmeticExpression(lhs, op, rhs);
     }
 
     private static ConstantExpression newLong(long val) {
@@ -172,7 +191,7 @@ public class ArithmeticTestCase {
     }
 
     private static void assertVerify(Expression lhs, Operator op, Expression rhs, DataType val) {
-        new ArithmeticExpression(lhs, op, rhs).verify(new VerificationContext(new SimpleTestAdapter()).setCurrentType(val));
+        new ArithmeticExpression(lhs, op, rhs).verify(val);
     }
 
     private static void assertVerifyThrows(Expression lhs, Operator op, Expression rhs, DataType val,
@@ -180,8 +199,7 @@ public class ArithmeticTestCase {
         ArithmeticExpression expression = null;
         try {
             expression = new ArithmeticExpression(lhs, op, rhs);
-            expression.setInputType(null, new VerificationContext(new SimpleTestAdapter()));
-            expression.verify(new VerificationContext(new SimpleTestAdapter()).setCurrentType(val));
+            expression.verify(val);
             fail("Expected exception");
         } catch (VerificationException e) {
             String expressionString = expression == null ? "of type '" + ArithmeticExpression.class.getSimpleName() + "'"

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/AttributeExpressionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/AttributeExpressionTestCase.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import org.junit.Test;
 
+import static com.yahoo.vespa.indexinglanguage.expressions.OutputAssert.assertExecute;
+import static com.yahoo.vespa.indexinglanguage.expressions.OutputAssert.assertVerify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -25,6 +27,16 @@ public class AttributeExpressionTestCase {
         assertFalse(exp.equals(new IndexExpression("foo")));
         assertEquals(exp, new AttributeExpression("foo"));
         assertEquals(exp.hashCode(), new AttributeExpression("foo").hashCode());
+    }
+
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        assertVerify(new AttributeExpression("foo"));
+    }
+
+    @Test
+    public void requireThatExpressionCanBeExecuted() {
+        assertExecute(new AttributeExpression("foo"));
     }
 
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/Base64DecodeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/Base64DecodeTestCase.java
@@ -10,10 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -69,7 +66,7 @@ public class Base64DecodeTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new Base64DecodeExpression();
         assertVerify(DataType.STRING, exp, DataType.LONG);
-        assertVerifyThrows("Invalid expression 'base64decode': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'base64decode': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'base64decode': Expected string input, got long", DataType.LONG, exp);
     }
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/Base64EncodeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/Base64EncodeTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -42,7 +40,7 @@ public class Base64EncodeTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new Base64EncodeExpression();
         assertVerify(DataType.LONG, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'base64encode': Expected long input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'base64encode': Expected long input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'base64encode': Expected long input, got string", DataType.STRING, exp);
     }
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/CatTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/CatTestCase.java
@@ -3,22 +3,14 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.Field;
-import com.yahoo.document.datatypes.Array;
-import com.yahoo.document.datatypes.FieldValue;
-import com.yahoo.document.datatypes.IntegerFieldValue;
-import com.yahoo.document.datatypes.StringFieldValue;
-import com.yahoo.document.datatypes.WeightedSet;
+import com.yahoo.document.datatypes.*;
 import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 
+
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -52,18 +44,23 @@ public class CatTestCase {
     }
 
     @Test
-    public void expressionCanBeVerified() {
+    public void requireThatExpressionCanBeVerified() {
         assertVerify(new ConstantExpression(new StringFieldValue("foo")),
                      new ConstantExpression(new StringFieldValue("bar")), null);
+        assertVerify(new SimpleExpression(DataType.STRING),
+                     new SimpleExpression(DataType.STRING), DataType.STRING);
         assertVerifyThrows(new SimpleExpression().setCreatedOutput(null),
                            new SimpleExpression().setCreatedOutput(DataType.STRING), null,
                            "Invalid expression 'SimpleExpression . SimpleExpression': In SimpleExpression: Attempting to concatenate a null value");
         assertVerifyThrows(new SimpleExpression(DataType.STRING),
+                           new SimpleExpression(DataType.INT), null,
+                           "Invalid expression of type 'CatExpression': Operands require conflicting input types, string vs int");
+        assertVerifyThrows(new SimpleExpression(DataType.STRING),
                            new SimpleExpression(DataType.STRING), null,
-                           "Invalid expression 'SimpleExpression': Expected string input, but no input is provided");
+                           "Invalid expression 'SimpleExpression . SimpleExpression': Expected string input, but no input is specified");
         assertVerifyThrows(new SimpleExpression(DataType.STRING),
                            new SimpleExpression(DataType.STRING), DataType.INT,
-                           "Invalid expression 'SimpleExpression': Expected string input, got int");
+                           "Invalid expression 'SimpleExpression . SimpleExpression': Expected string input, got int");
     }
 
     @Test
@@ -91,23 +88,22 @@ public class CatTestCase {
     }
 
     @Test
-    public void inputValueIsAvailableToAllInnerExpressions() {
-        var expression = new StatementExpression(new ConstantExpression(new StringFieldValue("foo")),
-                                                 new CatExpression(new ThisExpression(),
-                                                                   new ConstantExpression(new StringFieldValue("bar")),
-                                                                   new ThisExpression()));
-        expression.verify(new SimpleTestAdapter());
-        assertEquals(new StringFieldValue("foobarfoo"), expression.execute());
+    public void requireThatInputValueIsAvailableToAllInnerExpressions() {
+        assertEquals(new StringFieldValue("foobarfoo"),
+                     new StatementExpression(new ConstantExpression(new StringFieldValue("foo")),
+                                             new CatExpression(new ThisExpression(),
+                                                               new ConstantExpression(new StringFieldValue("bar")),
+                                                               new ThisExpression())).execute());
     }
 
     @Test
-    public void requiredInputTypeAllowsNull() {
+    public void requiredThatRequiredInputTypeAllowsNull() {
          assertVerify(new ConstantExpression(new StringFieldValue("foo")), new TrimExpression(), DataType.STRING);
          assertVerify(new TrimExpression(), new ConstantExpression(new StringFieldValue("foo")), DataType.STRING);
     }
 
     @Test
-    public void arraysAreConcatenated() {
+    public void requireThatArraysAreConcatenated() {
         Array<StringFieldValue> lhs = new Array<>(DataType.getArray(DataType.STRING));
         lhs.add(new StringFieldValue("6"));
         Array<StringFieldValue> rhs = new Array<>(DataType.getArray(DataType.STRING));
@@ -217,16 +213,13 @@ public class CatTestCase {
     }
 
     private static void assertVerify(Expression expA, Expression expB, DataType val) {
-        new CatExpression(expA, expB).verify(new VerificationContext(new SimpleTestAdapter()).setCurrentType(val));
+        new CatExpression(expA, expB).verify(val);
     }
 
     private static void assertVerifyThrows(Expression expA, Expression expB, DataType val, String expectedException) {
         try {
-            var expression = new CatExpression(expA, expB);
-            var context = new VerificationContext(new SimpleTestAdapter()).setCurrentType(val);
-            expression.setInputType(val, context);
-            expression.verify(context);
-            fail("Expected exception");
+            new CatExpression(expA, expB).verify(val);
+            fail();
         } catch (VerificationException e) {
             if (!e.getMessage().startsWith(expectedException)) {
                 assertEquals(expectedException, e.getMessage());
@@ -239,15 +232,12 @@ public class CatTestCase {
     }
 
     private static FieldValue evaluate(DataType typeA, FieldValue valA, DataType typeB, FieldValue valB) {
-        var adapter = new SimpleTestAdapter(new Field("a", typeA),
-                                            new Field("b", typeB));
-        var expression = new CatExpression(new InputExpression("a"), new InputExpression("b"));
-        expression.setInputType(null, new VerificationContext(adapter));
-        ExecutionContext context = new ExecutionContext(adapter);
-        context.setFieldValue("a", valA, null);
-        context.setFieldValue("b", valB, null);
-        expression.execute(context);
-        return context.getCurrentValue();
+        ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter(new Field("a", typeA),
+                                                                          new Field("b", typeB)));
+        ctx.setFieldValue("a", valA, null);
+        ctx.setFieldValue("b", valB, null);
+        new CatExpression(new InputExpression("a"), new InputExpression("b")).execute(ctx);
+        return ctx.getCurrentValue();
     }
 
     private static DataType evaluate(DataType typeA, DataType typeB) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ClearStateTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ClearStateTestCase.java
@@ -2,13 +2,10 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -59,10 +56,6 @@ public class ClearStateTestCase {
     private static class MyVerification extends VerificationContext {
 
         boolean cleared = false;
-
-        MyVerification() {
-            super(new SimpleTestAdapter());
-        }
 
         @Override
         public VerificationContext clear() {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/EchoTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/EchoTestCase.java
@@ -10,9 +10,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -54,6 +53,6 @@ public class EchoTestCase {
         Expression exp = new EchoExpression();
         assertVerify(DataType.INT, exp, DataType.INT);
         assertVerify(DataType.STRING, exp, DataType.STRING);
+        assertVerifyThrows("Invalid expression 'echo': Expected any input, but no input is specified", null, exp);
     }
-
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExactTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExactTestCase.java
@@ -2,11 +2,7 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
-import com.yahoo.document.annotation.Annotation;
-import com.yahoo.document.annotation.SpanList;
-import com.yahoo.document.annotation.SpanNode;
-import com.yahoo.document.annotation.SpanTree;
-import com.yahoo.document.annotation.SpanTrees;
+import com.yahoo.document.annotation.*;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
@@ -15,11 +11,7 @@ import java.util.Iterator;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -92,7 +84,7 @@ public class ExactTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new ExactExpression();
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'exact': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'exact': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'exact': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExpressionAssert.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExpressionAssert.java
@@ -2,8 +2,8 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
-import com.yahoo.document.datatypes.StringFieldValue;
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
+
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -18,24 +18,23 @@ class ExpressionAssert {
     }
 
     public static void assertVerify(DataType valueBefore, Expression expression, DataType expectedValueAfter) {
-        assertVerifyCtx(expression, expectedValueAfter, new VerificationContext(new SimpleTestAdapter()).setCurrentType(valueBefore));
+        assertVerifyCtx(expression, expectedValueAfter, new VerificationContext().setCurrentType(valueBefore));
     }
 
     public static void assertVerifyThrows(String expectedMessage, DataType valueBefore, Expression expression) {
-        assertVerifyThrows(expectedMessage, expression, new VerificationContext(new SimpleTestAdapter()).setCurrentType(valueBefore));
+        assertVerifyThrows(expectedMessage, expression, new VerificationContext().setCurrentType(valueBefore));
     }
 
     interface CreateExpression {
         Expression create();
     }
     public static void assertVerifyThrows(String expectedMessage, DataType valueBefore, CreateExpression createExpression) {
-        assertVerifyThrows(expectedMessage, createExpression, new VerificationContext(new SimpleTestAdapter()).setCurrentType(valueBefore));
+        assertVerifyThrows(expectedMessage, createExpression, new VerificationContext().setCurrentType(valueBefore));
     }
 
     public static void assertVerifyThrows(String expectedMessage, CreateExpression createExp, VerificationContext context) {
         try {
             Expression exp = createExp.create();
-            exp = new StatementExpression(new ConstantExpression(new StringFieldValue("test")), exp);
             exp.verify(context);
             fail("Expected exception");
         } catch (VerificationException e) {
@@ -44,7 +43,6 @@ class ExpressionAssert {
     }
     public static void assertVerifyThrows(String expectedMessage, Expression expression, VerificationContext context) {
         try {
-            expression.setInputType(context.getCurrentType(), context);
             expression.verify(context);
             fail("Expected exception");
         } catch (VerificationException e) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExpressionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExpressionTestCase.java
@@ -5,18 +5,22 @@ import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.IntegerFieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
  */
 public class ExpressionTestCase {
+
+    @Test
+    public void requireThatInputTypeIsCheckedBeforeExecute() {
+        assertExecute(newRequiredInput(DataType.INT), null);
+        assertExecute(newRequiredInput(DataType.INT), new IntegerFieldValue(69));
+        assertExecuteThrows(newRequiredInput(DataType.INT), new StringFieldValue("foo"),
+                            new IllegalArgumentException("expected int input, got string"));
+    }
 
     @Test
     public void requireThatOutputTypeIsCheckedAfterExecute() {
@@ -30,11 +34,22 @@ public class ExpressionTestCase {
     public void requireThatInputTypeIsCheckedBeforeVerify() {
         assertVerify(newRequiredInput(DataType.INT), DataType.INT);
         assertVerifyThrows(newRequiredInput(DataType.INT), null,
-                           "Invalid expression 'SimpleExpression': Expected int input, but no input is provided");
+                           "Invalid expression 'SimpleExpression': Expected int input, but no input is specified");
         assertVerifyThrows(newRequiredInput(DataType.INT), UnresolvedDataType.INSTANCE,
-                           "Invalid expression 'SimpleExpression': Expected int input, got unresolved");
+                           "Invalid expression 'SimpleExpression': Failed to resolve input type");
         assertVerifyThrows(newRequiredInput(DataType.INT), DataType.STRING,
                            "Invalid expression 'SimpleExpression': Expected int input, got string");
+    }
+
+    @Test
+    public void requireThatOutputTypeIsCheckedAfterVerify() {
+        assertVerify(newCreatedOutput(DataType.INT, DataType.INT), null);
+        assertVerifyThrows(newCreatedOutput(DataType.INT, (DataType)null), null,
+                           "Invalid expression 'SimpleExpression': Expected int output, but no output is specified");
+        assertVerifyThrows(newCreatedOutput(DataType.INT, UnresolvedDataType.INSTANCE), null,
+                           "Invalid expression 'SimpleExpression': Failed to resolve output type");
+        assertVerifyThrows(newCreatedOutput(DataType.INT, DataType.STRING), null,
+                           "Invalid expression 'SimpleExpression': Expected int output, got string");
     }
 
     @Test
@@ -73,15 +88,13 @@ public class ExpressionTestCase {
     }
 
     private static void assertVerify(Expression exp, DataType val) {
-        var context = new VerificationContext(new SimpleTestAdapter()).setCurrentType(val);
-        exp.setInputType(val, context);
-        exp.verify(context);
+        exp.verify(val);
     }
 
     private static void assertVerifyThrows(Expression exp, DataType val, String expectedException) {
         try {
-            assertVerify(exp, val);
-            fail("Expected exception");
+            exp.verify(val);
+            fail();
         } catch (VerificationException e) {
             assertEquals(expectedException, e.getMessage());
         }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/FlattenTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/FlattenTestCase.java
@@ -2,11 +2,7 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
-import com.yahoo.document.annotation.Annotation;
-import com.yahoo.document.annotation.AnnotationTypes;
-import com.yahoo.document.annotation.Span;
-import com.yahoo.document.annotation.SpanTree;
-import com.yahoo.document.annotation.SpanTrees;
+import com.yahoo.document.annotation.*;
 import com.yahoo.document.datatypes.StringFieldValue;
 import org.junit.Test;
 
@@ -91,7 +87,7 @@ public class FlattenTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new FlattenExpression();
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'flatten': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'flatten': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'flatten': Expected string input, got int", DataType.INT, exp);
     }
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ForEachTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ForEachTestCase.java
@@ -53,7 +53,7 @@ public class ForEachTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new ForEachExpression(SimpleExpression.newConversion(DataType.INT, DataType.STRING));
         assertVerify(DataType.getArray(DataType.INT), exp, DataType.getArray(DataType.STRING));
-        assertVerifyThrows("Invalid expression 'for_each { SimpleExpression }': Expected Array, Struct, WeightedSet or Map input, got no value", null, exp);
+        assertVerifyThrows("Invalid expression 'for_each { SimpleExpression }': Expected any input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'for_each { SimpleExpression }': Expected Array, Struct, WeightedSet or Map input, got int", DataType.INT, exp);
         assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, got string", DataType.getArray(DataType.STRING), exp);
     }
@@ -64,7 +64,7 @@ public class ForEachTestCase {
         type.addField(new Field("foo", DataType.INT));
         assertVerify(type, new ForEachExpression(new SimpleExpression()), type);
         assertVerifyThrows("Invalid expression 'SimpleExpression': Expected string input, got int", type, new ForEachExpression(SimpleExpression.newConversion(DataType.STRING, DataType.INT)));
-        assertVerifyThrows("Invalid expression 'for_each { SimpleExpression }': Struct field 'foo' has type int but expression produces string", type, new ForEachExpression(SimpleExpression.newConversion(DataType.INT, DataType.STRING)));
+        assertVerifyThrows("Invalid expression 'for_each { SimpleExpression }': Expected int output, got string", type, new ForEachExpression(SimpleExpression.newConversion(DataType.INT, DataType.STRING)));
     }
 
     @Test
@@ -240,6 +240,9 @@ public class ForEachTestCase {
 
         List<FieldValue> lst = new LinkedList<>();
 
+        MyCollector() {
+            super(null);
+        }
         @Override
         protected void doExecute(ExecutionContext context) {
             lst.add(context.getCurrentValue());

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/GetFieldTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/GetFieldTestCase.java
@@ -1,11 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
-import com.yahoo.document.DataType;
-import com.yahoo.document.Document;
-import com.yahoo.document.DocumentType;
-import com.yahoo.document.Field;
-import com.yahoo.document.StructDataType;
+import com.yahoo.document.*;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.document.datatypes.Struct;
@@ -14,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -44,8 +38,8 @@ public class GetFieldTestCase {
         type.addField(new Field("foo", DataType.STRING));
         Expression exp = new GetFieldExpression("foo");
         assertVerify(type, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'get_field foo': Expected a struct or map, but got no value", null, exp);
-        assertVerifyThrows("Invalid expression 'get_field foo': Expected a struct or map, but got int", DataType.INT, exp);
+        assertVerifyThrows("Invalid expression 'get_field foo': Expected any input, but no input is specified", null, exp);
+        assertVerifyThrows("Invalid expression 'get_field foo': Expected a struct or map, but got an int", DataType.INT, exp);
         assertVerifyThrows("Invalid expression 'get_field bar': Field 'bar' not found in struct type 'my_struct'", type, new GetFieldExpression("bar"));
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/GetVarTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/GetVarTestCase.java
@@ -9,10 +9,7 @@ import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import com.yahoo.vespa.indexinglanguage.parser.ParseException;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -36,7 +33,7 @@ public class GetVarTestCase {
 
     @Test
     public void requireThatExpressionCanBeVerified() {
-        VerificationContext ctx = new VerificationContext(new SimpleTestAdapter());
+        VerificationContext ctx = new VerificationContext();
         ctx.setVariable("foo", DataType.STRING);
 
         assertEquals(DataType.STRING, new GetVarExpression("foo").verify(ctx));

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/GuardTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/GuardTestCase.java
@@ -1,11 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.expressions;
 
-import com.yahoo.document.DataType;
-import com.yahoo.document.Document;
-import com.yahoo.document.DocumentType;
-import com.yahoo.document.DocumentUpdate;
-import com.yahoo.document.Field;
+import com.yahoo.document.*;
 import com.yahoo.document.datatypes.LongFieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.document.update.AssignValueUpdate;
@@ -21,12 +17,7 @@ import java.util.List;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -55,8 +46,8 @@ public class GuardTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new GuardExpression(SimpleExpression.newConversion(DataType.INT, DataType.STRING));
         assertVerify(DataType.INT, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, but no input is provided", null, exp);
-        assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, got string", DataType.STRING, exp);
+        assertVerifyThrows("Invalid expression 'guard { SimpleExpression; }': Expected int input, but no input is specified", null, exp);
+        assertVerifyThrows("Invalid expression 'guard { SimpleExpression; }': Expected int input, got string", DataType.STRING, exp);
     }
 
     @Test
@@ -67,7 +58,7 @@ public class GuardTestCase {
 
         Document doc = new Document(docType, "id:scheme:my_input::");
         doc.setFieldValue("my_str", new StringFieldValue("69"));
-        assertNotNull(doc = Expression.execute(Expression.fromString("guard { input my_str | to_long | attribute my_lng }"), doc));
+        assertNotNull(doc = Expression.execute(Expression.fromString("guard { input my_str | to_int | attribute my_lng }"), doc));
         assertEquals(new LongFieldValue(69), doc.getFieldValue("my_lng"));
     }
 
@@ -79,7 +70,7 @@ public class GuardTestCase {
 
         DocumentUpdate docUpdate = new DocumentUpdate(docType, "id:scheme:my_input::");
         docUpdate.addFieldUpdate(FieldUpdate.createAssign(docType.getField("my_str"), new StringFieldValue("69")));
-        assertNotNull(docUpdate = Expression.execute(Expression.fromString("guard { input my_str | to_long | attribute my_lng }"), docUpdate));
+        assertNotNull(docUpdate = Expression.execute(Expression.fromString("guard { input my_str | to_int | attribute my_lng }"), docUpdate));
 
         assertEquals(0, docUpdate.fieldPathUpdates().size());
         assertEquals(1, docUpdate.fieldUpdates().size());

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/HexDecodeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/HexDecodeTestCase.java
@@ -10,10 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +29,7 @@ public class HexDecodeTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new HexDecodeExpression();
         assertVerify(DataType.STRING, exp, DataType.LONG);
-        assertVerifyThrows("Invalid expression 'hexdecode': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'hexdecode': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'hexdecode': Expected string input, got long", DataType.LONG, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/HexEncodeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/HexEncodeTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -31,7 +29,7 @@ public class HexEncodeTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new HexEncodeExpression();
         assertVerify(DataType.LONG, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'hexencode': Expected long input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'hexencode': Expected long input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'hexencode': Expected long input, got string", DataType.STRING, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/IfThenTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/IfThenTestCase.java
@@ -3,14 +3,7 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.Field;
-import com.yahoo.document.datatypes.ByteFieldValue;
-import com.yahoo.document.datatypes.DoubleFieldValue;
-import com.yahoo.document.datatypes.FieldValue;
-import com.yahoo.document.datatypes.FloatFieldValue;
-import com.yahoo.document.datatypes.IntegerFieldValue;
-import com.yahoo.document.datatypes.LongFieldValue;
-import com.yahoo.document.datatypes.NumericFieldValue;
-import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.document.datatypes.*;
 import com.yahoo.document.serialization.FieldReader;
 import com.yahoo.document.serialization.FieldWriter;
 import com.yahoo.document.serialization.XmlStream;
@@ -22,11 +15,7 @@ import java.util.List;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
 import static com.yahoo.vespa.indexinglanguage.expressions.IfThenExpression.Comparator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -48,9 +37,31 @@ public class IfThenTestCase {
     }
 
     @Test
+    public void requireThatRequiredInputTypeCompatibilityIsVerified() {
+        Expression exp = newRequiredInput(DataType.STRING, Comparator.EQ, DataType.STRING,
+                                          DataType.STRING, DataType.STRING);
+        assertVerify(DataType.STRING, exp, DataType.STRING);
+        String prefix = "Invalid expression 'if (SimpleExpression == SimpleExpression) { SimpleExpression; } else { SimpleExpression; }': ";
+        assertVerifyThrows(prefix + "Expected string input, but no input is specified", null, exp);
+        assertVerifyThrows(prefix + "Expected string input, got int", DataType.INT, exp);
+        assertVerifyThrows("Invalid expression of type 'IfThenExpression': Operands require conflicting input types, int vs string", null, () -> newRequiredInput(DataType.INT, Comparator.EQ, DataType.STRING,
+                                                                                                                            DataType.STRING, DataType.STRING)
+                          );
+        assertVerifyThrows("Invalid expression of type 'IfThenExpression': Operands require conflicting input types, string vs int", null, () -> newRequiredInput(DataType.STRING, Comparator.EQ, DataType.INT,
+                                                                                                                            DataType.STRING, DataType.STRING)
+                          );
+        assertVerifyThrows("Invalid expression of type 'IfThenExpression': Operands require conflicting input types, string vs int", null, () -> newRequiredInput(DataType.STRING, Comparator.EQ, DataType.STRING,
+                                                                                                                            DataType.INT, DataType.STRING)
+                          );
+        assertVerifyThrows("Invalid expression of type 'IfThenExpression': Operands require conflicting input types, string vs int", null, () -> newRequiredInput(DataType.STRING, Comparator.EQ, DataType.STRING,
+                                                                                                                            DataType.STRING, DataType.INT)
+                          );
+    }
+
+    @Test
     public void requireThatExpressionCanBeVerified() {
         assertVerify(DataType.STRING, new FlattenExpression(), DataType.STRING);
-        assertVerifyThrows("Invalid expression 'flatten': Expected string input, but no input is provided", null, new FlattenExpression()
+        assertVerifyThrows("Invalid expression 'flatten': Expected string input, but no input is specified", null, new FlattenExpression()
                           );
         assertVerifyThrows("Invalid expression 'flatten': Expected string input, got int", DataType.INT, new FlattenExpression()
                           );
@@ -228,24 +239,17 @@ public class IfThenTestCase {
 
     @Test
     public void testRequiredInputType() {
-        var ifExpression = new IfThenExpression(new InputExpression("int1"),
+        var ifExpression = new IfThenExpression(new InputExpression("field1"),
                                                 Comparator.EQ,
                                                 new ConstantExpression(new IntegerFieldValue(0)),
                                                 wrapLikeTheParser(new ConstantExpression(new StringFieldValue("true"))),
                                                 wrapLikeTheParser(new ConstantExpression(new StringFieldValue("false"))));
-
-        SimpleTestAdapter adapter = new SimpleTestAdapter();
-        adapter.createField(new Field("int1", DataType.INT));
-        adapter.createField(new Field("string1", DataType.STRING));
-
-        ifExpression.verify(adapter);
-        assertNull(ifExpression.getInputType(new VerificationContext(adapter)));
+        assertNull(ifExpression.requiredInputType());
         assertEquals(DataType.STRING, ifExpression.createdOutputType());
 
         var expression = new ScriptExpression(new StatementExpression(ifExpression,
-                                                                      new AttributeExpression("string1")));
-        expression.verify(adapter);
-        assertNull(expression.getInputType(new VerificationContext(adapter)));
+                                                                      new AttributeExpression(null)));
+        assertNull(expression.requiredInputType());
     }
 
     private Expression wrapLikeTheParser(Expression expression) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/IndexExpressionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/IndexExpressionTestCase.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import org.junit.Test;
 
+import static com.yahoo.vespa.indexinglanguage.expressions.OutputAssert.assertExecute;
+import static com.yahoo.vespa.indexinglanguage.expressions.OutputAssert.assertVerify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -27,4 +29,13 @@ public class IndexExpressionTestCase {
         assertEquals(lhs.hashCode(), new IndexExpression("foo").hashCode());
     }
 
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        assertVerify(new IndexExpression("foo"));
+    }
+
+    @Test
+    public void requireThatExpressionCanBeExecuted() {
+        assertExecute(new IndexExpression("foo"));
+    }
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/JoinTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/JoinTestCase.java
@@ -9,9 +9,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -38,7 +36,7 @@ public class JoinTestCase {
         Expression exp = new JoinExpression(";");
         assertVerify(DataType.getArray(DataType.INT), exp, DataType.STRING);
         assertVerify(DataType.getArray(DataType.STRING), exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'join \";\"': Expected Array input, got no value", null, exp);
+        assertVerifyThrows("Invalid expression 'join \";\"': Expected any input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'join \";\"': Expected Array input, got type int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/LowerCaseTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/LowerCaseTestCase.java
@@ -9,9 +9,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -30,7 +28,7 @@ public class LowerCaseTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new LowerCaseExpression();
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'lowercase': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'lowercase': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'lowercase': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/NGramTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/NGramTestCase.java
@@ -2,12 +2,7 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
-import com.yahoo.document.annotation.Annotation;
-import com.yahoo.document.annotation.AnnotationTypes;
-import com.yahoo.document.annotation.SpanList;
-import com.yahoo.document.annotation.SpanNode;
-import com.yahoo.document.annotation.SpanTree;
-import com.yahoo.document.annotation.SpanTrees;
+import com.yahoo.document.annotation.*;
 import com.yahoo.document.datatypes.IntegerFieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.language.Linguistics;
@@ -21,13 +16,7 @@ import java.util.Iterator;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author bratseth
@@ -57,7 +46,7 @@ public class NGramTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new NGramExpression(new SimpleLinguistics(), 69);
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'ngram 69': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'ngram 69': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'ngram 69': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeTestCase.java
@@ -9,15 +9,13 @@ import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.Transformer;
 import com.yahoo.language.simple.SimpleLinguistics;
 import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -45,7 +43,7 @@ public class NormalizeTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new NormalizeExpression(new SimpleLinguistics());
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'normalize': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'normalize': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'normalize': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/OptimizePredicateTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/OptimizePredicateTestCase.java
@@ -7,17 +7,13 @@ import com.yahoo.document.datatypes.IntegerFieldValue;
 import com.yahoo.document.datatypes.LongFieldValue;
 import com.yahoo.document.datatypes.PredicateFieldValue;
 import com.yahoo.document.predicate.Predicate;
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyCtx;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -81,11 +77,11 @@ public class OptimizePredicateTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new OptimizePredicateExpression();
         String prefix = "Invalid expression 'optimize_predicate': ";
-        assertVerifyThrows(prefix + "Expected predicate input, but no input is provided", null, exp);
+        assertVerifyThrows(prefix + "Expected predicate input, but no input is specified", null, exp);
         assertVerifyThrows(prefix + "Expected predicate input, got int", DataType.INT, exp);
         assertVerifyThrows(prefix + "Variable 'arity' must be set", DataType.PREDICATE, exp);
 
-        VerificationContext context = new VerificationContext(new SimpleTestAdapter()).setCurrentType(DataType.PREDICATE);
+        VerificationContext context = new VerificationContext().setCurrentType(DataType.PREDICATE);
         context.setVariable("arity", DataType.STRING);
         ExpressionAssert.assertVerifyThrows(prefix + "Variable 'arity' must have type int", exp, context);
         context.setVariable("arity", DataType.INT);

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/OutputAssert.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/OutputAssert.java
@@ -7,9 +7,7 @@ import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -29,14 +27,12 @@ class OutputAssert {
     public static void assertVerify(OutputExpression exp) {
         assertVerify(new MyAdapter(null), DataType.INT, exp);
         assertVerify(new MyAdapter(null), DataType.STRING, exp);
-        assertVerifyThrows(new MyAdapter(null), null, exp, "Invalid expression '" + exp + "': Expected input, but no input is specified");
+        assertVerifyThrows(new MyAdapter(null), null, exp, "Invalid expression '" + exp + "': Expected any input, but no input is specified");
         assertVerifyThrows(new MyAdapter(new VerificationException((Expression) null, "foo")), DataType.INT, exp, "Invalid expression 'null': foo");
     }
 
     public static void assertVerify(FieldTypeAdapter adapter, DataType value, Expression exp) {
-        var context = new VerificationContext(adapter).setCurrentType(value);
-        assertEquals(value, exp.setInputType(value, context));
-        assertEquals(value, context.verify(exp).getCurrentType());
+        assertEquals(value, new VerificationContext(adapter).setCurrentType(value).verify(exp).getCurrentType());
     }
 
     public static void assertVerifyThrows(FieldTypeAdapter adapter, DataType value, Expression exp,

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ParenthesisTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ParenthesisTestCase.java
@@ -9,10 +9,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -40,8 +37,8 @@ public class ParenthesisTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new ParenthesisExpression(SimpleExpression.newConversion(DataType.INT, DataType.STRING));
         assertVerify(DataType.INT, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, but no input is provided", null, exp);
-        assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, got string", DataType.STRING, exp);
+        assertVerifyThrows("Invalid expression '(SimpleExpression)': Expected int input, but no input is specified", null, exp);
+        assertVerifyThrows("Invalid expression '(SimpleExpression)': Expected int input, got string", DataType.STRING, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ScriptTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ScriptTestCase.java
@@ -16,6 +16,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -57,6 +59,18 @@ public class ScriptTestCase {
                                        newStatement(new IndexExpression("bar"))));
         assertEquals(exp, newScript(foo, bar));
         assertEquals(exp.hashCode(), newScript(foo, bar).hashCode());
+    }
+
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        Expression exp = newScript(newStatement(SimpleExpression.newConversion(DataType.INT, DataType.STRING)));
+        assertVerify(DataType.INT, exp, DataType.STRING);
+        assertVerifyThrows("Invalid expression '{ SimpleExpression; }': Expected int input, but no input is specified", null, exp);
+        assertVerifyThrows("Invalid expression '{ SimpleExpression; }': Expected int input, got string", DataType.STRING, exp);
+
+        assertVerifyThrows("Invalid expression of type 'ScriptExpression': Statements require conflicting input types, int vs string", null, () -> newScript(newStatement(SimpleExpression.newConversion(DataType.INT, DataType.STRING)),
+                                                                                                                                                          newStatement(SimpleExpression.newConversion(DataType.STRING, DataType.INT)))
+                          );
     }
 
     @Test
@@ -247,6 +261,10 @@ public class ScriptTestCase {
 
     private static class ThrowingExpression extends Expression {
 
+        public ThrowingExpression() {
+            super(null);
+        }
+
         @Override
         protected void doExecute(ExecutionContext context) {
             throw new RuntimeException();
@@ -266,6 +284,7 @@ public class ScriptTestCase {
         private final String valueToSet;
 
         public PutCacheExpression(String keyToSet, String valueToSet) {
+            super(null);
             this.keyToSet = keyToSet;
             this.valueToSet = valueToSet;
         }
@@ -289,6 +308,7 @@ public class ScriptTestCase {
         private final String expectedValue;
 
         public AssertCacheExpression(String expectedKey, String expectedValue) {
+            super(null);
             this.expectedKey = expectedKey;
             this.expectedValue = expectedValue;
         }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SetLanguageTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SetLanguageTestCase.java
@@ -29,7 +29,7 @@ public class SetLanguageTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new SetLanguageExpression();
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'set_language': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'set_language': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'set_language': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SetVarTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SetVarTestCase.java
@@ -9,10 +9,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -39,10 +36,10 @@ public class SetVarTestCase {
         Expression exp = new SetVarExpression("foo");
         assertVerify(DataType.INT, exp, DataType.INT);
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'set_var foo': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'set_var foo': Expected any input, but no input is specified", null, exp);
 
         try {
-            new VerificationContext(new SimpleTestAdapter()).setVariable("foo", DataType.INT).setCurrentType(DataType.STRING).verify(exp);
+            new VerificationContext().setVariable("foo", DataType.INT).setCurrentType(DataType.STRING).verify(exp);
             fail();
         } catch (VerificationException e) {
             assertEquals("Invalid expression 'set_var foo': Cannot set variable 'foo' to type string: It is already set to type int", e.getMessage());

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SimpleExpression.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SimpleExpression.java
@@ -13,24 +13,13 @@ final class SimpleExpression extends Expression {
     private boolean hasVerifyValue = false;
     private FieldValue executeValue;
     private DataType verifyValue;
-    private final DataType requiredInput;
     private DataType createdOutput;
 
     public SimpleExpression() {
-        this(null);
+        super(null);
     }
-
     public SimpleExpression(DataType requiredInput) {
-        this.requiredInput = requiredInput;
-    }
-
-    @Override
-    public boolean requiresInput() { return requiredInput != null; }
-
-    public SimpleExpression setVerifyValue(DataType verifyValue) {
-        this.hasVerifyValue = true;
-        this.verifyValue = verifyValue;
-        return this;
+        super(requiredInput);
     }
 
     public SimpleExpression setExecuteValue(FieldValue executeValue) {
@@ -39,28 +28,15 @@ final class SimpleExpression extends Expression {
         return this;
     }
 
-    public SimpleExpression setCreatedOutput(DataType createdOutput) {
-        this.createdOutput = createdOutput;
+    public SimpleExpression setVerifyValue(DataType verifyValue) {
+        this.hasVerifyValue = true;
+        this.verifyValue = verifyValue;
         return this;
     }
 
-    @Override
-    public DataType setInputType(DataType inputType, VerificationContext context) {
-        super.setInputType(inputType, requiredInput, context);
-        return createdOutput;
-    }
-
-    @Override
-    public DataType setOutputType(DataType outputType, VerificationContext context) {
-        super.setOutputType(createdOutput, outputType, null, context);
-        return requiredInput;
-    }
-
-    @Override
-    protected void doVerify(VerificationContext context) {
-        if (hasVerifyValue) {
-            context.setCurrentType(verifyValue);
-        }
+    public SimpleExpression setCreatedOutput(DataType createdOutput) {
+        this.createdOutput = createdOutput;
+        return this;
     }
 
     @Override
@@ -71,13 +47,20 @@ final class SimpleExpression extends Expression {
     }
 
     @Override
+    protected void doVerify(VerificationContext context) {
+        if (hasVerifyValue) {
+            context.setCurrentType(verifyValue);
+        }
+    }
+
+    @Override
     public DataType createdOutputType() {
         return createdOutput;
     }
 
     @Override
     public int hashCode() {
-        return hashCode(executeValue) + hashCode(verifyValue) + hashCode(createdOutput);
+        return hashCode(executeValue) + hashCode(verifyValue) + hashCode(requiredInputType()) + hashCode(createdOutput);
     }
 
     @Override
@@ -87,6 +70,7 @@ final class SimpleExpression extends Expression {
         if (!equals(executeValue, other.executeValue)) return false;
         if (hasVerifyValue != other.hasVerifyValue) return false;
         if (!equals(verifyValue, other.verifyValue)) return false;
+        if (!equals(requiredInputType(), other.requiredInputType())) return false;
         if (!equals(createdOutput, other.createdOutput)) return false;
         return true;
     }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SimpleExpressionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SimpleExpressionTestCase.java
@@ -3,12 +3,9 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.IntegerFieldValue;
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -18,12 +15,14 @@ public class SimpleExpressionTestCase {
     @Test
     public void requireThatAccessorsWork() {
         SimpleExpression exp = new SimpleExpression();
+        assertNull(exp.requiredInputType());
         assertNull(exp.createdOutputType());
         assertNull(exp.execute());
-        assertNull(exp.verify(new SimpleTestAdapter()));
+        assertNull(exp.verify());
 
+        assertEquals(DataType.INT, new SimpleExpression(DataType.INT).requiredInputType());
         assertEquals(DataType.INT, new SimpleExpression().setCreatedOutput(DataType.INT).createdOutputType());
-        assertEquals(DataType.INT, new SimpleExpression().setVerifyValue(DataType.INT).verify(new SimpleTestAdapter()));
+        assertEquals(DataType.INT, new SimpleExpression().setVerifyValue(DataType.INT).verify());
         assertEquals(new IntegerFieldValue(69),
                      new SimpleExpression().setExecuteValue(new IntegerFieldValue(69)).execute());
     }
@@ -52,6 +51,7 @@ public class SimpleExpressionTestCase {
         assertEquals(exp, new SimpleExpression().setVerifyValue(DataType.INT));
 
         exp = new SimpleExpression(DataType.INT);
+        assertFalse(exp.equals(new SimpleExpression(DataType.STRING)));
         assertEquals(exp, new SimpleExpression(DataType.INT));
 
         exp = new SimpleExpression().setCreatedOutput(DataType.INT);

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SplitTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SplitTestCase.java
@@ -10,10 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -40,7 +37,7 @@ public class SplitTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new SplitExpression(";");
         assertVerify(DataType.STRING, exp, DataType.getArray(DataType.STRING));
-        assertVerifyThrows("Invalid expression 'split \";\"': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'split \";\"': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'split \";\"': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/StatementTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/StatementTestCase.java
@@ -4,18 +4,16 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.IntegerFieldValue;
+import com.yahoo.vespa.indexinglanguage.ScriptTester;
 import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
+
 
 import java.util.List;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -67,6 +65,21 @@ public class StatementTestCase {
     }
 
     @Test
+    public void requireThatRequiredInputIsDeterminedByFirstNonNullRequiredInput() {
+        assertEquals(DataType.INT, newStatement(SimpleExpression.newRequired(DataType.INT)).requiredInputType());
+        assertEquals(DataType.INT, newStatement(new SimpleExpression(),
+                                                SimpleExpression.newRequired(DataType.INT)).requiredInputType());
+        assertEquals(DataType.INT, newStatement(SimpleExpression.newRequired(DataType.INT),
+                                                SimpleExpression.newRequired(DataType.INT)).requiredInputType());
+    }
+
+    @Test
+    public void requireThatRequiredInputIsNullIfAnyOutputIsCreatedFirst() {
+        assertNull(newStatement(new SimpleExpression().setCreatedOutput(DataType.INT),
+                                new SimpleExpression(DataType.INT)).requiredInputType());
+    }
+
+    @Test
     public void requireThatCreatedOutputIsDeterminedByLastNonNullCreatedOutput() {
         assertEquals(DataType.STRING, newStatement(SimpleExpression.newOutput(DataType.STRING)).createdOutputType());
         assertEquals(DataType.STRING, newStatement(SimpleExpression.newOutput(DataType.INT),
@@ -79,6 +92,7 @@ public class StatementTestCase {
     public void requireThatInternalVerificationIsPerformed() {
         Expression exp = newStatement(SimpleExpression.newOutput(DataType.STRING),
                                       SimpleExpression.newConversion(DataType.INT, DataType.STRING));
+        assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, got string", null, exp);
         assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, got string", DataType.INT, exp);
         assertVerifyThrows("Invalid expression 'SimpleExpression': Expected int input, got string", DataType.STRING, exp);
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SubstringTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SubstringTestCase.java
@@ -9,10 +9,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -40,7 +37,7 @@ public class SubstringTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new SubstringExpression(6, 9);
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'substring 6 9': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'substring 6 9': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'substring 6 9': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SummaryExpressionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SummaryExpressionTestCase.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 
 import org.junit.Test;
 
+import static com.yahoo.vespa.indexinglanguage.expressions.OutputAssert.assertExecute;
+import static com.yahoo.vespa.indexinglanguage.expressions.OutputAssert.assertVerify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -27,4 +29,13 @@ public class SummaryExpressionTestCase {
         assertEquals(exp.hashCode(), new SummaryExpression("foo").hashCode());
     }
 
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        assertVerify(new SummaryExpression("foo"));
+    }
+
+    @Test
+    public void requireThatExpressionCanBeExecuted() {
+        assertExecute(new SummaryExpression("foo"));
+    }
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SwitchTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/SwitchTestCase.java
@@ -12,13 +12,7 @@ import java.util.Map;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -63,7 +57,7 @@ public class SwitchTestCase {
         Expression foo = SimpleExpression.newConversion(DataType.STRING, DataType.INT);
         Expression exp = new SwitchExpression(Map.of("foo", foo));
         assertVerify(DataType.STRING, exp, DataType.STRING); // does not touch output
-        assertVerifyThrows("Invalid expression 'switch { case \"foo\": SimpleExpression; }': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'switch { case \"foo\": SimpleExpression; }': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'switch { case \"foo\": SimpleExpression; }': Expected string input, got int", DataType.INT, exp);
     }
 
@@ -128,6 +122,7 @@ public class SwitchTestCase {
         Expression exp = new SwitchExpression(cases, defaultExp);
         assertEvaluate(new StringFieldValue("foo"), exp, new StringFieldValue("bar"));
         assertEvaluate(new StringFieldValue("baz"), exp, new StringFieldValue("cox"));
+        assertEvaluate(null, exp, new StringFieldValue("cox"));
     }
 
     private static void assertEvaluate(FieldValue input, Expression exp, FieldValue expectedOutVar) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ThisTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ThisTestCase.java
@@ -29,7 +29,7 @@ public class ThisTestCase {
         Expression exp = new ThisExpression();
         assertVerify(DataType.INT, exp, DataType.INT);
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'this': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'this': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToArrayTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToArrayTestCase.java
@@ -33,7 +33,7 @@ public class ToArrayTestCase {
         Expression exp = new ToArrayExpression();
         assertVerify(DataType.INT, exp, DataType.getArray(DataType.INT));
         assertVerify(DataType.STRING, exp, DataType.getArray(DataType.STRING));
-        assertVerifyThrows("Invalid expression 'to_array': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_array': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToBoolTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToBoolTestCase.java
@@ -33,7 +33,7 @@ public class ToBoolTestCase {
         Expression exp = new ToBoolExpression();
         assertVerify(DataType.INT, exp, DataType.BOOL);
         assertVerify(DataType.STRING, exp, DataType.BOOL);
-        assertVerifyThrows("Invalid expression 'to_bool': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_bool': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToByteTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToByteTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +30,7 @@ public class ToByteTestCase {
         Expression exp = new ToByteExpression();
         assertVerify(DataType.INT, exp, DataType.BYTE);
         assertVerify(DataType.STRING, exp, DataType.BYTE);
-        assertVerifyThrows("Invalid expression 'to_byte': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_byte': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToDoubleTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToDoubleTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +30,7 @@ public class ToDoubleTestCase {
         Expression exp = new ToDoubleExpression();
         assertVerify(DataType.INT, exp, DataType.DOUBLE);
         assertVerify(DataType.STRING, exp, DataType.DOUBLE);
-        assertVerifyThrows("Invalid expression 'to_double': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_double': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToEpochSecondExpressionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToEpochSecondExpressionTestCase.java
@@ -11,8 +11,8 @@ import org.junit.Test;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class ToEpochSecondExpressionTestCase {
     @Test
@@ -28,7 +28,7 @@ public class ToEpochSecondExpressionTestCase {
         Expression exp = new ToEpochSecondExpression();
         assertVerify(DataType.STRING, exp, DataType.LONG);
         assertVerifyThrows("Invalid expression 'to_epoch_second': Expected string input, got int", DataType.INT, exp);
-        assertVerifyThrows("Invalid expression 'to_epoch_second': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_epoch_second': Expected string input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToFloatTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToFloatTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +30,7 @@ public class ToFloatTestCase {
         Expression exp = new ToFloatExpression();
         assertVerify(DataType.INT, exp, DataType.FLOAT);
         assertVerify(DataType.STRING, exp, DataType.FLOAT);
-        assertVerifyThrows("Invalid expression 'to_float': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_float': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToIntegerTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToIntegerTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +30,7 @@ public class ToIntegerTestCase {
         Expression exp = new ToIntegerExpression();
         assertVerify(DataType.INT, exp, DataType.INT);
         assertVerify(DataType.STRING, exp, DataType.INT);
-        assertVerifyThrows("Invalid expression 'to_int': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_int': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToLongTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToLongTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +30,7 @@ public class ToLongTestCase {
         Expression exp = new ToLongExpression();
         assertVerify(DataType.INT, exp, DataType.LONG);
         assertVerify(DataType.STRING, exp, DataType.LONG);
-        assertVerifyThrows("Invalid expression 'to_long': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_long': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToPositionTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToPositionTestCase.java
@@ -12,9 +12,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -33,7 +31,7 @@ public class ToPositionTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new ToPositionExpression();
         assertVerify(DataType.STRING, exp, PositionDataType.INSTANCE);
-        assertVerifyThrows("Invalid expression 'to_pos': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_pos': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'to_pos': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToStringTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToStringTestCase.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -32,7 +30,7 @@ public class ToStringTestCase {
         Expression exp = new ToStringExpression();
         assertVerify(DataType.INT, exp, DataType.STRING);
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'to_string': Expected input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'to_string': Expected any input, but no input is specified", null, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToWsetTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ToWsetTestCase.java
@@ -61,7 +61,7 @@ public class ToWsetTestCase {
         ExpressionAssert.assertVerify(DataType.STRING, expression,
                                       DataType.getWeightedSet(DataType.STRING, createIfNonExistent, removeIfZero));
         assertVerifyThrows("Invalid expression '" + expression + "': " +
-                           "Expected input, but no input is provided", null, expression);
+                           "Expected any input, but no input is specified", null, expression);
     }
 
     private static void assertConvert(boolean createIfNonExistent, boolean removeIfZero) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/TokenizeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/TokenizeTestCase.java
@@ -15,12 +15,7 @@ import org.mockito.Mockito;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -53,7 +48,7 @@ public class TokenizeTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new TokenizeExpression(new SimpleLinguistics(), new AnnotatorConfig());
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'tokenize': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'tokenize': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'tokenize': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/TrimTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/TrimTestCase.java
@@ -9,9 +9,7 @@ import org.junit.Test;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Simon Thoresen Hult
@@ -30,7 +28,7 @@ public class TrimTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new TrimExpression();
         assertVerify(DataType.STRING, exp, DataType.STRING);
-        assertVerifyThrows("Invalid expression 'trim': Expected string input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'trim': Expected string input, but no input is specified", null, exp);
         assertVerifyThrows("Invalid expression 'trim': Expected string input, got int", DataType.INT, exp);
     }
 

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/VerificationContextTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/VerificationContextTestCase.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNull;
@@ -15,7 +14,7 @@ public class VerificationContextTestCase {
 
     @Test
     public void requireThatValueCanBeSet() {
-        VerificationContext ctx = new VerificationContext(new SimpleTestAdapter());
+        VerificationContext ctx = new VerificationContext();
         DataType val = DataType.STRING;
         ctx.setCurrentType(val);
         assertSame(val, ctx.getCurrentType());
@@ -23,7 +22,7 @@ public class VerificationContextTestCase {
 
     @Test
     public void requireThatVariablesCanBeSet() {
-        VerificationContext ctx = new VerificationContext(new SimpleTestAdapter());
+        VerificationContext ctx = new VerificationContext();
         DataType val = DataType.STRING;
         ctx.setVariable("foo", val);
         assertSame(val, ctx.getVariable("foo"));
@@ -31,7 +30,7 @@ public class VerificationContextTestCase {
 
     @Test
     public void requireThatClearRemovesValue() {
-        VerificationContext ctx = new VerificationContext(new SimpleTestAdapter());
+        VerificationContext ctx = new VerificationContext();
         ctx.setCurrentType(DataType.STRING);
         ctx.clear();
         assertNull(ctx.getCurrentType());
@@ -39,7 +38,7 @@ public class VerificationContextTestCase {
 
     @Test
     public void requireThatClearRemovesVariables() {
-        VerificationContext ctx = new VerificationContext(new SimpleTestAdapter());
+        VerificationContext ctx = new VerificationContext();
         ctx.setVariable("foo", DataType.STRING);
         ctx.clear();
         assertNull(ctx.getVariable("foo"));

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ZCurveTestCase.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -29,8 +30,8 @@ public class ZCurveTestCase {
     public void requireThatExpressionCanBeVerified() {
         Expression exp = new ZCurveExpression();
         assertVerify(PositionDataType.INSTANCE, exp, DataType.LONG);
-        assertVerifyThrows("Invalid expression 'zcurve': Expected input, but no input is provided", null, exp);
-        assertVerifyThrows("Invalid expression 'zcurve': This requires a struct as input, but got int", DataType.INT, exp);
+        assertVerifyThrows("Invalid expression 'zcurve': Expected position input, but no input is specified", null, exp);
+        assertVerifyThrows("Invalid expression 'zcurve': Expected position input, got int", DataType.INT, exp);
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/parser/PrecedenceTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/parser/PrecedenceTestCase.java
@@ -1,9 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage.parser;
 
-import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
-import com.yahoo.vespa.indexinglanguage.expressions.VerificationContext;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -19,11 +17,7 @@ public class PrecedenceTestCase {
         assertEquals("33", evaluate("1 + 2 . 3"));
     }
 
-    private static String evaluate(String expressionString) throws ParseException {
-        var expression = Expression.fromString(expressionString);
-        // TODO: Move setInputType propagation from StatementExpression to Expression to force type resolution also when no statement?
-        expression.setInputType(null, new VerificationContext(new SimpleTestAdapter()));
-        return String.valueOf(expression.execute());
+    private static String evaluate(String script) throws ParseException {
+        return String.valueOf(Expression.fromString(script).execute());
     }
-
 }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/IndexingLanguageResolver.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/IndexingLanguageResolver.java
@@ -58,11 +58,12 @@ public class IndexingLanguageResolver {
         if (indexingLanguageNode.isASTInstance(indexingElm.class)) {
             var expression = ((indexingElm)indexingLanguageNode.getOriginalSchemaNode()).expression;
 
-            if (expression != null && expression.requiresInput() && !context.fieldIndex().getIsInsideDoc(fieldDefinitionSymbol)) {
+            if (expression != null && expression.requiredInputType() != null && !context.fieldIndex().getIsInsideDoc(fieldDefinitionSymbol)) {
                 diagnostics.add(new SchemaDiagnostic.Builder()
                         .setRange(indexingLanguageNode.get(0).getRange())
                         .setMessage(
-                            "Fields defined outside the document must start with an expression creating a value (e.g 'input <field>')")
+                            "Expected " + expression.requiredInputType().getName() + " input, but no input is specified. " +
+                            "Fields defined outside the document must start with indexing statements explicitly collecting input.")
                         .setSeverity(DiagnosticSeverity.Error)
                         .build());
             }
@@ -126,10 +127,10 @@ public class IndexingLanguageResolver {
             statement originalNode = (statement)node.getOriginalIndexingNode();
             StatementExpression expression = originalNode.expression;
 
-            if (expression != null && expression.requiresInput() && !context.fieldIndex().getIsInsideDoc(containingFieldDefinition)) {
+            if (expression != null && expression.requiredInputType() != null && !context.fieldIndex().getIsInsideDoc(containingFieldDefinition)) {
                 diagnostics.add(new SchemaDiagnostic.Builder()
                     .setRange(node.getRange())
-                    .setMessage("Fields defined outside the document must start with an expression creating a value (e.g 'input <field>')")
+                    .setMessage("Expected " + expression.requiredInputType().getName() + " input, but no input is specified. Fields defined outside the document must start with indexing statements explicitly collecting input.")
                     .setSeverity(DiagnosticSeverity.Error)
                     .build());
             }

--- a/model-integration/src/main/java/ai/vespa/embedding/huggingface/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/huggingface/HuggingFaceEmbedder.java
@@ -110,21 +110,22 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
         tokenizer.close();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public Tensor embed(String text, Context context, TensorType targetType) {
-        if (targetType.dimensions().size() != 1) {
-            throw new IllegalArgumentException("Error in embedding to type '" + targetType + "': should only have one dimension.");
+    public Tensor embed(String text, Context context, TensorType tensorType) {
+        if (tensorType.dimensions().size() != 1) {
+            throw new IllegalArgumentException("Error in embedding to type '" + tensorType + "': should only have one dimension.");
         }
-        if (!targetType.dimensions().get(0).isIndexed()) {
-            throw new IllegalArgumentException("Error in embedding to type '" + targetType + "': dimension should be indexed.");
+        if (!tensorType.dimensions().get(0).isIndexed()) {
+            throw new IllegalArgumentException("Error in embedding to type '" + tensorType + "': dimension should be indexed.");
         }
         var embeddingResult = lookupOrEvaluate(context, prependInstruction(text, context));
         IndexedTensor tokenEmbeddings = embeddingResult.output;
-        if (targetType.valueType() == TensorType.Value.INT8) {
-            return binaryQuantization(embeddingResult, targetType);
+        if (tensorType.valueType() == TensorType.Value.INT8) {
+            return binaryQuantization(embeddingResult, tensorType);
         } else {
-            Tensor result = poolingStrategy.toSentenceEmbedding(targetType, tokenEmbeddings, embeddingResult.attentionMask);
-            return  normalize ? normalize(result, targetType) : result;
+            Tensor result = poolingStrategy.toSentenceEmbedding(tensorType, tokenEmbeddings, embeddingResult.attentionMask);
+            return  normalize ? normalize(result, tensorType) : result;
         }
     }
 
@@ -191,21 +192,21 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
         return new HFEmbeddingResult(tokenEmbeddings, attentionMask, context.getEmbedderId());
     }
 
-    private Tensor binaryQuantization(HuggingFaceEmbedder.HFEmbeddingResult embeddingResult, TensorType targetType) {
+    private Tensor binaryQuantization(HuggingFaceEmbedder.HFEmbeddingResult embeddingResult, TensorType tensorType) {
         long outputDimensions = embeddingResult.output().shape()[2];
-        long targetDimensions = targetType.dimensions().get(0).size().get();
-        //🪆 flexibility - packing only the first 8*targetDimension float values from the model output
-        long targetUnpackagedDimensions = 8 * targetDimensions;
-        if (targetUnpackagedDimensions > outputDimensions) {
-            throw new IllegalArgumentException("Cannot pack " + outputDimensions + " into " + targetDimensions + " int8's");
+        long targetDim = tensorType.dimensions().get(0).size().get();
+        //🪆 flexibility - packing only the first 8*targetDim float values from the model output
+        long floatDimensions = 8 * targetDim;
+        if(floatDimensions > outputDimensions) {
+            throw new IllegalArgumentException("Cannot pack " + outputDimensions + " into " + targetDim + " int8s");
         }
         //perform pooling and normalizing using float version before binary quantization
         TensorType poolingType = new TensorType.Builder(TensorType.Value.FLOAT).
-                                         indexed(targetType.indexedSubtype().dimensions().get(0).name(), targetUnpackagedDimensions)
-                                         .build();
+                indexed(tensorType.indexedSubtype().dimensions().get(0).name(),
+                        floatDimensions).build();
         Tensor result = poolingStrategy.toSentenceEmbedding(poolingType, embeddingResult.output(), embeddingResult.attentionMask());
         result = normalize? normalize(result, poolingType) : result;
-        result = binarize((IndexedTensor) result, targetType);
+        result = binarize((IndexedTensor) result, tensorType);
         return result;
     }
 
@@ -247,6 +248,5 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
 
     protected record HFEmbeddingResult(IndexedTensor output, Tensor attentionMask, String embedderId) {}
     protected record HFEmbedderCacheKey(String embedderId, Object embeddedValue) { }
-
 }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#32968

https://factory.vespa.ai/testrun/101261607/test/DeployMainAppsTest::deployApplications started to fail with this change
```
java.lang.AssertionError: aimail.emailsemanticsearch deployed with failure:
status: deploymentFailed, not active, log entries:
2024-12-10T19:53:23.370Z info Deploying platform version 8.455.6 and application dev build 263837 for dev-cd-us-west-1 of default2 ...
2024-12-10T19:53:32.216Z info Using CA signed certificate version 11
2024-12-10T19:53:35.264Z warning Deployment failed: Invalid application: For schema 'mail', field 'content_embedding': Invalid expression '(get_var A | to_array) . (get_var B | to_array) . (get_var C | to_array) . (get_var D | to_array)': Required to produce any, but this produces a string or collection expected:<0> but was:<1>
```