### PR TITLE
timelines for query and worst thread

### DIFF
--- a/client/go/internal/vespa/tracedoctor/timeline.go
+++ b/client/go/internal/vespa/tracedoctor/timeline.go
@@ -1,0 +1,30 @@
+package tracedoctor
+
+import "strings"
+
+type timeline struct {
+	list []timelineEntry
+}
+
+type timelineEntry struct {
+	when float64
+	what string
+}
+
+func (t *timeline) add(when float64, what string) {
+	t.list = append(t.list, timelineEntry{when, what})
+}
+
+func (t *timeline) addComment(what string) {
+	t.add(-1.0, what)
+}
+
+func (t *timeline) render(out *output) {
+	for _, entry := range t.list {
+		if entry.when < 0.0 {
+			out.fmt("%s%s\n", strings.Repeat(" ", 15), entry.what)
+		} else {
+			out.fmt("%10.3f ms: %s\n", entry.when, entry.what)
+		}
+	}
+}

--- a/client/go/internal/vespa/tracedoctor/timeline_test.go
+++ b/client/go/internal/vespa/tracedoctor/timeline_test.go
@@ -1,0 +1,44 @@
+package tracedoctor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimelineAdd(t *testing.T) {
+	tl := &timeline{}
+	tl.add(12.34, "Test Event")
+
+	assert.Len(t, tl.list, 1, "Expected 1 entry in the timeline")
+	assert.Equal(t, 12.34, tl.list[0].when, "Unexpected timestamp")
+	assert.Equal(t, "Test Event", tl.list[0].what, "Unexpected event name")
+}
+
+func TestTimelineAddComment(t *testing.T) {
+	tl := &timeline{}
+	tl.addComment("This is a comment")
+
+	assert.Len(t, tl.list, 1, "Expected 1 entry in the timeline")
+	assert.Equal(t, -1.0, tl.list[0].when, "Unexpected timestamp for comment")
+	assert.Equal(t, "This is a comment", tl.list[0].what, "Unexpected comment text")
+}
+
+func TestTimelineRender(t *testing.T) {
+	var buf bytes.Buffer
+	out := &output{out: &buf}
+
+	tl := &timeline{}
+	tl.add(1.23, "Start event")
+	tl.addComment("This is a comment")
+	tl.add(45.67, "End event")
+	tl.render(out)
+
+	expected := "" +
+		"     1.230 ms: Start event\n" +
+		"               This is a comment\n" +
+		"    45.670 ms: End event\n"
+
+	assert.Equal(t, expected, buf.String(), "Rendered output does not match expected")
+}

--- a/client/go/internal/vespa/tracedoctor/topn_perf.go
+++ b/client/go/internal/vespa/tracedoctor/topn_perf.go
@@ -1,0 +1,57 @@
+package tracedoctor
+
+import (
+	"sort"
+)
+
+type topNPerfEntry struct {
+	name       string
+	count      int64
+	selfTimeMs float64
+}
+
+type topNPerf struct {
+	entries map[string]*topNPerfEntry
+}
+
+func newTopNPerf() *topNPerf {
+	return &topNPerf{
+		entries: make(map[string]*topNPerfEntry),
+	}
+}
+
+func (tp *topNPerf) addSample(name string, count int64, selfTimeMs float64) {
+	if entry, exists := tp.entries[name]; exists {
+		entry.count += count
+		entry.selfTimeMs += selfTimeMs
+	} else {
+		tp.entries[name] = &topNPerfEntry{name: name, count: count, selfTimeMs: selfTimeMs}
+	}
+}
+
+func (tp *topNPerf) topN(n int) []topNPerfEntry {
+	entries := make([]topNPerfEntry, 0, len(tp.entries))
+	for _, entry := range tp.entries {
+		entries = append(entries, *entry)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].selfTimeMs > entries[j].selfTimeMs
+	})
+
+	if n > len(entries) {
+		n = len(entries)
+	}
+	return entries[:n]
+}
+
+func (tp *topNPerf) render(out *output) {
+	sortedEntries := tp.topN(len(tp.entries))
+	out.fmt("+-----------+-----------+\n")
+	out.fmt("|     count |   self_ms |\n")
+	out.fmt("+-----------+-----------+\n")
+	for _, entry := range sortedEntries {
+		out.fmt("|%10d |%10.3f | %s\n", entry.count, entry.selfTimeMs, entry.name)
+	}
+	out.fmt("+-----------+-----------+\n")
+}

