### PR TITLE
Don't fail early when using reference attribute in grouping expression.

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/GroupingValidator.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/GroupingValidator.java
@@ -110,10 +110,11 @@ public class GroupingValidator extends Searcher {
                 datatype == AttributesConfig.Attribute.Datatype.DOUBLE;
     }
 
-    static private boolean isSingleRawOrBoolAttribute(AttributesConfig.Attribute attribute) {
+    static private boolean isSingleRawBoolOrReferenceAttribute(AttributesConfig.Attribute attribute) {
         var datatype = attribute.datatype();
         return  (datatype == AttributesConfig.Attribute.Datatype.RAW ||
-                datatype == AttributesConfig.Attribute.Datatype.BOOL) &&
+                datatype == AttributesConfig.Attribute.Datatype.BOOL ||
+                datatype == AttributesConfig.Attribute.Datatype.REFERENCE) &&
                 attribute.collectiontype() == AttributesConfig.Attribute.Collectiontype.SINGLE;
     }
 
@@ -122,7 +123,7 @@ public class GroupingValidator extends Searcher {
         if (attribute == null) {
             throw new UnavailableAttributeException(clusterName, attributeName);
         }
-        if (isPrimitiveAttribute(attribute) || (!isMapLookup && isSingleRawOrBoolAttribute(attribute))) {
+        if (isPrimitiveAttribute(attribute) || (!isMapLookup && isSingleRawBoolOrReferenceAttribute(attribute))) {
             return;
         }
         throw new IllegalInputException("Grouping request references attribute '" +

--- a/container-search/src/test/java/com/yahoo/search/grouping/GroupingValidatorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/GroupingValidatorTestCase.java
@@ -178,8 +178,8 @@ public class GroupingValidatorTestCase {
     }
 
     @Test
-    void reference_attribute_throws() {
-        unsupported_attribute_type_throws("reference", AttributesConfig.Attribute.Datatype.REFERENCE, "reference");
+    void reference_attribute_is_ok() {
+        validate_attribute_type("reference", AttributesConfig.Attribute.Datatype.REFERENCE);
     }
 
     @Test


### PR DESCRIPTION
This is not yet supported in the backend, so it still results in an error in the query result. This change is done to unblock some failing tests.

@hmusum please review
@toregge FYI