### PR TITLE
Add support for Azure token scopes in ZtsClient

### DIFF
--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/DefaultZtsClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/DefaultZtsClient.java
@@ -41,8 +41,10 @@ import java.net.URI;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -234,16 +236,21 @@ public class DefaultZtsClient extends ClientBase implements ZtsClient {
 
     @Override
     public AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId, String azureTokenScope) {
-        return getExternalTemporaryCredentials("azure", athenzRole.domain(),
-                Map.of("athenzRoleName", athenzRole.roleName(), "azureClientId", azureIdentityId, "azureTokenScope", azureTokenScope),
-                AzureTemporaryCredentialsResponseEntity.class);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("athenzRoleName", athenzRole.roleName());
+        attributes.put("azureClientId", Objects.requireNonNull(azureIdentityId));
+        if (azureTokenScope != null) attributes.put("azureTokenScope", azureTokenScope);
+        return getExternalTemporaryCredentials("azure", athenzRole.domain(), attributes, AzureTemporaryCredentialsResponseEntity.class);
     }
 
     @Override
     public AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName, String azureTokenScope) {
-        return getExternalTemporaryCredentials("azure", athenzRole.domain(),
-                Map.of("athenzRoleName", athenzRole.roleName(), "azureResourceGroup", azureResourceGroup, "azureClientName", azureIdentityName, "azureTokenScope", azureTokenScope),
-                AzureTemporaryCredentialsResponseEntity.class);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("athenzRoleName", athenzRole.roleName());
+        attributes.put("azureResourceGroup", Objects.requireNonNull(azureResourceGroup));
+        attributes.put("azureClientName", Objects.requireNonNull(azureIdentityName));
+        if (azureTokenScope != null) attributes.put("azureTokenScope", azureTokenScope);
+        return getExternalTemporaryCredentials("azure", athenzRole.domain(), attributes, AzureTemporaryCredentialsResponseEntity.class);
     }
 
     private <T, U extends TemporaryCredentialsResponse<T>> T getExternalTemporaryCredentials(String provider, AthenzDomain domain, Map<String, String> attributes, Class<U> responseClass) {

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/DefaultZtsClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/DefaultZtsClient.java
@@ -233,16 +233,16 @@ public class DefaultZtsClient extends ClientBase implements ZtsClient {
     }
 
     @Override
-    public AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId) {
+    public AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId, String azureTokenScope) {
         return getExternalTemporaryCredentials("azure", athenzRole.domain(),
-                Map.of("athenzRoleName", athenzRole.roleName(), "azureClientId", azureIdentityId),
+                Map.of("athenzRoleName", athenzRole.roleName(), "azureClientId", azureIdentityId, "azureTokenScope", azureTokenScope),
                 AzureTemporaryCredentialsResponseEntity.class);
     }
 
     @Override
-    public AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName) {
+    public AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName, String azureTokenScope) {
         return getExternalTemporaryCredentials("azure", athenzRole.domain(),
-                Map.of("athenzRoleName", athenzRole.roleName(), "azureResourceGroup", azureResourceGroup, "azureClientName", azureIdentityName),
+                Map.of("athenzRoleName", athenzRole.roleName(), "azureResourceGroup", azureResourceGroup, "azureClientName", azureIdentityName, "azureTokenScope", azureTokenScope),
                 AzureTemporaryCredentialsResponseEntity.class);
     }
 

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/ZtsClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/ZtsClient.java
@@ -191,7 +191,7 @@ public interface ZtsClient extends AutoCloseable {
     /**
      * @param athenzRole      Athenz role to use when assuming credentials
      * @param azureIdentityId Client ID of the Azure identity to assume
-     * @param azureTokenScope
+     * @param azureTokenScope Scope of the Azure token. Null for default scope (https://management.azure.com/.default)
      * @return Azure temporary credentials
      */
     AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId, String azureTokenScope);
@@ -200,7 +200,7 @@ public interface ZtsClient extends AutoCloseable {
      * @param athenzRole         Athenz role to use when assuming credentials
      * @param azureResourceGroup Azure resource group that contains the target identity
      * @param azureIdentityName  Name of the Azure Identity to assume
-     * @param azureTokenScope
+     * @param azureTokenScope    Scope of the Azure token. Null for default scope (https://management.azure.com/.default)
      * @return Azure temporary credentials
      */
     AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName, String azureTokenScope);

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/ZtsClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/client/zts/ZtsClient.java
@@ -189,19 +189,21 @@ public interface ZtsClient extends AutoCloseable {
     AwsTemporaryCredentials getAwsTemporaryCredentials(AthenzDomain athenzDomain, AwsRole awsRole, Duration duration, String externalId);
 
     /**
-     * @param athenzRole Athenz role to use when assuming credentials
+     * @param athenzRole      Athenz role to use when assuming credentials
      * @param azureIdentityId Client ID of the Azure identity to assume
+     * @param azureTokenScope
      * @return Azure temporary credentials
      */
-    AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId);
+    AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureIdentityId, String azureTokenScope);
 
     /**
-     * @param athenzRole Athenz role to use when assuming credentials
+     * @param athenzRole         Athenz role to use when assuming credentials
      * @param azureResourceGroup Azure resource group that contains the target identity
-     * @param azureIdentityName Name of the Azure Identity to assume
+     * @param azureIdentityName  Name of the Azure Identity to assume
+     * @param azureTokenScope
      * @return Azure temporary credentials
      */
-    AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName);
+    AzureTemporaryCredentials getAzureTemporaryCredentials(AthenzRole athenzRole, String azureResourceGroup, String azureIdentityName, String azureTokenScope);
 
     /**
      * Check access to resource for a given principal


### PR DESCRIPTION
This change updates methods to include `azureTokenScope` as a parameter for obtaining Azure temporary credentials.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
