### PR TITLE
Revert "Add serialization for zone endpoint auth methods in load balancer (zookeeper)"

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
@@ -10,7 +10,6 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
-import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
@@ -46,7 +45,6 @@ public class AllocatedHostsSerializer {
     private static final String loadBalancerSettingsKey = "zoneEndpoint";
     private static final String publicField = "public";
     private static final String privateField = "private";
-    private static final String authMethodsField = "authMethods";
     private static final String allowedUrnsField = "allowedUrns";
     private static final String accessTypeField = "type";
     private static final String urnField = "urn";
@@ -235,12 +233,6 @@ public class AllocatedHostsSerializer {
     private static void toSlime(Cursor settingsObject, ZoneEndpoint settings) {
         settingsObject.setBool(publicField, settings.isPublicEndpoint());
         settingsObject.setBool(privateField, settings.isPrivateEndpoint());
-
-        Cursor authMethods = settingsObject.setArray(authMethodsField);
-        for(AuthMethod method : settings.authMethods()) {
-            authMethods.addString(method.name());
-        }
-
         if (settings.isPrivateEndpoint()) {
             Cursor allowedUrnsArray = settingsObject.setArray(allowedUrnsField);
             for (AllowedUrn urn : settings.allowedUrns()) {
@@ -259,9 +251,6 @@ public class AllocatedHostsSerializer {
         if ( ! settingsObject.valid()) return ZoneEndpoint.defaultEndpoint;
         return new ZoneEndpoint(settingsObject.field(publicField).asBool(),
                                 settingsObject.field(privateField).asBool(),
-                                SlimeUtils.entriesStream(settingsObject.field(authMethodsField))
-                                        .map(value -> AuthMethod.valueOf(value.asString()))
-                                        .toList(),
                                 SlimeUtils.entriesStream(settingsObject.field(allowedUrnsField))
                                           .map(urnObject -> new AllowedUrn(switch (urnObject.field(accessTypeField).asString()) {
                                                                                case "awsPrivateLink" ->  AccessType.awsPrivateLink;
@@ -271,6 +260,7 @@ public class AllocatedHostsSerializer {
                                                                            urnObject.field(urnField).asString()))
                                           .toList());
     }
+
 
     private static Optional<String> optionalString(Inspector inspector) {
         if ( ! inspector.valid()) return Optional.empty();

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
@@ -11,7 +11,6 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
-import com.yahoo.config.provision.zone.AuthMethod;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -71,7 +70,7 @@ public class AllocatedHostsSerializerTest {
                                bigSlowDiskSpeedNode,
                                anyDiskSpeedNode,
                                ClusterMembership.from("container/test/0/0", Version.fromString("6.73.1"),
-                                                      Optional.empty(), new ZoneEndpoint(true, true, List.of(AuthMethod.mtls, AuthMethod.token), List.of(new AllowedUrn(AccessType.awsPrivateLink, "burn")))),
+                                                      Optional.empty(), new ZoneEndpoint(true, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "burn")))),
                                Optional.empty(),
                                Optional.empty(),
                                Optional.empty()));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
-import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
@@ -64,7 +63,6 @@ public class LoadBalancerSerializer {
     private static final String settingsField = "settings";
     private static final String publicField = "public";
     private static final String privateField = "private";
-    private static final String authMethodsField = "authMethods";
     private static final String allowedUrnsField = "allowedUrns";
     private static final String accessTypeField = "type";
     private static final String urnField = "urn";
@@ -155,12 +153,6 @@ public class LoadBalancerSerializer {
     private static void toSlime(Cursor settingsObject, ZoneEndpoint settings) {
         settingsObject.setBool(publicField, settings.isPublicEndpoint());
         settingsObject.setBool(privateField, settings.isPrivateEndpoint());
-
-        Cursor authMethods = settingsObject.setArray(authMethodsField);
-        for(AuthMethod method : settings.authMethods()) {
-            authMethods.addString(method.name());
-        }
-
         if (settings.isPrivateEndpoint()) {
             Cursor allowedUrnsArray = settingsObject.setArray(allowedUrnsField);
             for (AllowedUrn urn : settings.allowedUrns()) {
@@ -179,18 +171,14 @@ public class LoadBalancerSerializer {
         if ( ! settingsObject.valid()) return ZoneEndpoint.defaultEndpoint;
         return new ZoneEndpoint(settingsObject.field(publicField).asBool(),
                                 settingsObject.field(privateField).asBool(),
-                                SlimeUtils.entriesStream(settingsObject.field(authMethodsField))
-                                        .map(field -> AuthMethod.valueOf(field.asString()))
-                                        .toList(),
                                 SlimeUtils.entriesStream(settingsObject.field(allowedUrnsField))
-                                        .map(urnObject -> new AllowedUrn(
-                                                switch (urnObject.field(accessTypeField).asString()) {
-                                                    case "awsPrivateLink" -> AccessType.awsPrivateLink;
-                                                    case "gcpServiceConnect" -> AccessType.gcpServiceConnect;
-                                                    default -> throw new IllegalArgumentException("unknown service access type in '" + urnObject + "'");
-                                                },
-                                                urnObject.field(urnField).asString()))
-                                        .toList());
+                                          .map(urnObject -> new AllowedUrn(switch (urnObject.field(accessTypeField).asString()) {
+                                                                               case "awsPrivateLink" -> AccessType.awsPrivateLink;
+                                                                               case "gcpServiceConnect" -> AccessType.gcpServiceConnect;
+                                                                               default -> throw new IllegalArgumentException("unknown service access type in '" + urnObject + "'");
+                                                                           },
+                                                                           urnObject.field(urnField).asString()))
+                                          .toList());
     }
 
     private static <T> Optional<T> optionalValue(Inspector field, Function<Inspector, T> fieldMapper) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
@@ -8,7 +8,6 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
-import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.vespa.hosted.provision.lb.DnsZone;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancer;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerId;
@@ -53,7 +52,7 @@ public class LoadBalancerSerializerTest {
                                                                         new Real(DomainName.of("real-2"),
                                                                                  "127.0.0.2",
                                                                                  4080)),
-                                                        new ZoneEndpoint(false, true, List.of(AuthMethod.mtls, AuthMethod.token), List.of(new AllowedUrn(AccessType.awsPrivateLink, "123"))),
+                                                        new ZoneEndpoint(false, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "123"))),
                                                         List.of(PrivateServiceId.of("foo"), PrivateServiceId.of("bar")),
                                                         CloudAccount.from("012345678912"))),
                                                 LoadBalancer.State.active,


### PR DESCRIPTION
Reverts vespa-engine/vespa#33153

Seems there are still some tags with issues, so we need to setup some migration logic before merging this. 