### PR TITLE
Stop using gzip in file distribution

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -21,7 +21,6 @@ import com.yahoo.vespa.filedistribution.FileReferenceDownload;
 import com.yahoo.vespa.filedistribution.LazyFileReferenceData;
 import com.yahoo.vespa.filedistribution.LazyTemporaryStorageFileReferenceData;
 import com.yahoo.vespa.flags.FlagSource;
-import com.yahoo.vespa.flags.Flags;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +43,6 @@ import static com.yahoo.vespa.filedistribution.FileApiErrorCodes.NOT_FOUND;
 import static com.yahoo.vespa.filedistribution.FileApiErrorCodes.OK;
 import static com.yahoo.vespa.filedistribution.FileApiErrorCodes.TRANSFER_FAILED;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
-import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.gzip;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.lz4;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.none;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType.zstd;
@@ -61,7 +59,7 @@ public class FileServer {
     /* In preferred order, the one used will be the first one matching one of the accepted compression
      * types sent in client request.
      */
-    private static final List<CompressionType> compressionTypesToServe = List.of(zstd, lz4, gzip, none);
+    private static final List<CompressionType> compressionTypesToServe = List.of(zstd, lz4, none);
     private static final String tempFilereferencedataPrefix = "filereferencedata";
     private static final Path tempFilereferencedataDir = Paths.get(System.getProperty("java.io.tmpdir"));
 
@@ -90,7 +88,7 @@ public class FileServer {
     @Inject
     public FileServer(ConfigserverConfig configserverConfig, FlagSource flagSource, FileDirectory fileDirectory) {
         this(createFileDownloader(getOtherConfigServersInCluster(configserverConfig)),
-             compressionTypesAsList(Flags.FILE_DISTRIBUTION_COMPRESSION_TYPES_TO_SERVE.bindTo(flagSource).value()),
+             compressionTypesToServe,
              fileDirectory);
         // Clean up temporary files from previous runs (e.g. if JVM was killed)
         try (var files = uncheck(() -> Files.list(tempFilereferencedataDir))) {
@@ -243,12 +241,6 @@ public class FileServer {
         if (configServers.isEmpty()) return FileDownloader.emptyConnectionPool();
 
         return new FileDistributionConnectionPool(new ConfigSourceSet(configServers), supervisor);
-    }
-
-    private static List<CompressionType> compressionTypesAsList(List<String> compressionTypes) {
-        return compressionTypes.stream()
-                               .map(CompressionType::valueOf)
-                               .toList();
     }
 
 }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReceiver.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReceiver.java
@@ -234,7 +234,7 @@ public class FileReceiver {
         long fileSize = req.parameters().get(3).asInt64();
         CompressionType compressionType = (req.parameters().size() > 4)
                 ? CompressionType.valueOf(req.parameters().get(4).asString())
-                : CompressionType.gzip; // fallback/legacy compression type
+                : CompressionType.lz4; // fallback/legacy compression type
         int sessionId = nextSessionId.getAndIncrement();
         int retval = 0;
         synchronized (sessions) {

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceCompressor.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceCompressor.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Utility class for compressing and decompressing files used in a file reference
@@ -118,7 +116,6 @@ public class FileReferenceCompressor {
     private OutputStream compressedOutputStream(File outputFile) throws IOException {
         return switch (type) {
             case compressed -> switch (compressionType) {
-                case gzip -> new GZIPOutputStream(new FileOutputStream(outputFile));
                 case lz4 -> new LZ4BlockOutputStream(new FileOutputStream(outputFile));
                 case none -> new FileOutputStream(outputFile);
                 case zstd -> new ZstdOutputStream(new FileOutputStream(outputFile));
@@ -130,7 +127,6 @@ public class FileReferenceCompressor {
     private InputStream decompressedInputStream(File inputFile) throws IOException {
         return switch (type) {
             case compressed -> switch (compressionType) {
-                case gzip -> new GZIPInputStream(new FileInputStream(inputFile));
                 case lz4 -> new LZ4BlockInputStream(new FileInputStream(inputFile));
                 case none -> new FileInputStream(inputFile);
                 case zstd -> new ZstdInputStream(new FileInputStream(inputFile));

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceData.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceData.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
 public abstract class FileReferenceData implements AutoCloseable {
 
     public enum Type { file, compressed }
-    public enum CompressionType { gzip, lz4, none, zstd }
+    public enum CompressionType { lz4, none, zstd }
 
     private final FileReference fileReference;
     private final String filename;


### PR DESCRIPTION
Very slow, uses more resources and native memory, not used for a long time