### PR TITLE
Skip validating streaming search cluster if streaming search is not used

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/StreamingSearchClusterChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/StreamingSearchClusterChangeValidator.java
@@ -30,6 +30,7 @@ public class StreamingSearchClusterChangeValidator implements ChangeValidator {
         context.previousModel().getContentClusters().forEach((clusterName, currentCluster) -> {
             ContentCluster nextCluster = context.model().getContentClusters().get(clusterName);
             if (nextCluster != null) {
+                if ( ! nextCluster.getSearch().hasStreaming()) return;
                 if (currentCluster.getSearch().getSearchCluster() != null && nextCluster.getSearch().getSearchCluster() != null) {
                     validateStreamingCluster(currentCluster, currentCluster.getSearch().getSearchCluster(),
                                              nextCluster, nextCluster.getSearch().getSearchCluster())


### PR DESCRIPTION
This was validated twice before this change. Avoids duplicate error message like:

```

	Document type 'music': Field 'sales' changed: data type: 'int' -> 'float'
	Document type 'music': Field 'sales' changed: data type: 'int' -> 'float'
```

