### PR TITLE
Add configurable max allowed message size for Put/Update operations

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1342,7 +1342,8 @@
       "public boolean forwardAllLogLevels()",
       "public long zookeeperPreAllocSize()",
       "public int documentV1QueueSize()",
-      "public int maxContentNodeMaintenanceOpConcurrency()"
+      "public int maxContentNodeMaintenanceOpConcurrency()",
+      "public int maxDistributorDocumentOperationSizeMib()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -124,6 +124,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default int documentV1QueueSize() { return -1; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxContentNodeMaintenanceOpConcurrency() { return -1; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default int maxDistributorDocumentOperationSizeMib() { return -1; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -80,6 +80,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private boolean logserverOtelCol = false;
     private boolean symmetricPutAndActivateReplicaSelection = false;
     private int maxContentNodeMaintenanceOpConcurrency = -1;
+    private int maxDistributorDocumentOperationSizeMib = -1;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
     @Override public boolean multitenant() { return multitenant; }
@@ -134,6 +135,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public boolean logserverOtelCol() { return logserverOtelCol; }
     @Override public boolean symmetricPutAndActivateReplicaSelection() { return symmetricPutAndActivateReplicaSelection; }
     @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
+    @Override public int maxDistributorDocumentOperationSizeMib() { return maxDistributorDocumentOperationSizeMib; }
 
     public TestProperties maxUnCommittedMemory(int maxUnCommittedMemory) {
         this.maxUnCommittedMemory = maxUnCommittedMemory;
@@ -356,6 +358,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setMaxContentNodeMaintenanceOpConcurrency(int maxConcurrency) {
         this.maxContentNodeMaintenanceOpConcurrency = maxConcurrency;
+        return this;
+    }
+
+    public TestProperties setMaxDistributorDocumentOperationSizeMib(int maxSizeMib) {
+        this.maxDistributorDocumentOperationSizeMib = maxSizeMib;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -36,6 +36,7 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
     private final int maxActivationInhibitedOutOfSyncGroups;
     private final int contentLayerMetadataFeatureLevel;
     private final boolean symmetricPutAndActivateReplicaSelection;
+    private final int maxDocumentOperationSizeMib;
 
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilderBase<DistributorCluster> {
 
@@ -100,13 +101,15 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
             int maxInhibitedGroups = featureFlags.maxActivationInhibitedOutOfSyncGroups();
             int contentLayerMetadataFeatureLevel = featureFlags.contentLayerMetadataFeatureLevel();
             boolean symmetricPutAndActivateReplicaSelection = featureFlags.symmetricPutAndActivateReplicaSelection();
+            int maxDocumentOperationSizeMib = featureFlags.maxDistributorDocumentOperationSizeMib();
 
             return new DistributorCluster(parent,
                     new BucketSplitting.Builder().build(new ModelElement(producerSpec)), gc,
                     hasIndexedDocumentType,
                     maxInhibitedGroups,
                     contentLayerMetadataFeatureLevel,
-                    symmetricPutAndActivateReplicaSelection);
+                    symmetricPutAndActivateReplicaSelection,
+                    maxDocumentOperationSizeMib);
         }
     }
 
@@ -114,7 +117,8 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
                                GcOptions gc, boolean hasIndexedDocumentType,
                                int maxActivationInhibitedOutOfSyncGroups,
                                int contentLayerMetadataFeatureLevel,
-                               boolean symmetricPutAndActivateReplicaSelection)
+                               boolean symmetricPutAndActivateReplicaSelection,
+                               int maxDocumentOperationSizeMib)
     {
         super(parent, "distributor");
         this.parent = parent;
@@ -124,6 +128,7 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
         this.maxActivationInhibitedOutOfSyncGroups = maxActivationInhibitedOutOfSyncGroups;
         this.contentLayerMetadataFeatureLevel = contentLayerMetadataFeatureLevel;
         this.symmetricPutAndActivateReplicaSelection = symmetricPutAndActivateReplicaSelection;
+        this.maxDocumentOperationSizeMib = maxDocumentOperationSizeMib;
     }
 
     @Override
