### PR TITLE
Use `= default` for inline defined virtual destructors

### DIFF
--- a/config/src/vespa/config/common/trace.h
+++ b/config/src/vespa/config/common/trace.h
@@ -16,7 +16,7 @@ namespace config {
  */
 struct Clock {
     virtual vespalib::system_time currentTime() const = 0;
-    virtual ~Clock() {}
+    virtual ~Clock() = default;
 };
 
 /**

--- a/config/src/vespa/config/file_acquirer/file_acquirer.h
+++ b/config/src/vespa/config/file_acquirer/file_acquirer.h
@@ -15,7 +15,7 @@ namespace config {
  **/
 struct FileAcquirer {
     virtual std::string wait_for(const std::string &file_ref, double timeout_s) = 0;
-    virtual ~FileAcquirer() {}
+    virtual ~FileAcquirer() = default;
 };
 
 /**

--- a/config/src/vespa/config/helper/ifetchercallback.h
+++ b/config/src/vespa/config/helper/ifetchercallback.h
@@ -9,14 +9,14 @@ class IGenerationCallback
 {
 public:
     virtual void notifyGenerationChange(int64_t generation) = 0;
-    virtual ~IGenerationCallback() {}
+    virtual ~IGenerationCallback() = default;
 };
 
 class ICallback
 {
 public:
     virtual void configure(std::unique_ptr<const ConfigInstance> config) = 0;
-    virtual ~ICallback() { }
+    virtual ~ICallback() = default;
 };
 
 /**

--- a/document/src/vespa/document/annotation/spantreevisitor.h
+++ b/document/src/vespa/document/annotation/spantreevisitor.h
@@ -9,7 +9,7 @@ class SpanList;
 class SimpleSpanList;
 
 struct SpanTreeVisitor {
-    virtual ~SpanTreeVisitor() {}
+    virtual ~SpanTreeVisitor() = default;
 
     virtual void visit(const Span &) = 0;
     virtual void visit(const SpanList &node) = 0;

--- a/document/src/vespa/document/fieldvalue/fieldvaluevisitor.h
+++ b/document/src/vespa/document/fieldvalue/fieldvaluevisitor.h
@@ -23,7 +23,7 @@ class TensorFieldValue;
 class ReferenceFieldValue;
 
 struct FieldValueVisitor {
-    virtual ~FieldValueVisitor() {}
+    virtual ~FieldValueVisitor() = default;
 
     virtual void visit(AnnotationReferenceFieldValue &value) = 0;
     virtual void visit(ArrayFieldValue &value) = 0;
@@ -46,7 +46,7 @@ struct FieldValueVisitor {
 };
 
 struct ConstFieldValueVisitor {
-    virtual ~ConstFieldValueVisitor() {}
+    virtual ~ConstFieldValueVisitor() = default;
 
     virtual void visit(const AnnotationReferenceFieldValue &value) = 0;
     virtual void visit(const ArrayFieldValue &value) = 0;

--- a/document/src/vespa/document/fieldvalue/fieldvaluewriter.h
+++ b/document/src/vespa/document/fieldvalue/fieldvaluewriter.h
@@ -8,7 +8,7 @@ namespace document {
 class FieldValue;
 
 struct FieldValueWriter {
-    virtual ~FieldValueWriter() {}
+    virtual ~FieldValueWriter() = default;
 
     virtual void writeFieldValue(const FieldValue &value) = 0;
     virtual void writeSerializedData(const void *buf, size_t length) = 0;

--- a/document/src/vespa/document/fieldvalue/structuredfieldvalue.h
+++ b/document/src/vespa/document/fieldvalue/structuredfieldvalue.h
@@ -51,7 +51,7 @@ protected:
 
     struct StructuredIterator {
         using UP = std::unique_ptr<StructuredIterator>;
-        virtual ~StructuredIterator() {}
+        virtual ~StructuredIterator() = default;
 
         virtual const Field* getNextField() = 0;
     };

--- a/document/src/vespa/document/predicate/predicate.h
+++ b/document/src/vespa/document/predicate/predicate.h
@@ -41,7 +41,7 @@ struct Predicate {
 struct PredicateNode {
     using UP = std::unique_ptr<PredicateNode>;
 
-    virtual ~PredicateNode() {}
+    virtual ~PredicateNode() = default;
 };
 
 class FeatureBase : public PredicateNode {

--- a/document/src/vespa/document/predicate/predicate_slime_visitor.h
+++ b/document/src/vespa/document/predicate/predicate_slime_visitor.h
@@ -23,7 +23,7 @@ protected:
     void visitChildren(const Inspector &i);
 
 public:
-    virtual ~PredicateSlimeVisitor() {}
+    virtual ~PredicateSlimeVisitor() = default;
 
     void visit(const Inspector &i);
 };

--- a/document/src/vespa/document/select/operator.h
+++ b/document/src/vespa/document/select/operator.h
@@ -25,7 +25,7 @@ private:
 
 public:
     Operator(std::string_view name);
-    virtual ~Operator() {}
+    virtual ~Operator() = default;
 
     virtual ResultList compare(const Value&, const Value&) const = 0;
     virtual ResultList trace(const Value&, const Value&,

--- a/document/src/vespa/document/serialization/fieldreader.h
+++ b/document/src/vespa/document/serialization/fieldreader.h
@@ -21,7 +21,7 @@ class WeightedSetFieldValue;
 
 class FieldReader {
 public:
-    virtual ~FieldReader() {}
+    virtual ~FieldReader() = default;
     virtual void read(const vespalib::FieldBase &field,
                       Document &value) = 0;
     virtual void read(const vespalib::FieldBase &field,

--- a/document/src/vespa/document/serialization/fieldwriter.h
+++ b/document/src/vespa/document/serialization/fieldwriter.h
@@ -21,7 +21,7 @@ class WeightedSetFieldValue;
 
 class FieldWriter {
 public:
-    virtual ~FieldWriter() {}
+    virtual ~FieldWriter() = default;
     virtual void write(const vespalib::FieldBase &field,
                        const Document &value) = 0;
     virtual void write(const vespalib::FieldBase &field,

--- a/document/src/vespa/document/update/updatevisitor.h
+++ b/document/src/vespa/document/update/updatevisitor.h
@@ -20,7 +20,7 @@ class TensorModifyUpdate;
 class TensorRemoveUpdate;
 
 struct UpdateVisitor {
-    virtual ~UpdateVisitor() {}
+    virtual ~UpdateVisitor() = default;
 
     virtual void visit(const DocumentUpdate &value) = 0;
     virtual void visit(const FieldUpdate &value) = 0;

--- a/document/src/vespa/document/util/printable.h
+++ b/document/src/vespa/document/util/printable.h
@@ -20,7 +20,7 @@ namespace document {
 
 class Printable {
 public:
-    virtual ~Printable() {}
+    virtual ~Printable() = default;
 
     /**
      * Print instance textual to the given stream.

--- a/eval/src/apps/tensor_conformance/generate.h
+++ b/eval/src/apps/tensor_conformance/generate.h
@@ -18,7 +18,7 @@ struct TestBuilder {
     {
         add(expression, inputs, {});
     }
-    virtual ~TestBuilder() {}
+    virtual ~TestBuilder() = default;
 };
 
 struct Generator {

--- a/eval/src/vespa/eval/eval/basic_nodes.h
+++ b/eval/src/vespa/eval/eval/basic_nodes.h
@@ -27,7 +27,7 @@ struct NodeVisitor;
  **/
 struct NodeHandler {
     virtual void handle(std::unique_ptr<nodes::Node> node) = 0;
-    virtual ~NodeHandler() {}
+    virtual ~NodeHandler() = default;
 };
 
 namespace nodes {
@@ -60,7 +60,7 @@ struct Node {
     virtual const Node &get_child(size_t idx) const = 0;
     virtual void detach_children(NodeHandler &handler) = 0;
     bool is_leaf() const { return (num_children() == 0); }
-    virtual ~Node() {}
+    virtual ~Node() = default;
 };
 
 using Node_UP = std::unique_ptr<Node>;

--- a/eval/src/vespa/eval/eval/function.h
+++ b/eval/src/vespa/eval/eval/function.h
@@ -18,7 +18,7 @@ enum class PassParams : uint8_t { SEPARATE, ARRAY, LAZY };
 struct SymbolExtractor {
     virtual void extract_symbol(const char *pos_in, const char *end_in,
                                 const char *&pos_out, std::string &symbol_out) const = 0;
-    virtual ~SymbolExtractor() {}
+    virtual ~SymbolExtractor() = default;
 };
 
 struct NodeVisitor;

--- a/eval/src/vespa/eval/eval/gbdt.h
+++ b/eval/src/vespa/eval/eval/gbdt.h
@@ -82,7 +82,7 @@ bool contains_gbdt(const nodes::Node &node, size_t limit);
 struct Forest {
     using UP = std::unique_ptr<Forest>;
     using eval_function = double (*)(const Forest *self, const double *args);
-    virtual ~Forest() {}
+    virtual ~Forest() = default;
 };
 
 /**

--- a/eval/src/vespa/eval/eval/llvm/llvm_wrapper.h
+++ b/eval/src/vespa/eval/eval/llvm/llvm_wrapper.h
@@ -34,7 +34,7 @@ namespace vespalib::eval {
  **/
 struct PluginState {
     using UP = std::unique_ptr<PluginState>;
-    virtual ~PluginState() {}
+    virtual ~PluginState() = default;
 };
 
 /**

--- a/eval/src/vespa/eval/eval/node_traverser.h
+++ b/eval/src/vespa/eval/eval/node_traverser.h
@@ -19,7 +19,7 @@ struct NodeTraverser {
     virtual bool open(const nodes::Node &) = 0;
     virtual void close(const nodes::Node &) = 0;
 
-    virtual ~NodeTraverser() {}
+    virtual ~NodeTraverser() = default;
 };
 
 }

--- a/eval/src/vespa/eval/eval/node_visitor.h
+++ b/eval/src/vespa/eval/eval/node_visitor.h
@@ -88,7 +88,7 @@ struct NodeVisitor {
     virtual void visit(const nodes::Bit                &) = 0;
     virtual void visit(const nodes::Hamming            &) = 0;
 
-    virtual ~NodeVisitor() {}
+    virtual ~NodeVisitor() = default;
 };
 
 /**

--- a/eval/src/vespa/eval/eval/tensor_function.h
+++ b/eval/src/vespa/eval/eval/tensor_function.h
@@ -114,7 +114,7 @@ struct TensorFunction
     virtual void visit_self(vespalib::ObjectVisitor &visitor) const;
     virtual void visit_children(vespalib::ObjectVisitor &visitor) const;
 
-    virtual ~TensorFunction() {}
+    virtual ~TensorFunction() = default;
 };
 
 /**

--- a/eval/src/vespa/eval/eval/test/eval_spec.h
+++ b/eval/src/vespa/eval/eval/test/eval_spec.h
@@ -86,7 +86,7 @@ public:
                                  const std::vector<double> &param_values,
                                  const std::string &expression,
                                  double expected_result) = 0;
-        virtual ~EvalTest() {}
+        virtual ~EvalTest() = default;
     };
     //-------------------------------------------------------------------------
     void add_terminal_cases();         // a, 1.0

--- a/eval/src/vespa/eval/eval/value_cache/constant_value.h
+++ b/eval/src/vespa/eval/eval/value_cache/constant_value.h
@@ -18,7 +18,7 @@ struct ConstantValue {
     virtual const ValueType &type() const = 0;
     virtual const Value &value() const = 0;
     using UP = std::unique_ptr<ConstantValue>;
-    virtual ~ConstantValue() {}
+    virtual ~ConstantValue() = default;
 };
 
 class SimpleConstantValue : public ConstantValue {
@@ -46,7 +46,7 @@ public:
  **/
 struct ConstantValueFactory {
     virtual ConstantValue::UP create(const std::string &path, const std::string &type) const = 0;
-    virtual ~ConstantValueFactory() {}
+    virtual ~ConstantValueFactory() = default;
 };
 
 } // namespace vespalib::eval

--- a/eval/src/vespa/eval/gp/gp.h
+++ b/eval/src/vespa/eval/gp/gp.h
@@ -54,7 +54,7 @@ struct MultiFunction {
     virtual size_t num_outputs() const = 0;
     virtual size_t num_alternatives() const = 0;
     virtual Result execute(const Input &input) const = 0;
-    virtual ~MultiFunction() {}
+    virtual ~MultiFunction() = default;
 };
 
 // simulated individual representing a multifunction

--- a/fbench/src/httpclient/httpclient.h
+++ b/fbench/src/httpclient/httpclient.h
@@ -30,7 +30,7 @@ protected:
   {
   public:
     ReaderInterface() {}
-    virtual ~ReaderInterface() {}
+    virtual ~ReaderInterface() = default;
 
     /**
      * This method is called by the @ref HTTPClient::Read(char *,

--- a/fnet/src/vespa/fnet/frt/invoker.h
+++ b/fnet/src/vespa/fnet/frt/invoker.h
@@ -19,7 +19,7 @@ public:
     /**
      * Destructor.  No cleanup needed for base class.
      */
-    virtual ~FRT_IRequestWait(void) {}
+    virtual ~FRT_IRequestWait() = default;
 
     virtual void RequestDone(FRT_RPCRequest *req) = 0;
 };
@@ -51,7 +51,7 @@ public:
     /**
      * Destructor.  No cleanup needed for base class.
      */
-    virtual ~FRT_ITimeoutHandler() {}
+    virtual ~FRT_ITimeoutHandler() = default;
 
     virtual void HandleTimeout() = 0;
 };

