### PR TITLE
Stop accepting gzip as compression method in file distribution

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -25,7 +25,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
-import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
@@ -38,7 +37,7 @@ import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType
 public class FileReferenceDownloader {
 
     private static final Logger log = Logger.getLogger(FileReferenceDownloader.class.getName());
-    private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(gzip, lz4, none, zstd);
+    private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(lz4, none, zstd);
 
     private final ExecutorService downloadExecutor =
             Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileReceiverTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileReceiverTest.java
@@ -17,7 +17,6 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
-import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
@@ -63,7 +62,6 @@ public class FileReceiverTest {
         writerB.write("2");
         writerB.close();
 
-        testWithCompression(dirWithFiles, gzip);
         testWithCompression(dirWithFiles, lz4);
         testWithCompression(dirWithFiles, zstd);
         testWithCompression(dirWithFiles, none);


### PR DESCRIPTION
Part 1: Make sure clients don't accept gzip