### PR TITLE
Validate no overlap of field rank `filter` and `filter-threshold` declarations

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
@@ -71,6 +71,7 @@ public class Processing {
                 TextMatch::new,
                 MultifieldIndexHarmonizer::new,
                 FilterFieldNames::new,
+                ValidateNoFieldRankFilterOverlap::new,
                 MatchConsistency::new,
                 ValidateStructTypeInheritance::new,
                 ValidateFieldTypes::new,

--- a/config-model/src/main/java/com/yahoo/schema/processing/ValidateNoFieldRankFilterOverlap.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/ValidateNoFieldRankFilterOverlap.java
@@ -1,0 +1,53 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.schema.RankProfileRegistry;
+import com.yahoo.schema.Schema;
+import com.yahoo.vespa.model.container.search.QueryProfiles;
+
+/**
+ * Processor which validates that a field <code>foo</code> cannot be declared as both
+ * <pre>
+ *   rank: filter
+ * </pre>
+ * and
+ * <pre>
+ *   rank foo {
+ *       filter-threshold: ...
+ *   }
+ * </pre>
+ * as part of the document field declaration + rank profile (or both within
+ * the same rank profile, if the document schema does not specify `rank: filter`
+ * but the rank profile specifies `rank foo: filter`).
+ *
+ * @author vekterli
+ */
+public class ValidateNoFieldRankFilterOverlap extends Processor {
+
+    public ValidateNoFieldRankFilterOverlap(Schema schema, DeployLogger deployLogger, RankProfileRegistry rankProfileRegistry, QueryProfiles queryProfiles) {
+        super(schema, deployLogger, rankProfileRegistry, queryProfiles);
+    }
+
+    @Override
+    public void process(boolean validate, boolean documentsOnly) {
+        if (!validate) {
+            return;
+        }
+        var rankProfiles = rankProfileRegistry.rankProfilesOf(schema);
+        for (var rp : rankProfiles) {
+            var rpFilterFields = rp.allFilterFields();
+            for (var field : schema.allConcreteFields()) {
+                boolean isFilter = rpFilterFields.contains(field.getName());
+                boolean hasExplicitFilterThreshold = rp.explicitFieldRankFilterThresholds().containsKey(field.getName());
+                if (isFilter && hasExplicitFilterThreshold) {
+                    throw newProcessException(schema.getName(), field.getName(),
+                            ("rank profile '%s' declares field as `rank %s { filter-threshold:... }`, but field " +
+                             "is also declared as `rank: filter`. These declarations are mutually exclusive.")
+                             .formatted(rp.name(), field.getName()));
+                }
+            }
+        }
+    }
+
+}

--- a/config-model/src/test/java/com/yahoo/schema/processing/ValidateNoFieldRankFilterOverlapTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/ValidateNoFieldRankFilterOverlapTest.java
@@ -1,0 +1,125 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.schema.ApplicationBuilder;
+import com.yahoo.schema.parser.ParseException;
+import com.yahoo.yolean.Exceptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author vekterli
+ */
+public class ValidateNoFieldRankFilterOverlapTest {
+
+    @Test
+    void document_field_with_rank_filter_and_profile_filter_threshold_overlap_is_rejected() throws ParseException {
+        try {
+            var schema = """
+                    search foo {
+                        document foo {
+                            field bar type string {
+                                indexing: index
+                                rank: filter
+                            }
+                        }
+                        rank-profile ole_ivars {
+                            rank bar {
+                                filter-threshold: 0.03
+                            }
+                        }
+                    }
+                    """;
+            ApplicationBuilder.createFromString(schema);
+            fail("Expected exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("For schema 'foo', field 'bar': " +
+                            "rank profile 'ole_ivars' declares field as `rank bar { filter-threshold:... }`, " +
+                            "but field is also declared as `rank: filter`. These declarations are mutually exclusive.",
+                    Exceptions.toMessageString(e));
+        }
+    }
+
+    @Test
+    void profile_field_with_rank_filter_and_filter_threshold_overlap_is_rejected() throws ParseException {
+        try {
+            var schema = """
+                    search foo {
+                        document foo {
+                            field bar type string {
+                                indexing: index
+                            }
+                        }
+                        rank-profile ole_ivars {
+                            rank bar: filter
+                            rank bar {
+                                filter-threshold: 0.03
+                            }
+                        }
+                    }
+                    """;
+            ApplicationBuilder.createFromString(schema);
+            fail("Expected exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("For schema 'foo', field 'bar': " +
+                            "rank profile 'ole_ivars' declares field as `rank bar { filter-threshold:... }`, " +
+                            "but field is also declared as `rank: filter`. These declarations are mutually exclusive.",
+                    Exceptions.toMessageString(e));
+        }
+    }
+
+    @Test
+    void field_with_rank_filter_and_filter_threshold_is_ok_in_different_rank_profiles() throws ParseException {
+        var schema = """
+                search foo {
+                    document foo {
+                        field bar type string {
+                            indexing: index
+                        }
+                    }
+                    rank-profile ole_ivars {
+                        rank bar: filter
+                    }
+                    rank-profile vikingarna {
+                        rank bar {
+                            filter-threshold: 0.03
+                        }
+                    }
+                }
+                """;
+        ApplicationBuilder.createFromString(schema); // Should not throw
+    }
+
+    @Test
+    void field_with_inherited_rank_filter_and_filter_threshold_overlap_is_rejected() throws ParseException {
+        try {
+            var schema = """
+                    search foo {
+                        document foo {
+                            field bar type string {
+                                indexing: index
+                            }
+                        }
+                        rank-profile base_profile {
+                            rank bar: filter
+                        }
+                        rank-profile child_profile inherits base_profile {
+                            rank bar {
+                                filter-threshold: 0.03
+                            }
+                        }
+                    }
+                    """;
+            ApplicationBuilder.createFromString(schema);
+            fail("Expected exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("For schema 'foo', field 'bar': " +
+                            "rank profile 'child_profile' declares field as `rank bar { filter-threshold:... }`, " +
+                            "but field is also declared as `rank: filter`. These declarations are mutually exclusive.",
+                    Exceptions.toMessageString(e));
+        }
+    }
+
+}


### PR DESCRIPTION
@geirst please review
@toregge FYI

A field ranking declaration cannot both state that a field should have `rank: filter` and _also_ have an explicit `filter-threshold`. This applies to both whether rank filter is declared in the document schema or in the rank profile (`filter-threshold` can only be declared in the rank profile). This restriction also holds if the rank profile is inherited.
