### PR TITLE
Bjorncs/document v1 no queue

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -301,7 +301,7 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
             log.log(WARNING, "Failed to empty request queue before shutdown timeout — " + operations.size() + " requests left");
 
         if ( ! visitOperations.isEmpty())
-            log.log(WARNING, "Failed to empty visitor operations queue before shutdown timeout — " + operations.size() + " operations left");
+            log.log(WARNING, "Failed to empty visitor operations queue before shutdown timeout — " + visitOperations.size() + " operations left");
 
         try {
             while (outstanding.get() > 0 && clock.instant().isBefore(doom))


### PR DESCRIPTION
FYI @vekterli @arnej27959 

The diff for `enqueueAndDispatch` is confusing how it's rendered. The original logic is in the first branch, while the `else` contains the new logic when `maxThrottled` == 0.