### PR TITLE
Magnus/lsp xml preprocessing

### DIFF
--- a/integration/schema-language-server/lemminx-vespa/pom.xml
+++ b/integration/schema-language-server/lemminx-vespa/pom.xml
@@ -24,6 +24,22 @@
       <artifactId>config-model</artifactId>
       <version>8-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>config-application-package</artifactId>
+      <version>8-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>config-model-api</artifactId>
+      <version>8-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>config-provisioning</artifactId>
+      <version>8-SNAPSHOT</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/ServicesURIResolverExtension.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/ServicesURIResolverExtension.java
@@ -1,14 +1,17 @@
 package ai.vespa.lemminx;
 
 import java.nio.file.Path;
+import java.util.logging.Logger;
 
 import org.eclipse.lemminx.uriresolver.URIResolverExtension;
 
 public class ServicesURIResolverExtension implements URIResolverExtension {
+    private static final Logger logger = Logger.getLogger(ServicesURIResolverExtension.class.getName());
     private String resourceURI;
 
     public ServicesURIResolverExtension(Path serverPath) { 
         resourceURI = serverPath.resolve("resources").resolve("schema").resolve("services.rng").toUri().toString();
+        logger.info("Resource URI: " + resourceURI);
     }
 
     @Override
@@ -16,5 +19,9 @@ public class ServicesURIResolverExtension implements URIResolverExtension {
         if (baseLocation != null && baseLocation.endsWith("services.xml")) {
             return resourceURI;
         } else return null;
+    }
+
+    public String getSchemaURI() {
+        return resourceURI;
     }
 }

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/VespaExtension.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/VespaExtension.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import java.util.logging.Logger;
 
 import org.eclipse.lemminx.XMLLanguageServer;
+import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.services.IXMLValidationService;
 import org.eclipse.lemminx.services.extensions.IDefinitionParticipant;
 import org.eclipse.lemminx.services.extensions.IDocumentLifecycleParticipant;
@@ -102,4 +103,14 @@ public class VespaExtension implements IXMLExtension {
         if (completionParticipant != null)
             registry.unregisterCompletionParticipant(completionParticipant);
 	}
+
+    /*
+     * Returns true if we manage this document
+     */
+    public static boolean match(DOMDocument xmlDocument) {
+        if (xmlDocument == null) return false;
+        String uri = xmlDocument.getDocumentURI();
+        if (uri == null) return false;
+        return uri.endsWith("services.xml");
+    }
 }

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/VespaExtension.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/VespaExtension.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Logger;
 
+import org.eclipse.lemminx.XMLLanguageServer;
 import org.eclipse.lemminx.services.IXMLValidationService;
 import org.eclipse.lemminx.services.extensions.IDefinitionParticipant;
 import org.eclipse.lemminx.services.extensions.IDocumentLifecycleParticipant;
