### PR TITLE
deprecate and do API cleanup

### DIFF
--- a/document/abi-spec.json
+++ b/document/abi-spec.json
@@ -2388,7 +2388,7 @@
       "public void setNewValues(com.yahoo.document.datatypes.Array)",
       "public com.yahoo.document.datatypes.Array getNewValues()",
       "public com.yahoo.document.datatypes.FieldPathIteratorHandler getIteratorHandler(com.yahoo.document.Document)",
-      "public void serialize(com.yahoo.document.serialization.VespaDocumentSerializer6)",
+      "public void serialize(com.yahoo.document.serialization.DocumentSerializer)",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",
       "public java.lang.String toString()"
@@ -2414,7 +2414,7 @@
       "public void setRemoveIfZero(boolean)",
       "public void setCreateMissingPath(boolean)",
       "public boolean isArithmetic()",
-      "public void serialize(com.yahoo.document.serialization.VespaDocumentSerializer6)",
+      "public void serialize(com.yahoo.document.serialization.DocumentSerializer)",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",
       "public java.lang.String toString()",
@@ -2468,7 +2468,7 @@
       "public com.yahoo.document.select.DocumentSelector getWhereClause()",
       "public java.lang.String getOriginalWhereClause()",
       "public void applyTo(com.yahoo.document.Document)",
-      "public void serialize(com.yahoo.document.serialization.VespaDocumentSerializer6)",
+      "public void serialize(com.yahoo.document.serialization.DocumentSerializer)",
       "public static com.yahoo.document.fieldpathupdate.FieldPathUpdate create(com.yahoo.document.fieldpathupdate.FieldPathUpdate$Type, com.yahoo.document.DocumentType, com.yahoo.document.serialization.DocumentUpdateReader)",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",
@@ -2853,7 +2853,10 @@
       "public abstract void write(com.yahoo.document.update.ClearValueUpdate, com.yahoo.document.DataType)",
       "public abstract void write(com.yahoo.document.update.TensorModifyUpdate)",
       "public abstract void write(com.yahoo.document.update.TensorAddUpdate)",
-      "public abstract void write(com.yahoo.document.update.TensorRemoveUpdate)"
+      "public abstract void write(com.yahoo.document.update.TensorRemoveUpdate)",
+      "public abstract void write(com.yahoo.document.fieldpathupdate.FieldPathUpdate)",
+      "public abstract void write(com.yahoo.document.fieldpathupdate.AddFieldPathUpdate)",
+      "public abstract void write(com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate)"
     ],
     "fields" : [ ]
   },
@@ -3025,7 +3028,6 @@
       "public"
     ],
     "methods" : [
-      "public final com.yahoo.document.DocumentTypeManager getDocumentTypeManager()",
       "public com.yahoo.document.DocumentTypeManager getTypeRepo()",
       "public void read(com.yahoo.document.Document)",
       "public void read(com.yahoo.vespa.objects.FieldBase, com.yahoo.document.Document)",
@@ -3053,7 +3055,6 @@
       "public void read(com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate)",
       "public void read(com.yahoo.document.fieldpathupdate.RemoveFieldPathUpdate)",
       "public void read(com.yahoo.document.fieldpathupdate.AddFieldPathUpdate)",
-      "public com.yahoo.document.update.ValueUpdate getValueUpdate(com.yahoo.document.DataType, com.yahoo.document.DataType)",
       "public void read(com.yahoo.document.update.FieldUpdate)",
       "public com.yahoo.document.DocumentId readDocumentId()",
       "public com.yahoo.document.DocumentType readDocumentType()",
@@ -3134,8 +3135,7 @@
       "public void write(com.yahoo.document.update.ClearValueUpdate, com.yahoo.document.DataType)",
       "public void write(com.yahoo.document.update.TensorModifyUpdate)",
       "public void write(com.yahoo.document.update.TensorAddUpdate)",
-      "public void write(com.yahoo.document.update.TensorRemoveUpdate)",
-      "public static long getSerializedSize(com.yahoo.document.Document)"
+      "public void write(com.yahoo.document.update.TensorRemoveUpdate)"
     ],
     "fields" : [ ]
   },

