### PR TITLE
Revert "Make FlagDbFile a FlagRepository, and the latter a FlagSource" MERGEOK

### DIFF
--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/ConfigServerFlagSource.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/ConfigServerFlagSource.java
@@ -3,9 +3,7 @@ package com.yahoo.vespa.configserver.flags;
 
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.vespa.configserver.flags.db.BootstrapFlagSource;
-import com.yahoo.vespa.configserver.flags.db.FlagsDbImpl;
 import com.yahoo.vespa.configserver.flags.db.ZooKeeperFlagSource;
-import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.flags.OrderedFlagSource;
 
 import java.nio.file.FileSystem;
@@ -17,8 +15,8 @@ import java.nio.file.FileSystems;
 public class ConfigServerFlagSource extends OrderedFlagSource {
 
     @Inject
-    public ConfigServerFlagSource(Curator curator) {
-        this(FileSystems.getDefault(), new FlagsDbImpl(curator));
+    public ConfigServerFlagSource(FlagsDb flagsDb) {
+        this(FileSystems.getDefault(), flagsDb);
     }
 
     ConfigServerFlagSource(FileSystem fileSystem, FlagsDb flagsDb) {

--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/FlagsDbImpl.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/FlagsDbImpl.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.configserver.flags.db;
 
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.component.annotation.Inject;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.configserver.flags.FlagsDb;
 import com.yahoo.vespa.curator.Curator;
@@ -19,12 +21,13 @@ import java.util.stream.Collectors;
 /**
  * @author hakonhall
  */
-public class FlagsDbImpl implements FlagsDb {
+public class FlagsDbImpl extends AbstractComponent implements FlagsDb {
     private static final Path ROOT_PATH = Path.fromString("/flags/v1");
 
     private final Curator curator;
     private final Curator.DirectoryCache cache;
 
+    @Inject
     public FlagsDbImpl(Curator curator) {
         this.curator = curator;
         curator.create(ROOT_PATH);
@@ -61,6 +64,11 @@ public class FlagsDbImpl implements FlagsDb {
 
     private static Path getZkPathFor(FlagId flagId) {
         return ROOT_PATH.append(flagId.toString());
+    }
+
+    @Override
+    public void deconstruct() {
+        cache.close(); // Also shuts down the executor service
     }
 
 }

--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -48,6 +48,7 @@
     <preprocess:include file='model-integration.xml' required='true' />
 
     <component id="com.yahoo.vespa.configserver.flags.ConfigServerFlagSource" bundle="configserver-flags"/>
+    <component id="com.yahoo.vespa.configserver.flags.db.FlagsDbImpl" bundle="configserver-flags"/>
 
     <component id="com.yahoo.vespa.service.slobrok.SlobrokMonitorManagerImpl" bundle="service-monitor" />
     <component id="com.yahoo.vespa.service.health.HealthMonitorManager" bundle="service-monitor" />

--- a/flags/src/main/java/com/yahoo/vespa/flags/FlagRepository.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FlagRepository.java
@@ -4,16 +4,10 @@ package com.yahoo.vespa.flags;
 import com.yahoo.vespa.flags.json.FlagData;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * @author hakonhall
  */
-public interface FlagRepository extends FlagSource {
+public interface FlagRepository {
     Map<FlagId, FlagData> getAllFlagData();
-
-    @Override
-    default Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
-        return Optional.ofNullable(getAllFlagData().get(id)).flatMap(flagData -> flagData.resolve(vector));
-    }
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/file/FlagDbFile.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/file/FlagDbFile.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.flags.file;
 import java.util.logging.Level;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.flags.FlagId;
-import com.yahoo.vespa.flags.FlagRepository;
 import com.yahoo.vespa.flags.json.FlagData;
 
 import java.io.IOException;
@@ -32,23 +31,26 @@ import static com.yahoo.yolean.Exceptions.uncheck;
  *
  * @author hakonhall
  */
-public class FlagDbFile implements FlagRepository {
+public class FlagDbFile {
     private static final Logger logger = Logger.getLogger(FlagDbFile.class.getName());
 
     private final Path path;
 
-    public FlagDbFile() { this(FileSystems.getDefault()); }
+    public FlagDbFile() {
+        this(FileSystems.getDefault());
+    }
 
     public FlagDbFile(FileSystem fileSystem) {
         this(fileSystem.getPath(Defaults.getDefaults().underVespaHome("var/vespa/flag.db")));
     }
 
-    public FlagDbFile(Path path) { this.path = path; }
+    public FlagDbFile(Path path) {
+        this.path = path;
+    }
 
-    public Path getPath() { return path; }
-
-    @Override
-    public Map<FlagId, FlagData> getAllFlagData() { return read(); }
+    public Path getPath() {
+        return path;
+    }
 
     public Map<FlagId, FlagData> read() {
         Optional<byte[]> bytes = readFile();
@@ -102,8 +104,7 @@ public class FlagDbFile implements FlagRepository {
     }
 
     private void writeFile(byte[] bytes) {
-        Path parent = path.getParent();
-        if (parent != null) uncheck(() -> Files.createDirectories(parent));
+        uncheck(() -> Files.createDirectories(path.getParent()));
         uncheck(() -> Files.write(path, bytes));
     }
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#33476

Broke the build:
``` 
[ERROR] Tests run: 46, Failures: 0, Errors: 46, Skipped: 0, Time elapsed: 7.499 s <<< FAILURE! -- in com.yahoo.vespa.hosted.billing.BillingApiHandlerV2Test
[ERROR] com.yahoo.vespa.hosted.billing.BillingApiHandlerV2Test.accountant_can_update_tenant_address_and_contact -- Time elapsed: 1.720 s <<< ERROR!
java.lang.RuntimeException: When resolving dependencies of 'com.yahoo.vespa.hosted.controller.security.CloudAccessControl'
	Suppressed: java.lang.NullPointerException: Cannot invoke "com.yahoo.application.container.JDisc.close()" because "this.container" is null
		at com.yahoo.vespa.hosted.controller.restapi.ControllerContainerTest.stopContainer(ControllerContainerTest.java:45)
		at java.base/java.lang.reflect.Method.invoke(Method.java:569)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.IllegalStateException: Multiple global components with class 'com.yahoo.vespa.flags.FlagSource' found : [ComponentNode{Node{componentId=com.yahoo.vespa.configserver.flags.db.FlagsDbImpl}, clazz=class com.yahoo.vespa.configserver.flags.db.FlagsDbImpl, key=null, configId='container/component/com.yahoo.vespa.configserver.flags.db.FlagsDbImpl'}, ComponentNode{Node{componentId=com.yahoo.vespa.flags.InMemoryFlagSource}, clazz=class com.yahoo.vespa.flags.InMemoryFlagSource, key=null, configId='container/component/com.yahoo.vespa.flags.InMemoryFlagSource'}]
``` 