### PR TITLE
Revert "Use more threads for FileServer thread pool"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -99,7 +99,7 @@ public class FileServer {
     FileServer(FileDownloader fileDownloader, List<CompressionType> compressionTypes, FileDirectory fileDirectory) {
         this.downloader = fileDownloader;
         this.fileDirectory = fileDirectory;
-        this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(Math.max(16, Runtime.getRuntime().availableProcessors() * 2),
+        this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
                                                                           new DaemonThreadFactory("file-server-"));
         this.compressionTypes = compressionTypes;
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#33373

Revert, the issue was CPU usage when compressing, not too few threads