### PR TITLE
Remove temporary bitvector limit setting for disk indexes.

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -1281,13 +1281,11 @@ struct CreateBlueprintParamsFixture {
    }
    void set_query_properties(std::string_view lower_limit, std::string_view upper_limit,
                              std::string_view target_hits_max_adjustment_factor,
-                             std::string_view fuzzy_matching_algorithm,
-                             std::string_view disk_index_bitvector_limit) {
+                             std::string_view fuzzy_matching_algorithm) {
        rank_properties.add(GlobalFilterLowerLimit::NAME, lower_limit);
        rank_properties.add(GlobalFilterUpperLimit::NAME, upper_limit);
        rank_properties.add(TargetHitsMaxAdjustmentFactor::NAME, target_hits_max_adjustment_factor);
        rank_properties.add(FuzzyAlgorithm::NAME, fuzzy_matching_algorithm);
-       rank_properties.add(DiskIndexBitvectorLimit::NAME, disk_index_bitvector_limit);
    }
    ~CreateBlueprintParamsFixture();
    CreateBlueprintParams extract(uint32_t active_docids = 9, uint32_t docid_limit = 10) const {
@@ -1300,25 +1298,22 @@ CreateBlueprintParamsFixture::~CreateBlueprintParamsFixture() = default;
 TEST_F(MatchingTest, create_blueprint_params_are_extracted_from_rank_profile)
 {
     CreateBlueprintParamsFixture f(0.2, 0.8, 5.0, FMA::DfaTable);
-    f.rank_setup.set_disk_index_bitvector_limit(0.04);
     auto params = f.extract();
     EXPECT_EQ(0.2, params.global_filter_lower_limit);
     EXPECT_EQ(0.8, params.global_filter_upper_limit);
     EXPECT_EQ(5.0, params.target_hits_max_adjustment_factor);
     EXPECT_EQ(FMA::DfaTable, params.fuzzy_matching_algorithm);
-    EXPECT_EQ(0.04, params.disk_index_bitvector_limit);
 }
 
 TEST_F(MatchingTest, create_blueprint_params_are_extracted_from_query)
 {
     CreateBlueprintParamsFixture f(0.2, 0.8, 5.0, FMA::DfaTable);
-    f.set_query_properties("0.15", "0.75", "3.0", "dfa_explicit", "0.02");
+    f.set_query_properties("0.15", "0.75", "3.0", "dfa_explicit");
     auto params = f.extract();
     EXPECT_EQ(0.15, params.global_filter_lower_limit);
     EXPECT_EQ(0.75, params.global_filter_upper_limit);
     EXPECT_EQ(3.0, params.target_hits_max_adjustment_factor);
     EXPECT_EQ(FMA::DfaExplicit, params.fuzzy_matching_algorithm);
-    EXPECT_EQ(0.02, params.disk_index_bitvector_limit);
 }
 
 TEST_F(MatchingTest, global_filter_params_are_scaled_with_active_hit_ratio)

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -355,7 +355,6 @@ MatchToolsFactory::extract_create_blueprint_params(const RankSetup& rank_setup, 
     auto fuzzy_matching_algorithm = FuzzyAlgorithm::lookup(rank_properties, rank_setup.get_fuzzy_matching_algorithm());
     double weakand_stop_word_adjust_limit = WeakAndStopWordAdjustLimit::lookup(rank_properties, rank_setup.get_weakand_stop_word_adjust_limit());
     double weakand_stop_word_drop_limit = WeakAndStopWordDropLimit::lookup(rank_properties, rank_setup.get_weakand_stop_word_drop_limit());
-    double disk_index_bitvector_limit = DiskIndexBitvectorLimit::lookup(rank_properties, rank_setup.get_disk_index_bitvector_limit());
 
     // Note that we count the reserved docid 0 as active.
     // This ensures that when searchable-copies=1, the ratio is 1.0.
@@ -366,8 +365,7 @@ MatchToolsFactory::extract_create_blueprint_params(const RankSetup& rank_setup, 
             target_hits_max_adjustment_factor,
             fuzzy_matching_algorithm,
             StopWordStrategy(weakand_stop_word_adjust_limit,
-                                                      weakand_stop_word_drop_limit, docid_limit),
-            disk_index_bitvector_limit};
+                             weakand_stop_word_drop_limit, docid_limit)};
 }
 
 AttributeOperationTask::AttributeOperationTask(const RequestContext & requestContext,

--- a/searchlib/src/tests/ranksetup/ranksetup_test.cpp
+++ b/searchlib/src/tests/ranksetup/ranksetup_test.cpp
@@ -563,7 +563,6 @@ TEST_F(RankSetupTest, rank_setup)
     env.getProperties().add(matching::FuzzyAlgorithm::NAME, "dfa_implicit");
     env.getProperties().add(matching::WeakAndStopWordAdjustLimit::NAME, "0.05");
     env.getProperties().add(matching::WeakAndStopWordDropLimit::NAME, "0.5");
-    env.getProperties().add(matching::DiskIndexBitvectorLimit::NAME, "0.04");
 
     RankSetup rs(_factory, env);
     EXPECT_FALSE(rs.has_match_features());
@@ -609,7 +608,6 @@ TEST_F(RankSetupTest, rank_setup)
     EXPECT_EQ(rs.get_fuzzy_matching_algorithm(), vespalib::FuzzyMatchingAlgorithm::DfaImplicit);
     EXPECT_EQ(rs.get_weakand_stop_word_adjust_limit(), 0.05);
     EXPECT_EQ(rs.get_weakand_stop_word_drop_limit(), 0.5);
-    EXPECT_EQ(rs.get_disk_index_bitvector_limit(), 0.04);
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
@@ -443,13 +443,6 @@ double WeakAndStopWordDropLimit::lookup(const Properties &props, double defaultV
     return lookupDouble(props, NAME, defaultValue);
 }
 
-const std::string DiskIndexBitvectorLimit::NAME("vespa.matching.diskindex.bitvector_limit");
-const double DiskIndexBitvectorLimit::DEFAULT_VALUE(1.0);
-double DiskIndexBitvectorLimit::lookup(const Properties& props) { return lookup(props, DEFAULT_VALUE); }
-double DiskIndexBitvectorLimit::lookup(const Properties& props, double default_value) {
-    return lookupDouble(props, NAME, default_value);
-}
-
 const std::string FilterThreshold::NAME("vespa.matching.filter_threshold");
 const std::optional<double> FilterThreshold::DEFAULT_VALUE(std::nullopt);
 std::optional<double> FilterThreshold::lookup(const search::fef::Properties &props) {

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.h
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.h
@@ -353,23 +353,12 @@ namespace matching {
     };
 
     /**
-     * Use bitvector posting list for terms searching in disk indexes that match more than this limit of the corpus.
-     * If a bitvector is not available for the term, mask the posocc posting list as a bitvector iterator.
-     **/
-    struct DiskIndexBitvectorLimit {
-        static const std::string NAME;
-        static const double DEFAULT_VALUE;
-        static double lookup(const Properties& props);
-        static double lookup(const Properties& props, double default_value);
-    };
-
-    /**
      * Property to extract the filter threshold settings for a query (see search::fef::FilterThreshold for details).
      * The per field filter threshold has precedence over the overall filter threshold.
      */
     struct FilterThreshold {
         static const std::string NAME;
-        static const std::optional<feature_t> DEFAULT_VALUE;
+        static const std::optional<double> DEFAULT_VALUE;
         static std::optional<double> lookup(const Properties& props);
         static std::optional<double> lookup_for_field(const Properties& props, const std::string& field_name);
         static void set(Properties& props, const std::string& threshold);

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -76,7 +76,6 @@ RankSetup::RankSetup(const BlueprintFactory &factory, const IIndexEnvironment &i
       _target_hits_max_adjustment_factor(20.0),
       _weakand_stop_word_adjust_limit(matching::WeakAndStopWordAdjustLimit::DEFAULT_VALUE),
       _weakand_stop_word_drop_limit(matching::WeakAndStopWordDropLimit::DEFAULT_VALUE),
-      _disk_index_bitvector_limit(matching::DiskIndexBitvectorLimit::DEFAULT_VALUE),
       _fuzzy_matching_algorithm(vespalib::FuzzyMatchingAlgorithm::DfaTable),
       _mutateOnMatch(),
       _mutateOnFirstPhase(),
@@ -135,7 +134,6 @@ RankSetup::configure()
     set_fuzzy_matching_algorithm(matching::FuzzyAlgorithm::lookup(_indexEnv.getProperties()));
     set_weakand_stop_word_adjust_limit(matching::WeakAndStopWordAdjustLimit::lookup(_indexEnv.getProperties()));
     set_weakand_stop_word_drop_limit(matching::WeakAndStopWordDropLimit::lookup(_indexEnv.getProperties()));
-    set_disk_index_bitvector_limit(matching::DiskIndexBitvectorLimit::lookup(_indexEnv.getProperties()));
     _mutateOnMatch._attribute = mutate::on_match::Attribute::lookup(_indexEnv.getProperties());
     _mutateOnMatch._operation = mutate::on_match::Operation::lookup(_indexEnv.getProperties());
     _mutateOnFirstPhase._attribute = mutate::on_first_phase::Attribute::lookup(_indexEnv.getProperties());

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -85,7 +85,6 @@ private:
     double                   _target_hits_max_adjustment_factor;
     double                   _weakand_stop_word_adjust_limit;
     double                   _weakand_stop_word_drop_limit;
-    double                   _disk_index_bitvector_limit;
     vespalib::FuzzyMatchingAlgorithm _fuzzy_matching_algorithm;
     MutateOperation          _mutateOnMatch;
     MutateOperation          _mutateOnFirstPhase;
@@ -416,8 +415,6 @@ public:
     double get_weakand_stop_word_adjust_limit() const { return _weakand_stop_word_adjust_limit; }
     void set_weakand_stop_word_drop_limit(double v) { _weakand_stop_word_drop_limit = v; }
     double get_weakand_stop_word_drop_limit() const { return _weakand_stop_word_drop_limit; }
-    void set_disk_index_bitvector_limit(double v) { _disk_index_bitvector_limit = v; }
-    double get_disk_index_bitvector_limit() const { return _disk_index_bitvector_limit; }
 
     /**
      * This method may be used to indicate that certain features

--- a/searchlib/src/vespa/searchlib/queryeval/create_blueprint_params.h
+++ b/searchlib/src/vespa/searchlib/queryeval/create_blueprint_params.h
@@ -18,20 +18,17 @@ struct CreateBlueprintParams
     double target_hits_max_adjustment_factor;
     vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm;
     queryeval::wand::StopWordStrategy weakand_stop_word_strategy;
-    double disk_index_bitvector_limit;
 
     CreateBlueprintParams(double global_filter_lower_limit_in,
                           double global_filter_upper_limit_in,
                           double target_hits_max_adjustment_factor_in,
                           vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm_in,
-                          queryeval::wand::StopWordStrategy weakand_stop_word_strategy_in,
-                          double disk_index_bitvector_limit_in)
+                          queryeval::wand::StopWordStrategy weakand_stop_word_strategy_in)
         : global_filter_lower_limit(global_filter_lower_limit_in),
           global_filter_upper_limit(global_filter_upper_limit_in),
           target_hits_max_adjustment_factor(target_hits_max_adjustment_factor_in),
           fuzzy_matching_algorithm(fuzzy_matching_algorithm_in),
-          weakand_stop_word_strategy(weakand_stop_word_strategy_in),
-          disk_index_bitvector_limit(disk_index_bitvector_limit_in)
+          weakand_stop_word_strategy(weakand_stop_word_strategy_in)
     {
     }
 
@@ -40,8 +37,7 @@ struct CreateBlueprintParams
                                 fef::indexproperties::matching::GlobalFilterUpperLimit::DEFAULT_VALUE,
                                 fef::indexproperties::matching::TargetHitsMaxAdjustmentFactor::DEFAULT_VALUE,
                                 fef::indexproperties::matching::FuzzyAlgorithm::DEFAULT_VALUE,
-                                queryeval::wand::StopWordStrategy::none(),
-                                fef::indexproperties::matching::DiskIndexBitvectorLimit::DEFAULT_VALUE)
+                                queryeval::wand::StopWordStrategy::none())
     {
     }
 };


### PR DESCRIPTION
This is replaced by the "filter-threshold" setting in a rank profile.

@toregge please review
@vekterli FYI