### PR TITLE
Clean up redundant `virtual` qualifier used with `override`

### DIFF
--- a/config/src/vespa/config/frt/slimeconfigrequest.h
+++ b/config/src/vespa/config/frt/slimeconfigrequest.h
@@ -33,7 +33,7 @@ public:
                        const std::string & methodName);
     ~SlimeConfigRequest();
     bool verifyState(const ConfigState & state) const override;
-    virtual std::unique_ptr<ConfigResponse> createResponse(FRT_RPCRequest * request) const override = 0;
+    std::unique_ptr<ConfigResponse> createResponse(FRT_RPCRequest * request) const override = 0;
 private:
     void populateSlimeRequest(const ConfigKey & key,
                               const std::string & configXxhash64,

--- a/document/src/vespa/document/datatype/documenttype.h
+++ b/document/src/vespa/document/datatype/documenttype.h
@@ -78,7 +78,7 @@ public:
     void inherit(const DocumentType &docType);
 
     bool isA(const DataType& other) const override;
-    virtual bool isDocument() const noexcept override { return true; }
+    bool isDocument() const noexcept override { return true; }
 
     const std::vector<const DocumentType *> & getInheritedTypes() const { return _inheritedTypes; };
 

--- a/document/src/vespa/document/datatype/tensor_data_type.h
+++ b/document/src/vespa/document/datatype/tensor_data_type.h
@@ -18,7 +18,7 @@ public:
     ~TensorDataType();
 
     bool isTensor() const noexcept override { return true; }
-    virtual const TensorDataType* cast_tensor() const noexcept override { return this; }
+    const TensorDataType* cast_tensor() const noexcept override { return this; }
     bool equals(const DataType& other) const noexcept override;
     std::unique_ptr<FieldValue> createFieldValue() const override;
     void print(std::ostream&, bool verbose, const std::string& indent) const override;

--- a/document/src/vespa/document/select/value.h
+++ b/document/src/vespa/document/select/value.h
@@ -111,10 +111,10 @@ public:
 
     virtual CommonValueType getCommonValue() const = 0;
 
-    virtual ResultList operator<(const Value& value) const override = 0;
+    ResultList operator<(const Value& value) const override = 0;
     virtual ResultList operator>(const IntegerValue& value) const = 0;
     virtual ResultList operator>(const FloatValue& value) const = 0;
-    virtual ResultList operator==(const Value& value) const override = 0;
+    ResultList operator==(const Value& value) const override = 0;
     virtual ResultList operator==(const IntegerValue& value) const = 0;
     virtual ResultList operator==(const FloatValue& value) const = 0;
 };

--- a/eval/src/tests/eval/function/function_test.cpp
+++ b/eval/src/tests/eval/function/function_test.cpp
@@ -464,7 +464,7 @@ struct MyTraverser : public NodeTraverser {
     explicit MyTraverser(size_t open_true_cnt_in)
         : open_true_cnt(open_true_cnt_in), history() {}
     ~MyTraverser() override;
-    virtual bool open(const nodes::Node &node) override {
+    bool open(const nodes::Node &node) override {
         history.emplace_back(true, node);
         if (open_true_cnt == 0) {
             return false;
@@ -472,7 +472,7 @@ struct MyTraverser : public NodeTraverser {
         --open_true_cnt;
         return true;
     }
-    virtual void close(const nodes::Node &node) override {
+    void close(const nodes::Node &node) override {
         history.emplace_back(false, node);
     }
     void verify(const nodes::Node &node, size_t &offset, size_t &open_cnt) {

--- a/eval/src/vespa/eval/eval/basic_nodes.h
+++ b/eval/src/vespa/eval/eval/basic_nodes.h
@@ -94,7 +94,7 @@ private:
     double _value;
 public:
     Number(double value_in) : _value(value_in) {}
-    virtual bool is_const_double() const override { return true; }
+    bool is_const_double() const override { return true; }
     double get_const_double_value() const override { return value(); }
     double value() const { return _value; }
     std::string dump(DumpContext &) const override;

--- a/eval/src/vespa/eval/eval/check_type.h
+++ b/eval/src/vespa/eval/eval/check_type.h
@@ -22,7 +22,7 @@ struct CheckTypeVisitor<> : EmptyNodeVisitor {
 
 template <typename HEAD, typename... TAIL>
 struct CheckTypeVisitor<HEAD, TAIL...> : CheckTypeVisitor<TAIL...> {
-    virtual void visit(const HEAD &) override { this->result = true; }
+    void visit(const HEAD &) override { this->result = true; }
 };
 
 template <typename... TYPES>

--- a/messagebus/src/tests/routing/routing.cpp
+++ b/messagebus/src/tests/routing/routing.cpp
@@ -250,7 +250,7 @@ SetReplyPolicyFactory::create(const string &param)
 }
 
 class TestException : public std::exception {
-    virtual const char* what() const noexcept override {
+    const char* what() const noexcept override {
         return "{test exception}";
     }
 };

--- a/searchcore/src/apps/vespa-gen-testdocs/vespa-gen-testdocs.cpp
+++ b/searchcore/src/apps/vespa-gen-testdocs/vespa-gen-testdocs.cpp
@@ -225,8 +225,8 @@ class ConstTextFieldGenerator : public FieldGenerator
     string _value;
 public:
     ConstTextFieldGenerator(std::vector<string> argv) noexcept;
-    virtual ~ConstTextFieldGenerator() override;
-    virtual void generateValue(vespalib::asciistream &doc, uint32_t id) override;
+    ~ConstTextFieldGenerator() override;
+    void generateValue(vespalib::asciistream &doc, uint32_t id) override;
 };
 
 ConstTextFieldGenerator::ConstTextFieldGenerator(std::vector<string> argv) noexcept
@@ -253,8 +253,8 @@ class PrefixTextFieldGenerator : public FieldGenerator
     uint32_t _div;
 public:
     PrefixTextFieldGenerator(std::vector<string> argv) noexcept;
-    virtual ~PrefixTextFieldGenerator() override;
-    virtual void generateValue(vespalib::asciistream &doc, uint32_t id) override;
+    ~PrefixTextFieldGenerator() override;
+    void generateValue(vespalib::asciistream &doc, uint32_t id) override;
 };
 
 PrefixTextFieldGenerator::PrefixTextFieldGenerator(std::vector<string> argv) noexcept
@@ -301,8 +301,8 @@ public:
                            uint32_t minFill,
                            uint32_t maxFill);
     virtual ~RandTextFieldGenerator();
-    virtual void setup() override;
-    virtual void generateValue(vespalib::asciistream &doc, uint32_t id) override;
+    void setup() override;
+    void generateValue(vespalib::asciistream &doc, uint32_t id) override;
 };
 
 
@@ -362,7 +362,7 @@ public:
                           vespalib::Rand48 &rnd,
                           const std::vector<uint32_t> &mods);
     virtual ~ModTextFieldGenerator();
-    virtual void generateValue(vespalib::asciistream &doc, uint32_t id) override;
+    void generateValue(vespalib::asciistream &doc, uint32_t id) override;
 };
 
 
@@ -400,7 +400,7 @@ class IdTextFieldGenerator : public FieldGenerator
 public:
     IdTextFieldGenerator(const string &name);
     virtual ~IdTextFieldGenerator();
-    virtual void generateValue(vespalib::asciistream &doc, uint32_t id) override;
+    void generateValue(vespalib::asciistream &doc, uint32_t id) override;
 };
 
 
@@ -434,8 +434,8 @@ public:
                           uint32_t low,
                           uint32_t count);
     virtual ~RandIntFieldGenerator();
-    virtual void generateValue(vespalib::asciistream &doc, uint32_t id) override;
-    virtual bool isString() const override { return false; }
+    void generateValue(vespalib::asciistream &doc, uint32_t id) override;
+    bool isString() const override { return false; }
 };
 
 
@@ -639,9 +639,9 @@ public:
     {
     }
 
-    virtual void usage(bool showHeader) override;
-    virtual bool getOptions(int argc, char **argv) override;
-    virtual int run() override;
+    void usage(bool showHeader) override;
+    bool getOptions(int argc, char **argv) override;
+    int run() override;
 };
 
 

--- a/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
+++ b/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
@@ -443,13 +443,13 @@ struct DumpOperationsOptions : public BaseOptions
     DumpOperationsOptions(int argc, const char* const* argv);
     ~DumpOperationsOptions();
     static std::string command() { return "dumpoperations"; }
