### PR TITLE
Propagate WeakAnd-related query property overrides

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7146,6 +7146,7 @@
       "public java.lang.Double getPostFilterThreshold()",
       "public java.lang.Double getApproximateThreshold()",
       "public java.lang.Double getTargetHitsMaxAdjustmentFactor()",
+      "public com.yahoo.search.query.ranking.WeakAnd getWeakAnd()",
       "public void setTermwiselimit(double)",
       "public void setNumThreadsPerSearch(int)",
       "public void setNumSearchPartitions(int)",
@@ -7167,6 +7168,7 @@
       "public static final java.lang.String POST_FILTER_THRESHOLD",
       "public static final java.lang.String APPROXIMATE_THRESHOLD",
       "public static final java.lang.String TARGET_HITS_MAX_ADJUSTMENT_FACTOR",
+      "public static final java.lang.String WEAKAND",
       "public java.lang.Double termwiseLimit"
     ]
   },
@@ -7298,6 +7300,32 @@
       "public static final java.lang.String FACTOR",
       "public static final java.lang.String TAILCOST",
       "public static final com.yahoo.processing.request.CompoundName enableProperty"
+    ]
+  },
+  "com.yahoo.search.query.ranking.WeakAnd" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [
+      "java.lang.Cloneable"
+    ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>()",
+      "public static com.yahoo.search.query.profile.types.QueryProfileType getArgumentType()",
+      "public java.lang.Double getStopWordLimit()",
+      "public java.lang.Double getAdjustTarget()",
+      "public void setStopWordLimit(double)",
+      "public void setAdjustTarget(double)",
+      "public void prepare(com.yahoo.search.query.ranking.RankProperties)",
+      "public com.yahoo.search.query.ranking.WeakAnd clone()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()",
+      "public bridge synthetic java.lang.Object clone()"
+    ],
+    "fields" : [
+      "public static final java.lang.String STOP_WORD_LIMIT",
+      "public static final java.lang.String ADJUST_TARGET"
     ]
   },
   "com.yahoo.search.query.rewrite.QueryRewriteSearcher" : {

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7313,9 +7313,9 @@
     "methods" : [
       "public void <init>()",
       "public static com.yahoo.search.query.profile.types.QueryProfileType getArgumentType()",
-      "public java.lang.Double getStopWordLimit()",
+      "public java.lang.Double getStopwordLimit()",
       "public java.lang.Double getAdjustTarget()",
-      "public void setStopWordLimit(double)",
+      "public void setStopwordLimit(double)",
       "public void setAdjustTarget(double)",
       "public void prepare(com.yahoo.search.query.ranking.RankProperties)",
       "public com.yahoo.search.query.ranking.WeakAnd clone()",
@@ -7324,7 +7324,7 @@
       "public bridge synthetic java.lang.Object clone()"
     ],
     "fields" : [
-      "public static final java.lang.String STOP_WORD_LIMIT",
+      "public static final java.lang.String STOPWORD_LIMIT",
       "public static final java.lang.String ADJUST_TARGET"
     ]
   },

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -94,12 +94,12 @@ public class QueryProperties extends Properties {
         addDualCasedRM(map, Matching.POST_FILTER_THRESHOLD, GetterSetter.of(query -> query.getRanking().getMatching().getPostFilterThreshold(), (query, value) -> query.getRanking().getMatching().setPostFilterThreshold(asDouble(value, 1.0))));
         addDualCasedRM(map, Matching.APPROXIMATE_THRESHOLD, GetterSetter.of(query -> query.getRanking().getMatching().getApproximateThreshold(), (query, value) -> query.getRanking().getMatching().setApproximateThreshold(asDouble(value, 0.05))));
         addDualCasedRM(map, Matching.TARGET_HITS_MAX_ADJUSTMENT_FACTOR, GetterSetter.of(query -> query.getRanking().getMatching().getTargetHitsMaxAdjustmentFactor(), (query, value) -> query.getRanking().getMatching().setTargetHitsMaxAdjustmentFactor(asDouble(value, 20.0))));
-        map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCHING, Matching.WEAKAND, WeakAnd.STOP_WORD_LIMIT),
-                GetterSetter.of(query -> query.getRanking().getMatching().getWeakAnd().getStopWordLimit(),
-                               (query, value) -> query.getRanking().getMatching().getWeakAnd().setStopWordLimit(asDouble(value, 1.0))));
+        map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCHING, Matching.WEAKAND, WeakAnd.STOPWORD_LIMIT),
+                GetterSetter.of(query -> query.getRanking().getMatching().getWeakAnd().getStopwordLimit(),
+                               (query, value) -> query.getRanking().getMatching().getWeakAnd().setStopwordLimit(asDouble(value, 1.0))));
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCHING, Matching.WEAKAND, WeakAnd.ADJUST_TARGET),
                 GetterSetter.of(query -> query.getRanking().getMatching().getWeakAnd().getAdjustTarget(),
-                               (query, value) -> query.getRanking().getMatching().getWeakAnd().setAdjustTarget(asDouble(value, 0.0))));
+                               (query, value) -> query.getRanking().getMatching().getWeakAnd().setAdjustTarget(asDouble(value, 1.0))));
 
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCH_PHASE, MatchPhase.ATTRIBUTE), GetterSetter.of(query -> query.getRanking().getMatchPhase().getAttribute(), (query, value) -> query.getRanking().getMatchPhase().setAttribute(asString(value, null))));
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCH_PHASE, MatchPhase.ASCENDING), GetterSetter.of(query -> query.getRanking().getMatchPhase().getAscending(), (query, value) -> query.getRanking().getMatchPhase().setAscending(asBoolean(value, false))));

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -23,6 +23,7 @@ import com.yahoo.search.query.ranking.MatchPhase;
 import com.yahoo.search.query.ranking.Matching;
 import com.yahoo.search.query.ranking.SoftTimeout;
 import com.yahoo.search.query.ranking.Significance;