--- a/document/src/main/java/com/yahoo/document/fieldpathupdate/AddFieldPathUpdate.java
+++ b/document/src/main/java/com/yahoo/document/fieldpathupdate/AddFieldPathUpdate.java
@@ -8,7 +8,7 @@ import com.yahoo.document.datatypes.CollectionFieldValue;
 import com.yahoo.document.datatypes.FieldPathIteratorHandler;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.serialization.DocumentUpdateReader;
-import com.yahoo.document.serialization.VespaDocumentSerializer6;
+import com.yahoo.document.serialization.DocumentSerializer;
 
 /**
  * @author Thomas Gundersen
@@ -97,7 +97,7 @@ public class AddFieldPathUpdate extends FieldPathUpdate {
     }
 
     @Override
-    public void serialize(VespaDocumentSerializer6 data) {
+    public void serialize(DocumentSerializer data) {
         data.write(this);
     }
 

--- a/document/src/main/java/com/yahoo/document/fieldpathupdate/AssignFieldPathUpdate.java
+++ b/document/src/main/java/com/yahoo/document/fieldpathupdate/AssignFieldPathUpdate.java
@@ -9,7 +9,7 @@ import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.NumericFieldValue;
 import com.yahoo.document.select.parser.ParseException;
 import com.yahoo.document.serialization.DocumentUpdateReader;
-import com.yahoo.document.serialization.VespaDocumentSerializer6;
+import com.yahoo.document.serialization.DocumentSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -237,7 +237,7 @@ public class AssignFieldPathUpdate extends FieldPathUpdate {
     }
 
     @Override
-    public void serialize(VespaDocumentSerializer6 data) {
+    public void serialize(DocumentSerializer data) {
         data.write(this);
     }
 

--- a/document/src/main/java/com/yahoo/document/fieldpathupdate/FieldPathUpdate.java
+++ b/document/src/main/java/com/yahoo/document/fieldpathupdate/FieldPathUpdate.java
@@ -11,7 +11,7 @@ import com.yahoo.document.select.Result;
 import com.yahoo.document.select.ResultList;
 import com.yahoo.document.select.parser.ParseException;
 import com.yahoo.document.serialization.DocumentUpdateReader;
-import com.yahoo.document.serialization.VespaDocumentSerializer6;
+import com.yahoo.document.serialization.DocumentSerializer;
 import java.util.ListIterator;
 import java.util.Objects;
 
@@ -131,7 +131,7 @@ public abstract class FieldPathUpdate {
         }
     }
 
-    public void serialize(VespaDocumentSerializer6 data) {
+    public void serialize(DocumentSerializer data) {
         data.write(this);
     }
 

--- a/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
+++ b/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
@@ -129,6 +129,10 @@ public class DocumentUpdateJsonSerializer {
             });
         }
 
+        @Override public void write(FieldPathUpdate update) { throw new IllegalStateException("should not end up here"); }
+        @Override public void write(AddFieldPathUpdate update) { throw new IllegalStateException("should not end up here"); }
+        @Override public void write(AssignFieldPathUpdate update)  { throw new IllegalStateException("should not end up here"); }
+
         private void write(FieldPath fieldPath, Collection<FieldPathUpdate> fieldPathUpdates, JsonGenerator generator) throws IOException {
             generator.writeObjectFieldStart(fieldPath.toString());
 

--- a/document/src/main/java/com/yahoo/document/serialization/DocumentDeserializerFactory.java
+++ b/document/src/main/java/com/yahoo/document/serialization/DocumentDeserializerFactory.java
@@ -25,6 +25,7 @@ public class DocumentDeserializerFactory {
      * Deprecated, use createHead instead.
      */
     @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public static DocumentDeserializer create6(DocumentTypeManager manager, GrowableByteBuffer buf) {
         return new VespaDocumentDeserializer6(manager, buf);
     }

