### PR TITLE
Avoid non-public endpoint in Azure test environments

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -241,7 +241,9 @@ public final class DeploymentSpec {
         if (   zone.environment().isTest()
             && instances().stream()
                           .anyMatch(spec -> spec.zoneEndpoints().getOrDefault(cluster, Map.of()).values().stream()
-                                                .anyMatch(endpoint -> ! endpoint.isPublicEndpoint())))
+                                                .anyMatch(endpoint -> ! endpoint.isPublicEndpoint()))
+               // Remove once Azure Private Link has been implemented
+            && !zone.region().value().startsWith("azure-"))
             return ZoneEndpoint.privateEndpoint;
 
         if (zone.environment().isManuallyDeployed())

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ZoneEndpoint.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ZoneEndpoint.java
@@ -37,10 +37,7 @@ public class ZoneEndpoint {
     private final List<AllowedUrn> allowedUrns;
 
     public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, List<AllowedUrn> allowedUrns) {
-        this.isPublicEndpoint = isPublicEndpoint;
-        this.isPrivateEndpoint = isPrivateEndpoint;
-        this.authMethods = List.of(AuthMethod.mtls);
-        this.allowedUrns = List.copyOf(allowedUrns);
+        this(isPublicEndpoint, isPrivateEndpoint, List.of(AuthMethod.mtls), allowedUrns);
     }
 
     public ZoneEndpoint(boolean isPublicEndpoint, boolean isPrivateEndpoint, List<AuthMethod> authMethods, List<AllowedUrn> allowedUrns) {
@@ -50,7 +47,7 @@ public class ZoneEndpoint {
         this.allowedUrns = List.copyOf(allowedUrns);
     }
 
-    /** Whether this has an endpoint which is visible from the public internet. */
+    /** Whether this has an endpoint accessible from the public internet, e.g. public IP and DNS records. */
     public boolean isPublicEndpoint() {
         return isPublicEndpoint;
     }


### PR DESCRIPTION
Currently getting "Azure only supports public endpoints" error when controller tries to deploy to test and staging environments.