### PR TITLE
Create a GroupingRequest with grouping properties

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/GroupingQueryParser.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/GroupingQueryParser.java
@@ -105,17 +105,17 @@ public class GroupingQueryParser extends Searcher {
         return timeZone;
     }
 
-    private static OptionalInt intProperty(Query q, CompoundName name) {
+    static OptionalInt intProperty(Query q, CompoundName name) {
         Integer val = q.properties().getInteger(name);
         return val != null ? OptionalInt.of(val) : OptionalInt.empty();
     }
 
-    private static OptionalLong longProperty(Query q, CompoundName name) {
+    static OptionalLong longProperty(Query q, CompoundName name) {
         Long val = q.properties().getLong(name);
         return val != null ? OptionalLong.of(val) : OptionalLong.empty();
     }
 
-    private static OptionalDouble doubleProperty(Query q, CompoundName name) {
+    static OptionalDouble doubleProperty(Query q, CompoundName name) {
         Double val = q.properties().getDouble(name);
         return val != null ? OptionalDouble.of(val) : OptionalDouble.empty();
     }

--- a/container-search/src/main/java/com/yahoo/search/grouping/GroupingQueryParser.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/GroupingQueryParser.java
@@ -19,9 +19,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.TimeZone;
 
 /**
@@ -74,10 +71,6 @@ public class GroupingQueryParser extends Searcher {
         request.setRootOperation(operation);
         request.setTimeZone(getTimeZone(query.properties().getString(PARAM_TIMEZONE, "utc")));
         request.continuations().addAll(continuations);
-        intProperty(query, PARAM_DEFAULT_MAX_GROUPS).ifPresent(request::setDefaultMaxGroups);
-        intProperty(query, PARAM_DEFAULT_MAX_HITS).ifPresent(request::setDefaultMaxHits);
-        longProperty(query, GROUPING_GLOBAL_MAX_GROUPS).ifPresent(request::setGlobalMaxGroups);
-        doubleProperty(query, PARAM_DEFAULT_PRECISION_FACTOR).ifPresent(request::setDefaultPrecisionFactor);
     }
 
     private List<Continuation> getContinuations(String param) {
@@ -103,21 +96,6 @@ public class GroupingQueryParser extends Searcher {
             cache.put(name, timeZone);
         }
         return timeZone;
-    }
-
-    static OptionalInt intProperty(Query q, CompoundName name) {
-        Integer val = q.properties().getInteger(name);
-        return val != null ? OptionalInt.of(val) : OptionalInt.empty();
-    }
-
-    static OptionalLong longProperty(Query q, CompoundName name) {
-        Long val = q.properties().getLong(name);
-        return val != null ? OptionalLong.of(val) : OptionalLong.empty();
-    }
-
-    static OptionalDouble doubleProperty(Query q, CompoundName name) {
-        Double val = q.properties().getDouble(name);
-        return val != null ? OptionalDouble.of(val) : OptionalDouble.empty();
     }
 
     private static class ZoneCache extends LinkedHashMap<String, TimeZone> {

--- a/container-search/src/main/java/com/yahoo/search/grouping/GroupingRequest.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/GroupingRequest.java
@@ -188,6 +188,22 @@ public class GroupingRequest {
         return newRequest;
     }
 
+    /**
+     * Creates a new grouping request with grouping properties and adds it to the query.getSelect().getGrouping() list
+     *
+     * @param query the query to attach the request to.
+     * @return The created request.
+     */
+    public static GroupingRequest newInstanceWithGroupingProperties(Query query) {
+        GroupingRequest newRequest = new GroupingRequest(query.getSelect());
+        GroupingQueryParser.intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_GROUPS).ifPresent(newRequest::setDefaultMaxGroups);
+        GroupingQueryParser.intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_HITS).ifPresent(newRequest::setDefaultMaxHits);
+        GroupingQueryParser.longProperty(query, GroupingQueryParser.GROUPING_GLOBAL_MAX_GROUPS).ifPresent(newRequest::setGlobalMaxGroups);
+        GroupingQueryParser.doubleProperty(query, GroupingQueryParser.PARAM_DEFAULT_PRECISION_FACTOR).ifPresent(newRequest::setDefaultPrecisionFactor);
+        query.getSelect().getGrouping().add(newRequest);
+        return newRequest;
+    }
+
     @Override
     public String toString() {
         return root == null ? "(empty)" : root.toString();

--- a/container-search/src/main/java/com/yahoo/search/grouping/GroupingRequest.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/GroupingRequest.java
@@ -3,6 +3,7 @@ package com.yahoo.search.grouping;
 
 import com.yahoo.api.annotations.Beta;
 import com.yahoo.net.URI;
+import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.grouping.request.GroupingOperation;
@@ -184,26 +185,28 @@ public class GroupingRequest {
      */
     public static GroupingRequest newInstance(Query query) {
         GroupingRequest newRequest = new GroupingRequest(query.getSelect());
+        intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_GROUPS).ifPresent(newRequest::setDefaultMaxGroups);
+        intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_HITS).ifPresent(newRequest::setDefaultMaxHits);
+        longProperty(query, GroupingQueryParser.GROUPING_GLOBAL_MAX_GROUPS).ifPresent(newRequest::setGlobalMaxGroups);
+        doubleProperty(query, GroupingQueryParser.PARAM_DEFAULT_PRECISION_FACTOR).ifPresent(newRequest::setDefaultPrecisionFactor);
         query.getSelect().getGrouping().add(newRequest);
         return newRequest;
     }
 
-    /**
-     * Creates a new grouping request with grouping properties and adds it to the query.getSelect().getGrouping() list
-     *
-     * @param query the query to attach the request to.
-     * @return The created request.
-     */
-    public static GroupingRequest newInstanceWithGroupingProperties(Query query) {
-        GroupingRequest newRequest = new GroupingRequest(query.getSelect());
-        GroupingQueryParser.intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_GROUPS).ifPresent(newRequest::setDefaultMaxGroups);
-        GroupingQueryParser.intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_HITS).ifPresent(newRequest::setDefaultMaxHits);
-        GroupingQueryParser.longProperty(query, GroupingQueryParser.GROUPING_GLOBAL_MAX_GROUPS).ifPresent(newRequest::setGlobalMaxGroups);
-        GroupingQueryParser.doubleProperty(query, GroupingQueryParser.PARAM_DEFAULT_PRECISION_FACTOR).ifPresent(newRequest::setDefaultPrecisionFactor);
-        query.getSelect().getGrouping().add(newRequest);
-        return newRequest;
+    private static OptionalInt intProperty(Query q, CompoundName name) {
+        Integer val = q.properties().getInteger(name);
+        return val != null ? OptionalInt.of(val) : OptionalInt.empty();
     }
 