+import com.yahoo.search.query.ranking.WeakAnd;
 import com.yahoo.tensor.Tensor;
 
 import java.util.HashMap;
@@ -93,6 +94,12 @@ public class QueryProperties extends Properties {
         addDualCasedRM(map, Matching.POST_FILTER_THRESHOLD, GetterSetter.of(query -> query.getRanking().getMatching().getPostFilterThreshold(), (query, value) -> query.getRanking().getMatching().setPostFilterThreshold(asDouble(value, 1.0))));
         addDualCasedRM(map, Matching.APPROXIMATE_THRESHOLD, GetterSetter.of(query -> query.getRanking().getMatching().getApproximateThreshold(), (query, value) -> query.getRanking().getMatching().setApproximateThreshold(asDouble(value, 0.05))));
         addDualCasedRM(map, Matching.TARGET_HITS_MAX_ADJUSTMENT_FACTOR, GetterSetter.of(query -> query.getRanking().getMatching().getTargetHitsMaxAdjustmentFactor(), (query, value) -> query.getRanking().getMatching().setTargetHitsMaxAdjustmentFactor(asDouble(value, 20.0))));
+        map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCHING, Matching.WEAKAND, WeakAnd.STOP_WORD_LIMIT),
+                GetterSetter.of(query -> query.getRanking().getMatching().getWeakAnd().getStopWordLimit(),
+                               (query, value) -> query.getRanking().getMatching().getWeakAnd().setStopWordLimit(asDouble(value, 1.0))));
+        map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCHING, Matching.WEAKAND, WeakAnd.ADJUST_TARGET),
+                GetterSetter.of(query -> query.getRanking().getMatching().getWeakAnd().getAdjustTarget(),
+                               (query, value) -> query.getRanking().getMatching().getWeakAnd().setAdjustTarget(asDouble(value, 0.0))));
 
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCH_PHASE, MatchPhase.ATTRIBUTE), GetterSetter.of(query -> query.getRanking().getMatchPhase().getAttribute(), (query, value) -> query.getRanking().getMatchPhase().setAttribute(asString(value, null))));
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.MATCH_PHASE, MatchPhase.ASCENDING), GetterSetter.of(query -> query.getRanking().getMatchPhase().getAscending(), (query, value) -> query.getRanking().getMatchPhase().setAscending(asBoolean(value, false))));

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/WeakAnd.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/WeakAnd.java
@@ -1,0 +1,83 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.query.ranking;
+
+import com.yahoo.search.query.profile.types.FieldDescription;
+import com.yahoo.search.query.profile.types.QueryProfileType;
+
+import java.util.Objects;
+
+/**
+ * Query properties exposing WeakAnd-specific settings.
+ *
+ * @author vekterli
+ */
+public class WeakAnd implements Cloneable {
+
+    private static final QueryProfileType argumentType;
+
+    public static final String STOP_WORD_LIMIT = "stopwordLimit";
+    public static final String ADJUST_TARGET = "adjustTarget";
+
+    static {
+        argumentType = new QueryProfileType(Matching.WEAKAND);
+        argumentType.setStrict(true);
+        argumentType.setBuiltin(true);
+        argumentType.addField(new FieldDescription(STOP_WORD_LIMIT, "double"));
+        argumentType.addField(new FieldDescription(ADJUST_TARGET, "double"));
+    }
+
+    public static QueryProfileType getArgumentType() { return argumentType; }
+
+    private Double stopWordLimit = null;
+    private Double adjustTarget = null;
+
+    public Double getStopWordLimit() { return stopWordLimit; }
+    public Double getAdjustTarget() { return adjustTarget; }
+
+    private static void validateRange(String field, double v, double lboundIncl, double uboundIncl) {
+        if (v < lboundIncl || v > uboundIncl) {
+            throw new IllegalArgumentException("%s must be in the range [%.1f, %.1f]. It is %.1f".formatted(field, lboundIncl, uboundIncl, v));
+        }
+    }
+
+    public void setStopWordLimit(double limit) {
+        validateRange(STOP_WORD_LIMIT, limit, 0.0, 1.0);
+        stopWordLimit = limit;
+    }
+    public void setAdjustTarget(double target) {
+        validateRange(ADJUST_TARGET, target, 0.0, 1.0);
+        adjustTarget = target;
+    }
+
+    /** Internal operation - DO NOT USE DIRECTLY */
+    public void prepare(RankProperties rankProperties) {
+        if (stopWordLimit != null) {
+            rankProperties.put("vespa.matching.weakand.stop_word_drop_limit", String.valueOf(stopWordLimit));
+        }
+        if (adjustTarget != null) {
+            rankProperties.put("vespa.matching.weakand.stop_word_adjust_limit", String.valueOf(adjustTarget));
+        }
+    }
+
+    @Override
+    public WeakAnd clone() {
+        try {
+            return (WeakAnd)super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException("Won't happen", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        WeakAnd weakAnd = (WeakAnd) o;
+        return Objects.equals(stopWordLimit, weakAnd.stopWordLimit) &&
+                Objects.equals(adjustTarget, weakAnd.adjustTarget);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stopWordLimit, adjustTarget);
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/WeakAnd.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/WeakAnd.java
@@ -15,23 +15,23 @@ public class WeakAnd implements Cloneable {
 
     private static final QueryProfileType argumentType;
 
-    public static final String STOP_WORD_LIMIT = "stopwordLimit";
+    public static final String STOPWORD_LIMIT = "stopwordLimit";
     public static final String ADJUST_TARGET = "adjustTarget";
 
     static {
         argumentType = new QueryProfileType(Matching.WEAKAND);
         argumentType.setStrict(true);
         argumentType.setBuiltin(true);
-        argumentType.addField(new FieldDescription(STOP_WORD_LIMIT, "double"));
+        argumentType.addField(new FieldDescription(STOPWORD_LIMIT, "double"));
         argumentType.addField(new FieldDescription(ADJUST_TARGET, "double"));
     }
 
     public static QueryProfileType getArgumentType() { return argumentType; }
 
-    private Double stopWordLimit = null;
+    private Double stopwordLimit = null;
     private Double adjustTarget = null;
 
-    public Double getStopWordLimit() { return stopWordLimit; }
+    public Double getStopwordLimit() { return stopwordLimit; }
     public Double getAdjustTarget() { return adjustTarget; }
 
     private static void validateRange(String field, double v, double lboundIncl, double uboundIncl) {
@@ -40,9 +40,9 @@ public class WeakAnd implements Cloneable {
         }
     }
 
-    public void setStopWordLimit(double limit) {
-        validateRange(STOP_WORD_LIMIT, limit, 0.0, 1.0);
-        stopWordLimit = limit;
+    public void setStopwordLimit(double limit) {
+        validateRange(STOPWORD_LIMIT, limit, 0.0, 1.0);
+        stopwordLimit = limit;
     }
     public void setAdjustTarget(double target) {
         validateRange(ADJUST_TARGET, target, 0.0, 1.0);
@@ -51,8 +51,8 @@ public class WeakAnd implements Cloneable {
 
     /** Internal operation - DO NOT USE DIRECTLY */
     public void prepare(RankProperties rankProperties) {
-        if (stopWordLimit != null) {
-            rankProperties.put("vespa.matching.weakand.stop_word_drop_limit", String.valueOf(stopWordLimit));
+        if (stopwordLimit != null) {
+            rankProperties.put("vespa.matching.weakand.stop_word_drop_limit", String.valueOf(stopwordLimit));
         }
         if (adjustTarget != null) {
             rankProperties.put("vespa.matching.weakand.stop_word_adjust_limit", String.valueOf(adjustTarget));
@@ -72,12 +72,12 @@ public class WeakAnd implements Cloneable {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         WeakAnd weakAnd = (WeakAnd) o;
-        return Objects.equals(stopWordLimit, weakAnd.stopWordLimit) &&
+        return Objects.equals(stopwordLimit, weakAnd.stopwordLimit) &&
                 Objects.equals(adjustTarget, weakAnd.adjustTarget);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stopWordLimit, adjustTarget);
+        return Objects.hash(stopwordLimit, adjustTarget);
     }
 }

--- a/container-search/src/test/java/com/yahoo/search/query/MatchingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/MatchingTestCase.java
@@ -21,7 +21,7 @@ public class MatchingTestCase {
         assertNull(query.getRanking().getMatching().getPostFilterThreshold());
         assertNull(query.getRanking().getMatching().getApproximateThreshold());
         assertNull(query.getRanking().getMatching().getTargetHitsMaxAdjustmentFactor());
-        assertNull(query.getRanking().getMatching().getWeakAnd().getStopWordLimit());
+        assertNull(query.getRanking().getMatching().getWeakAnd().getStopwordLimit());
         assertNull(query.getRanking().getMatching().getWeakAnd().getAdjustTarget());
     }
 
@@ -44,7 +44,7 @@ public class MatchingTestCase {
         assertEquals(Double.valueOf(0.8), query.getRanking().getMatching().getPostFilterThreshold());
         assertEquals(Double.valueOf(0.3), query.getRanking().getMatching().getApproximateThreshold());
         assertEquals(Double.valueOf(2.5), query.getRanking().getMatching().getTargetHitsMaxAdjustmentFactor());
-        assertEquals(Double.valueOf(0.6), query.getRanking().getMatching().getWeakAnd().getStopWordLimit());
+        assertEquals(Double.valueOf(0.6), query.getRanking().getMatching().getWeakAnd().getStopwordLimit());
         assertEquals(Double.valueOf(0.03), query.getRanking().getMatching().getWeakAnd().getAdjustTarget());
 
         query.prepare();


### PR DESCRIPTION
@geirst please review
@toregge FYI

Adds a new `weakand` property hierarchy under `ranking.matching` and exposes `stopwordLimit` and `adjustTarget`, which shall map 1-1 to the existing rank profile settings bearing the same names.

