### PR TITLE
handle overlapping indexed terms better.

### DIFF
--- a/document/src/vespa/document/annotation/span.h
+++ b/document/src/vespa/document/annotation/span.h
@@ -18,6 +18,7 @@ public:
 
     int32_t from() const { return _from; }
     int32_t length() const { return _length; }
+    int32_t to() const { return _from + _length; }
     Span & from(int32_t from_pos) { _from = from_pos; return *this; }
     Span & length(int32_t length_pos) { _length = length_pos; return *this; }
 
@@ -41,4 +42,3 @@ inline bool operator>(const Span &span1, const Span &span2) {
 }
 
 }  // namespace document
-

--- a/searchlib/src/vespa/searchlib/util/token_extractor.h
+++ b/searchlib/src/vespa/searchlib/util/token_extractor.h
@@ -22,13 +22,13 @@ namespace search::linguistics {
  */
 class TokenExtractor {
     const std::string& _field_name;
-    size_t                  _max_word_len;
+    size_t             _max_word_len;
 
 public:
     struct SpanTerm {
-        document::Span      span;
+        document::Span   span;
         std::string_view word;
-        bool                altered;
+        bool             altered;
 
         SpanTerm(const document::Span& span_, std::string_view word_, bool altered_) noexcept
             : span(span_),

--- a/searchsummary/src/vespa/searchsummary/docsummary/annotation_converter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/annotation_converter.cpp
@@ -93,9 +93,11 @@ AnnotationConverter::handleIndexingTerms(const StringFieldValue& value)
         int32_t curEnd = it->span.to();
         auto it_begin = it++;
         for (; it != ite && it->span.from() == curStart; ++it) {
+            // find longest span starting at same place
             curEnd = std::max(curEnd, it->span.to());
         }
         for (; it != ite && it->span.to() <= curEnd; ++it) {
+            // gather all spans contained within the block
         }
         document::Span curSpan(curStart, curEnd - curStart);
         handleAnnotations(curSpan, it_begin, it);


### PR DESCRIPTION
* pick the longest term at a given position;
* any terms within that span are considered as alternative variants (ala stems)

@toregge please review
@bratseth @bjormel FYI
