### PR TITLE
Avoid stack trace when removing LB after user has changed account or visibility

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -212,11 +212,13 @@ public class LoadBalancerProvisioner {
                 newLoadBalancer = loadBalancer.get().with(State.removable, nodeRepository.clock().instant());
                 throw new LoadBalancerServiceException("Could not (re)configure " + id + " due to change in load balancer visibility. The operation will be retried on next deployment");
             }
-            newLoadBalancer = loadBalancer.orElseGet(() -> createNewLoadBalancer(id, zoneEndpoint, requested));      // Determine id-seed.
-            newLoadBalancer = newLoadBalancer.with(provisionInstance(newLoadBalancer, zoneEndpoint, requested)); // Update instance.
-        } catch (LoadBalancerServiceException e) {
-            log.log(Level.WARNING, "Failed to provision load balancer", e);
-            throw e;
+            try {
+                newLoadBalancer = loadBalancer.orElseGet(() -> createNewLoadBalancer(id, zoneEndpoint, requested));      // Determine id-seed.
+                newLoadBalancer = newLoadBalancer.with(provisionInstance(newLoadBalancer, zoneEndpoint, requested)); // Update instance.
+            } catch (LoadBalancerServiceException e) {
+                log.log(Level.WARNING, "Failed to provision load balancer", e);
+                throw e;
+            }
         } finally {
             db.writeLoadBalancer(newLoadBalancer, fromState);
         }


### PR DESCRIPTION
We already log the message because an error response is returned:

`
2024-12-19 18:43:25.377 I cs cfg1 Returning response with response code 409, error-code:LOAD_BALANCER_NOT_READY, message=Could not (re)configure load balancer deviantart:personalsearch:default:default due to change in load balancer visibility. The operation will be retried on next deployment (HttpErrorResponse)
`
