### PR TITLE
Export com.yahoo.vespa.athenz.client.common

### DIFF
--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/common/package-info.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/common/package-info.java
@@ -1,0 +1,6 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+@ExportPackage
+package com.yahoo.vespa.athenz.client.common;
+
+import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
Needed to fix 
```
[2025-02-13 15:54:49] 
	Exception thrown while activating application.
	exception=
	com.yahoo.container.di.componentgraph.core.ComponentNode$ComponentConstructorException: Error constructing 'com.yahoo.vespa.hosted.HostedServiceRegistry': null
	Caused by: java.lang.NoClassDefFoundError: com/yahoo/vespa/athenz/client/common/ClientBase
	at ai.vespa.hosted.azure.AthenzTokenCredential$Builder.ztsClient(AthenzTokenCredential.java:81)
	at com.yahoo.vespa.hosted.clients.azure.AzureOsImageRegistry.<init>(AzureOsImageRegistry.java:41)
	at com.yahoo.vespa.hosted.HostedServiceRegistry.createOsImageRegistries(HostedServiceRegistry.java:495)
	Caused by: java.lang.ClassNotFoundException: com.yahoo.vespa.athenz.client.common.ClientBase not found by azure [38]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1591)
	at org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1976)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 3 more
```