### PR TITLE
Avoid using reserved identifier naming pattern

### DIFF
--- a/vespalib/src/vespa/vespalib/util/alloc.h
+++ b/vespalib/src/vespa/vespalib/util/alloc.h
@@ -11,7 +11,7 @@ namespace vespalib::alloc {
  * This represents an allocation.
  * It can be created, moved, swapped.
  * The allocation strategy is decided upon creation.
- * It can also create create additional allocations with the same allocation strategy.
+ * It can also create additional allocations with the same allocation strategy.
 **/
 class Alloc
 {


### PR DESCRIPTION
@toregge please review.

Identifiers of the form `_Uppercase` are reserved by the standard and should be avoided.

