### PR TITLE
Use deployment spec zone endpoint configuration directly

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1032,22 +1032,10 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         InstanceName instance = context.properties().applicationId().instance();
         ZoneId zone = ZoneId.from(context.properties().zone().environment(),
                                   context.properties().zone().region());
-
-        var supportsTokenAuthentication = context.properties()
-                .endpoints()
-                .stream()
-                .anyMatch(endpoint ->
-                        endpoint.authMethod() == ApplicationClusterEndpoint.AuthMethod.token &&
-                        endpoint.clusterId().equals(cluster.value()));
-        var authMethods = supportsTokenAuthentication ?
-                List.of(AuthMethod.mtls, AuthMethod.token) :
-                List.of(AuthMethod.mtls);
-
         return context
                 .getApplicationPackage()
                 .getDeploymentSpec()
-                .zoneEndpoint(instance, zone, cluster)
-                .withAuthMethods(authMethods);
+                .zoneEndpoint(instance, zone, cluster);
     }
 
     private static Map<String, String> getEnvironmentVariables(Element environmentVariables) {


### PR DESCRIPTION
With the addition of `<endpoint auth-method='token'/>` attribute in `DeploymentSpecXmlReader`, using the `DeploymentSpec` directly in this builder should be valid (but may not consider whether `token` is present in `services.xml`). I don't believe `ContainerEndpoint` can be used, given that auth data from `ZoneEndpoint` config is lost during endpoint generation and we can't know whether the endpoint should actually be in private DNS. 

Could you verify that this is valid approach @mpolden ? 
