### PR TITLE
Implicitly bump priority of `searchvisitor` instances

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -102,6 +102,11 @@ VisitorOperation::VisitorOperation(
     if (_toTime == 0) {
         _toTime = _op_ctx.generate_unique_timestamp();
     }
+    if (matches_visitor_library(_msg->getLibraryName(), "searchvisitor")) {
+        LOG(debug, "Implicitly expediting priority of visitor '%s' due to it being a search visitor",
+            _msg->getInstanceId().c_str());
+        _msg->setPriority(100); // TODO less magic numbers, and remove this workaround
+    }
 }
 
 VisitorOperation::~VisitorOperation() = default;


### PR DESCRIPTION
@geirst please review.

When the Document API protocol serialization was rewritten to use Protobuf, the legacy client operation priorities were intentionally omitted and instead all default to the same value (interleaving external ops with internal maintenance ops). This is because operation priorities for mutations cause a lot of headaches in the backend due to potential reordering in the persistence queues across nodes, and also risk starving critical internal operations.

However, this introduced a subtle regression where certain read-only operations that _should_ have a high priority no longer had them, in particular streaming search. Since so many operations are async internally on the content node, in practice this would only be noticeable as a problem if a node was completely swamped and all persistence threads were otherwise stalled.

As a pragmatic solution, this commit adds an implicit priority bump of visitors of type `searchvisitor`, which is the visitor instance type used by streaming search.

