### PR TITLE
feat(lsp): open yql query results file in a split screen view

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaMessageHandler.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaMessageHandler.java
@@ -58,9 +58,16 @@ public class SchemaMessageHandler {
         return client.showMessageRequest(params);
     }
 
-    public CompletableFuture<ShowDocumentResult> showDocument(String fileURI) {
-        return client.showDocument(new ShowDocumentParams(fileURI));
+    public CompletableFuture<ShowDocumentResult> showDocument(String fileURI, boolean openSplitScreen) {
+        var params = new ShowDocumentParams(fileURI);
+        params.setTakeFocus(!openSplitScreen);
+        return client.showDocument(params);
     }
+
+    public CompletableFuture<ShowDocumentResult> showDocument(String fileURI) {
+        return showDocument(fileURI, false);
+    }
+
 
     public CompletableFuture<ApplyWorkspaceEditResponse>  applyEdit(ApplyWorkspaceEditParams params) {
         return client.applyEdit(params);

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/RunVespaQuery.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/RunVespaQuery.java
@@ -78,7 +78,7 @@ public class RunVespaQuery implements SchemaCommand {
                 .build();
 
             context.messageHandler.applyEdit(new ApplyWorkspaceEditParams(wsEdit)).thenRun(() -> {
-                context.messageHandler.showDocument(targetFileURI);
+                context.messageHandler.showDocument(targetFileURI, true);
             });
         });
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Reimplementation of [https://github.com/vespa-engine/vespa/pull/33587](https://github.com/vespa-engine/vespa/pull/33587) using ShowDocumentParams to ensure not affecting other showdocument requests not from our language server.