### PR TITLE
Fail schema parsing when values are outside allowed range

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
@@ -257,16 +257,19 @@ public class ParsedRankProfile extends ParsedBlock {
 
     public void setWeakandStopwordLimit(double limit) {
         verifyThat(this.weakandStopwordLimit == null, "already has weakand stopword-limit");
+        verifyThat(limit >= 0.0 && limit <= 1.0, "weakand stopword-limit must be in range [0, 1]");
         this.weakandStopwordLimit = limit;
     }
 
     public void setWeakandAdjustTarget(double target) {
         verifyThat(this.weakandAdjustTarget == null, "already has weakand adjust-target");
+        verifyThat(target >= 0.0 && target <= 1.0, "weakand adjust-target must be in range [0, 1]");
         this.weakandAdjustTarget = target;
     }
 
     public void setFilterThreshold(double threshold) {
         verifyThat(this.filterThreshold == null, "already has filter-threshold");
+        verifyThat(threshold >= 0.0 && threshold <= 1.0, "filter-threshold must be in range [0, 1]");
         this.filterThreshold = threshold;
     }
 

--- a/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
@@ -183,7 +183,6 @@ public class SchemaParserTestCase {
         assertEquals(0.01, target.get());
     }
 
-
     @Test
     void filter_threshold_can_be_parsed() throws Exception {
         String input = joinLines("schema foo {",
@@ -195,6 +194,22 @@ public class SchemaParserTestCase {
         var target = schema.getRankProfiles().get(0).getFilterThreshold();
         assertTrue(target.isPresent());
         assertEquals(0.05, target.get());
+    }
+
+    private void assertRankProfileWithOutOfRangeThrows(String rpContent) {
+        var input = "schema foo { rank-profile rp { %s } }".formatted(rpContent);
+        var e = assertThrows(IllegalArgumentException.class, () -> parseString(input));
+        assertTrue(e.getMessage().contains("must be in range [0, 1]"));
+    }
+
+    @Test
+    void range_bounded_properties_fail_parsing_on_out_of_range_input() {
+        assertRankProfileWithOutOfRangeThrows("filter-threshold: -0.1");
+        assertRankProfileWithOutOfRangeThrows("filter-threshold: 1.1");
+        assertRankProfileWithOutOfRangeThrows("weakand { stopword-limit: -0.1 }");
+        assertRankProfileWithOutOfRangeThrows("weakand { stopword-limit: 1.1 }");
+        assertRankProfileWithOutOfRangeThrows("weakand { adjust-target: -0.1 }");
+        assertRankProfileWithOutOfRangeThrows("weakand { adjust-target: 1.1 }");
     }
 
     @Test


### PR DESCRIPTION
@geirst please review
@toregge FYI

Applies to rank profile fields `filter-threshold`, `adjust-target` and `stopword-limit`.
