### PR TITLE
Create dummy document v1 api handler when not configured

### DIFF
--- a/application/src/main/java/com/yahoo/application/container/JDisc.java
+++ b/application/src/main/java/com/yahoo/application/container/JDisc.java
@@ -5,6 +5,7 @@ import com.yahoo.api.annotations.Beta;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
+import com.yahoo.application.Application;
 import com.yahoo.application.Networking;
 import com.yahoo.application.container.handler.Request;
 import com.yahoo.application.container.handler.Response;
@@ -47,6 +48,7 @@ public final class JDisc implements AutoCloseable {
     private final boolean deletePathWhenClosing;
 
     private JDisc(Path path, boolean deletePathWhenClosing, Networking networking, ConfigModelRepo configModelRepo) {
+        System.setProperty(Application.vespaLocalProperty, "true");
         this.path = path;
         this.deletePathWhenClosing = deletePathWhenClosing;
         testDriver = TestDriver.newInstance(osgiFramework, "", false, //StandaloneContainerApplication.class,

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -11,6 +11,7 @@ import com.yahoo.vespa.model.container.component.BindingPattern;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 import com.yahoo.vespa.model.container.component.UserBindingPattern;
+import com.yahoo.vespa.model.container.xml.DocumentApiOptionsBuilder;
 import org.w3c.dom.Element;
 
 import java.nio.file.Path;
@@ -37,6 +38,20 @@ public class ContainerDocumentApi {
         addRestApiHandler(cluster, handlerOptions, portOverride);
         addFeedHandler(ds, cluster, handlerOptions, portOverride);
         addVespaClientContainerBundle(cluster);
+    }
+
+    // Used for creating dummy document api that will be used when document api is not configured
+    private ContainerDocumentApi(ContainerCluster<?> cluster) {
+        this.ignoreUndefinedFields = true;
+        var handlerOptions = DocumentApiOptionsBuilder.build(null);
+        var handler = newVespaClientHandler("com.yahoo.document.restapi.resource.DummyDocumentV1ApiHandler",
+                                            DOCUMENT_V1_PREFIX + "/*", handlerOptions, null, Set.of());
+        cluster.addComponent(handler);
+        addVespaClientContainerBundle(cluster);
+    }
+
+    public static ContainerDocumentApi createDummyApi(ContainerCluster<?> cluster) {
+        return new ContainerDocumentApi(cluster);
     }
 
     public static void addVespaClientContainerBundle(ContainerCluster<?> c) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -51,7 +51,9 @@ public class ContainerDocumentApi {
     }
 
     public static ContainerDocumentApi createDummyApi(ContainerCluster<?> cluster) {
-        return new ContainerDocumentApi(cluster);
+        return System.getProperty("vespa.local", "false").equals("true") // set by Application when running locally
+                ? null
+                : new ContainerDocumentApi(cluster);
     }
 
     public static void addVespaClientContainerBundle(ContainerCluster<?> c) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -788,10 +788,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     private void addDocumentApi(DeployState deployState, Element spec, ApplicationContainerCluster cluster, ConfigModelContext context) {
-        ContainerDocumentApi containerDocumentApi = buildDocumentApi(deployState, cluster, spec, context);
-        if (containerDocumentApi == null) return;
-
-        cluster.setDocumentApi(containerDocumentApi);
+        cluster.setDocumentApi(buildDocumentApi(deployState, cluster, spec, context));
     }
 
     private void addDocproc(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {
@@ -1278,7 +1275,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private ContainerDocumentApi buildDocumentApi(DeployState deployState, ApplicationContainerCluster cluster, Element spec, ConfigModelContext context) {
         Element documentApiElement = XML.getChild(spec, "document-api");
-        if (documentApiElement == null) return null;
+        if (documentApiElement == null) return ContainerDocumentApi.createDummyApi(cluster);
 
         ContainerDocumentApi.HandlerOptions documentApiOptions = DocumentApiOptionsBuilder.build(documentApiElement);
         Element ignoreUndefinedFields = XML.getChild(documentApiElement, "ignore-undefined-fields");

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -28,6 +28,7 @@ import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provisioning.FlavorsConfig;
 import com.yahoo.container.ComponentsConfig;
+import com.yahoo.container.Container;
 import com.yahoo.container.QrConfig;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.core.VipStatusConfig;
@@ -37,6 +38,7 @@ import com.yahoo.container.handler.metrics.MetricsV2Handler;
 import com.yahoo.container.handler.observability.ApplicationStatusHandler;
 import com.yahoo.container.jdisc.JdiscBindingsConfig;
 import com.yahoo.container.usability.BindingsOverviewHandler;
+import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.prelude.cluster.QrMonitorConfig;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.AbstractService;
@@ -815,6 +817,19 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
             } catch (IllegalArgumentException ignored) {
             }
         }
+    }
+
+    @Test
+    void dummy_document_api() {
+        Element clusterElem = DomBuilderTest.parse(
+                "<container version='1.0'>",
+                nodesXml,
+                "</container>");
+        var models = createModel(root, clusterElem);
+        assertEquals(1, models.get(0).getCluster().getAllComponents().stream()
+              .filter(component -> component.getComponentId().equals(
+                      new ComponentModel("com.yahoo.document.restapi.resource.DummyDocumentV1ApiHandler", null, "vespaclient-container-plugin").getComponentId()))
+                .count());
     }
 
     private void assertComponentConfigured(ApplicationContainer container, String id) {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DummyDocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DummyDocumentV1ApiHandler.java
@@ -40,6 +40,7 @@ public final class DummyDocumentV1ApiHandler extends ThreadedHttpRequestHandler 
         public HttpErrorResponse(int code, String msg) {
             super(code);
             Cursor root = slime.setObject();
+            root.setString("error-code", "NOT_FOUND");
             root.setString("message", msg);
         }
 

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DummyDocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DummyDocumentV1ApiHandler.java
@@ -1,0 +1,57 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.yahoo.container.jdisc.HttpRequest;
+import com.yahoo.container.jdisc.HttpResponse;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
+import com.yahoo.jdisc.Metric;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.JsonFormat;
+import com.yahoo.slime.Slime;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.Executor;
+
+/**
+ * HTTP handler for a mock /document/v1 API, used when &lt;document-api&gt; is not specified
+ * in services.xml. Returns http status code 404 and a message describing that API is not configured,
+ * pointing to documentation for how to do that.
+ *
+ * @author hmusum
+ */
+@SuppressWarnings("unused") // Created by config model
+public final class DummyDocumentV1ApiHandler extends ThreadedHttpRequestHandler {
+
+    @SuppressWarnings("unused") // Created by config model
+    public DummyDocumentV1ApiHandler(Executor executor, Metric metrics) {
+        super(executor, metrics);
+    }
+
+    @Override
+    public HttpResponse handle(HttpRequest request) {
+        return new HttpErrorResponse(404, "Document API is not configured in this cluster. See https://docs.vespa.ai/en/reference/services-container.html#document-api");
+    }
+
+    private static class HttpErrorResponse extends HttpResponse {
+
+        private final Slime slime = new Slime();
+
+        public HttpErrorResponse(int code, String msg) {
+            super(code);
+            Cursor root = slime.setObject();
+            root.setString("message", msg);
+        }
+
+
+        @Override
+        public void render(OutputStream stream) throws IOException {
+            new JsonFormat(true).encode(stream, slime);
+        }
+
+        @Override
+        public String getContentType() { return "application/json"; }
+
+    }
+
+}


### PR DESCRIPTION
If there is no document api configured (no <document-api> in services.xml) creatae a dummy handler that will return a message with pointers for how to configure it.