-    virtual std::string toString() const override {
+    std::string toString() const override {
         return vespalib::make_string("%s, domain=%s, first=%" PRIu64 ", last=%" PRIu64 ", configdir=%s",
                                      BaseOptions::toString().c_str(), domainName.c_str(),
                                      firstSerialNum, lastSerialNum,
                                      configDir.c_str());
     }
-    virtual Utility::UP createUtility() const override;
+    Utility::UP createUtility() const override;
 };
 
 DumpOperationsOptions::DumpOperationsOptions(int argc, const char* const* argv)

--- a/searchcore/src/tests/proton/attribute/attribute_aspect_delayer/attribute_aspect_delayer_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_aspect_delayer/attribute_aspect_delayer_test.cpp
@@ -125,7 +125,7 @@ class MyInspector : public IDocumentTypeInspector
 {
     std::set<std::string> _unchanged;
 public:
-    virtual bool hasUnchangedField(const std::string &name) const override {
+    bool hasUnchangedField(const std::string &name) const override {
         return _unchanged.count(name) > 0;
     }
     MyInspector()

--- a/searchcore/src/tests/proton/common/feedoperation_test.cpp
+++ b/searchcore/src/tests/proton/common/feedoperation_test.cpp
@@ -47,8 +47,8 @@ namespace {
 
 struct MyStreamHandler : NewConfigOperation::IStreamHandler {
     using SerialNum = NewConfigOperation::SerialNum;
-    virtual void serializeConfig(SerialNum, vespalib::nbostream &) override {}
-    virtual void deserializeConfig(SerialNum, vespalib::nbostream &) override {}
+    void serializeConfig(SerialNum, vespalib::nbostream &) override {}
+    void deserializeConfig(SerialNum, vespalib::nbostream &) override {}
 };
 
 

--- a/searchcore/src/tests/proton/common/job_tracked_flush_target_test.cpp
+++ b/searchcore/src/tests/proton/common/job_tracked_flush_target_test.cpp
@@ -29,7 +29,7 @@ struct MyFlushTask : public searchcorespi::FlushTask
     void run() override {
         _execGate.await(5s);
     }
-    virtual search::SerialNum getFlushSerial() const override { return 5; }
+    search::SerialNum getFlushSerial() const override { return 5; }
 };
 
 struct MyFlushTarget : public test::DummyFlushTarget

--- a/searchcore/src/tests/proton/initializer/task_runner_test.cpp
+++ b/searchcore/src/tests/proton/initializer/task_runner_test.cpp
@@ -46,7 +46,7 @@ public:
     {
     }
 
-    virtual void run() override { _log.append(_name); }
+    void run() override { _log.append(_name); }
     size_t get_transient_memory_usage() const override { return _transient_memory_usage; }
 };
 

--- a/searchcore/src/tests/proton/matching/docid_range_scheduler/docid_range_scheduler_bench.cpp
+++ b/searchcore/src/tests/proton/matching/docid_range_scheduler/docid_range_scheduler_bench.cpp
@@ -209,7 +209,7 @@ struct RangeChecker : vespalib::Rendezvous<std::reference_wrapper<const WorkTrac
     RangeChecker(size_t num_threads, size_t docid_limit_in)
         : vespalib::Rendezvous<std::reference_wrapper<const WorkTracker>,bool>(num_threads), docid_limit(docid_limit_in) {}
     ~RangeChecker() override;
-    virtual void mingle() override {
+    void mingle() override {
         std::vector<DocidRange> ranges;
         for (size_t i = 0; i < size(); ++i) {
             ranges.insert(ranges.end(), in(i).get().ranges.begin(), in(i).get().ranges.end());

--- a/searchcore/src/tests/proton/reference/gid_to_lid_mapper/gid_to_lid_mapper_test.cpp
+++ b/searchcore/src/tests/proton/reference/gid_to_lid_mapper/gid_to_lid_mapper_test.cpp
@@ -48,7 +48,7 @@ struct GidCollector : public search::IGidToLidMapperVisitor
           _map(map)
     {
     }
-    virtual void visit(const document::GlobalId &gid, uint32_t lid) const override { _map.insert(std::make_pair(gid, lid)); }
+    void visit(const document::GlobalId &gid, uint32_t lid) const override { _map.insert(std::make_pair(gid, lid)); }
 };
 
 GidMap collectGids(const std::unique_ptr<search::IGidToLidMapper> &mapper)

--- a/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/attribute_reprocessing_initializer_test.cpp
+++ b/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/attribute_reprocessing_initializer_test.cpp
@@ -111,7 +111,7 @@ struct MyDocTypeInspector : public IDocumentTypeInspector
           _newCfg(newCfg)
     {
     }
-    virtual bool hasUnchangedField(const std::string &name) const override {
+    bool hasUnchangedField(const std::string &name) const override {
         return _oldCfg._fields.count(name) > 0 &&
             _newCfg._fields.count(name) > 0;
     }
@@ -124,7 +124,7 @@ struct MyIndexschemaInspector : public IIndexschemaInspector
         : _schema(schema)
     {
     }
-    virtual bool isStringIndex(const std::string &name) const override {
+    bool isStringIndex(const std::string &name) const override {
         uint32_t fieldId = _schema.getIndexFieldId(name);
         if (fieldId == Schema::UNKNOWN_FIELD_ID) {
             return false;
@@ -212,7 +212,7 @@ public:
 };
 
 class Fixture : public InitializerTest {
-    virtual void TestBody() override {}
+    void TestBody() override {}
 };
 
 TEST_F(InitializerTest, require_that_new_field_does_NOT_require_attribute_populate)

--- a/searchcore/src/tests/proton/reprocessing/document_reprocessing_handler/document_reprocessing_handler_test.cpp
+++ b/searchcore/src/tests/proton/reprocessing/document_reprocessing_handler/document_reprocessing_handler_test.cpp
@@ -19,7 +19,7 @@ struct MyProcessor : public ReprocessingType
     DocumentId _docId;
 
     MyProcessor() : _lid(0), _docId() {}
-    virtual void handleExisting(uint32_t lid, const std::shared_ptr<Document> &doc) override {
+    void handleExisting(uint32_t lid, const std::shared_ptr<Document> &doc) override {
         _lid = lid;
         _docId = doc->getId();
     }

--- a/searchcore/src/tests/proton/server/health_adapter_test.cpp
+++ b/searchcore/src/tests/proton/server/health_adapter_test.cpp
@@ -14,7 +14,7 @@ struct MyStatusProducer : public StatusProducer {
         list.push_back(StatusReport::SP(new StatusReport(StatusReport::Params(comp).
                 state(state).message(msg))));
     }
-    virtual StatusReport::List getStatusReports() const override {
+    StatusReport::List getStatusReports() const override {
         return list;
     }
 };

--- a/searchcore/src/vespa/searchcore/proton/attribute/sequential_attributes_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/sequential_attributes_initializer.h
@@ -17,7 +17,7 @@ private:
 public:
     SequentialAttributesInitializer(uint32_t docIdLimit);
     AttributesVector getInitializedAttributes() const { return _initializedAttributes; }
-    virtual void add(AttributeInitializer::UP initializer) override;
+    void add(AttributeInitializer::UP initializer) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/common/document_type_inspector.h
+++ b/searchcore/src/vespa/searchcore/proton/common/document_type_inspector.h
@@ -20,7 +20,7 @@ public:
     DocumentTypeInspector(const document::DocumentType &oldDocType,
                           const document::DocumentType &newDocType);
 
-    virtual bool hasUnchangedField(const std::string &name) const override;
+    bool hasUnchangedField(const std::string &name) const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/deletebucketoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/deletebucketoperation.h
@@ -15,10 +15,10 @@ public:
     DeleteBucketOperation(const document::BucketId &bucketId);
     ~DeleteBucketOperation() override = default;
     const document::BucketId &getBucketId() const { return _bucketId; }
-    virtual void serialize(vespalib::nbostream &os) const override;
-    virtual void deserialize(vespalib::nbostream &is,
-                             const document::DocumentTypeRepo &repo) override;
-    virtual std::string toString() const override;
+    void serialize(vespalib::nbostream &os) const override;
+    void deserialize(vespalib::nbostream &is,
+                     const document::DocumentTypeRepo &repo) override;
+    std::string toString() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/joinbucketsoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/joinbucketsoperation.h
@@ -21,10 +21,10 @@ public:
     const document::BucketId &getSource1() const { return _source1; }
     const document::BucketId &getSource2() const { return _source2; }
     const document::BucketId &getTarget() const { return _target; }
-    virtual void serialize(vespalib::nbostream &os) const override;
-    virtual void deserialize(vespalib::nbostream &is,
-                             const document::DocumentTypeRepo &repo) override;
-    virtual std::string toString() const override;
+    void serialize(vespalib::nbostream &os) const override;
+    void deserialize(vespalib::nbostream &is,
+                     const document::DocumentTypeRepo &repo) override;
+    std::string toString() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/noopoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/noopoperation.h
@@ -10,10 +10,10 @@ struct NoopOperation : FeedOperation {
     NoopOperation(SerialNum serialNum);
     ~NoopOperation() override = default;
 
-    virtual void serialize(vespalib::nbostream &) const override {}
-    virtual void deserialize(vespalib::nbostream &,
-                             const document::DocumentTypeRepo &) override {}
-    virtual std::string toString() const override;
+    void serialize(vespalib::nbostream &) const override {}
+    void deserialize(vespalib::nbostream &,
+                     const document::DocumentTypeRepo &) override {}
+    std::string toString() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/splitbucketoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/splitbucketoperation.h
@@ -21,10 +21,10 @@ public:
     const document::BucketId &getSource() const { return _source; }
     const document::BucketId &getTarget1() const { return _target1; }
     const document::BucketId &getTarget2() const { return _target2; }
-    virtual void serialize(vespalib::nbostream &os) const override;
-    virtual void deserialize(vespalib::nbostream &is,
-                             const document::DocumentTypeRepo &repo) override;
-    virtual std::string toString() const override;
+    void serialize(vespalib::nbostream &os) const override;
+    void deserialize(vespalib::nbostream &is,
+                     const document::DocumentTypeRepo &repo) override;
+    std::string toString() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/tls_stats_factory.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/tls_stats_factory.h
@@ -19,7 +19,7 @@ class TlsStatsFactory : public ITlsStatsFactory
 public:
     TlsStatsFactory(std::shared_ptr<TransLogServer> tls);
     virtual ~TlsStatsFactory();
-    virtual TlsStatsMap create() override;
+    TlsStatsMap create() override;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference.h
@@ -25,10 +25,10 @@ public:
                         std::shared_ptr<const search::IDocumentMetaStoreContext> dmsContext,
                         std::shared_ptr<IGidToLidChangeHandler> gidToLidChangeHandler);
     virtual ~DocumentDBReference();
-    virtual std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(std::string_view name) override;
-    virtual std::shared_ptr<const search::IDocumentMetaStoreContext> getDocumentMetaStore() const override;
-    virtual std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() override;
-    virtual std::unique_ptr<GidToLidChangeRegistrator> makeGidToLidChangeRegistrator(const std::string &docTypeName) override;
+    std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(std::string_view name) override;
+    std::shared_ptr<const search::IDocumentMetaStoreContext> getDocumentMetaStore() const override;
+    std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() override;
+    std::unique_ptr<GidToLidChangeRegistrator> makeGidToLidChangeRegistrator(const std::string &docTypeName) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_registry.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/document_db_reference_registry.h
@@ -20,10 +20,10 @@ public:
     DocumentDBReferenceRegistry();
     virtual ~DocumentDBReferenceRegistry();
 
-    virtual std::shared_ptr<IDocumentDBReference> get(std::string_view docType) const override;
-    virtual std::shared_ptr<IDocumentDBReference> tryGet(std::string_view docType) const override;
-    virtual void add(std::string_view name, std::shared_ptr<IDocumentDBReference> referee) override;
-    virtual void remove(std::string_view name) override;
+    std::shared_ptr<IDocumentDBReference> get(std::string_view docType) const override;
+    std::shared_ptr<IDocumentDBReference> tryGet(std::string_view docType) const override;
+    void add(std::string_view name, std::shared_ptr<IDocumentDBReference> referee) override;
+    void remove(std::string_view name) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/reprocessing/attribute_reprocessing_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/attribute_reprocessing_initializer.h
@@ -56,9 +56,9 @@ public:
                                      search::SerialNum serialNum);
 
     // Implements IReprocessingInitializer
-    virtual bool hasReprocessors() const override;
+    bool hasReprocessors() const override;
 
-    virtual void initialize(IReprocessingHandler &handler) override;
+    void initialize(IReprocessingHandler &handler) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/reprocessing/document_reprocessing_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/reprocessing/document_reprocessing_handler.h
@@ -25,7 +25,7 @@ private:
     public:
         RewriteVisitor(DocumentReprocessingHandler &handler) : _handler(handler) {}
         // Implements search::IDocumentStoreRewriteVisitor
-        virtual void visit(uint32_t lid, const std::shared_ptr<document::Document> &doc) override {
+        void visit(uint32_t lid, const std::shared_ptr<document::Document> &doc) override {
             _handler.rewriteVisit(lid, doc);
         }
     };
@@ -58,18 +58,18 @@ public:
     }
 
     // Implements IReprocessingHandler
-    virtual void addReader(const IReprocessingReader::SP &reader) override {
+    void addReader(const IReprocessingReader::SP &reader) override {
         _readers.push_back(reader);
     }
 
-    virtual void addRewriter(const IReprocessingRewriter::SP &rewriter) override {
+    void addRewriter(const IReprocessingRewriter::SP &rewriter) override {
         _rewriters.push_back(rewriter);
     }
 
     // Implements search::IDocumentStoreReadVisitor
-    virtual void visit(uint32_t lid, const std::shared_ptr<document::Document> &doc) override;
+    void visit(uint32_t lid, const std::shared_ptr<document::Document> &doc) override;
 
-    virtual void visit(uint32_t lid) override;
+    void visit(uint32_t lid) override;
 
     void done();
 };

--- a/searchcore/src/vespa/searchcore/proton/server/docstorevalidator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/docstorevalidator.h
@@ -24,8 +24,8 @@ public:
     DocStoreValidator(IDocumentMetaStore &dms);
     ~DocStoreValidator() override;
 
-    virtual void visit(uint32_t lid, const std::shared_ptr<document::Document> &doc) override;
-    virtual void visit(uint32_t lid) override;
+    void visit(uint32_t lid, const std::shared_ptr<document::Document> &doc) override;
+    void visit(uint32_t lid) override;
 
     void visitDone();
     void killOrphans(search::IDocumentStore &store, search::SerialNum serialNum);

--- a/searchcore/src/vespa/searchcore/proton/server/document_subdb_collection_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_subdb_collection_initializer.h
@@ -22,7 +22,7 @@ public:
         _subDbInitializers.push_back(subDbInitializer);
         addDependency(subDbInitializer);
     }
-    virtual void run() override;
+    void run() override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.h
@@ -86,7 +86,7 @@ protected:
     DocIdLimit           _docIdLimit;
 
     std::shared_ptr<AttributeManager> getAndResetInitAttributeManager();
-    virtual IFlushTargetList getFlushTargetsInternal() override;
+    IFlushTargetList getFlushTargetsInternal() override;
     void reconfigure_attribute_metrics(const IAttributeManager& mgr);
 
     IReprocessingTask::UP createReprocessingTask(IReprocessingInitializer &initializer,
@@ -118,7 +118,7 @@ public:
     void onReprocessDone(SerialNum serialNum) override;
     SerialNum getOldestFlushedSerial() override;
     SerialNum getNewestFlushedSerial() override;
-    virtual void pruneRemovedFields(SerialNum serialNum) override;
+    void pruneRemovedFields(SerialNum serialNum) override;
     TransientResourceUsage get_transient_resource_usage() const override;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/test/disk_mem_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/test/disk_mem_usage_notifier.h
@@ -30,11 +30,11 @@ public:
     {
     }
     virtual ~DiskMemUsageNotifier() = default;
-    virtual void addDiskMemUsageListener(IDiskMemUsageListener *listener) override {
+    void addDiskMemUsageListener(IDiskMemUsageListener *listener) override {
         _listeners.push_back(listener);
         listener->notifyDiskMemUsage(_state);
     }
-    virtual void removeDiskMemUsageListener(IDiskMemUsageListener *listener) override {
+    void removeDiskMemUsageListener(IDiskMemUsageListener *listener) override {
         for (auto itr = _listeners.begin(); itr != _listeners.end(); ++itr) {
             if (*itr == listener) {
                 _listeners.erase(itr);

--- a/searchcore/src/vespa/searchcore/proton/test/executor_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/executor_observer.h
@@ -20,7 +20,7 @@ public:
     uint32_t getExecuteCnt() const { return _executeCnt; }
 
     // Implements vespalib::Executor
-    virtual Task::UP execute(Task::UP task) override {
+    Task::UP execute(Task::UP task) override {
         ++_executeCnt;
         return _executor.execute(std::move(task));
     }

--- a/searchcore/src/vespa/searchcore/proton/test/mock_document_db_reference.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_document_db_reference.h
@@ -14,16 +14,16 @@ namespace proton::test {
  */
 struct MockDocumentDBReference : public IDocumentDBReference {
     using SP = std::shared_ptr<MockDocumentDBReference>;
-    virtual std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(std::string_view) override {
+    std::shared_ptr<search::attribute::ReadableAttributeVector> getAttribute(std::string_view) override {
         return std::shared_ptr<search::attribute::ReadableAttributeVector>();
     }
-    virtual std::shared_ptr<const search::IDocumentMetaStoreContext> getDocumentMetaStore() const override {
+    std::shared_ptr<const search::IDocumentMetaStoreContext> getDocumentMetaStore() const override {
         return std::shared_ptr<const search::IDocumentMetaStoreContext>();
     }
-    virtual std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() override {
+    std::shared_ptr<search::IGidToLidMapperFactory> getGidToLidMapperFactory() override {
         return std::shared_ptr<search::IGidToLidMapperFactory>();
     }
-    virtual std::unique_ptr<GidToLidChangeRegistrator> makeGidToLidChangeRegistrator(const std::string &) override {
+    std::unique_ptr<GidToLidChangeRegistrator> makeGidToLidChangeRegistrator(const std::string &) override {
         return std::unique_ptr<GidToLidChangeRegistrator>();
     }
 };

--- a/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
+++ b/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
@@ -201,10 +201,10 @@ class ShowPostingListSubApp : public SubApp
     static uint64_t noWordNum() { return 0u; }
 public:
     ShowPostingListSubApp();
-    virtual ~ShowPostingListSubApp();
-    virtual void usage(bool showHeader) override;
-    virtual bool getOptions(int argc, char **argv) override;
-    virtual int run() override;
+    ~ShowPostingListSubApp() override;
+    void usage(bool showHeader) override;
+    bool getOptions(int argc, char **argv) override;
+    int run() override;
     void showPostingList();
     bool readDocIdLimit(const Schema &schema);
     bool readWordList(const SchemaUtil::IndexIterator &index);
@@ -657,10 +657,10 @@ class DumpWordsSubApp : public SubApp
     void extract_posocc_file_header_bit_size(const std::string& field_dir);
 public:
     DumpWordsSubApp();
-    virtual ~DumpWordsSubApp();
-    virtual void usage(bool showHeader) override;
-    virtual bool getOptions(int argc, char **argv) override;
-    virtual int run() override;
+    ~DumpWordsSubApp() override;
+    void usage(bool showHeader) override;
+    bool getOptions(int argc, char **argv) override;
+    int run() override;
     void dumpWords();
 };
 

--- a/searchlib/src/tests/aggregator/perdocexpr_test.cpp
+++ b/searchlib/src/tests/aggregator/perdocexpr_test.cpp
@@ -1327,7 +1327,7 @@ void testAggregationResult(AggregationResult & aggr, const AggrGetter & g,
 
 TEST(PerDocExprTest, testAggregationResults) {
     struct SumGetter : AggrGetter {
-        virtual const ResultNode &operator()(const AggregationResult & r) const override
+        const ResultNode &operator()(const AggregationResult & r) const override
         { return static_cast<const SumAggregationResult &>(r).getSum(); }
     };
     SumAggregationResult sum;

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -69,11 +69,11 @@ public:
     {
     }
 
-    virtual Buffer allocBuf(size_t size) override {
+    Buffer allocBuf(size_t size) override {
         return std::make_unique<BufferBuf>(size, search::FileSettings::DIRECTIO_ALIGNMENT);
     }
 
-    virtual void writeBuf(Buffer buf_in) override {
+    void writeBuf(Buffer buf_in) override {
         if (!_buf) {
             _buf = std::move(buf_in);
         } else {

--- a/searchlib/src/tests/attribute/multi_value_mapping/multi_value_mapping_test.cpp
+++ b/searchlib/src/tests/attribute/multi_value_mapping/multi_value_mapping_test.cpp
@@ -34,17 +34,17 @@ class MyAttribute : public search::NotImplementedAttribute
     using MultiValueType = typename MvMapping::MultiValueType;
     using ConstArrayRef = std::span<const MultiValueType>;
     MvMapping &_mvMapping;
-    virtual void onCommit() override { }
-    virtual void onUpdateStat() override { }
-    virtual void onShrinkLidSpace() override {
+    void onCommit() override { }
+    void onUpdateStat() override { }
+    void onShrinkLidSpace() override {
         uint32_t committedDocIdLimit = getCommittedDocIdLimit();
         _mvMapping.shrink(committedDocIdLimit);
         setNumDocs(committedDocIdLimit);
     }
-    virtual void reclaim_memory(generation_t oldest_used_gen) override {
+    void reclaim_memory(generation_t oldest_used_gen) override {
         _mvMapping.reclaim_memory(oldest_used_gen);
     }
-    virtual void before_inc_generation(generation_t current_gen) override {
+    void before_inc_generation(generation_t current_gen) override {
         _mvMapping.assign_generation(current_gen);
     }
 
@@ -53,13 +53,13 @@ public:
         : NotImplementedAttribute("test"),
           _mvMapping(mvMapping)
     {}
-    virtual bool addDoc(DocId &doc) override {
+    bool addDoc(DocId &doc) override {
         _mvMapping.addDoc(doc);
         incNumDocs();
         updateUncommittedDocIdLimit(doc);
         return false;
     }
-    virtual uint32_t clearDoc(uint32_t docId) override {
+    uint32_t clearDoc(uint32_t docId) override {
         assert(docId < _mvMapping.size());
         _mvMapping.set(docId, ConstArrayRef());
         return 1u;

--- a/searchlib/src/tests/attribute/multi_value_read_view/multi_value_read_view_test.cpp
+++ b/searchlib/src/tests/attribute/multi_value_read_view/multi_value_read_view_test.cpp
@@ -44,7 +44,7 @@ struct MyGidToLidMapperFactory : public MockGidToLidMapperFactory
 };
 
 struct MockReadGuard : public IDocumentMetaStoreContext::IReadGuard {
-    virtual const search::IDocumentMetaStore &get() const override {
+    const search::IDocumentMetaStore &get() const override {
         search::IDocumentMetaStore *nullStore = nullptr;
         return static_cast<search::IDocumentMetaStore &>(*nullStore);
     }

--- a/searchlib/src/tests/features/element_completeness/element_completeness_test.cpp
+++ b/searchlib/src/tests/features/element_completeness/element_completeness_test.cpp
@@ -56,7 +56,7 @@ struct IndexFixture {
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
     std::vector<std::string> expect;
     size_t dumped;
-    virtual void visitDumpFeature(const std::string &name) override {
+    void visitDumpFeature(const std::string &name) override {
         EXPECT_LT(dumped, expect.size());
         EXPECT_EQ(expect[dumped++], name);
     }

--- a/searchlib/src/tests/features/element_similarity_feature/element_similarity_feature_test.cpp
+++ b/searchlib/src/tests/features/element_similarity_feature/element_similarity_feature_test.cpp
@@ -67,7 +67,7 @@ struct FeatureDumpFixture : public IDumpFeatureVisitor {
     std::vector<std::string> actual;
     FeatureDumpFixture() : IDumpFeatureVisitor(), actual() {}
     ~FeatureDumpFixture() override;
-    virtual void visitDumpFeature(const std::string &name) override {
+    void visitDumpFeature(const std::string &name) override {
         actual.push_back(name);
     }
 };

--- a/searchlib/src/tests/features/item_raw_score/item_raw_score_test.cpp
+++ b/searchlib/src/tests/features/item_raw_score/item_raw_score_test.cpp
@@ -39,7 +39,7 @@ struct IndexFixture {
 };
 
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
-    virtual void visitDumpFeature(const std::string &) override {
+    void visitDumpFeature(const std::string &) override {
         FAIL() << "no features should be dumped";
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}

--- a/searchlib/src/tests/features/native_dot_product/native_dot_product_test.cpp
+++ b/searchlib/src/tests/features/native_dot_product/native_dot_product_test.cpp
@@ -39,7 +39,7 @@ struct IndexFixture {
 };
 
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
-    virtual void visitDumpFeature(const std::string &) override {
+    void visitDumpFeature(const std::string &) override {
         FAIL() << "no features should be dumped";
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}

--- a/searchlib/src/tests/features/raw_score/raw_score_test.cpp
+++ b/searchlib/src/tests/features/raw_score/raw_score_test.cpp
@@ -37,7 +37,7 @@ struct IndexFixture {
 };
 
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
-    virtual void visitDumpFeature(const std::string &) override {
+    void visitDumpFeature(const std::string &) override {
         FAIL() << "no features should be dumped";
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}

--- a/searchlib/src/tests/features/subqueries/subqueries_test.cpp
+++ b/searchlib/src/tests/features/subqueries/subqueries_test.cpp
@@ -35,7 +35,7 @@ struct IndexFixture {
 };
 
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
-    virtual void visitDumpFeature(const std::string &) override {
+    void visitDumpFeature(const std::string &) override {
         FAIL() << "no features should be dumped";
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}

--- a/searchlib/src/tests/features/text_similarity_feature/text_similarity_feature_test.cpp
+++ b/searchlib/src/tests/features/text_similarity_feature/text_similarity_feature_test.cpp
@@ -60,7 +60,7 @@ struct IndexFixture {
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
     std::vector<std::string> expect;
     size_t dumped;
-    virtual void visitDumpFeature(const std::string &name) override {
+    void visitDumpFeature(const std::string &name) override {
         EXPECT_LT(dumped, expect.size());
         EXPECT_EQ(expect[dumped++], name);
     }

--- a/searchlib/src/tests/fef/resolver/resolver_test.cpp
+++ b/searchlib/src/tests/fef/resolver/resolver_test.cpp
@@ -14,18 +14,18 @@ class BaseBlueprint : public Blueprint {
 public:
     BaseBlueprint() : Blueprint("base") { }
     ~BaseBlueprint() override;
-    virtual void visitDumpFeatures(const IIndexEnvironment &,
-                                   IDumpFeatureVisitor &) const override {}
-    virtual Blueprint::UP createInstance() const override { return Blueprint::UP(new BaseBlueprint()); }
-    virtual bool setup(const IIndexEnvironment & indexEnv,
-                       const ParameterList & params) override {
+    void visitDumpFeatures(const IIndexEnvironment &,
+                           IDumpFeatureVisitor &) const override {}
+    Blueprint::UP createInstance() const override { return Blueprint::UP(new BaseBlueprint()); }
+    bool setup(const IIndexEnvironment & indexEnv,
+               const ParameterList & params) override {
         (void) indexEnv; (void) params;
         describeOutput("foo", "foo");
         describeOutput("bar", "bar");
         describeOutput("baz", "baz");
         return true;
     }
-    virtual FeatureExecutor &createExecutor(const IQueryEnvironment &, vespalib::Stash &stash) const override {
+    FeatureExecutor &createExecutor(const IQueryEnvironment &, vespalib::Stash &stash) const override {
         std::vector<feature_t> values;
         values.push_back(0.0);
         values.push_back(0.0);
@@ -40,11 +40,11 @@ class CombineBlueprint : public Blueprint {
 public:
     CombineBlueprint() : Blueprint("combine") { }
     ~CombineBlueprint() override;
-    virtual void visitDumpFeatures(const IIndexEnvironment &,
-                                   IDumpFeatureVisitor &) const override {}
-    virtual Blueprint::UP createInstance() const override { return Blueprint::UP(new CombineBlueprint()); }
-    virtual bool setup(const IIndexEnvironment & indexEnv,
-                       const ParameterList & params) override {
+    void visitDumpFeatures(const IIndexEnvironment &,
+                           IDumpFeatureVisitor &) const override {}
+    Blueprint::UP createInstance() const override { return Blueprint::UP(new CombineBlueprint()); }
+    bool setup(const IIndexEnvironment & indexEnv,
+               const ParameterList & params) override {
         (void) indexEnv; (void) params;
         ASSERT_TRUE(defineInput("base.foo"));
         ASSERT_TRUE(defineInput("base.bar"));
@@ -52,7 +52,7 @@ public:
         describeOutput("out", "out");
         return true;
     }
-    virtual FeatureExecutor &createExecutor(const IQueryEnvironment &, vespalib::Stash &stash) const override {
+    FeatureExecutor &createExecutor(const IQueryEnvironment &, vespalib::Stash &stash) const override {
         return stash.create<features::SingleZeroValueExecutor>();
     }
 };

--- a/searchlib/src/tests/groupingengine/groupingengine_benchmark.cpp
+++ b/searchlib/src/tests/groupingengine/groupingengine_benchmark.cpp
@@ -144,7 +144,7 @@ private:
             _numrefs++;
         }
     }
-    virtual bool check(const vespalib::Identifiable &obj) const override { return obj.inherits(AttributeNode::classId); }
+    bool check(const vespalib::Identifiable &obj) const override { return obj.inherits(AttributeNode::classId); }
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/tests/groupingengine/groupingengine_test.cpp
+++ b/searchlib/src/tests/groupingengine/groupingengine_test.cpp
@@ -137,12 +137,12 @@ public:
     CheckAttributeReferences() : _numrefs(0) { }
     int _numrefs;
 private:
-    virtual void execute(vespalib::Identifiable &obj) override {
+    void execute(vespalib::Identifiable &obj) override {
         if (static_cast<AttributeNode &>(obj).getAttribute() != NULL) {
             _numrefs++;
         }
     }
-    virtual bool check(const vespalib::Identifiable &obj) const override { return obj.inherits(AttributeNode::classId); }
+    bool check(const vespalib::Identifiable &obj) const override { return obj.inherits(AttributeNode::classId); }
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/tests/memoryindex/field_index_remover/field_index_remover_test.cpp
+++ b/searchlib/src/tests/memoryindex/field_index_remover/field_index_remover_test.cpp
@@ -39,7 +39,7 @@ struct MockRemoveListener : public IFieldIndexRemoveListener {
     WordFieldVector _words;
     uint32_t _expDocId;
     uint32_t _fieldId;
-    virtual void remove(const std::string_view word, uint32_t docId) override {
+    void remove(const std::string_view word, uint32_t docId) override {
         EXPECT_EQ(_expDocId, docId);
         _words.emplace_back(word, _fieldId);
     }

--- a/searchlib/src/tests/postinglistbm/stress_runner.cpp
+++ b/searchlib/src/tests/postinglistbm/stress_runner.cpp
@@ -99,9 +99,9 @@ public:
     StressWorker& operator=(const StressWorker&) = delete;
 
     StressWorker(StressMaster& master, uint32_t id);
-    virtual ~StressWorker();
+    ~StressWorker() override;
 
-    virtual void run() override;
+    void run() override;
 };
 
 class DirectStressWorker : public StressWorker {

--- a/searchlib/src/tests/predicate/predicate_bounds_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_bounds_posting_list_test.cpp
@@ -15,8 +15,8 @@ using namespace search::predicate;
 namespace {
 
 struct DummyDocIdLimitProvider : public DocIdLimitProvider {
-    virtual uint32_t getDocIdLimit() const override { return 10000; }
-    virtual uint32_t getCommittedDocIdLimit() const override { return 10000; }
+    uint32_t getDocIdLimit() const override { return 10000; }
+    uint32_t getCommittedDocIdLimit() const override { return 10000; }
 };
 
 vespalib::GenerationHandler generation_handler;

--- a/searchlib/src/tests/predicate/predicate_index_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_index_test.cpp
@@ -23,8 +23,8 @@ using vespalib::DataBuffer;
 namespace {
 
 struct DummyDocIdLimitProvider : public DocIdLimitProvider {
-    virtual uint32_t getDocIdLimit() const override { return 10000; }
-    virtual uint32_t getCommittedDocIdLimit() const override { return 10000; }
+    uint32_t getDocIdLimit() const override { return 10000; }
+    uint32_t getCommittedDocIdLimit() const override { return 10000; }
 };
 
 vespalib::GenerationHandler generation_handler;

--- a/searchlib/src/tests/predicate/predicate_interval_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_interval_posting_list_test.cpp
@@ -14,8 +14,8 @@ using namespace search::predicate;
 namespace {
 
 struct DummyDocIdLimitProvider : public DocIdLimitProvider {
-    virtual uint32_t getDocIdLimit() const override { return 10000; }
-    virtual uint32_t getCommittedDocIdLimit() const override { return 10000; }
+    uint32_t getDocIdLimit() const override { return 10000; }
+    uint32_t getCommittedDocIdLimit() const override { return 10000; }
 };
 
 vespalib::GenerationHandler generation_handler;

--- a/searchlib/src/tests/predicate/predicate_zero_constraint_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_zero_constraint_posting_list_test.cpp
@@ -12,8 +12,8 @@ using namespace search::predicate;
 namespace {
 
 struct DummyDocIdLimitProvider : public DocIdLimitProvider {
-    virtual uint32_t getDocIdLimit() const override { return 10000; }
-    virtual uint32_t getCommittedDocIdLimit() const override { return 10000; }
+    uint32_t getDocIdLimit() const override { return 10000; }
+    uint32_t getCommittedDocIdLimit() const override { return 10000; }
 };
 
 vespalib::GenerationHandler generation_handler;

--- a/searchlib/src/tests/predicate/predicate_zstar_compressed_posting_list_test.cpp
+++ b/searchlib/src/tests/predicate/predicate_zstar_compressed_posting_list_test.cpp
@@ -15,8 +15,8 @@ using std::vector;
 namespace {
 
 struct DummyDocIdLimitProvider : public DocIdLimitProvider {
-    virtual uint32_t getDocIdLimit() const override { return 10000; }
-    virtual uint32_t getCommittedDocIdLimit() const override { return 10000; }
+    uint32_t getDocIdLimit() const override { return 10000; }
+    uint32_t getCommittedDocIdLimit() const override { return 10000; }
 };
 
 vespalib::GenerationHandler generation_handler;

--- a/searchlib/src/tests/predicate/simple_index_test.cpp
+++ b/searchlib/src/tests/predicate/simple_index_test.cpp
@@ -46,8 +46,8 @@ struct MyDataDeserializer : PostingDeserializer<MyData> {
 struct SimpleDocIdLimitProvider : public DocIdLimitProvider {
     uint32_t _doc_id_limit = 1;
     uint32_t _committed_doc_id_limit = 1;
-    virtual uint32_t getDocIdLimit() const override { return _doc_id_limit; }
-    virtual uint32_t getCommittedDocIdLimit() const override { return _committed_doc_id_limit; }
+    uint32_t getDocIdLimit() const override { return _doc_id_limit; }
+    uint32_t getCommittedDocIdLimit() const override { return _committed_doc_id_limit; }
 };
 
 constexpr uint64_t key = 0x123456;

--- a/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
+++ b/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
@@ -101,11 +101,11 @@ struct MockSearch : public SearchIterator {
         SearchIterator::initRange(begin, end);
         setDocId(_initial);
     }
-    virtual void doSeek(uint32_t) override {
+    void doSeek(uint32_t) override {
         ++seekCnt;
         setAtEnd();
     }
-    virtual void doUnpack(uint32_t) override {}
+    void doUnpack(uint32_t) override {}
 };
 
 struct MockFixture {

--- a/searchlib/src/tests/queryeval/monitoring_search_iterator/monitoring_search_iterator_test.cpp
+++ b/searchlib/src/tests/queryeval/monitoring_search_iterator/monitoring_search_iterator_test.cpp
@@ -24,12 +24,12 @@ struct HistorySearchIterator : public SearchIterator
     SearchHistory _history;
     mutable bool  _getPostingInfoCalled;
     HistorySearchIterator() : _history(), _getPostingInfoCalled(false) {}
-    virtual void doSeek(uint32_t docId) override {
+    void doSeek(uint32_t docId) override {
         _history.seek("x", docId);
         setDocId(docId);
     }
-    virtual void doUnpack(uint32_t docId) override { _history.unpack("x", docId); }
-    virtual const PostingInfo *getPostingInfo() const override {
+    void doUnpack(uint32_t docId) override { _history.unpack("x", docId); }
+    const PostingInfo *getPostingInfo() const override {
         _getPostingInfoCalled = true;
         return NULL;
     }

--- a/searchlib/src/tests/queryeval/sparse_vector_benchmark/sparse_vector_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/sparse_vector_benchmark/sparse_vector_benchmark_test.cpp
@@ -314,7 +314,7 @@ struct NoFilterStrategy : FilterStrategy {
 };
 
 struct PositiveFilterBeforeStrategy : FilterStrategy {
-    virtual std::string name() const override {
+    std::string name() const override {
         return vespalib::make_string("PositiveBefore");
     }
     SearchIterator::UP createRoot(SparseVectorFactory &vectorFactory, ChildFactory &childFactory, uint32_t childCnt, uint32_t limit) const override {
@@ -326,7 +326,7 @@ struct PositiveFilterBeforeStrategy : FilterStrategy {
 };
 
 struct NegativeFilterAfterStrategy : FilterStrategy {
-    virtual std::string name() const override {
+    std::string name() const override {
         return vespalib::make_string("NegativeAfter");
     }
     SearchIterator::UP createRoot(SparseVectorFactory &vectorFactory, ChildFactory &childFactory, uint32_t childCnt, uint32_t limit) const override {

--- a/searchlib/src/tests/ranksetup/ranksetup_test.cpp
+++ b/searchlib/src/tests/ranksetup/ranksetup_test.cpp
@@ -53,7 +53,7 @@ class DumpFeatureVisitor : public IDumpFeatureVisitor
 {
 public:
     DumpFeatureVisitor() {}
-    virtual void visitDumpFeature(const std::string & name) override {
+    void visitDumpFeature(const std::string & name) override {
         std::cout << "dump feature: " << name << std::endl;
     }
 };

--- a/searchlib/src/tests/transactionlogstress/translogstress.cpp
+++ b/searchlib/src/tests/transactionlogstress/translogstress.cpp
@@ -373,8 +373,8 @@ public:
         }
     }
     SerialNum getFrom() { return _from; }
-    virtual RPC::Result receive(const Packet & packet) override;
-    virtual void eof() override {
+    RPC::Result receive(const Packet & packet) override;
+    void eof() override {
         LOG(info, "VisitorAgent[%u]: eof", _id);
         setState(FINISHED);
     }

--- a/searchlib/src/vespa/searchlib/aggregation/aggregationresult.h
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregationresult.h
@@ -64,7 +64,7 @@ public:
     const ResultNode & getRank() const { return onGetRank(); }
     const ResultNode * getResult() const override { return &onGetRank(); }
     virtual ResultNode & getResult() { return const_cast<ResultNode &>(onGetRank()); }
-    virtual AggregationResult * clone() const override = 0;
+    AggregationResult * clone() const override = 0;
     const ExpressionNode * getExpression() const { return _expressionTree->getRoot(); }
     ExpressionNode * getExpression() { return _expressionTree->getRoot(); }
 protected:

--- a/searchlib/src/vespa/searchlib/attribute/attributememoryfilebufferwriter.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributememoryfilebufferwriter.h
@@ -16,9 +16,9 @@ class AttributeMemoryFileBufferWriter : public AttributeFileBufferWriter
 public:
     AttributeMemoryFileBufferWriter(IAttributeFileWriter &memoryFileWriter);
 
-    virtual ~AttributeMemoryFileBufferWriter();
+    ~AttributeMemoryFileBufferWriter() override;
 
-    virtual void onFlush(size_t nowSize) override;
+    void onFlush(size_t nowSize) override;
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/attributememoryfilewriter.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributememoryfilewriter.h
@@ -17,10 +17,10 @@ class AttributeMemoryFileWriter : public IAttributeFileWriter
     std::vector<Buffer> _bufs;
 public:
     AttributeMemoryFileWriter();
-    ~AttributeMemoryFileWriter();
-    virtual Buffer allocBuf(size_t size) override;
-    virtual void writeBuf(Buffer buf) override;
-    virtual std::unique_ptr<BufferWriter> allocBufferWriter() override;
+    ~AttributeMemoryFileWriter() override;
+    Buffer allocBuf(size_t size) override;
+    void writeBuf(Buffer buf) override;
+    std::unique_ptr<BufferWriter> allocBufferWriter() override;
     void writeTo(IAttributeFileWriter &writer);
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -352,20 +352,20 @@ public:
     virtual uint32_t clearDoc(DocId doc) = 0;
 
     // Implements IAttributeVector
-    virtual uint32_t get(DocId doc, EnumHandle *v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, const char **v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, largeint_t *v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, double *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, EnumHandle *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, const char **v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, largeint_t *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, double *v, uint32_t sz) const override = 0;
 
     virtual uint32_t get(DocId doc, std::string *v, uint32_t sz) const = 0;
 
 
     // Implements IAttributeVector
-    virtual uint32_t get(DocId doc, WeightedEnum *v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, WeightedString *v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, WeightedConstChar *v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, WeightedInt *v, uint32_t sz) const override = 0;
-    virtual uint32_t get(DocId doc, WeightedFloat *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, WeightedEnum *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, WeightedString *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, WeightedConstChar *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, WeightedInt *v, uint32_t sz) const override = 0;
+    uint32_t get(DocId doc, WeightedFloat *v, uint32_t sz) const override = 0;
 
     virtual int32_t getWeight(DocId doc, uint32_t idx) const;
 

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute_saver.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute_saver.h
@@ -36,7 +36,7 @@ private:
     const Store &_store;
     Enumerator _enumerator;
 
-    virtual bool onSave(IAttributeSaveTarget &saveTarget) override;
+    bool onSave(IAttributeSaveTarget &saveTarget) override;
 public:
     ReferenceAttributeSaver(vespalib::GenerationHandler::Guard &&guard,
                             const AttributeHeader &header,

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
@@ -168,8 +168,8 @@ public:
         return buf;
     }
 private:
-    virtual void set(const ResultNode&) override;
-    virtual size_t hash() const override { return 0; }
+    void set(const ResultNode&) override;
+    size_t hash() const override { return 0; }
     const FieldValue * _fv;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/integerresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/integerresultnode.h
@@ -15,7 +15,7 @@ class IntegerResultNode : public NumericResultNode
 public:
     DECLARE_ABSTRACT_RESULTNODE(IntegerResultNode);
 
-    virtual const BucketResultNode& getNullBucket() const override;
+    const BucketResultNode& getNullBucket() const override;
 };
 
 template <typename T>

--- a/searchlib/src/vespa/searchlib/expression/numericresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/numericresultnode.h
@@ -11,7 +11,7 @@ public:
     DECLARE_ABSTRACT_EXPRESSIONNODE(NumericResultNode);
     using CP = vespalib::IdentifiablePtr<NumericResultNode>;
     using UP = std::unique_ptr<NumericResultNode>;
-    virtual NumericResultNode *clone() const override = 0;
+    NumericResultNode *clone() const override = 0;
     virtual void multiply(const ResultNode & b) = 0;
     virtual void divide(const ResultNode & b) = 0;
     virtual void modulo(const ResultNode & b) = 0;

--- a/searchlib/src/vespa/searchlib/expression/resultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/resultnode.h
@@ -18,7 +18,7 @@ class BucketResultNode;
 
 #define DECLARE_RESULTNODE_NS1(ns, Class)               \
     DECLARE_IDENTIFIABLE_NS3(search, expression, ns, Class) \
-    virtual Class * clone() const override;
+    Class * clone() const override;
 
 #define DECLARE_RESULTNODE_SERIALIZE \
     ResultSerializer & onSerializeResult(ResultSerializer & os) const override; \

--- a/searchlib/src/vespa/searchlib/expression/singleresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/singleresultnode.h
@@ -12,7 +12,7 @@ public:
     DECLARE_ABSTRACT_RESULTNODE(SingleResultNode);
     using CP = vespalib::IdentifiablePtr<SingleResultNode>;
     using UP = std::unique_ptr<SingleResultNode>;
-    virtual SingleResultNode *clone() const override = 0;
+    SingleResultNode *clone() const override = 0;
 
     virtual void min(const ResultNode & b) = 0;
     virtual void max(const ResultNode & b) = 0;

--- a/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.h
+++ b/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.h
@@ -89,7 +89,7 @@ private:
         return table->get(index);
     }
 
-    virtual void handle_bind_match_data(const fef::MatchData &md) override;
+    void handle_bind_match_data(const fef::MatchData &md) override;
 
 public:
     NativeFieldMatchExecutor(const NativeFieldMatchExecutorSharedState& shared_state);

--- a/searchlib/src/vespa/searchlib/features/nativeproximityfeature.h
+++ b/searchlib/src/vespa/searchlib/features/nativeproximityfeature.h
@@ -92,7 +92,7 @@ private:
     feature_t calculateScoreForField(const FieldSetup & fs, uint32_t docId);
     feature_t calculateScoreForPair(const TermPair & pair, uint32_t fieldId, uint32_t docId);
 
-    virtual void handle_bind_match_data(const fef::MatchData &md) override;
+    void handle_bind_match_data(const fef::MatchData &md) override;
 
 public:
     NativeProximityExecutor(const NativeProximityExecutorSharedState& shared_state);

--- a/searchlib/src/vespa/searchlib/features/termdistancefeature.h
+++ b/searchlib/src/vespa/searchlib/features/termdistancefeature.h
@@ -30,7 +30,7 @@ private:
     std::optional<uint32_t> _element_gap;
     const fef::MatchData *_md;
 
-    virtual void handle_bind_match_data(const fef::MatchData &md) override;
+    void handle_bind_match_data(const fef::MatchData &md) override;
 
 public:
     TermDistanceExecutor(const fef::IQueryEnvironment & env,

--- a/searchlib/src/vespa/searchlib/fef/featureoverrider.h
+++ b/searchlib/src/vespa/searchlib/fef/featureoverrider.h
@@ -23,9 +23,9 @@ private:
     feature_t           _number;
     Value::UP           _object;
 
-    virtual void handle_bind_match_data(const MatchData &md) override;
-    virtual void handle_bind_inputs(std::span<const LazyValue> inputs) override;
-    virtual void handle_bind_outputs(std::span<NumberOrObject> outputs) override;
+    void handle_bind_match_data(const MatchData &md) override;
+    void handle_bind_inputs(std::span<const LazyValue> inputs) override;
+    void handle_bind_outputs(std::span<NumberOrObject> outputs) override;
 
 public:
     FeatureOverrider(const FeatureOverrider &) = delete;

--- a/searchlib/src/vespa/searchlib/fef/test/labels.h
+++ b/searchlib/src/vespa/searchlib/fef/test/labels.h
@@ -12,14 +12,14 @@ struct Labels {
     virtual ~Labels() = default;
 };
 struct NoLabel : public Labels {
-    virtual void inject(Properties &) const override {}
+    void inject(Properties &) const override {}
     ~NoLabel() override;
 };
 struct SingleLabel : public Labels {
     std::string label;
     uint32_t uid;
     SingleLabel(const std::string &l, uint32_t x) : label(l), uid(x) {}
-    virtual void inject(Properties &p) const override {
+    void inject(Properties &p) const override {
         vespalib::asciistream key;
         key << "vespa.label." << label << ".id";
         vespalib::asciistream value;

--- a/searchlib/src/vespa/searchlib/queryeval/emptysearch.h
+++ b/searchlib/src/vespa/searchlib/queryeval/emptysearch.h
@@ -20,7 +20,7 @@ protected:
         SearchIterator::initRange(begin, end);
         setAtEnd();
     }
-    virtual Trinary is_strict() const override;
+    Trinary is_strict() const override;
     Trinary matches_any() const override { return Trinary::False; }
 
 public:

--- a/searchlib/src/vespa/searchlib/test/features/distance_closeness_fixture.h
+++ b/searchlib/src/vespa/searchlib/test/features/distance_closeness_fixture.h
@@ -39,7 +39,7 @@ struct IndexEnvironmentFixture {
 };
 
 struct FeatureDumpFixture : public IDumpFeatureVisitor {
-    virtual void visitDumpFeature(const std::string &) override {
+    void visitDumpFeature(const std::string &) override {
         FAIL() << "no features should be dumped";
     }
     FeatureDumpFixture() : IDumpFeatureVisitor() {}

--- a/searchlib/src/vespa/searchlib/test/imported_attribute_fixture.cpp
+++ b/searchlib/src/vespa/searchlib/test/imported_attribute_fixture.cpp
@@ -10,7 +10,7 @@ namespace search {
 
 namespace {
     struct MockReadGuard : public IDocumentMetaStoreContext::IReadGuard {
-        virtual const search::IDocumentMetaStore &get() const override { abort(); }
+        const search::IDocumentMetaStore &get() const override { abort(); }
     };
 }
 

--- a/searchlib/src/vespa/searchlib/transactionlog/client_session.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/client_session.h
@@ -57,7 +57,7 @@ class Visitor : public Session
 public:
     Visitor(const std::string & domain, TransLogClient & tlc, Callback & callBack);
     bool visit(const SerialNum & from, const SerialNum & to);
-    virtual ~Visitor() override;
+    ~Visitor() override;
     RPC::Result visit(const Packet & packet) override { return _callback.receive(packet); }
     void eof() override    { _callback.eof(); }
 private:

--- a/searchsummary/src/tests/docsummary/document_id_dfw/document_id_dfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/document_id_dfw/document_id_dfw_test.cpp
@@ -54,8 +54,8 @@ make_doc_type_repo()
 }
 
 struct MyGetDocsumsStateCallback : GetDocsumsStateCallback {
-    virtual void fillSummaryFeatures(GetDocsumsState&) override {}
-    virtual void fillRankFeatures(GetDocsumsState&) override {}
+    void fillSummaryFeatures(GetDocsumsState&) override {}
+    void fillRankFeatures(GetDocsumsState&) override {}
     std::unique_ptr<MatchingElements> fill_matching_elements(const MatchingElementsFields &) override { abort(); }
 };
 

--- a/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
@@ -77,8 +77,8 @@ public:
 };
 
 struct MyGetDocsumsStateCallback : GetDocsumsStateCallback {
-    virtual void fillSummaryFeatures(GetDocsumsState&) override {}
-    virtual void fillRankFeatures(GetDocsumsState&) override {}
+    void fillSummaryFeatures(GetDocsumsState&) override {}
+    void fillRankFeatures(GetDocsumsState&) override {}
     std::unique_ptr<MatchingElements> fill_matching_elements(const MatchingElementsFields &) override { abort(); }
 };
 

--- a/searchsummary/src/tests/docsummary/result_class/result_class_test.cpp
+++ b/searchsummary/src/tests/docsummary/result_class/result_class_test.cpp
@@ -13,7 +13,7 @@ private:
 public:
     MockWriter(bool generated) : _generated(generated) {}
     bool isGenerated() const override { return _generated; }
-    virtual void insertField(uint32_t, const IDocsumStoreDocument*, GetDocsumsState&, vespalib::slime::Inserter &) const override {}
+    void insertField(uint32_t, const IDocsumStoreDocument*, GetDocsumsState&, vespalib::slime::Inserter &) const override {}
 };
 
 TEST(ResultClassTest, subset_of_fields_in_class_are_generated)

--- a/storage/src/tests/storageserver/documentapiconvertertest.cpp
+++ b/storage/src/tests/storageserver/documentapiconvertertest.cpp
@@ -44,19 +44,19 @@ const Bucket defaultBucket(defaultBucketSpace, BucketId(0));
 const TestAndSetCondition my_condition("my condition");
 
 struct MockBucketResolver : public BucketResolver {
-    virtual Bucket bucketFromId(const DocumentId &documentId) const override {
+    Bucket bucketFromId(const DocumentId &documentId) const override {
         if (documentId.getDocType() == "text/html") {
             return defaultBucket;
         }
         return Bucket(BucketSpace(0), BucketId(0));
     }
-    virtual BucketSpace bucketSpaceFromName(const std::string &bucketSpace) const override {
+    BucketSpace bucketSpaceFromName(const std::string &bucketSpace) const override {
         if (bucketSpace == defaultSpaceName) {
             return defaultBucketSpace;
         }
         return BucketSpace(0);
     }
-    virtual std::string nameFromBucketSpace(const document::BucketSpace &bucketSpace) const override {
+    std::string nameFromBucketSpace(const document::BucketSpace &bucketSpace) const override {
         if (bucketSpace == defaultBucketSpace) {
             return defaultSpaceName;
         }

--- a/storage/src/vespa/storageframework/generic/thread/taskthread.h
+++ b/storage/src/vespa/storageframework/generic/thread/taskthread.h
@@ -37,7 +37,7 @@ public:
     void pop() { _tasks.pop(); }
 
 private:
-    virtual ThreadWaitInfo doNonCriticalTick(ThreadIndex) override = 0;
+    ThreadWaitInfo doNonCriticalTick(ThreadIndex) override = 0;
 };
 
 template <typename Task>

--- a/streamingvisitors/src/tests/hitcollector/hitcollector_test.cpp
+++ b/streamingvisitors/src/tests/hitcollector/hitcollector_test.cpp
@@ -306,7 +306,7 @@ public:
           _bazValue()
     {}
     ~MyRankProgram();
-    virtual void run(uint32_t docid, const std::vector<search::fef::TermFieldMatchData> &) override {
+    void run(uint32_t docid, const std::vector<search::fef::TermFieldMatchData> &) override {
         _boxed_double = std::make_unique<DoubleValue>(docid + 30);
         _tensor = SimpleValue::from_spec(TensorSpec("tensor(x{})").add({{"x", "a"}}, docid + 20));
         _fooValue.as_number = docid + 10;

--- a/vbench/src/vbench/test/simple_http_result_handler.h
+++ b/vbench/src/vbench/test/simple_http_result_handler.h
@@ -19,10 +19,10 @@ private:
 
 public:
     SimpleHttpResultHandler();
-    ~SimpleHttpResultHandler();
-    virtual void handleHeader(const string &name, const string &value) override;
-    virtual void handleContent(const Memory &data) override;
-    virtual void handleFailure(const string &reason) override;
+    ~SimpleHttpResultHandler() override;
+    void handleHeader(const string &name, const string &value) override;
+    void handleContent(const Memory &data) override;
+    void handleFailure(const string &reason) override;
     const std::vector<std::pair<string, string> > &headers() const {
         return _headers;
     }

--- a/vespalib/src/tests/memory/memory_test.cpp
+++ b/vespalib/src/tests/memory/memory_test.cpp
@@ -17,7 +17,7 @@ class A : public B
 {
 public:
     ~A() override = default;
-    virtual A * clone() const override { return new A(*this); }
+    A * clone() const override { return new A(*this); }
 };
 
 TEST("require that MallocAutoPtr works as expected") {

--- a/vespalib/src/tests/util/generationhandler_stress/generation_handler_stress_test.cpp
+++ b/vespalib/src/tests/util/generationhandler_stress/generation_handler_stress_test.cpp
@@ -178,7 +178,7 @@ public:
           _context(context)
     {
     }
-    virtual void run() override { _f.readWork(*_context); }
+    void run() override { _f.readWork(*_context); }
 };
 
 class WriteWorkTask : public vespalib::Executor::Task
@@ -194,7 +194,7 @@ public:
           _context(context)
     {
     }
-    virtual void run() override { _f.writeWork(_cnt, *_context); }
+    void run() override { _f.writeWork(_cnt, *_context); }
 };
 
 }

--- a/vespalib/src/vespa/vespalib/data/slime/cursor.h
+++ b/vespalib/src/vespa/vespalib/data/slime/cursor.h
@@ -8,9 +8,9 @@
 namespace vespalib::slime {
 
 struct Cursor : public Inspector {
-    virtual Cursor &operator[](size_t idx) const override = 0;
-    virtual Cursor &operator[](Symbol sym) const override = 0;
-    virtual Cursor &operator[](Memory name) const override = 0;
+    Cursor &operator[](size_t idx) const override = 0;
+    Cursor &operator[](Symbol sym) const override = 0;
+    Cursor &operator[](Memory name) const override = 0;
 
     virtual Cursor &addNix() = 0;
     virtual Cursor &addBool(bool bit) = 0;

--- a/vespalib/src/vespa/vespalib/net/http/slime_explorer.h
+++ b/vespalib/src/vespa/vespalib/net/http/slime_explorer.h
@@ -22,9 +22,9 @@ private:
 
 public:
     SlimeExplorer(const slime::Inspector &self) : _self(self) {}
-    virtual void get_state(const slime::Inserter &inserter, bool full) const override;
-    virtual std::vector<std::string> get_children_names() const override;
-    virtual std::unique_ptr<StateExplorer> get_child(std::string_view name) const override;
+    void get_state(const slime::Inserter &inserter, bool full) const override;
+    std::vector<std::string> get_children_names() const override;
+    std::unique_ptr<StateExplorer> get_child(std::string_view name) const override;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/polymorphicarray.h
+++ b/vespalib/src/vespa/vespalib/util/polymorphicarray.h
@@ -70,7 +70,7 @@ public:
     using UP = std::unique_ptr<IArrayT>;
     virtual const B &operator[](size_t i) const = 0;
     virtual B &operator[](size_t i) = 0;
-    virtual IArrayT *clone() const override = 0;
+    IArrayT *clone() const override = 0;
     virtual iterator erase(iterator it) = 0;
     virtual const_iterator begin() const { return const_iterator(*this, 0); }
     virtual const_iterator end() const { return const_iterator(*this, size()); }


### PR DESCRIPTION
@toregge please review. Should be no functional changes.

Using both `virtual` and `override` as part of the same declaration is entirely redundant, but is also semantically iffy since `virtual` (at least to me) implies the _introduction_ of a vtable function entry, so the two keywords are saying mutually exclusive things.
