### PR TITLE
Wait longer before logging at level INFO

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
@@ -133,7 +133,7 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
 
     private void logFailure(Session session, FileReference fileReference, ApplicationId applicationId) {
         var deployed = Instant.ofEpochMilli(session.getMetaData().getDeployTimestamp());
-        var level = Duration.between(deployed, applicationRepository.clock().instant()).toMinutes() > 1
+        var level = Duration.between(deployed, applicationRepository.clock().instant()).toMinutes() > 2
                 ? INFO
                 : FINE;
         log.log(level, "Downloading application package (" + fileReference + ")" +


### PR DESCRIPTION
Download sometimes start a while after deployment and 1 minute is not long enough to say that this is something to worry about.