### PR TITLE
Add optional throttling of async maintenance operations 

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1341,7 +1341,8 @@
       "public boolean useLegacyWandQueryParsing()",
       "public boolean forwardAllLogLevels()",
       "public long zookeeperPreAllocSize()",
-      "public int documentV1QueueSize()"
+      "public int documentV1QueueSize()",
+      "public int maxContentNodeMaintenanceOpConcurrency()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -123,6 +123,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean forwardAllLogLevels() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default int documentV1QueueSize() { return -1; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default int maxContentNodeMaintenanceOpConcurrency() { return -1; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -79,6 +79,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private int persistenceThreadMaxFeedOpBatchSize = 1;
     private boolean logserverOtelCol = false;
     private boolean symmetricPutAndActivateReplicaSelection = false;
+    private int maxContentNodeMaintenanceOpConcurrency = -1;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
     @Override public boolean multitenant() { return multitenant; }
@@ -132,6 +133,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public int persistenceThreadMaxFeedOpBatchSize() { return persistenceThreadMaxFeedOpBatchSize; }
     @Override public boolean logserverOtelCol() { return logserverOtelCol; }
     @Override public boolean symmetricPutAndActivateReplicaSelection() { return symmetricPutAndActivateReplicaSelection; }
+    @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
 
     public TestProperties maxUnCommittedMemory(int maxUnCommittedMemory) {
         this.maxUnCommittedMemory = maxUnCommittedMemory;
@@ -349,6 +351,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setContainerEndpoints(Set<ContainerEndpoint> containerEndpoints) {
         this.endpoints = containerEndpoints;
+        return this;
+    }
+
+    public TestProperties setMaxContentNodeMaintenanceOpConcurrency(int maxConcurrency) {
+        this.maxContentNodeMaintenanceOpConcurrency = maxConcurrency;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
@@ -48,6 +48,7 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
     private final StorFilestorConfig.Response_sequencer_type.Enum responseSequencerType;
     private final boolean useAsyncMessageHandlingOnSchedule;
     private final int persistenceThreadMaxFeedOpBatchSize;
+    private final int maxContentNodeMaintenanceOpConcurrency;
 
     private static StorFilestorConfig.Response_sequencer_type.Enum convertResponseSequencerType(String sequencerType) {
         try {
@@ -64,6 +65,7 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
         this.responseSequencerType = convertResponseSequencerType(featureFlags.responseSequencerType());
         this.useAsyncMessageHandlingOnSchedule = featureFlags.useAsyncMessageHandlingOnSchedule();
         this.persistenceThreadMaxFeedOpBatchSize = featureFlags.persistenceThreadMaxFeedOpBatchSize();
+        this.maxContentNodeMaintenanceOpConcurrency = featureFlags.maxContentNodeMaintenanceOpConcurrency();
     }
 
 
@@ -77,6 +79,12 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
         builder.use_async_message_handling_on_schedule(useAsyncMessageHandlingOnSchedule);
         var throttleBuilder = new StorFilestorConfig.Async_operation_throttler.Builder();
         builder.async_operation_throttler(throttleBuilder);
+        if (maxContentNodeMaintenanceOpConcurrency > 0) {
+            var maintenanceThrottleBuilder = new StorFilestorConfig.Maintenance_operation_throttler.Builder();
+            maintenanceThrottleBuilder.type(StorFilestorConfig.Maintenance_operation_throttler.Type.DYNAMIC);
+            maintenanceThrottleBuilder.max_window_size(maxContentNodeMaintenanceOpConcurrency);
+            builder.maintenance_operation_throttler(maintenanceThrottleBuilder);
+        }
         builder.max_feed_op_batch_size(persistenceThreadMaxFeedOpBatchSize);
     }
 

--- a/configdefinitions/src/vespa/stor-filestor.def
+++ b/configdefinitions/src/vespa/stor-filestor.def
@@ -68,3 +68,22 @@ async_operation_throttler.resize_rate double default=3.0
 ## same bucket, as each operation would otherwise have to wait for the completion
 ## of all prior writes to the bucket.
 max_feed_op_batch_size int default=1
+
+## Specify throttling used for async _maintenance_ operations dispatched to Proton.
+## If enabled (i.e. set to DYNAMIC) this serves as a secondary throttling mechanism
+## for the following operations:
+##  - Put/Remove as part of merge apply diffs
+##  - RemoveByGid as part of bucket deletions
+##  - Remove as part of remove location (i.e. GC)
+##
+## Note that for a maintenance operation to be scheduled it has to _both_ acquire a
+## regular async operation throttler token _and_ a maintenance throttler token, in that
+## exact order.
+maintenance_operation_throttler.type enum { UNLIMITED, DYNAMIC } default=UNLIMITED
+## Internal maintenance throttler tuning parameters that only apply when type == DYNAMIC:
+maintenance_operation_throttler.window_size_increment int default=10
+maintenance_operation_throttler.window_size_decrement_factor double default=1.2
+maintenance_operation_throttler.window_size_backoff double default=0.95
+maintenance_operation_throttler.min_window_size int default=10
+maintenance_operation_throttler.max_window_size int default=-1 # < 0 implies INT_MAX
+maintenance_operation_throttler.resize_rate double default=2.0

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -208,6 +208,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean forwardAllLogLevels;
         private final long zookeeperPreAllocSize;
         private final int documentV1QueueSize;
+        private final int maxContentNodeMaintenanceOpConcurrency;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
             this.responseSequencer = Flags.RESPONSE_SEQUENCER_TYPE.bindTo(source).with(appId).with(version).value();
@@ -253,6 +254,7 @@ public class ModelContextImpl implements ModelContext {
             this.forwardAllLogLevels = PermanentFlags.FORWARD_ALL_LOG_LEVELS.bindTo(source).with(appId).with(version).value();
             this.zookeeperPreAllocSize = Flags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB.bindTo(source).value();
             this.documentV1QueueSize = Flags.DOCUMENT_V1_QUEUE_SIZE.bindTo(source).with(appId).with(version).value();
+            this.maxContentNodeMaintenanceOpConcurrency = Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY.bindTo(source).with(appId).with(version).value();
         }
 
         @Override public int heapSizePercentage() { return heapPercentage; }
@@ -304,6 +306,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean forwardAllLogLevels() { return forwardAllLogLevels; }
         @Override public long zookeeperPreAllocSize() { return zookeeperPreAllocSize; }
         @Override public int documentV1QueueSize() { return documentV1QueueSize; }
+        @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
     }
 
     public static class Properties implements ModelContext.Properties {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -353,6 +353,15 @@ public class Flags {
             "Use new incremental usage calculation for node snapshots",
             "Takes effect at controller startup");
 
+    public static final UnboundIntFlag MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY = defineIntFlag(
+            "max-content-node-maintenance-op-concurrency", -1,
+            List.of("vekterli"), "2025-03-07", "2025-09-01",
+            "Sets the maximum concurrency for maintenance-related operations on content nodes. " +
+            "Only intended as a manual emergency brake feature if a system is suddenly incapable of handling " +
+            "regular maintenance pressure.",
+            "Takes effect immediately",
+            INSTANCE_ID);
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,

--- a/storage/src/tests/persistence/filestorage/feed_operation_batching_test.cpp
+++ b/storage/src/tests/persistence/filestorage/feed_operation_batching_test.cpp
@@ -317,7 +317,7 @@ TEST_F(FeedOperationBatchingTest, batch_respects_persistence_throttling) {
     params.max_window_size = 3;
     params.window_size_increment = 1;
     _handler->use_dynamic_operation_throttling(true);
-    _handler->reconfigure_dynamic_throttler(params);
+    _handler->reconfigure_dynamic_operation_throttler(params);
     _handler->set_max_feed_op_batch_size(10); // > win size to make sure we test the right thing
 
     send_puts({{1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}});

--- a/storage/src/vespa/storage/persistence/apply_bucket_diff_entry_complete.cpp
+++ b/storage/src/vespa/storage/persistence/apply_bucket_diff_entry_complete.cpp
@@ -9,14 +9,16 @@ namespace storage {
 
 ApplyBucketDiffEntryComplete::ApplyBucketDiffEntryComplete(std::shared_ptr<ApplyBucketDiffState> state,
                                                            document::DocumentId doc_id,
-                                                           ThrottleToken throttle_token,
+                                                           ThrottleToken op_throttle_token,
+                                                           ThrottleToken maintenance_throttle_token,
                                                            const char *op,
                                                            const framework::Clock& clock,
                                                            metrics::DoubleAverageMetric& latency_metric)
     : _result_handler(nullptr),
       _state(std::move(state)),
       _doc_id(std::move(doc_id)),
-      _throttle_token(std::move(throttle_token)),
+      _op_throttle_token(std::move(op_throttle_token)),
+      _maintenance_throttle_token(std::move(maintenance_throttle_token)),
       _op(op),
       _start_time(clock),
       _latency_metric(latency_metric)
@@ -33,7 +35,8 @@ ApplyBucketDiffEntryComplete::onComplete(std::unique_ptr<spi::Result> result) no
     }
     double elapsed = _start_time.getElapsedTimeAsDouble();
     _latency_metric.addValue(elapsed);
-    _throttle_token.reset();
+    _maintenance_throttle_token.reset();
+    _op_throttle_token.reset();
     _state->on_entry_complete(std::move(result), _doc_id, _op);
 }
 

--- a/storage/src/vespa/storage/persistence/apply_bucket_diff_entry_complete.h
+++ b/storage/src/vespa/storage/persistence/apply_bucket_diff_entry_complete.h
@@ -22,14 +22,16 @@ class ApplyBucketDiffEntryComplete : public spi::OperationComplete
     const spi::ResultHandler*             _result_handler;
     std::shared_ptr<ApplyBucketDiffState> _state;
     document::DocumentId                  _doc_id;
-    ThrottleToken                         _throttle_token;
+    ThrottleToken                         _op_throttle_token;
+    ThrottleToken                         _maintenance_throttle_token;
     const char*                           _op;
     framework::MilliSecTimer              _start_time;
     metrics::DoubleAverageMetric&         _latency_metric;
 public:
     ApplyBucketDiffEntryComplete(std::shared_ptr<ApplyBucketDiffState> state,
                                  document::DocumentId doc_id,
-                                 ThrottleToken throttle_token,
+                                 ThrottleToken op_throttle_token,
+                                 ThrottleToken maintenance_throttle_token,
                                  const char *op, const framework::Clock& clock,
                                  metrics::DoubleAverageMetric& latency_metric);
     ~ApplyBucketDiffEntryComplete() override;

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -281,11 +281,14 @@ public:
 
     virtual ActiveOperationsStats get_active_operations_stats(bool reset_min_max) const = 0;
 
-    virtual vespalib::SharedOperationThrottler& operation_throttler() const noexcept = 0;
+    [[nodiscard]] virtual vespalib::SharedOperationThrottler& operation_throttler() const noexcept = 0;
+    [[nodiscard]] virtual vespalib::SharedOperationThrottler& maintenance_throttler() const noexcept = 0;
 
-    virtual void reconfigure_dynamic_throttler(const vespalib::SharedOperationThrottler::DynamicThrottleParams& params) = 0;
+    virtual void reconfigure_dynamic_operation_throttler(const vespalib::SharedOperationThrottler::DynamicThrottleParams& params) = 0;
+    virtual void reconfigure_dynamic_maintenance_throttler(const vespalib::SharedOperationThrottler::DynamicThrottleParams& params) = 0;
 
     virtual void use_dynamic_operation_throttling(bool use_dynamic) noexcept = 0;
+    virtual void use_dynamic_maintenance_throttling(bool use_dynamic) noexcept = 0;
 
     virtual void set_throttle_apply_bucket_diff_ops(bool throttle_apply_bucket_diff) noexcept = 0;
 


### PR DESCRIPTION
@toregge please review

When explicitly configured, operations related to "heavy" maintenance (merging, bucket deletion, GC) can have their max concurrency limited by a secondary dynamic throttling instance. Such operations must acquire _both_ a regular throttle token as well as a maintenance-specific throttle token (and always in this particular order).

This is configurable live. By default, an unlimited no-op throttler is used, which means only the regular persistence throttling mechanism is in play.

This PR also adds a `max-content-node-maintenance-op-concurrency` feature flag for controlling the throttling.