### PR TITLE
Revert back to previous semantic of headers with empty value

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
@@ -102,7 +102,11 @@ class HttpRequestFactory {
 
     public static void copyHeaders(Request jettyRequest, HttpRequest jdiscRequest) {
         jettyRequest.getHeaders()
-                .forEach(header -> jdiscRequest.headers().add(header.getName(), header.getValueList()));
+                .forEach(header -> {
+                    var values = header.getValueList();
+                    if (!values.isEmpty())
+                        jdiscRequest.headers().add(header.getName(), header.getValueList());
+                });
     }
 
     private static X509Certificate[] getCertChain(Request jettyRequest) {

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
@@ -103,9 +103,8 @@ class HttpRequestFactory {
     public static void copyHeaders(Request jettyRequest, HttpRequest jdiscRequest) {
         jettyRequest.getHeaders()
                 .forEach(header -> {
-                    var values = header.getValueList();
-                    if (!values.isEmpty())
-                        jdiscRequest.headers().add(header.getName(), header.getValueList());
+                    if (!header.getValue().isBlank())
+                        jdiscRequest.headers().add(header.getName(), header.getValue());
                 });
     }
 

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactoryTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactoryTest.java
@@ -12,12 +12,14 @@ import org.eclipse.jetty.server.Request;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -134,6 +136,17 @@ public class HttpRequestFactoryTest {
                 new MockContainer(),
                 createMockRequest("https", "example.com", "/search", "query=value"));
         assertEquals(LOCAL_PORT, request.getUri().getPort());
+    }
+
+    @Test
+    void ignores_headers_with_empty_value() {
+        var request = HttpRequestFactory.newJDiscRequest(
+                new MockContainer(),
+                JettyMockRequestBuilder.newBuilder()
+                        .uri("http", "example.com", LOCAL_PORT, "/search", "query=value")
+                        .header("X-Foo", List.of())
+                        .build());
+        assertTrue(request.headers().isEmpty(), () -> "Found headers: " + request.headers());
     }
 
     private Request createMockRequest(String scheme, String host, String path, String query) {

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/JettyMockRequestBuilder.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/JettyMockRequestBuilder.java
@@ -116,7 +116,10 @@ public class JettyMockRequestBuilder {
             this.method = method;
             this.connMetaData = new DummyConnectionMetadata(b, connector, connection);
             var mutableFields = HttpFields.build();
-            b.headers.forEach(mutableFields::put);
+            b.headers.forEach((key, values) -> {
+                if (values.isEmpty()) mutableFields.put(key, "");
+                else mutableFields.put(key, values);
+            });
             this.headers = mutableFields;
             this.attributes = new ConcurrentHashMap<>(b.attributes);
             this.wrapped = mock(HttpChannelState.ChannelRequest.class);


### PR DESCRIPTION
Ignore all headers with empty value to preserve the semantic of the previous Jetty 11 integration.

FYI @glebashnik @bjormel 