### PR TITLE
Do not trigger window resize if time delta is zero

### DIFF
--- a/vespalib/src/tests/shared_operation_throttler/shared_operation_throttler_test.cpp
+++ b/vespalib/src/tests/shared_operation_throttler/shared_operation_throttler_test.cpp
@@ -225,6 +225,16 @@ TEST(WindowedSharedOperationThrottlerTest, maximum_window_size_is_respected) {
     ASSERT_TRUE(window_size >= 40 && window_size <= 50);
 }
 
+TEST(WindowedSharedOperationThrottlerTest, zero_sized_acquire_time_delta_does_not_modify_window_size) {
+    WindowFixture f(1, 1, 2);
+    for (int i = 0; i < 3; ++i) {
+        auto token = f._throttler->try_acquire_one();
+        ASSERT_TRUE(token.valid());
+        EXPECT_EQ(f._throttler->current_window_size(), 1);
+        // No mock timer bump between iterations.
+    }
+}
+
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/util/shared_operation_throttler.cpp
+++ b/vespalib/src/vespa/vespalib/util/shared_operation_throttler.cpp
@@ -214,6 +214,9 @@ DynamicThrottlePolicy::process_request() noexcept
     }
 
     const uint64_t time = current_time_as_millis();
+    if (time == _resize_time) {
+        return; // Happened within the same millisecond; ignore. Avoids div by zero below.
+    }
     const double elapsed = time - _resize_time;
     _resize_time = time;
 


### PR DESCRIPTION
@toregge please review.

Prior to this commit, if the delta time in milliseconds between two candidate window resize events was zero, the local throughput would be computed as a floating point division of zero. I.e. positive infinity. This is likely somewhat optimistic when compared to the _actual_ throughput on the system. This would also always trigger an attempt at a window size increase.

Simply refrain from adjusting the window size based on throughput until there is a non-zero time delta.
