### PR TITLE
Add elementwise bm25 rank feature.

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -142,6 +142,7 @@ vespa_define_module(
     src/tests/features/constant
     src/tests/features/element_completeness
     src/tests/features/element_similarity_feature
+    src/tests/features/elementwise
     src/tests/features/euclidean_distance
     src/tests/features/first_phase_rank
     src/tests/features/imported_dot_product

--- a/searchlib/src/tests/features/bm25/bm25_test.cpp
+++ b/searchlib/src/tests/features/bm25/bm25_test.cpp
@@ -10,15 +10,111 @@
 #define ENABLE_GTEST_MIGRATION
 #include <vespa/searchlib/test/ft_test_app_base.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/value_codec.h>
 #include <cmath>
 
 using namespace search::features;
 using namespace search::fef;
 using namespace search::fef::objectstore;
+using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::TensorSpec;
 using CollectionType = FieldInfo::CollectionType;
 using StringVector = std::vector<std::string>;
 
-struct Bm25BlueprintTest : public ::testing::Test {
+struct TestParam {
+    std::string _name;
+    std::string _tensor_type_spec;
+    std::string _dimension_name;
+    std::string _cell_type_name;
+    bool        _elementwise;
+
+    TestParam(const std::string& name, const std::string& tensor_type_spec,
+              const std::string& dimension_name, const std::string& cell_type_name, bool elementwise);
+    TestParam(const TestParam&);
+    ~TestParam();
+    std::string feature_base_name() const;
+    std::string feature_name(const std::string& base_name, const StringVector& params) const;
+    StringVector wrap_params(const StringVector& params) const;
+    std::string feature_name(const StringVector& params) const;
+    std::string average_length_suffix() const;
+};
+
+TestParam::TestParam(const std::string& name, const std::string& tensor_type_spec,
+                     const std::string& dimension_name, const std::string& cell_type_name, bool elementwise)
+    : _name(name),
+      _tensor_type_spec(tensor_type_spec),
+      _dimension_name(dimension_name),
+      _cell_type_name(cell_type_name),
+      _elementwise(elementwise)
+{
+}
+
+TestParam::TestParam(const TestParam&) = default;
+TestParam::~TestParam() = default;
+
+std::string
+TestParam::feature_base_name() const
+{
+    return _elementwise ? "elementwise" : "bm25";
+}
+
+std::string
+TestParam::feature_name(const std::string& base_name, const StringVector& params) const
+{
+    FeatureNameBuilder builder;
+    builder.baseName(base_name);
+    for (auto& param : params) {
+        builder.parameter(param);
+    }
+    return builder.buildName();
+}
+
+StringVector
+TestParam::wrap_params(const StringVector& params) const
+{
+    if (!_elementwise) {
+        return params;
+    }
+    StringVector wrapped_params;
+    wrapped_params.emplace_back(feature_name("bm25", params));
+    wrapped_params.emplace_back(_dimension_name);
+    wrapped_params.emplace_back(_cell_type_name);
+    return wrapped_params;
+}
+
+std::string
+TestParam::feature_name(const StringVector& params) const
+{
+    return feature_name(feature_base_name(), wrap_params(params));
+}
+
+std::string
+TestParam::average_length_suffix() const
+{
+    return _elementwise ? "averageElementLength" : "averageFieldLength";
+}
+
+std::ostream& operator<<(std::ostream& os, const TestParam& param)
+{
+    os << param._name;
+    return os;
+}
+
+auto test_values = ::testing::Values(
+    TestParam("bm25", "error",
+              "", "", false),
+    TestParam("elementwiseBm25", "tensor(x{})",
+              "x", "double", true),
+    TestParam("elementwiseBm25float", "tensor<float>(x{})",
+              "x", "float", true),
+    TestParam("elementwiseBm25bfloat16", "tensor<bfloat16>(x{})",
+              "x", "bfloat16", true),
+    TestParam("elementwiseBm25int8", "tensor<int8>(x{})",
+              "x", "int8", true));
+
+struct Bm25BlueprintTest : public ::testing::TestWithParam<TestParam> {
     BlueprintFactory factory;
     test::IndexEnvironment index_env;
 
@@ -33,67 +129,74 @@ struct Bm25BlueprintTest : public ::testing::Test {
         builder.addField(FieldType::INDEX, CollectionType::WEIGHTEDSET, "iws");
         builder.addField(FieldType::ATTRIBUTE, CollectionType::SINGLE, "as");
     }
+    ~Bm25BlueprintTest() override;
 
     Blueprint::SP make_blueprint() const {
-        return factory.createBlueprint("bm25");
+        return factory.createBlueprint(GetParam().feature_base_name());
     }
+    std::string feature_name() const { return GetParam().feature_name({"is"}); }
 
     void expect_setup_fail(const StringVector& params) {
         auto blueprint = make_blueprint();
         test::DummyDependencyHandler deps(*blueprint);
-        EXPECT_FALSE(blueprint->setup(index_env, params));
+        EXPECT_FALSE(blueprint->setup(index_env, GetParam().wrap_params(params)));
     }
 
     Blueprint::SP expect_setup_succeed(const StringVector& params) {
         auto blueprint = make_blueprint();
         test::DummyDependencyHandler deps(*blueprint);
-        EXPECT_TRUE(blueprint->setup(index_env, params));
+        EXPECT_TRUE(blueprint->setup(index_env, GetParam().wrap_params(params)));
         EXPECT_EQ(0, deps.input.size());
         EXPECT_EQ(StringVector({"score"}), deps.output);
         return blueprint;
     }
 };
 
-TEST_F(Bm25BlueprintTest, blueprint_can_be_created_from_factory)
+Bm25BlueprintTest::~Bm25BlueprintTest() = default;
+
+
+INSTANTIATE_TEST_SUITE_P(Bm25BlueprintMultiTest, Bm25BlueprintTest, test_values, testing::PrintToStringParamName());
+
+TEST_P(Bm25BlueprintTest, blueprint_can_be_created_from_factory)
 {
     auto bp = factory.createBlueprint("bm25");
     EXPECT_TRUE(bp.get() != nullptr);
     EXPECT_TRUE(dynamic_cast<Bm25Blueprint*>(bp.get()) != nullptr);
 }
 
-TEST_F(Bm25BlueprintTest, blueprint_setup_fails_when_parameter_list_is_not_valid)
+TEST_P(Bm25BlueprintTest, blueprint_setup_fails_when_parameter_list_is_not_valid)
 {
     expect_setup_fail({});           // wrong parameter number
     expect_setup_fail({"as"});       // 'as' is an attribute
     expect_setup_fail({"is", "ia"}); // wrong parameter number
 }
 
-TEST_F(Bm25BlueprintTest, blueprint_setup_fails_when_k1_param_is_malformed)
+TEST_P(Bm25BlueprintTest, blueprint_setup_fails_when_k1_param_is_malformed)
 {
-    index_env.getProperties().add("bm25(is).k1", "malformed");
+    index_env.getProperties().add(feature_name() + ".k1", "malformed");
     expect_setup_fail({"is"});
 }
 
-TEST_F(Bm25BlueprintTest, blueprint_setup_fails_when_b_param_is_malformed)
+TEST_P(Bm25BlueprintTest, blueprint_setup_fails_when_b_param_is_malformed)
 {
-    index_env.getProperties().add("bm25(is).b", "malformed");
+    index_env.getProperties().add(feature_name() + ".b", "malformed");
     expect_setup_fail({"is"});
 }
 
-TEST_F(Bm25BlueprintTest, blueprint_setup_fails_when_avg_field_length_is_malformed)
+TEST_P(Bm25BlueprintTest, blueprint_setup_fails_when_avg_field_length_is_malformed)
 {
-    index_env.getProperties().add("bm25(is).averageFieldLength", "malformed");
+    index_env.getProperties().add(feature_name() + "."  + GetParam().average_length_suffix(), "malformed");
     expect_setup_fail({"is"});
 }
 
-TEST_F(Bm25BlueprintTest, blueprint_setup_succeeds_for_index_field)
+TEST_P(Bm25BlueprintTest, blueprint_setup_succeeds_for_index_field)
 {
     expect_setup_succeed({"is"});
     expect_setup_succeed({"ia"});
     expect_setup_succeed({"iws"});
 }
 
-TEST_F(Bm25BlueprintTest, blueprint_can_prepare_shared_state_with_average_field_length)
+TEST_P(Bm25BlueprintTest, blueprint_can_prepare_shared_state_with_average_field_length)
 {
     auto blueprint = expect_setup_succeed({"is"});
     test::QueryEnvironment query_env;
@@ -101,13 +204,17 @@ TEST_F(Bm25BlueprintTest, blueprint_can_prepare_shared_state_with_average_field_
         search::index::FieldLengthInfo(10.0, 10.0, 1);
     ObjectStore store;
     blueprint->prepareSharedState(query_env, store);
-    EXPECT_DOUBLE_EQ(10.0, as_value<double>(*store.get("bm25.afl.is")));
+    EXPECT_DOUBLE_EQ(10.0, as_value<double>(*store.get(GetParam()._elementwise ? "bm25.ael.is" : "bm25.afl.is")));
 }
 
-TEST_F(Bm25BlueprintTest, dump_features_for_all_index_fields)
+TEST_P(Bm25BlueprintTest, dump_features_for_all_index_fields)
 {
-    FtTestAppBase::FT_DUMP(factory, "bm25", index_env,
-                           StringList().add("bm25(is)").add("bm25(ia)").add("bm25(iws)"));
+    StringList expected;
+    if (!GetParam()._elementwise) {
+        expected.add("bm25(is)").add("bm25(ia)").add("bm25(iws)");
+    }
+    FtTestAppBase::FT_DUMP(factory, GetParam().feature_base_name(), index_env,
+                           expected);
 }
 
 struct Scorer {
@@ -128,7 +235,7 @@ struct Scorer {
     }
 };
 
-struct Bm25ExecutorTest : public ::testing::Test {
+struct Bm25ExecutorTest : public ::testing::TestWithParam<TestParam> {
     BlueprintFactory factory;
     FtFeatureTest test;
     test::MatchDataBuilder::UP match_data;
@@ -137,7 +244,7 @@ struct Bm25ExecutorTest : public ::testing::Test {
 
     Bm25ExecutorTest()
         : factory(),
-          test(factory, "bm25(foo)"),
+          test(factory, GetParam().feature_name({"foo"})),
           match_data()
     {
         setup_search_features(factory);
@@ -148,6 +255,7 @@ struct Bm25ExecutorTest : public ::testing::Test {
         add_query_term("bar", 45);
         test.getQueryEnv().getBuilder().set_avg_field_length("foo", 10);
     }
+    ~Bm25ExecutorTest() override;
     void add_query_term(const std::string& field_name, uint32_t matching_doc_count) {
         auto* term = test.getQueryEnv().getBuilder().addIndexNode({field_name});
         term->field(0).setDocFreq(matching_doc_count, total_doc_count);
@@ -160,8 +268,26 @@ struct Bm25ExecutorTest : public ::testing::Test {
         clear_term(1, 0);
         clear_term(2, 1);
     }
+    std::string feature_name() const { return GetParam().feature_name({"foo"}); }
+    TensorSpec normalize_spec(TensorSpec spec) {
+        auto tensor = value_from_spec(spec, FastValueBuilderFactory::get());
+        return spec_from_value(*tensor);
+    }
     bool execute(feature_t exp_score) {
-        return test.execute(exp_score, 0.000001);
+        constexpr double epsilon = 0.000001;
+        if (!GetParam()._elementwise) {
+            return test.execute(exp_score, epsilon);
+        }
+        TensorSpec exp_spec(GetParam()._tensor_type_spec);
+        if (exp_score != 0.0) {
+            exp_spec.add({{"x", "0"}}, exp_score);
+        }
+        exp_spec = normalize_spec(exp_spec);
+        auto value = test.resolveObjectFeature();
+        auto spec = spec_from_value(value.get());
+        bool success = true;
+        EXPECT_EQ(exp_spec, spec) << (success = false, "");
+        return success;
     }
     void clear_term(uint32_t term_id, uint32_t field_id) {
         auto* tfmd = match_data->getTermFieldMatchData(term_id, field_id);
@@ -172,8 +298,28 @@ struct Bm25ExecutorTest : public ::testing::Test {
         auto* tfmd = match_data->getTermFieldMatchData(term_id, field_id);
         ASSERT_TRUE(tfmd != nullptr);
         tfmd->reset(doc_id);
-        tfmd->setNumOccs(num_occs);
-        tfmd->setFieldLength(field_length);
+        if (!GetParam()._elementwise) {
+            tfmd->setNumOccs(num_occs);
+            tfmd->setFieldLength(field_length);
+        } else {
+            for (uint32_t pos = 0; pos < num_occs; ++pos) {
+                tfmd->appendPosition({0, pos, 1, field_length});
+            }
+        }
+    }
+
+    void append_term(uint32_t term_id, uint32_t field_id, uint32_t element_id, uint32_t element_length, uint16_t num_occs) {
+        auto* tfmd = match_data->getTermFieldMatchData(term_id, field_id);
+        ASSERT_TRUE(tfmd != nullptr);
+        if (!GetParam()._elementwise) {
+            // flatten
+            tfmd->setNumOccs(tfmd->getNumOccs() + num_occs);
+            tfmd->setFieldLength(tfmd->getFieldLength() + element_length);;
+        } else {
+            for (uint32_t pos = 0; pos < num_occs; ++pos) {
+                tfmd->appendPosition({element_id, pos, 1, element_length});
+            }
+        }
     }
 
     double idf(uint32_t matching_doc_count) const {
@@ -185,14 +331,18 @@ struct Bm25ExecutorTest : public ::testing::Test {
     }
 };
 
-TEST_F(Bm25ExecutorTest, score_is_calculated_for_a_single_term)
+Bm25ExecutorTest::~Bm25ExecutorTest() = default;
+
+INSTANTIATE_TEST_SUITE_P(Bm25ExecutorMultiTest, Bm25ExecutorTest, test_values, testing::PrintToStringParamName());
+
+TEST_P(Bm25ExecutorTest, score_is_calculated_for_a_single_term)
 {
     setup();
     prepare_term(0, 0, 3, 20);
     EXPECT_TRUE(execute(score(3.0, 20, idf(25))));
 }
 
-TEST_F(Bm25ExecutorTest, score_is_calculated_for_multiple_terms)
+TEST_P(Bm25ExecutorTest, score_is_calculated_for_multiple_terms)
 {
     setup();
     prepare_term(0, 0, 3, 20);
@@ -200,7 +350,7 @@ TEST_F(Bm25ExecutorTest, score_is_calculated_for_multiple_terms)
     EXPECT_TRUE(execute(score(3.0, 20, idf(25)) + score(7.0, 5.0, idf(35))));
 }
 
-TEST_F(Bm25ExecutorTest, term_that_does_not_match_document_is_ignored)
+TEST_P(Bm25ExecutorTest, term_that_does_not_match_document_is_ignored)
 {
     setup();
     prepare_term(0, 0, 3, 20);
@@ -209,23 +359,24 @@ TEST_F(Bm25ExecutorTest, term_that_does_not_match_document_is_ignored)
     EXPECT_TRUE(execute(score(3.0, 20, idf(25))));
 }
 
-TEST_F(Bm25ExecutorTest, term_searching_another_field_is_ignored)
+TEST_P(Bm25ExecutorTest, term_searching_another_field_is_ignored)
 {
     setup();
     prepare_term(2, 1, 3, 20);
     EXPECT_TRUE(execute(0.0));
 }
 
-TEST_F(Bm25ExecutorTest, uses_average_field_length_from_shared_state_if_found)
+TEST_P(Bm25ExecutorTest, uses_average_field_length_from_shared_state_if_found)
 {
-    test.getQueryEnv().getObjectStore().add("bm25.afl.foo", std::make_unique<AnyWrapper<double>>(15));
+    std::string key(GetParam()._elementwise ? "bm25.ael.foo" : "bm25.afl.foo");
+    test.getQueryEnv().getObjectStore().add(key, std::make_unique<AnyWrapper<double>>(15));
     setup();
     prepare_term(0, 0, 3, 20);
     scorer.avg_field_length = 15;
     EXPECT_TRUE(execute(score(3.0, 20, idf(25))));
 }
 
-TEST_F(Bm25ExecutorTest, calculates_inverse_document_frequency)
+TEST_P(Bm25ExecutorTest, calculates_inverse_document_frequency)
 {
     EXPECT_DOUBLE_EQ(std::log(1 + (99 + 0.5) / (1 + 0.5)),
                      Bm25Utils::calculate_inverse_document_frequency({1, 100}));
@@ -241,34 +392,34 @@ TEST_F(Bm25ExecutorTest, calculates_inverse_document_frequency)
                      Bm25Utils::calculate_inverse_document_frequency({0, 0}));
 }
 
-TEST_F(Bm25ExecutorTest, k1_param_can_be_overriden)
+TEST_P(Bm25ExecutorTest, k1_param_can_be_overriden)
 {
-    test.getIndexEnv().getProperties().add("bm25(foo).k1", "2.5");
+    test.getIndexEnv().getProperties().add(feature_name() + ".k1", "2.5");
     setup();
     prepare_term(0, 0, 3, 20);
     scorer.k1_param = 2.5;
     EXPECT_TRUE(execute(score(3.0, 20, idf(25))));
 }
 
-TEST_F(Bm25ExecutorTest, b_param_can_be_overriden)
+TEST_P(Bm25ExecutorTest, b_param_can_be_overriden)
 {
-    test.getIndexEnv().getProperties().add("bm25(foo).b", "0.9");
+    test.getIndexEnv().getProperties().add(feature_name() + ".b", "0.9");
     setup();
     prepare_term(0, 0, 3, 20);
     scorer.b_param = 0.9;
     EXPECT_TRUE(execute(score(3.0, 20, idf(25))));
 }
 
-TEST_F(Bm25ExecutorTest, avg_field_length_can_be_overriden)
+TEST_P(Bm25ExecutorTest, avg_field_length_can_be_overriden)
 {
-    test.getIndexEnv().getProperties().add("bm25(foo).averageFieldLength", "15");
+    test.getIndexEnv().getProperties().add(feature_name() + "." + GetParam().average_length_suffix(), "15");
     setup();
     prepare_term(0, 0, 3, 20);
     scorer.avg_field_length = 15;
     EXPECT_TRUE(execute(score(3.0, 20, idf(25))));
 }
 
-TEST_F(Bm25ExecutorTest, inverse_document_frequency_can_be_overriden_with_significance)
+TEST_P(Bm25ExecutorTest, inverse_document_frequency_can_be_overriden_with_significance)
 {
     test.getQueryEnv().getProperties().add("vespa.term.0.significance", "0.35");
     setup();
@@ -276,11 +427,31 @@ TEST_F(Bm25ExecutorTest, inverse_document_frequency_can_be_overriden_with_signif
     EXPECT_TRUE(execute(score(3.0, 20, 0.35)));
 }
 
-TEST_F(Bm25ExecutorTest, missing_interleaved_features_are_handled)
+TEST_P(Bm25ExecutorTest, missing_interleaved_features_are_handled)
 {
     setup();
     prepare_term(0, 0, 0, 0);
-    EXPECT_TRUE(execute(score(1.0, 10, idf(25))));
+    EXPECT_TRUE(execute(score(GetParam()._elementwise ? 0.0 : 1.0, 10, idf(25))));
+}
+
+TEST_P(Bm25ExecutorTest, multiple_elements)
+{
+    setup();
+    prepare_term(0, 0, 3, 20);
+    append_term(0, 0, 7, 5, 2);
+    if (!GetParam()._elementwise) {
+        // flattened
+        EXPECT_TRUE(execute(score(5, 25, idf(25))));
+    } else {
+        // One tensor cell for each matching element
+        auto value = test.resolveObjectFeature();
+        auto spec = spec_from_value(value.get());
+        TensorSpec exp_spec(GetParam()._tensor_type_spec);
+        exp_spec.add({{"x", "0"}}, score(3, 20, idf(25)));
+        exp_spec.add({{"x", "7"}}, score(2, 5, idf(25)));
+        exp_spec = normalize_spec(exp_spec);
+        EXPECT_EQ(exp_spec, spec);
+    }
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/features/bm25/bm25_test.cpp
+++ b/searchlib/src/tests/features/bm25/bm25_test.cpp
@@ -10,7 +10,6 @@
 #define ENABLE_GTEST_MIGRATION
 #include <vespa/searchlib/test/ft_test_app_base.h>
 #include <vespa/vespalib/gtest/gtest.h>
-#include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/value_codec.h>
 #include <cmath>
@@ -18,7 +17,6 @@
 using namespace search::features;
 using namespace search::fef;
 using namespace search::fef::objectstore;
-using vespalib::eval::FastValueBuilderFactory;
 using vespalib::eval::TensorSpec;
 using CollectionType = FieldInfo::CollectionType;
 using StringVector = std::vector<std::string>;
@@ -269,10 +267,6 @@ struct Bm25ExecutorTest : public ::testing::TestWithParam<TestParam> {
         clear_term(2, 1);
     }
     std::string feature_name() const { return GetParam().feature_name({"foo"}); }
-    TensorSpec normalize_spec(TensorSpec spec) {
-        auto tensor = value_from_spec(spec, FastValueBuilderFactory::get());
-        return spec_from_value(*tensor);
-    }
     bool execute(feature_t exp_score) {
         constexpr double epsilon = 0.000001;
         if (!GetParam()._elementwise) {
@@ -282,7 +276,7 @@ struct Bm25ExecutorTest : public ::testing::TestWithParam<TestParam> {
         if (exp_score != 0.0) {
             exp_spec.add({{"x", "0"}}, exp_score);
         }
-        exp_spec = normalize_spec(exp_spec);
+        exp_spec = exp_spec.normalize();
         auto value = test.resolveObjectFeature();
         auto spec = spec_from_value(value.get());
         bool success = true;
@@ -449,7 +443,7 @@ TEST_P(Bm25ExecutorTest, multiple_elements)
         TensorSpec exp_spec(GetParam()._tensor_type_spec);
         exp_spec.add({{"x", "0"}}, score(3, 20, idf(25)));
         exp_spec.add({{"x", "7"}}, score(2, 5, idf(25)));
-        exp_spec = normalize_spec(exp_spec);
+        exp_spec = exp_spec.normalize();
         EXPECT_EQ(exp_spec, spec);
     }
 }

--- a/searchlib/src/tests/features/elementwise/CMakeLists.txt
+++ b/searchlib/src/tests/features/elementwise/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+vespa_add_executable(searchlib_features_elementwise_test_app TEST
+    SOURCES
+    elementwise_test.cpp
+    DEPENDS
+    vespa_searchlib
+    searchlib_test
+    GTest::GTest
+)
+vespa_add_test(NAME searchlib_features_elementwise_test_app COMMAND searchlib_features_elementwise_test_app)

--- a/searchlib/src/tests/features/elementwise/elementwise_test.cpp
+++ b/searchlib/src/tests/features/elementwise/elementwise_test.cpp
@@ -1,0 +1,127 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchlib/features/elementwise_blueprint.h>
+#include <vespa/searchlib/features/setup.h>
+#include <vespa/searchlib/fef/blueprintfactory.h>
+#include <vespa/searchlib/fef/featurenamebuilder.h>
+#include <vespa/searchlib/fef/test/dummy_dependency_handler.h>
+#include <vespa/searchlib/fef/test/indexenvironment.h>
+#include <vespa/searchlib/fef/test/indexenvironmentbuilder.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using search::features::ElementwiseBlueprint;
+using search::features::setup_search_features;
+using search::fef::Blueprint;
+using search::fef::BlueprintFactory;
+using search::fef::FeatureNameBuilder;
+using search::fef::FieldInfo;
+using search::fef::FieldType;
+using search::fef::test::DummyDependencyHandler;
+using search::fef::test::IndexEnvironment;
+using search::fef::test::IndexEnvironmentBuilder;
+using CollectionType = FieldInfo::CollectionType;
+using StringVector = std::vector<std::string>;
+
+namespace {
+
+std::string elementwise_feature_base_name = "elementwise";
+
+std::string feature_name(const StringVector& params) {
+    FeatureNameBuilder builder;
+    builder.baseName(elementwise_feature_base_name);
+    for (auto& param : params) {
+        builder.parameter(param);
+    }
+    return builder.buildName();
+}
+
+}
+
+class ElementwiseBlueprintTest : public ::testing::Test {
+protected:
+    BlueprintFactory factory;
+    IndexEnvironment index_env;
+
+    ElementwiseBlueprintTest();
+    ~ElementwiseBlueprintTest() override;
+
+    std::shared_ptr<Blueprint> make_blueprint() const;
+    void expect_setup_fail(const StringVector& params);
+    void expect_bm25_setup_succeed(const StringVector& params);
+};
+
+ElementwiseBlueprintTest::ElementwiseBlueprintTest()
+    : ::testing::Test()
+{
+    setup_search_features(factory);
+    IndexEnvironmentBuilder builder(index_env);
+    builder.addField(FieldType::INDEX, CollectionType::SINGLE, "is");
+    builder.addField(FieldType::INDEX, CollectionType::ARRAY, "ia");
+    builder.addField(FieldType::INDEX, CollectionType::WEIGHTEDSET, "iws");
+    builder.addField(FieldType::ATTRIBUTE, CollectionType::SINGLE, "as");
+}
+
+ElementwiseBlueprintTest::~ElementwiseBlueprintTest() = default;
+
+std::shared_ptr<Blueprint>
+ElementwiseBlueprintTest::make_blueprint() const
+{
+    return factory.createBlueprint(elementwise_feature_base_name);
+}
+
+void
+ElementwiseBlueprintTest::expect_setup_fail(const StringVector& params)
+{
+    SCOPED_TRACE(feature_name(params));
+    auto blueprint = make_blueprint();
+    DummyDependencyHandler deps(*blueprint);
+    EXPECT_FALSE(blueprint->setup(index_env, params));
+    std::cerr << "fail msg: " << deps.fail_msg << std::endl;
+}
+
+void
+ElementwiseBlueprintTest::expect_bm25_setup_succeed(const StringVector& params)
+{
+    SCOPED_TRACE(feature_name(params));
+    auto blueprint = make_blueprint();
+    DummyDependencyHandler deps(*blueprint);
+    EXPECT_TRUE(blueprint->setup(index_env, params));
+    EXPECT_EQ(0, deps.input.size());
+    EXPECT_EQ(StringVector({"score"}), deps.output);
+}
+
+TEST_F(ElementwiseBlueprintTest, blueprint_can_be_created_from_factory)
+{
+    auto bp = factory.createBlueprint(elementwise_feature_base_name);
+    EXPECT_TRUE(bp.get() != nullptr);
+    EXPECT_TRUE(dynamic_cast<ElementwiseBlueprint*>(bp.get()) != nullptr);
+}
+
+TEST_F(ElementwiseBlueprintTest, blueprint_setup_fails_when_feature_is_unknown)
+{
+    expect_setup_fail({"unknownFeature", "x"});   // unknown feature
+
+}
+
+TEST_F(ElementwiseBlueprintTest, blueprint_setup_fails_when_parameter_list_is_not_valid)
+{
+    expect_setup_fail({});           // wrong parameter number
+    expect_setup_fail({"bm25"});   // wrong parameter number
+    expect_setup_fail({"bm25", "x"});   // wrong parameter number
+    expect_setup_fail({"bm25(as)", "x"});       // 'as' is an attribute
+    expect_setup_fail({"bm25(is,ia)", "x"}); // wrong parameter number
+}
+
+TEST_F(ElementwiseBlueprintTest, blueprint_setup_fails_when_cell_type_is_malformed)
+{
+    expect_setup_fail({"bm25(is)", "x", "complex"});
+}
+
+TEST_F(ElementwiseBlueprintTest, blueprint_setup_succeeds_for_index_field)
+{
+    expect_bm25_setup_succeed({"bm25(is)", "x"});
+    expect_bm25_setup_succeed({"bm25(ia)", "x"});
+    expect_bm25_setup_succeed({"bm25(iws)", "x"});
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/features/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/features/CMakeLists.txt
@@ -20,6 +20,11 @@ vespa_add_library(searchlib_features OBJECT
     dotproductfeature.cpp
     element_completeness_feature.cpp
     element_similarity_feature.cpp
+    elementwise_blueprint.cpp
+    elementwise_bm25_blueprint.cpp
+    elementwise_bm25_executor.cpp
+    elementwise_output.cpp
+    elementwise_utils.cpp
     euclidean_distance_feature.cpp
     fieldinfofeature.cpp
     fieldlengthfeature.cpp

--- a/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
@@ -123,7 +123,7 @@ Bm25Blueprint::setup(const fef::IIndexEnvironment& env, const fef::ParameterList
     if (_field == nullptr) {
         return false;
     }
-    Bm25Utils bm25_utils(getBaseName(), _field->name(), env.getProperties());
+    Bm25Utils bm25_utils(getBaseName() + "(" + _field->name() + ").", env.getProperties());
 
     if (bm25_utils.lookup_param(Bm25Utils::k1(), _k1_param) == Trinary::Undefined) {
         return false;

--- a/searchlib/src/vespa/searchlib/features/bm25_feature.h
+++ b/searchlib/src/vespa/searchlib/features/bm25_feature.h
@@ -1,5 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#pragma once
+
+#include "bm25_utils.h"
 #include <vespa/searchlib/fef/blueprint.h>
 #include <vespa/searchlib/fef/featureexecutor.h>
 
@@ -9,20 +12,7 @@ namespace search::features {
  * Executor for the BM25 ranking algorithm over a single index field.
  */
 class Bm25Executor : public fef::FeatureExecutor {
-private:
-    struct QueryTerm {
-        fef::TermFieldHandle handle;
-        const fef::TermFieldMatchData* tfmd;
-        double idf_mul_k1_plus_one;
-        double degraded_score;
-        QueryTerm(fef::TermFieldHandle handle_, double inverse_doc_freq, double k1_param) noexcept
-            : handle(handle_),
-              tfmd(nullptr),
-              idf_mul_k1_plus_one(inverse_doc_freq * (k1_param + 1)),
-              degraded_score(inverse_doc_freq)
-        {}
-    };
-
+    using QueryTerm = Bm25Utils::QueryTerm;
     using QueryTermVector = std::vector<QueryTerm>;
 
     QueryTermVector _terms;

--- a/searchlib/src/vespa/searchlib/features/bm25_utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/bm25_utils.cpp
@@ -19,12 +19,13 @@ using vespalib::Trinary;
 
 namespace search::features {
 
+std::string Bm25Utils::_average_element_length("averageElementLength");
 std::string Bm25Utils::_average_field_length("averageFieldLength");
 std::string Bm25Utils::_b("b");
 std::string Bm25Utils::_k1("k1");
 
-Bm25Utils::Bm25Utils(const std::string &base_name, const std::string &field_name, const fef::Properties& properties)
-    : _property_key_prefix(base_name + "(" + field_name + ")."),
+Bm25Utils::Bm25Utils(const std::string& property_key_prefix, const fef::Properties& properties)
+    : _property_key_prefix(property_key_prefix),
       _properties(properties)
 {
 }

--- a/searchlib/src/vespa/searchlib/features/bm25_utils.h
+++ b/searchlib/src/vespa/searchlib/features/bm25_utils.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/searchlib/fef/handle.h>
 #include <vespa/vespalib/util/trinary.h>
 #include <optional>
 #include <string>
@@ -13,29 +14,45 @@ class IQueryEnvironment;
 class ITermData;
 class ITermFieldData;
 class Properties;
+class TermFieldMatchData;
 
 }
 
 namespace search::features {
 
 /*
- * Class containing shared code between bm25 feature and bm25PerElement feature.
+ * Class containing shared code between bm25 ranking feature and elementwise bm25 ranking feature.
  */
 class Bm25Utils {
     std::string _property_key_prefix;
     const fef::Properties& _properties;
+    static std::string _average_element_length;
     static std::string _average_field_length;
     static std::string _b;
     static std::string _k1;
 public:
-     Bm25Utils(const std::string& base_name, const std::string& field_name, const fef::Properties& properties);
-     ~Bm25Utils();
+    struct QueryTerm {
+        fef::TermFieldHandle handle;
+        const fef::TermFieldMatchData* tfmd;
+        double idf_mul_k1_plus_one;
+        double degraded_score;
+        QueryTerm(fef::TermFieldHandle handle_, double inverse_doc_freq, double k1_param) noexcept
+            : handle(handle_),
+              tfmd(nullptr),
+              idf_mul_k1_plus_one(inverse_doc_freq * (k1_param + 1)),
+              degraded_score(inverse_doc_freq)
+        {}
+    };
+
+    Bm25Utils(const std::string& property_key_prefix, const fef::Properties& properties);
+    ~Bm25Utils();
     vespalib::Trinary lookup_param(const std::string& param, double& result) const;
     vespalib::Trinary lookup_param(const std::string& param, std::optional<double>& result) const;
     static double calculate_inverse_document_frequency(search::fef::DocumentFrequency doc_freq) noexcept;
     static double get_inverse_document_frequency(const fef::ITermFieldData &term_field,
                                                  const fef::IQueryEnvironment &env,
                                                  const fef::ITermData &term);
+    static const std::string& average_element_length() noexcept { return _average_element_length; }
     static const std::string& average_field_length() noexcept { return _average_field_length; }
     static const std::string& b() noexcept { return _b; }
     static const std::string& k1() noexcept { return _k1; }

--- a/searchlib/src/vespa/searchlib/features/elementwise_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_blueprint.cpp
@@ -103,9 +103,8 @@ ElementwiseBlueprint::setup(const fef::IIndexEnvironment& env, const fef::Parame
     const auto& nested_feature_base_name = feature_name_parser.baseName();
     auto itr = _nested_blueprints->find(nested_feature_base_name);
     if (itr == _nested_blueprints->end()) {
-        return fail("'%s' is not supported as first argument to %s feature",
-                    nested_feature_base_name.c_str(),
-                    getBaseName().c_str());
+        return fail("'%s' is not a feature with elementwise support",
+                    nested_feature_base_name.c_str());
     }
     _inner_blueprint = itr->second->createInstance();
     DependencyHandlerGuard dependency_handler_guard(*_inner_blueprint, get_dependency_handler());

--- a/searchlib/src/vespa/searchlib/features/elementwise_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_blueprint.cpp
@@ -1,0 +1,137 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "elementwise_blueprint.h"
+#include "elementwise_bm25_blueprint.h"
+#include "elementwise_utils.h"
+#include <vespa/eval/eval/value_type_spec.h>
+#include <vespa/searchlib/fef/featurenameparser.h>
+#include <vespa/searchlib/fef/parametervalidator.h>
+
+using vespalib::eval::CellType;
+
+namespace search::features {
+
+using fef::FeatureNameParser;
+using fef::ParameterDescriptions;
+using fef::ParameterValidator;
+
+namespace {
+
+class DependencyHandlerGuard {
+    fef::Blueprint& _blueprint;
+
+public:
+    DependencyHandlerGuard(fef::Blueprint& blueprint, fef::Blueprint::DependencyHandler* handler);
+    ~DependencyHandlerGuard();
+};
+
+DependencyHandlerGuard::DependencyHandlerGuard(fef::Blueprint& blueprint, fef::Blueprint::DependencyHandler* handler)
+    : _blueprint(blueprint)
+{
+    if (handler != nullptr) {
+        _blueprint.attach_dependency_handler(*handler);
+    }
+}
+
+DependencyHandlerGuard::~DependencyHandlerGuard()
+{
+    _blueprint.detach_dependency_handler();
+}
+
+}
+
+ElementwiseBlueprint::ElementwiseBlueprint()
+    : ElementwiseBlueprint(make_default_nested_blueprints())
+{
+}
+
+ElementwiseBlueprint::ElementwiseBlueprint(NestedBlueprints nested_blueprints)
+    : fef::Blueprint(ElementwiseUtils::elementwise_feature_base_name()),
+      _inner_blueprint(),
+      _nested_blueprints(std::move(nested_blueprints))
+{
+}
+
+ElementwiseBlueprint::~ElementwiseBlueprint() = default;
+
+ElementwiseBlueprint::NestedBlueprints
+ElementwiseBlueprint::make_default_nested_blueprints()
+{
+    auto nested_blueprints = std::make_shared<NestedBlueprints::element_type>();
+    nested_blueprints->emplace("bm25", std::make_shared<ElementwiseBm25Blueprint>());
+    return nested_blueprints;
+}
+
+void
+ElementwiseBlueprint::visitDumpFeatures(const fef::IIndexEnvironment&, fef::IDumpFeatureVisitor&) const
+{
+}
+
+std::unique_ptr<fef::Blueprint>
+ElementwiseBlueprint::createInstance() const
+{
+    return std::make_unique<ElementwiseBlueprint>(_nested_blueprints);
+}
+
+fef::ParameterDescriptions
+ElementwiseBlueprint::getDescriptions() const
+{
+    return fef::ParameterDescriptions().
+        desc().feature().string().
+        desc().feature().string().string();
+}
+
+bool
+ElementwiseBlueprint::setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params)
+{
+    const auto& feature_name = params[0].getValue();
+    const auto& dim_name = params[1].getValue();
+    std::optional<CellType> cell_type;
+    if (params.size() > 2) {
+        const auto& cell_type_name = params[2].getValue();
+        cell_type = vespalib::eval::value_type::cell_type_from_name(cell_type_name);
+        if (!cell_type.has_value()) {
+            return fail("'%s' is not a valid tensor cell type", cell_type_name.c_str());
+        }
+    } else {
+        cell_type.emplace(CellType::DOUBLE);
+    }
+    FeatureNameParser feature_name_parser(feature_name);
+    if (!feature_name_parser.valid()) {
+        return fail("'%s' is not a valid feature name", feature_name.c_str());
+    }
+    const auto& nested_feature_base_name = feature_name_parser.baseName();
+    auto itr = _nested_blueprints->find(nested_feature_base_name);
+    if (itr == _nested_blueprints->end()) {
+        return fail("'%s' is not supported as first argument to %s feature",
+                    nested_feature_base_name.c_str(),
+                    getBaseName().c_str());
+    }
+    _inner_blueprint = itr->second->createInstance();
+    DependencyHandlerGuard dependency_handler_guard(*_inner_blueprint, get_dependency_handler());
+    StringVector nested_params = feature_name_parser.parameters();
+    nested_params.emplace_back(dim_name);
+    nested_params.emplace_back(vespalib::eval::value_type::cell_type_to_name(cell_type.value()));
+    auto nested_descs = _inner_blueprint->getDescriptions();
+    ParameterValidator validator(env, nested_params, nested_descs);
+    auto result = validator.validate();
+    if (!result.valid()) {
+        return fail("The parameter list used for setting up %s for %s is not valid: %s",
+                    nested_feature_base_name.c_str(), getBaseName().c_str(), result.getError().c_str());
+    }
+    return _inner_blueprint->setup(env, result.getParameters());
+}
+
+void
+ElementwiseBlueprint::prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const
+{
+    _inner_blueprint->prepareSharedState(env, store);
+}
+
+fef::FeatureExecutor&
+ElementwiseBlueprint::createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const
+{
+    return _inner_blueprint->createExecutor(env, stash);
+}
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_blueprint.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_blueprint.h
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/fef/blueprint.h>
+#include <map>
+
+namespace search::features {
+
+/**
+ * Blueprint for the elementwise ranking feature. It manages an inner blueprint that creates tensor values as output.
+ *
+ * Example usage: elementwise(bm25(i),x,float) will calculate bm25 feature per element in the field 'i', creating
+ * a tensor with a single mapped dimension 'x' that contains an elementwise aggregated float bm25 score for each term
+ * matching the field. The dimension and cell type are passed as extra parameters to the inner blueprint and calls to
+ * prepareSharedState() and createExecutor() are proxied to the inner blueprint.
+ *
+ * Inner feature name and dimension name are mandatory arguments. Cell type is optional with 'double' as default value.
+ * e.g. both elementwise(bm25(i),x,double) and elementwise(bm25(i),x) will pass (i,x,double) to the inner elementwise
+ * bm25 ranking feature blueprint and rank property keys used for tuning must always contain the cell type name.
+ */
+class ElementwiseBlueprint : public fef::Blueprint {
+public:
+    using NestedBlueprints = std::shared_ptr<std::map<std::string, std::shared_ptr<fef::Blueprint>>>;
+private:
+    std::unique_ptr<fef::Blueprint> _inner_blueprint;
+    NestedBlueprints                _nested_blueprints; // known blueprints that can be first argument to elementwise blueprint
+
+    static NestedBlueprints make_default_nested_blueprints();
+public:
+    ElementwiseBlueprint();
+    ElementwiseBlueprint(NestedBlueprints nested_blueprints);
+    ~ElementwiseBlueprint() override;
+    void visitDumpFeatures(const fef::IIndexEnvironment& env, fef::IDumpFeatureVisitor& visitor) const override;
+    std::unique_ptr<fef::Blueprint> createInstance() const override;
+    fef::ParameterDescriptions getDescriptions() const override;
+    bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
+    void prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const override;
+    fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;
+};
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.cpp
@@ -99,7 +99,7 @@ ElementwiseBm25Blueprint::setup(const fef::IIndexEnvironment& env, const fef::Pa
     }
     _empty_output = vespalib::eval::value_from_spec(_output_tensor_type.to_spec(), FastValueBuilderFactory::get());
     FeatureType output_type = FeatureType::object(_output_tensor_type);
-    describeOutput("score", "The bm25 score for all terms searching in the given index field", output_type);
+    describeOutput("score", "The elementwise bm25 score for all terms searching in the given index field", output_type);
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.cpp
@@ -1,0 +1,126 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "elementwise_bm25_blueprint.h"
+#include "bm25_utils.h"
+#include "elementwise_bm25_executor.h"
+#include "elementwise_blueprint.h"
+#include "elementwise_utils.h"
+#include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/value_codec.h>
+#include <vespa/searchlib/fef/featurenamebuilder.h>
+#include <vespa/searchlib/fef/objectstore.h>
+#include <vespa/vespalib/util/stash.h>
+
+namespace search::features {
+
+using fef::AnyWrapper;
+using fef::Blueprint;
+using fef::FeatureExecutor;
+using fef::FeatureNameBuilder;
+using fef::FeatureType;
+using fef::FieldType;
+using fef::IQueryEnvironment;
+using fef::objectstore::as_value;
+using vespalib::Trinary;
+using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::ValueType;
+
+
+namespace {
+
+double constexpr default_k1_param = 1.2;
+double constexpr default_b_param = 0.75;
+std::string bm25_feature_base_name("bm25");
+
+std::string
+make_avg_element_length_key(const std::string& base_name, const std::string& field_name)
+{
+    return base_name + ".ael." + field_name;
+}
+
+double
+get_average_element_length(const IQueryEnvironment& env, const std::string& field_name)
+{
+    auto info = env.get_field_length_info(field_name);
+    return info.get_average_element_length();
+}
+
+}
+
+ElementwiseBm25Blueprint::ElementwiseBm25Blueprint()
+    : fef::Blueprint("elementwiseBm25"),
+      _field(nullptr),
+      _k1_param(default_k1_param),
+      _b_param(default_b_param),
+      _avg_element_length(),
+      _output_tensor_type(ValueType::error_type())
+{
+}
+
+ElementwiseBm25Blueprint::~ElementwiseBm25Blueprint() = default;
+
+void
+ElementwiseBm25Blueprint::visitDumpFeatures(const fef::IIndexEnvironment&, fef::IDumpFeatureVisitor&) const
+{
+}
+
+std::unique_ptr<fef::Blueprint>
+ElementwiseBm25Blueprint::createInstance() const
+{
+    return std::make_unique<ElementwiseBm25Blueprint>();
+}
+
+fef::ParameterDescriptions
+ElementwiseBm25Blueprint::getDescriptions() const
+{
+    return fef::ParameterDescriptions().desc().indexField(fef::ParameterCollection::ANY).string().string();
+}
+
+bool
+ElementwiseBm25Blueprint::setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params)
+{
+    _field = params[0].asField();
+    auto elementwise_feature_name = ElementwiseUtils::feature_name(bm25_feature_base_name, params);
+    Bm25Utils bm25_utils( elementwise_feature_name +".", env.getProperties());
+
+    if (bm25_utils.lookup_param(Bm25Utils::k1(), _k1_param) == Trinary::Undefined) {
+        return false;
+    }
+    if (bm25_utils.lookup_param(Bm25Utils::b(), _b_param) == Trinary::Undefined) {
+        return false;
+    }
+    if (bm25_utils.lookup_param(Bm25Utils::average_element_length(), _avg_element_length) == Trinary::Undefined) {
+        return false;
+    }
+    auto fail_message = ElementwiseUtils::build_output_tensor_type(_output_tensor_type, params[1].getValue(),
+                                                                   params[2].getValue());
+    if (fail_message.has_value()) {
+        return fail("%s", fail_message.value().c_str());
+    }
+    _empty_output = vespalib::eval::value_from_spec(_output_tensor_type.to_spec(), FastValueBuilderFactory::get());
+    FeatureType output_type = FeatureType::object(_output_tensor_type);
+    describeOutput("score", "The bm25 score for all terms searching in the given index field", output_type);
+    return true;
+}
+
+void
+ElementwiseBm25Blueprint::prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const
+{
+    std::string key = make_avg_element_length_key(bm25_feature_base_name, _field->name());
+    if (store.get(key) == nullptr) {
+        double avg_element_length = _avg_element_length.value_or(get_average_element_length(env, _field->name()));
+        store.add(key, std::make_unique<AnyWrapper<double>>(avg_element_length));
+    }
+}
+
+fef::FeatureExecutor&
+ElementwiseBm25Blueprint::createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const
+{
+    const auto* lookup_result = env.getObjectStore().get(make_avg_element_length_key(bm25_feature_base_name, _field->name()));
+    double avg_element_length = lookup_result != nullptr ?
+                              as_value<double>(*lookup_result) :
+                              _avg_element_length.value_or(get_average_element_length(env, _field->name()));
+    return stash.create<ElementwiseBm25Executor>(*_field, env, avg_element_length, _k1_param, _b_param, *_empty_output);
+}
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.h
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/fef/blueprint.h>
+
+namespace search::features {
+
+/**
+ * Blueprint for the elementwise bm25 ranking feature. It is created by the setup member function in the elementwise
+ * ranking feature blueprint.
+ *
+ * This blueprint expects 3 parameters: index field name, dimension name and cell type.
+ *
+ * Example usage: elementwise(bm25(i),x,float) cause the elementwise ranking feature blueprint to create this blueprint
+ * with parameters (i,x,float) and proxy calls to prepareSharedState() and createExecutor() to this blueprint.
+ * The executor returned by createExecutor() will calculate bm25 feature per element in the field 'i', creating
+ * a tensor with a single mapped dimension 'x' that contains an elementwise aggregated float bm25 score for each term
+ * matching the field.
+ */
+class ElementwiseBm25Blueprint : public fef::Blueprint {
+    const fef::FieldInfo* _field;
+    double _k1_param;
+    double _b_param;
+    std::optional<double> _avg_element_length;
+    vespalib::eval::ValueType              _output_tensor_type;
+    std::unique_ptr<vespalib::eval::Value> _empty_output;
+public:
+    ElementwiseBm25Blueprint();
+    ~ElementwiseBm25Blueprint() override;
+    void visitDumpFeatures(const fef::IIndexEnvironment& env, fef::IDumpFeatureVisitor& visitor) const override;
+    std::unique_ptr<fef::Blueprint> createInstance() const override;
+    fef::ParameterDescriptions getDescriptions() const override;
+    bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
+    void prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const override;
+    fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;
+
+};
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_executor.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_executor.cpp
@@ -1,0 +1,98 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "elementwise_bm25_executor.h"
+#include "bm25_utils.h"
+#include <vespa/searchlib/fef/itermdata.h>
+#include <vespa/searchlib/fef/iqueryenvironment.h>
+#include <vespa/searchlib/fef/match_data_details.h>
+
+namespace search::features {
+
+using fef::ITermData;
+using fef::ITermFieldData;
+using fef::MatchDataDetails;
+using vespalib::eval::Value;
+
+
+ElementwiseBm25Executor::ElementwiseBm25Executor(const fef::FieldInfo& field,
+                           const fef::IQueryEnvironment& env,
+                           double avg_element_length,
+                           double k1_param,
+                           double b_param,
+                           const Value& empty_output)
+    : FeatureExecutor(),
+      _terms(),
+      _avg_element_length(avg_element_length),
+      _k1_mul_b(k1_param * b_param),
+      _k1_mul_one_minus_b(k1_param * (1 - b_param)),
+      _scores(),
+      _output(empty_output)
+{
+    for (size_t i = 0; i < env.getNumTerms(); ++i) {
+        const ITermData* term = env.getTerm(i);
+        for (size_t j = 0; j < term->numFields(); ++j) {
+            const ITermFieldData& term_field = term->field(j);
+            if (field.id() == term_field.getFieldId()) {
+                _terms.emplace_back(term_field.getHandle(MatchDataDetails::Normal),
+                                    Bm25Utils::get_inverse_document_frequency(term_field, env, *term),
+                                    k1_param);
+            }
+        }
+    }
+}
+
+ElementwiseBm25Executor::~ElementwiseBm25Executor() = default;
+
+void
+ElementwiseBm25Executor::handle_bind_match_data(const fef::MatchData& match_data)
+{
+    for (auto& term : _terms) {
+        term.tfmd = match_data.resolveTermField(term.handle);
+    }
+}
+
+void
+ElementwiseBm25Executor::apply_bm25_score(uint32_t num_occs, uint32_t element_id, uint32_t element_length,
+                                          const QueryTerm& term)
+{
+    feature_t norm_element_length = ((feature_t) element_length) / _avg_element_length;
+    feature_t numerator = num_occs * term.idf_mul_k1_plus_one;
+    feature_t denominator = num_occs + (_k1_mul_one_minus_b + _k1_mul_b * norm_element_length);
+    feature_t score = numerator / denominator;
+    auto ins_res = _scores.insert(std::make_pair(element_id, score));
+    if (!ins_res.second) {
+        ins_res.first->second += score;
+    }
+}
+
+void
+ElementwiseBm25Executor::execute(uint32_t doc_id)
+{
+    _scores.clear();
+    uint32_t element_id = 0;
+    uint32_t element_length = 0;
+    uint32_t num_occs = 0;
+    for (const auto& term : _terms) {
+        if (term.tfmd->getDocId() == doc_id) {
+            num_occs = 0;
+            for (auto& pos : *term.tfmd) {
+                if (num_occs > 0 && element_id == pos.getElementId()) {
+                    ++num_occs;
+                } else {
+                    if (num_occs > 0) {
+                        apply_bm25_score(num_occs, element_id, element_length, term);
+                    }
+                    num_occs = 1;
+                    element_id = pos.getElementId();
+                    element_length = pos.getElementLen();
+                }
+            }
+            if (num_occs > 0) {
+                apply_bm25_score(num_occs, element_id, element_length, term);
+            }
+        }
+    }
+    outputs().set_object(0, _output.build(_scores));
+}
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_executor.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_executor.h
@@ -1,0 +1,46 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/fef/featureexecutor.h>
+#include "bm25_utils.h"
+#include "elementwise_output.h"
+#include <vespa/vespalib/stllike/hash_map.h>
+
+namespace search::fef { class IQueryEnvironment; }
+
+namespace search::features {
+
+/**
+ * Executor for the elementwise bm25 ranking algorithm over a single index field. It calculates aggregated bm25 scores
+ * for each element in the field across the terms searching the field. These scores are then used to build an output
+ * tensor with a single mapped dimension, with element id as label value and aggregated bm25 score as tensor cell value.
+ */
+class ElementwiseBm25Executor : public fef::FeatureExecutor {
+    using QueryTerm = Bm25Utils::QueryTerm;
+    using QueryTermVector = std::vector<QueryTerm>;
+
+    QueryTermVector _terms;
+    double _avg_element_length;
+
+    // The 'k1' param determines term frequency saturation characteristics.
+    // The 'b' param adjusts the effects of the element length of the document matched compared to the average element length.
+    double _k1_mul_b;
+    double _k1_mul_one_minus_b;
+    vespalib::hash_map<uint32_t, double> _scores; // element id -> aggregated score mapping
+    ElementwiseOutput _output;
+
+    void apply_bm25_score(uint32_t num_occs, uint32_t element_id, uint32_t element_length, const QueryTerm& term);
+public:
+    ElementwiseBm25Executor(const fef::FieldInfo &field,
+                            const fef::IQueryEnvironment &env,
+                            double avg_element_length,
+                            double k1_param,
+                            double b_param,
+                            const vespalib::eval::Value& empty_output);
+    ~ElementwiseBm25Executor() override;
+    void handle_bind_match_data(const fef::MatchData& match_data) override;
+    void execute(uint32_t docId) override;
+};
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_output.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_output.cpp
@@ -1,0 +1,68 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "elementwise_output.h"
+#include <vespa/searchlib/tensor/fast_value_view.h>
+
+
+using search::tensor::FastValueView;
+using vespalib::SharedStringRepo;
+using vespalib::eval::TypedCells;
+using vespalib::eval::TypifyCellType;
+
+namespace search::features {
+
+namespace {
+
+struct InitializeCells {
+    template <typename CT, typename VCT>
+    static void invoke(VCT& cells) { cells = std::vector<CT>(); };
+};
+
+}
+
+struct ElementwiseOutput::CallBuilderHelper {
+    template <typename CT>
+    static TypedCells invoke(ElementwiseOutput& output, const vespalib::hash_map<uint32_t, double>& scores) {
+        return output.build_helper<CT>(scores);
+    }
+};
+
+
+ElementwiseOutput::ElementwiseOutput(const vespalib::eval::Value& empty_output)
+    : _labels(),
+      _cells(),
+      _empty_output(empty_output),
+      _output()
+{
+    typify_invoke<1, TypifyCellType, InitializeCells>(_empty_output.type().cell_type(), _cells);
+}
+
+ElementwiseOutput::~ElementwiseOutput() = default;
+
+template <typename CT>
+TypedCells
+ElementwiseOutput::build_helper(const vespalib::hash_map<uint32_t, double>& scores)
+{
+    auto& cells = std::get<std::vector<CT>>(_cells);
+    cells.clear();
+    for (auto& elem : scores) {
+        _labels->push_back(SharedStringRepo::Handle::handle_from_number(elem.first).id());
+        cells.emplace_back(static_cast<CT>(elem.second));
+    }
+    return TypedCells(cells);
+}
+
+const vespalib::eval::Value&
+ElementwiseOutput::build(const vespalib::hash_map<uint32_t, double>& scores)
+{
+    if (scores.empty()) {
+        return _empty_output;
+    }
+    _labels.reset();
+    _labels.emplace();
+    auto cells = typify_invoke<1, TypifyCellType, CallBuilderHelper>(_empty_output.type().cell_type(), *this, scores);
+    _output = std::make_unique<FastValueView>(_empty_output.type(), _labels->view(), cells, 1, (size_t)cells.size);
+    return *_output;
+}
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_output.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_output.h
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/eval/eval/value.h>
+#include <vespa/vespalib/stllike/hash_map.h>
+#include <vespa/vespalib/util/shared_string_repo.h>
+#include <optional>
+#include <variant>
+
+namespace search::features {
+
+/*
+ * Class containing a locally built output tensor for elementwise features. The tensor has a single mapped dimension
+ * with element id as label value and the score for the element as cell value. Lifetime of output tensor is until
+ * build() or destructor is called.
+ */
+class ElementwiseOutput {
+        struct CallBuilderHelper;
+        friend struct CallBuilderHelper;
+        std::optional<vespalib::SharedStringRepo::Handles> _labels;
+        std::variant<std::monostate, std::vector<double>, std::vector<float>, std::vector<vespalib::BFloat16>, std::vector<vespalib::eval::Int8Float>> _cells;
+        const vespalib::eval::Value& _empty_output;
+        std::unique_ptr<vespalib::eval::Value> _output;
+
+       template <typename CT>
+       vespalib::eval::TypedCells build_helper(const vespalib::hash_map<uint32_t, double>& scores);
+    public:
+        ElementwiseOutput(const vespalib::eval::Value& empty_output);
+        ~ElementwiseOutput();
+        const vespalib::eval::Value &build(const vespalib::hash_map<uint32_t, double>& scores);
+};
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_utils.cpp
@@ -1,0 +1,52 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "elementwise_utils.h"
+
+#include <memory>
+#include <vespa/eval/eval/value_type_spec.h>
+#include <vespa/searchlib/fef/featurenamebuilder.h>
+#include <vespa/vespalib/util/stringfmt.h>
+
+namespace search::features {
+
+using fef::FeatureNameBuilder;
+using vespalib::eval::CellType;
+using vespalib::eval::ValueType;
+using vespalib::make_string;
+
+std::string ElementwiseUtils::_elementwise_feature_base_name = "elementwise";
+
+std::string
+ElementwiseUtils::feature_name(const std::string& nested_feature_base_name, const fef::ParameterList& params)
+{
+    FeatureNameBuilder builder;
+    constexpr size_t extra_params = 2;
+    builder.baseName(nested_feature_base_name);
+    size_t num_params = params.size();
+    size_t param_idx = 0;
+    for (; param_idx + extra_params < num_params; ++param_idx) {
+        builder.parameter(params[param_idx].getValue());
+    }
+    auto nested_feature_name = builder.buildName();
+    builder.baseName(_elementwise_feature_base_name);
+    builder.clearParameters();
+    builder.parameter(nested_feature_name);
+    for (; param_idx < num_params; ++param_idx) {
+        builder.parameter(params[param_idx].getValue());
+    }
+    return builder.buildName();
+}
+
+std::optional<std::string>
+ElementwiseUtils::build_output_tensor_type(ValueType& output_tensor_type, const std::string& dimension_name,
+                                           const std::string& cell_type_name)
+{
+    auto cell_type = vespalib::eval::value_type::cell_type_from_name(cell_type_name);
+    if (!cell_type.has_value()) {
+        return make_string("'%s' is not a valid tensor cell type", cell_type_name.c_str());
+    }
+    output_tensor_type = ValueType::make_type(cell_type.value(), {{dimension_name}});
+    return std::nullopt;
+}
+
+}

--- a/searchlib/src/vespa/searchlib/features/elementwise_utils.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_utils.h
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/eval/eval/value.h>
+#include <vespa/searchlib/fef/parameter.h>
+#include <optional>
+
+namespace search::features {
+
+/*
+ * Class containing shared code between elementwise ranking features.
+ */
+class ElementwiseUtils {
+    static std::string _elementwise_feature_base_name;
+public:
+    static const std::string& elementwise_feature_base_name() noexcept { return _elementwise_feature_base_name; }
+    /*
+     * Create elementwise rank feature name from inner feature base name and parameter list. This name can be used as
+     * rank property key prefix when handling tuning. e.g. "bm25", ["i", "x", "float"] maps to
+     * "elementwise(bm25(i),x,float)".
+     */
+    static std::string feature_name(const std::string& nested_feature_base_name, const fef::ParameterList& params);
+    static std::optional<std::string> build_output_tensor_type(vespalib::eval::ValueType& output_tensor_type,
+                                                               const std::string& dimension_name,
+                                                               const std::string& cell_type_name);
+};
+
+}

--- a/searchlib/src/vespa/searchlib/features/setup.cpp
+++ b/searchlib/src/vespa/searchlib/features/setup.cpp
@@ -16,6 +16,7 @@
 #include "dotproductfeature.h"
 #include "element_completeness_feature.h"
 #include "element_similarity_feature.h"
+#include "elementwise_blueprint.h"
 #include "euclidean_distance_feature.h"
 #include "fieldinfofeature.h"
 #include "fieldlengthfeature.h"
@@ -86,6 +87,7 @@ void setup_search_features(fef::IBlueprintRegistry & registry)
     registry.addPrototype(std::make_shared<DotProductBlueprint>());
     registry.addPrototype(std::make_shared<ElementCompletenessBlueprint>());
     registry.addPrototype(std::make_shared<ElementSimilarityBlueprint>());
+    registry.addPrototype(std::make_shared<ElementwiseBlueprint>());
     registry.addPrototype(std::make_shared<EuclideanDistanceBlueprint>());
     registry.addPrototype(std::make_shared<FieldInfoBlueprint>());
     registry.addPrototype(std::make_shared<FieldLengthBlueprint>());

--- a/searchlib/src/vespa/searchlib/fef/blueprint.h
+++ b/searchlib/src/vespa/searchlib/fef/blueprint.h
@@ -133,6 +133,11 @@ protected:
     lookupAttribute(const std::string & key, std::string_view attrName, const IQueryEnvironment & env);
     static std::string createAttributeKey(std::string_view attrName);
 
+    /*
+     * Used by elementwise blueprint to forward dependency handler.
+     */
+    DependencyHandler *get_dependency_handler() const noexcept { return _dependency_handler; }
+
 public:
     Blueprint(const Blueprint &) = delete;
     Blueprint &operator=(const Blueprint &) = delete;


### PR DESCRIPTION
The rank feature elementwise(bm25(i),x,float) will calculate elementwise bm25 ranking for field 'i' over terms searching in 'i' and create an output tensor with type tensor<float>(x{}) with element id as label value and aggregated bm25 score for the element as tensor cell value.

@geirst : please review
@vekterli : FYI
