### PR TITLE
feat(LSP): add vsix to deploy action

### DIFF
--- a/.github/workflows/lspDeploy.yml
+++ b/.github/workflows/lspDeploy.yml
@@ -84,4 +84,5 @@ jobs:
             --notes-file ./clients/github-release/README.md \
             --latest=false \
             -t "Vespa Language Server ${{ steps.retrieve_version.outputs.VERSION }}" \
-            './clients/github-release/target/vespa-language-server_${{ steps.retrieve_version.outputs.VERSION }}.jar' 
+            './clients/github-release/target/vespa-language-server_${{ steps.retrieve_version.outputs.VERSION }}.jar' \
+            './clients/vscode/vespa-language-support-${{ steps.retrieve_version.outputs.VERSION }}.vsix'


### PR DESCRIPTION
Adds the .vsix extension file to the GH release, so people can install the extension in other vscode-based editors.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
