### PR TITLE
Increase number of buffers for TensorBufferStore from 8Ki to 16Ki.

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/tensor_buffer_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_buffer_store.h
@@ -18,7 +18,7 @@ namespace search::tensor {
  */
 class TensorBufferStore : public TensorStore
 {
-    using RefType = vespalib::datastore::EntryRefT<19>;
+    using RefType = vespalib::datastore::EntryRefT<18>;
     using ArrayStoreType = vespalib::datastore::ArrayStore<char, RefType, TensorBufferTypeMapper>;
     vespalib::eval::ValueType _tensor_type;
     TensorBufferOperations    _ops;

--- a/vespalib/src/vespa/vespalib/datastore/entryref.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/entryref.cpp
@@ -10,7 +10,8 @@ template EntryRefT<31u, 1u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<22u,10u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<20u,12u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<19u,13u>::EntryRefT(size_t, uint32_t);
-template EntryRefT<18u, 6u>::EntryRefT(size_t, uint32_t);
+template EntryRefT<18, 14u>::EntryRefT(size_t, uint32_t);
+template EntryRefT<18u, 6u>::EntryRefT(size_t, uint32_t); // predicate interval store
 template EntryRefT<15u,17u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<10u,22u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<10u,10u>::EntryRefT(size_t, uint32_t);


### PR DESCRIPTION
This comes with a cost of 192Ki extra bytes used for the data store (8Ki * sizeof(vespalib::datastore::BufferAndMeta)).

@vekterli : please review
@geirst : FYI
