### PR TITLE
Add support for no compression of file references

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -44,6 +44,7 @@ import static com.yahoo.vespa.filedistribution.FileApiErrorCodes.TRANSFER_FAILED
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
+import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type.compressed;
@@ -58,7 +59,7 @@ public class FileServer {
     /* In preferred order, the one used will be the first one matching one of the accepted compression
      * types sent in client request.
      */
-    private static final List<CompressionType> compressionTypesToServe = List.of(zstd, lz4, gzip);
+    private static final List<CompressionType> compressionTypesToServe = List.of(zstd, lz4, gzip, none);
     private static final String tempFilereferencedataPrefix = "filereferencedata";
     private static final Path tempFilereferencedataDir = Paths.get(System.getProperty("java.io.tmpdir"));
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceCompressor.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceCompressor.java
@@ -120,6 +120,7 @@ public class FileReferenceCompressor {
             case compressed -> switch (compressionType) {
                 case gzip -> new GZIPOutputStream(new FileOutputStream(outputFile));
                 case lz4 -> new LZ4BlockOutputStream(new FileOutputStream(outputFile));
+                case none -> new FileOutputStream(outputFile);
                 case zstd -> new ZstdOutputStream(new FileOutputStream(outputFile));
             };
             case file -> new FileOutputStream(outputFile);
@@ -131,6 +132,7 @@ public class FileReferenceCompressor {
             case compressed -> switch (compressionType) {
                 case gzip -> new GZIPInputStream(new FileInputStream(inputFile));
                 case lz4 -> new LZ4BlockInputStream(new FileInputStream(inputFile));
+                case none -> new FileInputStream(inputFile);
                 case zstd -> new ZstdInputStream(new FileInputStream(inputFile));
             };
             case file -> new FileInputStream(inputFile);

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceData.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceData.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
 public abstract class FileReferenceData implements AutoCloseable {
 
     public enum Type { file, compressed }
-    public enum CompressionType { gzip, lz4, zstd }
+    public enum CompressionType { gzip, lz4, none, zstd }
 
     private final FileReference fileReference;
     private final String filename;

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
+import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
 
 /**
@@ -37,7 +38,7 @@ import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType
 public class FileReferenceDownloader {
 
     private static final Logger log = Logger.getLogger(FileReferenceDownloader.class.getName());
-    private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(gzip, lz4, zstd);
+    private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(gzip, lz4, none, zstd);
 
     private final ExecutorService downloadExecutor =
             Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
@@ -80,7 +81,7 @@ public class FileReferenceDownloader {
                 return;
             var timeout = rpcTimeout.orElse(Duration.between(Instant.now(), end));
             log.log(Level.FINE, "Wait until download of " + fileReference + " has started, retryCount " + retryCount +
-                    ", timeout" + timeout + " (request from " + fileReferenceDownload.client() + ")");
+                    ", timeout " + timeout + " (request from " + fileReferenceDownload.client() + ")");
             if ( ! timeout.isNegative() && startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout))
                 return;
 


### PR DESCRIPTION
Want to compare different compression methods, none should be nice for a baseline (and might also be a realistic method to use if data is already compressed).