### PR TITLE
Log if min-node-ratio-per-group is low and there are many small groups.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
@@ -166,15 +166,15 @@ public class ClusterControllerConfig extends AnyConfigProducer implements Fleetc
 
     }
 
-    private record ClusterControllerTuning(Optional<Duration> initProgressTime,
-                                           Optional<Duration> transitionTime,
-                                           Optional<Long> maxPrematureCrashes,
-                                           Optional<Duration> stableStateTimePeriod,
-                                           Optional<Double> minDistributorUpRatio,
-                                           Optional<Double> minStorageUpRatio,
-                                           Optional<Integer> maxGroupsAllowedDown,
-                                           Optional<Double> minNodeRatioPerGroup,
-                                           Optional<Integer> minSplitBits) {
+    public record ClusterControllerTuning(Optional<Duration> initProgressTime,
+                                          Optional<Duration> transitionTime,
+                                          Optional<Long> maxPrematureCrashes,
+                                          Optional<Duration> stableStateTimePeriod,
+                                          Optional<Double> minDistributorUpRatio,
+                                          Optional<Double> minStorageUpRatio,
+                                          Optional<Integer> maxGroupsAllowedDown,
+                                          Optional<Double> minNodeRatioPerGroup,
+                                          Optional<Integer> minSplitBits) {
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -47,11 +47,11 @@ import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -134,6 +134,47 @@ public class ContentClusterTest extends ContentBaseTest {
         ProtonConfig protonConfig = new ProtonConfig(protonBuilder);
         assertEquals(1, protonConfig.distribution().searchablecopies());
         assertEquals(5, protonConfig.distribution().redundancy());
+    }
+
+    @Test
+    void testWarningWhenManyGroupsWithFewNodes() {
+        var services =
+                "<content version=\"1.0\" id=\"storage\">\n" +
+                        "  <documents/>" +
+                        "  <redundancy>3</redundancy>\n" +
+                        "  <group name='root'>" +
+                        "    <distribution partitions='1|1|*'/>" +
+                        "    <group name='g-1' distribution-key='0'>" +
+                        "      <node hostalias='mockhost' distribution-key='0'/>" +
+                        "      <node hostalias='mockhost' distribution-key='1'/>" +
+                        "    </group>" +
+                        "    <group name='g-2' distribution-key='1'>" +
+                        "      <node hostalias='mockhost' distribution-key='2'/>" +
+                        "      <node hostalias='mockhost' distribution-key='3'/>" +
+                        "    </group>" +
+                        "    <group name='g-3' distribution-key='1'>" +
+                        "      <node hostalias='mockhost' distribution-key='4'/>" +
+                        "      <node hostalias='mockhost' distribution-key='5'/>" +
+                        "    </group>" +
+                        "  </group>" +
+                        "</content>";
+
+        var messages = new ArrayList<>();
+        DeployLogger logger = (level, message) -> {
+            if (level == Level.INFO) {
+                messages.add(message);
+            }
+        };
+        var deployState = new DeployState.Builder()
+                .applicationPackage(new MockApplicationPackage.Builder().withServices(services).build())
+                .deployLogger(logger)
+                .build();
+        new TestDriver().buildModel(deployState);
+        assertEquals(1, messages.size());
+        assertEquals("In cluster 'storage': min-node-ratio-per-group should be set to 1 when there are 3 or more groups (3)" +
+                             " and there are 3 or fewer nodes in the group (2)." +
+                             " See https://docs.vespa.ai/en/reference/services-content.html?mode=cloud#min-node-ratio-per-group",
+                     messages.get(0));
     }
 
     @Test


### PR DESCRIPTION
It's better to advise users to set this to 1 in these cases, so the whole group goes down if one node goes down, so log and point to doc about this.

An alternative i to just set min-node-ratio-per-group to 1 in code and don't log.