### PR TITLE
Add constructor taking `ContainerThreadPool`

### DIFF
--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -913,6 +913,7 @@
     "methods" : [
       "public void <init>(java.util.concurrent.Executor)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
+      "public void <init>(com.yahoo.container.handler.threadpool.ContainerThreadPool, com.yahoo.jdisc.Metric)",
       "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric, boolean)",
       "public abstract com.yahoo.container.jdisc.HttpResponse handle(com.yahoo.container.jdisc.HttpRequest)",

--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
@@ -3,6 +3,7 @@ package com.yahoo.container.jdisc;
 
 import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.component.annotation.Inject;
+import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.container.logging.AccessLogEntry;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.Request;
@@ -46,9 +47,14 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
         this(executor, null);
     }
 
-    @Inject
+    // TODO: deprecate this and other overloads taking executor as argument
     public ThreadedHttpRequestHandler(Executor executor, Metric metric) {
         this(executor, metric, false);
+    }
+
+    @Inject
+    public ThreadedHttpRequestHandler(ContainerThreadPool pool, Metric metric) {
+        this(pool.executor(), metric, false);
     }
 
     // TODO: deprecate this and the Context class. The context component set up in the model does not get a dedicated thread pool.


### PR DESCRIPTION
Ensure handler is using the thread pool intended for request handlers, not the common pool.

FYI @glebashnik @gjoranv 