--- a/document/src/main/java/com/yahoo/document/serialization/DocumentSerializerFactory.java
+++ b/document/src/main/java/com/yahoo/document/serialization/DocumentSerializerFactory.java
@@ -24,6 +24,7 @@ public class DocumentSerializerFactory {
      * Deprecated, use createHead instead.
      */
     @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public static DocumentSerializer create6(GrowableByteBuffer buf) {
         return new VespaDocumentSerializer6(buf);
     }
@@ -34,6 +35,7 @@ public class DocumentSerializerFactory {
      * Deprecated, use createHead instead.
      */
     @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public static DocumentSerializer create6() {
         return new VespaDocumentSerializer6(new GrowableByteBuffer(8 * 1024, 2.0f));
     }

--- a/document/src/main/java/com/yahoo/document/serialization/DocumentUpdateWriter.java
+++ b/document/src/main/java/com/yahoo/document/serialization/DocumentUpdateWriter.java
@@ -13,6 +13,9 @@ import com.yahoo.document.update.RemoveValueUpdate;
 import com.yahoo.document.update.TensorAddUpdate;
 import com.yahoo.document.update.TensorModifyUpdate;
 import com.yahoo.document.update.TensorRemoveUpdate;
+import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
+import com.yahoo.document.fieldpathupdate.AddFieldPathUpdate;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 
 /**
  * Interface for writing document updates in custom serializers.
@@ -31,4 +34,8 @@ public interface DocumentUpdateWriter {
     void write(TensorModifyUpdate update);
     void write(TensorAddUpdate update);
     void write(TensorRemoveUpdate update);
+
+    void write(FieldPathUpdate update);
+    void write(AddFieldPathUpdate update);
+    void write(AssignFieldPathUpdate update);
 }

--- a/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializer6.java
+++ b/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializer6.java
@@ -75,6 +75,7 @@ import static com.yahoo.text.Utf8.calculateStringPositions;
  *
  * @author baldersheim
  */
+@Deprecated(forRemoval = true)
 public class VespaDocumentDeserializer6 extends BufferSerializer implements DocumentDeserializer {
 
     private final DocumentTypeManager manager;
@@ -89,22 +90,22 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         this.version = Document.SERIALIZED_VERSION;
     }
 
-    final public DocumentTypeManager getDocumentTypeManager() { return manager; }
-
     @Override
     public DocumentTypeManager getTypeRepo() {
         return manager;
     }
 
+    @Override
     public void read(Document document) {
         read(null, document);
     }
 
+    @Override
     public void read(FieldBase field, Document doc) {
         // Verify that we have correct version
         version = getShort(null);
         if (version < 8 || version > Document.SERIALIZED_VERSION) {
-            throw new DeserializationException("Unknown version " + version + ", expected " + 
+            throw new DeserializationException("Unknown version " + version + ", expected " +
                                                Document.SERIALIZED_VERSION + ".");
         }
 
@@ -129,10 +130,12 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(FieldBase field, FieldValue value) {
         throw new IllegalArgumentException("read not implemented yet.");
     }
 
+    @Override
     public <T extends FieldValue> void read(FieldBase field, Array<T> array) {
         int numElements = getNumCollectionElems();
         ArrayList<T> list = new ArrayList<>(numElements);
@@ -146,6 +149,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         array.addAll(list);
     }
 
+    @Override
     public <K extends FieldValue, V extends FieldValue> void read(FieldBase field, MapFieldValue<K, V> map) {
         int numElements = getNumCollectionElems();
         Map<K,V> hash = new HashMap<>();
@@ -169,9 +173,11 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         return numElements;
     }
 
+    @Override
     public <T extends FieldValue> void read(FieldBase field, CollectionFieldValue<T> value) {
         throw new IllegalArgumentException("read not implemented yet.");
     }
+    @Override
     public void read(FieldBase field, ByteFieldValue value)    { value.assign(getByte(null)); }
 
     @Override
@@ -179,11 +185,16 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         value.setBoolean((getByte(null) != 0));
     }
 
+    @Override
     public void read(FieldBase field, DoubleFieldValue value)  { value.assign(getDouble(null)); }
+    @Override
     public void read(FieldBase field, FloatFieldValue value)   { value.assign(getFloat(null)); }
+    @Override
     public void read(FieldBase field, IntegerFieldValue value) { value.assign(getInt(null)); }
+    @Override
     public void read(FieldBase field, LongFieldValue value)    { value.assign(getLong(null)); }
 
+    @Override
     public void read(FieldBase field, Raw value) {
         int rawsize = getInt(null);
         byte[] rawBytes = getBytes(null, rawsize);
@@ -197,6 +208,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         value.assign(BinaryFormat.decode(buf));
     }
 
+    @Override
     public void read(FieldBase field, StringFieldValue value) {
         byte coding = getByte(null);
 
@@ -258,6 +270,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(FieldBase fieldDef, Struct s) {
         s.setVersion(version);
         s.clear();
@@ -296,10 +309,12 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         position(afterPos);
     }
 
+    @Override
     public void read(FieldBase field, StructuredFieldValue value) {
         throw new IllegalArgumentException("read not implemented yet.");
     }
 
+    @Override
     public <T extends FieldValue> void read(FieldBase field, WeightedSet<T> ws) {
         WeightedSetDataType type = ws.getDataType();
         getInt(null); // Have no need for type
@@ -320,6 +335,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
 
     }
 
+    @Override
     public void read(FieldBase field, AnnotationReference value) {
         int seqId = buf.getInt1_2_4Bytes();
         try {
@@ -369,6 +385,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         return end;
     }
 
+    @Override
     public void read(DocumentUpdate update) {
         update.setId(new DocumentId(this));
         update.setDocumentType(readDocumentType());
@@ -391,6 +408,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
     }
 
 
+    @Override
     public void read(FieldPathUpdate update) {
         String fieldPath = getString(null);
         String whereClause = getString(null);
@@ -403,6 +421,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(AssignFieldPathUpdate update) {
         byte flags = getByte(null);
         update.setRemoveIfZero((flags & AssignFieldPathUpdate.REMOVE_IF_ZERO) != 0);
@@ -417,10 +436,12 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(RemoveFieldPathUpdate update) {
 
     }
 
+    @Override
     public void read(AddFieldPathUpdate update) {
         DataType dt = update.getFieldPath().getResultingDataType();
         FieldValue fv = dt.createFieldValue();
@@ -433,7 +454,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         update.setNewValues((Array)fv);
     }
 
-    public ValueUpdate getValueUpdate(DataType superType, DataType subType) {
+    private ValueUpdate getValueUpdate(DataType superType, DataType subType) {
         int vuTypeId = getInt(null);
 
         ValueUpdate.ValueUpdateClassID op = ValueUpdate.ValueUpdateClassID.getID(vuTypeId);
@@ -498,6 +519,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(FieldUpdate fieldUpdate) {
         int fieldId = getInt(null);
         Field field = fieldUpdate.getDocumentType().getField(fieldId);
@@ -518,18 +540,20 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public DocumentId readDocumentId() {
         Utf8String uri = new Utf8String(parseNullTerminatedString(getBuf().getByteBuffer()));
         return DocumentId.createFromSerialized(uri.toString());
     }
 
+    @Override
     public DocumentType readDocumentType() {
         Utf8Array docTypeName = parseNullTerminatedString();
         int ignoredVersion = getShort(null); // used to hold the version
 
         DocumentType docType = manager.getDocumentType(new DataTypeName(docTypeName));
         if (docType == null) {
-            throw new DeserializationException("No known document type with name " + 
+            throw new DeserializationException("No known document type with name " +
                                                new Utf8String(docTypeName));
         }
         return docType;
@@ -609,10 +633,12 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(SpanTree tree) {
         readSpanTree(tree, true);
     }
 
+    @Override
     public void read(Annotation annotation) {
         int annotationTypeId = buf.getInt();
         AnnotationType type = manager.getAnnotationTypeRegistry().getType(annotationTypeId);
@@ -657,6 +683,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(Span span) {
         byte type = buf.get();
         if (type != Span.ID) {
@@ -678,6 +705,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         span.setLength(length);
     }
 
+    @Override
     public void read(SpanList spanList) {
         byte type = buf.get();
         if (type != SpanList.ID) {
@@ -689,6 +717,7 @@ public class VespaDocumentDeserializer6 extends BufferSerializer implements Docu
         }
     }
 
+    @Override
     public void read(AlternateSpanList altSpanList) {
         byte type = buf.get();
         if (type != AlternateSpanList.ID) {

--- a/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializerHead.java
+++ b/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializerHead.java
@@ -17,6 +17,7 @@ import com.yahoo.tensor.TensorType;
  *
  * @author baldersheim
  */
+@SuppressWarnings("removal")
 public class VespaDocumentDeserializerHead extends VespaDocumentDeserializer6 {
 
     public VespaDocumentDeserializerHead(DocumentTypeManager manager, GrowableByteBuffer buffer) {

--- a/document/src/main/java/com/yahoo/document/serialization/VespaDocumentSerializer6.java
+++ b/document/src/main/java/com/yahoo/document/serialization/VespaDocumentSerializer6.java
@@ -71,6 +71,7 @@ import static com.yahoo.text.Utf8.calculateBytePositions;
  *
  * @author baldersheim
  **/
+@Deprecated(forRemoval = true)
 public class VespaDocumentSerializer6 extends BufferSerializer implements DocumentSerializer {
 
     private int spanNodeCounter = -1;
@@ -80,10 +81,12 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         super(buf);
     }
 
+    @Override
     public void write(Document doc) {
         write(new Field(doc.getDataType().getName(), 0, doc.getDataType()), doc);
     }
 
+    @Override
     public void write(FieldBase field, Document doc) {
         buf.putShort(Document.SERIALIZED_VERSION);
 
@@ -120,6 +123,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, FieldValue value) {
         throw new IllegalArgumentException("Not Implemented");
     }
@@ -130,6 +134,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param array - field value
      */
+    @Override
     public <T extends FieldValue> void write(FieldBase field, Array<T> array) {
         buf.putInt1_2_4Bytes(array.size());
 
@@ -140,6 +145,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
 
     }
 
+    @Override
     public <K extends FieldValue, V extends FieldValue> void write(FieldBase field, MapFieldValue<K, V> map) {
         buf.putInt1_2_4Bytes(map.size());
         for (Map.Entry<K, V> e : map.entrySet()) {
@@ -154,6 +160,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, ByteFieldValue value) {
         buf.put(value.getByte());
     }
@@ -170,6 +177,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public <T extends FieldValue> void write(FieldBase field, CollectionFieldValue<T> value) {
         throw new IllegalArgumentException("Not Implemented");
     }
@@ -180,6 +188,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, DoubleFieldValue value) {
         buf.putDouble(value.getDouble());
     }
@@ -190,6 +199,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, FloatFieldValue value) {
         buf.putFloat(value.getFloat());
     }
@@ -200,6 +210,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, IntegerFieldValue value) {
         buf.putInt(value.getInteger());
     }
@@ -210,6 +221,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, LongFieldValue value) {
         buf.putLong(value.getLong());
     }
@@ -220,6 +232,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, Raw value) {
         ByteBuffer rawBuf = value.getByteBuffer();
         int origPos = rawBuf.position();
@@ -242,6 +255,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, StringFieldValue value) {
         byte[] stringBytes = createUTF8CharArray(value.getString());
 
@@ -315,6 +329,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param s     - field value
      */
+    @Override
     public void write(FieldBase field, StructuredFieldValue s) {
         // Serialize all parts first.. As we need to know length before starting
         // Serialize all the fields.
@@ -373,6 +388,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param value - field value
      */
+    @Override
     public void write(FieldBase field, Struct value) {
         write(field, (StructuredFieldValue) value);
     }
@@ -383,6 +399,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param field - field description (name and data type)
      * @param ws    - field value
      */
+    @Override
     public <T extends FieldValue> void write(FieldBase field, WeightedSet<T> ws) {
         WeightedSetDataType type = ws.getDataType();
         putInt(null, type.getNestedType().getId());
@@ -406,6 +423,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
 
     }
 
+    @Override
     public void write(FieldBase field, AnnotationReference value) {
         int annotationId = value.getReference().getScratchId();
         if (annotationId >= 0) {
@@ -415,11 +433,13 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(DocumentId id) {
         put(null, id.getScheme().toUtf8().getBytes());
         putByte(null, (byte) 0);
     }
 
+    @Override
     public void write(DocumentType type) {
         byte[] docType = createUTF8CharArray(type.getName());
         put(null, docType);
@@ -427,10 +447,12 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         putShort(null, (short) 0); // Used to hold the version. Is now always 0.
     }
 
+    @Override
     public void write(DocumentRemove documentRemove) {
         throw new UnsupportedOperationException("serializing remove not implemented");
     }
 
+    @Override
     public void write(Annotation annotation) {
         buf.putInt(annotation.getType().getId());  //name hash
 
@@ -468,6 +490,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         buf.position(end);
     }
 
+    @Override
     public void write(SpanTree tree) {
         //we don't support serialization of nested span trees:
         if (spanNodeCounter >= 0) {
@@ -509,6 +532,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(SpanNode spanNode) {
         if (spanNodeCounter >= 0) {
             spanNode.setScratchId(spanNodeCounter++);
@@ -524,6 +548,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(Span span) {
         buf.put(Span.ID);
 
@@ -538,6 +563,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(SpanList spanList) {
         buf.put(SpanList.ID);
         buf.putInt1_2_4Bytes(spanList.numChildren());
@@ -547,6 +573,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(AlternateSpanList altSpanList) {
         buf.put(AlternateSpanList.ID);
         buf.putInt1_2_4Bytes(altSpanList.getNumSubTrees());
@@ -581,12 +608,14 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(FieldPathUpdate update) {
         putByte(null, (byte)update.getUpdateType().getCode());
         put(null, update.getOriginalFieldPath());
         put(null, update.getOriginalWhereClause());
     }
 
+    @Override
     public void write(AssignFieldPathUpdate update) {
         write((FieldPathUpdate)update);
         byte flags = 0;
@@ -606,6 +635,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
         }
     }
 
+    @Override
     public void write(AddFieldPathUpdate update) {
         write((FieldPathUpdate)update);
         update.getNewValues().serialize(this);
@@ -694,7 +724,7 @@ public class VespaDocumentSerializer6 extends BufferSerializer implements Docume
      * @param doc The Document whose size to calculate.
      * @return The size in bytes.
      */
-    public static long getSerializedSize(Document doc) {
+    static long getSerializedSize(Document doc) {
         DocumentSerializer serializer = new VespaDocumentSerializer6(new GrowableByteBuffer(8 * 1024, 2.0f));
         serializer.write(doc);
         return serializer.getBuf().position();

--- a/document/src/main/java/com/yahoo/document/serialization/VespaDocumentSerializerHead.java
+++ b/document/src/main/java/com/yahoo/document/serialization/VespaDocumentSerializerHead.java
@@ -11,6 +11,7 @@ import com.yahoo.io.GrowableByteBuffer;
  *
  * @author baldersheim
  */
+@SuppressWarnings("removal")
 public class VespaDocumentSerializerHead extends VespaDocumentSerializer6 {
 
     public VespaDocumentSerializerHead(GrowableByteBuffer buf) {

--- a/document/src/test/java/com/yahoo/document/serialization/SerializationHelperTestCase.java
+++ b/document/src/test/java/com/yahoo/document/serialization/SerializationHelperTestCase.java
@@ -28,7 +28,7 @@ public class SerializationHelperTestCase {
 
         assertTrue(data.position() == 0);
 
-        Utf8Array thisIsATest = VespaDocumentDeserializer6.parseNullTerminatedString(data.getBuf().getByteBuffer());
+        Utf8Array thisIsATest = VespaDocumentDeserializerHead.parseNullTerminatedString(data.getBuf().getByteBuffer());
 
         assertTrue(thisIsATest.equals(new Utf8Array(Utf8.toBytes("This is a test."))));
         assertTrue(data.position() == 16);
@@ -38,7 +38,7 @@ public class SerializationHelperTestCase {
 
         assertTrue(data.position() == 0);
 
-        Utf8Array thisIsATestAgain = VespaDocumentDeserializer6.parseNullTerminatedString(data.getBuf().getByteBuffer(), 15);
+        Utf8Array thisIsATestAgain = VespaDocumentDeserializerHead.parseNullTerminatedString(data.getBuf().getByteBuffer(), 15);
 
         assertTrue(thisIsATestAgain.equals(new Utf8Array(Utf8.toBytes("This is a test."))));
         assertTrue(data.position() == 16);


### PR DESCRIPTION
@vekterli please review
@bjorncs FYI

note: this changes some APIs that it's not expected that any vespa users will use, but it should be backwards (source) compatible anyways.  The goal here is to mark the "6" version as deprecated and only use it indirectly, so it can be removed at some later time.
