### PR TITLE
Make direct message scheduling from RPC threads live (re-)configurable

### DIFF
--- a/configdefinitions/src/vespa/stor-filestor.def
+++ b/configdefinitions/src/vespa/stor-filestor.def
@@ -35,7 +35,7 @@ bucket_merge_chunk_size int default=16772216 restart
 ## gets the next async message to handle (if any) as part of scheduling a storage message.
 ## This async message is then handled by the calling thread immediately,
 ## instead of going via a persistence thread.
-use_async_message_handling_on_schedule bool default=false restart
+use_async_message_handling_on_schedule bool default=false
 
 ## The noise level used when deciding whether a resource usage sample should be reported to the cluster controller.
 ##

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -205,7 +205,7 @@ FileStorManager::on_configure(const StorFilestorConfig& config)
     // If true, this is not the first configure.
     const bool liveUpdate = ! _threads.empty();
 
-    _use_async_message_handling_on_schedule = config.useAsyncMessageHandlingOnSchedule;
+    _use_async_message_handling_on_schedule.store(config.useAsyncMessageHandlingOnSchedule, std::memory_order_relaxed);
     _host_info_reporter.set_noise_level(config.resourceUsageReporterNoiseLevel);
     const bool use_dynamic_throttling = (config.asyncOperationThrottler.type == StorFilestorConfig::AsyncOperationThrottler::Type::DYNAMIC);
 
@@ -329,7 +329,7 @@ FileStorManager::handlePersistenceMessage(const shared_ptr<api::StorageMessage>&
     api::ReturnCode errorCode(api::ReturnCode::OK);
     LOG(spam, "Received %s. Attempting to queue it.", msg->getType().getName().c_str());
 
-    if (_use_async_message_handling_on_schedule) {
+    if (use_async_message_handling_on_schedule()) {
        auto result = _filestorHandler->schedule_and_get_next_async_message(msg);
        if (result.was_scheduled()) {
            if (result.has_async_message()) {

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -66,7 +66,7 @@ class FileStorManager : public StorageLinkQueued,
     std::unique_ptr<BucketOwnershipNotifier>         _bucketOwnershipNotifier;
 
     std::unique_ptr<StorFilestorConfig> _config;
-    bool                                _use_async_message_handling_on_schedule;
+    std::atomic<bool>                   _use_async_message_handling_on_schedule;
     std::shared_ptr<FileStorMetrics>    _metrics;
     std::unique_ptr<FileStorHandler>    _filestorHandler;
     std::unique_ptr<vespalib::ISequencedTaskExecutor> _sequencedExecutor;
@@ -138,6 +138,10 @@ private:
     StorBucketDatabase::WrappedEntry mapOperationToDisk(api::StorageMessage&, const document::Bucket&);
     StorBucketDatabase::WrappedEntry mapOperationToBucketAndDisk(api::BucketCommand&, const document::DocumentId*);
     bool handlePersistenceMessage(const std::shared_ptr<api::StorageMessage>&);
+
+    [[nodiscard]] bool use_async_message_handling_on_schedule() const noexcept {
+        return _use_async_message_handling_on_schedule.load(std::memory_order_relaxed);
+    }
 
     // Document operations
     bool onPut(const std::shared_ptr<api::PutCommand>&) override;


### PR DESCRIPTION
@geirst or @toregge please review
@hmusum FYI

Previously was tagged as `restart` even though it was internally a live reconfig. However, the live reconfig did not use atomics to ensure well-defined behavior. This commit adds that.
