### PR TITLE
Revert "Respect searchable-copies 1 also with min-redundancy"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
@@ -21,8 +21,6 @@ public class RedundancyBuilder {
     private Integer globalMinRedundancy = null;
 
     public RedundancyBuilder(ModelElement clusterXml) {
-        readyCopies = clusterXml.childAsInteger("engine.proton.searchable-copies");
-
         ModelElement redundancyElement = clusterXml.child("redundancy");
         if (redundancyElement != null) {
             initialRedundancy = redundancyElement.integerAttribute("reply-after");
@@ -35,7 +33,7 @@ public class RedundancyBuilder {
                     throw new IllegalArgumentException("Final redundancy must be higher than or equal to initial redundancy");
                 }
             }
-
+            readyCopies = clusterXml.childAsInteger("engine.proton.searchable-copies");
             if (readyCopies != null && readyCopies > finalRedundancy)
                 throw new IllegalArgumentException("Number of searchable copies can not be higher than final redundancy");
         }

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1914,36 +1914,6 @@ public class ModelProvisioningTest {
     }
 
     @Test
-    public void testMinRedundancyAndSearchableCopies() {
-        String services =
-                "<?xml version='1.0' encoding='utf-8' ?>" +
-                "<services>" +
-                "  <container version='1.0' id='container1'>" +
-                "     <nodes count='1'/>" +
-                "  </container>" +
-                "  <content version='1.0'>" +
-                "     <min-redundancy>2</min-redundancy>" +
-                "     <engine><proton><searchable-copies>1</searchable-copies></proton></engine>" +
-                "     <documents>" +
-                "       <document type='type1' mode='index'/>" +
-                "     </documents>" +
-                "     <nodes count='2'/>" +
-                "   </content>" +
-                "</services>";
-        VespaModelTester tester = new VespaModelTester();
-        tester.setHosted(true);
-        tester.addHosts(6);
-        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("container1"));
-
-        var contentCluster = model.getContentClusters().get("content");
-        ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
-        contentCluster.getSearch().getConfig(protonBuilder);
-        ProtonConfig protonConfig = new ProtonConfig(protonBuilder);
-        assertEquals(1, protonConfig.distribution().searchablecopies());
-        assertEquals(2, protonConfig.distribution().redundancy());
-    }
-
-    @Test
     public void testMinRedundancyMetWithinGroup() {
         String services =
                 "<?xml version='1.0' encoding='utf-8' ?>" +


### PR DESCRIPTION
Reverts vespa-engine/vespa#33528

Fails for a customer that has this config:


```
        <min-redundancy>2</min-redundancy>

 <engine>
            <proton>
                <searchable-copies>2</searchable-copies>

        <nodes deploy:environment="dev" count="2" groups="2">
```

with:

```

Caused by: com.yahoo.vespa.config.server.http.InvalidApplicationException: Invalid application
...
Caused by: java.lang.IllegalArgumentException: In content cluster 'foo'
...	
Caused by: java.lang.IllegalArgumentException: Number of searchable copies (2) can not be higher than final redundancy (1)
```