### PR TITLE
chore: push forward the expire of the Legacy Trust Store feature flag.

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -436,7 +436,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag USE_LEGACY_STORE = defineFeatureFlag(
             "use-legacy-trust-store", true,
-            List.of("marlon"), "2024-12-05", "2025-02-01",
+            List.of("marlon"), "2024-12-05", "2025-03-01",
             "Use legacy trust store for CA, or new one",
             "Takes effect on restart of OCI containers");
 


### PR DESCRIPTION
## What

Pushed forward the expiration date of the Legacy Trust Store feature flag

## Why

We're still rolling this out.