### PR TITLE
Revert "always normalize query items for juniper"

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
@@ -47,7 +47,6 @@ Memory TIMEOUT("timeout");
 void
 DocsumContext::initState()
 {
-    _docsumState.query_normalization(this);
     const DocsumRequest & req = _request;
     _docsumState._args.initFromDocsumRequest(req);
     auto [session, expectSession] = Matcher::lookupSearchSession(_sessionMgr, req);
@@ -145,16 +144,6 @@ DocsumContext::fill_matching_elements(const MatchingElementsFields &fields)
         return _matcher->get_matching_elements(_request, _searchCtx, _attrCtx, _sessionMgr, fields);
     }
     return std::make_unique<MatchingElements>();
-}
-
-bool DocsumContext::is_text_matching(std::string_view) const noexcept {
-    // this is for dynamic teaser only; all those fields should be text matching
-    return true;
-}
-
-Normalizing DocsumContext::normalizing_mode(std::string_view) const noexcept {
-    // this is for dynamic teaser only; it always does lowercase/accent removal.
-    return Normalizing::LOWERCASE_AND_FOLD;
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.h
@@ -19,9 +19,7 @@ namespace matching {
  * The DocsumContext class is responsible for performing a docsum request and
  * creating a docsum reply.
  **/
-class DocsumContext : public search::docsummary::GetDocsumsStateCallback,
-                      public search::QueryNormalization
-{
+class DocsumContext : public search::docsummary::GetDocsumsStateCallback {
 private:
     const search::engine::DocsumRequest  & _request;
     search::docsummary::IDocsumWriter    & _docsumWriter;
@@ -54,8 +52,7 @@ public:
     void fillSummaryFeatures(search::docsummary::GetDocsumsState& state) override;
     void fillRankFeatures(search::docsummary::GetDocsumsState& state) override;
     std::unique_ptr<search::MatchingElements> fill_matching_elements(const search::MatchingElementsFields &fields) override;
-    bool is_text_matching(std::string_view index) const noexcept override;
-    Normalizing normalizing_mode(std::string_view index) const noexcept override;
 };
 
 } // namespace proton
+


### PR DESCRIPTION
Reverts vespa-engine/vespa#33406

looks like this broke "encoding" system test

@toregge please review and merge
