### PR TITLE
Avoid parsing which will be overwritten

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5361,6 +5361,7 @@
       "public void setQueryString(java.lang.String)",
       "public java.lang.String getQueryString()",
       "public com.yahoo.search.query.QueryTree getQueryTree()",
+      "public com.yahoo.search.query.QueryTree getQueryTree(boolean)",
       "public void clearQueryTree()",
       "public java.lang.String getFilter()",
       "public void setFilter(java.lang.String)",
@@ -5491,6 +5492,7 @@
       "public"
     ],
     "methods" : [
+      "public void <init>()",
       "public void <init>(com.yahoo.prelude.query.Item)",
       "public void setIndexName(java.lang.String)",
       "public com.yahoo.prelude.query.Item$ItemType getItemType()",

--- a/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
@@ -27,6 +27,10 @@ import java.util.ListIterator;
  */
 public class QueryTree extends CompositeItem {
 
+    public QueryTree() {
+        setRoot(new NullItem());
+    }
+
     public QueryTree(Item root) {
         setRoot(root);
     }
@@ -104,7 +108,7 @@ public class QueryTree extends CompositeItem {
 
     /** Returns true if this represents the null query */
     public boolean isEmpty() {
-        return getRoot() instanceof NullItem || getItemCount() == 0;
+        return getRoot() == null || getRoot() instanceof NullItem || getItemCount() == 0;
     }
 
     // -------------- Facade

--- a/container-search/src/main/java/com/yahoo/search/yql/MinimalQueryInserter.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/MinimalQueryInserter.java
@@ -115,7 +115,7 @@ public class MinimalQueryInserter extends Searcher {
                                                                            maxHits + "."));
             }
         }
-        query.getModel().getQueryTree().setRoot(newTree.getRoot());
+        query.getModel().getQueryTree(false).setRoot(newTree.getRoot());
         query.getPresentation().getSummaryFields().addAll(parser.getYqlSummaryFields());
 
         GroupingQueryParser.validate(query);

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -799,7 +799,6 @@ public class YqlParser implements Parser {
         // TODO: Add support for default arguments if property results in nothing
         List<OperatorNode<ExpressionOperator>> args = ast.getArgument(1);
         String wordData = getStringContents(args.get(0));
-
         Boolean allowEmpty = getAnnotation(ast, USER_INPUT_ALLOW_EMPTY, Boolean.class,
                                            Boolean.FALSE, "flag for allowing NullItem to be returned");
         if (allowEmpty && (wordData == null || wordData.isEmpty())) return new NullItem();


### PR DESCRIPTION
The string in this test fails the heuristic parser and that caused an error even when overriding the grammar since the query string was lazily parsed with the default grammar just to be immediately thrown away.