### PR TITLE
Suuport feature flag RESOURCE_LIMIT_LOW_WATERMARK_DIFFERENCE

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1319,6 +1319,7 @@
       "public int maxActivationInhibitedOutOfSyncGroups()",
       "public double resourceLimitDisk()",
       "public double resourceLimitMemory()",
+      "public double resourceLimitLowWatermarkDifference()",
       "public double resourceLimitMemorySmallNodes()",
       "public double minNodeRatioPerGroup()",
       "public boolean forwardIssuesAsErrors()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -100,6 +100,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxActivationInhibitedOutOfSyncGroups() { return 0; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitDisk() { return 0.75; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitMemory() { return 0.8; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitLowWatermarkDifference() { return 0.0; }
         @ModelFeatureFlag(owners = {"hmusum"}, removeAfter = "8.475") default double resourceLimitMemorySmallNodes() { return 0.75; }
         @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default double minNodeRatioPerGroup() { return 0.0; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean forwardIssuesAsErrors() { return true; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -58,6 +58,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private List<X509Certificate> operatorCertificates = List.of();
     private double resourceLimitDisk = 0.75;
     private double resourceLimitMemory = 0.8;
+    private double resourceLimitLowWatermarkDifference = 0.0;
     private double minNodeRatioPerGroup = 0.0;
     private int maxUnCommittedMemory = 123456;
     private boolean useV8GeoPositions = true;
@@ -109,6 +110,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public List<X509Certificate> operatorCertificates() { return operatorCertificates; }
     @Override public double resourceLimitDisk() { return resourceLimitDisk; }
     @Override public double resourceLimitMemory() { return resourceLimitMemory; }
+    @Override public double resourceLimitLowWatermarkDifference() { return resourceLimitLowWatermarkDifference; }
     @Override public double minNodeRatioPerGroup() { return minNodeRatioPerGroup; }
     @Override public int maxUnCommittedMemory() { return maxUnCommittedMemory; }
     @Override public boolean useV8GeoPositions() { return useV8GeoPositions; }
@@ -256,6 +258,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setResourceLimitMemory(double value) {
         this.resourceLimitMemory = value;
+        return this;
+    }
+
+    public TestProperties setResourceLimitLowWatermarkDifference(double value) {
+        this.resourceLimitLowWatermarkDifference = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.model.content.cluster;
 import com.google.common.base.Preconditions;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelContext;
-import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AnyConfigProducer;
 import com.yahoo.config.model.producer.TreeConfigProducer;
@@ -101,7 +100,6 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
     private Integer maxNodesPerMerge;
     private final Zone zone;
     private final Optional<Integer> distributionBitsInPreviousModel;
-    private final ModelContext.FeatureFlags featureFlags;
 
     public enum DistributionMode { LEGACY, STRICT, LOOSE }
     private DistributionMode distributionMode;
@@ -185,6 +183,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
             var resourceLimits = new ClusterResourceLimits.Builder(isHosted,
                                                                    deployState.featureFlags().resourceLimitDisk(),
                                                                    resourceLimitMemory,
+                                                                   deployState.featureFlags().resourceLimitLowWatermarkDifference(),
                                                                    deployState.getDeployLogger())
                     .build(contentElement);
 
@@ -468,7 +467,6 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
         this.documentSelection = routingSelection;
         this.zone = deployState.zone();
         this.distributionBitsInPreviousModel = distributionBitsInPreviousModel(deployState, clusterId);
-        this.featureFlags = deployState.featureFlags();
     }
 
     public ClusterSpec.Id id() { return ClusterSpec.Id.from(clusterId); }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
@@ -23,6 +23,7 @@ public class ClusterResourceLimitsTest {
         private final boolean hostedVespa;
         private final ResourceLimits.Builder ctrlBuilder = new ResourceLimits.Builder();
         private final ResourceLimits.Builder nodeBuilder = new ResourceLimits.Builder();
+        private double lowWatermarkDifference = 0.0;
 
         public Fixture() {
             this(false);
@@ -48,11 +49,16 @@ public class ClusterResourceLimitsTest {
             nodeBuilder.setMemoryLimit(limit);
             return this;
         }
+        public Fixture lowWatermarkDifference(double lowWatermarkDifference) {
+            this.lowWatermarkDifference = lowWatermarkDifference;
+            return this;
+        }
         public ClusterResourceLimits build() {
             ModelContext.FeatureFlags featureFlags = new TestProperties();
             var builder = new ClusterResourceLimits.Builder(hostedVespa,
                                                             featureFlags.resourceLimitDisk(),
                                                             featureFlags.resourceLimitMemory(),
+                                                            lowWatermarkDifference,
                                                             new TestLogger());
             builder.setClusterControllerBuilder(ctrlBuilder);
             builder.setContentNodeBuilder(nodeBuilder);
@@ -62,47 +68,49 @@ public class ClusterResourceLimitsTest {
 
     @Test
     void content_node_limits_are_derived_from_cluster_controller_limits_if_not_set() {
-        assertLimits(0.4, 0.7, 0.76, 0.85,
+        assertLimits(0.4, 0.7, 0.76, 0.85, 0.0,
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7));
-        assertLimits(0.4, 0.8, 0.76, 0.9,
+        assertLimits(0.4, 0.8, 0.76, 0.9, 0.0,
                 new Fixture().ctrlDisk(0.4));
-        assertLimits(0.75, 0.7, 0.9, 0.85,
+        assertLimits(0.75, 0.7, 0.9, 0.85, 0.0,
                 new Fixture().ctrlMemory(0.7));
+        assertLimits(0.75, 0.7, 0.9, 0.85, 0.05,
+                     new Fixture().ctrlMemory(0.7).lowWatermarkDifference(0.05));
     }
 
     @Test
     void content_node_limits_can_be_set_explicit() {
-        assertLimits(0.4, 0.7, 0.9, 0.95,
+        assertLimits(0.4, 0.7, 0.9, 0.95, 0.0,
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7).nodeDisk(0.9).nodeMemory(0.95));
-        assertLimits(0.4, 0.8, 0.95, 0.9,
+        assertLimits(0.4, 0.8, 0.95, 0.9, 0.0,
                 new Fixture().ctrlDisk(0.4).nodeDisk(0.95));
-        assertLimits(0.75, 0.7, 0.9, 0.95,
+        assertLimits(0.75, 0.7, 0.9, 0.95, 0.0,
                 new Fixture().ctrlMemory(0.7).nodeMemory(0.95));
     }
 
     @Test
     void cluster_controller_limits_are_equal_to_content_node_limits_minus_one_percent_if_not_set() {
-        assertLimits(0.89, 0.94, 0.9, 0.95,
+        assertLimits(0.89, 0.94, 0.9, 0.95, 0.0,
                 new Fixture().nodeDisk(0.9).nodeMemory(0.95));
-        assertLimits(0.89, 0.8, 0.9, 0.9,
+        assertLimits(0.89, 0.8, 0.9, 0.9, 0.0,
                 new Fixture().nodeDisk(0.9));
-        assertLimits(0.75, 0.94, 0.9, 0.95,
+        assertLimits(0.75, 0.94, 0.9, 0.95, 0.0,
                 new Fixture().nodeMemory(0.95));
-        assertLimits(0.75, 0.0, 0.9, 0.005,
+        assertLimits(0.75, 0.0, 0.9, 0.005, 0.0,
                 new Fixture().nodeMemory(0.005));
     }
 
     @Test
     void limits_are_derived_from_the_other_if_not_set() {
-        assertLimits(0.6, 0.94, 0.84, 0.95,
+        assertLimits(0.6, 0.94, 0.84, 0.95, 0.0,
                 new Fixture().ctrlDisk(0.6).nodeMemory(0.95));
-        assertLimits(0.89, 0.7, 0.9, 0.85,
+        assertLimits(0.89, 0.7, 0.9, 0.85, 0.0,
                 new Fixture().ctrlMemory(0.7).nodeDisk(0.9));
     }
 
     @Test
     void default_resource_limits_when_feed_block_is_enabled_in_distributor() {
-        assertLimits(0.75, 0.8, 0.9, 0.9,
+        assertLimits(0.75, 0.8, 0.9, 0.9, 0.0,
                 new Fixture(true));
     }
 
@@ -124,8 +132,8 @@ public class ClusterResourceLimitsTest {
         var limits = hostedBuild(featureFlags, false);
 
         // Verify that limits from feature flags are used
-        assertLimits(0.85, 0.90, limits.getClusterControllerLimits());
-        assertLimits(0.94, 0.95, limits.getContentNodeLimits());
+        assertLimits(0.85, 0.90, 0.0, limits.getClusterControllerLimits());
+        assertLimits(0.94, 0.95, 0.0, limits.getContentNodeLimits());
     }
 
     @Test
@@ -170,19 +178,22 @@ public class ClusterResourceLimitsTest {
         ClusterResourceLimits.Builder builder = new ClusterResourceLimits.Builder(true,
                                                                                   featureFlags.resourceLimitDisk(),
                                                                                   featureFlags.resourceLimitMemory(),
+                                                                                  0.0,
                                                                                   new TestLogger());
         return builder.build(new ModelElement((limitsInXml ? clusterXml : noLimitsXml).getDocumentElement()));
     }
 
-    private void assertLimits(Double expCtrlDisk, Double expCtrlMemory, Double expNodeDisk, Double expNodeMemory, Fixture f) {
+    private void assertLimits(Double expCtrlDisk, Double expCtrlMemory, Double expNodeDisk,
+                              Double expNodeMemory, Double expLowWatermarkDifference, Fixture f) {
         var limits = f.build();
-        assertLimits(expCtrlDisk, expCtrlMemory, limits.getClusterControllerLimits());
-        assertLimits(expNodeDisk, expNodeMemory, limits.getContentNodeLimits());
+        assertLimits(expCtrlDisk, expCtrlMemory, expLowWatermarkDifference, limits.getClusterControllerLimits());
+        assertLimits(expNodeDisk, expNodeMemory, expLowWatermarkDifference, limits.getContentNodeLimits());
     }
 
-    private void assertLimits(Double expDisk, Double expMemory, ResourceLimits limits) {
+    private void assertLimits(Double expDisk, Double expMemory, Double expLowWatermarkDifference, ResourceLimits limits) {
         assertLimit(expDisk, limits.getDiskLimit(), "disk");
         assertLimit(expMemory, limits.getMemoryLimit(), "memory");
+        assertLimit(expLowWatermarkDifference, limits.getLowWatermarkDifference(), "lowWaterMarkDifference");
     }
 
     private void assertLimit(Double expLimit, Optional<Double> actLimit, String limitType) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
@@ -88,10 +88,12 @@ public class ContentSchemaClusterTest {
     }
 
     private static void assertClusterControllerResourceLimits(double expDiskLimit, double expMemoryLimit, ContentCluster cluster) {
-        var limits = getFleetcontrollerConfig(cluster).cluster_feed_block_limit();
+        var config = getFleetcontrollerConfig(cluster);
+        var limits = config.cluster_feed_block_limit();
         assertEquals(3, limits.size());
         assertEquals(expDiskLimit, limits.get("disk"), EPSILON);
         assertEquals(expMemoryLimit, limits.get("memory"), EPSILON);
+        assertEquals(0.0, config.cluster_feed_block_noise_level(), EPSILON);
     }
 
     @Test

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -175,6 +175,7 @@ public class ModelContextImpl implements ModelContext {
         private final int maxActivationInhibitedOutOfSyncGroups;
         private final double resourceLimitDisk;
         private final double resourceLimitMemory;
+        private final double resourceLimitLowWatermarkDifference;
         private final double minNodeRatioPerGroup;
         private final boolean containerDumpHeapOnShutdownTimeout;
         private final int maxUnCommittedMemory;
@@ -220,6 +221,7 @@ public class ModelContextImpl implements ModelContext {
             this.maxActivationInhibitedOutOfSyncGroups = Flags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS.bindTo(source).with(appId).with(version).value();
             this.resourceLimitDisk = PermanentFlags.RESOURCE_LIMIT_DISK.bindTo(source).with(appId).with(version).value();
             this.resourceLimitMemory = PermanentFlags.RESOURCE_LIMIT_MEMORY.bindTo(source).with(appId).with(version).value();
+            this.resourceLimitLowWatermarkDifference = PermanentFlags.RESOURCE_LIMIT_LOW_WATERMARK_DIFFERENCE.bindTo(source).with(appId).with(version).value();
             this.minNodeRatioPerGroup = Flags.MIN_NODE_RATIO_PER_GROUP.bindTo(source).with(appId).with(version).value();
             this.containerDumpHeapOnShutdownTimeout = PermanentFlags.CONTAINER_DUMP_HEAP_ON_SHUTDOWN_TIMEOUT.bindTo(source).with(appId).with(version).value();
             this.maxUnCommittedMemory = Flags.MAX_UNCOMMITTED_MEMORY.bindTo(source).with(appId).with(version).value();
@@ -268,6 +270,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public int maxActivationInhibitedOutOfSyncGroups() { return maxActivationInhibitedOutOfSyncGroups; }
         @Override public double resourceLimitDisk() { return resourceLimitDisk; }
         @Override public double resourceLimitMemory() { return resourceLimitMemory; }
+        @Override public double resourceLimitLowWatermarkDifference() { return resourceLimitLowWatermarkDifference; }
         @Override public double minNodeRatioPerGroup() { return minNodeRatioPerGroup; }
         @Override public boolean containerDumpHeapOnShutdownTimeout() { return containerDumpHeapOnShutdownTimeout; }
         @Override public int maxUnCommittedMemory() { return maxUnCommittedMemory; }


### PR DESCRIPTION
Support setting cluster controller config based on the feature flag. Config set is cluster_feed_block_noise_level, which by default is 0.0.

The flag value is an absolute number, so e.g. 0.01 implies that a block limit of 0.8 effectively becomes 0.79 for an already blocked node. This value will be in effect for both disk and memory resource limits.