### PR TITLE
Reduce FileDownloader timeout in maintainer

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
@@ -43,6 +43,7 @@ import static com.yahoo.vespa.config.server.session.Session.Status.PREPARE;
 public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
 
     private static final Logger log = Logger.getLogger(ApplicationPackageMaintainer.class.getName());
+    private static final Duration fileDownloaderTimeout = Duration.ofSeconds(30);
 
     private final File downloadDirectory;
     private final Supervisor supervisor = new Supervisor(new Transport("filedistribution-pool")).setDropEmptyBuffers(true);
@@ -126,7 +127,7 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
         List<String> otherConfigServersInCluster = getOtherConfigServersInCluster(applicationRepository.configserverConfig());
         ConfigSourceSet configSourceSet = new ConfigSourceSet(otherConfigServersInCluster);
         ConnectionPool connectionPool = new FileDistributionConnectionPool(configSourceSet, supervisor);
-        return new FileDownloader(connectionPool, supervisor, downloadDirectory, Duration.ofSeconds(60));
+        return new FileDownloader(connectionPool, supervisor, downloadDirectory, fileDownloaderTimeout);
     }
 
     @Override


### PR DESCRIPTION
We don't know which config server has the file, so it's better to have lower timeout and retry another server (also since downloader does retries within timeout, might need to look into that).