### PR TITLE
Reduce max relative merge memory usage from 3% to 1.5%

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
@@ -195,7 +195,7 @@ public class StorageClusterTest {
     void assertMergeAutoScaleConfigHasExpectedValues(StorServerConfig.Merge_throttling_memory_limit limit) {
         assertEquals(128L*1024*1024,    limit.auto_lower_bound_bytes());
         assertEquals(2L*1024*1024*1024, limit.auto_upper_bound_bytes());
-        assertEquals(0.03,              limit.auto_phys_mem_scale_factor(), 0.000001);
+        assertEquals(0.015,             limit.auto_phys_mem_scale_factor(), 0.000001);
     }
 
     @Test

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -55,8 +55,8 @@ merge_throttling_memory_limit.max_usage_bytes long default=0
 ## content node. Note that the result of this multiplication is capped at both
 ## ends by the auto_(lower|upper)_bound_bytes config values.
 ##
-## Default: 3% of physical memory
-merge_throttling_memory_limit.auto_phys_mem_scale_factor double default=0.03
+## Default: 1.5% of physical memory
+merge_throttling_memory_limit.auto_phys_mem_scale_factor double default=0.015
 
 ## The absolute minimum memory limit that can be set when automatically
 ## deducing the limit from physical memory on the node.


### PR DESCRIPTION
@geirst please review. Reducing the upper bound will be done separately once we have observed that this change does not incur an adverse merge performance impact in practice.
@toregge FYI

Merge memory limits are by default set as a percentage of the process' memory limit, capped by lower and upper bounds.

On nodes with the vast majority of memory taken up by attributes, using 3% of memory on merging might be a much larger relative percentage jump in _heap_ memory, which can cause feed block limits to be crossed if the node's already operating very close to the limit.

