### PR TITLE
Reapply "Add serialization for zone endpoint auth methods in load balancer (zookeeper)"

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
@@ -10,6 +10,7 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
+import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
@@ -45,6 +46,7 @@ public class AllocatedHostsSerializer {
     private static final String loadBalancerSettingsKey = "zoneEndpoint";
     private static final String publicField = "public";
     private static final String privateField = "private";
+    private static final String authMethodsField = "authMethods";
     private static final String allowedUrnsField = "allowedUrns";
     private static final String accessTypeField = "type";
     private static final String urnField = "urn";
@@ -233,6 +235,12 @@ public class AllocatedHostsSerializer {
     private static void toSlime(Cursor settingsObject, ZoneEndpoint settings) {
         settingsObject.setBool(publicField, settings.isPublicEndpoint());
         settingsObject.setBool(privateField, settings.isPrivateEndpoint());
+
+        Cursor authMethods = settingsObject.setArray(authMethodsField);
+        for(AuthMethod method : settings.authMethods()) {
+            authMethods.addString(method.name());
+        }
+
         if (settings.isPrivateEndpoint()) {
             Cursor allowedUrnsArray = settingsObject.setArray(allowedUrnsField);
             for (AllowedUrn urn : settings.allowedUrns()) {
@@ -251,6 +259,9 @@ public class AllocatedHostsSerializer {
         if ( ! settingsObject.valid()) return ZoneEndpoint.defaultEndpoint;
         return new ZoneEndpoint(settingsObject.field(publicField).asBool(),
                                 settingsObject.field(privateField).asBool(),
+                                SlimeUtils.entriesStream(settingsObject.field(authMethodsField))
+                                        .map(value -> AuthMethod.valueOf(value.asString()))
+                                        .toList(),
                                 SlimeUtils.entriesStream(settingsObject.field(allowedUrnsField))
                                           .map(urnObject -> new AllowedUrn(switch (urnObject.field(accessTypeField).asString()) {
                                                                                case "awsPrivateLink" ->  AccessType.awsPrivateLink;
@@ -260,7 +271,6 @@ public class AllocatedHostsSerializer {
                                                                            urnObject.field(urnField).asString()))
                                           .toList());
     }
-
 
     private static Optional<String> optionalString(Inspector inspector) {
         if ( ! inspector.valid()) return Optional.empty();

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
+import com.yahoo.config.provision.zone.AuthMethod;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -70,7 +71,7 @@ public class AllocatedHostsSerializerTest {
                                bigSlowDiskSpeedNode,
                                anyDiskSpeedNode,
                                ClusterMembership.from("container/test/0/0", Version.fromString("6.73.1"),
-                                                      Optional.empty(), new ZoneEndpoint(true, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "burn")))),
+                                                      Optional.empty(), new ZoneEndpoint(true, true, List.of(AuthMethod.mtls, AuthMethod.token), List.of(new AllowedUrn(AccessType.awsPrivateLink, "burn")))),
                                Optional.empty(),
                                Optional.empty(),
                                Optional.empty()));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
+import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
@@ -63,6 +64,7 @@ public class LoadBalancerSerializer {
     private static final String settingsField = "settings";
     private static final String publicField = "public";
     private static final String privateField = "private";
+    private static final String authMethodsField = "authMethods";
     private static final String allowedUrnsField = "allowedUrns";
     private static final String accessTypeField = "type";
     private static final String urnField = "urn";
@@ -153,6 +155,12 @@ public class LoadBalancerSerializer {
     private static void toSlime(Cursor settingsObject, ZoneEndpoint settings) {
         settingsObject.setBool(publicField, settings.isPublicEndpoint());
         settingsObject.setBool(privateField, settings.isPrivateEndpoint());
+
+        Cursor authMethods = settingsObject.setArray(authMethodsField);
+        for(AuthMethod method : settings.authMethods()) {
+            authMethods.addString(method.name());
+        }
+
         if (settings.isPrivateEndpoint()) {
             Cursor allowedUrnsArray = settingsObject.setArray(allowedUrnsField);
             for (AllowedUrn urn : settings.allowedUrns()) {
@@ -171,14 +179,18 @@ public class LoadBalancerSerializer {
         if ( ! settingsObject.valid()) return ZoneEndpoint.defaultEndpoint;
         return new ZoneEndpoint(settingsObject.field(publicField).asBool(),
                                 settingsObject.field(privateField).asBool(),
+                                SlimeUtils.entriesStream(settingsObject.field(authMethodsField))
+                                        .map(field -> AuthMethod.valueOf(field.asString()))
+                                        .toList(),
                                 SlimeUtils.entriesStream(settingsObject.field(allowedUrnsField))
-                                          .map(urnObject -> new AllowedUrn(switch (urnObject.field(accessTypeField).asString()) {
-                                                                               case "awsPrivateLink" -> AccessType.awsPrivateLink;
-                                                                               case "gcpServiceConnect" -> AccessType.gcpServiceConnect;
-                                                                               default -> throw new IllegalArgumentException("unknown service access type in '" + urnObject + "'");
-                                                                           },
-                                                                           urnObject.field(urnField).asString()))
-                                          .toList());
+                                        .map(urnObject -> new AllowedUrn(
+                                                switch (urnObject.field(accessTypeField).asString()) {
+                                                    case "awsPrivateLink" -> AccessType.awsPrivateLink;
+                                                    case "gcpServiceConnect" -> AccessType.gcpServiceConnect;
+                                                    default -> throw new IllegalArgumentException("unknown service access type in '" + urnObject + "'");
+                                                },
+                                                urnObject.field(urnField).asString()))
+                                        .toList());
     }
 
     private static <T> Optional<T> optionalValue(Inspector field, Function<Inspector, T> fieldMapper) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
@@ -8,6 +8,7 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
+import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.vespa.hosted.provision.lb.DnsZone;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerId;
@@ -52,7 +53,7 @@ public class LoadBalancerSerializerTest {
                                                                         new Real(DomainName.of("real-2"),
                                                                                  "127.0.0.2",
                                                                                  4080)),
-                                                        new ZoneEndpoint(false, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "123"))),
+                                                        new ZoneEndpoint(false, true, List.of(AuthMethod.mtls, AuthMethod.token), List.of(new AllowedUrn(AccessType.awsPrivateLink, "123"))),
                                                         List.of(PrivateServiceId.of("foo"), PrivateServiceId.of("bar")),
                                                         CloudAccount.from("012345678912"))),
                                                 LoadBalancer.State.active,


### PR DESCRIPTION
Reapply revert from vespa-engine/vespa#33150

Provisioning issue was caused by an outdated zone tag. Auth method change indicated a config change which triggered a validation check. When tags are updated this change should proceed as intended. @freva 

As for the empty `authMethods` list in ZK, this should be updated in `LoadBalancerProvisioner::223` and be correctly provided to activate in `LoadBalancerProvisioner::134`, so even if ZK was updated during deploy this shouldn't be an issue. Could you verify @mpolden?

