### PR TITLE
improve match profiling with multi-bit-vector iterators

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
@@ -250,6 +250,7 @@ MultiBitVectorIteratorBase::optimizeMultiSearch(SearchIterator::UP parentIt)
     if (canOptimize(parent)) {
         MultiSearch::Children stolen;
         std::vector<size_t> _unpackIndex;
+        std::vector<size_t> stolen_indexes;
         bool strict(false);
         size_t insertPosition(0);
         for (size_t it(firstStealable(parent)); it != parent.getChildren().size(); ) {
@@ -264,6 +265,7 @@ MultiBitVectorIteratorBase::optimizeMultiSearch(SearchIterator::UP parentIt)
                 if ( ! strict && (bit->is_strict() == Trinary::True)) {
                     strict = true;
                 }
+                stolen_indexes.push_back(stolen.size() + it);
                 stolen.push_back(std::move(bit));
             } else {
                 it++;
@@ -296,6 +298,7 @@ MultiBitVectorIteratorBase::optimizeMultiSearch(SearchIterator::UP parentIt)
         if (parent.getChildren().empty()) {
             return next;
         } else {
+            nextM.set_stolen_indexes(std::move(stolen_indexes));
             parent.insert(insertPosition, std::move(next));
         }
     }
@@ -305,6 +308,18 @@ MultiBitVectorIteratorBase::optimizeMultiSearch(SearchIterator::UP parentIt)
     }
 
     return parentIt;
+}
+
+size_t
+MultiBitVectorIteratorBase::remap_index(size_t index) {
+    for (size_t i = 1; i < _stolen_indexes.size(); ++i) {
+        if (_stolen_indexes[i] <= index) {
+            ++index;
+        } else {
+            break;
+        }
+    }
+    return index;
 }
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.h
@@ -61,6 +61,17 @@ public:
     ~MultiBitVectorIteratorBase() override;
     void initRange(uint32_t beginId, uint32_t endId) override;
     void addUnpackIndex(size_t index) { _unpackInfo.add(index); }
+    // Which siblings have we stolen. We have taken the place of the first one.
+    void set_stolen_indexes(std::vector<size_t> stolen_indexes) {
+        _stolen_indexes = std::move(stolen_indexes);
+    }
+    // Given the index of a sibling of this iterator;
+    // at what position was it placed before this iterator stole its siblings.
+    // Note that an iterator may have multiple MultiBitVector iterators as siblings,
+    // but only one who has stolen its siblings.
+    size_t remap_index(size_t index);
+    MultiBitVectorIteratorBase *as_multi_bit_vector_base() noexcept override { return this; }
+
     /**
      * Will steal and optimize bitvectoriterators if it can
      * Might return itself or a new structure.
@@ -74,6 +85,7 @@ private:
     static SearchIterator::UP optimizeMultiSearch(SearchIterator::UP parent);
 
     UnpackInfo  _unpackInfo;
+    std::vector<size_t> _stolen_indexes;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/multisearch.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/multisearch.cpp
@@ -57,8 +57,10 @@ MultiSearch::initRange(uint32_t beginid, uint32_t endid)
 void
 MultiSearch::transform_children(std::function<SearchIterator::UP(SearchIterator::UP, size_t)> f)
 {
-    for (size_t i = 0; i < _children.size(); ++i) {
-        _children[i] = f(std::move(_children[i]), i);
+    SearchIterator::TransformChildrenHelper helper;
+    for (auto &child: _children) {
+        size_t idx = helper.index_of(*child);
+        child = f(std::move(child), idx);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/searchiterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/searchiterator.cpp
@@ -8,6 +8,7 @@
 #include <vespa/vespalib/util/classname.h>
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/vespalib/data/slime/inserter.h>
+#include <vespa/searchlib/queryeval/multibitvectoriterator.h>
 
 namespace search::queryeval {
 
@@ -122,7 +123,19 @@ SearchIterator::transform_children(std::function<SearchIterator::UP(SearchIterat
 {
 }
 
+size_t
+SearchIterator::TransformChildrenHelper::index_of(search::queryeval::SearchIterator &next) {
+    size_t idx = _idx++;
+    for (auto *ptr: _list) {
+        idx = ptr->remap_index(idx);
+    }
+    if (auto *mbv = next.as_multi_bit_vector_base()) {
+        _list.push_back(mbv);
+    }
+    return idx;
 }
+
+} // search::queryeval
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
reverse-map iterator child indexes to make them match the shape of the originating blueprint tree.

This enables all iterators not directly removed or replaced to be directly matched against their blueprint counterpart.

Note that all cost for the multi-bit-vector implementation will be credited to the blueprint node representing the replaced iterator. The blueprint nodes representing the removed iterators will not get any profiling samples.

@toregge please review
@arnej27959 FYI