### PR TITLE
Avoid priority inversion when batching persistence messages

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -95,6 +95,10 @@ public:
         [[nodiscard]] size_t size() const noexcept { return messages.size(); }
         // Precondition: messages.size() == 1
         [[nodiscard]] LockedMessage release_as_single_msg() noexcept;
+        // Precondition: !messages.empty()
+        [[nodiscard]] uint8_t min_priority() const noexcept {
+            return messages[0].first->getPriority();
+        }
     };
 
     class ScheduleAsyncResult {

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -25,7 +25,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/member.hpp>
-#include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <vespa/storage/common/messagesender.h>
@@ -58,12 +57,12 @@ public:
         MessageEntry(const std::shared_ptr<api::StorageMessage>& cmd,
                      const document::Bucket& bucket,
                      vespalib::steady_time scheduled_at_time);
-        MessageEntry(MessageEntry &&) noexcept ;
-        MessageEntry(const MessageEntry &) noexcept;
-        MessageEntry & operator = (const MessageEntry &) = delete;
+        MessageEntry(MessageEntry&&) noexcept;
+        MessageEntry(const MessageEntry&) noexcept;
+        MessageEntry& operator=(const MessageEntry&) = delete;
         ~MessageEntry();
 
-        bool operator<(const MessageEntry& entry) const {
+        bool operator<(const MessageEntry& entry) const noexcept {
             return (_priority < entry._priority);
         }
     };


### PR DESCRIPTION
@geirst please review.

The persistence operation queue has multiple indexes/views: one global priority queue (across buckets) and one logical FIFO per bucket. The next message to process is picked based on priority order, then attempted extended using implicit batching (if it's possible, i.e. operations are batchable). Automatic operation batching is per-bucket, so this process therefore uses the FIFO ordering, stopping the batch at the first operation that is not batchable for a bucket.

This is vulnerable to priority inversion, where there for a given bucket exists a low priority non-batchable operation that is first in _FIFO_ order but far back in _priority_ order. The presence of such an operation will implicitly prevent batching of higher priority operations. Since the throughput of the system is reduced, this will also make it take longer before the low priority operation ends up having its time to shine, prolonging the inversion period.

Note that this is mostly noticeable when feeding a dataset that originates from a prior visiting job, which means it's already in bucket order (and thus contending for bucket-level write locks) instead of being uniformly distributed.

To avoid this when filling a batch, ignore (skip) operations with lesser priority than the one the batch was originally created around. Processing order will still be the same, as skipped operations would have been processed after the batched operations either way.

