### PR TITLE
Support weakand configuration for a rank profile.

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/RankProfile.java
@@ -104,6 +104,8 @@ public class RankProfile implements Cloneable {
     private Double postFilterThreshold = null;
     private Double approximateThreshold = null;
     private Double targetHitsMaxAdjustmentFactor = null;
+    private Double weakandStopwordLimit = null;
+    private Double weakandAdjustTarget = null;
 
     /** The drop limit used to drop hits with rank score less than or equal to this value */
     private double rankScoreDropLimit = -Double.MAX_VALUE;
@@ -780,6 +782,8 @@ public class RankProfile implements Cloneable {
     public void setPostFilterThreshold(double threshold) { this.postFilterThreshold = threshold; }
     public void setApproximateThreshold(double threshold) { this.approximateThreshold = threshold; }
     public void setTargetHitsMaxAdjustmentFactor(double factor) { this.targetHitsMaxAdjustmentFactor = factor; }
+    public void setWeakandStopwordLimit(double limit) { this.weakandStopwordLimit = limit; }
+    public void setWeakandAdjustTarget(double target) { this.weakandAdjustTarget = target; }
 
     public OptionalDouble getTermwiseLimit() {
         if (termwiseLimit != null) return OptionalDouble.of(termwiseLimit);
@@ -806,6 +810,20 @@ public class RankProfile implements Cloneable {
             return OptionalDouble.of(targetHitsMaxAdjustmentFactor);
         }
         return uniquelyInherited(RankProfile::getTargetHitsMaxAdjustmentFactor, OptionalDouble::isPresent, "target-hits-max-adjustment-factor").orElse(OptionalDouble.empty());
+    }
+
+    public OptionalDouble getWeakandStopwordLimit() {
+        if (weakandStopwordLimit != null) {
+            return OptionalDouble.of(weakandStopwordLimit);
+        }
+        return uniquelyInherited(RankProfile::getWeakandStopwordLimit, OptionalDouble::isPresent, "weakand-stopword-limit").orElse(OptionalDouble.empty());
+    }
+
+    public OptionalDouble getWeakandAdjustTarget() {
+        if (weakandAdjustTarget != null) {
+            return OptionalDouble.of(weakandAdjustTarget);
+        }
+        return uniquelyInherited(RankProfile::getWeakandAdjustTarget, OptionalDouble::isPresent, "weakand-adjust-target").orElse(OptionalDouble.empty());
     }
 
     /** Whether we should ignore the default rank features. Set to null to use inherited */

--- a/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
@@ -169,6 +169,8 @@ public class RawRankProfile {
         private final OptionalDouble postFilterThreshold;
         private final OptionalDouble approximateThreshold;
         private final OptionalDouble targetHitsMaxAdjustmentFactor;
+        private final OptionalDouble weakandStopwordLimit;
+        private final OptionalDouble weakandAdjustTarget;
         private final double rankScoreDropLimit;
         private final double secondPhaseRankScoreDropLimit;
         private final boolean sortBlueprintsByCost;
@@ -220,6 +222,8 @@ public class RawRankProfile {
             postFilterThreshold = compiled.getPostFilterThreshold();
             approximateThreshold = compiled.getApproximateThreshold();
             targetHitsMaxAdjustmentFactor = compiled.getTargetHitsMaxAdjustmentFactor();
+            weakandStopwordLimit = compiled.getWeakandStopwordLimit();
+            weakandAdjustTarget = compiled.getWeakandAdjustTarget();
             keepRankCount = compiled.getKeepRankCount();
             rankScoreDropLimit = compiled.getRankScoreDropLimit();
             secondPhaseRankScoreDropLimit = compiled.getSecondPhaseRankScoreDropLimit();
@@ -482,6 +486,12 @@ public class RawRankProfile {
             }
             if (targetHitsMaxAdjustmentFactor.isPresent()) {
                 properties.add(new Pair<>("vespa.matching.nns.target_hits_max_adjustment_factor", String.valueOf(targetHitsMaxAdjustmentFactor.getAsDouble())));
+            }
+            if (weakandStopwordLimit.isPresent()) {
+                properties.add(new Pair<>("vespa.matching.weakand.stop_word_drop_limit", String.valueOf(weakandStopwordLimit.getAsDouble())));
+            }
+            if (weakandAdjustTarget.isPresent()) {
+                properties.add(new Pair<>("vespa.matching.weakand.stop_word_adjust_limit", String.valueOf(weakandAdjustTarget.getAsDouble())));
             }
             if (matchPhaseSettings != null) {
                 properties.add(new Pair<>("vespa.matchphase.degradation.attribute", matchPhaseSettings.getAttribute()));

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
@@ -48,6 +48,8 @@ public class ParsedRankProfile extends ParsedBlock {
     private String secondPhaseExpression = null;
     private Boolean strict = null;
     private Boolean useSignificanceModel = null;
+    private Double weakandStopwordLimit = null;
+    private Double weakandAdjustTarget = null;
     private final List<MutateOperation> mutateOperations = new ArrayList<>();
     private final List<String> inherited = new ArrayList<>();
     private final Map<String, Boolean> fieldsRankFilter = new LinkedHashMap<>();
@@ -103,6 +105,9 @@ public class ParsedRankProfile extends ParsedBlock {
     Optional<Boolean> isStrict() { return Optional.ofNullable(this.strict); }
 
     Optional<Boolean> isUseSignificanceModel() { return Optional.ofNullable(this.useSignificanceModel); }
+
+    Optional<Double> getWeakandStopwordLimit() { return Optional.ofNullable(this.weakandStopwordLimit); }
+    Optional<Double> getWeakandAdjustTarget() { return Optional.ofNullable(this.weakandAdjustTarget); }
 
     public void addSummaryFeatures(FeatureList features) { this.summaryFeatures.add(features); }
     public void addMatchFeatures(FeatureList features) { this.matchFeatures.add(features); }
@@ -239,6 +244,17 @@ public class ParsedRankProfile extends ParsedBlock {
         verifyThat(this.useSignificanceModel == null, "already has use-model");
         this.useSignificanceModel = useSignificanceModel;
     }
+
+    public void setWeakandStopwordLimit(double limit) {
+        verifyThat(this.weakandStopwordLimit == null, "already has weakand stopword-limit");
+        this.weakandStopwordLimit = limit;
+    }
+
+    public void setWeakandAdjustTarget(double target) {
+        verifyThat(this.weakandAdjustTarget == null, "already has weakand adjust-target");
+        this.weakandAdjustTarget = target;
+    }
+
     public void setTermwiseLimit(double limit) {
         verifyThat(termwiseLimit == null, "already has termwise-limit");
         this.termwiseLimit = limit;

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
@@ -64,6 +64,8 @@ public class ParsedRankingConverter {
         parsed.getPostFilterThreshold().ifPresent(profile::setPostFilterThreshold);
         parsed.getApproximateThreshold().ifPresent(profile::setApproximateThreshold);
         parsed.getTargetHitsMaxAdjustmentFactor().ifPresent(profile::setTargetHitsMaxAdjustmentFactor);
+        parsed.getWeakandStopwordLimit().ifPresent(profile::setWeakandStopwordLimit);
+        parsed.getWeakandAdjustTarget().ifPresent(profile::setWeakandAdjustTarget);
         parsed.getKeepRankCount().ifPresent(profile::setKeepRankCount);
         parsed.getMinHitsPerThread().ifPresent(profile::setMinHitsPerThread);
         parsed.getNumSearchPartitions().ifPresent(profile::setNumSearchPartitions);

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -190,6 +190,9 @@ TOKEN :
 | < ONNX_MODEL: "onnx-model">
 | < SIGNIFICANCE: "significance">
 | < USE_MODEL: "use-model">
+| < WEAKAND: "weakand">
+| < STOPWORD_LIMIT: "stopword-limit">
+| < ADJUST_TARGET: "adjust-target">
 | < INTRAOP_THREADS: "intraop-threads">
 | < INTEROP_THREADS: "interop-threads">
 | < GPU_DEVICE: "gpu-device">
@@ -1776,7 +1779,8 @@ void rankProfileItem(ParsedSchema schema, ParsedRankProfile profile) : { }
       | summaryFeatures(profile)
       | onnxModelInProfile(profile)
       | strict(profile)
-      | significance(profile))
+      | significance(profile)
+      | weakand(profile))
 }
 
 /**
@@ -2158,6 +2162,36 @@ void significanceItem(ParsedRankProfile profile) :
         ( <TRUE>  { profile.setUseSignificanceModel(true);  } ) |
         ( <FALSE> { profile.setUseSignificanceModel(false); } )
     )
+}
+
+void weakand(ParsedRankProfile profile) :
+{}
+{
+    <WEAKAND> lbrace() (weakandItem(profile) (<NL>)*)* <RBRACE>
+    {}
+}
+
+void weakandItem(ParsedRankProfile profile) :
+{}
+{
+    ( weakandStopwordLimit(profile)
+      | weakandAdjustTarget(profile))
+}
+
+void weakandStopwordLimit(ParsedRankProfile profile) :
+{
+    double limit;
+}
+{
+    (<STOPWORD_LIMIT> <COLON> limit = floatValue()) { profile.setWeakandStopwordLimit(limit); }
+}
+
+void weakandAdjustTarget(ParsedRankProfile profile) :
+{
+    double target;
+}
+{
+    (<ADJUST_TARGET> <COLON> target = floatValue()) { profile.setWeakandAdjustTarget(target); }
 }
 
 /**
@@ -2694,6 +2728,7 @@ String identifierWithDash() :
     ( identifier = identifier() { return identifier; } )
     |
     ( <IDENTIFIER_WITH_DASH>
+    | <ADJUST_TARGET>
     | <APPROXIMATE_THRESHOLD>
     | <CREATE_IF_NONEXISTENT>
     | <CUTOFF_FACTOR>
@@ -2750,6 +2785,7 @@ String identifierWithDash() :
     | <REMOVE_IF_ZERO>
     | <RERANK_COUNT>
     | <SECOND_PHASE>
+    | <STOPWORD_LIMIT>
     | <STRUCT_FIELD>
     | <SUMMARY_TO>
     | <TARGET_HITS_MAX_ADJUSTMENT_FACTOR>
@@ -2854,11 +2890,11 @@ String identifier() : { }
       | <SSOVERRIDE>
       | <SSTITLE>
       | <SSURL>
+      | <SIGNIFICANCE>
       | <STATIC>
       | <STEMMING>
       | <STRENGTH>
       | <STRICT>
-      | <SIGNIFICANCE>
       | <STRING>
       | <STRUCT>
       | <SUBSTRING>
@@ -2875,6 +2911,7 @@ String identifier() : { }
       | <UNCASED>
       | <URI>
       | <VARIABLE>
+      | <WEAKAND>
       | <WEIGHT>
       | <WEIGHTEDSET>
       | <WORD>

--- a/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
@@ -154,6 +154,36 @@ public class SchemaParserTestCase {
     }
 
     @Test
+    void weakand_stopword_limit_can_be_parsed() throws Exception {
+        String input = joinLines("schema foo {",
+                        "rank-profile rp {",
+                            "weakand {",
+                                "stopword-limit: 0.6",
+                            "}",
+                        "}",
+                    "}");
+        var schema = parseString(input);
+        var limit = schema.getRankProfiles().get(0).getWeakandStopwordLimit();
+        assertTrue(limit.isPresent());
+        assertEquals(0.6, limit.get());
+    }
+
+    @Test
+    void weakand_adjust_target_can_be_parsed() throws Exception {
+        String input = joinLines("schema foo {",
+                        "rank-profile rp {",
+                            "weakand {",
+                                "adjust-target: 0.01",
+                            "}",
+                        "}",
+                    "}");
+        var schema = parseString(input);
+        var target = schema.getRankProfiles().get(0).getWeakandAdjustTarget();
+        assertTrue(target.isPresent());
+        assertEquals(0.01, target.get());
+    }
+
+    @Test
     void maxOccurrencesCanBeParsed() throws Exception {
         String input = joinLines
                 ("schema foo {",

--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -380,6 +380,9 @@ TOKEN :
 | < ONNX_MODEL: "onnx-model">
 | < SIGNIFICANCE: "significance">
 | < USE_MODEL: "use-model">
+| < WEAKAND: "weakand">
+| < STOPWORD_LIMIT: "stopword-limit">
+| < ADJUST_TARGET: "adjust-target">
 | < INTRAOP_THREADS: "intraop-threads">
 | < INTEROP_THREADS: "interop-threads">
 | < GPU_DEVICE: "gpu-device">
@@ -2072,6 +2075,7 @@ void rankProfileItem(ParsedSchema schema, ParsedRankProfile profile) : { }
        | onnxModelInProfile(profile)
        | strictElm(profile)
        | significanceElm(profile)
+       | weakandElm(profile)
     )
 ;
 
@@ -2476,6 +2480,36 @@ void significanceItem(ParsedRankProfile profile) :
         ( <TRUE>  { profile.setUseSignificanceModel(true);  } ) |
         ( <FALSE> { profile.setUseSignificanceModel(false); } )
     )
+;
+
+void weakandElm(ParsedRankProfile profile) :
+{}
+
+    <WEAKAND> openLbrace() (weakandItem(profile) | <NL>)* <RBRACE>
+    {}
+;
+
+void weakandItem(ParsedRankProfile profile) :
+{}
+
+    ( weakandStopwordLimit(profile)
+      | weakandAdjustTarget(profile))
+;
+
+void weakandStopwordLimit(ParsedRankProfile profile) :
+{
+    double limit;
+}
+
+    (<STOPWORD_LIMIT> <COLON> limit = floatValue()) { profile.setWeakandStopwordLimit(limit); }
+;
+
+void weakandAdjustTarget(ParsedRankProfile profile) :
+{
+    double target;
+}
+
+    (<ADJUST_TARGET> <COLON> target = floatValue()) { profile.setWeakandAdjustTarget(target); }
 ;
 
 /**
@@ -3028,6 +3062,7 @@ String identifierWithDashStr :
     ( identifier = identifierStr { return identifier; } )
     |
     ( <IDENTIFIER_WITH_DASH>
+    | <ADJUST_TARGET>
     | <APPROXIMATE_THRESHOLD>
     | <CREATE_IF_NONEXISTENT>
     | <CUTOFF_FACTOR>
@@ -3084,6 +3119,7 @@ String identifierWithDashStr :
     | <REMOVE_IF_ZERO>
     | <RERANK_COUNT>
     | <SECOND_PHASE>
+    | <STOPWORD_LIMIT>
     | <STRUCT_FIELD>
     | <SUMMARY_TO>
     | <TARGET_HITS_MAX_ADJUSTMENT_FACTOR>
@@ -3210,6 +3246,7 @@ String identifierStr :
       | <UNCASED>
       | <URI>
       | <VARIABLE>
+      | <WEAKAND>
       | <WEIGHT>
       | <WEIGHTEDSET>
       | <WORD>


### PR DESCRIPTION
Makes it possible to configure the following for improved performance:
  - stopword-limit: Specifies what the weakand considers to be a stopword and dropped during evaluation.
  - adjust-target: Used to adjust the initial score threshold of the weakand heap.

@toregge please review
@vekterli FYI