### PR TITLE
Change MMAP madvise default to SEQUENTIAL for search.

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -89,7 +89,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default double feedConcurrency() { return 0.5; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double feedNiceness() { return 0.0; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int maxUnCommittedMemory() { return 130000; }
-        @ModelFeatureFlag(owners = {"vekterli"}) default String searchMmapAdvise() { return "NORMAL"; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default String searchMmapAdvise() { return "SEQUENTIAL"; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default boolean containerDumpHeapOnShutdownTimeout() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int heapSizePercentage() { return 0; }
         @ModelFeatureFlag(owners = {"bjorncs", "tokle"}) default List<String> allowedAthenzProxyIdentities() { return List.of(); }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -61,7 +61,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private double resourceLimitLowWatermarkDifference = 0.0;
     private double minNodeRatioPerGroup = 0.0;
     private int maxUnCommittedMemory = 123456;
-    private String searchMmapAdvise = "NORMAL";
+    private String searchMmapAdvise = "SEQUENTIAL";
     private boolean useV8GeoPositions = true;
     private List<String> environmentVariables = List.of();
     private int mbus_java_num_targets = 2;

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -132,7 +132,7 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
         try {
             return ProtonConfig.Search.Mmap.Advise.Enum.valueOf(searchMmapAdvise);
         } catch (Throwable t) {
-            return ProtonConfig.Search.Mmap.Advise.Enum.NORMAL;
+            return ProtonConfig.Search.Mmap.Advise.Enum.SEQUENTIAL;
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
@@ -46,7 +46,6 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
         tuneFlushConcurrentThreads(builder.flush);
         tuneSummaryReadIo(builder.summary.read);
         tuneSummaryCache(builder.summary.cache);
-        tuneSearchReadIo(builder.search.mmap);
     }
 
     private void tuneSummaryCache(ProtonConfig.Summary.Cache.Builder builder) {
@@ -96,12 +95,6 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
     private void tuneSummaryReadIo(ProtonConfig.Summary.Read.Builder builder) {
         if (resources.diskSpeed() == NodeResources.DiskSpeed.fast) {
             builder.io(ProtonConfig.Summary.Read.Io.DIRECTIO);
-        }
-    }
-
-    private void tuneSearchReadIo(ProtonConfig.Search.Mmap.Builder builder) {
-        if (resources.diskSpeed() == NodeResources.DiskSpeed.slow) {
-            builder.advise(ProtonConfig.Search.Mmap.Advise.SEQUENTIAL);
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
@@ -793,7 +793,7 @@ public class ContentBuilderTest extends DomBuilderTest {
         verifySearchMmapAdvise("NORMAL", ProtonConfig.Search.Mmap.Advise.Enum.NORMAL);
         verifySearchMmapAdvise("RANDOM", ProtonConfig.Search.Mmap.Advise.Enum.RANDOM);
         verifySearchMmapAdvise("SEQUENTIAL", ProtonConfig.Search.Mmap.Advise.Enum.SEQUENTIAL);
-        verifySearchMmapAdvise("UNKNOWN", ProtonConfig.Search.Mmap.Advise.Enum.NORMAL);
+        verifySearchMmapAdvise("UNKNOWN", ProtonConfig.Search.Mmap.Advise.Enum.SEQUENTIAL);
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/NodeResourcesTuningTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/NodeResourcesTuningTest.java
@@ -123,12 +123,6 @@ public class NodeResourcesTuningTest {
     }
 
     @Test
-    void require_that_search_read_mmap_advise_is_set_based_on_disk() {
-        assertSearchReadAdvise(ProtonConfig.Search.Mmap.Advise.NORMAL, true);
-        assertSearchReadAdvise(ProtonConfig.Search.Mmap.Advise.SEQUENTIAL, false);
-    }
-
-    @Test
     void require_that_summary_cache_max_bytes_is_set_based_on_memory() {
         assertEquals(1 * GiB / 25, configFromMemorySetting(1 + memoryOverheadGb, 0).summary().cache().maxbytes());
         assertEquals(256 * GiB / 25, configFromMemorySetting(256 + memoryOverheadGb, 0).summary().cache().maxbytes());

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -70,7 +70,7 @@ public class Flags {
             INSTANCE_ID);
 
     public static final UnboundStringFlag SEARCH_MMAP_ADVISE = defineStringFlag(
-            "search-mmap-advise", "NORMAL",
+            "search-mmap-advise", "SEQUENTIAL",
             List.of("vekterli"), "2025-02-14", "2025-06-01",
             "Sets the MMAP advise setting used for disk based posting lists on the content node. " +
             "Valid values are [NORMAL, RANDOM, SEQUENTIAL]",


### PR DESCRIPTION
Benchmarking of lexical search using a Wikipedia dataset has shown that madvise SEQUENTIAL for disk index posting list files results in lower 99 percentile query latencies and better utilization of the I/O subsystem.

@vekterli please review
@toregge FYI