### PR TITLE
Reapply "Implement sort blob writers for remaining attribute vectors"

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -1978,20 +1978,22 @@ TEST(DocumentMetaStoreTest, serialize_for_sort)
     EXPECT_EQ(12u, SZ);
     EXPECT_EQ(SZ, dms.getFixedWidth());
     uint8_t asc_dest[SZ];
-    EXPECT_EQ(0, dms.serializeForAscendingSort(3, asc_dest, sizeof(asc_dest), nullptr));
-    EXPECT_EQ(-1, dms.serializeForAscendingSort(1, asc_dest, sizeof(asc_dest) - 1, nullptr));
+    auto asc_writer = dms.make_sort_blob_writer(true, nullptr);
+    EXPECT_EQ(0, asc_writer->write(3, asc_dest, sizeof(asc_dest)));
+    EXPECT_EQ(-1, asc_writer->write(1, asc_dest, sizeof(asc_dest) - 1));
     document::GlobalId gid;
 
-    EXPECT_EQ(SZ, dms.serializeForAscendingSort(1, asc_dest, sizeof(asc_dest), nullptr));
+    EXPECT_EQ(SZ, asc_writer->write(1, asc_dest, sizeof(asc_dest)));
     EXPECT_TRUE(dms.getGid(1, gid));
     EXPECT_EQ(0, memcmp(asc_dest, gid.get(), SZ));
 
-    EXPECT_EQ(SZ, dms.serializeForAscendingSort(2, asc_dest, sizeof(asc_dest), nullptr));
+    EXPECT_EQ(SZ, asc_writer->write(2, asc_dest, sizeof(asc_dest)));
     EXPECT_TRUE(dms.getGid(2, gid));
     EXPECT_EQ(0, memcmp(asc_dest, gid.get(), SZ));
 
     uint8_t desc_dest[SZ];
-    EXPECT_EQ(SZ, dms.serializeForDescendingSort(2, desc_dest, sizeof(desc_dest), nullptr));
+    auto desc_writer = dms.make_sort_blob_writer(false, nullptr);
+    EXPECT_EQ(SZ, desc_writer->write(2, desc_dest, sizeof(desc_dest)));
     for (size_t i(0); i < SZ; i++) {
         EXPECT_EQ(0xff - asc_dest[i], desc_dest[i]);
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -1122,6 +1122,51 @@ DocumentMetaStore::onSerializeForDescendingSort(DocId lid, void * serTo, long av
     return document::GlobalId::LENGTH;
 }
 
+namespace {
+
+template <bool ascending>
+class DocumentMetaStoreSortBlobWriter : public search::attribute::ISortBlobWriter {
+private:
+    const DocumentMetaStore& _dms;
+public:
+    DocumentMetaStoreSortBlobWriter(const DocumentMetaStore& dms) noexcept : _dms(dms) {}
+    long write(uint32_t docid, void* buf, long available) const override;
+};
+
+template <bool ascending>
+long
+DocumentMetaStoreSortBlobWriter<ascending>::write(uint32_t docid, void* buf, long available) const
+{
+    if (!_dms.validLid(docid)) {
+        return 0;
+    }
+    if (available < document::GlobalId::LENGTH) {
+        return -1;
+    }
+    if constexpr (ascending) {
+        memcpy(buf, _dms.getRawMetaData(docid).getGid().get(), document::GlobalId::LENGTH);
+    } else {
+        const auto* src = static_cast<const uint8_t*>(_dms.getRawMetaData(docid).getGid().get());
+        auto* dst = static_cast<uint8_t*>(buf);
+        for (size_t i = 0; i < document::GlobalId::LENGTH; ++i) {
+            dst[i] = 0xff - src[i];
+        }
+    }
+    return document::GlobalId::LENGTH;
+}
+
+}
+
+std::unique_ptr<search::attribute::ISortBlobWriter>
+DocumentMetaStore::make_sort_blob_writer(bool ascending, const search::common::BlobConverter*) const
+{
+    if (ascending) {
+        return std::make_unique<DocumentMetaStoreSortBlobWriter<true>>(*this);
+    } else {
+        return std::make_unique<DocumentMetaStoreSortBlobWriter<false>>(*this);
+    }
+}
+
 }  // namespace proton
 
 namespace vespalib::btree {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -274,6 +274,7 @@ public:
     bool is_sortable() const noexcept override;
     long onSerializeForAscendingSort(DocId, void *, long, const search::common::BlobConverter *) const override;
     long onSerializeForDescendingSort(DocId, void *, long, const search::common::BlobConverter *) const override;
+    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const override;
 };
 
 }

