### PR TITLE
Disable http/2 h2c for token auth feeding from cli

### DIFF
--- a/client/go/internal/cli/cmd/feed.go
+++ b/client/go/internal/cli/cmd/feed.go
@@ -151,7 +151,9 @@ func createServices(n int, timeout time.Duration, cli *CLI, waiter *Waiter) ([]h
 		// Create a separate HTTP client for each service
 		client := cli.httpClientFactory(timeout)
 		// Feeding should always use HTTP/2
-		httputil.ForceHTTP2(client, service.TLSOptions.KeyPair, service.TLSOptions.CACertificatePEM, service.TLSOptions.TrustAll)
+		if authMethod != "token" {
+			httputil.ForceHTTP2(client, service.TLSOptions.KeyPair, service.TLSOptions.CACertificatePEM, service.TLSOptions.TrustAll)
+		}
 		service.SetClient(client)
 		services = append(services, service)
 	}


### PR DESCRIPTION
Disable token feeding over http/2 due to TLS/h2c issue. 