--- a/fnet/src/vespa/fnet/frt/isharedblob.h
+++ b/fnet/src/vespa/fnet/frt/isharedblob.h
@@ -12,7 +12,7 @@ public:
     virtual uint32_t getLen() = 0;
     virtual const char *getData() = 0;
 protected:
-    virtual ~FRT_ISharedBlob() {}
+    virtual ~FRT_ISharedBlob() = default;
 };
 
 

--- a/fnet/src/vespa/fnet/frt/rpcrequest.h
+++ b/fnet/src/vespa/fnet/frt/rpcrequest.h
@@ -18,7 +18,7 @@ public:
     /**
      * Destructor.  No cleanup needed for base class.
      */
-    virtual ~FRT_IAbortHandler(void) {}
+    virtual ~FRT_IAbortHandler() = default;
 
     virtual bool HandleAbort() = 0;
 };
@@ -31,7 +31,7 @@ public:
     /**
      * Destructor.  No cleanup needed for base class.
      */
-    virtual ~FRT_IReturnHandler(void) {}
+    virtual ~FRT_IReturnHandler() = default;
 
     virtual void HandleReturn() = 0;
     virtual FNET_Connection *GetConnection() = 0;

--- a/fnet/src/vespa/fnet/iexecutable.h
+++ b/fnet/src/vespa/fnet/iexecutable.h
@@ -18,6 +18,6 @@ public:
     /**
      * empty
      **/
-    virtual ~FNET_IExecutable() {}
+    virtual ~FNET_IExecutable() = default;
 };
 

--- a/fnet/src/vespa/fnet/packet.h
+++ b/fnet/src/vespa/fnet/packet.h
@@ -25,7 +25,7 @@ public:
     FNET_Packet() {}
 
     /** Does nothing. **/
-    virtual ~FNET_Packet() {}
+    virtual ~FNET_Packet() = default;
 
 
     /**

--- a/fsa/src/vespa/fsa/detector.h
+++ b/fsa/src/vespa/fsa/detector.h
@@ -47,7 +47,7 @@ public:
     /** Default constructor. */
     Hits() {}
     /** Destructor. */
-    virtual ~Hits() {};
+    virtual ~Hits() = default;
 
     /**
      * @brief Method to receive results from the detector.

--- a/fsa/src/vespa/fsa/fsa.h
+++ b/fsa/src/vespa/fsa/fsa.h
@@ -771,10 +771,7 @@ public:
      */
     HashedState(const HashedState& s) : State(s), _hash(s._hash) {}
 
-    /**
-     * @brief Destructor.
-     */
-    virtual ~HashedState() {}
+    ~HashedState() override = default;
 
     using State::start;
     using State::delta;
