### PR TITLE
add more token support (document and visit)

### DIFF
--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -110,7 +110,7 @@ func TestLocalConfig(t *testing.T) {
 	assertConfigCommand(t, configHome, `application = t1.a1.default
 cluster = <unset>
 color = auto
-debug-mode = false
+debug = false
 instance = foo
 quiet = false
 target = cloud

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -110,6 +110,7 @@ func TestLocalConfig(t *testing.T) {
 	assertConfigCommand(t, configHome, `application = t1.a1.default
 cluster = <unset>
 color = auto
+debug-mode = false
 instance = foo
 quiet = false
 target = cloud

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -34,6 +34,7 @@ const (
 	targetFlag      = "target"
 	colorFlag       = "color"
 	quietFlag       = "quiet"
+	debugModeFlag   = "debug-mode"
 
 	anyTarget = iota
 	localTargetOnly
@@ -248,6 +249,7 @@ func (c *CLI) configureFlags() map[string]*pflag.Flag {
 		zone        string
 		color       string
 		quiet       bool
+		debugMode   bool
 	)
 	c.cmd.PersistentFlags().StringVarP(&target, targetFlag, "t", "local", `The target platform to use. Must be "local", "cloud", "hosted" or an URL`)
 	c.cmd.PersistentFlags().StringVarP(&application, applicationFlag, "a", "", `The application to use (cloud only). Format "tenant.application.instance" - instance is optional`)
@@ -256,6 +258,9 @@ func (c *CLI) configureFlags() map[string]*pflag.Flag {
 	c.cmd.PersistentFlags().StringVarP(&zone, zoneFlag, "z", "", "The zone to use. This defaults to a dev zone (cloud only)")
 	c.cmd.PersistentFlags().StringVarP(&color, colorFlag, "c", "auto", `Whether to use colors in output. Must be "auto", "never", or "always"`)
 	c.cmd.PersistentFlags().BoolVarP(&quiet, quietFlag, "q", false, "Print only errors")
+	c.cmd.PersistentFlags().BoolVar(&debugMode, debugModeFlag, false, `Print debugging output`)
+	c.cmd.PersistentFlags().MarkHidden(debugModeFlag)
+
 	flags := make(map[string]*pflag.Flag)
 	c.cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
 		flags[flag.Name] = flag
@@ -348,7 +353,9 @@ func (c *CLI) printInfo(msg ...interface{}) {
 }
 
 func (c *CLI) printDebug(msg ...interface{}) {
-	fmt.Fprintln(c.Stderr, color.CyanString("Debug:"), fmt.Sprint(msg...))
+	if debugMode, _ := c.config.get(debugModeFlag); debugMode == "true" {
+		fmt.Fprintln(c.Stderr, color.CyanString("Debug:"), fmt.Sprint(msg...))
+	}
 }
 
 func (c *CLI) printWarning(msg interface{}, hints ...string) {

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -34,7 +34,7 @@ const (
 	targetFlag      = "target"
 	colorFlag       = "color"
 	quietFlag       = "quiet"
-	debugModeFlag   = "debug-mode"
+	debugModeFlag   = "debug"
 
 	anyTarget = iota
 	localTargetOnly

--- a/client/go/internal/cli/cmd/select_auth_method.go
+++ b/client/go/internal/cli/cmd/select_auth_method.go
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/vespa-engine/vespa/client/go/internal/admin/envvars"
+)
+
+func (cli *CLI) selectAuthMethod() (authMethod string) {
+	token := cli.Environment[envvars.VESPA_CLI_DATA_PLANE_TOKEN]
+	authMethod = "mtls"
+	if token != "" {
+		cli.printDebug("The VESPA_CLI_DATA_PLANE_TOKEN environment variable is set, using token authentication")
+		authMethod = "token"
+	}
+	return
+}
+
+func (cli *CLI) addBearerToken(header *http.Header) error {
+	token := cli.Environment[envvars.VESPA_CLI_DATA_PLANE_TOKEN]
+	if token != "" {
+		if header.Get("Authorization") != "" {
+			err := fmt.Errorf("header 'Authorization' cannot be set in combination with VESPA_CLI_DATA_PLANE_TOKEN")
+			return errHint(err, "Unset the VESPA_CLI_DATA_PLANE_TOKEN environment variable or remove the Authorization header")
+		}
+		header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+	return nil
+}

--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -28,7 +28,6 @@ type visitArgs struct {
 	makeFeed       bool
 	jsonLines      bool
 	pretty         bool
-	debugMode      bool
 	chunkCount     int
 	from           string
 	to             string
@@ -53,9 +52,7 @@ func (v *visitArgs) writeString(s string) {
 }
 
 func (v *visitArgs) debugPrint(s string) {
-	if v.debugMode {
-		v.cli.printDebug(s)
-	}
+	v.cli.printDebug(s)
 }
 
 func (v *visitArgs) dumpDocuments(documents []DocumentBlob) {
@@ -123,6 +120,14 @@ $ vespa visit --field-set "[id]" # list document IDs
 			if err != nil {
 				return err
 			}
+			if service.AuthMethod == "token" {
+				err = cli.addBearerToken(&header)
+				if err != nil {
+					return err
+				}
+				service.TLSOptions.CertificateFile = ""
+				service.TLSOptions.PrivateKeyFile = ""
+			}
 			if vArgs.verbose {
 				service.CurlWriter = vespa.CurlWriter{Writer: cli.Stderr}
 			}
@@ -140,7 +145,6 @@ $ vespa visit --field-set "[id]" # list document IDs
 	cmd.Flags().StringVar(&vArgs.contentCluster, "content-cluster", "*", `Which content cluster to visit documents from`)
 	cmd.Flags().StringVar(&vArgs.fieldSet, "field-set", "", `Which fieldset to ask for`)
 	cmd.Flags().StringVar(&vArgs.selection, "selection", "", `Select subset of cluster`)
-	cmd.Flags().BoolVar(&vArgs.debugMode, "debug-mode", false, `Print debugging output`)
 	cmd.Flags().BoolVar(&vArgs.jsonLines, "json-lines", true, `Output documents as JSON lines`)
 	cmd.Flags().BoolVar(&vArgs.makeFeed, "make-feed", false, `Output JSON array suitable for vespa-feeder`)
 	cmd.Flags().BoolVar(&vArgs.pretty, "pretty-json", false, `Format pretty JSON`)


### PR DESCRIPTION
move debug-mode flag to common code, but make it hidden
use printDebug instead of trace, enabled by --debug-mode
separate out some common code for token handling

Note: also clears key/cert file options, to avoid confusion, especially when printing the curl command

@evgiz please review
@bratseth FYI
