### PR TITLE
Fail when conflict between tensor field and non-tensor field in fieldset

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/FieldSetSettings.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/FieldSetSettings.java
@@ -149,11 +149,9 @@ public class FieldSetSettings extends Processor {
             }
         }
         if (!tensorFields.isEmpty() && !nonTensorFields.isEmpty()) {
-            var fullMsg = "For schema '" + schema.getName() + "', fieldset '" + fieldSet.getName() + "': " +
-                    "Tensor fields ['" + String.join("', '", tensorFields) + "'] " +
-                    "cannot be mixed with non-tensor fields ['" + String.join("', '", nonTensorFields) + "'] " +
-                    "in the same fieldset. See " + fieldSetDocUrl;
-            deployLogger.logApplicationPackage(Level.WARNING, fullMsg);
+            throw new IllegalArgumentException("For schema '" + schema.getName() + "', fieldset '" + fieldSet.getName() + "': " +
+                    "Illegal mixing of tensor fields ['" + String.join("','", tensorFields) + "'] " +
+                    "and non-tensor fields ['" + String.join("','", nonTensorFields) + "']");
         }
     }
 }

--- a/config-model/src/test/java/com/yahoo/schema/processing/FieldSetSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/FieldSetSettingsTestCase.java
@@ -15,6 +15,7 @@ import static com.yahoo.schema.document.MatchType.WORD;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FieldSetSettingsTestCase {
 
@@ -42,10 +43,8 @@ public class FieldSetSettingsTestCase {
 
     @Test
     public void illegalFieldTypeMix() {
-        var logger = new TestableDeployLogger();
-        assertDoesNotThrow(() -> createFromStrings(logger, childSd( "fieldset default { fields: ci, pt }"), parentSd()));
-        assertArrayEquals(new String[]{"For schema 'child', fieldset 'default': Tensor fields ['pt'] cannot be mixed with non-tensor fields ['ci'] in the same fieldset. " +
-                "See https://docs.vespa.ai/en/reference/schema-reference.html#fieldset"}, logger.warnings.toArray());
+        var e = assertThrows(IllegalArgumentException.class, () -> createFromStrings(new BaseDeployLogger(), childSd( "fieldset default { fields: ci, pt }"), parentSd()));
+        assertEquals("For schema 'child', fieldset 'default': Illegal mixing of tensor fields ['pt'] and non-tensor fields ['ci']", e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Followup to https://github.com/vespa-engine/vespa/pull/32174, we can now fail instead of just logging a warning.