@@ -894,7 +891,7 @@ public:
     /**
      * @brief Destructor.
      */
-    virtual ~CounterState() {}
+    ~CounterState() override = default;
 
     using State::start;
     using State::delta;
@@ -1184,7 +1181,7 @@ public:
     /**
      * @brief Destructor.
      */
-    virtual ~MemoryState() {}
+    ~MemoryState() override = default;
 
     using State::start;
     using State::delta;
@@ -1338,7 +1335,7 @@ public:
     /**
      * @brief Destructor.
      */
-    virtual ~HashedMemoryState() {}
+    ~HashedMemoryState() override = default;
 
     using State::start;
     using State::delta;
@@ -1488,7 +1485,7 @@ public:
     /**
      * @brief Destructor.
      */
-    virtual ~HashedCounterState() {}
+    ~HashedCounterState() override = default;
 
     using State::start;
     using State::delta;

--- a/fsa/src/vespa/fsa/tokenizer.h
+++ b/fsa/src/vespa/fsa/tokenizer.h
@@ -36,7 +36,7 @@ public:
   /**
    * @brief Destructor.
    */
-  virtual ~Tokenizer() {}
+  virtual ~Tokenizer() = default;
 
   /**
    * @brief Initialize the tokenizer.

--- a/fsa/src/vespa/fsa/wordchartokenizer.h
+++ b/fsa/src/vespa/fsa/wordchartokenizer.h
@@ -67,7 +67,7 @@ public:
     _lowercase(true)
   {}
 
-  virtual ~WordCharTokenizer() {}
+  ~WordCharTokenizer() override = default;
 
   Punctuation getPunctuation() const { return _punctuation; }
   void setPunctuation(Punctuation punct) { _punctuation=punct; }

--- a/fsa/src/vespa/fsamanagers/refcountable.h
+++ b/fsa/src/vespa/fsamanagers/refcountable.h
@@ -68,7 +68,7 @@ public:
   /**
    * @brief Destructor
    */
