### PR TITLE
Handle parsing errors in semantic rules better

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/SemanticRules.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/SemanticRules.java
@@ -74,8 +74,8 @@ public class SemanticRules implements Serializable, SemanticRulesConfig.Producer
             try {
                 toMap(config);  // validates config
                 ensureZeroOrOneDefaultRule(config);
-            } catch (ParseException | IOException e) {
-                throw new RuntimeException(e);
+            } catch (ParseException e) {
+                throw new IllegalArgumentException(e);
             }
             return rules;
         }
@@ -109,7 +109,7 @@ public class SemanticRules implements Serializable, SemanticRulesConfig.Producer
             }
         }
 
-        static Map<String, com.yahoo.prelude.semantics.RuleBase> toMap(SemanticRulesConfig config) throws ParseException, IOException {
+        static Map<String, com.yahoo.prelude.semantics.RuleBase> toMap(SemanticRulesConfig config) throws ParseException {
             RuleImporter ruleImporter = new RuleImporter(config, true, new SimpleLinguistics());
             Map<String, com.yahoo.prelude.semantics.RuleBase> ruleBaseMap = new HashMap<>();
             for (SemanticRulesConfig.Rulebase ruleBaseConfig : config.rulebase()) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/search/SemanticRulesTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/search/SemanticRulesTest.java
@@ -29,7 +29,7 @@ public class SemanticRulesTest {
     private static final String rootWithDuplicateDefault = basePath + "semanticrules_with_duplicate_default_rule";
 
     @Test
-    void semanticRulesTest() throws ParseException, IOException {
+    void semanticRulesTest() throws ParseException {
         SemanticRuleBuilder ruleBuilder = new SemanticRuleBuilder();
         SemanticRules rules = ruleBuilder.build(FilesApplicationPackage.fromFile(new File(root)));
         SemanticRulesConfig.Builder configBuilder = new SemanticRulesConfig.Builder();
@@ -49,8 +49,8 @@ public class SemanticRulesTest {
     void rulesWithErrors() {
         try {
             new SemanticRuleBuilder().build(FilesApplicationPackage.fromFile(new File(rootWithErrors)));
-            fail("should fail with exception");
-        } catch (Exception e) {
+            fail("should fail with IllegalArgumentException, so that it is reported to the user as an error in application package");
+        } catch (IllegalArgumentException e) {
             assertEquals("com.yahoo.prelude.semantics.parser.ParseException: Could not parse rule 'invalid'", e.getMessage());
         }
     }
@@ -59,8 +59,8 @@ public class SemanticRulesTest {
     void rulesWithDuplicateDefault() {
         try {
             new SemanticRuleBuilder().build(FilesApplicationPackage.fromFile(new File(rootWithDuplicateDefault)));
-            fail("should fail with exception");
-        } catch (Exception e) {
+            fail("should fail with IllegalArgumentException, so that it is reported to the user as an error in application package");
+        } catch (IllegalArgumentException e) {
             assertEquals("Rules [one, other] are both marked as the default rule, there can only be one", e.getMessage());
         }
     }


### PR DESCRIPTION
Throw IllegalArgumentException when there are parse errors in semantic rules, this will return an invalid application package error to the user with appropriate message instead of internal server error as it is today.

IllegalArgumentException will be translated to 400 Bad Request in repsonse from config server.