### PR TITLE
Increase timeout for file downloader

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -57,7 +57,7 @@ public class FileServer {
 
     private static final Logger log = Logger.getLogger(FileServer.class.getName());
 
-    private static final Duration timeout = Duration.ofSeconds(30);
+    private static final Duration timeout = Duration.ofSeconds(60);
     /* In preferred order, the one used will be the first one matching one of the accepted compression
      * types sent in client request.
      */


### PR DESCRIPTION
When asking servers for a file it might take some time to compress files before server returns, epsecially on servers with few CPU cores, so increase timeout