### PR TITLE
Log time spent compressing file references

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -43,6 +44,7 @@ import static com.yahoo.vespa.filedistribution.FileApiErrorCodes.TRANSFER_FAILED
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
+import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type.compressed;
@@ -55,13 +57,16 @@ public class FileServer {
 
     // Set this low, to make sure we don't wait for a long time trying to download file
     private static final Duration timeout = Duration.ofSeconds(10);
-    private static final List<CompressionType> compressionTypesToServe = List.of(zstd, lz4, gzip); // In preferred order
+    /* In preferred order, the one used will be the first one matching one of the accepted compression
+     * types sent in client request.
+     */
+    private static final List<CompressionType> compressionTypesToServe = List.of(zstd, lz4, gzip);
     private static final String tempFilereferencedataPrefix = "filereferencedata";
     private static final Path tempFilereferencedataDir = Paths.get(System.getProperty("java.io.tmpdir"));
 
     private final FileDirectory fileDirectory;
     private final ThreadPoolExecutor executor;
-    private final FileDownloader downloader;
+    private final FileDownloader downloader; // downloads files from other config servers
     private final List<CompressionType> compressionTypes; // compression types to use, in preferred order
 
     public static class ReplayStatus {
@@ -136,7 +141,12 @@ public class FileServer {
         log.log(Level.FINE, () -> "accepted compression types: " + acceptedCompressionTypes + ", will use " + compressionType);
         if (file.isDirectory()) {
             Path tempFile = Files.createTempFile(tempFilereferencedataDir, tempFilereferencedataPrefix, reference.value());
-            File compressedFile = new FileReferenceCompressor(compressed, compressionType).compress(file.getParentFile(), tempFile.toFile());
+            var start = Instant.now();
+            File compressedFile = new FileReferenceCompressor(compressed, compressionType)
+                    .compress(file.getParentFile(), tempFile.toFile());
+            var duration = Duration.between(start, Instant.now());
+            log.log((duration.compareTo(Duration.ofSeconds(10)) > 0) ? Level.INFO : Level.FINE,
+                    () -> "compressed " + reference + " with " + compressionType + " in " + Duration.between(start, Instant.now()));
             return new LazyTemporaryStorageFileReferenceData(reference, file.getName(), compressed, compressedFile, compressionType);
         } else {
             return new LazyFileReferenceData(reference, file.getName(), Type.file, file, compressionType);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -44,7 +44,6 @@ import static com.yahoo.vespa.filedistribution.FileApiErrorCodes.TRANSFER_FAILED
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
-import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type.compressed;
@@ -55,8 +54,7 @@ public class FileServer {
 
     private static final Logger log = Logger.getLogger(FileServer.class.getName());
 
-    // Set this low, to make sure we don't wait for a long time trying to download file
-    private static final Duration timeout = Duration.ofSeconds(10);
+    private static final Duration timeout = Duration.ofSeconds(30);
     /* In preferred order, the one used will be the first one matching one of the accepted compression
      * types sent in client request.
      */


### PR DESCRIPTION
Some testing reveals compression is taking longer time than expected, on hardware with few CPU cores. Want to get some data before deciding how to handle it.
Also increase timeout.