### PR TITLE
Clean-up golang part

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -86,7 +86,6 @@ jobs:
           echo "Changes detected between ${previous_tag} and ${new_tag}."
           echo "has-changes=true" >> "${GITHUB_OUTPUT}"
 
-
   build-test:
     runs-on: ubuntu-latest
 
@@ -106,6 +105,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          working-directory: client/go
+          only-new-issues: true
 
       - name: build
         run: |

--- a/client/go/.golangci.yaml
+++ b/client/go/.golangci.yaml
@@ -1,0 +1,44 @@
+version: "2"
+linters:
+  enable:
+    - asciicheck
+    - bidichk
+    - copyloopvar
+    - dupword
+    - errname
+    - errorlint
+    - errcheck
+    - godot
+    - misspell
+    - musttag
+    - nakedret
+    - nilerr
+    - predeclared
+    - staticcheck
+    - unconvert
+    - unused
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/client/go/internal/admin/clusterstate/cluster_state.go
+++ b/client/go/internal/admin/clusterstate/cluster_state.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vespa-engine/vespa/client/go/internal/osutil"
 )
 
-// common struct used various places in the clustercontroller REST api:
+// common struct used various places in the clustercontroller REST api.
 type StateAndReason struct {
 	State  string `json:"state"`
 	Reason string `json:"reason"`
@@ -29,7 +29,7 @@ func (s *StateAndReason) writeTo(buf *strings.Builder) {
 	}
 }
 
