### PR TITLE
Update Feature Flags - Push ahead LegacyTrustStore support

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -322,7 +322,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag USE_LEGACY_STORE = defineFeatureFlag(
             "use-legacy-trust-store", true,
-            List.of("marlon"), "2024-12-05", "2025-03-01",
+            List.of("marlon"), "2024-12-05", "2025-04-01",
             "Use legacy trust store for CA, or new one",
             "Takes effect on restart of OCI containers");
 


### PR DESCRIPTION
## What

* Push forward the expiry of `use-legacy-trust-store` flag.

## Why

* Rollout not completed yet.

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