@@ -31,7 +32,7 @@ public class VespaExtension implements IXMLExtension {
 
     HoverParticipant hoverParticipant;
     IXMLValidationService validationService;
-    URIResolverExtension uriResolverExtension;
+    ServicesURIResolverExtension uriResolverExtension;
     IDefinitionParticipant definitionParticipant;
     IDocumentLifecycleParticipant documentLifecycleParticipant;
     IDiagnosticsParticipant diagnosticsParticipant;
@@ -45,7 +46,12 @@ public class VespaExtension implements IXMLExtension {
 	@Override
 	public void start(InitializeParams params, XMLExtensionsRegistry registry) {
         try {
-            serverPath = Paths.get(new File(VespaExtension.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getCanonicalPath()).getParent();
+            serverPath = Paths.get(new File(
+                VespaExtension.class.getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI()
+            ).getCanonicalPath()).getParent();
 
             UnpackRNGFiles.unpackRNGFiles(
                 serverPath
@@ -63,7 +69,7 @@ public class VespaExtension implements IXMLExtension {
         uriResolverExtension         = new ServicesURIResolverExtension(serverPath);
         definitionParticipant        = new DefinitionParticipant();
         documentLifecycleParticipant = new DocumentLifecycleParticipant(registry.getCommandService());
-        diagnosticsParticipant       = new DiagnosticsParticipant();
+        diagnosticsParticipant       = new DiagnosticsParticipant(uriResolverExtension);
         codeActionParticipant        = new CodeActionParticipant();
         completionParticipant        = new CompletionParticipant();
 
@@ -77,7 +83,6 @@ public class VespaExtension implements IXMLExtension {
         registry.registerCompletionParticipant(completionParticipant);
 
         logger.info("Vespa LemminX extension activated");
-
 	}
 
 	@Override

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/CodeActionParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/CodeActionParticipant.java
@@ -15,6 +15,7 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 import com.google.gson.JsonPrimitive;
 
+import ai.vespa.lemminx.VespaExtension;
 import ai.vespa.lemminx.participants.DiagnosticsParticipant.DiagnosticCode;
 
 public class CodeActionParticipant implements ICodeActionParticipant {
@@ -22,6 +23,9 @@ public class CodeActionParticipant implements ICodeActionParticipant {
 
     @Override
     public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) throws CancellationException {
+        if (!VespaExtension.match(request.getDocument()))
+            return;
+
         Diagnostic diagnostic = request.getDiagnostic();
         if (diagnostic.getCode() != null && diagnostic.getCode().isRight()) {
             Integer diagnosticNumber = diagnostic.getCode().getRight();

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/CompletionParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/CompletionParticipant.java
@@ -8,6 +8,7 @@ import org.eclipse.lemminx.services.extensions.completion.ICompletionResponse;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import ai.vespa.lemminx.VespaExtension;
 import ai.vespa.lemminx.command.SchemaLSCommands;
 
 public class CompletionParticipant implements ICompletionParticipant {
@@ -31,6 +32,10 @@ public class CompletionParticipant implements ICompletionParticipant {
     @Override
     public void onAttributeValue(String valuePrefix, ICompletionRequest request, ICompletionResponse response,
             CancelChecker cancelChecker) throws Exception {
+
+        if (!VespaExtension.match(request.getXMLDocument()))
+            return;
+
         if ("document".equals(request.getCurrentTag()) && "type".equals(request.getCurrentAttributeName())) {
             for (String schemaName : SchemaLSCommands.instance().getDefinedSchemas()) {
                 response.addCompletionItem(new CompletionItem(schemaName));

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DefinitionParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DefinitionParticipant.java
@@ -10,6 +10,7 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import ai.vespa.lemminx.VespaExtension;
 import ai.vespa.lemminx.command.SchemaLSCommands;
 
 public class DefinitionParticipant implements IDefinitionParticipant {
@@ -17,6 +18,9 @@ public class DefinitionParticipant implements IDefinitionParticipant {
 
     @Override
     public void findDefinition(IDefinitionRequest request, List<LocationLink> locations, CancelChecker cancelChecker) {
+
+        if (!VespaExtension.match(request.getXMLDocument()))
+            return;
 
         DOMAttr attribute = request.getCurrentAttribute();
 

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DiagnosticsParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DiagnosticsParticipant.java
@@ -1,7 +1,20 @@
 package ai.vespa.lemminx.participants;
 
+import java.io.File;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
@@ -15,10 +28,37 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
-import org.w3c.dom.Node;
+import org.w3c.dom.Document;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXParseException;
 
+import com.thaiopensource.util.PropertyMap;
+import com.thaiopensource.util.PropertyMapBuilder;
+import com.thaiopensource.validate.ValidateProperty;
+import com.thaiopensource.validate.ValidationDriver;
+import com.thaiopensource.validate.auto.AutoSchemaReader;
+import com.yahoo.config.application.XmlPreProcessor;
+import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.Tags;
+
+import ai.vespa.lemminx.ServicesURIResolverExtension;
 import ai.vespa.lemminx.command.SchemaLSCommands;
 
+/**
+ * DiagnosticsParticipant that performs validation after Vespa Preprocessing.
+ * Due to Lemminx' implementation of the DOM and parser, it seems impossible to run 
+ * preprocessing on a parsed DOM. This is sad because it means we cannot connect preprocessing 
+ * errors to their locations in the document as it was prior to preprocessing.
+ *
+ * For now the workaround is to remove existing diagnostics (from Lemminx validation) that no longer
+ * exist after the preprocessing step. To identify equal diagnostics, string hashing of the 
+ * error messages is used, because that is the only information left from the {@link SAXParseException}
+ * objects after Lemminx has validated.
+ */
 public class DiagnosticsParticipant implements IDiagnosticsParticipant {
     private static final Logger logger = Logger.getLogger(DiagnosticsParticipant.class.getName());
 
@@ -31,14 +71,28 @@ public class DiagnosticsParticipant implements IDiagnosticsParticipant {
     }
 
     private final static DiagnosticCode[] diagnosticCodeValues = DiagnosticCode.values();
+    private Set<String> validationErrorSet = new HashSet<>();
+    private ValidationDriver schemaValidationDriver;
+
+    public DiagnosticsParticipant(ServicesURIResolverExtension uriResolverExtension) {
+        setupValidationDriver(uriResolverExtension.getSchemaURI());
+    }
 
     @Override
     public void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
             XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
+
+        this.validationErrorSet.clear();
+
+        // Fills the validationErrorSet with "actual" errors, i.e. errors that still occur after 
+        // preprocessing.
+        preprocessAndValidateDocument(xmlDocument);
+
+        diagnostics.removeIf(diagnostic -> !this.validationErrorSet.contains(diagnostic.getMessage()));
+
         DiagnosticsContext context = new DiagnosticsContext(xmlDocument, diagnostics, SchemaLSCommands.instance().hasSetupWorkspace());
         traverse(xmlDocument.getDocumentElement(), context);
     }
-
 
     public static DiagnosticCode codeFromInt(int code) {
         if (code < 0 || diagnosticCodeValues.length <= code) return DiagnosticCode.GENERIC;
@@ -75,6 +129,102 @@ public class DiagnosticsParticipant implements IDiagnosticsParticipant {
                 diagnostic.setData(docName);
                 context.diagnostics.add(diagnostic);
             }
+        }
+    }
+
+    private void preprocessAndValidateDocument(DOMDocument xmlDocument) {
+        if (xmlDocument.getTextDocument() == null || xmlDocument.getTextDocument().getUri() == null) {
+            logger.warning("Could not get document URI. Preprocessing will not be performed.");
+            return;
+        }
+        URI documentURI = URI.create(xmlDocument.getTextDocument().getUri());
+        File applicationDir = new File(documentURI).getParentFile();
+
+        // The settings for the preprocessor are currently set arbitrarily.
+        // They do not affect much of the diagnostics.
+        // With more intelligent LSP from preprocessing a user could set these values somewhere 
+        // and preview the modified XML.
+        XmlPreProcessor preProcessor = new XmlPreProcessor(
+            applicationDir,
+            new StringReader(xmlDocument.getTextDocument().getText()),
+            InstanceName.defaultName(),
+            Environment.dev,
+            RegionName.defaultName(),
+            CloudName.DEFAULT,
+            Tags.empty()
+        );
+
+        try {
+            Document preprocessed = preProcessor.run();
+            schemaValidationDriver.validate(new InputSource(new StringReader(documentAsString(preprocessed, false))));
+        } catch (Exception ex) {
+            // Most exceptions are processed by CustomErrorHandler
+            logger.warning("Exception occured during Vespa XML validation: " + ex.getMessage());
+            return;
+        }
+    }
+
+    /**
+     * Helper for converting a {@link Document} to a String used to validate a document after preprocessing
+     * @param document
+     * @param prettyPrint
+     * @return
+     * @throws TransformerException
+     */
+    static String documentAsString(Document document, boolean prettyPrint) throws TransformerException {
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        if (prettyPrint) {
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        } else {
+            transformer.setOutputProperty(OutputKeys.INDENT, "no");
+        }
+        StringWriter writer = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(writer));
+        String[] lines = writer.toString().split("\n");
+        var b = new StringBuilder();
+        for (String line : lines)
+            if ( ! line.isBlank())
+                b.append(line).append("\n");
+        return b.toString();
+    }
+
+    /**
+     * @param validationSchemaURI Extracted from application JAR when LSP loads.
+     */
+    private void setupValidationDriver(String validationSchemaURI) {
+        schemaValidationDriver = new ValidationDriver(PropertyMap.EMPTY, instanceProperties(), new AutoSchemaReader());
+        try {
+            InputSource inputSource = ValidationDriver.uriOrFileInputSource(validationSchemaURI);
+            logger.info(inputSource.getSystemId());
+            if (!schemaValidationDriver.loadSchema(inputSource)) {
+                logger.info("Could not load schema");
+                return;
+            }
+        } catch (Exception ex) {
+            logger.warning("Exception when loading schema: " + ex.getMessage());
+            return;
+        }
+
+    }
+
+    private final CustomErrorHandler errorHandler = new CustomErrorHandler();
+    private PropertyMap instanceProperties() {
+        PropertyMapBuilder builder = new PropertyMapBuilder();
+        builder.put(ValidateProperty.ERROR_HANDLER, errorHandler);
+        return builder.toPropertyMap();
+    }
+
+    private class CustomErrorHandler implements ErrorHandler {
+        public void warning(SAXParseException e) {
+            validationErrorSet.add(e.getMessage());
+        }
+
+        public void error(SAXParseException e) {
+            validationErrorSet.add(e.getMessage());
+        }
+
+        public void fatalError(SAXParseException e) {
+            validationErrorSet.add(e.getMessage());
         }
     }
 }

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DiagnosticsParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DiagnosticsParticipant.java
@@ -48,6 +48,7 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Tags;
 
 import ai.vespa.lemminx.ServicesURIResolverExtension;
+import ai.vespa.lemminx.VespaExtension;
 import ai.vespa.lemminx.command.SchemaLSCommands;
 
 /**
@@ -87,6 +88,9 @@ public class DiagnosticsParticipant implements IDiagnosticsParticipant {
     @Override
     public void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
             XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
+
+        if (!VespaExtension.match(xmlDocument))
+            return;
 
         this.validationErrorSet.clear();
 

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DocumentLifecycleParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/DocumentLifecycleParticipant.java
@@ -8,6 +8,7 @@ import org.eclipse.lemminx.services.extensions.IDocumentLifecycleParticipant;
 import org.eclipse.lemminx.services.extensions.commands.IXMLCommandService;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 
+import ai.vespa.lemminx.VespaExtension;
 import ai.vespa.lemminx.command.SchemaLSCommands;
 
 public class DocumentLifecycleParticipant implements IDocumentLifecycleParticipant {
@@ -20,6 +21,9 @@ public class DocumentLifecycleParticipant implements IDocumentLifecycleParticipa
 
     @Override
     public void didOpen(DOMDocument document) {
+        if (!VespaExtension.match(document))
+            return;
+
         try {
             String fileURI = document.getTextDocument().getUri();
             SchemaLSCommands.instance().sendSetupWorkspaceRequest(fileURI);

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/HoverParticipant.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/participants/HoverParticipant.java
@@ -21,6 +21,8 @@ import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import ai.vespa.lemminx.VespaExtension;
+
 /**
  * TODO: refactor and handle tags with the same name based on context.
  */
@@ -34,6 +36,9 @@ public class HoverParticipant implements IHoverParticipant {
 
     @Override
     public Hover onTag(IHoverRequest request, CancelChecker cancelChecker) throws Exception {
+        if (!VespaExtension.match(request.getXMLDocument()))
+            return null;
+
         if (request.getCurrentTag() == null) return null;
 
         DOMNode iterator = request.getNode();


### PR DESCRIPTION
Fix problem of showing errors on valid services.xml. It makes the validation less strict, so some invalid xml documents may now not show errors.

Also it now doesn't run on other xml files than services.xml.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
