### PR TITLE
Publish the config-model-fat RPMs separately to allow download of thi…

### DIFF
--- a/.buildkite/publish-artifacts.sh
+++ b/.buildkite/publish-artifacts.sh
@@ -12,10 +12,11 @@ cd "$WORKDIR/artifacts/$ARCH"
 
 tar -cf rpm-repo.tar rpms &
 tar -cf maven-repo.tar maven-repo
+cp -a rpms/vespa-config-model-fat-*.rpm .
 wait
 
-for FILE in *.tar; do
+for FILE in *.tar *.rpm; do
     cosign sign-blob -y --oidc-provider=buildkite-agent --output-signature "$FILE.sig" --output-certificate "$FILE.pem" "$FILE"
 done
 
-buildkite-agent artifact upload "*.tar;*.tar.sig;*.tar.pem" "$BUILDKITE_ARTIFACT_DESTINATION/$VESPA_VERSION/artifacts/$ARCH"
+buildkite-agent artifact upload "*.tar;*.tar.sig;*.tar.pem;*.rpm;*.rpm.sig;*.rpm.pem" "$BUILDKITE_ARTIFACT_DESTINATION/$VESPA_VERSION/artifacts/$ARCH"


### PR DESCRIPTION
…s single RPM for multiple versions when creating config model collections.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
