### PR TITLE
Add supported authentication methods to ZoneEndpoint configuration

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -33,6 +33,7 @@ import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provision.ZoneEndpoint;
+import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.jdisc.DataplaneProxyService;
@@ -1039,12 +1040,15 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                 .endpoints()
                 .stream()
                 .anyMatch(endpoint -> endpoint.authMethod() == ApplicationClusterEndpoint.AuthMethod.token);
+        var authMethods = supportsTokenAuthentication ?
+                List.of(AuthMethod.mtls, AuthMethod.token) :
+                List.of(AuthMethod.mtls);
 
         return context
                 .getApplicationPackage()
                 .getDeploymentSpec()
                 .zoneEndpoint(instance, zone, cluster)
-                .withSupportsTokenAuthentication(supportsTokenAuthentication);
+                .withAuthMethods(authMethods);
     }
 
     private static Map<String, String> getEnvironmentVariables(Element environmentVariables) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1034,7 +1034,17 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         InstanceName instance = context.properties().applicationId().instance();
         ZoneId zone = ZoneId.from(context.properties().zone().environment(),
                                   context.properties().zone().region());
-        return context.getApplicationPackage().getDeploymentSpec().zoneEndpoint(instance, zone, cluster);
+
+        var supportsTokenAuthentication = context.properties()
+                .endpoints()
+                .stream()
+                .anyMatch(endpoint -> endpoint.authMethod() == ApplicationClusterEndpoint.AuthMethod.token);
+
+        return context
+                .getApplicationPackage()
+                .getDeploymentSpec()
+                .zoneEndpoint(instance, zone, cluster)
+                .withSupportsTokenAuthentication(supportsTokenAuthentication);
     }
 
     private static Map<String, String> getEnvironmentVariables(Element environmentVariables) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ZoneEndpoint.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ZoneEndpoint.java
@@ -27,16 +27,25 @@ public class ZoneEndpoint {
      * </ol>
      */
     public static final int generation = 0;
-    public static final ZoneEndpoint defaultEndpoint = new ZoneEndpoint(true, false, List.of());
-    public static final ZoneEndpoint privateEndpoint = new ZoneEndpoint(false, false, List.of());
+    public static final ZoneEndpoint defaultEndpoint = new ZoneEndpoint(true, false, false, List.of());
+    public static final ZoneEndpoint privateEndpoint = new ZoneEndpoint(false, false, false, List.of());
 
     private final boolean isPublicEndpoint;
     private final boolean isPrivateEndpoint;
+    private final boolean supportsTokenAuthentication;
     private final List<AllowedUrn> allowedUrns;
 
     public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, List<AllowedUrn> allowedUrns) {
         this.isPublicEndpoint = isPublicEndpoint;
         this.isPrivateEndpoint = isPrivateEndpoint;
+        this.supportsTokenAuthentication = false;
+        this.allowedUrns = List.copyOf(allowedUrns);
+    }
+
+    public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, boolean supportsTokenAuthentication, List<AllowedUrn> allowedUrns) {
+        this.isPublicEndpoint = isPublicEndpoint;
+        this.isPrivateEndpoint = isPrivateEndpoint;
+        this.supportsTokenAuthentication = supportsTokenAuthentication;
         this.allowedUrns = List.copyOf(allowedUrns);
     }
 