--- a/client/go/internal/vespa/tracedoctor/topn_perf_test.go
+++ b/client/go/internal/vespa/tracedoctor/topn_perf_test.go
@@ -1,0 +1,40 @@
+package tracedoctor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTopNPerfAddSample(t *testing.T) {
+	tp := newTopNPerf()
+	tp.addSample("A", 2, 10.5)
+	tp.addSample("B", 1, 20.2)
+	tp.addSample("A", 3, 5.0)
+	tp.addSample("C", 1, 30.0)
+	tp.addSample("B", 2, 15.8)
+
+	assert.Equal(t, int64(5), tp.entries["A"].count)
+	assert.Equal(t, 15.5, tp.entries["A"].selfTimeMs)
+	assert.Equal(t, int64(3), tp.entries["B"].count)
+	assert.Equal(t, 36.0, tp.entries["B"].selfTimeMs)
+	assert.Equal(t, int64(1), tp.entries["C"].count)
+	assert.Equal(t, 30.0, tp.entries["C"].selfTimeMs)
+}
+
+func TestTopNPerfTopN(t *testing.T) {
+	tp := newTopNPerf()
+	tp.addSample("A", 2, 10.5)
+	tp.addSample("B", 1, 20.2)
+	tp.addSample("A", 3, 5.0)
+	tp.addSample("C", 1, 30.0)
+	tp.addSample("B", 2, 15.8)
+
+	top2 := tp.topN(2)
+	assert.Equal(t, 2, len(top2))
+	assert.Equal(t, "B", top2[0].name)
+	assert.Equal(t, "C", top2[1].name)
+
+	top5 := tp.topN(5)
+	assert.Equal(t, 3, len(top5))
+}

