### PR TITLE
Use more threads for FileServer thread pool

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -95,7 +95,7 @@ public class FileServer {
     FileServer(FileDownloader fileDownloader, List<CompressionType> compressionTypes, FileDirectory fileDirectory) {
         this.downloader = fileDownloader;
         this.fileDirectory = fileDirectory;
-        this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
+        this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(Math.max(16, Runtime.getRuntime().availableProcessors() * 2),
                                                                           new DaemonThreadFactory("file-server-"));
         this.compressionTypes = compressionTypes;
     }


### PR DESCRIPTION
Seeing requests stalling due to all threads being in use, for cases where nodes has few cores