### PR TITLE
Revert "Set timeout for RPC call proton.prepareRestart to infinity"

### DIFF
--- a/searchcore/src/apps/vespa-proton-cmd/vespa-proton-cmd.cpp
+++ b/searchcore/src/apps/vespa-proton-cmd/vespa-proton-cmd.cpp
@@ -19,10 +19,6 @@ LOG_SETUP("vespa-proton-cmd");
 
 namespace pandora::rtc_cmd {
 
-namespace {
-    const double NEVER(-1.0);
-}
-
 class App
 {
 private:
@@ -329,7 +325,7 @@ public:
             }
         } else if (strcmp(argv[2], "prepareRestart") == 0) {
             _req->SetMethodName("proton.prepareRestart");
-            invokeRPC(false, NEVER);
+            invokeRPC(false, 600.0);
             invoked = true;
             if (! _req->IsError()) {
                 printf("OK: prepareRestart enabled\n");


### PR DESCRIPTION
Reverts vespa-engine/vespa#32376

This does not work in practice as sentinel blocks until this has finished before stopping the process, need a lower timeout

@arnej27959 please review
@toregge FYI
