### PR TITLE
Disable GC logging to stdout by default

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -328,7 +328,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         var memoryPct = getMemoryPercentage().orElse(null);
         int heapsize = truncateTo4SignificantBits(memoryPct != null && memoryPct.asAbsoluteGb().isPresent()
                                                   ? (int) (memoryPct.asAbsoluteGb().getAsDouble() * 1024) : 1536);
-        builder.jvm.verbosegc(true)
+        builder.jvm.verbosegc(false)
                 .availableProcessors(0)
                 .compressedClassSpaceSize(0)
                 .minHeapsize(heapsize) // These cause restarts when changed, so we try to keep them stable.

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
@@ -182,7 +182,7 @@ public class DocprocBuilderTest extends DomBuilderTest {
     void testQrStartConfig() {
         QrStartConfig.Jvm jvm = qrStartConfig.jvm();
         assertTrue(jvm.server());
-        assertTrue(jvm.verbosegc());
+        assertFalse(jvm.verbosegc());
         assertEquals("-XX:+UseG1GC -XX:MaxTenuringThreshold=15", jvm.gcopts());
         assertEquals(1536, jvm.minHeapsize());
         assertEquals(1536, jvm.heapsize());

--- a/container-search/src/main/resources/configdefinitions/search.config.qr-start.def
+++ b/container-search/src/main/resources/configdefinitions/search.config.qr-start.def
@@ -6,7 +6,7 @@ namespace=search.config
 jvm.server bool default=true restart
 
 ## Debug logging of Garbage Collection
-jvm.verbosegc bool default=true restart
+jvm.verbosegc bool default=false restart
 
 ## Garbage Collection tuning parameters
 jvm.gcopts string default="-XX:+UseG1GC -XX:MaxTenuringThreshold=15 -XX:NewRatio=1" restart


### PR DESCRIPTION
Disable GC logging for application container clusters and the default setting in config definition.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