--- a/searchlib/src/tests/attribute/imported_attribute_vector/imported_attribute_vector_test.cpp
+++ b/searchlib/src/tests/attribute/imported_attribute_vector/imported_attribute_vector_test.cpp
@@ -642,7 +642,8 @@ void check_make_sort_blob_writer_is_forwarded_with_remapped_lid() {
     FixtureT f;
     int dummy_tag;
     void* ser_to = &dummy_tag;
-    auto writer = f.get_imported_attr()->make_sort_blob_writer(true, &f.mock_converter);
+    auto read_guard = f.get_imported_attr();
+    auto writer = read_guard->make_sort_blob_writer(true, &f.mock_converter);
     EXPECT_TRUE(f.mock_target->_make_sort_blob_writer_called);
     EXPECT_TRUE(f.mock_target->_ascending);
     EXPECT_EQ(&f.mock_converter, f.mock_target->_bc);

--- a/searchlib/src/tests/attribute/raw_attribute/raw_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/raw_attribute/raw_attribute_test.cpp
@@ -110,27 +110,29 @@ TEST_F(RawAttributeTest, implements_serialize_for_sort) {
     memset(buf, 0, sizeof(buf));
     _attr->addDocs(10);
     _attr->commit();
-    EXPECT_EQ(1, _attr->serializeForAscendingSort(1, buf, sizeof(buf)));
+    auto asc_writer = _attr->make_sort_blob_writer(true, nullptr);
+    auto desc_writer = _attr->make_sort_blob_writer(false, nullptr);
+    EXPECT_EQ(1, asc_writer->write(1, buf, sizeof(buf)));
     EXPECT_EQ(0, buf[0]);
-    EXPECT_EQ(1, _attr->serializeForDescendingSort(1, buf, sizeof(buf)));
+    EXPECT_EQ(1, desc_writer->write(1, buf, sizeof(buf)));
     EXPECT_EQ(0xff, buf[0]);
     _raw->set_raw(1, raw_hello);
-    EXPECT_EQ(6, _attr->serializeForAscendingSort(1, buf, sizeof(buf)));
+    EXPECT_EQ(6, asc_writer->write(1, buf, sizeof(buf)));
     uint8_t hello_asc[] = {0x01+'h', 0x01+'e', 0x01+'l', 0x01+'l', 0x01+'o', 0x00};
     EXPECT_EQ(0, memcmp(hello_asc, buf, 6));
-    EXPECT_EQ(6, _attr->serializeForDescendingSort(1, buf, sizeof(buf)));
+    EXPECT_EQ(6, desc_writer->write(1, buf, sizeof(buf)));
     uint8_t hello_desc[] = {0xfe -'h', 0xfe -'e', 0xfe -'l', 0xfe -'l', 0xfe -'o', 0xff};
     EXPECT_EQ(0, memcmp(hello_desc, buf, 6));
     _raw->set_raw(1, escapes);
-    EXPECT_EQ(8, _attr->serializeForAscendingSort(1, buf, sizeof(buf)));
+    EXPECT_EQ(8, asc_writer->write(1, buf, sizeof(buf)));
     uint8_t escapes_asc[] = {0x02, 0x01, 0xff, 0xff, 0xff, 0xfe, 0x02, 0x00};
     EXPECT_EQ(0, memcmp(escapes_asc, buf, 8));
-    EXPECT_EQ(8, _attr->serializeForDescendingSort(1, buf, sizeof(buf)));
+    EXPECT_EQ(8, desc_writer->write(1, buf, sizeof(buf)));
     uint8_t escapes_desc[] = {0xfd, 0xfe, 0x00, 0x00, 0x00, 0x01, 0xfd, 0xff};
     EXPECT_EQ(0, memcmp(escapes_desc, buf, 8));
     _raw->set_raw(1, raw_long_hello);
-    EXPECT_EQ(-1, _attr->serializeForAscendingSort(1, buf, sizeof(buf)));
-    EXPECT_EQ(-1, _attr->serializeForDescendingSort(1, buf, sizeof(buf)));
+    EXPECT_EQ(-1, asc_writer->write(1, buf, sizeof(buf)));
+    EXPECT_EQ(-1, desc_writer->write(1, buf, sizeof(buf)));
 }
 
 TEST_F(RawAttributeTest, save_and_load)

--- a/searchlib/src/vespa/searchlib/attribute/attrvector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attrvector.h
@@ -130,6 +130,7 @@ private:
     long on_serialize_for_sort(DocId doc, void* serTo, long available) const;
     long onSerializeForAscendingSort(DocId doc, void* serTo, long available, const search::common::BlobConverter* bc) const override;
     long onSerializeForDescendingSort(DocId doc, void* serTo, long available, const search::common::BlobConverter* bc) const override;
+    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -229,5 +230,6 @@ private:
     long on_serialize_for_sort(DocId doc, void* serTo, long available, const search::common::BlobConverter* bc, bool asc) const;
     long onSerializeForAscendingSort(DocId doc, void* serTo, long available, const search::common::BlobConverter* bc) const override;
     long onSerializeForDescendingSort(DocId doc, void* serTo, long available, const search::common::BlobConverter* bc) const override;
+    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const override;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/attrvector.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attrvector.hpp
@@ -111,6 +111,24 @@ NumericDirectAttrVector<F, B>::on_serialize_for_sort(DocId doc, void* serTo, lon
     return writer.write(serTo, available);
 }
 
+template <typename BaseType, bool ascending>
+class NumericDirectSortBlobWriter : public search::attribute::ISortBlobWriter {
+private:
+    const std::vector<BaseType>& _data;
+    const std::vector<uint32_t>& _idx;
+public:
+    NumericDirectSortBlobWriter(const std::vector<BaseType>& data, const std::vector<uint32_t>& idx) noexcept
+        : _data(data), _idx(idx) {}
+    long write(uint32_t docid, void* buf, long available) const override {
+        search::attribute::NumericSortBlobWriter<BaseType, ascending> writer;
+        std::span<const BaseType> values(_data.data() + _idx[docid], _idx[docid + 1] - _idx[docid]);
+        for (auto& v : values) {
+            writer.candidate(v);
+        }
+        return writer.write(buf, available);
+    }
+};
+
 template <typename F, typename B>
 long
 NumericDirectAttrVector<F, B>::onSerializeForAscendingSort(DocId doc, void* serTo, long available, const search::common::BlobConverter* bc) const
@@ -129,6 +147,20 @@ NumericDirectAttrVector<F, B>::onSerializeForDescendingSort(DocId doc, void* ser
         return search::NumericDirectAttribute<B>::onSerializeForDescendingSort(doc, serTo, available, bc);
     }
     return on_serialize_for_sort<false>(doc, serTo, available);
+}
+
+template <typename F, typename B>
+std::unique_ptr<search::attribute::ISortBlobWriter>
+NumericDirectAttrVector<F, B>::make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const
+{
+    if (!F::IsMultiValue()) {
+        return search::NumericDirectAttribute<B>::make_sort_blob_writer(ascending, converter);
+    }
+    if (ascending) {
+        return std::make_unique<NumericDirectSortBlobWriter<BaseType, true>>(this->_data, this->_idx);
+    } else {
+        return std::make_unique<NumericDirectSortBlobWriter<BaseType, false>>(this->_data, this->_idx);
+    }
 }
 
 template <typename F>
