### PR TITLE
First step in changing MMAP madvise default to SEQUENTIAL for search.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
@@ -100,8 +100,8 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
     }
 
     private void tuneSearchReadIo(ProtonConfig.Search.Mmap.Builder builder) {
-        if (resources.diskSpeed() == NodeResources.DiskSpeed.fast) {
-            builder.advise(ProtonConfig.Search.Mmap.Advise.RANDOM);
+        if (resources.diskSpeed() == NodeResources.DiskSpeed.slow) {
+            builder.advise(ProtonConfig.Search.Mmap.Advise.SEQUENTIAL);
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/NodeResourcesTuningTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/NodeResourcesTuningTest.java
@@ -124,8 +124,8 @@ public class NodeResourcesTuningTest {
 
     @Test
     void require_that_search_read_mmap_advise_is_set_based_on_disk() {
-        assertSearchReadAdvise(ProtonConfig.Search.Mmap.Advise.RANDOM, true);
-        assertSearchReadAdvise(ProtonConfig.Search.Mmap.Advise.NORMAL, false);
+        assertSearchReadAdvise(ProtonConfig.Search.Mmap.Advise.NORMAL, true);
+        assertSearchReadAdvise(ProtonConfig.Search.Mmap.Advise.SEQUENTIAL, false);
     }
 
     @Test


### PR DESCRIPTION
Benchmarking of lexical search using a Wikipedia dataset has shown that madvise SEQUENTIAL for disk index posting list files results in lower 99 percentile query latencies and better utilization of the I/O subsystem.

Rollout is complete for node flavors with slow disks.

@vekterli please review
@bjorncs @toregge FYI