### PR TITLE
Revert "Fail if 'boost' is lower than 'threads'"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
@@ -50,8 +50,6 @@ public abstract class ContainerThreadpool extends SimpleComponent implements Con
             if (threadsElem != null) {
                 min = parseMultiplier(threadsElem.getTextContent());
                 max = threadsElem.hasAttribute("boost") ? parseMultiplier(threadsElem.getAttribute("boost")) : min;
-                if (Math.abs(min) > Math.abs(max))
-                    throw new IllegalArgumentException("For <threadpool>: 'boost' must be greater than <threads>");
             } else if (minElem != null) {
                 min = parseFixed(minElem.getTextContent());
             }


### PR DESCRIPTION
Reverts vespa-engine/vespa#33578

One integration test started failing, customer needs to update their app first.