@@ -167,6 +199,30 @@ StringDirectAttrVector<F>::on_serialize_for_sort(DocId doc, void* serTo, long av
     return writer.write();
 }
 
+class StringDirectSortBlobWriter : public search::attribute::ISortBlobWriter {
+private:
+    const std::vector<char>& _buffer;
+    const search::StringAttribute::OffsetVector& _offsets;
+    const std::vector<uint32_t>& _idx;
+    const search::common::BlobConverter* _converter;
+    bool _ascending;
+public:
+    StringDirectSortBlobWriter(const std::vector<char>& buffer, const search::StringAttribute::OffsetVector& offsets,
+                               const std::vector<uint32_t>& idx, const search::common::BlobConverter* converter,
+                               bool ascending)
+        : _buffer(buffer), _offsets(offsets), _idx(idx), _converter(converter), _ascending(ascending) {}
+    long write(uint32_t docid, void* buf, long available) const override {
+        search::attribute::StringSortBlobWriter writer(buf, available, _converter, _ascending);
+        std::span<const uint32_t> offsets(_offsets.data() + _idx[docid], _idx[docid + 1] - _idx[docid]);
+        for (auto& offset : offsets) {
+            if (!writer.candidate(&_buffer[offset])) {
+                return -1;
+            }
+        }
+        return writer.write();
+    }
+};
+
 template <typename F>
 bool
 StringDirectAttrVector<F>::is_sortable() const noexcept