@@ -139,6 +144,9 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
             builder.enable_operation_cancellation(true);
         }
         builder.symmetric_put_and_activate_replica_selection(symmetricPutAndActivateReplicaSelection);
+        if (maxDocumentOperationSizeMib > 0 && maxDocumentOperationSizeMib < 2048) {
+            builder.max_document_operation_message_size_bytes(maxDocumentOperationSizeMib * 1024 * 1024);
+        }
         bucketSplitting.getConfig(builder);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1565,6 +1565,25 @@ public class ContentClusterTest extends ContentBaseTest {
         assertTrue(resolveDistributorSymmetricReplicaSelectionConfig(true));
     }
 
+    private int resolveMaxDistributorDocOperationSizeConfig(Integer flagValue) throws Exception {
+        return resolveDistributorConfig((props) -> {
+            if (flagValue != null) {
+                props.setMaxDistributorDocumentOperationSizeMib(flagValue);
+            }
+        }).max_document_operation_message_size_bytes();
+    }
+
+    @Test
+    void distributor_max_document_operation_size_config_is_controlled_by_properties() throws Exception {
+        int mi = 1024 * 1024;
+        assertEquals(-1,      resolveMaxDistributorDocOperationSizeConfig(null)); // defaults to -1
+        assertEquals(-1,      resolveMaxDistributorDocOperationSizeConfig(-2));
+        assertEquals(-1,      resolveMaxDistributorDocOperationSizeConfig(0));
+        assertEquals(100*mi,  resolveMaxDistributorDocOperationSizeConfig(100));
+        assertEquals(2047*mi, resolveMaxDistributorDocOperationSizeConfig(2047));
+        assertEquals(-1,      resolveMaxDistributorDocOperationSizeConfig(2048));
+    }
+
     @Test
     void node_distribution_key_outside_legal_range_is_disallowed() {
         // Only [0, UINT16_MAX - 1] is a valid range. UINT16_MAX is a special content layer-internal

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -209,6 +209,7 @@ public class ModelContextImpl implements ModelContext {
         private final long zookeeperPreAllocSize;
         private final int documentV1QueueSize;
         private final int maxContentNodeMaintenanceOpConcurrency;
+        private final int maxDistributorDocumentOperationSizeMib;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
             this.responseSequencer = Flags.RESPONSE_SEQUENCER_TYPE.bindTo(source).with(appId).with(version).value();
@@ -255,6 +256,7 @@ public class ModelContextImpl implements ModelContext {
             this.zookeeperPreAllocSize = Flags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB.bindTo(source).value();
             this.documentV1QueueSize = Flags.DOCUMENT_V1_QUEUE_SIZE.bindTo(source).with(appId).with(version).value();
             this.maxContentNodeMaintenanceOpConcurrency = Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY.bindTo(source).with(appId).with(version).value();
+            this.maxDistributorDocumentOperationSizeMib = Flags.MAX_DISTRIBUTOR_DOCUMENT_OPERATION_SIZE_MIB.bindTo(source).with(appId).with(version).value();
         }
 
         @Override public int heapSizePercentage() { return heapPercentage; }
@@ -307,6 +309,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public long zookeeperPreAllocSize() { return zookeeperPreAllocSize; }
         @Override public int documentV1QueueSize() { return documentV1QueueSize; }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
+        @Override public int maxDistributorDocumentOperationSizeMib() { return maxDistributorDocumentOperationSizeMib; }
     }
 
     public static class Properties implements ModelContext.Properties {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -362,6 +362,15 @@ public class Flags {
             "Takes effect immediately",
             INSTANCE_ID);
 
+    public static final UnboundIntFlag MAX_DISTRIBUTOR_DOCUMENT_OPERATION_SIZE_MIB = defineIntFlag(
+            "max-distributor-document-operation-size-mib", -1,
+            List.of("vekterli"), "2025-03-17", "2025-10-01",
+            "Sets the maximum size in MiB of a document operation (Put or Update) that a distributor " +
+            "will accept when it arrives over the Document API. Any value outside (1, 2048) implies " +
+            "effectively unbounded behavior. Setting this value too low will have the obvious consequences.",
+            "Takes effect immediately",
+            INSTANCE_ID);
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -26,6 +26,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _maxNodesPerMerge(16),
       _max_consecutively_inhibited_maintenance_ticks(20),
       _max_activation_inhibited_out_of_sync_groups(0),
+      _max_document_operation_message_size_bytes(INT32_MAX),
       _lastGarbageCollectionChange(vespalib::duration::zero()),
       _garbageCollectionInterval(0),
       _minPendingMaintenanceOps(100),
@@ -152,6 +153,11 @@ DistributorConfiguration::configure(const DistributorManagerConfig & config)
     _enable_operation_cancellation = config.enableOperationCancellation;
     _minimumReplicaCountingMode = deriveReplicaCountingMode(config.minimumReplicaCountingMode);
     _symmetric_put_and_activate_replica_selection = config.symmetricPutAndActivateReplicaSelection;
+    if (config.maxDocumentOperationMessageSizeBytes > 0) {
+        _max_document_operation_message_size_bytes = config.maxDocumentOperationMessageSizeBytes;
+    } else {
+        _max_document_operation_message_size_bytes = INT32_MAX;
+    }
 
     if (config.maxClusterClockSkewSec >= 0) {
         _maxClusterClockSkew = std::chrono::seconds(config.maxClusterClockSkewSec);

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -231,6 +231,14 @@ public:
         return _max_activation_inhibited_out_of_sync_groups;
     }
 
+    [[nodiscard]] uint32_t max_document_operation_message_size_bytes() const noexcept {
+        return _max_document_operation_message_size_bytes;
+    }
+    void set_max_document_operation_message_size_bytes(uint32_t max_size_bytes) noexcept {
+        // We use uint32_t internally but cap to INT32_MAX due to wire format restrictions
+        _max_document_operation_message_size_bytes = std::min(max_size_bytes, static_cast<uint32_t>(INT32_MAX));
+    }
+
     [[nodiscard]] bool enable_operation_cancellation() const noexcept {
         return _enable_operation_cancellation;
     }
@@ -239,7 +247,7 @@ public:
     }
 
     [[nodiscard]] bool containsTimeStatement(const std::string& documentSelection) const;
-    
+
 private:
     StorageComponent& _component;
     
@@ -251,6 +259,7 @@ private:
     uint32_t _maxNodesPerMerge;
     uint32_t _max_consecutively_inhibited_maintenance_ticks;
     uint32_t _max_activation_inhibited_out_of_sync_groups;
+    uint32_t _max_document_operation_message_size_bytes;
 
     std::string _garbageCollectionSelection;
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -166,6 +166,19 @@ enable_operation_cancellation bool default=false
 ## likely to reflect these changes as part of visible search results.
 symmetric_put_and_activate_replica_selection bool default=false
 
+## Iff set to a value > 0, will enforce a size check on Put and Update operations arriving
+## at the distributor, where over-sized messages will be explicitly rejected with a
+## non-retryable error code. Intended as a safety measure to prevent overly large documents
+## from being accepted into the cluster.
+##
+## The message size is estimated based on the uncompressed on-wire serialized payload size,
+## so it's only a (possibly inaccurate) proxy for the actual impact the underlying document
+## operation will have on the backend. But it's a "free" heuristic since we already have
+## that information available from the RPC subsystem.
+##
+## Any number <= 0 implicitly defaults to 2GiB (INT32_MAX), i.e. effectively unbounded.
+max_document_operation_message_size_bytes int default=-1
+
 ## TODO GC very soon, it has no effect.
 priority_merge_out_of_sync_copies int default=120
 

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -312,9 +312,25 @@ std::string extract_reindexing_token(const api::PutCommand& cmd) {
 
 }
 
+bool ExternalOperationHandler::message_size_is_above_put_or_update_limit(uint32_t msg_size) const noexcept {
+    return (msg_size > _op_ctx.distributor_config().max_document_operation_message_size_bytes());
+}
+
+void ExternalOperationHandler::reject_as_oversized_message(api::StorageCommand& cmd) {
+    const uint32_t limit = _op_ctx.distributor_config().max_document_operation_message_size_bytes();
+    std::string msg = vespalib::make_string("Message size (%u bytes) exceeds maximum configured limit (%u bytes)",
+                                            cmd.getApproxByteSize(), limit);
+    // TODO increment a metric
+    bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::REJECTED, std::move(msg)));
+}
+
 bool ExternalOperationHandler::onPut(const std::shared_ptr<api::PutCommand>& cmd) {
-    if (_op_ctx.cluster_state_bundle().block_feed_in_cluster()) {
-        bounce_with_feed_blocked(*cmd);
+    if (message_size_is_above_put_or_update_limit(cmd->getApproxByteSize())) [[unlikely]] {
+        reject_as_oversized_message(*cmd);
+        return true;
+    }
+    if (_op_ctx.cluster_state_bundle().block_feed_in_cluster()) [[unlikely]] {
+        bounce_with_feed_blocked(*cmd); // TODO also metric?
         return true;
     }
 
@@ -364,8 +380,12 @@ bool ExternalOperationHandler::onPut(const std::shared_ptr<api::PutCommand>& cmd
 
 
 bool ExternalOperationHandler::onUpdate(const std::shared_ptr<api::UpdateCommand>& cmd) {
+    if (message_size_is_above_put_or_update_limit(cmd->getApproxByteSize())) [[unlikely]] {
+        reject_as_oversized_message(*cmd);
+        return true;
+    }
     if (_op_ctx.cluster_state_bundle().block_feed_in_cluster() &&
-            document::FeedRejectHelper::mustReject(*cmd->getUpdate()))
+        document::FeedRejectHelper::mustReject(*cmd->getUpdate())) [[unlikely]]
     {
         bounce_with_feed_blocked(*cmd);
         return true;

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -119,6 +119,8 @@ private:
     void bounce_with_result(api::StorageCommand& cmd, const api::ReturnCode& result);
     void bounce_with_feed_blocked(api::StorageCommand& cmd);
     std::shared_ptr<Operation> try_generate_get_operation(const std::shared_ptr<api::GetCommand>&);
+    [[nodiscard]] bool message_size_is_above_put_or_update_limit(uint32_t msg_size) const noexcept;
+    void reject_as_oversized_message(api::StorageCommand& cmd);
 
     bool checkSafeTimeReached(api::StorageCommand& cmd);
     api::ReturnCode makeSafeTimeRejectionResult(TimePoint unsafeTime);

--- a/storage/src/vespa/storageapi/messageapi/storagemessage.h
+++ b/storage/src/vespa/storageapi/messageapi/storagemessage.h
@@ -334,7 +334,7 @@ public:
         HIGH = 50,
         VERYHIGH = 0
     }; // FIXME
-    //static const unsigned int NUM_PRIORITIES = UINT8_MAX;
+
     static const char* getPriorityString(Priority);
 
 private:
@@ -391,9 +391,9 @@ public:
 
     /**
      *  Returns the approximate memory footprint (in bytes) of a storage message.
-     *  By default, returns 50 bytes.
+     *  If unset, returns 50 bytes.
      */
-    uint32_t getApproxByteSize() const noexcept {
+    [[nodiscard]] uint32_t getApproxByteSize() const noexcept {
         return _approxByteSize;
     }
 


### PR DESCRIPTION
@toregge please review.

Iff the config is set to a value > 0, the distributor will enforce a size check on Put and Update operations arriving over the Document API, where over-sized messages will be explicitly rejected with a non-retryable error code. This is enforced at the distributor arrival edge since we want rejections to happen prior to any replication.

Intended as a safety measure to prevent overly large documents from being accepted into the cluster.

The message size is estimated based on the uncompressed on-wire serialized payload size, so it's only a (possibly inaccurate) proxy for the actual impact the underlying document operation will have on the backend. But it's a "free" heuristic since we already have that information available from the RPC subsystem.

Any number <= 0 implicitly defaults to 2 GiB (`INT32_MAX`), i.e. effectively unbounded.

Also add a feature flag `max-distributor-document-operation-size-mib` that controls this config, but is expressed in MiB instead of bytes for simplicity.