### PR TITLE
Extend CLI `document get` to fetch multiple documents.

### DIFF
--- a/client/go/internal/cli/cmd/document.go
+++ b/client/go/internal/cli/cmd/document.go
@@ -114,7 +114,9 @@ func readDocuments(ids []string, timeoutSecs int, waiter *Waiter, printCurl bool
 
 	for _, docId := range parsedIds {
 		result := client.Get(docId, fieldSet)
-		printResult(cli, operationResult(true, document.Document{Id: docId}, service, result), true)
+		if err := printResult(cli, operationResult(true, document.Document{Id: docId}, service, result), true); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

We had a use-case where we needed to pull many individual documents from a Vespa instance for relay to another. The existing `document get` mechanism incurred a lot of process overhead to retrieve multiple documents, so I adapted the client to allow multiple id's to be passed and processed serially. It will loop until all specified document retrievals are completed, it does not halt early for server errors or missing documents as the original implementation did not.