### PR TITLE
fix: run vespa.exe directly on windows instead of unsanitized cmd.exe

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/RunVespaQuery.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/RunVespaQuery.java
@@ -108,7 +108,7 @@ public class RunVespaQuery implements SchemaCommand {
         ProcessBuilder builder = new ProcessBuilder();
 
         if (isWindows) {
-            builder.command("cmd.exe", "/c", "vespa", "query", query); // TODO: Test this on windows
+            builder.command("vespa.exe", "query", query);
         } else {
             builder.command("vespa", "query", query);
         }


### PR DESCRIPTION
Tested on Windows 10 with vespa.exe existing in Path.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
