### PR TITLE
Use one FileDownloader in config server

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -12,6 +12,7 @@ import com.yahoo.config.provision.TransientException;
 import com.yahoo.container.handler.VipStatus;
 import com.yahoo.container.jdisc.state.StateMonitor;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
+import com.yahoo.vespa.config.server.filedistribution.FileServer;
 import com.yahoo.vespa.config.server.maintenance.ConfigServerMaintenance;
 import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.version.VersionState;
@@ -74,15 +75,15 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
     @Inject
     public ConfigServerBootstrap(ApplicationRepository applicationRepository, RpcServer server,
                                  VersionState versionState, StateMonitor stateMonitor, VipStatus vipStatus,
-                                 FileDirectory fileDirectory) {
+                                 FileDirectory fileDirectory, FileServer fileServer) {
         this(applicationRepository, server, versionState, stateMonitor, vipStatus, EXIT_JVM,
-             vipStatusMode(applicationRepository), fileDirectory);
+             vipStatusMode(applicationRepository), fileDirectory, fileServer);
     }
 
     protected ConfigServerBootstrap(ApplicationRepository applicationRepository, RpcServer server,
                                     VersionState versionState, StateMonitor stateMonitor, VipStatus vipStatus,
                                     RedeployingApplicationsFails exitIfRedeployingApplicationsFails,
-                                    VipStatusMode vipStatusMode, FileDirectory fileDirectory) {
+                                    VipStatusMode vipStatusMode, FileDirectory fileDirectory, FileServer fileServer) {
         this.applicationRepository = applicationRepository;
         this.server = server;
         this.versionState = versionState;
@@ -94,7 +95,7 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
         this.exitIfRedeployingApplicationsFails = exitIfRedeployingApplicationsFails;
         this.clock = applicationRepository.clock();
         rpcServerExecutor = Executors.newSingleThreadExecutor(new DaemonThreadFactory("config server RPC server"));
-        configServerMaintenance = new ConfigServerMaintenance(applicationRepository, fileDirectory);
+        configServerMaintenance = new ConfigServerMaintenance(applicationRepository, fileDirectory, fileServer);
         configServerMaintenance.startBeforeBootstrap();
         log.log(Level.FINE, () -> "VIP status mode: " + vipStatusMode);
         initializing(vipStatusMode);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
@@ -5,6 +5,7 @@ import com.yahoo.concurrent.maintenance.Maintainer;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.application.ConfigConvergenceChecker;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
+import com.yahoo.vespa.config.server.filedistribution.FileServer;
 import com.yahoo.vespa.curator.Curator;
 
 import java.time.Clock;
@@ -28,19 +29,21 @@ public class ConfigServerMaintenance {
     private final Curator curator;
     private final ConfigConvergenceChecker convergenceChecker;
     private final FileDirectory fileDirectory;
+    private final FileServer fileServer;
     private final Duration interval;
 
-    public ConfigServerMaintenance(ApplicationRepository applicationRepository, FileDirectory fileDirectory) {
+    public ConfigServerMaintenance(ApplicationRepository applicationRepository, FileDirectory fileDirectory, FileServer fileServer) {
         this.applicationRepository = applicationRepository;
         this.curator = applicationRepository.tenantRepository().getCurator();
         this.convergenceChecker = applicationRepository.configConvergenceChecker();
         this.fileDirectory = fileDirectory;
+        this.fileServer = fileServer;
         this.interval = Duration.ofMinutes(applicationRepository.configserverConfig().maintainerIntervalMinutes());
     }
 
     public void startBeforeBootstrap() {
         if (moreThanOneConfigServer())
-            maintainers.add(new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofSeconds(15)));
+            maintainers.add(new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofSeconds(15), fileServer));
         maintainers.add(new TenantsMaintainer(applicationRepository, curator, interval, Clock.systemUTC()));
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -21,6 +21,7 @@ import com.yahoo.path.Path;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.config.server.deploy.DeployTester;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
+import com.yahoo.vespa.config.server.filedistribution.FileServer;
 import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.version.VersionState;
 import com.yahoo.vespa.config.server.version.VespaVersion;
@@ -258,13 +259,17 @@ public class ConfigServerBootstrapTest {
                                             VersionState versionState) {
         StateMonitor stateMonitor = StateMonitor.createForTesting();
         VipStatus vipStatus = createVipStatus(stateMonitor);
+        ConfigserverConfig configserverConfig = tester.applicationRepository().configserverConfig();
+        FileDirectory fileDirectory = new FileDirectory(configserverConfig);
+        FileServer fileServer = new FileServer(configserverConfig, fileDirectory);
         return new Bootstrapper(tester.applicationRepository(),
                                 rpcServer,
                                 versionState,
                                 stateMonitor,
                                 vipStatus,
                                 vipStatusMode,
-                                new FileDirectory(tester.applicationRepository().configserverConfig()));
+                                fileDirectory,
+                                fileServer);
     }
 
     private void waitUntil(BooleanSupplier booleanSupplier, String messageIfWaitingFails) throws InterruptedException {
@@ -363,8 +368,10 @@ public class ConfigServerBootstrapTest {
                             StateMonitor stateMonitor,
                             VipStatus vipStatus,
                             VipStatusMode vipStatusMode,
-                            FileDirectory fileDirectory) {
-            super(applicationRepository, server, versionState, stateMonitor, vipStatus, CONTINUE, vipStatusMode, fileDirectory);
+                            FileDirectory fileDirectory,
+                            FileServer fileServer) {
+            super(applicationRepository, server, versionState, stateMonitor, vipStatus, CONTINUE, vipStatusMode,
+                  fileDirectory, fileServer);
         }
 
         @Override


### PR DESCRIPTION
FileDownloader keeps tracks of downloads in progress, this does not work if we have more than one (an file received that is unknown because the other downloader started downloading it will not be handled correctly).