### PR TITLE
Do response metric aggregation through Jetty's request log interface

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyResponseWriter.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyResponseWriter.java
@@ -158,7 +158,7 @@ class JettyResponseWriter implements ResponseHandler {
                         if (jettyHeaders.get(HttpHeader.CONTENT_TYPE) == null) {
                             jettyHeaders.add(HttpHeader.CONTENT_TYPE, "text/plain;charset=utf-8");
                         }
-                        jettyRequest.setAttribute(ResponseMetricAggregator.requestTypeAttribute,
+                        jettyRequest.setAttribute(MetricAggregatingRequestLog.requestTypeAttribute,
                                 jdiscResponse.getRequestType());
                     }
                 }

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ServerMetricReporter.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ServerMetricReporter.java
@@ -26,10 +26,10 @@ class ServerMetricReporter {
     private final Metric metric;
     private final Server jetty;
     private final StatisticsHandler statisticsHandler;
-    private final ResponseMetricAggregator responseMetricAggregator;
+    private final MetricAggregatingRequestLog responseMetricAggregator;
 
     ServerMetricReporter(Metric metric, Server jetty, StatisticsHandler statisticsHandler,
-                         ResponseMetricAggregator responseMetricAggregator) {
+                         MetricAggregatingRequestLog responseMetricAggregator) {
         this.metric = metric;
         this.jetty = jetty;
         this.statisticsHandler = statisticsHandler;
@@ -67,14 +67,14 @@ class ServerMetricReporter {
             setJettyThreadpoolMetrics();
         }
 
-        private void setServerMetrics(ResponseMetricAggregator statisticsCollector) {
+        private void setServerMetrics(MetricAggregatingRequestLog statisticsCollector) {
             long timeSinceStarted = System.currentTimeMillis() - timeStarted.toEpochMilli();
             metric.set(MetricDefinitions.STARTED_MILLIS, timeSinceStarted, null);
 
             addResponseMetrics(statisticsCollector);
         }
 
-        private void addResponseMetrics(ResponseMetricAggregator statisticsCollector) {
+        private void addResponseMetrics(MetricAggregatingRequestLog statisticsCollector) {
             statisticsCollector.reportSnapshot(metric);
         }
 

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -192,12 +192,11 @@ public class HttpServerTest {
         driver.client()
                 .newGet("/status.html").addHeader("Host", "localhost").addHeader("Host", "vespa.ai").execute()
                 .expectStatusCode(is(BAD_REQUEST)).expectContent(containsString("HTTP ERROR 400 Duplicate Host Header"));
-        // TODO figure out what to do with this metric - currently missing for built-in responses
-//        var aggregator = ResponseMetricAggregator.getBean(driver.server());
-//        var metric = waitForStatistics(aggregator);
-//        assertEquals(400, metric.dimensions.statusCode);
-//        assertEquals("GET", metric.dimensions.method);
-//        assertTrue(driver.close());
+        var aggregator = MetricAggregatingRequestLog.getBean(driver.server());
+        var metric = waitForStatistics(aggregator);
+        assertEquals(400, metric.dimensions.statusCode);
+        assertEquals("GET", metric.dimensions.method);
+        assertTrue(driver.close());
     }
 
     @Test
@@ -638,9 +637,9 @@ public class HttpServerTest {
         RequestTypeHandler handler = new RequestTypeHandler();
         var cfg = new ServerConfig.Builder().metric(new ServerConfig.Metric.Builder().reporterEnabled(false));
         JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(handler, cfg, new ConnectorConfig.Builder());
-        var statisticsCollector = ResponseMetricAggregator.getBean(driver.server());;
+        var statisticsCollector = MetricAggregatingRequestLog.getBean(driver.server());;
         {
-            List<ResponseMetricAggregator.StatisticsEntry> stats = statisticsCollector.takeStatistics();
+            List<MetricAggregatingRequestLog.StatisticsEntry> stats = statisticsCollector.takeStatistics();
             assertEquals(0, stats.size());
         }
 
@@ -674,8 +673,8 @@ public class HttpServerTest {
         assertTrue(driver.close());
     }
 
-    private ResponseMetricAggregator.StatisticsEntry waitForStatistics(ResponseMetricAggregator statisticsCollector) {
-        List<ResponseMetricAggregator.StatisticsEntry> entries = List.of();
+    private MetricAggregatingRequestLog.StatisticsEntry waitForStatistics(MetricAggregatingRequestLog statisticsCollector) {
+        List<MetricAggregatingRequestLog.StatisticsEntry> entries = List.of();
         int tries = 0;
         // Wait up to 30 seconds before giving up
         while (entries.isEmpty() && tries < 300) {

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLogTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLogTest.java
@@ -1,8 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.server.jetty;
 
-import com.yahoo.jdisc.http.server.jetty.ResponseMetricAggregator.StatisticsEntry;
-import org.eclipse.jetty.http.HttpFields;
+import com.yahoo.jdisc.http.server.jetty.MetricAggregatingRequestLog.StatisticsEntry;
 import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,11 +15,11 @@ import static org.hamcrest.Matchers.equalTo;
  * @author ollivir
  * @author bjorncs
  */
-public class ResponseMetricAggregatorTest {
+public class MetricAggregatingRequestLogTest {
 
     private final List<String> monitoringPaths = List.of("/status.html");
     private final List<String> searchPaths = List.of("/search");
-    private final ResponseMetricAggregator collector = new ResponseMetricAggregator(monitoringPaths, searchPaths, List.of(), false, null);
+    private final MetricAggregatingRequestLog collector = new MetricAggregatingRequestLog(monitoringPaths, searchPaths, List.of(), false);
 
     @BeforeEach
     public void initializeCollector() {
@@ -129,8 +128,8 @@ public class ResponseMetricAggregatorTest {
                 .uri(scheme, "localhost", 8080, path, null)
                 .protocol(HttpVersion.HTTP_1_1.asString());
         if (explicitRequestType != null)
-            builder.attribute(ResponseMetricAggregator.requestTypeAttribute, explicitRequestType);
-        collector.onResponseBegin(builder.build(), responseCode, HttpFields.EMPTY);
+            builder.attribute(MetricAggregatingRequestLog.requestTypeAttribute, explicitRequestType);
+        collector.onResponse(builder.build(), responseCode);
     }
 
     private static void assertStatisticsEntry(List<StatisticsEntry> result, String scheme, String method, String name,


### PR DESCRIPTION
Handlers are not invoked if the request is failed during HTTP request parsing, e.g. invalid headers. Use the request log interface instead to ensure we those responses are covered in our metrics.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