--- a/client/go/internal/vespa/tracedoctor/tracedoctor.go
+++ b/client/go/internal/vespa/tracedoctor/tracedoctor.go
@@ -52,9 +52,11 @@ func extractTiming(queryResult slime.Value) *timing {
 	if !obj.Valid() {
 		return nil
 	}
-	return &timing{queryMs: obj.Field("querytime").AsDouble() * 1000.0,
+	return &timing{
+		queryMs:   obj.Field("querytime").AsDouble() * 1000.0,
 		summaryMs: obj.Field("summaryfetchtime").AsDouble() * 1000.0,
-		totalMs:   obj.Field("searchtime").AsDouble() * 1000.0}
+		totalMs:   obj.Field("searchtime").AsDouble() * 1000.0,
+	}
 }
 
 type output struct {
@@ -74,45 +76,93 @@ type Context struct {
 }
 
 func NewContext(root slime.Value) *Context {
-	return &Context{root: root,
-		timing: extractTiming(root)}
+	return &Context{
+		root:   root,
+		timing: extractTiming(root),
+	}
+}
+
+func selectSlowestSearch(traces []protonTrace) (int, *protonTrace, float64) {
+	var slowest *protonTrace
+	var slowestDuration float64
+	var totalDuration float64
+	for i := range traces {
+		duration := traces[i].durationMs()
+		totalDuration += duration
+		if slowest == nil || duration > slowestDuration {
+			slowest = &traces[i]
+			slowestDuration = duration
+		}
+	}
+	others := totalDuration - slowestDuration
+	if len(traces) > 1 {
+		others /= float64(len(traces) - 1)
+	}
+	return len(traces), slowest, others
+}
+
+func selectSlowestThread(threads []threadTrace) (int, *threadTrace, float64) {
+	var slowest *threadTrace
+	var slowestPerf float64
+	var totalPerf float64
+	for i := range threads {
+		perf := threads[i].profTimeMs()
+		totalPerf += perf
+		if slowest == nil || perf > slowestPerf {
+			slowest = &threads[i]
+			slowestPerf = perf
+		}
+	}
+	others := totalPerf - slowestPerf
+	if len(threads) > 1 {
+		others /= float64(len(threads) - 1)
+	}
+	return len(threads), slowest, others
+}
+
+func (ctx *Context) analyzeThread(trace protonTrace, thread threadTrace, out *output) {
+	thread.timeline().render(out)
+	threadSummary := threadSummary{
+		matchMs:       thread.matchTimeMs(),
+		firstPhaseMs:  thread.firstPhaseTimeMs(),
+		secondPhaseMs: thread.secondPhaseTimeMs(),
+	}
+	threadSummary.render(out)
+	queryPerf := trace.extractQuery()
+	queryPerf.importMatchPerf(thread)
+	out.fmt("\nMatch profiling for thread #%d (total time was %f ms):\n", thread.id, thread.matchTimeMs())
+	queryPerf.render(out)
+	out.fmt("\nFirst phase rank profiling for thread #%d (total time was %f ms):\n", thread.id, thread.firstPhaseTimeMs())
+	thread.firstPhasePerf().render(out)
+	out.fmt("\nSecond phase rank profiling for thread #%d (total time was %f ms):\n", thread.id, thread.secondPhaseTimeMs())
+	thread.secondPhasePerf().render(out)
+}
+
+func (ctx *Context) analyzeProtonTrace(trace protonTrace, out *output) {
+	trace.timeline().render(out)
+	cnt, worst, peers := selectSlowestThread(trace.findThreadTraces())
+	if worst != nil {
+		out.fmt("found %d threads, slowest matching/ranking was thread #%d: %.3f ms\n",
+			cnt, worst.id, worst.profTimeMs())
+		if cnt > 1 {
+			out.fmt("(average of other threads was %.3f ms)\n", peers)
+		}
+		ctx.analyzeThread(trace, *worst, out)
+	}
 }
 
 func (ctx *Context) Analyze(stdout io.Writer) error {
 	out := &output{out: stdout}
 	ctx.timing.render(out)
-	list := findProtonTraces(ctx.root)
-	if len(list) == 0 {
-		return fmt.Errorf("could not locate any back-end searches")
-	}
-	var mp = -1
-	for i, p := range list {
-		if mp < 0 || p.durationMs() > list[mp].durationMs() {
-			mp = i
+	cnt, worst, peers := selectSlowestSearch(findProtonTraces(ctx.root))
+	if worst != nil {
+		out.fmt("found %d searches, slowest search was: %s[%d]: %.3f ms%s\n",
+			cnt, worst.documentType(), worst.distributionKey(), worst.durationMs(),
+			ctx.timing.percentageOfQuery(worst.durationMs()))
+		if cnt > 1 {
+			out.fmt("(average of other searches was %.3f ms)\n", peers)
 		}
+		ctx.analyzeProtonTrace(*worst, out)
 	}
-	out.fmt("found %d searches, slowest search was: %s[%d]: %10.3f ms%s\n",
-		len(list), list[mp].documentType(), list[mp].distributionKey(),
-		list[mp].durationMs(), ctx.timing.percentageOfQuery(list[mp].durationMs()))
-	list[mp].renderSummary(out)
-	threads := list[mp].findThreadTraces()
-	if len(threads) == 0 {
-		return fmt.Errorf("search thread information is missing")
-	}
-	var mt = -1
-	for i, t := range threads {
-		if mt < 0 || t.profTimeMs() > threads[mt].profTimeMs() {
-			mt = i
-		}
-	}
-	out.fmt("found %d threads, slowest matching/ranking was thread #%d: %10.3f ms\n",
-		len(threads), mt, threads[mt].profTimeMs())
-	threadSummary := threadSummary{matchMs: threads[mt].matchTimeMs(),
-		firstPhaseMs:  threads[mt].firstPhaseTimeMs(),
-		secondPhaseMs: threads[mt].secondPhaseTimeMs()}
-	threadSummary.render(out)
-	queryPerf := list[mp].extractQuery()
-	queryPerf.importMatchPerf(threads[mt])
-	queryPerf.render(out)
 	return out.err
 }


### PR DESCRIPTION
also flat profiling for first and second phase ranking for the worst thread

worst performers (search/thread) is compared to the (exclusive) average of the other samples
