### PR TITLE
Remove deprecated space between literal operator quotes and suffix.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/size_literals.h
+++ b/vespalib/src/vespa/vespalib/util/size_literals.h
@@ -4,18 +4,18 @@
 
 #include <cstddef>
 
-constexpr size_t operator "" _Ki(unsigned long long k_in) {
+constexpr size_t operator ""_Ki(unsigned long long k_in) {
 	return size_t(k_in << 10u);
 }
 
-constexpr size_t operator "" _Mi(unsigned long long m_in) {
+constexpr size_t operator ""_Mi(unsigned long long m_in) {
 	return size_t(m_in << 20u);
 }
 
-constexpr size_t operator "" _Gi(unsigned long long g_in) {
+constexpr size_t operator ""_Gi(unsigned long long g_in) {
 	return size_t(g_in << 30u);
 }
 
-constexpr size_t operator "" _Ti(unsigned long long t_in) {
+constexpr size_t operator ""_Ti(unsigned long long t_in) {
 	return size_t(t_in << 40u);
 }

--- a/vespalib/src/vespa/vespalib/util/static_string.h
+++ b/vespalib/src/vespa/vespalib/util/static_string.h
@@ -9,7 +9,7 @@ namespace vespalib {
 
 class StaticStringView;
 namespace literals {
-constexpr StaticStringView operator "" _ssv(const char *literal, size_t size);
+constexpr StaticStringView operator ""_ssv(const char *literal, size_t size);
 } // literals
 
 /**
@@ -18,7 +18,7 @@ constexpr StaticStringView operator "" _ssv(const char *literal, size_t size);
 class StaticStringView {
 private:
     std::string_view _view;
-    friend constexpr StaticStringView literals::operator "" _ssv(const char *, size_t);
+    friend constexpr StaticStringView literals::operator ""_ssv(const char *, size_t);
     constexpr StaticStringView(const char *literal, size_t size) noexcept
       : _view(literal, size) {}
 public:
@@ -28,7 +28,7 @@ public:
 };
 
 namespace literals {
-constexpr StaticStringView operator "" _ssv(const char *literal, size_t size) {
+constexpr StaticStringView operator ""_ssv(const char *literal, size_t size) {
     return {literal, size};
 }
 } // literals


### PR DESCRIPTION
See CWG2521 for rationale.

@vekterli : please review
