### PR TITLE
Prepare for more options in the sort spec for attribute vectors.

### DIFF
--- a/searchlib/src/vespa/searchcommon/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchcommon/attribute/CMakeLists.txt
@@ -5,6 +5,7 @@ vespa_add_library(searchcommon_searchcommon_attribute OBJECT
     basictype.cpp
     collectiontype.cpp
     config.cpp
+    default_sort_blob_writer.cpp
     search_context_params.cpp
     status.cpp
     DEPENDS

--- a/searchlib/src/vespa/searchcommon/attribute/default_sort_blob_writer.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/default_sort_blob_writer.cpp
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "default_sort_blob_writer.h"
+#include "iattributevector.h"
+
+namespace search::attribute {
+
+template <bool ascending>
+DefaultSortBlobWriter<ascending>::DefaultSortBlobWriter(const IAttributeVector& attr, const common::BlobConverter* converter)
+    : _attr(attr),
+      _converter(converter)
+{
+}
+
+template <bool ascending>
+long
+DefaultSortBlobWriter<ascending>::write(uint32_t docid, void* buf, long available) const
+{
+    if constexpr (ascending) {
+        return _attr.serializeForAscendingSort(docid, buf, available, _converter);
+    } else {
+        return _attr.serializeForDescendingSort(docid, buf, available, _converter);
+    }
+}
+
+template class DefaultSortBlobWriter<true>;
+template class DefaultSortBlobWriter<false>;
+
+}

--- a/searchlib/src/vespa/searchcommon/attribute/default_sort_blob_writer.h
+++ b/searchlib/src/vespa/searchcommon/attribute/default_sort_blob_writer.h
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "i_sort_blob_writer.h"
+
+namespace search::common { class BlobConverter; }
+
+namespace search::attribute {
+
+class IAttributeVector;
+
+/**
+ * Writer for sort blobs that uses the IAttributeVector serializeForXXXSort() API.
+ * This implementation is used in a transition period until serializeForXXXSort() is removed.
+ */
+template <bool ascending>
+class DefaultSortBlobWriter : public ISortBlobWriter {
+private:
+    const IAttributeVector& _attr;
+    const common::BlobConverter* _converter;
+
+public:
+    DefaultSortBlobWriter(const IAttributeVector& attr, const common::BlobConverter* converter);
+    long write(uint32_t docid, void* buf, long available) const override;
+};
+
+}

--- a/searchlib/src/vespa/searchcommon/attribute/i_sort_blob_writer.h
+++ b/searchlib/src/vespa/searchcommon/attribute/i_sort_blob_writer.h
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+
+namespace search::attribute {
+
+/**
+ * Interface for writing a serialized form of an attribute vector used for sorting.
+ * The serialized form can be used by memcmp() and sort order will be preserved.
+ */
+class ISortBlobWriter {
+public:
+    virtual ~ISortBlobWriter() = default;
+
+    /**
+     * Serialize and write the values for the given document into the given buffer.
+     *
+     * @param docid     The document id to serialize.
+     * @param buf       The buffer to serialize into.
+     * @param available Number of bytes available in the buffer.
+     * @return The number of bytes written, -1 if not enough space.
+     */
+    virtual long write(uint32_t docid, void* buf, long available) const = 0;
+};
+
+}

--- a/searchlib/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchlib/src/vespa/searchcommon/attribute/iattributevector.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include "collectiontype.h"
 #include "basictype.h"
+#include "collectiontype.h"
+#include "default_sort_blob_writer.h"
 #include <vespa/searchcommon/common/iblobconverter.h>
 #include <vespa/vespalib/datastore/atomic_entry_ref.h>
 #include <ostream>
@@ -24,6 +25,7 @@ namespace search::attribute {
 
 class IMultiValueAttribute;
 class ISearchContext;
+class ISortBlobWriter;
 class SearchContextParams;
 
 /**
@@ -459,6 +461,14 @@ public:
      */
     long serializeForDescendingSort(DocId doc, void * serTo, long available, const common::BlobConverter * bc=nullptr) const {
         return onSerializeForDescendingSort(doc, serTo, available, bc);
+    }
+
+    virtual std::unique_ptr<ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const {
+        if (ascending) {
+            return std::make_unique<DefaultSortBlobWriter<true>>(*this, converter);
+        } else {
+            return std::make_unique<DefaultSortBlobWriter<false>>(*this, converter);
+        }
     }
 
     /**

--- a/searchlib/src/vespa/searchlib/common/sortresults.h
+++ b/searchlib/src/vespa/searchlib/common/sortresults.h
@@ -12,6 +12,7 @@
 namespace search::attribute {
     class IAttributeContext;
     class IAttributeVector;
+    class ISortBlobWriter;
 }
 /**
  * Sort the given array of results.
@@ -72,14 +73,14 @@ public:
 
     struct VectorRef
     {
-        VectorRef(uint32_t type, const search::attribute::IAttributeVector * vector, const search::common::BlobConverter *converter) noexcept
-            : _type(type),
-              _vector(vector),
-              _converter(converter)
-        { }
+        VectorRef(uint32_t type, const search::attribute::IAttributeVector * vector, const search::common::BlobConverter *converter) noexcept;
         uint32_t                 _type;
         const search::attribute::IAttributeVector *_vector;
         const search::common::BlobConverter *_converter;
+        std::unique_ptr<search::attribute::ISortBlobWriter> _writer;
+        bool has_ascending_sort_order() const {
+            return _type == ASC_VECTOR || _type == ASC_RANK || _type == ASC_DOCID;
+        }
     };
 
     struct SortData : public search::RankedHit


### PR DESCRIPTION
This change allows selecting the appropriate implementation for writing sort blobs for attribute vectors at setup time instead of per document. Currently, only a default writer is used by calling the IAttributeVector::serializeForXXXSort() API. This API will be removed in the near future.

@toregge please review