### PR TITLE
Never write parts to disk MERGEOK

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationApiHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationApiHandler.java
@@ -76,7 +76,7 @@ public class ApplicationApiHandler extends SessionHandler {
                 zone,
                 new MultiPartFormParser(
                         Paths.get(Defaults.getDefaults().underVespaHome("var/tmp/jetty-multiform-part-data")),
-                        BytesQuantity.ofMB(10).toBytes()));
+                        -1 /* Never cache to disk */));
     }
 
     ApplicationApiHandler(Context ctx,


### PR DESCRIPTION
Follow previous configuration for Jetty 11's `MultiPartFormInputStream` where all parts where cached to memory, irrespective of size.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
