### PR TITLE
Add field-specific rank `filter-threshold` setting

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/RankProfile.java
@@ -138,6 +138,9 @@ public class RankProfile implements Cloneable {
 
     private Set<String> filterFields = new HashSet<>();
 
+    // Field-level `rank my_field { filter-threshold: ... }` that overrides the profile-level `filter-threshold` (if any)
+    private Map<String, Double> explicitFieldRankFilterThresholds = new LinkedHashMap<>();
+
     private final RankProfileRegistry rankProfileRegistry;
 
     private final TypeSettings attributeTypes = new TypeSettings();
@@ -1010,6 +1013,14 @@ public class RankProfile implements Cloneable {
         Set<String> combined = new LinkedHashSet<>(inheritedFilterFields);
         combined.addAll(filterFields());
         return combined;
+    }
+
+    public void setExplicitFieldRankFilterThresholds(Map<String, Double> fieldFilterThresholds) {
+        explicitFieldRankFilterThresholds = new LinkedHashMap<>(fieldFilterThresholds);
+    }
+
+    public Map<String, Double> explicitFieldRankFilterThresholds() {
+        return explicitFieldRankFilterThresholds;
     }
 
     private ExpressionFunction parseRankingExpression(String name, List<String> arguments, String expression) throws ParseException {

--- a/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
@@ -184,6 +184,7 @@ public class RawRankProfile {
         private final Map<String, String> attributeTypes;
         private final Map<Reference, RankProfile.Input> inputs;
         private final Set<String> filterFields = new java.util.LinkedHashSet<>();
+        private Map<String, Double> explicitFieldRankFilterThresholds = new LinkedHashMap<>();
         private final String rankprofileName;
 
         private RankingExpression firstPhaseRanking;
@@ -271,6 +272,7 @@ public class RawRankProfile {
 
         private void deriveFilterFields(RankProfile rp) {
             filterFields.addAll(rp.allFilterFields());
+            explicitFieldRankFilterThresholds.putAll(rp.explicitFieldRankFilterThresholds());
         }
 
         private void derivePropertiesAndFeaturesFromFunctions(Map<String, RankProfile.RankingExpressionFunction> functions,
@@ -497,6 +499,9 @@ public class RawRankProfile {
             }
             if (filterThreshold.isPresent()) {
                 properties.add(new Pair<>("vespa.matching.filter_threshold", String.valueOf(filterThreshold.getAsDouble())));
+            }
+            for (var fieldAndThreshold : explicitFieldRankFilterThresholds.entrySet()) {
+                properties.add(new Pair<>("vespa.matching.filter_threshold.%s".formatted(fieldAndThreshold.getKey()), String.valueOf(fieldAndThreshold.getValue())));
             }
             if (matchPhaseSettings != null) {
                 properties.add(new Pair<>("vespa.matchphase.degradation.attribute", matchPhaseSettings.getAttribute()));

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
@@ -54,6 +54,7 @@ public class ParsedRankProfile extends ParsedBlock {
     private final List<MutateOperation> mutateOperations = new ArrayList<>();
     private final List<String> inherited = new ArrayList<>();
     private final Map<String, Boolean> fieldsRankFilter = new LinkedHashMap<>();
+    private final Map<String, Double> fieldsRankFilterThreshold = new LinkedHashMap<>();
     private final Map<String, Integer> fieldsRankWeight = new LinkedHashMap<>();
     private final Map<String, ParsedRankFunction> functions = new LinkedHashMap<>();
     private final Map<String, String> fieldsRankType = new LinkedHashMap<>();
@@ -94,6 +95,7 @@ public class ParsedRankProfile extends ParsedBlock {
     Optional<String> getGlobalPhaseExpression() { return Optional.ofNullable(this.globalPhaseExpression); }
 
     Map<String, Boolean> getFieldsWithRankFilter() { return Collections.unmodifiableMap(fieldsRankFilter); }
+    Map<String, Double> getFieldsWithRankFilterThreshold() { return Collections.unmodifiableMap(fieldsRankFilterThreshold); }
     Map<String, Integer> getFieldsWithRankWeight() { return Collections.unmodifiableMap(fieldsRankWeight); }
     Map<String, String> getFieldsWithRankType() { return Collections.unmodifiableMap(fieldsRankType); }
     Map<String, List<String>> getRankProperties() { return Collections.unmodifiableMap(rankProperties); }
@@ -138,6 +140,12 @@ public class ParsedRankProfile extends ParsedBlock {
 
     public void addFieldRankFilter(String field, boolean filter) {
         fieldsRankFilter.put(field, filter);
+    }
+
+    public void addFieldRankFilterThreshold(String field, double filterThreshold) {
+        verifyThat(!fieldsRankFilterThreshold.containsKey(field), "already has rank filter-threshold for field", field);
+        verifyThat(filterThreshold >= 0.0 && filterThreshold <= 1.0, "must be a value in range [0, 1]", field);
+        fieldsRankFilterThreshold.put(field, filterThreshold);
     }
 
     public void addFieldRankType(String field, String type) {

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
@@ -94,6 +94,8 @@ public class ParsedRankingConverter {
         parsed.getFieldsWithRankFilter().forEach
                                                 ((fieldName, isFilter) -> profile.addRankSetting(fieldName, RankProfile.RankSetting.Type.PREFERBITVECTOR, isFilter));
 
+        profile.setExplicitFieldRankFilterThresholds(parsed.getFieldsWithRankFilterThreshold());
+
         parsed.getFieldsWithRankWeight().forEach
                                                 ((fieldName, weight) -> profile.addRankSetting(fieldName, RankProfile.RankSetting.Type.WEIGHT, weight));
 

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -2428,10 +2428,15 @@ void fieldRankType(ParsedRankProfile profile) :
 void fieldRankFilter(ParsedRankProfile profile) :
 {
     String name;
+    double filterThreshold;
 }
 {
-    <RANK> name = identifier() <COLON> <FILTER>
-    { profile.addFieldRankFilter(name, true); }
+    <RANK> name = identifier()
+    ( ( <COLON> <FILTER> ) { profile.addFieldRankFilter(name, true); }
+    | ( lbrace() <FILTER_THRESHOLD> <COLON> filterThreshold = floatValue()
+        { profile.addFieldRankFilterThreshold(name, filterThreshold); }
+        ( <NL> )* <RBRACE> )
+    )
 }
 
 /**

--- a/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
@@ -198,6 +198,31 @@ public class SchemaParserTestCase {
     }
 
     @Test
+    void field_rank_specific_filter_threshold_can_be_parsed() throws Exception {
+        String input = """
+          schema foo {
+            rank-profile rp {
+              rank bar {
+                filter-threshold: 0.05
+              }
+              rank zoid {
+                filter-threshold: 0.07
+              }
+              rank baz: filter
+            }
+          }""";
+        var schema = parseString(input);
+        var rp = schema.getRankProfiles().get(0);
+        var thresholds = rp.getFieldsWithRankFilterThreshold();
+        assertEquals(2, thresholds.size());
+        assertEquals(0.05, thresholds.getOrDefault("bar", 0.0), 0.000001);
+        assertEquals(0.07, thresholds.getOrDefault("zoid", 0.0), 0.000001);
+        // Old-school binary rank filter still supported as expected
+        assertEquals(1, rp.getFieldsWithRankFilter().size());
+        assertTrue(rp.getFieldsWithRankFilter().get("baz"));
+    }
+
+    @Test
     void maxOccurrencesCanBeParsed() throws Exception {
         String input = joinLines
                 ("schema foo {",

--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -2755,10 +2755,15 @@ void fieldRankType(ParsedRankProfile profile) :
 void fieldRankFilter(ParsedRankProfile profile) :
 {
     String name;
+    double filterThreshold;
 }
  
-    <RANK> name = identifierStr() <COLON> <FILTER>
-    { profile.addFieldRankFilter(name, true); }
+    <RANK> name = identifierStr()
+    ( ( <COLON> <FILTER> ) { profile.addFieldRankFilter(name, true); }
+    | ( openLbrace() <FILTER_THRESHOLD> <COLON> filterThreshold = floatValue()
+        { profile.addFieldRankFilterThreshold(name, filterThreshold); }
+        ( <NL> )* <RBRACE> )
+    )
 ;
 
 /**


### PR DESCRIPTION
@geirst please review
@toregge FYI

With this commit `rank-profile` supports two `rank` variants, where the latter is newly introduced:

```
rank-profile my_profile {
  rank foo_field: filter

  rank bar_field {
    filter-threshold: 0.03
  }
}
```

