### PR TITLE
Estimate bytes read from disk as part of flush and use this estimate

### DIFF
--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -116,12 +116,22 @@ flush.preparerestart.replayoperationcost double default=3000.0
 ## The cost of writing a byte when flushing components to disk.
 ##
 ## The number of bytes to write (for a set of flushed components) * writecost
-## gives an estimate of the total cost of flushing this set of components.
+## gives an estimate of the write cost of flushing this set of components.
 ##
 ## The prepare for restart flush strategy will choose a set of components to flush
 ## such that the cost of flushing these + the cost of replaying the transaction log
 ## is as low as possible.
 flush.preparerestart.writecost double default=1.0
+
+## The cost of reading a byte when flushing components to disk.
+##
+## The number of bytes to read (for a set of flushed components) * readcost
+## gives an estimate of the read cost of flushing this set of components.
+##
+## Components that only read from memory will return 0 for the number of
+## bytes to read, currently only paged attributes will have a nonzero
+## read cost.
+flush.preparerestart.readcost double default=1.0
 
 ## Control io options during write both under dump and fusion.
 indexing.write.io enum {NORMAL, OSYNC, DIRECTIO} default=DIRECTIO restart

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -169,7 +169,8 @@ FlushableAttribute::FlushableAttribute(AttributeVectorSP attr,
       _attributeFieldWriter(attributeFieldWriter),
       _hwInfo(hwInfo),
       _attrDir(attrDir),
-      _replay_operation_cost(0.0)
+      _replay_operation_cost(0.0),
+      _paged(_attr->getConfig().paged())
 {
     _lastStats.setPathElementsToLog(8);
     auto &config = attr->getConfig();
@@ -249,6 +250,20 @@ uint64_t
 FlushableAttribute::getApproxBytesToWriteToDisk() const
 {
     return _attr->getEstimatedSaveByteSize();
+}
+
+uint64_t
+FlushableAttribute::get_approx_bytes_to_read_from_disk() const noexcept
+{
+    if (_paged) {
+        /*
+         * The amount of data read from disk for paged attributse scales
+         * linearly with the amount of data to write to disk.
+         */
+        return getApproxBytesToWriteToDisk();
+    } else {
+        return 0;
+    }
 }
 
 double

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.h
@@ -38,6 +38,7 @@ private:
     vespalib::HwInfo                         _hwInfo;
     std::shared_ptr<AttributeDirectory>      _attrDir;
     double                                   _replay_operation_cost;
+    bool                                     _paged;
 
     Task::UP internalInitFlush(SerialNum currentSerial);
 
@@ -58,21 +59,22 @@ public:
                        vespalib::ISequencedTaskExecutor &attributeFieldWriter,
                        const vespalib::HwInfo &hwInfo);
 
-    virtual ~FlushableAttribute();
+    ~FlushableAttribute() override;
 
     void setCleanUpAfterFlush(bool cleanUp) { _cleanUpAfterFlush = cleanUp; }
 
     TransientResourceUsage get_transient_resource_usage() const;
 
     // Implements IFlushTarget
-    virtual MemoryGain getApproxMemoryGain() const override;
-    virtual DiskGain getApproxDiskGain() const override;
-    virtual Time getLastFlushTime() const override;
-    virtual SerialNum getFlushedSerialNum() const override;
-    virtual Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
-    virtual FlushStats getLastFlushStats() const override { return _lastStats; }
-    virtual uint64_t getApproxBytesToWriteToDisk() const override;
-    virtual double get_replay_operation_cost() const override;
+    MemoryGain getApproxMemoryGain() const override;
+    DiskGain getApproxDiskGain() const override;
+    Time getLastFlushTime() const override;
+    SerialNum getFlushedSerialNum() const override;
+    Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
+    FlushStats getLastFlushStats() const override { return _lastStats; }
+    uint64_t getApproxBytesToWriteToDisk() const override;
+    uint64_t get_approx_bytes_to_read_from_disk() const noexcept override;
+    double get_replay_operation_cost() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.cpp
@@ -12,9 +12,18 @@ CachedFlushTarget::CachedFlushTarget(const IFlushTarget::SP &target)
       _memoryGain(target->getApproxMemoryGain()),
       _diskGain(target->getApproxDiskGain()),
       _approxBytesToWriteToDisk(target->getApproxBytesToWriteToDisk()),
+      _approx_bytes_to_read_from_disk(target->get_approx_bytes_to_read_from_disk()),
       _replay_operation_cost(target->get_replay_operation_cost()),
       _needUrgentFlush(target->needUrgentFlush()),
       _priority(target->getPriority())
 { }
+
+CachedFlushTarget::~CachedFlushTarget() = default;
+
+uint64_t
+CachedFlushTarget::get_approx_bytes_to_read_from_disk() const noexcept
+{
+    return _approx_bytes_to_read_from_disk;
+}
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.h
@@ -20,6 +20,7 @@ private:
     MemoryGain        _memoryGain;
     DiskGain          _diskGain;
     uint64_t          _approxBytesToWriteToDisk;
+    uint64_t          _approx_bytes_to_read_from_disk;
     double            _replay_operation_cost;
     bool              _needUrgentFlush;
     Priority          _priority;
@@ -33,6 +34,7 @@ public:
      * @param target The target to decorate.
      */
     CachedFlushTarget(const IFlushTarget::SP &target);
+    ~CachedFlushTarget() override;
 
     /**
      * Returns the decorated flush target. This should not be used for anything
@@ -58,6 +60,7 @@ public:
     FlushStats getLastFlushStats() const override { return _target->getLastFlushStats(); }
 
     uint64_t getApproxBytesToWriteToDisk() const override { return _approxBytesToWriteToDisk; }
+    uint64_t get_approx_bytes_to_read_from_disk() const noexcept override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidate.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidate.cpp
@@ -12,8 +12,10 @@ FlushTargetCandidate::FlushTargetCandidate(std::shared_ptr<FlushContext> flush_c
       _current_serial(current_serial),
       _replay_cost(_replay_operation_cost * (_current_serial - _flushed_serial)),
       _approx_bytes_to_write_to_disk(_flush_context->getTarget()->getApproxBytesToWriteToDisk()),
+      _approx_bytes_to_read_from_disk(_flush_context->getTarget()->get_approx_bytes_to_read_from_disk()),
       _write_cost(_approx_bytes_to_write_to_disk * cfg.flushTargetWriteCost),
-      _always_flush(_replay_cost >= _write_cost)
+      _read_cost(_approx_bytes_to_read_from_disk * cfg.flush_target_read_cost),
+      _always_flush(_replay_cost >= _write_cost + _read_cost)
 {
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidate.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidate.h
@@ -21,7 +21,9 @@ class FlushTargetCandidate
     search::SerialNum             _current_serial;
     double                        _replay_cost;
     uint64_t                      _approx_bytes_to_write_to_disk;
+    uint64_t                      _approx_bytes_to_read_from_disk;
     double                        _write_cost;
+    double                        _read_cost;
     bool                          _always_flush;
 
     using Config = PrepareRestartFlushStrategy::Config;
@@ -31,6 +33,7 @@ public:
     const std::shared_ptr<FlushContext> &get_flush_context() const { return _flush_context; }
     search::SerialNum  get_flushed_serial() const { return _flushed_serial; }
     double get_write_cost() const { return _write_cost; }
+    double get_read_cost() const noexcept { return _read_cost; }
     bool get_always_flush() const { return _always_flush; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidates.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidates.cpp
@@ -55,6 +55,17 @@ calculateFlushTargetsWriteCost(std::span<const FlushTargetCandidate> candidates,
     return result;
 }
 
+double
+calculate_flush_targets_read_cost(std::span<const FlushTargetCandidate> candidates,
+                                  size_t num_candidates)
+{
+    double result = 0;
+    for (size_t i = 0; i < num_candidates; ++i) {
+        result += candidates[i].get_read_cost();
+    }
+    return result;
+}
+
 }
 
 FlushTargetCandidates::FlushTargetCandidates(std::span<const FlushTargetCandidate> candidates,
@@ -69,7 +80,8 @@ FlushTargetCandidates::FlushTargetCandidates(std::span<const FlushTargetCandidat
                                                                        _num_candidates,
                                                                        tlsStats))),
       _flushTargetsWriteCost(calculateFlushTargetsWriteCost(_candidates,
-                                                            _num_candidates))
+                                                            _num_candidates)),
+      _flush_targets_read_cost(calculate_flush_targets_read_cost(_candidates, num_candidates))
 {
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidates.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_target_candidates.h
@@ -33,6 +33,7 @@ private:
     size_t  _num_candidates;
     TlsReplayCost _tlsReplayCost;
     double _flushTargetsWriteCost;
+    double _flush_targets_read_cost;
 
     using Config = PrepareRestartFlushStrategy::Config;
 
@@ -46,7 +47,9 @@ public:
 
     TlsReplayCost getTlsReplayCost() const { return _tlsReplayCost; }
     double getFlushTargetsWriteCost() const { return _flushTargetsWriteCost; }
-    double getTotalCost() const { return getTlsReplayCost().totalCost() + getFlushTargetsWriteCost(); }
+    double get_flush_targets_read_cost() const noexcept { return _flush_targets_read_cost; }
+    double getTotalCost() const { return getTlsReplayCost().totalCost() + getFlushTargetsWriteCost() +
+        get_flush_targets_read_cost(); }
     FlushContext::List getCandidates() const;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.cpp
@@ -22,10 +22,18 @@ FlushTargetProxy::FlushTargetProxy(const IFlushTarget::SP &target,
 {
 }
 
+FlushTargetProxy::~FlushTargetProxy() = default;
+
 IFlushTarget::Task::UP
 FlushTargetProxy::initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token)
 {
     return _target->initFlush(currentSerial, std::move(flush_token));
+}
+
+uint64_t
+FlushTargetProxy::get_approx_bytes_to_read_from_disk() const noexcept
+{
+    return _target->get_approx_bytes_to_read_from_disk();
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.h
@@ -32,6 +32,7 @@ public:
      * @param prefix   The prefix to prepend to the target
      */
     FlushTargetProxy(const IFlushTarget::SP &target, const std::string & prefix);
+    ~FlushTargetProxy() override;
     /**
      * Returns the decorated flush target. This should not be used for anything
      * but testing, as invoking a method on the returned target beats the
@@ -48,6 +49,7 @@ public:
     bool needUrgentFlush() const override { return _target->needUrgentFlush(); }
     Priority getPriority() const override { return _target->getPriority(); }
     uint64_t getApproxBytesToWriteToDisk() const override { return _target->getApproxBytesToWriteToDisk(); }
+    uint64_t get_approx_bytes_to_read_from_disk() const noexcept override;
     searchcorespi::FlushStats getLastFlushStats() const override { return _target->getLastFlushStats(); }
     double get_replay_operation_cost() const override { return _target->get_replay_operation_cost(); }
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;

--- a/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.cpp
@@ -21,10 +21,12 @@ using FlushTargetCandidatesList = std::vector<FlushTargetCandidates::UP>;
 
 PrepareRestartFlushStrategy::Config::Config(double tlsReplayByteCost_,
                                             double tlsReplayOperationCost_,
-                                            double flushTargetWriteCost_)
+                                            double flushTargetWriteCost_,
+                                            double flush_target_read_cost_)
     : tlsReplayByteCost(tlsReplayByteCost_),
       tlsReplayOperationCost(tlsReplayOperationCost_),
-      flushTargetWriteCost(flushTargetWriteCost_)
+      flushTargetWriteCost(flushTargetWriteCost_),
+      flush_target_read_cost(flush_target_read_cost_)
 {
 }
 
@@ -113,22 +115,26 @@ findBestTargetsToFlush(const FlushContext::List &unsortedFlushContexts,
     for (size_t numCandidates = 1; numCandidates <= candidates.size(); ++numCandidates) {
         FlushTargetCandidates nextSet(candidates, numCandidates, tlsStats, cfg);
         LOG(debug, "findBestTargetsToFlush(): Created candidate set: "
-                "flushTargets=[%s], tlsReplayBytesCost=%f, tlsReplayOperationsCost=%f, flushTargetsWriteCost=%f, totalCost=%f",
+                "flushTargets=[%s], tlsReplayBytesCost=%f, tlsReplayOperationsCost=%f, "
+                "flushTargetsWriteCost=%f, flush_targets_read_cost=%f, totalCost=%f",
                 toString(nextSet.getCandidates()).c_str(),
                 nextSet.getTlsReplayCost().bytesCost,
                 nextSet.getTlsReplayCost().operationsCost,
                 nextSet.getFlushTargetsWriteCost(),
+                nextSet.get_flush_targets_read_cost(),
                 nextSet.getTotalCost());
         if (nextSet.getTotalCost() < bestSet.getTotalCost()) {
             bestSet = nextSet;
         }
     }
     LOG(info, "findBestTargetsToFlush(): Best candidate set: "
-            "flushTargets=[%s], tlsReplayBytesCost=%f, tlsReplayOperationsCost=%f, flushTargetsWriteCost=%f, totalCost=%f",
+            "flushTargets=[%s], tlsReplayBytesCost=%f, tlsReplayOperationsCost=%f, "
+            "flushTargetsWriteCost=%f, flush_targets_read_cost=%f, totalCost=%f",
             toString(bestSet.getCandidates()).c_str(),
             bestSet.getTlsReplayCost().bytesCost,
             bestSet.getTlsReplayCost().operationsCost,
             bestSet.getFlushTargetsWriteCost(),
+            bestSet.get_flush_targets_read_cost(),
             bestSet.getTotalCost());
     return bestSet.getCandidates();
 }

--- a/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.h
@@ -24,9 +24,11 @@ public:
         double tlsReplayByteCost;
         double tlsReplayOperationCost;
         double flushTargetWriteCost;
+        double flush_target_read_cost;
         Config(double tlsReplayByteCost_,
                double tlsReplayOperationCost_,
-               double flushTargetWriteCost_);
+               double flushTargetWriteCost_,
+               double flush_target_read_cost_);
     };
 
 private:

--- a/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.cpp
@@ -30,4 +30,10 @@ JobTrackedFlushTarget::initFlush(SerialNum currentSerial, std::shared_ptr<search
     return FlushTask::UP();
 }
 
+uint64_t
+JobTrackedFlushTarget::get_approx_bytes_to_read_from_disk() const noexcept
+{
+    return _target->get_approx_bytes_to_read_from_disk();
+}
+
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.h
@@ -52,6 +52,7 @@ public:
     uint64_t getApproxBytesToWriteToDisk() const override {
         return _target->getApproxBytesToWriteToDisk();
     }
+    uint64_t get_approx_bytes_to_read_from_disk() const noexcept override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/prepare_restart_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/prepare_restart_handler.cpp
@@ -40,7 +40,8 @@ createPrepareRestartConfig(const PrepareRestartHandler::ProtonConfig &protonCfg)
 {
     return PrepareRestartFlushStrategy::Config(protonCfg.flush.preparerestart.replaycost,
                                                protonCfg.flush.preparerestart.replayoperationcost,
-                                               protonCfg.flush.preparerestart.writecost);
+                                               protonCfg.flush.preparerestart.writecost,
+                                               protonCfg.flush.preparerestart.readcost);
 }
 
 }

--- a/searchcore/src/vespa/searchcorespi/flush/iflushtarget.cpp
+++ b/searchcore/src/vespa/searchcorespi/flush/iflushtarget.cpp
@@ -20,4 +20,12 @@ LeafFlushTarget::LeafFlushTarget(const std::string &name, const Type &type, cons
     : IFlushTarget(name, type, component)
 {}
 
+LeafFlushTarget::~LeafFlushTarget() = default;
+
+uint64_t
+LeafFlushTarget::get_approx_bytes_to_read_from_disk() const noexcept
+{
+    return 0;
+}
+
 }

--- a/searchcore/src/vespa/searchcorespi/flush/iflushtarget.h
+++ b/searchcore/src/vespa/searchcorespi/flush/iflushtarget.h
@@ -136,6 +136,11 @@ public:
     virtual uint64_t getApproxBytesToWriteToDisk() const = 0;
 
     /**
+     * Returns the approximate amount of bytes this target reads from disk if flushed.
+     */
+    virtual uint64_t get_approx_bytes_to_read_from_disk() const noexcept = 0;
+
+    /**
      * Return cost of replaying a feed operation relative to cost of reading a feed operation from tls.
      */
     virtual double get_replay_operation_cost() const = 0;
@@ -188,8 +193,10 @@ public:
 class LeafFlushTarget : public IFlushTarget {
 public:
     LeafFlushTarget(const std::string &name, const Type &type, const Component &component) noexcept;
+    ~LeafFlushTarget() override;
     bool needUrgentFlush() const override { return false; }
     Priority getPriority() const override { return Priority::NORMAL; }
+    uint64_t get_approx_bytes_to_read_from_disk() const noexcept override;
     double get_replay_operation_cost() const override { return 0.0; }
 };
 


### PR DESCRIPTION
in prepare for restart flush strategy. This allows prepare restart flush strategy to consider paged attributes as more expensive to flush.

@vekterli : please review
@geirst : FYI
