### PR TITLE
Rename DiskIndexWithDestrcturoCallback to DiskIndexWithDestructorClea…

### DIFF
--- a/searchcore/src/vespa/searchcorespi/index/indexdisklayout.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexdisklayout.cpp
@@ -37,6 +37,13 @@ IndexDiskLayout::getFusionDir(uint32_t sourceId) const
 }
 
 std::string
+IndexDiskLayout::get_dir(const IndexDiskDir& index_disk_dir) const
+{
+    auto id = index_disk_dir.get_id();
+    return index_disk_dir.is_fusion_index() ? getFusionDir(id) : getFlushDir(id);
+}
+
+std::string
 IndexDiskLayout::getSerialNumFileName(const std::string &dir)
 {
     return dir + "/serial.dat";

--- a/searchcore/src/vespa/searchcorespi/index/indexdisklayout.h
+++ b/searchcore/src/vespa/searchcorespi/index/indexdisklayout.h
@@ -26,6 +26,9 @@ public:
     IndexDiskLayout(const std::string &baseDir);
     std::string getFlushDir(uint32_t sourceId) const;
     std::string getFusionDir(uint32_t sourceId) const;
+    const std::string& get_base_dir() const noexcept { return _baseDir; }
+    std::string get_dir(const IndexDiskDir& index_disk_dir) const;
+
     static IndexDiskDir get_index_disk_dir(const std::string& dir);
 
     static std::string getSerialNumFileName(const std::string &dir);

--- a/searchcore/src/vespa/searchcorespi/index/indexmaintainer.h
+++ b/searchcore/src/vespa/searchcorespi/index/indexmaintainer.h
@@ -74,7 +74,7 @@ class IndexMaintainer : public IIndexManager,
     const std::string _base_dir;
     const WarmupConfig     _warmupConfig;
     std::shared_ptr<DiskIndexes>  _disk_indexes;
-    IndexDiskLayout        _layout;
+    std::shared_ptr<IndexDiskLayout> _layout;
     Schema                  _schema;             // Protected by SL + IUL
     std::shared_ptr<const Schema> _activeFusionSchema; // Protected by SL + IUL
     // Protected by SL + IUL
@@ -129,7 +129,7 @@ class IndexMaintainer : public IIndexManager,
     std::mutex                       _state_lock;        // Outer lock (SL)
     mutable std::mutex               _index_update_lock; // Inner lock (IUL)
     mutable std::mutex               _new_search_lock;   // Inner lock (NSL)
-    std::mutex                       _remove_lock;       // Lock for removing indexes.
+    std::shared_ptr<std::mutex>      _remove_lock;       // Lock for removing indexes.
     FusionSpec                       _fusion_spec;       // Protected by FL
     mutable std::mutex               _fusion_lock;       // Fusion spec lock (FL)
     uint32_t                         _maxFlushed;        // Protected by NSL
@@ -165,7 +165,6 @@ class IndexMaintainer : public IIndexManager,
                             SerialNum serialNum);
 
     void updateActiveFusionPrunedSchema(const Schema &schema);
-    void deactivateDiskIndexes(std::string indexDir);
     std::shared_ptr<IDiskIndex> loadDiskIndex(const std::string &indexDir);
     std::shared_ptr<IDiskIndex> reloadDiskIndex(const IDiskIndex &oldIndex);
 


### PR DESCRIPTION
…nup.

Don't use IndexMaintainer instance during cleanup.

@geirst : please review
@vekterli : FYI