@@ -192,4 +248,14 @@ StringDirectAttrVector<F>::onSerializeForDescendingSort(DocId doc, void* serTo, 
         return search::StringDirectAttribute::onSerializeForDescendingSort(doc, serTo, available, bc);
     }
     return on_serialize_for_sort(doc, serTo, available, bc, false);
+}
+
+template <typename F>
+std::unique_ptr<search::attribute::ISortBlobWriter>
+StringDirectAttrVector<F>::make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const
+{
+    if (!F::IsMultiValue()) {
+        return search::StringDirectAttribute::make_sort_blob_writer(ascending, converter);
+    }
+    return std::make_unique<StringDirectSortBlobWriter>(this->_buffer, this->_offsets, this->_idx, converter, ascending);
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -299,4 +299,24 @@ long ImportedAttributeVectorReadGuard::onSerializeForDescendingSort(DocId doc,
     return _target_attribute.serializeForDescendingSort(getTargetLid(doc), serTo, available, bc);
 }
 
+class ImportedAttributeVectorReadGuard::SortBlobWriter : public attribute::ISortBlobWriter {
+private:
+    const ImportedAttributeVectorReadGuard& _attr;
+    std::unique_ptr<attribute::ISortBlobWriter> _target_writer;
+
+public:
+    SortBlobWriter(const ImportedAttributeVectorReadGuard& attr,
+                   std::unique_ptr<attribute::ISortBlobWriter> target_writer)
+        : _attr(attr), _target_writer(std::move(target_writer))
+    {}
+    long write(uint32_t docid, void* buf, long available) const override {
+        return _target_writer->write(_attr.getTargetLid(docid), buf, available);
+    }
+};
+
+std::unique_ptr<attribute::ISortBlobWriter>
+ImportedAttributeVectorReadGuard::make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const {
+    return std::make_unique<SortBlobWriter>(*this, _target_attribute.make_sort_blob_writer(ascending, converter));
+}
+
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -91,6 +91,7 @@ public:
     const IArrayEnumReadView* make_read_view(ArrayEnumTag tag, vespalib::Stash& stash) const override;
     const IWeightedSetEnumReadView* make_read_view(WeightedSetEnumTag tag, vespalib::Stash& stash) const override;
 private:
+    class SortBlobWriter;
     using AtomicTargetLid = vespalib::datastore::AtomicValueWrapper<uint32_t>;
     using TargetLids = std::span<const AtomicTargetLid>;
     std::shared_ptr<MetaStoreReadGuard>  _target_document_meta_store_read_guard;
@@ -115,6 +116,7 @@ protected:
                                      const common::BlobConverter * bc) const override;
     long onSerializeForDescendingSort(DocId doc, void * serTo, long available,
                                       const common::BlobConverter * bc) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/raw_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/raw_attribute.cpp
@@ -60,6 +60,18 @@ long serialize_for_sort(std::span<const char> raw, void* serTo, long available)
     return raw.size() + extra;
 }
 
+template <bool desc>
+class RawAttributeSortBlobWriter : public ISortBlobWriter {
+private:
+    const RawAttribute& _attr;
+public:
+    RawAttributeSortBlobWriter(const RawAttribute& attr) noexcept : _attr(attr) {}
+    long write(uint32_t docid, void* buf, long available) const override {
+        auto raw = _attr.get_raw(docid);
+        return serialize_for_sort<desc>(raw, buf, available);
+    }
+};
+
 }
 
 bool
@@ -80,6 +92,17 @@ RawAttribute::onSerializeForDescendingSort(DocId doc, void* serTo, long availabl
 {
     auto raw = get_raw(doc);
     return serialize_for_sort<true>(raw, serTo, available);
+}
+
+std::unique_ptr<attribute::ISortBlobWriter>
+RawAttribute::make_sort_blob_writer(bool ascending, const common::BlobConverter*) const
+{
+    if (ascending) {
+        // Note: Template argument for the writer is "descending".
+        return std::make_unique<RawAttributeSortBlobWriter<false>>(*this);
+    } else {
+        return std::make_unique<RawAttributeSortBlobWriter<true>>(*this);
+    }
 }
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/raw_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/raw_attribute.h
@@ -18,6 +18,7 @@ public:
     bool is_sortable() const noexcept override;
     long onSerializeForAscendingSort(DocId doc, void* serTo, long available, const common::BlobConverter*) const override;
     long onSerializeForDescendingSort(DocId doc, void* serTo, long available, const common::BlobConverter*) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
 };
 
 }


### PR DESCRIPTION
This reapplies https://github.com/vespa-engine/vespa/pull/33666 with a fix.

@toregge please review