-// cluster state as returned by the clustercontroller REST api:
+// cluster state as returned by the clustercontroller REST api.
 type ClusterState struct {
 	State struct {
 		Generated StateAndReason `json:"generated"`

--- a/client/go/internal/admin/clusterstate/cluster_state.go
+++ b/client/go/internal/admin/clusterstate/cluster_state.go
@@ -90,7 +90,7 @@ func (cs *ClusterState) String() string {
 }
 
 func (model *VespaModelConfig) getClusterState(cluster string) (*ClusterState, *ClusterControllerSpec) {
-	errs := make([]string, 0, 0)
+	errs := make([]string, 0)
 	ccs := model.findClusterControllers()
 	if len(ccs) == 0 {
 		trace.Trace("No cluster controllers found in vespa model:", model)

--- a/client/go/internal/admin/clusterstate/get_cluster_state.go
+++ b/client/go/internal/admin/clusterstate/get_cluster_state.go
@@ -17,9 +17,7 @@ import (
 )
 
 func NewGetClusterStateCmd() *cobra.Command {
-	var (
-		curOptions Options
-	)
+	var curOptions Options
 	cmd := &cobra.Command{
 		Use:               "vespa-get-cluster-state [-h] [-v] [-f] [-c cluster]",
 		Short:             "Get the cluster state of a given cluster.",

--- a/client/go/internal/admin/clusterstate/get_node_state.go
+++ b/client/go/internal/admin/clusterstate/get_node_state.go
@@ -32,9 +32,7 @@ const (
 )
 
 func NewGetNodeStateCmd() *cobra.Command {
-	var (
-		curOptions Options
-	)
+	var curOptions Options
 	cmd := &cobra.Command{
 		Use:               "vespa-get-node-state [-h] [-v] [-c cluster] [-t type] [-i index]",
 		Short:             "Get the state of a node.",

--- a/client/go/internal/admin/clusterstate/get_node_state.go
+++ b/client/go/internal/admin/clusterstate/get_node_state.go
@@ -88,7 +88,6 @@ func runGetNodeState(opts *Options) {
 			trace.Warning("no nodes for service type: ", s.serviceType)
 			continue
 		}
-
 	}
 }
 

--- a/client/go/internal/admin/clusterstate/known_state.go
+++ b/client/go/internal/admin/clusterstate/known_state.go
@@ -10,7 +10,6 @@ import (
 
 type KnownState string
 
-// these are all the valid node states:
 const (
 	StateUp          KnownState = "up"
 	StateDown        KnownState = "down"

--- a/client/go/internal/admin/clusterstate/known_state.go
+++ b/client/go/internal/admin/clusterstate/known_state.go
@@ -30,5 +30,5 @@ func knownState(s string) (KnownState, error) {
 			return v, nil
 		}
 	}
-	return KnownState("unknown"), fmt.Errorf("<Wanted State> must be one of %v, was %s\n", alternatives, s)
+	return KnownState("unknown"), fmt.Errorf("<Wanted State> must be one of %v, was %s", alternatives, s)
 }

--- a/client/go/internal/admin/clusterstate/options.go
+++ b/client/go/internal/admin/clusterstate/options.go
@@ -83,7 +83,7 @@ func (v *Options) String() string {
 	}
 	if v.NodeIndex >= 0 {
 		buf.WriteString(" node-index=")
-		buf.WriteString(strconv.Itoa(int(v.NodeIndex)))
+		buf.WriteString(strconv.Itoa(v.NodeIndex))
 	}
 	if v.WantedState != "" {
 		buf.WriteString(" WantedState=")

--- a/client/go/internal/admin/clusterstate/run_curl.go
+++ b/client/go/internal/admin/clusterstate/run_curl.go
@@ -6,6 +6,7 @@ package clusterstate
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -63,7 +64,8 @@ func curlPost(url string, input []byte) (string, error) {
 	trace.Trace("running curl:", cmd.String())
 	err = cmd.Run(&out, os.Stderr)
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			if ee.ProcessState.ExitCode() == 7 {
 				return "", fmt.Errorf("HTTP request to %s failed, could not connect", url)
 			}

--- a/client/go/internal/admin/clusterstate/set_node_state.go
+++ b/client/go/internal/admin/clusterstate/set_node_state.go
@@ -44,9 +44,9 @@ func NewSetNodeStateCmd() *cobra.Command {
 		Args: func(cmd *cobra.Command, args []string) error {
 			switch {
 			case len(args) < 1:
-				return fmt.Errorf("Missing <Wanted State>")
+				return fmt.Errorf("missing <Wanted State>")
 			case len(args) > 2:
-				return fmt.Errorf("Too many arguments, maximum is 2")
+				return fmt.Errorf("too many arguments, maximum is 2")
 			}
 			_, err := knownState(args[0])
 			return err

--- a/client/go/internal/admin/clusterstate/set_node_state.go
+++ b/client/go/internal/admin/clusterstate/set_node_state.go
@@ -33,9 +33,7 @@ that is currently down can not be forced into retired state, but can be forced i
 )
 
 func NewSetNodeStateCmd() *cobra.Command {
-	var (
-		curOptions Options
-	)
+	var curOptions Options
 	cmd := &cobra.Command{
 		Use:     usageSetNodeState,
 		Short:   "vespa-set-node-state [Options] <Wanted State> [Description]",

--- a/client/go/internal/admin/defaults/defaults.go
+++ b/client/go/internal/admin/defaults/defaults.go
@@ -156,9 +156,7 @@ func VespaConfigSourcesRpcAddrs() []string {
 	cs := VespaConfigserverRpcAddrs()
 	rv := make([]string, 0, len(cs)+1)
 	rv = append(rv, VespaConfigProxyRpcAddr())
-	for _, addr := range cs {
-		rv = append(rv, addr)
-	}
+	rv = append(rv, cs...)
 	return rv
 }
 

--- a/client/go/internal/admin/deploy/activate.go
+++ b/client/go/internal/admin/deploy/activate.go
@@ -38,7 +38,7 @@ func RunActivate(opts *Options, args []string) error {
 		fmt.Println("Timestamp: ", result.Deploy.Timestamp)
 		fmt.Println("Generation:", result.Application.Generation)
 	} else {
-		err = fmt.Errorf("Request failed. HTTP status code: %d\n%s", code, result.Message)
+		err = fmt.Errorf("request failed. HTTP status code: %d\n%s", code, result.Message)
 	}
 	return err
 }

--- a/client/go/internal/admin/deploy/cmd.go
+++ b/client/go/internal/admin/deploy/cmd.go
@@ -20,9 +20,7 @@ func reallySimpleHelp(cmd *cobra.Command, args []string) {
 }
 
 func NewDeployCmd() *cobra.Command {
-	var (
-		curOptions Options
-	)
+	var curOptions Options
 	if err := vespa.LoadDefaultEnv(); err != nil {
 		osutil.ExitErr(err)
 	}

--- a/client/go/internal/admin/deploy/curl.go
+++ b/client/go/internal/admin/deploy/curl.go
@@ -90,7 +90,7 @@ func runCurl(cmd *curl.Command, stdout io.Writer) error {
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
-			if ee.ProcessState.ExitCode() == 7 {
+			if ee.ExitCode() == 7 {
 				return fmt.Errorf("HTTP request failed. Could not connect to %s", cmd.URLPrefix())
 			}
 		}

--- a/client/go/internal/admin/deploy/curl.go
+++ b/client/go/internal/admin/deploy/curl.go
@@ -6,6 +6,7 @@ package deploy
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -87,7 +88,8 @@ func runCurl(cmd *curl.Command, stdout io.Writer) error {
 	trace.Trace("running curl:", cmd.String())
 	err := cmd.Run(stdout, os.Stderr)
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			if ee.ProcessState.ExitCode() == 7 {
 				return fmt.Errorf("HTTP request failed. Could not connect to %s", cmd.URLPrefix())
 			}

--- a/client/go/internal/admin/deploy/fetch.go
+++ b/client/go/internal/admin/deploy/fetch.go
@@ -44,7 +44,7 @@ func RunFetch(opts *Options, args []string) error {
 }
 
 func fetchDirectory(name string, input *bytes.Buffer) {
-	err := os.MkdirAll(name, 0755)
+	err := os.MkdirAll(name, 0o755)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
 		return

--- a/client/go/internal/admin/deploy/persist.go
+++ b/client/go/internal/admin/deploy/persist.go
@@ -26,7 +26,7 @@ func createVespaDeployDir() (string, error) {
 		return "", err
 	}
 	vespaDeployTempDir := filepath.Join(tempDir, currentUser.Username, vespaDeployDir)
-	if err := os.MkdirAll(vespaDeployTempDir, 0700); err != nil {
+	if err := os.MkdirAll(vespaDeployTempDir, 0o700); err != nil {
 		return "", err
 	}
 	return vespaDeployTempDir, nil
@@ -46,7 +46,7 @@ func createTenantDir(tenant string) string {
 		osutil.ExitErr(err)
 	}
 	tdir := filepath.Join(vespaDeployTempDir, tenant)
-	if err := os.MkdirAll(tdir, 0700); err != nil {
+	if err := os.MkdirAll(tdir, 0o700); err != nil {
 		osutil.ExitErr(err)
 	}
 	return tdir
@@ -54,7 +54,7 @@ func createTenantDir(tenant string) string {
 
 func writeConfigsourceUrlUsed(url string) {
 	fn := configsourceUrlUsedFile()
-	os.WriteFile(fn, []byte(url), 0600)
+	os.WriteFile(fn, []byte(url), 0o600)
 }
 
 func getConfigsourceUrlUsed() string {
@@ -70,7 +70,7 @@ func writeSessionIdToFile(tenant, newSessionId string) {
 	if newSessionId != "" {
 		dir := createTenantDir(tenant)
 		fn := filepath.Join(dir, sessionIdFileName)
-		os.WriteFile(fn, []byte(newSessionId), 0600)
+		os.WriteFile(fn, []byte(newSessionId), 0o600)
 		trace.Trace("wrote", newSessionId, "to", fn)
 	}
 }

--- a/client/go/internal/admin/deploy/prepare.go
+++ b/client/go/internal/admin/deploy/prepare.go
@@ -33,7 +33,7 @@ func RunPrepare(opts *Options, args []string) (err error) {
 	} else if looksLikeNumber(args[0]) {
 		response, err = doPrepare(opts, args[0])
 	} else {
-		err = fmt.Errorf("Command failed. No directory or zip file found: '%s'", args[0])
+		err = fmt.Errorf("command failed. No directory or zip file found: '%s'", args[0])
 	}
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func RunPrepare(opts *Options, args []string) (err error) {
 		fmt.Println(entry.Level+":", entry.Message)
 	}
 	if code != 200 {
-		return fmt.Errorf("Request failed. HTTP status code: %d\n%s", code, result.Message)
+		return fmt.Errorf("request failed. HTTP status code: %d\n%s", code, result.Message)
 	}
 	fmt.Println(result.Message)
 	return err

--- a/client/go/internal/admin/deploy/upload.go
+++ b/client/go/internal/admin/deploy/upload.go
@@ -43,7 +43,7 @@ func doUpload(opts *Options, args []string) (result string, err error) {
 		result, err = uploadToConfigSource(opts, src, args)
 		if err == nil {
 			writeConfigsourceUrlUsed(src)
-			return
+			break
 		}
 	}
 	return

--- a/client/go/internal/admin/deploy/upload.go
+++ b/client/go/internal/admin/deploy/upload.go
@@ -26,7 +26,7 @@ func RunUpload(opts *Options, args []string) error {
 		return err
 	}
 	if code != 200 {
-		return fmt.Errorf("Request failed. HTTP status code: %d\n%s", code, result.Message)
+		return fmt.Errorf("request failed. HTTP status code: %d\n%s", code, result.Message)
 	}
 	fmt.Println(result.Message)
 	writeSessionIdToFile(opts.Tenant, result.SessionID)
@@ -58,7 +58,7 @@ func uploadToConfigSource(opts *Options, src string, args []string) (string, err
 	} else {
 		f, err := os.Open(args[0])
 		if err != nil {
-			return "", fmt.Errorf("Command failed. No such directory found: '%s'", args[0])
+			return "", fmt.Errorf("command failed. No such directory found: '%s'", args[0])
 		}
 		defer f.Close()
 		st, err := f.Stat()
@@ -67,14 +67,14 @@ func uploadToConfigSource(opts *Options, src string, args []string) (string, err
 		}
 		if st.Mode().IsRegular() {
 			if !strings.HasSuffix(args[0], ".zip") {
-				return "", fmt.Errorf("Application must be a zip file, was '%s'", args[0])
+				return "", fmt.Errorf("application must be a zip file, was '%s'", args[0])
 			}
 			return uploadFile(opts, src, f, args[0])
 		}
 		if st.Mode().IsDir() {
 			return uploadDirectory(opts, src, args[0])
 		}
-		return "", fmt.Errorf("Bad arg '%s' with FileMode %v", args[0], st.Mode())
+		return "", fmt.Errorf("bad argument '%s' with FileMode %v", args[0], st.Mode())
 	}
 }
 

--- a/client/go/internal/admin/deploy/urls.go
+++ b/client/go/internal/admin/deploy/urls.go
@@ -25,7 +25,7 @@ func makeConfigsourceUrl(opts *Options) string {
 }
 
 func makeConfigsourceUrls(opts *Options) []string {
-	var results = make([]string, 0, 3)
+	results := make([]string, 0, 3)
 	if opts.ServerHost == "" {
 		home := vespa.FindHome()
 		backticks := osutil.BackTicksForwardStderr

--- a/client/go/internal/admin/jvm/container.go
+++ b/client/go/internal/admin/jvm/container.go
@@ -44,7 +44,7 @@ func (cb *containerBase) ConfigId() string {
 
 func keysOfMap(m map[string]string) []string {
 	keys := make([]string, 0, len(m))
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	return keys

--- a/client/go/internal/admin/jvm/mem_avail.go
+++ b/client/go/internal/admin/jvm/mem_avail.go
@@ -44,16 +44,15 @@ func readLineFrom(filename string) (string, error) {
 func vespa_cg2get(limitname string) (output string, err error) {
 	return vespa_cg2get_impl("", limitname)
 }
-func vespa_cg2get_impl(rootdir, limitname string) (output string, err error) {
-	_, err = os.Stat(rootdir + "/sys/fs/cgroup/cgroup.controllers")
-	if err != nil {
+func vespa_cg2get_impl(rootdir, limitname string) (string, error) {
+	if _, err := os.Stat(rootdir + "/sys/fs/cgroup/cgroup.controllers"); err != nil {
 		trace.Trace("no cgroups:", err)
-		return
+		return "", err
 	}
 	cgroup_content, err := readLineFrom(rootdir + "/proc/self/cgroup")
 	if err != nil {
 		trace.Trace("no cgroup for self:", err)
-		return
+		return "", err
 	}
 	min_value := "max"
 	path := rootdir + "/sys/fs/cgroup"

--- a/client/go/internal/admin/jvm/mem_avail.go
+++ b/client/go/internal/admin/jvm/mem_avail.go
@@ -44,6 +44,7 @@ func readLineFrom(filename string) (string, error) {
 func vespa_cg2get(limitname string) (output string, err error) {
 	return vespa_cg2get_impl("", limitname)
 }
+
 func vespa_cg2get_impl(rootdir, limitname string) (string, error) {
 	if _, err := os.Stat(rootdir + "/sys/fs/cgroup/cgroup.controllers"); err != nil {
 		trace.Trace("no cgroups:", err)

--- a/client/go/internal/admin/jvm/mem_avail_test.go
+++ b/client/go/internal/admin/jvm/mem_avail_test.go
@@ -11,9 +11,8 @@ import (
 func TestCg2Get(t *testing.T) {
 	trace.AdjustVerbosity(0)
 	const MM = "memory.max"
-	res, err := vespa_cg2get(MM)
 
-	res, err = vespa_cg2get_impl("mock-cg2/a", MM)
+	res, err := vespa_cg2get_impl("mock-cg2/a", MM)
 	assert.Nil(t, err)
 	assert.Equal(t, "123", res)
 

--- a/client/go/internal/admin/jvm/mem_options.go
+++ b/client/go/internal/admin/jvm/mem_options.go
@@ -39,7 +39,7 @@ func (opts *Options) CurMaxHeapSize(fallback AmountOfMemory) AmountOfMemory {
 
 func (opts *Options) AddDefaultHeapSizeArgs(minHeapSize, maxHeapSize AmountOfMemory) {
 	trace.Trace("AddDefaultHeapSizeArgs", minHeapSize, "/", maxHeapSize)
-	minHeapSize = opts.CurMinHeapSize(minHeapSize)
+	opts.CurMinHeapSize(minHeapSize)
 	maxHeapSize = opts.CurMaxHeapSize(maxHeapSize)
 	opts.MaybeAddHugepages(maxHeapSize)
 }

--- a/client/go/internal/admin/jvm/mem_options.go
+++ b/client/go/internal/admin/jvm/mem_options.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (opts *Options) getOrSetHeapSize(prefix string, heapSize AmountOfMemory) AmountOfMemory {
-	var missing bool = true
+	var missing = true
 	for _, x := range opts.jvmArgs {
 		if strings.HasPrefix(x, prefix) {
 			x = strings.TrimPrefix(x, prefix)

--- a/client/go/internal/admin/jvm/mem_options.go
+++ b/client/go/internal/admin/jvm/mem_options.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (opts *Options) getOrSetHeapSize(prefix string, heapSize AmountOfMemory) AmountOfMemory {
-	var missing = true
+	missing := true
 	for _, x := range opts.jvmArgs {
 		if strings.HasPrefix(x, prefix) {
 			x = strings.TrimPrefix(x, prefix)

--- a/client/go/internal/admin/jvm/mem_options_test.go
+++ b/client/go/internal/admin/jvm/mem_options_test.go
@@ -11,9 +11,9 @@ func TestAdjustment(t *testing.T) {
 	lastAdj := 64
 	for i := range 4096 {
 		adj := adjustAvailableMemory(MegaBytesOfMemory(i)).ToMB()
-		assert.True(t, int(adj) >= lastAdj)
-		lastAdj = int(adj)
+		assert.True(t, adj >= lastAdj)
+		lastAdj = adj
 	}
 	adj := adjustAvailableMemory(MegaBytesOfMemory(30700)).ToMB()
-	assert.Equal(t, 30000, int(adj))
+	assert.Equal(t, 30000, adj)
 }

--- a/client/go/internal/admin/jvm/memory.go
+++ b/client/go/internal/admin/jvm/memory.go
@@ -83,7 +83,7 @@ func ParseJvmMemorySpec(spec string) (result AmountOfMemory, err error) {
 		case 'g', 'G':
 			result = GigaBytesOfMemory(int(val))
 		default:
-			err = fmt.Errorf("Unknown suffix in JVM memory spec '%s'", spec)
+			err = fmt.Errorf("unknown suffix in JVM memory spec '%s'", spec)
 		}
 	}
 	return

--- a/client/go/internal/admin/jvm/memory.go
+++ b/client/go/internal/admin/jvm/memory.go
@@ -21,12 +21,15 @@ type AmountOfMemory struct {
 func BytesOfMemory(v int64) AmountOfMemory {
 	return AmountOfMemory{numBytes: v}
 }
+
 func KiloBytesOfMemory(v int64) AmountOfMemory {
 	return BytesOfMemory(v * PowerOfTwo10)
 }
+
 func MegaBytesOfMemory(v int) AmountOfMemory {
 	return BytesOfMemory(int64(v) * PowerOfTwo20)
 }
+
 func GigaBytesOfMemory(v int) AmountOfMemory {
 	return BytesOfMemory(int64(v) * PowerOfTwo30)
 }
@@ -34,15 +37,19 @@ func GigaBytesOfMemory(v int) AmountOfMemory {
 func (v AmountOfMemory) ToBytes() int64 {
 	return v.numBytes
 }
+
 func (v AmountOfMemory) ToKB() int64 {
 	return v.numBytes / PowerOfTwo10
 }
+
 func (v AmountOfMemory) ToMB() int {
 	return int(v.numBytes / PowerOfTwo20)
 }
+
 func (v AmountOfMemory) ToGB() int {
 	return int(v.numBytes / PowerOfTwo30)
 }
+
 func (v AmountOfMemory) AsJvmSpec() string {
 	val := v.ToKB()
 	suffix := "k"

--- a/client/go/internal/admin/jvm/options.go
+++ b/client/go/internal/admin/jvm/options.go
@@ -29,8 +29,8 @@ func NewOptions(c Container) *Options {
 	fixSpec := osutil.FixSpec{
 		UserId:   vespaUid,
 		GroupId:  vespaGid,
-		DirMode:  0755,
-		FileMode: 0644,
+		DirMode:  0o755,
+		FileMode: 0o644,
 	}
 	return &Options{
 		container:   c,

--- a/client/go/internal/admin/jvm/properties.go
+++ b/client/go/internal/admin/jvm/properties.go
@@ -99,7 +99,7 @@ func writeEnvAsProperties(envv []string, propsFile string) {
 		panic("missing propsFile")
 	}
 	trace.Trace("write props file:", propsFile)
-	err := os.WriteFile(propsFile, envAsProperties(envv), 0600)
+	err := os.WriteFile(propsFile, envAsProperties(envv), 0o600)
 	if err != nil {
 		osutil.ExitErr(err)
 	}

--- a/client/go/internal/admin/prog/numactl.go
+++ b/client/go/internal/admin/prog/numactl.go
@@ -67,8 +67,6 @@ func (p *Spec) prependNumaCtl(args []string) []string {
 		result = append(result, "--interleave")
 		result = append(result, "all")
 	}
-	for _, arg := range args {
-		result = append(result, arg)
-	}
+	result = append(result, args...)
 	return result
 }

--- a/client/go/internal/admin/prog/numactl_test.go
+++ b/client/go/internal/admin/prog/numactl_test.go
@@ -17,7 +17,7 @@ func setup(t *testing.T, testFileName string) {
 	trace.AdjustVerbosity(1)
 	mockBinParent = strings.TrimSuffix(testFileName, "/numactl_test.go")
 	tmpBin = t.TempDir() + "/mock.bin.numactl_test"
-	err := os.MkdirAll(tmpBin, 0755)
+	err := os.MkdirAll(tmpBin, 0o755)
 	assert.Nil(t, err)
 	t.Setenv("PATH", fmt.Sprintf("%s:%s", tmpBin, os.Getenv("PATH")))
 }

--- a/client/go/internal/admin/prog/numactl_test.go
+++ b/client/go/internal/admin/prog/numactl_test.go
@@ -86,5 +86,4 @@ func TestNumaCtlDetection(t *testing.T) {
 	spec.ConfigureNumaCtl()
 	assert.Equal(t, true, spec.shouldUseNumaCtl)
 	assert.Equal(t, 0, spec.numaSocket)
-
 }

--- a/client/go/internal/admin/prog/valgrind.go
+++ b/client/go/internal/admin/prog/valgrind.go
@@ -69,12 +69,8 @@ func (p *Spec) valgrindLogOption() string {
 func (p *Spec) prependValgrind(args []string) []string {
 	result := make([]string, 0, 15+len(args))
 	result = append(result, VALGRIND_PROG)
-	for _, arg := range p.valgrindOptions() {
-		result = append(result, arg)
-	}
+	result = append(result, p.valgrindOptions()...)
 	result = append(result, p.valgrindLogOption())
-	for _, arg := range args {
-		result = append(result, arg)
-	}
+	result = append(result, args...)
 	return result
 }

--- a/client/go/internal/admin/prog/valgrind_test.go
+++ b/client/go/internal/admin/prog/valgrind_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/vespa-engine/vespa/client/go/internal/osutil"
 )
 
-var tmpBin string
-var mockBinParent string
+var (
+	tmpBin        string
+	mockBinParent string
+)
 
 func useMock(prog, target string) {
 	mock := fmt.Sprintf("%s/mockbin/%s", mockBinParent, prog)
@@ -31,7 +33,7 @@ func setupValgrind(t *testing.T, testFileName string) {
 	t.Setenv("VESPA_HOME", mockBinParent+"/mock_vespahome")
 	mockBinParent = strings.TrimSuffix(testFileName, "/valgrind_test.go")
 	tmpBin = t.TempDir() + "/mock.bin.valgrind_test"
-	err := os.MkdirAll(tmpBin, 0755)
+	err := os.MkdirAll(tmpBin, 0o755)
 	assert.Nil(t, err)
 	t.Setenv("PATH", fmt.Sprintf("%s:%s", tmpBin, os.Getenv("PATH")))
 }

--- a/client/go/internal/admin/vespa-wrapper/configserver/fix_dirs_and_files.go
+++ b/client/go/internal/admin/vespa-wrapper/configserver/fix_dirs_and_files.go
@@ -13,8 +13,8 @@ func makeFixSpec() osutil.FixSpec {
 	return osutil.FixSpec{
 		UserId:   vespaUid,
 		GroupId:  vespaGid,
-		DirMode:  0755,
-		FileMode: 0644,
+		DirMode:  0o755,
+		FileMode: 0o644,
 	}
 }
 

--- a/client/go/internal/admin/vespa-wrapper/logfmt/cmd.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/cmd.go
@@ -22,9 +22,7 @@ func RunCmdLine() {
 }
 
 func NewLogfmtCmd() *cobra.Command {
-	var (
-		curOptions Options = NewOptions()
-	)
+	curOptions := NewOptions()
 	cmd := &cobra.Command{
 		Use:   "vespa-logfmt",
 		Short: "convert vespa.log to human-readable format",

--- a/client/go/internal/admin/vespa-wrapper/logfmt/formatflags.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/formatflags.go
@@ -9,7 +9,7 @@ import (
 type OutputFormat int
 
 const (
-	FormatVespa OutputFormat = iota //default is vespa
+	FormatVespa OutputFormat = iota // default is vespa
 	FormatRaw
 	FormatJSON
 )

--- a/client/go/internal/admin/vespa-wrapper/logfmt/plusminusflag.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/plusminusflag.go
@@ -34,8 +34,8 @@ func applyPlusMinus(val string, target plusMinusFlag) error {
 	val = strings.ReplaceAll(val, "+", ",+")
 	if target.unchanged() {
 		// user wants to reset flags?
-		if minus == false && plus == false {
-			for k, _ := range target.flags() {
+		if !minus && !plus {
+			for k := range target.flags() {
 				target.flags()[k] = false
 			}
 		}
@@ -54,7 +54,7 @@ func applyPlusMinus(val string, target plusMinusFlag) error {
 			continue
 		}
 		if k == "all" {
-			for k, _ := range target.flags() {
+			for k := range target.flags() {
 				target.flags()[k] = changeTo
 			}
 		} else if _, ok := target.flags()[k]; !ok {

--- a/client/go/internal/admin/vespa-wrapper/logfmt/regexflag_test.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/regexflag_test.go
@@ -5,9 +5,10 @@
 package logfmt
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func assertMatch(t *testing.T, re string, flag *regexFlag, texts ...string) {

--- a/client/go/internal/admin/vespa-wrapper/logfmt/showflags_test.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/showflags_test.go
@@ -5,10 +5,11 @@
 package logfmt
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShowFlags(t *testing.T) {

--- a/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
@@ -69,26 +69,26 @@ func (t *unixTail) openTail() {
 	if err != nil {
 		return
 	}
-	sz, err := file.Seek(0, os.SEEK_END)
+	sz, err := file.Seek(0, io.SeekEnd)
 	if err != nil {
 		return
 	}
 	if sz < lastLinesSize {
-		sz, err = file.Seek(0, os.SEEK_SET)
+		sz, err = file.Seek(0, io.SeekStart)
 		if err == nil {
 			// just read from start of file, all OK
 			t.setFile(file)
 		}
 		return
 	}
-	sz, _ = file.Seek(-lastLinesSize, os.SEEK_END)
+	sz, _ = file.Seek(-lastLinesSize, io.SeekEnd)
 	n, err := file.Read(t.lineBuf)
 	if err != nil {
 		return
 	}
 	for i := range n {
 		if t.lineBuf[i] == '\n' {
-			sz, err = file.Seek(sz+int64(i+1), os.SEEK_SET)
+			sz, err = file.Seek(sz+int64(i+1), io.SeekStart)
 			if err == nil {
 				t.setFile(file)
 			}
@@ -147,16 +147,16 @@ loop:
 			continue
 		}
 		if err == io.EOF {
-			pos, _ := t.curFile.Seek(0, os.SEEK_CUR)
+			pos, _ := t.curFile.Seek(0, io.SeekCurrent)
 			for cnt := 0; cnt < 100; cnt++ {
 				time.Sleep(10 * time.Millisecond)
-				sz, _ := t.curFile.Seek(0, os.SEEK_END)
+				sz, _ := t.curFile.Seek(0, io.SeekEnd)
 				if sz != pos {
 					if sz < pos {
 						// truncation case
 						pos = 0
 					}
-					t.curFile.Seek(pos, os.SEEK_SET)
+					t.curFile.Seek(pos, io.SeekStart)
 					continue loop
 				}
 			}

--- a/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
@@ -8,6 +8,7 @@ package logfmt
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -136,7 +137,7 @@ loop:
 		}
 		bytes, err := t.reader.ReadSlice('\n')
 		t.lineBuf = append(t.lineBuf, bytes...)
-		if err == bufio.ErrBufferFull {
+		if errors.Is(err, bufio.ErrBufferFull) {
 			continue
 		}
 		if err == nil {

--- a/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
@@ -74,7 +74,7 @@ func (t *unixTail) openTail() {
 		return
 	}
 	if sz < lastLinesSize {
-		sz, err = file.Seek(0, io.SeekStart)
+		_, err = file.Seek(0, io.SeekStart)
 		if err == nil {
 			// just read from start of file, all OK
 			t.setFile(file)
@@ -88,7 +88,7 @@ func (t *unixTail) openTail() {
 	}
 	for i := range n {
 		if t.lineBuf[i] == '\n' {
-			sz, err = file.Seek(sz+int64(i+1), io.SeekStart)
+			_, err = file.Seek(sz+int64(i+1), io.SeekStart)
 			if err == nil {
 				t.setFile(file)
 			}

--- a/client/go/internal/admin/vespa-wrapper/services/start.go
+++ b/client/go/internal/admin/vespa-wrapper/services/start.go
@@ -40,7 +40,7 @@ func checkjava() {
 		osutil.ExitErr(err)
 	}
 	if !strings.Contains(out, "64-Bit Server VM") {
-		osutil.ExitErr(fmt.Errorf("java must invoke the 64-bit Java VM, but -version says:\n%s\n", out))
+		osutil.ExitErr(fmt.Errorf("java must invoke the 64-bit Java VM, but -version says:\n%s", out))
 	}
 }
 

--- a/client/go/internal/admin/vespa-wrapper/services/tuning.go
+++ b/client/go/internal/admin/vespa-wrapper/services/tuning.go
@@ -55,7 +55,7 @@ func drop_caches() {
 
 func increase_vm_max_map_count() {
 	const need_minimum = 262144
-	var min_as_text string = strconv.Itoa(need_minimum)
+	min_as_text := strconv.Itoa(need_minimum)
 	const name = "vm.max_map_count"
 	trace.Debug("Checking: " + VM_MAX_MAP_COUNT)
 	data, err := os.ReadFile(VM_MAX_MAP_COUNT)

--- a/client/go/internal/admin/vespa-wrapper/startcbinary/common_env.go
+++ b/client/go/internal/admin/vespa-wrapper/startcbinary/common_env.go
@@ -40,7 +40,6 @@ func configureCommonEnv(spec *prog.Spec) {
 		"vespa-configproxy-cmd",
 		"vespa-config-status",
 	}, " "))
-
 }
 
 func configurePath(spec *prog.Spec) {

--- a/client/go/internal/build/build.go
+++ b/client/go/internal/build/build.go
@@ -1,4 +1,4 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package build
 
-var Version string = "0.0.0-devel" // Overriden by linker flag as part of build
+var Version string = "0.0.0-devel" // Overridden by linker flag as part of build

--- a/client/go/internal/cli/auth/auth0/auth0.go
+++ b/client/go/internal/cli/auth/auth0/auth0.go
@@ -212,7 +212,7 @@ func (a *Client) RemoveCredentials() error {
 
 func writeConfig(provider auth0Provider, path string) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	version := 1
@@ -227,7 +227,7 @@ func writeConfig(provider auth0Provider, path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, jsonConfig, 0600)
+	return os.WriteFile(path, jsonConfig, 0o600)
 }
 
 func readConfig(path string) (auth0Provider, error) {

--- a/client/go/internal/cli/auth/auth0/auth0.go
+++ b/client/go/internal/cli/auth/auth0/auth0.go
@@ -104,7 +104,7 @@ func NewClient(httpClient httputil.Client, options Options) (*Client, error) {
 
 func (a *Client) getDeviceFlowConfig() (flowConfig, error) {
 	url := a.options.SystemURL + "/auth0/v1/device-flow-config"
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return flowConfig{}, err
 	}

--- a/client/go/internal/cli/auth/auth0/auth0_test.go
+++ b/client/go/internal/cli/auth/auth0/auth0_test.go
@@ -32,7 +32,7 @@ func TestConfigWriting(t *testing.T) {
 	creds1 := Credentials{
 		AccessToken: "some-token",
 		Scopes:      []string{"foo", "bar"},
-		ExpiresAt:   time.Date(2022, 03, 01, 15, 45, 50, 0, time.UTC),
+		ExpiresAt:   time.Date(2022, 0o3, 0o1, 15, 45, 50, 0, time.UTC),
 	}
 	require.Nil(t, client.WriteCredentials(creds1))
 	expected := `{
@@ -62,7 +62,7 @@ func TestConfigWriting(t *testing.T) {
 	creds2 := Credentials{
 		AccessToken: "another-token",
 		Scopes:      []string{"baz"},
-		ExpiresAt:   time.Date(2022, 03, 01, 15, 45, 50, 0, time.UTC),
+		ExpiresAt:   time.Date(2022, 0o3, 0o1, 15, 45, 50, 0, time.UTC),
 	}
 	require.Nil(t, client.WriteCredentials(creds2))
 	expected = `{

--- a/client/go/internal/cli/auth/secrets.go
+++ b/client/go/internal/cli/auth/secrets.go
@@ -8,8 +8,10 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
-type realKeyring struct{}
-type dummyKeyring struct{}
+type (
+	realKeyring  struct{}
+	dummyKeyring struct{}
+)
 
 func NewKeyring() SecretStore {
 	if env := os.Getenv("VESPA_CLI_DUMMY_KEYRING"); env != "" {
@@ -39,7 +41,7 @@ func dummyRingFileName(namespace, key string) (string, error) {
 		return "", err
 	}
 	home := userHome + "/.vespa"
-	if err := os.MkdirAll(home, 0700); err != nil {
+	if err := os.MkdirAll(home, 0o700); err != nil {
 		return "", err
 	}
 	return home + "/keyring." + namespace + "." + key, nil
@@ -51,7 +53,7 @@ func (k *dummyKeyring) Set(namespace, key, value string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(fn, []byte(value), 0400)
+	return os.WriteFile(fn, []byte(value), 0o400)
 }
 
 // Get gets a value for the given namespace and key.

--- a/client/go/internal/cli/auth/zts/zts.go
+++ b/client/go/internal/cli/auth/zts/zts.go
@@ -71,7 +71,7 @@ func (c *Client) Authenticate(request *http.Request) error {
 // AccessToken returns an access token within the domain configured in client c.
 func (c *Client) AccessToken() (Token, error) {
 	data := fmt.Sprintf("grant_type=client_credentials&scope=%s:domain", c.domain)
-	req, err := http.NewRequest("POST", c.tokenURL.String(), strings.NewReader(data))
+	req, err := http.NewRequest(http.MethodPost, c.tokenURL.String(), strings.NewReader(data))
 	if err != nil {
 		return Token{}, err
 	}

--- a/client/go/internal/cli/cmd/api_key.go
+++ b/client/go/internal/cli/cmd/api_key.go
@@ -82,7 +82,7 @@ func doApiKey(cli *CLI, overwriteKey bool, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not create api key: %w", err)
 	}
-	if err := os.WriteFile(apiKeyFile, apiKey, 0600); err == nil {
+	if err := os.WriteFile(apiKeyFile, apiKey, 0o600); err == nil {
 		cli.printSuccess("Developer private key for tenant ", color.CyanString(app.Tenant), " written to '", apiKeyFile, "'")
 		return printPublicKey(system, apiKeyFile, app.Tenant)
 	} else {

--- a/client/go/internal/cli/cmd/api_key.go
+++ b/client/go/internal/cli/cmd/api_key.go
@@ -76,7 +76,7 @@ func doApiKey(cli *CLI, overwriteKey bool, args []string) error {
 		err := fmt.Errorf("refusing to overwrite '%s'", apiKeyFile)
 		cli.printErr(err, "Use -f to overwrite it")
 		printPublicKey(system, apiKeyFile, app.Tenant)
-		return ErrCLI{error: err, quiet: true}
+		return CLIError{error: err, quiet: true}
 	}
 	apiKey, err := vespa.CreateAPIKey()
 	if err != nil {

--- a/client/go/internal/cli/cmd/auth_show.go
+++ b/client/go/internal/cli/cmd/auth_show.go
@@ -56,7 +56,7 @@ func doAuthShow(cli *CLI, args []string) error {
 		return err
 	}
 	url := service.BaseURL + "/user/v1/user"
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -223,7 +223,7 @@ func copyCertificate(tlsOptions vespa.TLSOptions, cli *CLI, pkg vespa.Applicatio
 		return errHint(fmt.Errorf("could not read certificate file: %w", err))
 	}
 	dstPath := filepath.Join(pkg.Path, "security", "clients.pem")
-	if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 		return fmt.Errorf("could not create security directory: %w", err)
 	}
 	err = ioutil.AtomicWriteFile(dstPath, data)

--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -52,7 +52,7 @@ func testCert(t *testing.T, subcommand []string) {
 func TestCertCompressedPackage(t *testing.T) {
 	_, pkgDir := mock.ApplicationPackageDir(t, true, false)
 	zipFile := filepath.Join(pkgDir, "target", "application.zip")
-	err := os.MkdirAll(filepath.Dir(zipFile), 0755)
+	err := os.MkdirAll(filepath.Dir(zipFile), 0o755)
 	assert.Nil(t, err)
 	_, err = os.Create(zipFile)
 	assert.Nil(t, err)

--- a/client/go/internal/cli/cmd/clone.go
+++ b/client/go/internal/cli/cmd/clone.go
@@ -78,7 +78,7 @@ type zipFile struct {
 }
 
 func (c *cloner) createDirectory(path string) error {
-	if err := os.Mkdir(path, 0755); err != nil {
+	if err := os.Mkdir(path, 0o755); err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			entries, err := os.ReadDir(path)
 			if err != nil {
@@ -280,7 +280,7 @@ func copyFromZip(f *zip.File, destinationDir string, zipEntryPrefix string) erro
 	destinationPath := filepath.Join(destinationDir, filepath.FromSlash(strings.TrimPrefix(f.Name, zipEntryPrefix)))
 	if strings.HasSuffix(f.Name, "/") {
 		if f.Name != zipEntryPrefix { // root is already created
-			if err := os.Mkdir(destinationPath, 0755); err != nil {
+			if err := os.Mkdir(destinationPath, 0o755); err != nil {
 				return err
 			}
 		}

--- a/client/go/internal/cli/cmd/clone.go
+++ b/client/go/internal/cli/cmd/clone.go
@@ -212,7 +212,7 @@ func (c *cloner) downloadZip(cachedFiles []zipFile) (string, bool, error) {
 	// the cached copy if GitHub is unavailable.
 	cacheHit := zipPath != ""
 	err := c.cli.spinner(c.cli.Stderr, color.YellowString("Downloading sample apps ..."), func() error {
-		request, err := http.NewRequest("GET", "https://github.com/vespa-engine/sample-apps/archive/refs/heads/master.zip", nil)
+		request, err := http.NewRequest(http.MethodGet, "https://github.com/vespa-engine/sample-apps/archive/refs/heads/master.zip", nil)
 		if err != nil {
 			return fmt.Errorf("invalid url: %w", err)
 		}

--- a/client/go/internal/cli/cmd/clone_list.go
+++ b/client/go/internal/cli/cmd/clone_list.go
@@ -37,7 +37,7 @@ func listSampleAppsAt(url string, client httputil.Client) ([]string, error) {
 }
 
 func getRepositoryFiles(url string, client httputil.Client) ([]repositoryFile, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/go/internal/cli/cmd/clone_test.go
+++ b/client/go/internal/cli/cmd/clone_test.go
@@ -51,7 +51,7 @@ func TestClone(t *testing.T) {
 
 	// Clone to current directory (dot)
 	emptyDir := filepath.Join(tempDir, "mypath1")
-	require.Nil(t, os.Mkdir(emptyDir, 0755))
+	require.Nil(t, os.Mkdir(emptyDir, 0o755))
 	require.Nil(t, os.Chdir(emptyDir))
 	httpClient.NextStatus(http.StatusNotModified)
 	require.Nil(t, cli.Run("clone", sampleAppName, "."))
@@ -62,7 +62,7 @@ func TestClone(t *testing.T) {
 	// Clone to non-empty directory
 	httpClient.NextStatus(http.StatusNotModified)
 	nonEmptyDir := filepath.Join(tempDir, "mypath2")
-	require.Nil(t, os.MkdirAll(filepath.Join(nonEmptyDir, "more"), 0755))
+	require.Nil(t, os.MkdirAll(filepath.Join(nonEmptyDir, "more"), 0o755))
 	require.NotNil(t, cli.Run("clone", sampleAppName, nonEmptyDir))
 	assert.Equal(t, "Error: could not create directory: "+nonEmptyDir+" already exists and is not empty\n", stderr.String())
 	stderr.Reset()
@@ -112,5 +112,5 @@ func assertFiles(t *testing.T, app string) {
 
 	scriptStat, err := os.Stat(filepath.Join(app, "bin", "convert-msmarco.sh"))
 	require.Nil(t, err)
-	assert.Equal(t, os.FileMode(0755), scriptStat.Mode())
+	assert.Equal(t, os.FileMode(0o755), scriptStat.Mode())
 }

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -478,7 +478,6 @@ func (c *Config) readTLSOptions(app vespa.ApplicationID, targetType string) (ves
 		options.PrivateKeyFile = keyFile
 	} else {
 		return vespa.TLSOptions{}, err
-
 	}
 	// CA certificate
 	_, options.TrustAll = c.environment["VESPA_CLI_DATA_PLANE_TRUST_ALL"]

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -324,7 +324,7 @@ func (c *Config) loadLocalConfigFrom(parent string) error {
 }
 
 func (c *Config) write() error {
-	if err := os.MkdirAll(c.homeDir, 0700); err != nil {
+	if err := os.MkdirAll(c.homeDir, 0o700); err != nil {
 		return err
 	}
 	configFile := filepath.Join(c.homeDir, configFile)
@@ -569,12 +569,12 @@ func (c *Config) writeSessionID(app vespa.ApplicationID, sessionID int64) error 
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(sessionPath, []byte(fmt.Sprintf("%d\n", sessionID)), 0600)
+	return os.WriteFile(sessionPath, []byte(fmt.Sprintf("%d\n", sessionID)), 0o600)
 }
 
 func (c *Config) applicationFilePath(app vespa.ApplicationID, name string) (string, error) {
 	appDir := filepath.Join(c.homeDir, app.String())
-	if err := os.MkdirAll(appDir, 0700); err != nil {
+	if err := os.MkdirAll(appDir, 0o700); err != nil {
 		return "", err
 	}
 	return filepath.Join(appDir, name), nil
@@ -722,7 +722,7 @@ func vespaCliHome(env map[string]string) (string, error) {
 		}
 		home = filepath.Join(userHome, ".vespa")
 	}
-	if err := os.MkdirAll(home, 0700); err != nil {
+	if err := os.MkdirAll(home, 0o700); err != nil {
 		return "", err
 	}
 	return home, nil
@@ -737,7 +737,7 @@ func vespaCliCacheDir(env map[string]string) (string, error) {
 		}
 		cacheDir = filepath.Join(userCacheDir, "vespa")
 	}
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", err
 	}
 	return cacheDir, nil

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -452,7 +452,7 @@ func (c *Config) credentialsPEM(envVar string, credentialsFile credentialsFile) 
 		}
 		return nil, "", err
 	}
-	return []byte(pem), credentialsFile.path, nil
+	return pem, credentialsFile.path, nil
 }
 
 func (c *Config) readTLSOptions(app vespa.ApplicationID, targetType string) (vespa.TLSOptions, error) {

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -78,7 +78,7 @@ func TestConfig(t *testing.T) {
 	yamlConfig := string(data)
 	assert.NotContains(t, yamlConfig, "zone:")
 	config := yamlConfig + "zone: \"\"\n"
-	require.Nil(t, os.WriteFile(configFile, []byte(config), 0600))
+	require.Nil(t, os.WriteFile(configFile, []byte(config), 0o600))
 	assertConfigCommand(t, configHome, "zone = <unset>\n", "config", "get", "zone")
 }
 
@@ -162,7 +162,7 @@ func TestReadAPIKey(t *testing.T) {
 	require.NotNil(t, err)
 
 	// From default path when it exists
-	require.Nil(t, os.WriteFile(filepath.Join(cli.config.homeDir, "t1.api-key.pem"), []byte("foo"), 0600))
+	require.Nil(t, os.WriteFile(filepath.Join(cli.config.homeDir, "t1.api-key.pem"), []byte("foo"), 0o600))
 	key, err = cli.config.readAPIKey(cli, "t1")
 	require.Nil(t, err)
 	assert.Equal(t, []byte("foo"), key)
@@ -175,7 +175,7 @@ func TestReadAPIKey(t *testing.T) {
 
 	// From file specified in environment
 	keyFile := filepath.Join(t.TempDir(), "key")
-	require.Nil(t, os.WriteFile(keyFile, []byte("bar"), 0600))
+	require.Nil(t, os.WriteFile(keyFile, []byte("bar"), 0o600))
 	cli, _, _ = newTestCLI(t, "VESPA_CLI_API_KEY_FILE="+keyFile)
 	key, err = cli.config.readAPIKey(cli, "t1")
 	require.Nil(t, err)
@@ -189,7 +189,7 @@ func TestReadAPIKey(t *testing.T) {
 
 	// Prefer Auth0 if we have auth config
 	cli, _, _ = newTestCLI(t)
-	require.Nil(t, os.WriteFile(filepath.Join(cli.config.homeDir, "auth.json"), []byte("foo"), 0600))
+	require.Nil(t, os.WriteFile(filepath.Join(cli.config.homeDir, "auth.json"), []byte("foo"), 0o600))
 	key, err = cli.config.readAPIKey(cli, "t1")
 	require.Nil(t, err)
 	assert.Nil(t, key)
@@ -229,9 +229,9 @@ func TestConfigReadTLSOptions(t *testing.T) {
 	certFile := filepath.Join(homeDir, "cert")
 	keyFile := filepath.Join(homeDir, "key")
 	caCertFile := filepath.Join(homeDir, "cacert")
-	require.Nil(t, os.WriteFile(certFile, pemCert, 0600))
-	require.Nil(t, os.WriteFile(keyFile, pemKey, 0600))
-	require.Nil(t, os.WriteFile(caCertFile, []byte("cacert"), 0600))
+	require.Nil(t, os.WriteFile(certFile, pemCert, 0o600))
+	require.Nil(t, os.WriteFile(keyFile, pemKey, 0o600))
+	require.Nil(t, os.WriteFile(caCertFile, []byte("cacert"), 0o600))
 	assertTLSOptions(t, homeDir, app,
 		vespa.TargetLocal,
 		vespa.TLSOptions{
@@ -251,8 +251,8 @@ func TestConfigReadTLSOptions(t *testing.T) {
 	// Key pair resides in default paths
 	defaultCertFile := filepath.Join(homeDir, app.String(), "data-plane-public-cert.pem")
 	defaultKeyFile := filepath.Join(homeDir, app.String(), "data-plane-private-key.pem")
-	require.Nil(t, os.WriteFile(defaultCertFile, pemCert, 0600))
-	require.Nil(t, os.WriteFile(defaultKeyFile, pemKey, 0600))
+	require.Nil(t, os.WriteFile(defaultCertFile, pemCert, 0o600))
+	require.Nil(t, os.WriteFile(defaultKeyFile, pemKey, 0o600))
 	assertTLSOptions(t, homeDir, app,
 		vespa.TargetLocal,
 		vespa.TLSOptions{

--- a/client/go/internal/cli/cmd/deploy_test.go
+++ b/client/go/internal/cli/cmd/deploy_test.go
@@ -105,10 +105,10 @@ func TestDeployCloudFastWait(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	httpClient.NextResponseString(200, `ok`)
-	httpClient.NextResponseString(200, `{"active": false, "status": "unsuccesful"}`)
-	httpClient.NextResponseString(200, `{"active": false, "status": "unsuccesful"}`)
+	httpClient.NextResponseString(200, `{"active": false, "status": "unsuccessful"}`)
+	httpClient.NextResponseString(200, `{"active": false, "status": "unsuccessful"}`)
 	require.NotNil(t, cli.Run("deploy", pkgDir))
-	assert.Equal(t, stderr.String(), "Error: deployment failed: run 0 ended with unsuccessful status: unsuccesful\n")
+	assert.Equal(t, stderr.String(), "Error: deployment failed: run 0 ended with unsuccessful status: unsuccessful\n")
 	assert.True(t, httpClient.Consumed())
 
 	// Deployment which is running does not return error

--- a/client/go/internal/cli/cmd/deploy_test.go
+++ b/client/go/internal/cli/cmd/deploy_test.go
@@ -345,7 +345,7 @@ func assertPackageUpload(requestNumber int, url string, client *mock.HTTPClient,
 	assert.Equal(t, url, req.URL.String())
 	assert.Equal(t, "application/zip", req.Header.Get("Content-Type"))
 	assert.Equal(t, "POST", req.Method)
-	var body = req.Body
+	body := req.Body
 	assert.NotNil(t, body)
 	buf := make([]byte, 7) // Just check the first few bytes
 	body.Read(buf)

--- a/client/go/internal/cli/cmd/document.go
+++ b/client/go/internal/cli/cmd/document.go
@@ -70,7 +70,7 @@ func sendOperation(op document.Operation, args []string, timeoutSecs int, waiter
 		return err
 	}
 	if len(args) == 0 && data == "" {
-		return fmt.Errorf("Must provide either a file name or use the --data parameter")
+		return fmt.Errorf("must provide either a file name or use the --data parameter")
 	}
 
 	var id string

--- a/client/go/internal/cli/cmd/feed.go
+++ b/client/go/internal/cli/cmd/feed.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -210,7 +211,7 @@ func enqueueFrom(r io.ReadCloser, dispatcher *document.Dispatcher, cli *CLI) err
 	defer r.Close()
 	for {
 		doc, err := dec.Decode()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/client/go/internal/cli/cmd/feed_test.go
+++ b/client/go/internal/cli/cmd/feed_test.go
@@ -39,8 +39,8 @@ func TestFeed(t *testing.T) {
 }`)
 	jsonFile1 := filepath.Join(td, "docs1.jsonl")
 	jsonFile2 := filepath.Join(td, "docs2.jsonl")
-	require.Nil(t, os.WriteFile(jsonFile1, doc, 0644))
-	require.Nil(t, os.WriteFile(jsonFile2, doc, 0644))
+	require.Nil(t, os.WriteFile(jsonFile1, doc, 0o644))
+	require.Nil(t, os.WriteFile(jsonFile2, doc, 0o644))
 
 	httpClient.NextResponseString(200, `{"message":"OK"}`)
 	httpClient.NextResponseString(200, `{"message":"OK"}`)
@@ -118,7 +118,7 @@ func TestFeedInvalid(t *testing.T) {
   "fields": {"foo": "invalid json"
 }`)
 	jsonFile := filepath.Join(td, "docs.jsonl")
-	require.Nil(t, os.WriteFile(jsonFile, doc, 0644))
+	require.Nil(t, os.WriteFile(jsonFile, doc, 0o644))
 	httpClient.NextResponseString(200, `{"message":"OK"}`)
 	require.NotNil(t, cli.Run("feed", "-t", "http://127.0.0.1:8080", jsonFile))
 

--- a/client/go/internal/cli/cmd/inspect.go
+++ b/client/go/internal/cli/cmd/inspect.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/tracedoctor"
-	"os"
 )
 
 type inspectProfileOptions struct {

--- a/client/go/internal/cli/cmd/login.go
+++ b/client/go/internal/cli/cmd/login.go
@@ -70,7 +70,6 @@ This command runs a browser-based authentication flow for the Vespa Cloud contro
 				res, err = a.Authenticator.Wait(ctx, state)
 				return err
 			})
-
 			if err != nil {
 				switch err.Error() {
 				case "600":

--- a/client/go/internal/cli/cmd/login.go
+++ b/client/go/internal/cli/cmd/login.go
@@ -74,7 +74,7 @@ This command runs a browser-based authentication flow for the Vespa Cloud contro
 			if err != nil {
 				switch err.Error() {
 				case "600":
-					return errHint(fmt.Errorf("Your organization require SSO for Vespa Cloud access"),
+					return errHint(fmt.Errorf("your organization require SSO for Vespa Cloud access"),
 						"Please login by entering your email in the email address field")
 				default:
 					return fmt.Errorf("login error: %w", err)

--- a/client/go/internal/cli/cmd/prod.go
+++ b/client/go/internal/cli/cmd/prod.go
@@ -213,7 +213,7 @@ func writeWithBackup(stdout io.Writer, pkg vespa.ApplicationPackage, filename, c
 		}
 	}
 	fmt.Fprintf(stdout, "Writing %s\n", color.GreenString(dst))
-	return os.WriteFile(dst, []byte(contents), 0644)
+	return os.WriteFile(dst, []byte(contents), 0o644)
 }
 
 func updateRegions(cli *CLI, stdin *bufio.Reader, deploymentXML xml.Deployment, system vespa.System) (xml.Deployment, error) {

--- a/client/go/internal/cli/cmd/prod.go
+++ b/client/go/internal/cli/cmd/prod.go
@@ -315,9 +315,9 @@ func promptNodeCount(cli *CLI, stdin *bufio.Reader, clusterID string, nodeCount 
 	fmt.Fprintf(cli.Stdout, "Documentation: %s\n", color.GreenString("https://cloud.vespa.ai/en/reference/services"))
 	fmt.Fprintf(cli.Stdout, "Example: %s\nExample: %s\n\n", color.YellowString("4"), color.YellowString("[2,8]"))
 	validator := func(input string) error {
-		min, _, err := xml.ParseNodeCount(input)
-		if min < 2 {
-			return errHint(fmt.Errorf("at least 2 nodes are required for all clusters in a production environment, got %d", min), "See https://cloud.vespa.ai/en/production-deployment")
+		minNodeCount, _, err := xml.ParseNodeCount(input)
+		if minNodeCount < 2 {
+			return errHint(fmt.Errorf("at least 2 nodes are required for all clusters in a production environment, got %d", minNodeCount), "See https://cloud.vespa.ai/en/production-deployment")
 		}
 		return err
 	}

--- a/client/go/internal/cli/cmd/prod_test.go
+++ b/client/go/internal/cli/cmd/prod_test.go
@@ -96,7 +96,7 @@ func createApplication(t *testing.T, pkgDir string, java bool, skipTests bool) {
 		appDir = filepath.Join(pkgDir, "target", "application")
 		testsDir = filepath.Join(pkgDir, "target", "application-test")
 	}
-	if err := os.MkdirAll(appDir, 0755); err != nil {
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	deploymentXML := `<deployment version="1.0">
@@ -104,7 +104,7 @@ func createApplication(t *testing.T, pkgDir string, java bool, skipTests bool) {
     <region>aws-us-east-1c</region>
   </prod>
 </deployment>`
-	if err := os.WriteFile(filepath.Join(appDir, "deployment.xml"), []byte(deploymentXML), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(appDir, "deployment.xml"), []byte(deploymentXML), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	servicesXML := `<services version="1.0" xmlns:deploy="vespa" xmlns:preprocess="properties">
@@ -124,16 +124,16 @@ func createApplication(t *testing.T, pkgDir string, java bool, skipTests bool) {
   </content>
 </services>`
 
-	if err := os.WriteFile(filepath.Join(appDir, "services.xml"), []byte(servicesXML), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(appDir, "services.xml"), []byte(servicesXML), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if java {
-		if err := os.WriteFile(filepath.Join(pkgDir, "pom.xml"), []byte(""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(pkgDir, "pom.xml"), []byte(""), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 	if !skipTests {
-		if err := os.MkdirAll(testsDir, 0755); err != nil {
+		if err := os.MkdirAll(testsDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		testBytes := []byte("{\"steps\":[{}]}")
@@ -144,10 +144,10 @@ func createApplication(t *testing.T, pkgDir string, java bool, skipTests bool) {
 }
 
 func writeTest(path string, content []byte, t *testing.T) {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, content, 0644); err != nil {
+	if err := os.WriteFile(path, content, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -173,8 +173,8 @@ func TestProdDeployWithoutCertificate(t *testing.T) {
 	cli.Environment["VESPA_CLI_API_KEY_FILE"] = filepath.Join(cli.config.homeDir, "t1.api-key.pem")
 
 	// We have clients.pem, but no key pair for the application
-	require.Nil(t, os.MkdirAll(filepath.Join(pkgDir, "security"), 0755))
-	require.Nil(t, os.WriteFile(filepath.Join(pkgDir, "security", "clients.pem"), []byte{}, 0644))
+	require.Nil(t, os.MkdirAll(filepath.Join(pkgDir, "security"), 0o755))
+	require.Nil(t, os.WriteFile(filepath.Join(pkgDir, "security", "clients.pem"), []byte{}, 0o644))
 	httpClient.NextResponseString(200, `{"build": 42}`)
 	assert.Nil(t, cli.Run("prod", "deploy", pkgDir))
 	assert.Contains(t, stdout.String(), "Success: Deployed '"+pkgDir+"' with build number 42")

--- a/client/go/internal/cli/cmd/query.go
+++ b/client/go/internal/cli/cmd/query.go
@@ -181,7 +181,7 @@ func query(cli *CLI, arguments []string, opts *queryOptions, waiter *Waiter) err
 	defer response.Body.Close()
 
 	if response.StatusCode == 200 {
-		var output io.Writer = cli.Stdout
+		output := cli.Stdout
 		if opts.profile {
 			profileFile, err := os.Create(opts.profileFile)
 			if err != nil {

--- a/client/go/internal/cli/cmd/query.go
+++ b/client/go/internal/cli/cmd/query.go
@@ -180,7 +180,7 @@ func query(cli *CLI, arguments []string, opts *queryOptions, waiter *Waiter) err
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode == 200 {
+	if response.StatusCode == http.StatusOK {
 		output := cli.Stdout
 		if opts.profile {
 			profileFile, err := os.Create(opts.profileFile)
@@ -196,7 +196,7 @@ func query(cli *CLI, arguments []string, opts *queryOptions, waiter *Waiter) err
 		}
 	} else if response.StatusCode/100 == 4 {
 		err := fmt.Errorf("invalid query: %s\n%s", response.Status, ioutil.ReaderToJSON(response.Body))
-		if response.StatusCode == 403 && authMethod == "token" {
+		if response.StatusCode == http.StatusForbidden && authMethod == "token" {
 			return errHint(err, "Make sure the VESPA_CLI_DATA_PLANE_TOKEN environment variable is set to a valid token")
 		}
 		return err

--- a/client/go/internal/cli/cmd/query_test.go
+++ b/client/go/internal/cli/cmd/query_test.go
@@ -146,7 +146,7 @@ func TestQueryPostFile(t *testing.T) {
 
 	tmpFileName := filepath.Join(t.TempDir(), "tq1.json")
 	jsonQuery := []byte(`{"yql": "some yql here"}`)
-	require.Nil(t, os.WriteFile(tmpFileName, jsonQuery, 0644))
+	require.Nil(t, os.WriteFile(tmpFileName, jsonQuery, 0o644))
 
 	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "--file", tmpFileName))
 	assert.Equal(t, mockResponse+"\n", stdout.String())
@@ -165,7 +165,7 @@ func TestQueryPostFileWithArgs(t *testing.T) {
 
 	tmpFileName := filepath.Join(t.TempDir(), "tq2.json")
 	jsonQuery := []byte(`{"yql": "some yql here"}`)
-	require.Nil(t, os.WriteFile(tmpFileName, jsonQuery, 0644))
+	require.Nil(t, os.WriteFile(tmpFileName, jsonQuery, 0o644))
 
 	assert.Nil(t, cli.Run(
 		"-t", "http://foo.bar:1234/",

--- a/client/go/internal/cli/cmd/query_test.go
+++ b/client/go/internal/cli/cmd/query_test.go
@@ -197,21 +197,6 @@ func assertStreamingQuery(t *testing.T, expectedOutput, body string, args ...str
 	assert.Equal(t, expectedOutput, stdout.String())
 }
 
-func assertStreamingQueryErr(t *testing.T, expectedOut, expectedErr, body string, args ...string) {
-	t.Helper()
-	client := &mock.HTTPClient{}
-	response := mock.HTTPResponse{Status: 200, Header: make(http.Header)}
-	response.Header.Set("Content-Type", "text/event-stream")
-	response.Body = []byte(body)
-	client.NextResponse(response)
-	cli, stdout, stderr := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.NotNil(t, cli.Run(append(args, "-t", "http://127.0.0.1:8080", "query", "select something")...))
-	assert.Equal(t, expectedErr, stderr.String())
-	assert.Equal(t, expectedOut, stdout.String())
-}
-
 func assertQuery(t *testing.T, expectedQuery string, query ...string) {
 	client := &mock.HTTPClient{}
 	client.NextResponseString(200, "{\"query\":\"result\"}")

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -56,7 +56,6 @@ type CLI struct {
 
 	now           func() time.Time
 	retryInterval time.Duration
-	waitTimeout   *time.Duration
 
 	cmd     *cobra.Command
 	config  *Config

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -618,7 +619,8 @@ func (c *CLI) Run(args ...string) error {
 	c.cmd.SetArgs(args)
 	err := c.cmd.Execute()
 	if err != nil {
-		if cliErr, ok := err.(CLIError); ok {
+		var cliErr CLIError
+		if errors.As(err, &cliErr) {
 			if !cliErr.quiet {
 				if cliErr.warn {
 					c.printWarning(cliErr, cliErr.hints...)

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -565,7 +565,7 @@ func (c *CLI) createCloudTarget(targetType string, opts targetOptions, customURL
 	return vespa.CloudTarget(c.httpClient, apiAuth, deploymentAuth, apiOptions, deploymentOptions, logOptions, c.retryInterval)
 }
 
-// system returns the appropiate system for the target configured in this CLI.
+// system returns the appropriate system for the target configured in this CLI.
 func (c *CLI) system(targetType string) (vespa.System, error) {
 	name := c.Environment["VESPA_CLI_CLOUD_SYSTEM"]
 	if name != "" {

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -67,9 +67,9 @@ type CLI struct {
 	ztsFactory        ztsFactory
 }
 
-// ErrCLI is an error returned to the user. It wraps an exit status, a regular error and optional hints for resolving
+// CLIError is an error returned to the user. It wraps an exit status, a regular error and optional hints for resolving
 // the error.
-type ErrCLI struct {
+type CLIError struct {
 	Status int
 	warn   bool
 	quiet  bool
@@ -92,7 +92,9 @@ type targetType struct {
 }
 
 // errHint creates a new CLI error, with optional hints that will be printed after the error
-func errHint(err error, hints ...string) ErrCLI { return ErrCLI{Status: 1, hints: hints, error: err} }
+func errHint(err error, hints ...string) CLIError {
+	return CLIError{Status: 1, hints: hints, error: err}
+}
 
 type executor interface {
 	LookPath(name string) (string, error)
@@ -616,7 +618,7 @@ func (c *CLI) Run(args ...string) error {
 	c.cmd.SetArgs(args)
 	err := c.cmd.Execute()
 	if err != nil {
-		if cliErr, ok := err.(ErrCLI); ok {
+		if cliErr, ok := err.(CLIError); ok {
 			if !cliErr.quiet {
 				if cliErr.warn {
 					c.printWarning(cliErr, cliErr.hints...)

--- a/client/go/internal/cli/cmd/status.go
+++ b/client/go/internal/cli/cmd/status.go
@@ -205,7 +205,7 @@ func printServiceStatus(s *vespa.Service, format string, waiter *Waiter, cli *CL
 	switch format {
 	case "human":
 		desc := s.Description()
-		desc = strings.ToUpper(string(desc[0])) + string(desc[1:])
+		desc = strings.ToUpper(string(desc[0])) + desc[1:]
 		sb.WriteString(fmt.Sprintf("%s at %s is ", desc, color.CyanString(s.BaseURL)))
 		if err == nil {
 			sb.WriteString(color.GreenString("ready"))

--- a/client/go/internal/cli/cmd/status.go
+++ b/client/go/internal/cli/cmd/status.go
@@ -184,7 +184,7 @@ $ vespa status deployment -t local [session-id] --wait 600
 				if waiter.Timeout == 0 && !errors.Is(err, vespa.ErrDeployment) {
 					hints = []string{"Consider using the --wait flag to increase the wait period", "--wait 120 will make this command wait for completion up to 2 minutes"}
 				}
-				return ErrCLI{Status: 1, warn: true, hints: hints, error: err}
+				return CLIError{Status: 1, warn: true, hints: hints, error: err}
 			}
 			if t.IsCloud() {
 				log.Printf("Deployment run %s has completed", color.CyanString(strconv.FormatInt(id, 10)))

--- a/client/go/internal/cli/cmd/test.go
+++ b/client/go/internal/cli/cmd/test.go
@@ -56,7 +56,7 @@ $ vespa test src/test/application/tests/system-test/feed-and-query.json`,
 				for _, test := range failed {
 					fmt.Fprintln(cli.Stdout, test)
 				}
-				return ErrCLI{Status: 3, error: fmt.Errorf("tests failed"), quiet: true}
+				return CLIError{Status: 3, error: fmt.Errorf("tests failed"), quiet: true}
 			} else {
 				plural := "s"
 				if count == 1 {

--- a/client/go/internal/cli/cmd/test.go
+++ b/client/go/internal/cli/cmd/test.go
@@ -226,7 +226,7 @@ func verify(step step, defaultCluster string, defaultParameters map[string]strin
 		if err != nil {
 			return "", "", err
 		}
-		ok := false
+		var ok bool
 		service, ok = context.clusters[cluster]
 		if !ok && waiter != nil {
 			// Cache service so we don't have to discover it for every step
@@ -330,8 +330,7 @@ func verify(step step, defaultCluster string, defaultParameters map[string]strin
 }
 
 func compare(expected interface{}, actual interface{}, path string) (string, string, string, error) {
-	typeMatch := false
-	valueMatch := false
+	var typeMatch, valueMatch bool
 	switch u := expected.(type) {
 	case nil:
 		typeMatch = actual == nil

--- a/client/go/internal/cli/cmd/test_test.go
+++ b/client/go/internal/cli/cmd/test_test.go
@@ -128,8 +128,8 @@ func TestSingleTestWithCloudAndEndpoints(t *testing.T) {
 	certFile := filepath.Join(certDir, "cert")
 	kp, err := vespa.CreateKeyPair()
 	require.Nil(t, err)
-	require.Nil(t, os.WriteFile(keyFile, kp.PrivateKey, 0600))
-	require.Nil(t, os.WriteFile(certFile, kp.Certificate, 0600))
+	require.Nil(t, os.WriteFile(keyFile, kp.PrivateKey, 0o600))
+	require.Nil(t, os.WriteFile(certFile, kp.Certificate, 0o600))
 
 	client := &mock.HTTPClient{}
 	cli, stdout, stderr := newTestCLI(

--- a/client/go/internal/cli/cmd/version.go
+++ b/client/go/internal/cli/cmd/version.go
@@ -63,7 +63,7 @@ func checkVersion(cli *CLI) error {
 }
 
 func latestRelease(cli *CLI) (release, error) {
-	req, err := http.NewRequest("GET", "https://api.github.com/repos/vespa-engine/vespa/releases", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/vespa-engine/vespa/releases", nil)
 	if err != nil {
 		return release{}, err
 	}

--- a/client/go/internal/cli/cmd/vespa/main.go
+++ b/client/go/internal/cli/cmd/vespa/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -24,7 +25,8 @@ func main() {
 		fatal(1, err)
 	}
 	if err := cli.Run(); err != nil {
-		if cliErr, ok := err.(cmd.CLIError); ok {
+		var cliErr cmd.CLIError
+		if errors.As(err, &cliErr) {
 			fatal(cliErr.Status, nil)
 		} else {
 			fatal(1, nil)

--- a/client/go/internal/cli/cmd/vespa/main.go
+++ b/client/go/internal/cli/cmd/vespa/main.go
@@ -24,7 +24,7 @@ func main() {
 		fatal(1, err)
 	}
 	if err := cli.Run(); err != nil {
-		if cliErr, ok := err.(cmd.ErrCLI); ok {
+		if cliErr, ok := err.(cmd.CLIError); ok {
 			fatal(cliErr.Status, nil)
 		} else {
 			fatal(1, nil)

--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -233,7 +233,7 @@ func probeHandler(vArgs *visitArgs, service *vespa.Service, cli *CLI) (res Opera
 	}
 	request := &http.Request{
 		URL:    url,
-		Method: "GET",
+		Method: http.MethodGet,
 		Header: vArgs.header,
 	}
 	timeout := time.Duration(90) * time.Second
@@ -242,7 +242,7 @@ func probeHandler(vArgs *visitArgs, service *vespa.Service, cli *CLI) (res Opera
 		return Failure("Request failed: " + err.Error())
 	}
 	defer response.Body.Close()
-	if response.StatusCode == 200 {
+	if response.StatusCode == http.StatusOK {
 		handlersInfo, err := parseHandlersOutput(response.Body)
 		if err != nil || len(handlersInfo.Handlers) == 0 {
 			cli.printWarning("Could not parse JSON response from"+urlPath, err.Error())
@@ -393,7 +393,7 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 	}
 	request := &http.Request{
 		URL:    url,
-		Method: "GET",
+		Method: http.MethodGet,
 		Header: vArgs.header,
 	}
 	timeout := time.Duration(900) * time.Second
@@ -403,7 +403,7 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 	}
 	defer response.Body.Close()
 	vvo, err := parseVisitOutput(response.Body)
-	if response.StatusCode == 200 {
+	if response.StatusCode == http.StatusOK {
 		if err == nil {
 			totalDocCount += vvo.DocumentCount
 			if vvo.DocumentCount != len(vvo.Documents) {

--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -88,9 +88,7 @@ func (v *visitArgs) dumpDocuments(documents []DocumentBlob) {
 var totalDocCount int
 
 func newVisitCmd(cli *CLI) *cobra.Command {
-	var (
-		vArgs visitArgs
-	)
+	var vArgs visitArgs
 	cmd := &cobra.Command{
 		Use:   "visit",
 		Short: "Retrieve and print all documents from Vespa",
@@ -198,9 +196,7 @@ func checkArguments(vArgs visitArgs) (res OperationResult) {
 	}
 	for _, b := range vArgs.bucketSpaces {
 		switch b {
-		case
-			"default",
-			"global":
+		case "default", "global":
 			// Do nothing
 		default:
 			return Failure("Invalid 'bucket-space' argument '" + b + "', must be 'default' or 'global'")
@@ -314,7 +310,7 @@ func probeVisit(vArgs *visitArgs, service *vespa.Service) []string {
 
 func runVisit(vArgs *visitArgs, service *vespa.Service) (res OperationResult) {
 	vArgs.debugPrint(fmt.Sprintf("trying to visit: '%s'", vArgs.contentCluster))
-	var totalDocuments = 0
+	totalDocuments := 0
 	var continuationToken string
 	for {
 		var vvo *VespaVisitOutput

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestQuoteFunc(t *testing.T) {
-	var buf []byte = make([]byte, 3)
+	buf := make([]byte, 3)
 	buf[0] = 'a'
 	buf[2] = 'z'
 	for i := range 256 {

--- a/client/go/internal/cli/cmd/waiter.go
+++ b/client/go/internal/cli/cmd/waiter.go
@@ -84,7 +84,7 @@ func (w *Waiter) maybeWaitFor(service *vespa.Service) error {
 	}
 	// Send probe request to determine if we need to wait at all
 	if err := service.Wait(0); err == nil {
-		return err
+		return nil
 	}
 	w.cli.printInfo("Waiting up to ", color.CyanString(w.Timeout.String()), " for ", service.Description(), "...")
 	return service.Wait(w.Timeout)
@@ -94,7 +94,7 @@ func (w *Waiter) services(target vespa.Target) ([]*vespa.Service, error) {
 	// Send probe request to determine if we need to wait at all
 	services, err := target.ContainerServices(0)
 	if err == nil {
-		return services, err
+		return services, nil
 	}
 	if w.Timeout > 0 {
 		w.cli.printInfo("Waiting up to ", color.CyanString(w.Timeout.String()), " for cluster discovery...")
@@ -112,7 +112,7 @@ func (w *Waiter) Deployment(target vespa.Target, wantedID int64) (int64, error) 
 	// Send probe request to determine if we need to wait at all
 	id, err := target.AwaitDeployment(wantedID, 0)
 	if err == nil {
-		return id, err
+		return id, nil
 	}
 	timeout := w.Timeout
 	if timeout > 0 {

--- a/client/go/internal/httputil/httputil.go
+++ b/client/go/internal/httputil/httputil.go
@@ -17,14 +17,14 @@ import (
 
 // Client represents a HTTP client usable by the Vespa CLI.
 type Client interface {
-	Do(request *http.Request, timeout time.Duration) (response *http.Response, error error)
+	Do(request *http.Request, timeout time.Duration) (response *http.Response, err error)
 }
 
 type defaultClient struct {
 	client *http.Client
 }
 
-func (c *defaultClient) Do(request *http.Request, timeout time.Duration) (response *http.Response, error error) {
+func (c *defaultClient) Do(request *http.Request, timeout time.Duration) (response *http.Response, err error) {
 	if c.client.Timeout != timeout { // Set wanted timeout
 		c.client.Timeout = timeout
 	}

--- a/client/go/internal/ioutil/ioutil.go
+++ b/client/go/internal/ioutil/ioutil.go
@@ -38,7 +38,7 @@ func IsExecutable(path string) bool {
 	return !errors.Is(err, os.ErrNotExist) &&
 		info != nil &&
 		info.Mode().IsRegular() &&
-		((int(info.Mode()) & 0111) == 0111)
+		((int(info.Mode()) & 0o111) == 0o111)
 }
 
 // ReaderToString Returns the content of reader as a string. Read errors are ignored.

--- a/client/go/internal/ioutil/ioutil_test.go
+++ b/client/go/internal/ioutil/ioutil_test.go
@@ -13,7 +13,7 @@ func TestPathExists(t *testing.T) {
 	assert.Equal(t, false, Exists("nosuchthing.go"))
 
 	tmpDir := t.TempDir()
-	err := os.MkdirAll(tmpDir+"/no", 0755)
+	err := os.MkdirAll(tmpDir+"/no", 0o755)
 	assert.Nil(t, err)
 	err = os.MkdirAll(tmpDir+"/no/such", 0)
 	assert.Nil(t, err)
@@ -22,7 +22,7 @@ func TestPathExists(t *testing.T) {
 
 func TestIsDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	err := os.MkdirAll(tmpDir+"/no", 0755)
+	err := os.MkdirAll(tmpDir+"/no", 0o755)
 	assert.Nil(t, err)
 	assert.Equal(t, true, IsDir(tmpDir+"/no"))
 	err = os.MkdirAll(tmpDir+"/no/such", 0)
@@ -35,7 +35,7 @@ func TestIsRegularFile(t *testing.T) {
 	assert.Equal(t, true, IsFile("ioutil.go"))
 	assert.Equal(t, false, IsFile("."))
 	tmpDir := t.TempDir()
-	err := os.MkdirAll(tmpDir+"/no", 0755)
+	err := os.MkdirAll(tmpDir+"/no", 0o755)
 	assert.Nil(t, err)
 	err = os.MkdirAll(tmpDir+"/no/such", 0)
 	assert.Nil(t, err)
@@ -46,7 +46,7 @@ func TestIsExecutableFile(t *testing.T) {
 	assert.Equal(t, false, IsExecutable("io.go"))
 	assert.Equal(t, false, IsExecutable("nosuchthing.go"))
 	tmpDir := t.TempDir()
-	err := os.WriteFile(tmpDir+"/run.sh", []byte("#!/bin/sh\necho foo\n"), 0755)
+	err := os.WriteFile(tmpDir+"/run.sh", []byte("#!/bin/sh\necho foo\n"), 0o755)
 	assert.Nil(t, err)
 	assert.Equal(t, true, IsExecutable(tmpDir+"/run.sh"))
 	/* unix only:

--- a/client/go/internal/mock/vespa.go
+++ b/client/go/internal/mock/vespa.go
@@ -14,7 +14,7 @@ func ApplicationPackageDir(t *testing.T, java, cert bool) (string, string) {
 	t.Helper()
 	rootDir := t.TempDir()
 	appDir := filepath.Join(rootDir, "src", "main", "application")
-	if err := os.MkdirAll(appDir, 0755); err != nil {
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	servicesXML := filepath.Join(appDir, "services.xml")
@@ -28,7 +28,7 @@ func ApplicationPackageDir(t *testing.T, java, cert bool) (string, string) {
 	}
 	if cert {
 		securityDir := filepath.Join(appDir, "security")
-		if err := os.MkdirAll(securityDir, 0755); err != nil {
+		if err := os.MkdirAll(securityDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := os.Create(filepath.Join(securityDir, "clients.pem")); err != nil {

--- a/client/go/internal/osutil/execvp.go
+++ b/client/go/internal/osutil/execvp.go
@@ -43,5 +43,5 @@ func Execvpe(prog string, argv []string, envv []string) error {
 func Execve(prog string, argv []string, envv []string) error {
 	trace.Trace("run cmd:", strings.Join(argv, " "))
 	err := unix.Exec(prog, argv, envv)
-	return fmt.Errorf("cannot execute '%s': %v", prog, err)
+	return fmt.Errorf("cannot execute '%s': %w", prog, err)
 }

--- a/client/go/internal/osutil/fix_fs.go
+++ b/client/go/internal/osutil/fix_fs.go
@@ -24,8 +24,8 @@ func NewFixSpec() FixSpec {
 	return FixSpec{
 		UserId:   -1,
 		GroupId:  -1,
-		DirMode:  0755,
-		FileMode: 0644,
+		DirMode:  0o755,
+		FileMode: 0o644,
 	}
 }
 

--- a/client/go/internal/osutil/fix_fs_test.go
+++ b/client/go/internal/osutil/fix_fs_test.go
@@ -85,8 +85,8 @@ func TestSimpleFixes(t *testing.T) {
 
 func TestSuperUserOnly(t *testing.T) {
 	trace.AdjustVerbosity(0)
-	var userId int = -1
-	var groupId int = -1
+	userId := -1
+	groupId := -1
 	if os.Getuid() != 0 {
 		trace.Trace("skip TestSuperUserOnly, uid != 0")
 		return

--- a/client/go/internal/osutil/fix_fs_test.go
+++ b/client/go/internal/osutil/fix_fs_test.go
@@ -16,13 +16,13 @@ import (
 func setup(t *testing.T) string {
 	tt := t.TempDir()
 	tmpDir, _ := filepath.EvalSymlinks(tt)
-	err := os.MkdirAll(tmpDir+"/a", 0755)
+	err := os.MkdirAll(tmpDir+"/a", 0o755)
 	assert.Nil(t, err)
 	err = os.MkdirAll(tmpDir+"/a/bad", 0)
 	assert.Nil(t, err)
-	err = os.WriteFile(tmpDir+"/a/f1", []byte{10}, 0644)
+	err = os.WriteFile(tmpDir+"/a/f1", []byte{10}, 0o644)
 	assert.Nil(t, err)
-	err = os.WriteFile(tmpDir+"/a/f2", []byte{10}, 0111)
+	err = os.WriteFile(tmpDir+"/a/f2", []byte{10}, 0o111)
 	assert.Nil(t, err)
 	return tmpDir
 }
@@ -51,32 +51,32 @@ func testFixSpec(t *testing.T, spec FixSpec) {
 	info, err := os.Stat(tmpDir + "/a")
 	assert.Nil(t, err)
 	assert.Equal(t, true, info.IsDir())
-	assert.Equal(t, 0755, int(info.Mode())&0777)
+	assert.Equal(t, 0o755, int(info.Mode())&0o777)
 
 	info, err = os.Stat(tmpDir + "/b")
 	assert.Nil(t, err)
 	assert.Equal(t, true, info.IsDir())
-	assert.Equal(t, 0755, int(info.Mode())&0777)
+	assert.Equal(t, 0o755, int(info.Mode())&0o777)
 
 	info, err = os.Stat(tmpDir + "/a/bad")
 	assert.Nil(t, err)
 	assert.Equal(t, true, info.IsDir())
-	assert.Equal(t, 0755, int(info.Mode())&0777)
+	assert.Equal(t, 0o755, int(info.Mode())&0o777)
 
 	info, err = os.Stat(tmpDir + "/a/bad/ok")
 	assert.Nil(t, err)
 	assert.Equal(t, true, info.IsDir())
-	assert.Equal(t, 0755, int(info.Mode())&0777)
+	assert.Equal(t, 0o755, int(info.Mode())&0o777)
 
 	info, err = os.Stat(tmpDir + "/a/f1")
 	assert.Nil(t, err)
 	assert.Equal(t, false, info.IsDir())
-	assert.Equal(t, 0644, int(info.Mode())&0777)
+	assert.Equal(t, 0o644, int(info.Mode())&0o777)
 
 	info, err = os.Stat(tmpDir + "/a/f2")
 	assert.Nil(t, err)
 	assert.Equal(t, false, info.IsDir())
-	assert.Equal(t, 0644, int(info.Mode())&0777)
+	assert.Equal(t, 0o644, int(info.Mode())&0o777)
 }
 
 func TestSimpleFixes(t *testing.T) {

--- a/client/go/internal/osutil/fix_fs_test.go
+++ b/client/go/internal/osutil/fix_fs_test.go
@@ -85,7 +85,6 @@ func TestSimpleFixes(t *testing.T) {
 
 func TestSuperUserOnly(t *testing.T) {
 	trace.AdjustVerbosity(0)
-	userId := -1
 	groupId := -1
 	if os.Getuid() != 0 {
 		trace.Trace("skip TestSuperUserOnly, uid != 0")
@@ -102,6 +101,7 @@ func TestSuperUserOnly(t *testing.T) {
 		trace.Trace("skip TestSuperUserOnly, user nobody was not found")
 		return
 	}
+	var userId int
 	userId, err = strconv.Atoi(u.Uid)
 	if err != nil || userId < 1 {
 		trace.Trace("skip TestSuperUserOnly, user ID of nobody was not found")

--- a/client/go/internal/osutil/run_cmd.go
+++ b/client/go/internal/osutil/run_cmd.go
@@ -5,6 +5,7 @@ package osutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,7 +25,8 @@ const (
 )
 
 func analyzeError(err error) string {
-	exitErr, wasEe := err.(*exec.ExitError)
+	var exitErr *exec.ExitError
+	wasEe := errors.As(err, &exitErr)
 	if !wasEe {
 		return ""
 	}

--- a/client/go/internal/osutil/run_cmd.go
+++ b/client/go/internal/osutil/run_cmd.go
@@ -30,7 +30,7 @@ func analyzeError(err error) string {
 	if !wasEe {
 		return ""
 	}
-	status, wasWs := exitErr.ProcessState.Sys().(syscall.WaitStatus)
+	status, wasWs := exitErr.Sys().(syscall.WaitStatus)
 	if !wasWs {
 		return err.Error()
 	}

--- a/client/go/internal/vespa/application.go
+++ b/client/go/internal/vespa/application.go
@@ -303,7 +303,7 @@ type PackageOptions struct {
 	// If true, a Maven-based Vespa application package is required to be compiled
 	Compiled bool
 
-	// If true, only consider the source directores of the application package
+	// If true, only consider the source directors of the application package
 	SourceOnly bool
 }
 

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -206,14 +206,14 @@ func contentHash(r io.Reader) (string, io.Reader, error) {
 	if r == nil {
 		r = strings.NewReader("") // Request without body
 	}
-	var copy bytes.Buffer
-	teeReader := io.TeeReader(r, &copy) // Copy reader contents while we hash it
+	var buf bytes.Buffer
+	teeReader := io.TeeReader(r, &buf) // Copy reader contents while we hash it
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, teeReader); err != nil {
 		return "", nil, err
 	}
 	hashSum := hasher.Sum(nil)
-	return base64.StdEncoding.EncodeToString(hashSum), &copy, nil
+	return base64.StdEncoding.EncodeToString(hashSum), &buf, nil
 }
 
 func randomSerialNumber() (*big.Int, error) {

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -200,7 +200,6 @@ func FingerprintMD5(pemPublicKey []byte) (string, error) {
 		hexDigits[i] = hex.EncodeToString([]byte{c})
 	}
 	return strings.Join(hexDigits, ":"), nil
-
 }
 
 func contentHash(r io.Reader) (string, io.Reader, error) {

--- a/client/go/internal/vespa/crypto_test.go
+++ b/client/go/internal/vespa/crypto_test.go
@@ -32,7 +32,7 @@ func TestSignRequest(t *testing.T) {
 		KeyID:         "my-key",
 		PemPrivateKey: privateKey,
 	}
-	req, err := http.NewRequest("POST", "https://example.com", strings.NewReader("body"))
+	req, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader("body"))
 	if err != nil {
 		assert.Nil(t, err)
 	}

--- a/client/go/internal/vespa/crypto_test.go
+++ b/client/go/internal/vespa/crypto_test.go
@@ -30,7 +30,7 @@ func TestSignRequest(t *testing.T) {
 		now:           func() time.Time { return fixedTime },
 		rnd:           rnd,
 		KeyID:         "my-key",
-		PemPrivateKey: []byte(privateKey),
+		PemPrivateKey: privateKey,
 	}
 	req, err := http.NewRequest("POST", "https://example.com", strings.NewReader("body"))
 	if err != nil {

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -211,7 +211,7 @@ func fetchFromConfigServer(deployment DeploymentOptions, path string) error {
 
 func renameOrCopyTmpFile(srcPath, dstPath string) error {
 	if err := os.Rename(srcPath, dstPath); err == nil {
-		return err
+		return nil
 	}
 	src, err := os.Open(srcPath)
 	if err != nil {

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -136,7 +136,7 @@ func Fetch(deployment DeploymentOptions, path string) (string, error) {
 }
 
 func deployServiceGet(url string, deployment DeploymentOptions, w io.Writer) error {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func Prepare(deployment DeploymentOptions) (PrepareResult, error) {
 	if err != nil {
 		return PrepareResult{}, err
 	}
-	req, err := http.NewRequest("PUT", prepareURL.String(), nil)
+	req, err := http.NewRequest(http.MethodPut, prepareURL.String(), nil)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -317,7 +317,7 @@ func Activate(sessionID int64, deployment DeploymentOptions) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("PUT", u.String(), nil)
+	req, err := http.NewRequest(http.MethodPut, u.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func Deactivate(deployment DeploymentOptions) error {
 	if err != nil {
 		return err
 	}
-	req := &http.Request{URL: u, Method: "DELETE"}
+	req := &http.Request{URL: u, Method: http.MethodDelete}
 	resp, err := deployServiceDo(req, 30*time.Second, deployment)
 	if err != nil {
 		return err
@@ -438,7 +438,7 @@ func Submit(opts DeploymentOptions, submission Submission) (int64, error) {
 	}
 	request := &http.Request{
 		URL:    u,
-		Method: "POST",
+		Method: http.MethodPost,
 		Body:   io.NopCloser(&body),
 		Header: make(http.Header),
 	}
@@ -516,7 +516,7 @@ func newDeploymentRequest(url *url.URL, opts DeploymentOptions) (*http.Request, 
 	}
 	return &http.Request{
 		URL:    url,
-		Method: "POST",
+		Method: http.MethodPost,
 		Header: header,
 		Body:   io.NopCloser(body),
 	}, nil
@@ -563,11 +563,11 @@ func uploadApplicationPackage(url *url.URL, opts DeploymentOptions) (PrepareResu
 }
 
 func checkResponse(req *http.Request, response *http.Response) error {
-	if response.StatusCode == 401 || response.StatusCode == 403 {
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("deployment failed: %w (status %d)\n%s", ErrUnauthorized, response.StatusCode, ioutil.ReaderToJSON(response.Body))
 	} else if response.StatusCode/100 == 4 {
 		return fmt.Errorf("invalid application package (status %d)\n%s", response.StatusCode, extractError(response.Body))
-	} else if response.StatusCode != 200 {
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("error from deploy API at %s (status %d):\n%s", req.URL.Host, response.StatusCode, ioutil.ReaderToJSON(response.Body))
 	}
 	return nil

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -63,9 +63,9 @@ type Submission struct {
 }
 
 type LogLinePrepareResponse struct {
-	Time    int64
-	Level   string
-	Message string
+	Time    int64  `json:"time"`
+	Level   string `json:"level"`
+	Message string `json:"message"`
 }
 
 type PrepareResult struct {

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -249,7 +249,7 @@ func fetchFilesFromConfigServer(deployment DeploymentOptions, contentURL *url.UR
 				return err
 			}
 		} else {
-			if err := os.MkdirAll(filepath.Dir(entryName), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(entryName), 0o755); err != nil {
 				return err
 			}
 			f, err := os.Create(entryName)

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -204,7 +204,7 @@ func fetchFromConfigServer(deployment DeploymentOptions, path string) error {
 		return err
 	}
 	if err = renameOrCopyTmpFile(zipFile, path); err != nil {
-		return fmt.Errorf("Could neither rename nor copy %s to %s: %w", zipFile, path, err)
+		return fmt.Errorf("could neither rename nor copy %s to %s: %w", zipFile, path, err)
 	}
 	return err
 }

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -3,6 +3,7 @@ package vespa
 
 import (
 	"archive/zip"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -312,7 +313,7 @@ func parseMultiPart(t *testing.T, req *http.Request) map[string][]byte {
 	mr := multipart.NewReader(req.Body, params["boundary"])
 	for {
 		p, err := mr.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -294,10 +294,10 @@ func assertFindApplicationPackage(t *testing.T, zipOrDir string, fixture pkgFixt
 
 func writeFile(t *testing.T, name string) {
 	t.Helper()
-	err := os.MkdirAll(filepath.Dir(name), 0755)
+	err := os.MkdirAll(filepath.Dir(name), 0o755)
 	assert.Nil(t, err)
 	if !strings.HasSuffix(name, string(os.PathSeparator)) {
-		err = os.WriteFile(name, []byte{0}, 0644)
+		err = os.WriteFile(name, []byte{0}, 0o644)
 		assert.Nil(t, err)
 	}
 }

--- a/client/go/internal/vespa/detect_hostname.go
+++ b/client/go/internal/vespa/detect_hostname.go
@@ -45,7 +45,7 @@ func HasOnlyIpV6() bool {
 // to our services, preferably the canonical DNS name.
 // If automatic detection fails, "localhost" will be returned, so
 // single-node setups still have a good chance of working.
-// Use the enviroment variable VESPA_HOSTNAME to override.
+// Use the environment variable VESPA_HOSTNAME to override.
 func FindOurHostname() (string, error) {
 	env := os.Getenv(envvars.VESPA_HOSTNAME)
 	if env != "" {

--- a/client/go/internal/vespa/document/circuit_breaker.go
+++ b/client/go/internal/vespa/document/circuit_breaker.go
@@ -12,7 +12,7 @@ type CircuitState int
 const (
 	// CircuitClosed represents a closed circuit. Documents are processed successfully
 	CircuitClosed CircuitState = iota
-	// CircuitHalfOpen represents a half-open circuit. Some errors have happend, but processing may still recover
+	// CircuitHalfOpen represents a half-open circuit. Some errors have happened, but processing may still recover
 	CircuitHalfOpen
 	// CircuitOpen represents a open circuit. Something is broken. We should no longer process documents
 	CircuitOpen

--- a/client/go/internal/vespa/document/document.go
+++ b/client/go/internal/vespa/document/document.go
@@ -234,7 +234,7 @@ func (d *Decoder) readBool() (bool, error) {
 
 func (d *Decoder) Decode() (Document, error) {
 	doc, err := d.decode()
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return doc, fmt.Errorf("invalid operation at byte offset %d: %w", d.dec.InputOffset(), err)
 	}
 	return doc, err

--- a/client/go/internal/vespa/document/document_test.go
+++ b/client/go/internal/vespa/document/document_test.go
@@ -220,9 +220,7 @@ func TestDocumentDecoderInvalid(t *testing.T) {
 	}
 
 	dec = NewDecoder(strings.NewReader(`{}`))
-	_, err = dec.Decode()
-	wantErr = "invalid operation at byte offset 2: no id specified"
-	if !errors.Is(err, ErrMissingId) {
+	if _, err = dec.Decode(); !errors.Is(err, ErrMissingId) {
 		t.Errorf("want error %q, got %q", ErrMissingId, err.Error())
 	}
 }

--- a/client/go/internal/vespa/document/document_test.go
+++ b/client/go/internal/vespa/document/document_test.go
@@ -166,7 +166,7 @@ func testDocumentDecoder(t *testing.T, jsonLike string) {
 	result := []Document{}
 	for {
 		doc, err := dec.Decode()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -260,7 +260,7 @@ func TestGenerator(t *testing.T) {
 	var docs []Document
 	for {
 		doc, err := dec.Decode()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			t.Fatal(err)

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -173,16 +173,16 @@ func (c *Client) methodAndURL(d Document, buf *bytes.Buffer) (string, string) {
 
 func (c *Client) leastBusyClient() *countingHTTPClient {
 	leastBusy := c.httpClients[0]
-	min := int64(math.MaxInt64)
+	minInflight := int64(math.MaxInt64)
 	next := c.sendCount.Add(1)
 	start := int(next) % len(c.httpClients)
 	for i := range c.httpClients {
 		j := (i + start) % len(c.httpClients)
 		client := c.httpClients[j]
 		inflight := client.inflight.Load()
-		if inflight < min {
+		if inflight < minInflight {
 			leastBusy = client
-			min = inflight
+			minInflight = inflight
 		}
 	}
 	leastBusy.inflight.Add(1)

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -352,6 +352,6 @@ func (c *Client) resultWithResponse(resp *http.Response, sentBytes int, result R
 	}
 	result.Latency = elapsed
 	result.BytesSent = int64(sentBytes)
-	result.BytesRecv = int64(written)
+	result.BytesRecv = written
 	return result
 }

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -321,11 +321,11 @@ func resultWithErr(result Result, err error, elapsed time.Duration) Result {
 func (c *Client) resultWithResponse(resp *http.Response, sentBytes int, result Result, elapsed time.Duration, buf *bytes.Buffer, copyBody bool) Result {
 	result.HTTPStatus = resp.StatusCode
 	switch resp.StatusCode {
-	case 200:
+	case http.StatusOK:
 		result.Status = StatusSuccess
-	case 412:
+	case http.StatusPreconditionFailed:
 		result.Status = StatusConditionNotMet
-	case 502, 504, 507:
+	case http.StatusBadGateway, http.StatusGatewayTimeout, http.StatusInsufficientStorage:
 		result.Status = StatusVespaFailure
 	default:
 		result.Status = StatusTransportFailure

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -40,7 +40,7 @@ type Client struct {
 	pending     chan *pendingDocument
 }
 
-// ClientOptions specifices the configuration options of a feed client.
+// ClientOptions specifics the configuration options of a feed client.
 type ClientOptions struct {
 	BaseURL     string
 	Header      http.Header

--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -82,7 +82,7 @@ func TestClientSend(t *testing.T) {
 	httpClient := mock.HTTPClient{ReadBody: true}
 	client, _ := NewClient(ClientOptions{
 		BaseURL: "https://example.com:1337",
-		Timeout: time.Duration(5 * time.Second),
+		Timeout: 5 * time.Second,
 	}, []httputil.Client{&httpClient})
 	clock := manualClock{t: time.Now(), tick: time.Second}
 	client.now = clock.now
@@ -163,7 +163,7 @@ func TestClientGet(t *testing.T) {
 	httpClient := mock.HTTPClient{ReadBody: true}
 	client, _ := NewClient(ClientOptions{
 		BaseURL: "https://example.com:1337",
-		Timeout: time.Duration(5 * time.Second),
+		Timeout: 5 * time.Second,
 	}, []httputil.Client{&httpClient})
 	clock := manualClock{t: time.Now(), tick: time.Second}
 	client.now = clock.now
@@ -206,7 +206,7 @@ func TestClientSendCompressed(t *testing.T) {
 	httpClient := &mock.HTTPClient{ReadBody: true}
 	client, _ := NewClient(ClientOptions{
 		BaseURL: "https://example.com:1337",
-		Timeout: time.Duration(5 * time.Second),
+		Timeout: 5 * time.Second,
 	}, []httputil.Client{httpClient})
 
 	bigBody := fmt.Sprintf(`{"fields": {"foo": "%s"}}`, strings.Repeat("s", 512+1))
@@ -343,7 +343,7 @@ func benchmarkClientSend(b *testing.B, compression Compression, document Documen
 	client, _ := NewClient(ClientOptions{
 		Compression: compression,
 		BaseURL:     "https://example.com:1337",
-		Timeout:     time.Duration(5 * time.Second),
+		Timeout:     5 * time.Second,
 	}, []httputil.Client{&httpClient})
 	b.ResetTimer() // ignore setup
 	for n := 0; n < b.N; n++ {

--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -58,26 +58,36 @@ func assertLeastBusy(t *testing.T, id int, client *Client) {
 }
 
 func TestClientSend(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		in     Document
 		method string
 		url    string
 	}{
-		{Document{Create: true, Id: mustParseId("id:ns:type::doc1"), Operation: OperationUpdate, Body: []byte(`{"fields":{"foo": "123"}}`)},
+		{
+			Document{Create: true, Id: mustParseId("id:ns:type::doc1"), Operation: OperationUpdate, Body: []byte(`{"fields":{"foo": "123"}}`)},
 			"PUT",
-			"https://example.com:1337/document/v1/ns/type/docid/doc1?timeout=5000ms&create=true"},
-		{Document{Id: mustParseId("id:ns:type::doc2"), Operation: OperationUpdate, Body: []byte(`{"fields":{"foo": "456"}}`)},
+			"https://example.com:1337/document/v1/ns/type/docid/doc1?timeout=5000ms&create=true",
+		},
+		{
+			Document{Id: mustParseId("id:ns:type::doc2"), Operation: OperationUpdate, Body: []byte(`{"fields":{"foo": "456"}}`)},
 			"PUT",
-			"https://example.com:1337/document/v1/ns/type/docid/doc2?timeout=5000ms"},
-		{Document{Id: mustParseId("id:ns:type::doc3"), Operation: OperationRemove},
+			"https://example.com:1337/document/v1/ns/type/docid/doc2?timeout=5000ms",
+		},
+		{
+			Document{Id: mustParseId("id:ns:type::doc3"), Operation: OperationRemove},
 			"DELETE",
-			"https://example.com:1337/document/v1/ns/type/docid/doc3?timeout=5000ms"},
-		{Document{Condition: "foo", Id: mustParseId("id:ns:type::doc4"), Operation: OperationUpdate, Body: []byte(`{"fields":{"baz": "789"}}`)},
+			"https://example.com:1337/document/v1/ns/type/docid/doc3?timeout=5000ms",
+		},
+		{
+			Document{Condition: "foo", Id: mustParseId("id:ns:type::doc4"), Operation: OperationUpdate, Body: []byte(`{"fields":{"baz": "789"}}`)},
 			"PUT",
-			"https://example.com:1337/document/v1/ns/type/docid/doc4?timeout=5000ms&condition=foo"},
-		{Document{Id: mustParseId("id:ns:type::doc5"), Operation: OperationPut, Body: []byte(`{"fields":{"baz": "789"}}`)},
+			"https://example.com:1337/document/v1/ns/type/docid/doc4?timeout=5000ms&condition=foo",
+		},
+		{
+			Document{Id: mustParseId("id:ns:type::doc5"), Operation: OperationPut, Body: []byte(`{"fields":{"baz": "789"}}`)},
 			"POST",
-			"https://example.com:1337/document/v1/ns/type/docid/doc5?timeout=5000ms"},
+			"https://example.com:1337/document/v1/ns/type/docid/doc5?timeout=5000ms",
+		},
 	}
 	httpClient := mock.HTTPClient{ReadBody: true}
 	client, _ := NewClient(ClientOptions{

--- a/client/go/internal/vespa/document/throttler.go
+++ b/client/go/internal/vespa/document/throttler.go
@@ -15,7 +15,7 @@ type Throttler interface {
 	Sent()
 	// Success notifies the throttler that document operation succeeded.
 	Success()
-	// Throttled notifies the throttler that a throttling event occured while count documents were in-flight.
+	// Throttled notifies the throttler that a throttling event occurred while count documents were in-flight.
 	Throttled(count int64)
 	// TargetInflight returns the ideal number of documents to have in-flight now.
 	TargetInflight() int64

--- a/client/go/internal/vespa/document/throttler.go
+++ b/client/go/internal/vespa/document/throttler.go
@@ -11,7 +11,7 @@ import (
 const throttlerWeight = 0.7
 
 type Throttler interface {
-	// Sent notifies the the throttler that a document has been sent.
+	// Sent notifies the throttler that a document has been sent.
 	Sent()
 	// Success notifies the throttler that document operation succeeded.
 	Success()

--- a/client/go/internal/vespa/find_home.go
+++ b/client/go/internal/vespa/find_home.go
@@ -26,14 +26,14 @@ func FindHome() string {
 		return ev
 	}
 	// some helper functions...
-	var dirName = func(path string) string {
+	dirName := func(path string) string {
 		idx := strings.LastIndex(path, "/")
 		if idx < 0 {
 			return ""
 		}
 		return path[:idx]
 	}
-	var findPath = func() string {
+	findPath := func() string {
 		myProgName := os.Args[0]
 		if strings.HasPrefix(myProgName, "/") {
 			trace.Debug("findPath", myProgName, "=>", dirName(myProgName))

--- a/client/go/internal/vespa/load_env.go
+++ b/client/go/internal/vespa/load_env.go
@@ -50,20 +50,22 @@ type loadEnvReceiver interface {
 	currentValue(varName string) string
 }
 
-type osEnvReceiver struct {
-}
+type osEnvReceiver struct{}
 
 func (p *osEnvReceiver) fallbackVar(varName, varVal string) {
 	if os.Getenv(varName) == "" {
 		os.Setenv(varName, varVal)
 	}
 }
+
 func (p *osEnvReceiver) overrideVar(varName, varVal string) {
 	os.Setenv(varName, varVal)
 }
+
 func (p *osEnvReceiver) unsetVar(varName string) {
 	os.Unsetenv(varName)
 }
+
 func (p *osEnvReceiver) currentValue(varName string) string {
 	return os.Getenv(varName)
 }
@@ -118,7 +120,7 @@ func loadDefaultEnvTo(r loadEnvReceiver) error {
 
 // borrowed some code from strings.Fields() implementation:
 func nSpacedFields(s string, n int) []string {
-	var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+	asciiSpace := [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
 	a := make([]string, n)
 	na := 0
 	i := 0
@@ -175,20 +177,24 @@ func newShellEnvExporter() *shellEnvExporter {
 		unsetVars:  make(map[string]string),
 	}
 }
+
 func (p *shellEnvExporter) fallbackVar(varName, varVal string) {
 	old := p.currentValue(varName)
 	if old == "" || old == varVal {
 		p.overrideVar(varName, varVal)
 	}
 }
+
 func (p *shellEnvExporter) overrideVar(varName, varVal string) {
 	delete(p.unsetVars, varName)
 	p.exportVars[varName] = shellQuote(varVal)
 }
+
 func (p *shellEnvExporter) unsetVar(varName string) {
 	delete(p.exportVars, varName)
 	p.unsetVars[varName] = "unset"
 }
+
 func (p *shellEnvExporter) currentValue(varName string) string {
 	if p.unsetVars[varName] != "" {
 		return ""

--- a/client/go/internal/vespa/load_env.go
+++ b/client/go/internal/vespa/load_env.go
@@ -121,13 +121,12 @@ func nSpacedFields(s string, n int) []string {
 	var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
 	a := make([]string, n)
 	na := 0
-	fieldStart := 0
 	i := 0
 	// Skip spaces in the front of the input.
 	for i < len(s) && asciiSpace[s[i]] != 0 {
 		i++
 	}
-	fieldStart = i
+	fieldStart := i
 	for i < len(s) && na+1 < n {
 		if asciiSpace[s[i]] == 0 {
 			i++

--- a/client/go/internal/vespa/load_env_test.go
+++ b/client/go/internal/vespa/load_env_test.go
@@ -18,12 +18,12 @@ func setup(t *testing.T, contents string) string {
 	bdir := vdir + "/bin"
 	cdir := vdir + "/conf/vespa"
 	envf := cdir + "/default-env.txt"
-	err := os.MkdirAll(cdir, 0755)
+	err := os.MkdirAll(cdir, 0o755)
 	assert.Nil(t, err)
 	t.Setenv("VESPA_HOME", vdir)
-	err = os.MkdirAll(bdir, 0755)
+	err = os.MkdirAll(bdir, 0o755)
 	assert.Nil(t, err)
-	err = os.WriteFile(envf, []byte(contents), 0644)
+	err = os.WriteFile(envf, []byte(contents), 0o644)
 	assert.Nil(t, err)
 	return tmp
 }

--- a/client/go/internal/vespa/load_env_test.go
+++ b/client/go/internal/vespa/load_env_test.go
@@ -61,8 +61,8 @@ func TestLoadEnvWhiteSpace(t *testing.T) {
 	setup(t, `
 # vespa env vars file
 override VESPA_V1 v1
- override  VESPA_V2  v2 
-override VESPA_V3 spaced v3 v3
+ override  VESPA_V2  v2
+override VESPA_V3 spaced v3 vv
 override VESPA_V4 " quoted spaced "
 override VESPA_V5 v5
 `)
@@ -72,7 +72,7 @@ override VESPA_V5 v5
 	// check results
 	assert.Equal(t, os.Getenv("VESPA_V1"), "v1")
 	assert.Equal(t, os.Getenv("VESPA_V2"), "v2")
-	assert.Equal(t, os.Getenv("VESPA_V3"), "spaced v3 v3")
+	assert.Equal(t, os.Getenv("VESPA_V3"), "spaced v3 vv")
 	assert.Equal(t, os.Getenv("VESPA_V4"), " quoted spaced ")
 	assert.Equal(t, os.Getenv("VESPA_V5"), "v5")
 }

--- a/client/go/internal/vespa/prestart.go
+++ b/client/go/internal/vespa/prestart.go
@@ -26,8 +26,8 @@ func RunPreStart() error {
 	fixSpec := osutil.FixSpec{
 		UserId:   vespaUid,
 		GroupId:  vespaGid,
-		DirMode:  0755,
-		FileMode: 0644,
+		DirMode:  0o755,
+		FileMode: 0o644,
 	}
 	fixSpec.FixDir("logs")
 	fixSpec.FixDir("logs/vespa")

--- a/client/go/internal/vespa/slime/array.go
+++ b/client/go/internal/vespa/slime/array.go
@@ -17,6 +17,7 @@ func (arr *arrayValue) Entry(index int) Value {
 	}
 	return Invalid
 }
+
 func (arr *arrayValue) EachEntry(f func(index int, value Value)) {
 	for i, x := range arr.value {
 		f(i, x)

--- a/client/go/internal/vespa/slime/array_test.go
+++ b/client/go/internal/vespa/slime/array_test.go
@@ -3,8 +3,9 @@
 package slime
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func leafTestValues() []Value {
@@ -27,12 +28,13 @@ func TestArray(t *testing.T) {
 	}
 
 	expect := []expectLeaf{
-		expectLeaf{mytype: EMPTY},
-		expectLeaf{mytype: BOOL, boolVal: true},
-		expectLeaf{mytype: LONG, longVal: 5, doubleVal: 5},
-		expectLeaf{mytype: DOUBLE, longVal: 5, doubleVal: 5.5},
-		expectLeaf{mytype: STRING, stringVal: "foo"},
-		expectLeaf{mytype: DATA, dataVal: []byte{1, 2, 3}}}
+		{mytype: EMPTY},
+		{mytype: BOOL, boolVal: true},
+		{mytype: LONG, longVal: 5, doubleVal: 5},
+		{mytype: DOUBLE, longVal: 5, doubleVal: 5.5},
+		{mytype: STRING, stringVal: "foo"},
+		{mytype: DATA, dataVal: []byte{1, 2, 3}},
+	}
 
 	var expectIndex int
 	var collect []Value

--- a/client/go/internal/vespa/slime/error.go
+++ b/client/go/internal/vespa/slime/error.go
@@ -4,9 +4,7 @@ package slime
 
 import "errors"
 
-var (
-	Invalid Value = ErrorMsg("invalid value")
-)
+var Invalid Value = ErrorMsg("invalid value")
 
 type errorValue struct {
 	emptyValue

--- a/client/go/internal/vespa/slime/inserter_test.go
+++ b/client/go/internal/vespa/slime/inserter_test.go
@@ -3,8 +3,9 @@
 package slime
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInsertRoot(t *testing.T) {

--- a/client/go/internal/vespa/slime/json.go
+++ b/client/go/internal/vespa/slime/json.go
@@ -12,9 +12,7 @@ import (
 	"strings"
 )
 
-var (
-	hex []byte = []byte("0123456789ABCDEF")
-)
+var hex []byte = []byte("0123456789ABCDEF")
 
 func fromHexDigit(digit byte) int {
 	switch digit {

--- a/client/go/internal/vespa/slime/json.go
+++ b/client/go/internal/vespa/slime/json.go
@@ -250,8 +250,8 @@ type jsonDecoder struct {
 
 func (d *jsonDecoder) next() {
 	if d.err == nil {
-		len, e := d.input.Read(d.buf)
-		if len == 1 {
+		bytesRead, e := d.input.Read(d.buf)
+		if bytesRead == 1 {
 			d.c = d.buf[0]
 		} else {
 			if e != nil {

--- a/client/go/internal/vespa/slime/json.go
+++ b/client/go/internal/vespa/slime/json.go
@@ -261,13 +261,13 @@ func (d *jsonDecoder) next() {
 			}
 			d.c = 0
 		}
-	} else if d.err == io.EOF {
+	} else if errors.Is(d.err, io.EOF) {
 		d.err = errors.New("input underflow")
 	}
 }
 
 func (d *jsonDecoder) fail(msg string) {
-	if d.err == nil || d.err == io.EOF {
+	if d.err == nil || errors.Is(d.err, io.EOF) {
 		d.err = errors.New(msg)
 		d.c = 0
 	}

--- a/client/go/internal/vespa/slime/json_test.go
+++ b/client/go/internal/vespa/slime/json_test.go
@@ -4,10 +4,11 @@ package slime
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func checkJson(t *testing.T, value Value, compact bool, expect ...string) {

--- a/client/go/internal/vespa/slime/leaf_test.go
+++ b/client/go/internal/vespa/slime/leaf_test.go
@@ -3,8 +3,9 @@
 package slime
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type expectLeaf struct {

--- a/client/go/internal/vespa/slime/object.go
+++ b/client/go/internal/vespa/slime/object.go
@@ -18,6 +18,7 @@ func (obj *objectValue) Field(name string) Value {
 	}
 	return Invalid
 }
+
 func (obj *objectValue) EachField(f func(name string, value Value)) {
 	for n, x := range obj.value {
 		f(n, x)

--- a/client/go/internal/vespa/slime/object_test.go
+++ b/client/go/internal/vespa/slime/object_test.go
@@ -3,8 +3,9 @@
 package slime
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func dummyFieldNames(n int) []string {
@@ -25,12 +26,13 @@ func TestObject(t *testing.T) {
 	}
 
 	expect := map[string]expectLeaf{
-		"a": expectLeaf{mytype: EMPTY},
-		"b": expectLeaf{mytype: BOOL, boolVal: true},
-		"c": expectLeaf{mytype: LONG, longVal: 5, doubleVal: 5},
-		"d": expectLeaf{mytype: DOUBLE, longVal: 5, doubleVal: 5.5},
-		"e": expectLeaf{mytype: STRING, stringVal: "foo"},
-		"f": expectLeaf{mytype: DATA, dataVal: []byte{1, 2, 3}}}
+		"a": {mytype: EMPTY},
+		"b": {mytype: BOOL, boolVal: true},
+		"c": {mytype: LONG, longVal: 5, doubleVal: 5},
+		"d": {mytype: DOUBLE, longVal: 5, doubleVal: 5.5},
+		"e": {mytype: STRING, stringVal: "foo"},
+		"f": {mytype: DATA, dataVal: []byte{1, 2, 3}},
+	}
 
 	collect := make(map[string]Value)
 	obj.EachField(func(name string, val Value) {

--- a/client/go/internal/vespa/slime/path.go
+++ b/client/go/internal/vespa/slime/path.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 )
 
-var (
-	noSelector Selector = &selectSelf{}
-)
+var noSelector Selector = &selectSelf{}
 
 type Selector interface {
 	Select(value Value) Value

--- a/client/go/internal/vespa/slime/path_test.go
+++ b/client/go/internal/vespa/slime/path_test.go
@@ -3,8 +3,9 @@
 package slime
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func createComplexValue(t *testing.T) Value {

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -190,7 +190,7 @@ func (s *Service) SetClient(client httputil.Client) {
 func (s *Service) Wait(timeout time.Duration) error {
 	// A path that does not need authentication, on any target
 	url := strings.TrimRight(s.BaseURL, "/") + "/status.html"
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func deployRequest(target Target, fn responseFunc, reqFn requestFunc, timeout, r
 }
 
 func pollLogs(target Target, logsURL string, options LogOptions, retryInterval time.Duration) error {
-	req, err := http.NewRequest("GET", logsURL, nil)
+	req, err := http.NewRequest(http.MethodGet, logsURL, nil)
 	if err != nil {
 		return err
 	}

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -238,7 +238,7 @@ func FindService(name string, authMethod string, services []*Service) (*Service,
 		if name == s.Name {
 			return s, nil
 		}
-		var prettyName = color.CyanString("%s", s.Name)
+		prettyName := color.CyanString("%s", s.Name)
 		if s.AuthMethod != "" {
 			prettyName = fmt.Sprintf("%s (%s)", prettyName, s.AuthMethod)
 		}

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -167,7 +167,7 @@ func (s *Service) Do(request *http.Request, timeout time.Duration) (*http.Respon
 	}
 	if s.auth != nil {
 		if err := s.auth.Authenticate(request); err != nil {
-			return nil, fmt.Errorf("%w: %s", errAuth, err)
+			return nil, fmt.Errorf("%w: %w", errAuth, err)
 		}
 	}
 	if err := s.CurlWriter.print(request, s.TLSOptions, timeout); err != nil {
@@ -175,7 +175,7 @@ func (s *Service) Do(request *http.Request, timeout time.Duration) (*http.Respon
 	}
 	resp, err := s.httpClient.Do(request, timeout)
 	if isTLSAlert(err) {
-		return nil, fmt.Errorf("%w: %s", errAuth, err)
+		return nil, fmt.Errorf("%w: %w", errAuth, err)
 	}
 	return resp, err
 }
@@ -326,7 +326,7 @@ func pollLogs(target Target, logsURL string, options LogOptions, retryInterval t
 	}
 	// Ignore wait error because logFunc has no concept of completion, we just want to print log entries until timeout is reached
 	if _, err := deployRequest(target, logFunc, requestFunc, timeout, retryInterval); err != nil && !errors.Is(err, ErrWaitTimeout) {
-		return fmt.Errorf("failed to read logs: %s", err)
+		return fmt.Errorf("failed to read logs: %w", err)
 	}
 	return nil
 }

--- a/client/go/internal/vespa/target_cloud.go
+++ b/client/go/internal/vespa/target_cloud.go
@@ -168,7 +168,7 @@ func (t *cloudTarget) CompatibleWith(clientVersion version.Version) error {
 	if clientVersion.IsZero() { // development version is always fine
 		return nil
 	}
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/cli/v1/", t.apiOptions.System.URL), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/cli/v1/", t.apiOptions.System.URL), nil)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (t *cloudTarget) PrintLog(options LogOptions) error {
 
 func (t *cloudTarget) discoverLatestRun(timeout time.Duration) (int64, error) {
 	runsURL := t.apiOptions.System.RunsURL(t.deploymentOptions.Deployment) + "?limit=1"
-	req, err := http.NewRequest("GET", runsURL, nil)
+	req, err := http.NewRequest(http.MethodGet, runsURL, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -244,7 +244,7 @@ func (t *cloudTarget) AwaitDeployment(runID int64, timeout time.Duration) (int64
 		runID = lastRunID
 	}
 	runURL := t.apiOptions.System.RunURL(t.deploymentOptions.Deployment, runID)
-	req, err := http.NewRequest("GET", runURL, nil)
+	req, err := http.NewRequest(http.MethodGet, runURL, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -313,7 +313,7 @@ func (t *cloudTarget) discoverEndpoints(timeout time.Duration) (map[string][]clu
 		t.apiOptions.System.URL,
 		t.deploymentOptions.Deployment.Application.Tenant, t.deploymentOptions.Deployment.Application.Application, t.deploymentOptions.Deployment.Application.Instance,
 		t.deploymentOptions.Deployment.Zone.Environment, t.deploymentOptions.Deployment.Zone.Region)
-	req, err := http.NewRequest("GET", deploymentURL, nil)
+	req, err := http.NewRequest(http.MethodGet, deploymentURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/go/internal/vespa/target_cloud.go
+++ b/client/go/internal/vespa/target_cloud.go
@@ -78,7 +78,8 @@ type logMessage struct {
 // CloudTarget creates a Target for the Vespa Cloud or hosted Vespa platform.
 func CloudTarget(httpClient httputil.Client, apiAuth Authenticator, deploymentAuth Authenticator,
 	apiOptions APIOptions, deploymentOptions CloudDeploymentOptions,
-	logOptions LogOptions, retryInterval time.Duration) (Target, error) {
+	logOptions LogOptions, retryInterval time.Duration,
+) (Target, error) {
 	return &cloudTarget{
 		httpClient:        httpClient,
 		apiOptions:        apiOptions,
@@ -128,8 +129,8 @@ func (t *cloudTarget) ContainerServices(timeout time.Duration) ([]*Service, erro
 		clusterTargets = make(map[string][]clusterTarget)
 		for cluster, url := range t.deploymentOptions.ClusterURLs {
 			clusterTargets[cluster] = []clusterTarget{
-				clusterTarget{URL: url, AuthMethod: "mtls"},
-				clusterTarget{URL: url, AuthMethod: "token"},
+				{URL: url, AuthMethod: "mtls"},
+				{URL: url, AuthMethod: "token"},
 			}
 		}
 	} else {

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -81,7 +81,7 @@ func (t *customTarget) CompatibleWith(minVersion version.Version) error {
 		return err
 	}
 	versionURL := deployService.BaseURL + "/state/v1/version"
-	req, err := http.NewRequest("GET", versionURL, nil)
+	req, err := http.NewRequest(http.MethodGet, versionURL, nil)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (t *customTarget) serviceStatus(wantedGeneration int64, timeout time.Durati
 		return serviceStatus{}, err
 	}
 	url := fmt.Sprintf("%s/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default/serviceconverge", deployService.BaseURL)
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return serviceStatus{}, err
 	}

--- a/client/go/internal/vespa/tracedoctor/ann.go
+++ b/client/go/internal/vespa/tracedoctor/ann.go
@@ -4,6 +4,7 @@ package tracedoctor
 
 import (
 	"fmt"
+
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 )
 

--- a/client/go/internal/vespa/tracedoctor/extract.go
+++ b/client/go/internal/vespa/tracedoctor/extract.go
@@ -4,10 +4,11 @@ package tracedoctor
 
 import (
 	"fmt"
-	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 )
 
 type queryTree struct {

--- a/client/go/internal/vespa/tracedoctor/extract_test.go
+++ b/client/go/internal/vespa/tracedoctor/extract_test.go
@@ -3,9 +3,10 @@
 package tracedoctor
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
-	"testing"
 )
 
 type testFactory struct{}

--- a/client/go/internal/vespa/tracedoctor/json_as_table_test.go
+++ b/client/go/internal/vespa/tracedoctor/json_as_table_test.go
@@ -5,10 +5,11 @@ package tracedoctor
 import (
 	"bufio"
 	"fmt"
-	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 	"os"
 	"sort"
 	"testing"
+
+	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 )
 
 // experimenting with rendering json as nested table

--- a/client/go/internal/vespa/tracedoctor/multi_line_test.go
+++ b/client/go/internal/vespa/tracedoctor/multi_line_test.go
@@ -1,8 +1,9 @@
 package tracedoctor
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitText(t *testing.T) {

--- a/client/go/internal/vespa/tracedoctor/table.go
+++ b/client/go/internal/vespa/tracedoctor/table.go
@@ -3,8 +3,9 @@
 package tracedoctor
 
 import (
-	"github.com/mattn/go-runewidth"
 	"strings"
+
+	"github.com/mattn/go-runewidth"
 )
 
 type edgeMask uint8

--- a/client/go/internal/vespa/tracedoctor/table_test.go
+++ b/client/go/internal/vespa/tracedoctor/table_test.go
@@ -4,9 +4,10 @@ package tracedoctor
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRenderTable(t *testing.T) {

--- a/client/go/internal/vespa/tracedoctor/tracedoctor.go
+++ b/client/go/internal/vespa/tracedoctor/tracedoctor.go
@@ -4,9 +4,10 @@ package tracedoctor
 
 import (
 	"fmt"
-	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 	"io"
 	"sort"
+
+	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
 )
 
 type timing struct {

--- a/client/go/internal/vespa/tracedoctor/tracedoctor_test.go
+++ b/client/go/internal/vespa/tracedoctor/tracedoctor_test.go
@@ -3,9 +3,10 @@
 package tracedoctor
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
-	"testing"
 )
 
 func addExampleTiming(obj slime.Value) {

--- a/client/go/internal/vespa/xml/config.go
+++ b/client/go/internal/vespa/xml/config.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -318,7 +319,7 @@ func Replace(r io.Reader, parentName, name string, data interface{}) (string, er
 	done := false
 	for {
 		token, err := dec.Token()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return "", err

--- a/client/go/internal/vespa/xml/config.go
+++ b/client/go/internal/vespa/xml/config.go
@@ -211,21 +211,21 @@ func ParseResources(s string) (Resources, error) {
 // ParseNodeCount parses a node count range from string s.
 func ParseNodeCount(s string) (int, int, error) {
 	parseErr := fmt.Errorf("invalid node count: %q", s)
-	min, max := 0, 0
+	minNodeCount, maxNodeCount := 0, 0
 	n, err := strconv.Atoi(s)
 	if err == nil {
-		min = n
-		max = n
+		minNodeCount = n
+		maxNodeCount = n
 	} else if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
 		parts := strings.Split(s[1:len(s)-1], ",")
 		if len(parts) != 2 {
 			return 0, 0, parseErr
 		}
-		min, err = strconv.Atoi(strings.TrimSpace(parts[0]))
+		minNodeCount, err = strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return 0, 0, parseErr
 		}
-		max, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+		maxNodeCount, err = strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
 			return 0, 0, parseErr
 		}
@@ -233,10 +233,10 @@ func ParseNodeCount(s string) (int, int, error) {
 		return 0, 0, parseErr
 	}
 
-	if min <= 0 || min > max {
+	if minNodeCount <= 0 || minNodeCount > maxNodeCount {
 		return 0, 0, parseErr
 	}
-	return min, max, nil
+	return minNodeCount, maxNodeCount, nil
 }
 
 // IsProdRegion returns whether string s is a valid production region.

--- a/client/go/internal/vespa/xml/config.go
+++ b/client/go/internal/vespa/xml/config.go
@@ -211,7 +211,7 @@ func ParseResources(s string) (Resources, error) {
 // ParseNodeCount parses a node count range from string s.
 func ParseNodeCount(s string) (int, int, error) {
 	parseErr := fmt.Errorf("invalid node count: %q", s)
-	minNodeCount, maxNodeCount := 0, 0
+	var minNodeCount, maxNodeCount int
 	n, err := strconv.Atoi(s)
 	if err == nil {
 		minNodeCount = n

--- a/client/go/internal/vespa/xml/config_test.go
+++ b/client/go/internal/vespa/xml/config_test.go
@@ -321,15 +321,15 @@ func assertReplace(t *testing.T, input, want, parentElement, element string, dat
 }
 
 func assertNodeCount(t *testing.T, input string, wantMin, wantMax int, wantErr bool) {
-	min, max, err := ParseNodeCount(input)
+	minNodeCount, maxNodeCount, err := ParseNodeCount(input)
 	if wantErr {
 		if err == nil {
 			t.Errorf("want error for input %q", input)
 		}
 		return
 	}
-	if min != wantMin || max != wantMax {
-		t.Errorf("got min = %d, max = %d, want min = %d, max = %d", min, max, wantMin, wantMax)
+	if minNodeCount != wantMin || maxNodeCount != wantMax {
+		t.Errorf("got min = %d, max = %d, want min = %d, max = %d", minNodeCount, maxNodeCount, wantMin, wantMax)
 	}
 }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## What
This pull request introduces several changes to the Go client codebase, focusing on improving code quality, adding linting support, and addressing minor issues such as formatting, error handling, and code cleanup. The most important changes include enabling linting with `golangci-lint`, adding a configuration file for linters, and making various code improvements across multiple files.

### Linting and Configuration:
* Added `golangci-lint` as a step in the GitHub Actions workflow for the Go client to ensure code quality and detect issues in new changes.
* Introduced a `.golangci.yaml` configuration file to enable specific linters and define exclusions and formatting rules.

### Code Quality Improvements:
* Replaced numeric file permission literals (e.g., `0755`) with octal literals (e.g., `0o755`) for better readability and consistency.
* Simplified loop constructs by removing unnecessary variables

### Error Handling and Formatting:
* Improved error messages by standardizing capitalization and formatting
* Enhanced error handling by using `errors.As` for type assertion and wrapping errors with additional context. 

### Cleanup and Refactoring:
* Removed redundant variable declarations and unused code blocks to simplify function implementations.
* Refactored function signatures and return statements for clarity and consistency.