@@ -48,6 +57,11 @@ public class ZoneEndpoint {
     /** Whether this has an endpoint which is visible through private DNS of the cloud. */
     public boolean isPrivateEndpoint() {
         return isPrivateEndpoint;
+    }
+
+    /** Whether this supports token authentication for private endpoints in cloud. */
+    public boolean supportsTokenAuthentication() {
+        return supportsTokenAuthentication;
     }
 
     /** List of allowed URNs, for specified private access types. */
@@ -64,12 +78,22 @@ public class ZoneEndpoint {
         return equals(defaultEndpoint);
     }
 
+    public ZoneEndpoint withSupportsTokenAuthentication(boolean supported) {
+        return new ZoneEndpoint(
+                this.isPublicEndpoint,
+                this.isPrivateEndpoint,
+                supported,
+                this.allowedUrns
+        );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ZoneEndpoint that = (ZoneEndpoint) o;
-        return isPublicEndpoint == that.isPublicEndpoint && isPrivateEndpoint == that.isPrivateEndpoint && allowedUrns.equals(that.allowedUrns);
+        return isPublicEndpoint == that.isPublicEndpoint && isPrivateEndpoint == that.isPrivateEndpoint &&
+                supportsTokenAuthentication == that.supportsTokenAuthentication && allowedUrns.equals(that.allowedUrns);
     }
 
     @Override

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ZoneEndpoint.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ZoneEndpoint.java
@@ -2,6 +2,7 @@
 package com.yahoo.config.provision;
 
 import ai.vespa.validation.Validation;
+import com.yahoo.config.provision.zone.AuthMethod;
 
 import java.util.List;
 import java.util.Objects;
@@ -27,25 +28,25 @@ public class ZoneEndpoint {
      * </ol>
      */
     public static final int generation = 0;
-    public static final ZoneEndpoint defaultEndpoint = new ZoneEndpoint(true, false, false, List.of());
-    public static final ZoneEndpoint privateEndpoint = new ZoneEndpoint(false, false, false, List.of());
+    public static final ZoneEndpoint defaultEndpoint = new ZoneEndpoint(true, false, List.of(AuthMethod.mtls), List.of());
+    public static final ZoneEndpoint privateEndpoint = new ZoneEndpoint(false, false, List.of(AuthMethod.mtls), List.of());
 
     private final boolean isPublicEndpoint;
     private final boolean isPrivateEndpoint;
-    private final boolean supportsTokenAuthentication;
+    private final List<AuthMethod> authMethods;
     private final List<AllowedUrn> allowedUrns;
 
     public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, List<AllowedUrn> allowedUrns) {
         this.isPublicEndpoint = isPublicEndpoint;
         this.isPrivateEndpoint = isPrivateEndpoint;
-        this.supportsTokenAuthentication = false;
+        this.authMethods = List.of(AuthMethod.mtls);
         this.allowedUrns = List.copyOf(allowedUrns);
     }
 
-    public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, boolean supportsTokenAuthentication, List<AllowedUrn> allowedUrns) {
+    public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, List<AuthMethod> authMethods, List<AllowedUrn> allowedUrns) {
         this.isPublicEndpoint = isPublicEndpoint;
         this.isPrivateEndpoint = isPrivateEndpoint;
-        this.supportsTokenAuthentication = supportsTokenAuthentication;
+        this.authMethods = authMethods;
         this.allowedUrns = List.copyOf(allowedUrns);
     }
 
@@ -59,9 +60,9 @@ public class ZoneEndpoint {
         return isPrivateEndpoint;
     }
 
-    /** Whether this supports token authentication for private endpoints in cloud. */
-    public boolean supportsTokenAuthentication() {
-        return supportsTokenAuthentication;
+    /** List of allowed authentication methods for private endpoints. */
+    public List<AuthMethod> authMethods() {
+        return authMethods;
     }
 
     /** List of allowed URNs, for specified private access types. */
@@ -78,11 +79,11 @@ public class ZoneEndpoint {
         return equals(defaultEndpoint);
     }
 
-    public ZoneEndpoint withSupportsTokenAuthentication(boolean supported) {
+    public ZoneEndpoint withAuthMethods(List<AuthMethod> authMethods) {
         return new ZoneEndpoint(
                 this.isPublicEndpoint,
                 this.isPrivateEndpoint,
-                supported,
+                authMethods,
                 this.allowedUrns
         );
     }
@@ -93,7 +94,7 @@ public class ZoneEndpoint {
         if (o == null || getClass() != o.getClass()) return false;
         ZoneEndpoint that = (ZoneEndpoint) o;
         return isPublicEndpoint == that.isPublicEndpoint && isPrivateEndpoint == that.isPrivateEndpoint &&
-                supportsTokenAuthentication == that.supportsTokenAuthentication && allowedUrns.equals(that.allowedUrns);
+                authMethods.equals(that.authMethods) && allowedUrns.equals(that.allowedUrns);
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -247,6 +247,7 @@ public class LoadBalancerProvisioner {
                                              .orElse(Set.of()); // Targeted reals are changed on activation.
         ZoneEndpoint settings = new ZoneEndpoint(zoneEndpoint.isPublicEndpoint(),
                                                  zoneEndpoint.isPrivateEndpoint(),
+                                                 zoneEndpoint.supportsTokenAuthentication(),
                                                  currentLoadBalancer.instance()
                                                                     .map(LoadBalancerInstance::settings)
                                                                     .map(ZoneEndpoint::allowedUrns)

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -247,7 +247,7 @@ public class LoadBalancerProvisioner {
                                              .orElse(Set.of()); // Targeted reals are changed on activation.
         ZoneEndpoint settings = new ZoneEndpoint(zoneEndpoint.isPublicEndpoint(),
                                                  zoneEndpoint.isPrivateEndpoint(),
-                                                 zoneEndpoint.supportsTokenAuthentication(),
+                                                 zoneEndpoint.authMethods(),
                                                  currentLoadBalancer.instance()
                                                                     .map(LoadBalancerInstance::settings)
                                                                     .map(ZoneEndpoint::allowedUrns)


### PR DESCRIPTION
Add configuration to indicate which authentication methods are supported for zone endpoints - to be used in load balancer provisioning to set up appropriate resources. 