-  virtual ~RefCountable(void) {}
+  virtual ~RefCountable() = default;
 
   /**
    * @brief Increase reference count.

--- a/logd/src/logd/forwarder.h
+++ b/logd/src/logd/forwarder.h
@@ -18,7 +18,7 @@ using ForwardMap = std::map<ns_log::Logger::LogLevel, bool>;
 class Forwarder {
 public:
     using UP = std::unique_ptr<Forwarder>;
-    virtual ~Forwarder() {}
+    virtual ~Forwarder() = default;
     virtual void forwardLine(std::string_view log_line) = 0;
     virtual void flush() = 0;
     virtual int badLines() const = 0;

--- a/messagebus/src/vespa/messagebus/iprotocol.h
+++ b/messagebus/src/vespa/messagebus/iprotocol.h
@@ -22,7 +22,7 @@ protected:
 public:
     IProtocol(const IProtocol &) = delete;
     IProtocol & operator = (const IProtocol &) = delete;
-    virtual ~IProtocol() {}
+    virtual ~IProtocol() = default;
 
     /**
      * Convenience typedef for an auto pointer to an IProtocol object.

--- a/messagebus/src/vespa/messagebus/ireplyhandler.h
+++ b/messagebus/src/vespa/messagebus/ireplyhandler.h
@@ -19,7 +19,7 @@ protected:
 public:
     IReplyHandler(const IReplyHandler &) = delete;
     IReplyHandler & operator = (const IReplyHandler &) = delete;
-    virtual ~IReplyHandler() {}
+    virtual ~IReplyHandler() = default;
 
     /**
      * This method is invoked by messagebus to deliver a Reply.

--- a/messagebus/src/vespa/messagebus/network/rpcsend.h
+++ b/messagebus/src/vespa/messagebus/network/rpcsend.h
@@ -38,7 +38,7 @@ class RPCSend : public FRT_Invokable,
 public:
     class Params {
     public:
-        virtual ~Params() {}
+        virtual ~Params() = default;
         virtual vespalib::Version getVersion() const = 0;
         virtual std::string_view getProtocol() const = 0;
         virtual uint32_t getTraceLevel() const = 0;

--- a/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_factory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_factory.h
@@ -20,7 +20,7 @@ struct IAttributeFactory
 {
     using SP = std::shared_ptr<IAttributeFactory>;
     using AttributeVectorSP = std::shared_ptr<search::AttributeVector>;
-    virtual ~IAttributeFactory() {}
+    virtual ~IAttributeFactory() = default;
     virtual AttributeVectorSP create(const std::string &name,
                                      const search::attribute::Config &cfg) const = 0;
     virtual void setupEmpty(const AttributeVectorSP &vec,

--- a/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_initializer_registry.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_initializer_registry.h
@@ -12,7 +12,7 @@ namespace proton {
  */
 struct IAttributeInitializerRegistry
 {
-    virtual ~IAttributeInitializerRegistry() {}
+    virtual ~IAttributeInitializerRegistry() = default;
     virtual void add(AttributeInitializer::UP initializer) = 0;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/bucketdb/ibucketdbhandlerinitializer.h
+++ b/searchcore/src/vespa/searchcore/proton/bucketdb/ibucketdbhandlerinitializer.h
@@ -12,7 +12,7 @@ class IBucketDBHandlerInitializer
 {
 public:
     IBucketDBHandlerInitializer() { }
-    virtual ~IBucketDBHandlerInitializer() {}
+    virtual ~IBucketDBHandlerInitializer() = default;
 
     virtual void addDocumentMetaStore(IDocumentMetaStore *dms, search::SerialNum flushedSerialNum) = 0;
 };

--- a/searchcore/src/vespa/searchcore/proton/common/statusreport.h
+++ b/searchcore/src/vespa/searchcore/proton/common/statusreport.h
@@ -116,7 +116,7 @@ public:
  **/
 struct StatusProducer {
     virtual StatusReport::List getStatusReports() const = 0;
-    virtual ~StatusProducer() {}
+    virtual ~StatusProducer() = default;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/operation_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/operation_listener.h
@@ -12,7 +12,7 @@ namespace proton::documentmetastore {
 class OperationListener {
 public:
     using SP = std::shared_ptr<OperationListener>;
-    virtual ~OperationListener() {}
+    virtual ~OperationListener() = default;
     virtual void notify_remove_batch() = 0;
     virtual void notify_remove() = 0;
 };

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/joinbucketsoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/joinbucketsoperation.h
@@ -17,7 +17,7 @@ public:
     JoinBucketsOperation(const document::BucketId &source1,
                          const document::BucketId &source2,
                          const document::BucketId &target);
-    virtual ~JoinBucketsOperation() {}
+    ~JoinBucketsOperation() override = default;
     const document::BucketId &getSource1() const { return _source1; }
     const document::BucketId &getSource2() const { return _source2; }
     const document::BucketId &getTarget() const { return _target; }

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/newconfigoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/newconfigoperation.h
@@ -7,7 +7,7 @@ namespace proton {
 
     namespace feedoperation {
         struct IStreamHandler {
-            virtual ~IStreamHandler() {}
+            virtual ~IStreamHandler() = default;
             virtual void serializeConfig(search::SerialNum serialNum, vespalib::nbostream &os) = 0;
             virtual void deserializeConfig(search::SerialNum serialNum, vespalib::nbostream &is) = 0;
         };

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/noopoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/noopoperation.h
@@ -8,7 +8,7 @@ namespace proton {
 struct NoopOperation : FeedOperation {
     NoopOperation() : FeedOperation(FeedOperation::NOOP) {}
     NoopOperation(SerialNum serialNum);
-    virtual ~NoopOperation() {}
+    ~NoopOperation() override = default;
 
     virtual void serialize(vespalib::nbostream &) const override {}
     virtual void deserialize(vespalib::nbostream &,

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/splitbucketoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/splitbucketoperation.h
@@ -17,7 +17,7 @@ public:
     SplitBucketOperation(const document::BucketId &source,
                          const document::BucketId &target1,
                          const document::BucketId &target2);
-    virtual ~SplitBucketOperation() {}
+    ~SplitBucketOperation() override = default;
     const document::BucketId &getSource() const { return _source; }
     const document::BucketId &getTarget1() const { return _target1; }
     const document::BucketId &getTarget2() const { return _target2; }

--- a/searchcore/src/vespa/searchcore/proton/matching/docid_range_scheduler.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/docid_range_scheduler.h
@@ -112,7 +112,7 @@ struct DocidRangeScheduler {
     virtual size_t unassigned_size() const = 0;
     virtual IdleObserver make_idle_observer() const = 0;
     virtual DocidRange share_range(size_t thread_id, DocidRange todo) = 0;
-    virtual ~DocidRangeScheduler() {}
+    virtual ~DocidRangeScheduler() = default;
 };
 
 /**

--- a/searchcore/src/vespa/searchcore/proton/matching/i_match_loop_communicator.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/i_match_loop_communicator.h
@@ -32,7 +32,7 @@ struct IMatchLoopCommunicator {
     virtual double estimate_match_frequency(const Matches &matches) = 0;
     virtual TaggedHits get_second_phase_work(SortedHitSequence sortedHits, size_t thread_id) = 0;
     virtual std::pair<Hits,RangePair> complete_second_phase(TaggedHits my_results, size_t thread_id) = 0;
-    virtual ~IMatchLoopCommunicator() {}
+    virtual ~IMatchLoopCommunicator() = default;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/i_resource_write_filter.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/i_resource_write_filter.h
@@ -29,7 +29,7 @@ struct IResourceWriteFilter
         const std::string &message() const { return _message; }
     };
 
-    virtual ~IResourceWriteFilter() {}
+    virtual ~IResourceWriteFilter() = default;
 
     virtual bool acceptWriteOperation() const = 0;
     virtual State getAcceptState() const = 0;

--- a/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_handler.h
@@ -13,7 +13,7 @@ namespace proton {
  */
 struct IReprocessingHandler
 {
-    virtual ~IReprocessingHandler() {}
+    virtual ~IReprocessingHandler() = default;
 
     /**
      * Adds the given processing reader to this handler.

--- a/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_initializer.h
@@ -13,7 +13,7 @@ struct IReprocessingInitializer
 {
     using UP = std::unique_ptr<IReprocessingInitializer>;
 
-    virtual ~IReprocessingInitializer() {}
+    virtual ~IReprocessingInitializer() = default;
 
     /**
      * Returns whether this initializer has any reprocessors to add to the handler.

--- a/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_rewriter.h
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_rewriter.h
@@ -14,7 +14,7 @@ struct IReprocessingRewriter
 {
     using SP = std::shared_ptr<IReprocessingRewriter>;
 
-    virtual ~IReprocessingRewriter() {}
+    virtual ~IReprocessingRewriter() = default;
 
     /**
      * Handle and rewrite the given existing document.

--- a/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_task.h
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/i_reprocessing_task.h
@@ -34,7 +34,7 @@ public:
         {}
     };
 
-    virtual ~IReprocessingTask() {}
+    virtual ~IReprocessingTask() = default;
 
     /**
      * Run reprocessing task.

--- a/searchcore/src/vespa/searchcore/proton/server/feedconfigstore.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedconfigstore.h
@@ -7,8 +7,7 @@
 namespace proton {
 
 struct FeedConfigStore : NewConfigOperation::IStreamHandler {
-    virtual ~FeedConfigStore() {}
-
+    ~FeedConfigStore() override = default;
 };
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/i_disk_mem_usage_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_disk_mem_usage_listener.h
@@ -13,7 +13,7 @@ namespace proton {
 class IDiskMemUsageListener
 {
 public:
-    virtual ~IDiskMemUsageListener() {}
+    virtual ~IDiskMemUsageListener() = default;
     virtual void notifyDiskMemUsage(DiskMemUsageState state) = 0;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/i_document_subdb_owner.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_document_subdb_owner.h
@@ -17,7 +17,7 @@ class IDocumentSubDBOwner
 {
 public:
     using SessionManager = matching::SessionManager;
-    virtual ~IDocumentSubDBOwner() {}
+    virtual ~IDocumentSubDBOwner() = default;
     virtual document::BucketSpace getBucketSpace() const = 0;
     virtual std::string getName() const = 0;
     virtual uint32_t getDistributionKey() const = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/i_feed_handler_owner.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_feed_handler_owner.h
@@ -11,7 +11,7 @@ namespace proton {
  * feed handler.
  */
 struct IFeedHandlerOwner {
-    virtual ~IFeedHandlerOwner() {}
+    virtual ~IFeedHandlerOwner() = default;
     virtual void onTransactionLogReplayDone() = 0;
     virtual void enterRedoReprocessState() = 0;
     virtual void onPerformPrune(search::SerialNum flushedSerial) = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/ibucketfreezelistener.h
+++ b/searchcore/src/vespa/searchcore/proton/server/ibucketfreezelistener.h
@@ -13,7 +13,7 @@ namespace proton {
 class IBucketFreezeListener
 {
 public:
-    virtual ~IBucketFreezeListener() {}
+    virtual ~IBucketFreezeListener() = default;
 
     /**
      * Signal that the given bucket has been thawed.

--- a/searchcore/src/vespa/searchcore/proton/server/ibucketfreezer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/ibucketfreezer.h
@@ -9,7 +9,7 @@ namespace proton {
 class IBucketFreezer
 {
 public:
-    virtual ~IBucketFreezer() {}
+    virtual ~IBucketFreezer() = default;
     virtual void freezeBucket(document::BucketId bucket) = 0;
     virtual void thawBucket(document::BucketId bucket) = 0;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/ireplaypackethandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/ireplaypackethandler.h
@@ -29,7 +29,7 @@ namespace feedoperation { struct IStreamHandler; }
  */
 struct IReplayPacketHandler
 {
-    virtual ~IReplayPacketHandler() {}
+    virtual ~IReplayPacketHandler() = default;
     virtual void replay(const PutOperation &op) = 0;
     virtual void replay(const RemoveOperation &op) = 0;
     virtual void replay(const UpdateOperation &op) = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/isummaryadapter.h
+++ b/searchcore/src/vespa/searchcore/proton/server/isummaryadapter.h
@@ -26,7 +26,7 @@ public:
     using DocumentIdT = search::DocumentIdT;
     using DocumentTypeRepo = document::DocumentTypeRepo;
 
-    virtual ~ISummaryAdapter() {}
+    virtual ~ISummaryAdapter() = default;
 
     // feed interface
     virtual void put(SerialNum serialNum, const DocumentIdT lid, const Document &doc) = 0;

--- a/searchcore/src/vespa/searchcorespi/index/i_thread_service.h
+++ b/searchcore/src/vespa/searchcorespi/index/i_thread_service.h
@@ -14,7 +14,7 @@ struct IThreadService : public vespalib::ThreadExecutor
     IThreadService(const IThreadService &) = delete;
     IThreadService & operator = (const IThreadService &) = delete;
     IThreadService() = default;
-    virtual ~IThreadService() {}
+    virtual ~IThreadService() = default;
 
     /**
      * Run the given runnable in the underlying thread and wait until its done.

--- a/searchcore/src/vespa/searchcorespi/index/idiskindex.h
+++ b/searchcore/src/vespa/searchcorespi/index/idiskindex.h
@@ -12,7 +12,7 @@ namespace searchcorespi::index {
  */
 struct IDiskIndex : public IndexSearchable {
     using SP = std::shared_ptr<IDiskIndex>;
-    virtual ~IDiskIndex() {}
+    ~IDiskIndex() override = default;
 
     /**
      * Returns the directory in which this disk index exists.

--- a/searchcore/src/vespa/searchcorespi/index/iindexcollection.h
+++ b/searchcore/src/vespa/searchcorespi/index/iindexcollection.h
@@ -18,7 +18,7 @@ public:
     using UP = std::unique_ptr<IIndexCollection>;
     using SP = std::shared_ptr<IIndexCollection>;
 
-    virtual ~IIndexCollection() {}
+    virtual ~IIndexCollection() = default;
 
     /**
      * Returns the source selector used to determine which index to use for each document.

--- a/searchcore/src/vespa/searchcorespi/index/imemoryindex.h
+++ b/searchcore/src/vespa/searchcorespi/index/imemoryindex.h
@@ -19,7 +19,7 @@ struct IMemoryIndex : public searchcorespi::IndexSearchable {
     using LidVector = std::vector<uint32_t>;
     using SP = std::shared_ptr<IMemoryIndex>;
     using OnWriteDoneType = std::shared_ptr<vespalib::IDestructorCallback>;
-    virtual ~IMemoryIndex() {}
+    ~IMemoryIndex() override = default;
 
     /**
      * Returns true if this memory index has received any document insert operations.

--- a/searchlib/src/vespa/searchlib/engine/docsumapi.h
+++ b/searchlib/src/vespa/searchlib/engine/docsumapi.h
@@ -25,7 +25,7 @@ public:
     /**
      * Empty, needed for subclassing
      **/
-    virtual ~DocsumClient() {}
+    virtual ~DocsumClient() = default;
 };
 
 /**
@@ -65,7 +65,7 @@ public:
     /**
      * Empty, needed for subclassing
      **/
-    virtual ~DocsumServer() {}
+    virtual ~DocsumServer() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/engine/monitorapi.h
+++ b/searchlib/src/vespa/searchlib/engine/monitorapi.h
@@ -25,7 +25,7 @@ public:
     /**
      * Empty, needed for subclassing
      **/
-    virtual ~MonitorClient() {}
+    virtual ~MonitorClient() = default;
 };
 
 /**
@@ -57,7 +57,7 @@ public:
     /**
      * Empty, needed for subclassing
      **/
-    virtual ~MonitorServer() {}
+    virtual ~MonitorServer() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/engine/searchapi.h
+++ b/searchlib/src/vespa/searchlib/engine/searchapi.h
@@ -25,7 +25,7 @@ public:
     /**
      * Empty, needed for subclassing
      **/
-    virtual ~SearchClient() {}
+    virtual ~SearchClient() = default;
 };
 
 /**
@@ -57,7 +57,7 @@ public:
     /**
      * Empty, needed for subclassing
      **/
-    virtual ~SearchServer() {}
+    virtual ~SearchServer() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/features/foreachfeature.h
+++ b/searchlib/src/vespa/searchlib/features/foreachfeature.h
@@ -135,7 +135,7 @@ private:
     };
     struct ExecutorCreatorBase {
         virtual fef::FeatureExecutor &create(uint32_t numInputs, vespalib::Stash &stash) const = 0;
-        virtual ~ExecutorCreatorBase() {}
+        virtual ~ExecutorCreatorBase() = default;
     };
 
     Dimension _dimension;

--- a/searchlib/src/vespa/searchlib/fef/featureexecutor.h
+++ b/searchlib/src/vespa/searchlib/fef/featureexecutor.h
@@ -164,7 +164,7 @@ public:
     /**
      * Virtual destructor to allow subclassing.
      **/
-    virtual ~FeatureExecutor() {}
+    virtual ~FeatureExecutor() = default;
 };
 
 double LazyValue::as_number(uint32_t docid) const {

--- a/searchlib/src/vespa/searchlib/fef/iblueprintregistry.h
+++ b/searchlib/src/vespa/searchlib/fef/iblueprintregistry.h
@@ -23,7 +23,7 @@ public:
     /**
      * Virtual destructor to allow safe subclassing.
      **/
-    virtual ~IBlueprintRegistry() {}
+    virtual ~IBlueprintRegistry() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/fef/iindexenvironment.h
+++ b/searchlib/src/vespa/searchlib/fef/iindexenvironment.h
@@ -117,7 +117,7 @@ public:
     /**
      * Virtual destructor to allow safe subclassing.
      **/
-    virtual ~IIndexEnvironment() {}
+    virtual ~IIndexEnvironment() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/fef/test/labels.h
+++ b/searchlib/src/vespa/searchlib/fef/test/labels.h
@@ -9,7 +9,7 @@ namespace search::fef::test {
 
 struct Labels {
     virtual void inject(Properties &p) const = 0;
-    virtual ~Labels() {}
+    virtual ~Labels() = default;
 };
 struct NoLabel : public Labels {
     virtual void inject(Properties &) const override {}

--- a/searchlib/src/vespa/searchlib/index/i_field_length_inspector.h
+++ b/searchlib/src/vespa/searchlib/index/i_field_length_inspector.h
@@ -12,7 +12,7 @@ namespace search::index {
  */
 class IFieldLengthInspector {
 public:
-    virtual ~IFieldLengthInspector() {}
+    virtual ~IFieldLengthInspector() = default;
 
     /**
      * Returns the field length info for the given index field, or empty info if the field is not found.

--- a/searchlib/src/vespa/searchlib/memoryindex/i_field_index_insert_listener.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/i_field_index_insert_listener.h
@@ -9,7 +9,7 @@ namespace search::memoryindex {
  */
 class IFieldIndexInsertListener {
 public:
-    virtual ~IFieldIndexInsertListener() {}
+    virtual ~IFieldIndexInsertListener() = default;
 
     /**
      * Called when a {wordRef, docId} tuple is inserted into the field index.

--- a/searchlib/src/vespa/searchlib/memoryindex/i_field_index_remove_listener.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/i_field_index_remove_listener.h
@@ -12,7 +12,7 @@ namespace search::memoryindex {
  */
 class IFieldIndexRemoveListener {
 public:
-    virtual ~IFieldIndexRemoveListener() {}
+    virtual ~IFieldIndexRemoveListener() = default;
 
     /**
      * Called when a {word, docId} tuple is removed from the field index.

--- a/searchlib/src/vespa/searchlib/memoryindex/i_ordered_field_index_inserter.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/i_ordered_field_index_inserter.h
@@ -18,7 +18,7 @@ namespace search::memoryindex {
  */
 class IOrderedFieldIndexInserter {
 public:
-    virtual ~IOrderedFieldIndexInserter() {}
+    virtual ~IOrderedFieldIndexInserter() = default;
 
     /**
      * Set next word to operate on.

--- a/searchlib/src/vespa/searchlib/predicate/common.h
+++ b/searchlib/src/vespa/searchlib/predicate/common.h
@@ -19,7 +19,7 @@ struct Constants {
 struct DocIdLimitProvider {
     virtual uint32_t getDocIdLimit() const = 0;
     virtual uint32_t getCommittedDocIdLimit() const = 0;
-    virtual ~DocIdLimitProvider() {}
+    virtual ~DocIdLimitProvider() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.h
@@ -16,19 +16,19 @@ class ISaver;
 
 template <typename Key = uint64_t, typename DocId = uint32_t>
 struct SimpleIndexDeserializeObserver {
-    virtual ~SimpleIndexDeserializeObserver() {}
+    virtual ~SimpleIndexDeserializeObserver() = default;
     virtual void notifyInsert(Key key, DocId docId, uint32_t k) = 0;
 };
 
 template <typename Posting>
 struct PostingSaver {
-    virtual ~PostingSaver() {}
+    virtual ~PostingSaver() = default;
     virtual void save(const Posting &posting, BufferWriter& writer) const = 0;
 };
 
 template <typename Posting>
 struct PostingDeserializer {
-    virtual ~PostingDeserializer() {}
+    virtual ~PostingDeserializer() = default;
     virtual Posting deserialize(vespalib::DataBuffer &buffer) = 0;
 };
 

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -165,7 +165,7 @@ public:
           _explore_additional_hits(explore_additional_hits),
           _distance_threshold(distance_threshold)
     {}
-    virtual ~NearestNeighborTerm() {}
+    ~NearestNeighborTerm() override = default;
     const std::string& get_query_tensor_name() const { return _query_tensor_name; }
     uint32_t get_target_num_hits() const { return _target_num_hits; }
     bool get_allow_approximate() const { return _allow_approximate; }

--- a/searchlib/src/vespa/searchlib/queryeval/idiversifier.h
+++ b/searchlib/src/vespa/searchlib/queryeval/idiversifier.h
@@ -7,7 +7,7 @@
 namespace search::queryeval {
 
 struct IDiversifier {
-    virtual ~IDiversifier() {}
+    virtual ~IDiversifier() = default;
     /**
      * Will tell if this document should be kept, and update state for further filtering.
      */

--- a/searchlib/src/vespa/searchlib/queryeval/isourceselector.h
+++ b/searchlib/src/vespa/searchlib/queryeval/isourceselector.h
@@ -91,7 +91,7 @@ public:
     /**
      * empty; defined for safe subclassing.
      **/
-    virtual ~ISourceSelector() {}
+    virtual ~ISourceSelector() = default;
 private:
     uint32_t _baseId;
     Source   _defaultSource;

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_factory.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_factory.h
@@ -17,7 +17,7 @@ class NearestNeighborIndex;
  */
 class NearestNeighborIndexFactory {
 public:
-    virtual ~NearestNeighborIndexFactory() {}
+    virtual ~NearestNeighborIndexFactory() = default;
     virtual std::unique_ptr<NearestNeighborIndex> make(const DocVectorAccess& vectors,
                                                        size_t vector_size,
                                                        bool multi_vector_index,

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_loader.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_loader.h
@@ -9,7 +9,7 @@ namespace search::tensor {
  */
 class NearestNeighborIndexLoader {
 public:
-    virtual ~NearestNeighborIndexLoader() {}
+    virtual ~NearestNeighborIndexLoader() = default;
 
     /**
      * Loads the next part of the index (e.g. the node corresponding to a given document)

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_saver.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_saver.h
@@ -20,7 +20,7 @@ namespace search::tensor {
  */
 class NearestNeighborIndexSaver {
 public:
-    virtual ~NearestNeighborIndexSaver() {}
+    virtual ~NearestNeighborIndexSaver() = default;
 
     /**
      * Saves the index in binary form using the given writer.

--- a/searchlib/src/vespa/searchlib/tensor/prepare_result.h
+++ b/searchlib/src/vespa/searchlib/tensor/prepare_result.h
@@ -9,7 +9,7 @@ namespace search::tensor {
  */
 class PrepareResult {
 public:
-    virtual ~PrepareResult() {}
+    virtual ~PrepareResult() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/tensor/random_level_generator.h
+++ b/searchlib/src/vespa/searchlib/tensor/random_level_generator.h
@@ -12,7 +12,7 @@ namespace search::tensor {
 class RandomLevelGenerator {
 public:
     using UP = std::unique_ptr<RandomLevelGenerator>;
-    virtual ~RandomLevelGenerator() {}
+    virtual ~RandomLevelGenerator() = default;
     virtual uint32_t max_level() = 0;
 };
 

--- a/searchsummary/src/tests/juniper/suite.h
+++ b/searchsummary/src/tests/juniper/suite.h
@@ -83,7 +83,7 @@ public:
     void Run();                  // Calls Test::run() repeatedly
     long Report() const;
     void Free(); // deletes tests
-    virtual ~Suite(void) {}
+    virtual ~Suite() = default;
 
 private:
     std::string        m_name;

--- a/searchsummary/src/tests/juniper/test.h
+++ b/searchsummary/src/tests/juniper/test.h
@@ -77,7 +77,7 @@ class Test {
 public:
     explicit Test(std::ostream* osptr = 0, const char* name = NULL);
     explicit Test(const char* name);
-    virtual ~Test() {}
+    virtual ~Test() = default;
     virtual void Run() = 0;
 
     const char*               get_name() const;

--- a/searchsummary/src/vespa/juniper/ITokenProcessor.h
+++ b/searchsummary/src/vespa/juniper/ITokenProcessor.h
@@ -43,7 +43,7 @@ public:
         }
     };
 
-    virtual ~ITokenProcessor() {}
+    virtual ~ITokenProcessor() = default;
 
     /** handle the next token
      *  @param token The token to process.

--- a/searchsummary/src/vespa/juniper/dpinterface.h
+++ b/searchsummary/src/vespa/juniper/dpinterface.h
@@ -40,7 +40,7 @@ class Docsum;
  */
 class DocsumProcessor {
 public:
-    virtual ~DocsumProcessor() {}
+    virtual ~DocsumProcessor() = default;
 
     /** Process a docsum with this processor. Processing can in the cases where
      *  token based processing is necessary just be implemented as setting

--- a/searchsummary/src/vespa/juniper/matchelem.h
+++ b/searchsummary/src/vespa/juniper/matchelem.h
@@ -20,7 +20,7 @@ using keylist = std::set<key_occ*, sequential_elem<key_occ*>>;
 class MatchElement {
 public:
     MatchElement(off_t startpos, off_t starttoken);
-    virtual ~MatchElement() {}
+    virtual ~MatchElement() = default;
     virtual void   set_valid() = 0; // Mark this element and its subelements as valid
     virtual void   add_to_keylist(keylist& kl) = 0;
     virtual void   dump(std::string& s) = 0;

--- a/searchsummary/src/vespa/juniper/rpinterface.h
+++ b/searchsummary/src/vespa/juniper/rpinterface.h
@@ -58,7 +58,7 @@ class Result;
 
 class Summary {
 public:
-    virtual ~Summary() {}
+    virtual ~Summary() = default;
     // The textual representation of the generated summary
     virtual const char* Text() const = 0;
     virtual size_t      Length() const = 0;

--- a/searchsummary/src/vespa/juniper/simplemap.h
+++ b/searchsummary/src/vespa/juniper/simplemap.h
@@ -10,7 +10,7 @@ public:
 
     explicit simplemap(simplemap& m) { _map = m.map(); }
 
-    virtual ~simplemap() {}
+    virtual ~simplemap() = default;
 
     _val insert(_key key, _val val) {
         typename std::pair<typename std::map<_key, _val>::iterator, bool> p =

--- a/slobrok/src/vespa/slobrok/server/exchange_manager.h
+++ b/slobrok/src/vespa/slobrok/server/exchange_manager.h
@@ -36,7 +36,7 @@ private:
     {
     public:
         virtual void donePackage(WorkPackage *pkg, bool somedenied) = 0;
-        virtual ~IWorkPkgWait() {}
+        virtual ~IWorkPkgWait() = default;
     };
 
     class WorkPackage

--- a/slobrok/src/vespa/slobrok/server/i_monitored_server.h
+++ b/slobrok/src/vespa/slobrok/server/i_monitored_server.h
@@ -15,7 +15,7 @@ class IMonitoredServer
 {
 public:
     virtual void notifyDisconnected() = 0; // lost connection to service
-    virtual ~IMonitoredServer() {}
+    virtual ~IMonitoredServer() = default;
 };
 
 //-----------------------------------------------------------------------------

--- a/slobrok/src/vespa/slobrok/server/i_rpc_server_manager.h
+++ b/slobrok/src/vespa/slobrok/server/i_rpc_server_manager.h
@@ -24,7 +24,7 @@ public:
     virtual void notifyFailedRpcSrv(ManagedRpcServer *rpcsrv, std::string errmsg) = 0;
     virtual void notifyOkRpcSrv(ManagedRpcServer *rpcsrv) = 0;
     virtual FRT_Supervisor *getSupervisor() = 0;
-    virtual ~IRpcServerManager() {}
+    virtual ~IRpcServerManager() = default;
 };
 
 //-----------------------------------------------------------------------------

--- a/slobrok/src/vespa/slobrok/server/request_completion_handler.h
+++ b/slobrok/src/vespa/slobrok/server/request_completion_handler.h
@@ -13,7 +13,7 @@ namespace slobrok {
  **/
 struct CompletionHandler {
     virtual void doneHandler(OkState result) = 0;
-    virtual ~CompletionHandler() {}
+    virtual ~CompletionHandler() = default;
 };
 
 class RequestCompletionHandler : public CompletionHandler {

--- a/slobrok/src/vespa/slobrok/server/service_map_history.h
+++ b/slobrok/src/vespa/slobrok/server/service_map_history.h
@@ -32,7 +32,7 @@ public:
          **/
         virtual void handle(MapDiff updateDiff) = 0;
     protected:
-        virtual ~DiffCompletionHandler() {}
+        virtual ~DiffCompletionHandler() = default;
     };
 
 private:

--- a/storage/src/tests/persistence/common/filestortestfixture.h
+++ b/storage/src/tests/persistence/common/filestortestfixture.h
@@ -39,7 +39,7 @@ public:
 
     struct StorageLinkInjector
     {
-        virtual ~StorageLinkInjector() {}
+        virtual ~StorageLinkInjector() = default;
 
         virtual void inject(DummyStorageLink&) const = 0;
     };

--- a/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.h
+++ b/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.h
@@ -60,7 +60,7 @@ public:
     // Mapping from content node index to statistics for all bucket spaces on that node.
     using PerNodeBucketSpacesStats = std::unordered_map<uint16_t, BucketSpacesStats>;
 
-    virtual ~BucketSpacesStatsProvider() {}
+    virtual ~BucketSpacesStatsProvider() = default;
     virtual PerNodeBucketSpacesStats getBucketSpacesStats() const = 0;
 };
 

--- a/storage/src/vespa/storage/persistence/messages.h
+++ b/storage/src/vespa/storage/persistence/messages.h
@@ -199,7 +199,7 @@ public:
     class AbortPredicate {
         virtual bool doShouldAbort(const document::Bucket&) const = 0;
     public:
-        virtual ~AbortPredicate() {}
+        virtual ~AbortPredicate() = default;
         bool shouldAbort(const document::Bucket &bucket) const {
             return doShouldAbort(bucket);
         }

--- a/storage/src/vespa/storage/storageserver/applicationgenerationfetcher.h
+++ b/storage/src/vespa/storage/storageserver/applicationgenerationfetcher.h
@@ -16,7 +16,7 @@ namespace storage {
 
 class ApplicationGenerationFetcher {
 public:
-    virtual ~ApplicationGenerationFetcher() {}
+    virtual ~ApplicationGenerationFetcher() = default;
 
     virtual int64_t getGeneration() const = 0;
     virtual std::string getComponentName() const = 0;

--- a/storage/src/vespa/storage/storageutil/resumeguard.h
+++ b/storage/src/vespa/storage/storageutil/resumeguard.h
@@ -7,7 +7,7 @@ class ResumeGuard {
 public:
     class Callback {
     public:
-        virtual ~Callback() {};
+        virtual ~Callback() = default;
 
         virtual void resume() = 0;
     };

--- a/storage/src/vespa/storage/visiting/visitormessagesession.h
+++ b/storage/src/vespa/storage/visiting/visitormessagesession.h
@@ -15,7 +15,7 @@ namespace storage {
 struct VisitorMessageSession {
     using UP = std::unique_ptr<VisitorMessageSession>;
 
-    virtual ~VisitorMessageSession() {}
+    virtual ~VisitorMessageSession() = default;
 
     virtual mbus::Result send(std::unique_ptr<documentapi::DocumentMessage>) = 0;
 

--- a/storage/src/vespa/storageframework/generic/component/componentregister.h
+++ b/storage/src/vespa/storageframework/generic/component/componentregister.h
@@ -18,7 +18,7 @@ namespace storage::framework {
 struct ManagedComponent;
 
 struct ComponentRegister {
-    virtual ~ComponentRegister() {}
+    virtual ~ComponentRegister() = default;
 
     virtual void registerComponent(ManagedComponent&) = 0;
     virtual void requestShutdown(std::string_view reason) = 0;

--- a/vbench/src/vbench/core/closeable.h
+++ b/vbench/src/vbench/core/closeable.h
@@ -10,7 +10,7 @@ namespace vbench {
 struct Closeable
 {
     virtual void close() = 0;
-    virtual ~Closeable() {}
+    virtual ~Closeable() = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/core/handler.h
+++ b/vbench/src/vbench/core/handler.h
@@ -13,7 +13,7 @@ template <typename T>
 struct Handler
 {
     virtual void handle(std::unique_ptr<T> obj) = 0;
-    virtual ~Handler() {}
+    virtual ~Handler() = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/core/provider.h
+++ b/vbench/src/vbench/core/provider.h
@@ -13,7 +13,7 @@ template <typename T>
 struct Provider
 {
     virtual std::unique_ptr<T> provide() = 0;
-    virtual ~Provider() {}
+    virtual ~Provider() = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/core/taintable.h
+++ b/vbench/src/vbench/core/taintable.h
@@ -14,7 +14,7 @@ struct Taintable
 {
     static const Taintable &nil();
     virtual const Taint &tainted() const = 0;
-    virtual ~Taintable() {}
+    virtual ~Taintable() = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/http/http_result_handler.h
+++ b/vbench/src/vbench/http/http_result_handler.h
@@ -18,7 +18,7 @@ struct HttpResultHandler
     virtual void handleHeader(const string &name, const string &value) = 0;
     virtual void handleContent(const Memory &data) = 0;
     virtual void handleFailure(const string &reason) = 0;
-    virtual ~HttpResultHandler() {}
+    virtual ~HttpResultHandler() = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/vbench/analyzer.h
+++ b/vbench/src/vbench/vbench/analyzer.h
@@ -11,7 +11,7 @@ struct Analyzer : public Handler<Request>
 {
     using UP = std::unique_ptr<Analyzer>;
     virtual void report() = 0;
-    virtual ~Analyzer() {}
+    ~Analyzer() override = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/vbench/generator.h
+++ b/vbench/src/vbench/vbench/generator.h
@@ -13,7 +13,7 @@ struct Generator : public vespalib::Runnable,
 {
     using UP = std::unique_ptr<Generator>;
     virtual void abort() = 0;
-    virtual ~Generator() {}
+    ~Generator() override = default;
 };
 
 } // namespace vbench

--- a/vbench/src/vbench/vbench/tagger.h
+++ b/vbench/src/vbench/vbench/tagger.h
@@ -10,7 +10,7 @@ namespace vbench {
 struct Tagger : public Handler<Request>
 {
     using UP = std::unique_ptr<Tagger>;
-    virtual ~Tagger() {}
+    ~Tagger() override = default;
 };
 
 } // namespace vbench

--- a/vespalib/src/vespa/vespalib/data/slime/array_traverser.h
+++ b/vespalib/src/vespa/vespalib/data/slime/array_traverser.h
@@ -11,7 +11,7 @@ namespace vespalib::slime {
  **/
 struct ArrayTraverser {
     virtual void entry(size_t idx, const Inspector &inspector) = 0;
-    virtual ~ArrayTraverser() {}
+    virtual ~ArrayTraverser() = default;
 };
 
 } // namespace vespalib::slime

--- a/vespalib/src/vespa/vespalib/data/slime/inspector.h
+++ b/vespalib/src/vespa/vespalib/data/slime/inspector.h
@@ -37,7 +37,7 @@ struct Inspector {
     virtual Inspector &operator[](Symbol sym) const = 0;
     virtual Inspector &operator[](Memory name) const = 0;
 
-    virtual ~Inspector() {}
+    virtual ~Inspector() = default;
 };
 
 bool operator==(const Inspector &a, const Inspector &b);

--- a/vespalib/src/vespa/vespalib/data/slime/object_traverser.h
+++ b/vespalib/src/vespa/vespalib/data/slime/object_traverser.h
@@ -14,7 +14,7 @@ class Symbol;
  **/
 struct ObjectSymbolTraverser {
     virtual void field(const Symbol &symbol, const Inspector &inspector) = 0;
-    virtual ~ObjectSymbolTraverser() {}
+    virtual ~ObjectSymbolTraverser() = default;
 };
 
 /**
@@ -23,7 +23,7 @@ struct ObjectSymbolTraverser {
  **/
 struct ObjectTraverser {
     virtual void field(const Memory &symbol, const Inspector &inspector) = 0;
-    virtual ~ObjectTraverser() {}
+    virtual ~ObjectTraverser() = default;
 };
 
 } // namespace vespalib::slime

--- a/vespalib/src/vespa/vespalib/data/slime/symbol_inserter.h
+++ b/vespalib/src/vespa/vespalib/data/slime/symbol_inserter.h
@@ -12,7 +12,7 @@ namespace vespalib::slime {
  **/
 struct SymbolInserter {
     virtual Symbol insert() = 0;
-    virtual ~SymbolInserter() {}
+    virtual ~SymbolInserter() = default;
 };
 
 } // namespace vespalib::slime

--- a/vespalib/src/vespa/vespalib/datastore/i_compaction_context.h
+++ b/vespalib/src/vespa/vespalib/datastore/i_compaction_context.h
@@ -16,7 +16,7 @@ namespace vespalib::datastore {
  */
 struct ICompactionContext {
     using UP = std::unique_ptr<ICompactionContext>;
-    virtual ~ICompactionContext() {}
+    virtual ~ICompactionContext() = default;
     virtual void compact(std::span<AtomicEntryRef> refs) = 0;
 };
 

--- a/vespalib/src/vespa/vespalib/metrics/clock.h
+++ b/vespalib/src/vespa/vespalib/metrics/clock.h
@@ -24,7 +24,7 @@ struct Tick {
     virtual TimeStamp first() = 0;
     virtual void kill() = 0;
     virtual bool alive() const = 0;
-    virtual ~Tick() {}
+    virtual ~Tick() = default;
 };
 
 } // namespace vespalib::metrics

--- a/vespalib/src/vespa/vespalib/metrics/metrics_manager.h
+++ b/vespalib/src/vespa/vespalib/metrics/metrics_manager.h
@@ -23,7 +23,7 @@ class MetricsManager
     : public std::enable_shared_from_this<MetricsManager>
 {
 public:
-    virtual ~MetricsManager() {}
+    virtual ~MetricsManager() = default;
 
     /**
      * Get or create a counter metric.

--- a/vespalib/src/vespa/vespalib/net/async_resolver.h
+++ b/vespalib/src/vespa/vespalib/net/async_resolver.h
@@ -32,20 +32,20 @@ public:
 
     struct ResultHandler {
         virtual void handle_result(SocketAddress addr) = 0;
-        virtual ~ResultHandler() {}
+        virtual ~ResultHandler() = default;
         using SP = std::shared_ptr<ResultHandler>;
         using WP = std::weak_ptr<ResultHandler>;
     };
 
     struct Clock {
         virtual time_point now() = 0;
-        virtual ~Clock() {}
+        virtual ~Clock() = default;
         using SP = std::shared_ptr<Clock>;
     };
 
     struct HostResolver {
         virtual std::string ip_address(const std::string &host_name) = 0;
-        virtual ~HostResolver() {}
+        virtual ~HostResolver() = default;
         using SP = std::shared_ptr<HostResolver>;
     };
 

--- a/vespalib/src/vespa/vespalib/net/http/component_config_producer.h
+++ b/vespalib/src/vespa/vespalib/net/http/component_config_producer.h
@@ -18,10 +18,10 @@ struct ComponentConfigProducer {
     };
     struct Consumer {
         virtual void add(const Config &config) = 0;
-        virtual ~Consumer() {}
+        virtual ~Consumer() = default;
     };
     virtual void getComponentConfig(Consumer &consumer) = 0;
-    virtual ~ComponentConfigProducer() {}
+    virtual ~ComponentConfigProducer() = default;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/health_producer.h
+++ b/vespalib/src/vespa/vespalib/net/http/health_producer.h
@@ -13,7 +13,7 @@ struct HealthProducer {
         Health(bool o, const std::string &m) : ok(o), msg(m) {}
     };
     virtual Health getHealth() const = 0;
-    virtual ~HealthProducer() {}
+    virtual ~HealthProducer() = default;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/socket.h
+++ b/vespalib/src/vespa/vespalib/net/socket.h
@@ -16,7 +16,7 @@ struct Socket {
     using UP = std::unique_ptr<Socket>;
     virtual ssize_t read(char *buf, size_t len) = 0;
     virtual ssize_t write(const char *buf, size_t len) = 0;
-    virtual ~Socket() {}
+    virtual ~Socket() = default;
 };
 
 struct SimpleSocket : public Socket {

--- a/vespalib/src/vespa/vespalib/util/benchmark_timer.h
+++ b/vespalib/src/vespa/vespalib/util/benchmark_timer.h
@@ -62,7 +62,7 @@ private:
 
     struct Loop {
         virtual void perform(size_t cnt) const = 0;
-        virtual ~Loop() {}
+        virtual ~Loop() = default;
     };
 
     struct Caller : Loop {

--- a/vespalib/src/vespa/vespalib/util/cpu_usage.h
+++ b/vespalib/src/vespa/vespalib/util/cpu_usage.h
@@ -29,7 +29,7 @@ duration total_cpu_usage() noexcept;
 struct ThreadSampler {
     using UP = std::unique_ptr<ThreadSampler>;
     virtual duration sample() const noexcept = 0;
-    virtual ~ThreadSampler() {}
+    virtual ~ThreadSampler() = default;
 };
 
 ThreadSampler::UP create_thread_sampler(bool force_mock_impl = false, double expected_util = 0.16);
@@ -135,7 +135,7 @@ private:
     struct ThreadTracker {
         using SP = std::shared_ptr<ThreadTracker>;
         virtual Sample sample() noexcept = 0;
-        virtual ~ThreadTracker() {}
+        virtual ~ThreadTracker() = default;
     };
 
     class ThreadTrackerImpl : public ThreadTracker {

--- a/vespalib/src/vespa/vespalib/util/dual_merge_director.h
+++ b/vespalib/src/vespa/vespalib/util/dual_merge_director.h
@@ -23,7 +23,7 @@ class DualMergeDirector
 public:
     struct Source {
         virtual void merge(Source &rhs) = 0;
-        virtual ~Source() {}
+        virtual ~Source() = default;
     };
 
 private:

--- a/vespalib/src/vespa/vespalib/util/polymorphicarraybase.h
+++ b/vespalib/src/vespa/vespalib/util/polymorphicarraybase.h
@@ -6,7 +6,7 @@ namespace vespalib {
 
 class IArrayBase {
 public:
-    virtual ~IArrayBase() {}
+    virtual ~IArrayBase() = default;
     virtual void resize(size_t sz) = 0;
     virtual void reserve(size_t sz) = 0;
     virtual void clear() = 0;

--- a/vespalib/src/vespa/vespalib/util/printable.h
+++ b/vespalib/src/vespa/vespalib/util/printable.h
@@ -40,7 +40,7 @@ class asciistream;
 
 class Printable {
 public:
-    virtual ~Printable() {}
+    virtual ~Printable() = default;
 
     /**
      * Print instance textual to the given stream.
@@ -92,7 +92,7 @@ public:
 
 class AsciiPrintable : public Printable {
 public:
-    virtual ~AsciiPrintable() {}
+    ~AsciiPrintable() override = default;
 
     enum PrintMode {
         NORMAL,

--- a/vespalib/src/vespa/vespalib/util/programoptions.h
+++ b/vespalib/src/vespa/vespalib/util/programoptions.h
@@ -47,7 +47,7 @@ struct ProgramOptions {
      * units.
      */
     struct Configurable {
-        virtual ~Configurable() {}
+        virtual ~Configurable() = default;
         /**
          * Called on configurables to have it register its options.
          * Unit must hang onto lifetimetoken until command line parsing have

--- a/vespalib/src/vespa/vespalib/util/runnable.h
+++ b/vespalib/src/vespa/vespalib/util/runnable.h
@@ -33,7 +33,7 @@ struct Runnable {
     /**
      * Empty virtual destructor to enable subclassing.
      **/
-    virtual ~Runnable() {}
+    virtual ~Runnable() = default;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/sequence.h
+++ b/vespalib/src/vespa/vespalib/util/sequence.h
@@ -17,7 +17,7 @@ struct Sequence
     virtual bool valid() const = 0;
     virtual T get() const = 0;
     virtual void next() = 0;
-    virtual ~Sequence() {}
+    virtual ~Sequence() = default;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/syncable.h
+++ b/vespalib/src/vespa/vespalib/util/syncable.h
@@ -19,7 +19,7 @@ public:
      **/
     virtual Syncable &sync() = 0;
 
-    virtual ~Syncable() {}
+    virtual ~Syncable() = default;
 };
 
 } // namespace vespalib

--- a/vespamalloc/src/vespamalloc/malloc/common.h
+++ b/vespamalloc/src/vespamalloc/malloc/common.h
@@ -112,7 +112,7 @@ private:
 
 class IAllocator {
 public:
-    virtual ~IAllocator() {}
+    virtual ~IAllocator() = default;
     virtual bool initThisThread() = 0;
     virtual bool quitThisThread() = 0;
     virtual void enableThreadSupport() = 0;


### PR DESCRIPTION
@toregge please review. This should not change any semantics.

Also cleans up places where a destructor in a derived class was tagged as `virtual` where `override` was the intended semantics.