### PR TITLE
Initial commit for the global-phase rank-score-drop-limit

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/RankProfile.java
@@ -111,6 +111,7 @@ public class RankProfile implements Cloneable {
     /** The drop limit used to drop hits with rank score less than or equal to this value */
     private double rankScoreDropLimit = -Double.MAX_VALUE;
     private double secondPhaseRankScoreDropLimit = -Double.MAX_VALUE;
+    private double globalPhaseRankScoreDropLimit = -Double.MAX_VALUE;
 
     private Set<ReferenceNode> summaryFeatures;
     private String inheritedSummaryFeaturesProfileName;
@@ -871,6 +872,16 @@ public class RankProfile implements Cloneable {
         }
         return uniquelyInherited(RankProfile::getSecondPhaseRankScoreDropLimit, c -> c > -Double.MAX_VALUE, "second-phase rank-score-drop-limit")
                 .orElse(secondPhaseRankScoreDropLimit);
+    }
+
+    public void setGlobalPhaseRankScoreDropLimit(double limit) { this.globalPhaseRankScoreDropLimit = limit; }
+
+    public double getGlobalPhaseRankScoreDropLimit() {
+        if (globalPhaseRankScoreDropLimit > -Double.MAX_VALUE) {
+            return globalPhaseRankScoreDropLimit;
+        }
+        return uniquelyInherited(RankProfile::getGlobalPhaseRankScoreDropLimit, c -> c > -Double.MAX_VALUE, "global-phase rank-score-drop-limit")
+                .orElse(globalPhaseRankScoreDropLimit);
     }
 
     public void addFunction(String name, List<String> arguments, String expression, boolean inline) {

--- a/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
@@ -174,6 +174,7 @@ public class RawRankProfile {
         private final OptionalDouble filterThreshold;
         private final double rankScoreDropLimit;
         private final double secondPhaseRankScoreDropLimit;
+        private final double globalPhaseRankScoreDropLimit;
         private final boolean sortBlueprintsByCost;
         private final boolean alwaysMarkPhraseExpensive;
 
@@ -230,6 +231,7 @@ public class RawRankProfile {
             keepRankCount = compiled.getKeepRankCount();
             rankScoreDropLimit = compiled.getRankScoreDropLimit();
             secondPhaseRankScoreDropLimit = compiled.getSecondPhaseRankScoreDropLimit();
+            globalPhaseRankScoreDropLimit = compiled.getGlobalPhaseRankScoreDropLimit();
             ignoreDefaultRankFeatures = compiled.getIgnoreDefaultRankFeatures();
             rankProperties = new ArrayList<>(compiled.getRankProperties());
 
@@ -525,6 +527,9 @@ public class RawRankProfile {
             }
             if (globalPhaseRerankCount > -1) {
                 properties.add(new Pair<>("vespa.globalphase.rerankcount", globalPhaseRerankCount + ""));
+            }
+            if (globalPhaseRankScoreDropLimit > -Double.MAX_VALUE) {
+                properties.add(new Pair<>("vespa.globalphase.rankscoredroplimit", globalPhaseRankScoreDropLimit + ""));
             }
             if (rankScoreDropLimit > -Double.MAX_VALUE) {
                 properties.add(new Pair<>("vespa.hitcollector.rankscoredroplimit", rankScoreDropLimit + ""));

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
@@ -28,6 +28,7 @@ public class ParsedRankProfile extends ParsedBlock {
     private boolean ignoreDefaultRankFeatures = false;
     private Double rankScoreDropLimit = null;
     private Double secondPhaseRankScoreDropLimit = null;
+    private Double globalPhaseRankScoreDropLimit = null;
     private Double termwiseLimit = null;
     private Double postFilterThreshold = null;
     private Double approximateThreshold = null;
@@ -92,6 +93,7 @@ public class ParsedRankProfile extends ParsedBlock {
     List<MutateOperation> getMutateOperations() { return List.copyOf(mutateOperations); }
     List<String> getInherited() { return List.copyOf(inherited); }
     Optional<Integer> getGlobalPhaseRerankCount() { return Optional.ofNullable(this.globalPhaseRerankCount); }
+    Optional<Double> getGlobalPhaseRankScoreDropLimit() { return Optional.ofNullable(this.globalPhaseRankScoreDropLimit); }
     Optional<String> getGlobalPhaseExpression() { return Optional.ofNullable(this.globalPhaseExpression); }
 
     Map<String, Boolean> getFieldsWithRankFilter() { return Collections.unmodifiableMap(fieldsRankFilter); }
@@ -223,6 +225,11 @@ public class ParsedRankProfile extends ParsedBlock {
     public void setSecondPhaseRankScoreDropLimit(double limit) {
         verifyThat(secondPhaseRankScoreDropLimit == null, "already has rank-score-drop-limit for second phase");
         this.secondPhaseRankScoreDropLimit = limit;
+    }
+
+    public void setGlobalPhaseRankScoreDropLimit(double limit) {
+        verifyThat(globalPhaseRankScoreDropLimit == null, "already has global-phase rank-score-drop-limit");
+        this.globalPhaseRankScoreDropLimit = limit;
     }
 
     public void setRerankCount(int count) {

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
@@ -60,6 +60,7 @@ public class ParsedRankingConverter {
 
         parsed.getRankScoreDropLimit().ifPresent(profile::setRankScoreDropLimit);
         parsed.getSecondPhaseRankScoreDropLimit().ifPresent(profile::setSecondPhaseRankScoreDropLimit);
+        parsed.getGlobalPhaseRankScoreDropLimit().ifPresent(profile::setGlobalPhaseRankScoreDropLimit);
         parsed.getTermwiseLimit().ifPresent(profile::setTermwiseLimit);
         parsed.getPostFilterThreshold().ifPresent(profile::setPostFilterThreshold);
         parsed.getApproximateThreshold().ifPresent(profile::setApproximateThreshold);

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -2027,10 +2027,12 @@ void globalPhaseItem(ParsedRankProfile profile) :
 {
     String expression;
     int rerankCount;
+    double dropLimit;
 }
 {
     ( expression = expression()                       { profile.setGlobalPhaseExpression(expression); }
     | (<RERANK_COUNT> <COLON> rerankCount = integer()) { profile.setGlobalPhaseRerankCount(rerankCount); }
+    | (<RANK_SCORE_DROP_LIMIT> <COLON> dropLimit = floatValue()) { profile.setGlobalPhaseRankScoreDropLimit(dropLimit); }
     )
 }
 

--- a/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
@@ -98,6 +98,7 @@ public class SchemaParserTestCase {
                     global-phase {
                         expression: onnx(mymodel)
                         rerank-count: 79
+                        rank-score-drop-limit: 1.0
                     }
                 }
             }
@@ -116,8 +117,10 @@ public class SchemaParserTestCase {
         assertEquals("bar", rp1.name());
         assertTrue(rp1.getGlobalPhaseRerankCount().isPresent());
         assertTrue(rp1.getGlobalPhaseExpression().isPresent());
+        assertTrue(rp1.getGlobalPhaseRankScoreDropLimit().isPresent());
         assertEquals(79, rp1.getGlobalPhaseRerankCount().get());
         assertEquals("onnx(mymodel)", rp1.getGlobalPhaseExpression().get());
+        assertEquals(1.0d, rp1.getGlobalPhaseRankScoreDropLimit().get());
     }
 
     @Test

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7089,6 +7089,8 @@
       "public static com.yahoo.search.query.profile.types.QueryProfileType getArgumentType()",
       "public void setRerankCount(int)",
       "public java.lang.Integer getRerankCount()",
+      "public void setRankScoreDropLimit(double)",
+      "public java.lang.Double getRankScoreDropLimit()",
       "public int hashCode()",
       "public boolean equals(java.lang.Object)",
       "public com.yahoo.search.query.ranking.GlobalPhase clone()",

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -113,6 +113,9 @@ public class QueryProperties extends Properties {
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.GLOBAL_PHASE, Ranking.RERANKCOUNT),
                 GetterSetter.of(query -> query.getRanking().getGlobalPhase().getRerankCount(),
                                 (query, value) -> query.getRanking().getGlobalPhase().setRerankCount(asInteger(value, null))));
+        map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.GLOBAL_PHASE, Ranking.RANKSCOREDROPLIMIT),
+                GetterSetter.of(query -> query.getRanking().getGlobalPhase().getRankScoreDropLimit(),
+                        (query, value) -> query.getRanking().getGlobalPhase().setRankScoreDropLimit(asDouble(value, null))));
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.SOFTTIMEOUT, SoftTimeout.ENABLE), GetterSetter.of(query -> query.getRanking().getSoftTimeout().getEnable(), (query, value) -> query.getRanking().getSoftTimeout().setEnable(asBoolean(value, true))));
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.SOFTTIMEOUT, SoftTimeout.FACTOR), GetterSetter.of(query -> query.getRanking().getSoftTimeout().getFactor(), (query, value) -> query.getRanking().getSoftTimeout().setFactor(asDouble(value, null))));
         map.put(CompoundName.fromComponents(Ranking.RANKING, Ranking.SOFTTIMEOUT, SoftTimeout.TAILCOST), GetterSetter.of(query -> query.getRanking().getSoftTimeout().getTailcost(), (query, value) -> query.getRanking().getSoftTimeout().setTailcost(asDouble(value, null))));

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/GlobalPhase.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/GlobalPhase.java
@@ -28,6 +28,7 @@ public class GlobalPhase implements Cloneable {
     public static QueryProfileType getArgumentType() { return argumentType; }
 
     private Integer rerankCount = null;
+    private Double rankScoreDropLimit = null;
 
     /**
      * Sets the number of hits for which the global-phase function will be evaluated.
@@ -38,9 +39,22 @@ public class GlobalPhase implements Cloneable {
     /** Returns the rerank-count that will be used, or null if not set */
     public Integer getRerankCount() { return rerankCount; }
 
+    /**
+     * Sets the number of hits for which the global-phase function will be evaluated.
+     * When set, this overrides the setting in the rank profile.
+     */
+    public void setRankScoreDropLimit(double rankScoreDropLimit) {
+        this.rankScoreDropLimit = rankScoreDropLimit;
+    }
+
+    /** Returns the rankScoreDropLimit that will be used, or null if not set */
+    public Double getRankScoreDropLimit() {
+        return rankScoreDropLimit;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.rerankCount);
+        return Objects.hash(this.rerankCount, this.rankScoreDropLimit);
     }
 
     @Override
@@ -48,6 +62,7 @@ public class GlobalPhase implements Cloneable {
         if (o == this) return true;
         if (o instanceof GlobalPhase other) {
             if ( ! Objects.equals(this.rerankCount, other.rerankCount)) return false;
+            if ( ! Objects.equals(this.rankScoreDropLimit, other.rankScoreDropLimit)) return false;
             return true;
         }
         return false;
@@ -58,6 +73,7 @@ public class GlobalPhase implements Cloneable {
         try {
             GlobalPhase clone = (GlobalPhase)super.clone();
             clone.rerankCount = this.rerankCount;
+            clone.rankScoreDropLimit = this.rankScoreDropLimit;
             return clone;
         }
         catch (CloneNotSupportedException e) {

--- a/container-search/src/main/java/com/yahoo/search/ranking/GlobalPhaseSetup.java
+++ b/container-search/src/main/java/com/yahoo/search/ranking/GlobalPhaseSetup.java
@@ -20,18 +20,21 @@ class GlobalPhaseSetup {
 
     final FunEvalSpec globalPhaseEvalSpec;
     final int rerankCount;
+    final double rankScoreDropLimit;
     final Collection<String> matchFeaturesToHide;
     final List<NormalizerSetup> normalizers;
     final Map<String, Tensor> defaultValues;
 
     GlobalPhaseSetup(FunEvalSpec globalPhaseEvalSpec,
                      final int rerankCount,
+                     final double rankScoreDropLimit,
                      Collection<String> matchFeaturesToHide,
                      List<NormalizerSetup> normalizers,
                      Map<String, Tensor> defaultValues)
     {
         this.globalPhaseEvalSpec = globalPhaseEvalSpec;
         this.rerankCount = rerankCount;
+        this.rankScoreDropLimit = rankScoreDropLimit;
         this.matchFeaturesToHide = matchFeaturesToHide;
         this.normalizers = normalizers;
         this.defaultValues = defaultValues;
@@ -145,6 +148,7 @@ class GlobalPhaseSetup {
         }
         Supplier<FunctionEvaluator> functionEvaluatorSource = null;
         int rerankCount = -1;
+        double rankScoreDropLimit = -Double.MAX_VALUE;
         Set<String> namesToHide = new HashSet<>();
         Set<String> matchFeatures = new HashSet<>();
         Map<String, String> renameFeatures = new HashMap<>();
@@ -152,6 +156,9 @@ class GlobalPhaseSetup {
         for (var prop : rp.fef().property()) {
             if (prop.name().equals("vespa.globalphase.rerankcount")) {
                 rerankCount = Integer.parseInt(prop.value());
+            }
+            if (prop.name().equals("vespa.globalphase.rankscoredroplimit")) {
+                rankScoreDropLimit = Double.parseDouble(prop.value());
             }
             if (prop.name().equals("vespa.rank.globalphase")) {
                 functionEvaluatorSource = () -> model.evaluatorOf("globalphase");
@@ -198,7 +205,7 @@ class GlobalPhaseSetup {
             Supplier<Evaluator> supplier = SimpleEvaluator.wrap(functionEvaluatorSource);
             var gfun = new FunEvalSpec(supplier, mainResolver.fromQuery, mainResolver.fromMF);
             var defaultValues = extraDefaultQueryFeatureValues(rp, mainResolver.fromQuery, normalizers);
-            return new GlobalPhaseSetup(gfun, rerankCount, namesToHide, normalizers, defaultValues);
+            return new GlobalPhaseSetup(gfun, rerankCount, rankScoreDropLimit, namesToHide, normalizers, defaultValues);
         }
         return null;
     }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Implements https://github.com/vespa-engine/vespa/issues/31619

Continuation of https://github.com/vespa-engine/vespa/issues/29955

The idea is to iterate through all hits in the global phase **after re-ranking** and drop those with a lower score than the set threshold.

Or should drop in the global phase work like in the second phase: drop within the reranked hits?