### PR TITLE
Set memory resource limit lower for content nodes with less than 8 Gib memory

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1319,6 +1319,7 @@
       "public int maxActivationInhibitedOutOfSyncGroups()",
       "public double resourceLimitDisk()",
       "public double resourceLimitMemory()",
+      "public double resourceLimitMemorySmallNodes()",
       "public double minNodeRatioPerGroup()",
       "public boolean forwardIssuesAsErrors()",
       "public boolean useV8GeoPositions()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -100,6 +100,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxActivationInhibitedOutOfSyncGroups() { return 0; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitDisk() { return 0.75; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitMemory() { return 0.8; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitMemorySmallNodes() { return 0.8; }
         @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default double minNodeRatioPerGroup() { return 0.0; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean forwardIssuesAsErrors() { return true; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean useV8GeoPositions() { return false; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -61,6 +61,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private List<X509Certificate> operatorCertificates = List.of();
     private double resourceLimitDisk = 0.75;
     private double resourceLimitMemory = 0.8;
+    private double resourceLimitMemorySmallNodes = 0.8;
     private double minNodeRatioPerGroup = 0.0;
     private boolean containerDumpHeapOnShutdownTimeout = false;
     private double containerShutdownTimeout = 50.0;
@@ -122,6 +123,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public List<X509Certificate> operatorCertificates() { return operatorCertificates; }
     @Override public double resourceLimitDisk() { return resourceLimitDisk; }
     @Override public double resourceLimitMemory() { return resourceLimitMemory; }
+    @Override public double resourceLimitMemorySmallNodes() { return resourceLimitMemorySmallNodes; }
     @Override public double minNodeRatioPerGroup() { return minNodeRatioPerGroup; }
     @Override public double containerShutdownTimeout() { return containerShutdownTimeout; }
     @Override public boolean containerDumpHeapOnShutdownTimeout() { return containerDumpHeapOnShutdownTimeout; }
@@ -308,6 +310,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setResourceLimitMemory(double value) {
         this.resourceLimitMemory = value;
+        return this;
+    }
+
+    public TestProperties setResourceLimitMemorySmallNodes(double value) {
+        this.resourceLimitMemorySmallNodes = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -76,16 +76,13 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
         private final Map<String, NewDocumentType> documentDefinitions;
         private final Set<NewDocumentType> globallyDistributedDocuments;
         private final double fractionOfMemoryReserved;
-        private final ResourceLimits resourceLimits;
 
         public Builder(Map<String, NewDocumentType> documentDefinitions,
                        Set<NewDocumentType> globallyDistributedDocuments,
-                       double fractionOfMemoryReserved, ResourceLimits resourceLimits)
-        {
+                       double fractionOfMemoryReserved) {
             this.documentDefinitions = documentDefinitions;
             this.globallyDistributedDocuments = globallyDistributedDocuments;
             this.fractionOfMemoryReserved = fractionOfMemoryReserved;
-            this.resourceLimits = resourceLimits;
         }
 
         @Override
@@ -104,7 +101,6 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
             if (tuning != null) {
                 search.setTuning(new DomSearchTuningBuilder().build(deployState, search, tuning.getXml()));
             }
-            search.setResourceLimits(resourceLimits);
 
             buildSearchCluster(deployState, clusterElem, clusterName, search);
             return search;
@@ -238,13 +234,13 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
         SearchNode searchNode;
         if (element == null) {
             searchNode = SearchNode.create(parent, "" + node.getDistributionKey(), node.getDistributionKey(), spec,
-                                           clusterName, node, flushOnShutdown, tuning, resourceLimits, deployState.isHosted(),
+                                           clusterName, node, flushOnShutdown, tuning, deployState.isHosted(),
                                            fractionOfMemoryReserved, deployState.featureFlags(), syncTransactionLog);
             searchNode.setHostResource(node.getHostResource());
             searchNode.initService(deployState);
         } else {
             searchNode = new SearchNode.Builder("" + node.getDistributionKey(), spec, clusterName, node, flushOnShutdown,
-                                                tuning, resourceLimits, fractionOfMemoryReserved, syncTransactionLog)
+                                                tuning, fractionOfMemoryReserved, syncTransactionLog)
                     .build(deployState, parent, element.getXml());
         }
         if (searchCluster != null) {
@@ -270,7 +266,7 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
 
     public void setTuning(Tuning tuning) { this.tuning = tuning; }
 
-    private void setResourceLimits(ResourceLimits resourceLimits) {
+    public void setResourceLimits(ResourceLimits resourceLimits) {
         this.resourceLimits = resourceLimits;
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1708,7 +1708,7 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(0.864, protonConfigBuilder.build().writefilter().disklimit(), 0.001);
         assertEquals(0.84, protonConfigBuilder.build().writefilter().memorylimit(), 0.001);
 
-        // Resource limits should for content nodes should be changed based on new values above
+        // Resource limits for content nodes should be changed based on new values above
         // Tested since values can be set for both clusters and nodes in general
         var protonConfigBuilder2 = new ProtonConfig.Builder();
         contentCluster.getSearch().getSearchNodes().get(0).getConfig(protonConfigBuilder2);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -14,9 +14,9 @@ import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.config.model.test.TestDriver;
 import com.yahoo.config.model.test.TestRoot;
-import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
@@ -1675,12 +1675,12 @@ public class ContentClusterTest extends ContentBaseTest {
                     <redundancy>1</redundancy>
                     <documents/>
                     <nodes count='1'>
-                      <resources vcpu='1' memory='3Gb' />
+                      <resources vcpu='1' memory='8Gb' />
                     </nodes>
                   </content>
                 </services>
                 """;
-        var provisioner = new InMemoryProvisioner(10, false);
+        var provisioner = new InMemoryProvisioner(4, new NodeResources(1, 8, 50, 0.3), false);
         var properties = new TestProperties()
                 .setHostedVespa(true)
                 .setMultitenant(true)

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1702,7 +1702,7 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(0.66, config.cluster_feed_block_limit().get("disk"), 0.001);
         assertEquals(0.68, config.cluster_feed_block_limit().get("memory"), 0.001);
 
-        // Resource limits should for content cluster should be changed based on new values above
+        // Resource limits for content cluster should be changed based on new values above
         var protonConfigBuilder = new ProtonConfig.Builder();
         model.getConfig(protonConfigBuilder, "foo/search/cluster.foo");
         assertEquals(0.864, protonConfigBuilder.build().writefilter().disklimit(), 0.001);

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchNodeTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchNodeTest.java
@@ -43,7 +43,7 @@ public class SearchNodeTest {
                                                ModelContext.FeatureFlags featureFlags,
                                                Boolean syncTransactionLog) {
         return SearchNode.create(root, name, distributionKey, nodeSpec, "mycluster", null, flushOnShutDown,
-                null, null, isHosted, 0.0, featureFlags, syncTransactionLog);
+                null, isHosted, 0.0, featureFlags, syncTransactionLog);
     }
 
     private static SearchNode createSearchNode(MockRoot root, Boolean syncTransactionLog) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -179,6 +179,7 @@ public class ModelContextImpl implements ModelContext {
         private final int maxActivationInhibitedOutOfSyncGroups;
         private final double resourceLimitDisk;
         private final double resourceLimitMemory;
+        private final double resourceLimitMemorySmallNodes;
         private final double minNodeRatioPerGroup;
         private final boolean containerDumpHeapOnShutdownTimeout;
         private final boolean loadCodeAsHugePages;
@@ -231,6 +232,7 @@ public class ModelContextImpl implements ModelContext {
             this.maxActivationInhibitedOutOfSyncGroups = Flags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS.bindTo(source).with(appId).with(version).value();
             this.resourceLimitDisk = PermanentFlags.RESOURCE_LIMIT_DISK.bindTo(source).with(appId).with(version).value();
             this.resourceLimitMemory = PermanentFlags.RESOURCE_LIMIT_MEMORY.bindTo(source).with(appId).with(version).value();
+            this.resourceLimitMemorySmallNodes = Flags.RESOURCE_LIMIT_MEMORY_FOR_SMALL_NODES.bindTo(source).with(appId).with(version).value();
             this.minNodeRatioPerGroup = Flags.MIN_NODE_RATIO_PER_GROUP.bindTo(source).with(appId).with(version).value();
             this.containerDumpHeapOnShutdownTimeout = Flags.CONTAINER_DUMP_HEAP_ON_SHUTDOWN_TIMEOUT.bindTo(source).with(appId).with(version).value();
             this.loadCodeAsHugePages = Flags.LOAD_CODE_AS_HUGEPAGES.bindTo(source).with(appId).with(version).value();
@@ -288,6 +290,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public int maxActivationInhibitedOutOfSyncGroups() { return maxActivationInhibitedOutOfSyncGroups; }
         @Override public double resourceLimitDisk() { return resourceLimitDisk; }
         @Override public double resourceLimitMemory() { return resourceLimitMemory; }
+        @Override public double resourceLimitMemorySmallNodes() { return resourceLimitMemorySmallNodes; }
         @Override public double minNodeRatioPerGroup() { return minNodeRatioPerGroup; }
         @Override public double containerShutdownTimeout() { return containerShutdownTimeout; }
         @Override public boolean containerDumpHeapOnShutdownTimeout() { return containerDumpHeapOnShutdownTimeout; }


### PR DESCRIPTION
Use feature flag (default value same as for nodes with more memory) to set memory limit for content nodes in vespa cloud