+    private static OptionalLong longProperty(Query q, CompoundName name) {
+        Long val = q.properties().getLong(name);
+        return val != null ? OptionalLong.of(val) : OptionalLong.empty();
+    }
+
+    private static OptionalDouble doubleProperty(Query q, CompoundName name) {
+        Double val = q.properties().getDouble(name);
+        return val != null ? OptionalDouble.of(val) : OptionalDouble.empty();
+    }
     @Override
     public String toString() {
         return root == null ? "(empty)" : root.toString();

--- a/container-search/src/test/java/com/yahoo/search/grouping/GroupingRequestTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/GroupingRequestTestCase.java
@@ -6,12 +6,16 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.grouping.result.Group;
 import com.yahoo.search.grouping.result.RootGroup;
+import com.yahoo.search.query.profile.QueryProfile;
 import com.yahoo.search.result.Hit;
+import com.yahoo.search.test.QueryTestCase;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -126,6 +130,26 @@ public class GroupingRequestTestCase {
 
         GroupingRequest bar = GroupingRequest.newInstance(query);
         assertEquals(List.of(foo, bar), query.getSelect().getGrouping());
+    }
+
+    @Test
+    void requireThatGroupingPropertiesAreReflected() {
+        QueryProfile profile = new QueryProfile("myProfile");
+        profile.set("grouping.defaultMaxHits", "-1", null);
+        profile.set("grouping.defaultMaxGroups", "-1", null);
+        profile.set("grouping.defaultPrecisionFactor", "1.0", null);
+        profile.set("grouping.globalMaxGroups", "-1", null);
+        Query query = new Query(QueryTestCase.httpEncode("/search?queryProfile=myProfile"), profile.compile(null));
+
+        assertEquals(List.of(), query.getSelect().getGrouping());
+
+        GroupingRequest foo = GroupingRequest.newInstanceWithGroupingProperties(query);
+
+        assertEquals(List.of(foo), query.getSelect().getGrouping());
+        assertEquals(OptionalInt.of(-1), query.getSelect().getGrouping().get(0).defaultMaxHits());
+        assertEquals(OptionalInt.of(-1), query.getSelect().getGrouping().get(0).defaultMaxGroups());
+        assertEquals(OptionalDouble.of(1.0), query.getSelect().getGrouping().get(0).defaultPrecisionFactor());
+        assertEquals(OptionalLong.of(-1), query.getSelect().getGrouping().get(0).globalMaxGroups());
     }
     
 

--- a/container-search/src/test/java/com/yahoo/search/grouping/GroupingRequestTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/GroupingRequestTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping;
 
-import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.grouping.result.Group;
@@ -143,7 +142,7 @@ public class GroupingRequestTestCase {
 
         assertEquals(List.of(), query.getSelect().getGrouping());
 
-        GroupingRequest foo = GroupingRequest.newInstanceWithGroupingProperties(query);
+        GroupingRequest foo = GroupingRequest.newInstance(query);
 
         assertEquals(List.of(foo), query.getSelect().getGrouping());
         assertEquals(OptionalInt.of(-1), query.getSelect().getGrouping().get(0).defaultMaxHits());


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The values from the query profile are not reflected when creating a GroupingRequest.

**Describe the solution you'd like**
We want to create GroupingRequest whose default values are determined by grouping.defaultMaxGroups/ grouping.defaultMaxHits/ grouping.globalMaxGroups/ grouping.defaultPrecisionFactor in the query profile.

**Describe alternatives you've considered**
We have implemented initProperty and longProperty methods in our container to set the default values in the query profile.

```
public Result search(Query query, Execution execution) {
    GroupingRequest request = GroupingRequest.newInstance(query);
    intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_GROUPS).ifPresent(request::setDefaultMaxGroups);
    intProperty(query, GroupingQueryParser.PARAM_DEFAULT_MAX_HITS).ifPresent(request::setDefaultMaxHits);
    longProperty(query, GroupingQueryParser.GROUPING_GLOBAL_MAX_GROUPS).ifPresent(request::setGlobalMaxGroups);
    // ...
    // some logic here
    // ...
}

private static OptionalInt intProperty(com.yahoo.search.Query q, CompoundName name) {
    Integer val = q.properties().getInteger(name);
    return val != null ? OptionalInt.of(val) : OptionalInt.empty();
}

private static OptionalLong longProperty(com.yahoo.search.Query q, CompoundName name) {
    Long val = q.properties().getLong(name);
    return val != null ? OptionalLong.of(val) : OptionalLong.empty();
}
```

**Additional context**
We cannot use the setDefaultPrecisionFactor method in GroupingRequest because it is package-private. 
