### PR TITLE
use enum values to match iterator with blueprint

### DIFF
--- a/searchcore/src/tests/proton/matching/match_phase_limiter/match_phase_limiter_test.cpp
+++ b/searchcore/src/tests/proton/matching/match_phase_limiter/match_phase_limiter_test.cpp
@@ -86,7 +86,7 @@ struct MockBlueprint : SimpleLeafBlueprint {
         }
         return std::make_unique<MockSearch>(spec, term, strict(), tfmda, postings_fetched);
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
     void fetchPostings(const search::queryeval::ExecuteInfo &) override {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -235,7 +235,7 @@ public:
 
     bool isWhiteList() const noexcept final { return true; }
 
-    SearchIterator::UP createFilterSearch(FilterConstraint) const override {
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint) const override {
         if (_all_lids_active) {
             return std::make_unique<FullSearch>();
         }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -208,9 +208,6 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
         _query.extractLocations(_queryEnv.locations());
         trace.addEvent(5, "Build query execution plan");
         _query.reserveHandles(_requestContext, searchContext, _mdl);
-        if (trace.getLevel() >= 6) { // will dump blueprint later
-            _query.enumerate_blueprint_nodes();
-        }
         trace.addEvent(5, "Optimize query execution plan");
         bool sort_by_cost = SortBlueprintsByCost::check(_queryEnv.getProperties(), rankSetup.sort_blueprints_by_cost());
         double hitRate = std::min(1.0, double(maxNumHits)/double(searchContext.getDocIdLimit()));
@@ -222,6 +219,9 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
             _query.handle_global_filter(_requestContext, searchContext.getDocIdLimit(),
                                         _create_blueprint_params.global_filter_lower_limit,
                                         _create_blueprint_params.global_filter_upper_limit, trace, sort_by_cost);
+        }
+        if (trace.getLevel() >= 6) { // will dump blueprint later
+            _query.enumerate_blueprint_nodes();
         }
         _query.freeze();
         trace.addEvent(5, "Prepare shared state for multi-threaded rank executors");

--- a/searchlib/src/apps/vespa-query-analyzer/vespa-query-analyzer.cpp
+++ b/searchlib/src/apps/vespa-query-analyzer/vespa-query-analyzer.cpp
@@ -295,7 +295,6 @@ BlueprintMeta blueprint_meta;
 
 struct Node {
     std::string  type = "unknown";
-    uint32_t          id = 0;
     uint32_t          docid_limit = 0;
     std::string  field_name;
     std::string  query_term;
@@ -314,7 +313,6 @@ struct Node {
     explicit Node(const Inspector &obj) {
         extract(type, obj["[type]"]);
         type = strip_name(type);
-        id = obj["id"].asLong();
         docid_limit = obj["docid_limit"].asLong();
         query_term = obj["query_term"].asString().make_stringview();
         if (query_term.size() > 0) {
@@ -354,9 +352,6 @@ struct Node {
     ~Node();
     std::string name() const {
         std::string res = type;
-        if (id > 0) {
-            res.append(fmt("[%u]", id));
-        }
         if (query_term.size() > 0) {
             if (field_name.size() > 0) {
                 res.append(fmt(" %s:%s", field_name.c_str(), query_term.c_str()));

--- a/searchlib/src/tests/queryeval/blueprint/blueprint_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/blueprint_test.cpp
@@ -48,7 +48,7 @@ public:
     createIntermediateSearch(MultiSearch::Children subSearches, MatchData &md) const override {
         return std::make_unique<MySearch>("or", std::move(subSearches), &md, strict());
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
     static MyOr& create() { return *(new MyOr()); }
@@ -136,7 +136,7 @@ struct MyTerm : SimpleLeafBlueprint {
     SearchIterator::UP createLeafSearch(const search::fef::TermFieldMatchDataArray &) const override {
         return {};
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 };

--- a/searchlib/src/tests/queryeval/blueprint/mysearch.h
+++ b/searchlib/src/tests/queryeval/blueprint/mysearch.h
@@ -141,7 +141,7 @@ public:
     // make public
     using LeafBlueprint::set_want_global_filter;
 
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 };

--- a/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
+++ b/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
@@ -70,7 +70,7 @@ struct LeafProxy : SimpleLeafBlueprint {
         child->sort(in_flow);
     }
     SearchIteratorUP createLeafSearch(const TermFieldMatchDataArray &) const override { abort(); }
-    SearchIteratorUP createFilterSearch(Constraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(Constraint constraint) const override {
         return child->createFilterSearch(constraint);
     }
 };
@@ -87,7 +87,7 @@ struct CheckParamsProxy : LeafProxy {
         expect_inherit_strict(expect_inherit_strict_in), expect_same_constraint(expect_same_constraint_in) {}
     CheckParamsProxy(std::unique_ptr<Blueprint> child_in)
       : LeafProxy(std::move(child_in)), expect_forced_strict(true), expect_inherit_strict(false), expect_same_constraint(true) {}
-    SearchIteratorUP createFilterSearch(Constraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(Constraint constraint) const override {
         if (expect_forced_strict) {
             EXPECT_EQ(strict(), true);
         } else {
@@ -105,7 +105,7 @@ struct CheckDroppedProxy : LeafProxy {
     mutable bool used;
     CheckDroppedProxy(std::unique_ptr<Blueprint> child_in)
       : LeafProxy(std::move(child_in)), used(false) {}
-    SearchIteratorUP createFilterSearch(Constraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(Constraint constraint) const override {
         used = true;
         return child->createFilterSearch(constraint);
     }

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -376,7 +376,7 @@ public:
         (void) tfmda;
         return _sc->createIterator(&_tfmd, strict());
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 private:
@@ -817,8 +817,8 @@ TEST(QueryEvalTest, require_that_we_can_insert_indexes_into_unpack_info_that_we_
 
 TEST(QueryEvalTest, test_true_search)
 {
-    EXPECT_EQ(16u, sizeof(EmptySearch));
-    EXPECT_EQ(24u, sizeof(TrueSearch));
+    EXPECT_EQ(24u, sizeof(EmptySearch));
+    EXPECT_EQ(32u, sizeof(TrueSearch));
 
     TermFieldMatchData tfmd;
     TrueSearch t(tfmd);

--- a/searchlib/src/tests/queryeval/simple_phrase/simple_phrase_test.cpp
+++ b/searchlib/src/tests/queryeval/simple_phrase/simple_phrase_test.cpp
@@ -41,7 +41,7 @@ struct MyTerm : public search::queryeval::SimpleLeafBlueprint {
     SearchIterator::UP createLeafSearch(const search::fef::TermFieldMatchDataArray &) const override {
         return {};
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 };

--- a/searchlib/src/tests/queryeval/termwise_eval/termwise_eval_test.cpp
+++ b/searchlib/src/tests/queryeval/termwise_eval/termwise_eval_test.cpp
@@ -89,7 +89,7 @@ struct MyBlueprint : SimpleLeafBlueprint {
     SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &) const override {
         return std::make_unique<MyTerm>(hits, strict());
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 };

--- a/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
+++ b/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
@@ -349,7 +349,7 @@ struct VerifyMatchData {
         FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
             return default_flow_stats(docid_limit, 0, 0);
         }
-        [[nodiscard]] SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        [[nodiscard]] SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
             return create_default_filter(constraint);
         }
     };

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -165,13 +165,13 @@ public:
         return _search_context->createIterator(tfmda[0], strict());
     }
 
-    SearchIterator::UP createSearch(fef::MatchData &md) const override {
+    SearchIterator::UP createSearchImpl(fef::MatchData &md) const override {
         const State &state = getState();
         assert(state.numFields() == 1);
         return _search_context->createIterator(state.field(0).resolve(md), strict());
     }
 
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         (void) constraint; // We provide an iterator with exact results, so no need to take constraint into consideration.
         auto wrapper = std::make_unique<FilterWrapper>(getState().numFields());
         wrapper->wrap(createLeafSearch(wrapper->tfmda()));
@@ -309,7 +309,7 @@ public:
             return std::make_unique<LocationPreFilterIterator<false, Parent>>(std::move(children));
         }
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 
@@ -375,7 +375,7 @@ public:
         }
         return FastS_AllocLocationIterator(_attribute.getNumDocs(), strict(), _location);
     }
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
     void visitMembers(vespalib::ObjectVisitor& visitor) const override {
@@ -518,7 +518,7 @@ public:
                                                               _scoresAdjustFrequency, get_docid_limit()),
                                                         _weights, _terms, _attr, strict(), readonly_scores_heap);
     }
-    std::unique_ptr<SearchIterator> createFilterSearch(FilterConstraint constraint) const override;
+    std::unique_ptr<SearchIterator> createFilterSearchImpl(FilterConstraint constraint) const override;
     bool always_needs_unpack() const override { return true; }
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;
 };
@@ -526,7 +526,7 @@ public:
 DirectWandBlueprint::~DirectWandBlueprint() = default;
 
 std::unique_ptr<SearchIterator>
-DirectWandBlueprint::createFilterSearch(FilterConstraint constraint) const
+DirectWandBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     if (constraint == Blueprint::FilterConstraint::UPPER_BOUND) {
         std::vector<DocidWithWeightIterator> iterators;

--- a/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
@@ -170,7 +170,7 @@ AttributeWeightedSetBlueprint::createLeafSearch(const fef::TermFieldMatchDataArr
 }
 
 queryeval::SearchIterator::UP
-AttributeWeightedSetBlueprint::createFilterSearch(FilterConstraint) const
+AttributeWeightedSetBlueprint::createFilterSearchImpl(FilterConstraint) const
 {
     std::vector<std::unique_ptr<queryeval::SearchIterator>> children;
     children.reserve(_contexts.size());

--- a/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.h
@@ -34,7 +34,7 @@ public:
     void sort(queryeval::InFlow in_flow) override;
     queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     queryeval::SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
-    queryeval::SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    queryeval::SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
     void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
 };

--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
@@ -80,7 +80,7 @@ public:
 
     std::unique_ptr<queryeval::SearchIterator> createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
 
-    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(FilterConstraint constraint) const override;
+    std::unique_ptr<queryeval::SearchIterator> createFilterSearchImpl(FilterConstraint constraint) const override;
     std::unique_ptr<queryeval::MatchingElementsSearch> create_matching_elements_search(const MatchingElementsFields &fields) const override;
     void visitMembers(vespalib::ObjectVisitor& visitor) const override {
         LeafBlueprint::visitMembers(visitor);

--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.hpp
@@ -174,7 +174,7 @@ DirectMultiTermBlueprint<PostingStoreType, SearchType>::createLeafSearch(const f
 
 template <typename PostingStoreType, typename SearchType>
 std::unique_ptr<queryeval::SearchIterator>
-DirectMultiTermBlueprint<PostingStoreType, SearchType>::createFilterSearch(FilterConstraint) const
+DirectMultiTermBlueprint<PostingStoreType, SearchType>::createFilterSearchImpl(FilterConstraint) const
 {
     assert(getState().numFields() == 1);
     auto wrapper = std::make_unique<FilterWrapper>(getState().numFields());

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
@@ -162,7 +162,7 @@ DiskTermBlueprint::createLeafSearch(const TermFieldMatchDataArray & tfmda) const
 }
 
 SearchIterator::UP
-DiskTermBlueprint::createFilterSearch(FilterConstraint) const
+DiskTermBlueprint::createFilterSearchImpl(FilterConstraint) const
 {
     auto wrapper = std::make_unique<queryeval::FilterWrapper>(getState().numFields());
     auto & tfmda = wrapper->tfmda();

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
@@ -57,7 +57,7 @@ public:
 
     void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
 
-    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(FilterConstraint) const override;
+    std::unique_ptr<queryeval::SearchIterator> createFilterSearchImpl(FilterConstraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
 };

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
@@ -287,7 +287,7 @@ public:
         return result;
     }
 
-    SearchIterator::UP createFilterSearch(FilterConstraint) const override {
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint) const override {
         auto wrapper = std::make_unique<queryeval::FilterWrapper>(getState().numFields());
         auto & tfmda = wrapper->tfmda();
         wrapper->wrap(make_search_iterator<interleaved_features>(_posting_itr, _feature_store, _field_id, tfmda));

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -661,7 +661,7 @@ IntermediateBlueprint::set_global_filter(const GlobalFilter &global_filter, doub
 }
 
 SearchIterator::UP
-IntermediateBlueprint::createSearch(fef::MatchData &md) const
+IntermediateBlueprint::createSearchImpl(fef::MatchData &md) const
 {
     MultiSearch::Children subSearches;
     subSearches.reserve(_children.size());
@@ -818,7 +818,7 @@ LeafBlueprint::set_matching_phase(MatchingPhase) noexcept
 }
 
 SearchIterator::UP
-LeafBlueprint::createSearch(fef::MatchData &md) const
+LeafBlueprint::createSearchImpl(fef::MatchData &md) const
 {
     const State &state = getState();
     fef::TermFieldMatchDataArray tfmda;

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -391,8 +391,16 @@ public:
 
     virtual void set_matching_phase(MatchingPhase matching_phase) noexcept = 0;
 
-    virtual SearchIteratorUP createSearch(fef::MatchData &md) const = 0;
-    virtual SearchIteratorUP createFilterSearch(FilterConstraint constraint) const = 0;
+protected:
+    virtual SearchIteratorUP createSearchImpl(fef::MatchData &md) const = 0;
+    virtual SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const = 0;
+    SearchIteratorUP tag_with_id(SearchIteratorUP itr) const noexcept {
+        itr->set_id(id());
+        return itr;
+    }
+public:
+    SearchIteratorUP createSearch(fef::MatchData &md) const { return tag_with_id(createSearchImpl(md)); }
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const { return tag_with_id(createFilterSearchImpl(constraint)); }
     static SearchIteratorUP create_and_filter(const Children &children, bool strict, FilterConstraint constraint);
     static SearchIteratorUP create_or_filter(const Children &children, bool strict, FilterConstraint constraint);
     static SearchIteratorUP create_atmost_and_filter(const Children &children, bool strict, FilterConstraint constraint);
@@ -506,7 +514,7 @@ public:
     IntermediateBlueprint &addChild(Blueprint::UP child);
     Blueprint::UP removeChild(size_t n);
     Blueprint::UP removeLastChild() { return removeChild(childCnt() - 1); }
-    SearchIteratorUP createSearch(fef::MatchData &md) const override;
+    SearchIteratorUP createSearchImpl(fef::MatchData &md) const override;
     
     virtual HitEstimate combine(const std::vector<HitEstimate> &data) const = 0;
     virtual FieldSpecBaseList exposeFields() const = 0;
@@ -565,7 +573,7 @@ public:
     void fetchPostings(const ExecuteInfo &execInfo) override;
     void freeze() final;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;
-    SearchIteratorUP createSearch(fef::MatchData &md) const override;
+    SearchIteratorUP createSearchImpl(fef::MatchData &md) const override;
     const LeafBlueprint * asLeaf() const noexcept final { return this; }
 
     virtual bool getRange(std::string & from, std::string & to) const;

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.cpp
@@ -80,7 +80,7 @@ DotProductBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray
 }
 
 SearchIterator::UP
-DotProductBlueprint::createFilterSearch(FilterConstraint constraint) const
+DotProductBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_or_filter(_terms, strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.h
@@ -37,7 +37,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
     SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;

--- a/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.cpp
@@ -99,7 +99,7 @@ EquivBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &outputs) co
 }
 
 SearchIterator::UP
-EquivBlueprint::createFilterSearch(FilterConstraint constraint) const
+EquivBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_or_filter(_terms, strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.h
@@ -26,7 +26,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
 
     SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
@@ -201,7 +201,7 @@ AndNotBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-AndNotBlueprint::createFilterSearch(FilterConstraint constraint) const
+AndNotBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_andnot_filter(get_children(), strict(), constraint);
 }
@@ -302,7 +302,7 @@ AndBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-AndBlueprint::createFilterSearch(FilterConstraint constraint) const
+AndBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_and_filter(get_children(), strict(), constraint);
 }
@@ -397,7 +397,7 @@ OrBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-OrBlueprint::createFilterSearch(FilterConstraint constraint) const
+OrBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_or_filter(get_children(), strict(), constraint);
 }
@@ -531,7 +531,7 @@ WeakAndBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-WeakAndBlueprint::createFilterSearch(FilterConstraint constraint) const
+WeakAndBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_or_filter(get_children(), strict(), constraint);
 }
@@ -597,10 +597,10 @@ NearBlueprint::sort(Children &children, InFlow in_flow) const
 }
 
 SearchIterator::UP
-NearBlueprint::createSearch(fef::MatchData &md) const
+NearBlueprint::createSearchImpl(fef::MatchData &md) const
 {
     need_normal_features_for_children(*this, md);
-    return IntermediateBlueprint::createSearch(md);
+    return IntermediateBlueprint::createSearchImpl(md);
 }
 
 SearchIterator::UP
@@ -618,7 +618,7 @@ NearBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-NearBlueprint::createFilterSearch(FilterConstraint constraint) const
+NearBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_and_filter(get_children(), strict(), constraint);
 }
@@ -658,10 +658,10 @@ ONearBlueprint::sort(Children &, InFlow) const
 }
 
 SearchIterator::UP
-ONearBlueprint::createSearch(fef::MatchData &md) const
+ONearBlueprint::createSearchImpl(fef::MatchData &md) const
 {
     need_normal_features_for_children(*this, md);
-    return IntermediateBlueprint::createSearch(md);
+    return IntermediateBlueprint::createSearchImpl(md);
 }
 
 SearchIterator::UP
@@ -681,7 +681,7 @@ ONearBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-ONearBlueprint::createFilterSearch(FilterConstraint constraint) const
+ONearBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_and_filter(get_children(), strict(), constraint);
 }
@@ -769,7 +769,7 @@ RankBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 }
 
 SearchIterator::UP
-RankBlueprint::createFilterSearch(FilterConstraint constraint) const
+RankBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_first_child_filter(get_children(), constraint);
 }
@@ -839,7 +839,7 @@ SourceBlenderBlueprint::createIntermediateSearch(MultiSearch::Children sub_searc
 }
 
 SearchIterator::UP
-SourceBlenderBlueprint::createFilterSearch(FilterConstraint constraint) const
+SourceBlenderBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_or_filter(get_children(), strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
@@ -28,7 +28,7 @@ public:
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(FilterConstraint constraint) const override;
+    createFilterSearchImpl(FilterConstraint constraint) const override;
 private:
     AnyFlow my_flow(InFlow in_flow) const override;
     uint8_t calculate_cost_tier() const override {
@@ -55,7 +55,7 @@ public:
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(FilterConstraint constraint) const override;
+    createFilterSearchImpl(FilterConstraint constraint) const override;
 private:
     AnyFlow my_flow(InFlow in_flow) const override;
 };
@@ -79,7 +79,7 @@ public:
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(FilterConstraint constraint) const override;
+    createFilterSearchImpl(FilterConstraint constraint) const override;
 private:
     AnyFlow my_flow(InFlow in_flow) const override;
     uint8_t calculate_cost_tier() const override;
@@ -109,7 +109,7 @@ public:
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
-    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
 
     explicit WeakAndBlueprint(uint32_t n) : WeakAndBlueprint(n, wand::StopWordStrategy::none(), true) {}
     WeakAndBlueprint(uint32_t n, wand::StopWordStrategy stop_word_strategy, bool thread_safe);
@@ -136,11 +136,11 @@ public:
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, InFlow in_flow) const override;
-    SearchIteratorUP createSearch(fef::MatchData &md) const override;
+    SearchIteratorUP createSearchImpl(fef::MatchData &md) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
-    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
 
     explicit NearBlueprint(uint32_t window) noexcept : _window(window) {}
 };
@@ -158,11 +158,11 @@ public:
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, InFlow in_flow) const override;
-    SearchIteratorUP createSearch(fef::MatchData &md) const override;
+    SearchIteratorUP createSearchImpl(fef::MatchData &md) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
-    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
 
     explicit ONearBlueprint(uint32_t window) noexcept : _window(window) {}
 };
@@ -183,7 +183,7 @@ public:
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(FilterConstraint constraint) const override;
+    createFilterSearchImpl(FilterConstraint constraint) const override;
     uint8_t calculate_cost_tier() const override {
         return (childCnt() > 0) ? get_children()[0]->getState().cost_tier() : State::COST_TIER_NORMAL;
     }
@@ -210,7 +210,7 @@ public:
     createIntermediateSearch(MultiSearch::Children subSearches,
                              fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(FilterConstraint constraint) const override;
+    createFilterSearchImpl(FilterConstraint constraint) const override;
 
     /** check if this blueprint has the same source selector as the other */
     bool isCompatibleWith(const SourceBlenderBlueprint &other) const;

--- a/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.cpp
@@ -23,7 +23,7 @@ EmptyBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &) c
 }
 
 SearchIterator::UP
-EmptyBlueprint::createFilterSearch(FilterConstraint /* constraint */) const
+EmptyBlueprint::createFilterSearchImpl(FilterConstraint /* constraint */) const
 {
     return std::make_unique<EmptySearch>();
 }
@@ -46,7 +46,7 @@ AlwaysTrueBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray
 }
 
 SearchIterator::UP
-AlwaysTrueBlueprint::createFilterSearch(FilterConstraint /* constraint */) const
+AlwaysTrueBlueprint::createFilterSearchImpl(FilterConstraint /* constraint */) const
 {
     return std::make_unique<FullSearch>();
 }
@@ -73,7 +73,7 @@ SimpleBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &) 
 }
 
 SearchIterator::UP
-SimpleBlueprint::createFilterSearch(FilterConstraint constraint) const
+SimpleBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     auto search = std::make_unique<SimpleSearch>(_result, strict());
     search->tag(_tag +

--- a/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.h
@@ -20,7 +20,7 @@ public:
     EmptyBlueprint(FieldSpecBase field) : SimpleLeafBlueprint(field) {}
     EmptyBlueprint() = default;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
     EmptyBlueprint *as_empty() noexcept final override { return this; }
 };
 
@@ -31,7 +31,7 @@ protected:
 public:
     AlwaysTrueBlueprint();
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
     const AlwaysTrueBlueprint *asAlwaysTrue() const noexcept override { return this; }
 };
 
@@ -52,7 +52,7 @@ public:
     SimpleBlueprint &tag(const std::string &tag);
     const std::string &tag() const { return _tag; }
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -96,7 +96,7 @@ public:
         return default_flow_stats(docid_limit, _result.inspect().size(), 0);
     }
 
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 };

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -76,7 +76,7 @@ public:
     }
     
     std::unique_ptr<SearchIterator> createLeafSearch(const search::fef::TermFieldMatchDataArray& tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;

--- a/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
@@ -57,7 +57,7 @@ public:
 
     SearchIterator::UP
     createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
 

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -117,7 +117,7 @@ SameElementBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArra
 }
 
 SearchIterator::UP
-SameElementBlueprint::createFilterSearch(FilterConstraint constraint) const
+SameElementBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_and_filter(_terms, strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -42,7 +42,7 @@ public:
 
     std::unique_ptr<SameElementSearch> create_same_element_search(search::fef::TermFieldMatchData& tfmd) const;
     SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     const std::vector<Blueprint::UP> &terms() const { return _terms; }
     const std::string &field_name() const { return _field_name; }

--- a/searchlib/src/vespa/searchlib/queryeval/searchiterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/searchiterator.cpp
@@ -6,11 +6,21 @@
 #include <vespa/vespalib/objects/object2slime.h>
 #include <vespa/vespalib/objects/visit.h>
 #include <vespa/vespalib/util/classname.h>
+#include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/vespalib/data/slime/inserter.h>
 #include <vespa/searchlib/queryeval/multibitvectoriterator.h>
 
 namespace search::queryeval {
+
+std::string
+SearchIterator::make_id_ref_str() const
+{
+    if (_id == 0) {
+        return "[]";
+    }
+    return vespalib::make_string("[%u]", _id);
+}
 
 BitVector::UP
 SearchIterator::get_hits(uint32_t begin_id)

--- a/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
@@ -50,6 +50,12 @@ private:
      */
     uint32_t _endid;
 
+    /**
+     * if non-zero, this value refers to the blueprint node used to
+     * create this iterator.
+     **/
+    uint32_t _id;
+
     void and_hits_into_strict(BitVector &result, uint32_t begin_id);
     void and_hits_into_non_strict(BitVector &result, uint32_t begin_id);
 protected:
@@ -77,6 +83,10 @@ protected:
     void setAtEnd() noexcept { _docid = search::endDocId; }
 
 public:
+    void set_id(uint32_t value) noexcept { _id = value; }
+    uint32_t id() const noexcept { return _id; }
+    virtual std::string make_id_ref_str() const;
+
     using Trinary=vespalib::Trinary;
     // doSeek and doUnpack are called by templated classes, so making
     // them public to avoid complicated friend requests. Note that if
@@ -184,7 +194,7 @@ public:
     /**
      * The constructor sets the current document id to @ref beginId.
      **/
-    SearchIterator() noexcept : _docid(0), _endid(0) { }
+    SearchIterator() noexcept : _docid(0), _endid(0), _id(0) { }
     SearchIterator(const SearchIterator &) = delete;
     SearchIterator &operator=(const SearchIterator &) = delete;
 

--- a/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.cpp
@@ -96,7 +96,7 @@ SimplePhraseBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &tfmd
 }
 
 SearchIterator::UP
-SimplePhraseBlueprint::createFilterSearch(FilterConstraint constraint) const
+SimplePhraseBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_and_filter(_terms, strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.h
@@ -34,7 +34,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
     SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
 };

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.cpp
@@ -97,7 +97,7 @@ ParallelWeakAndBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
 }
 
 std::unique_ptr<SearchIterator>
-ParallelWeakAndBlueprint::createFilterSearch(FilterConstraint constraint) const
+ParallelWeakAndBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_atmost_or_filter(_terms, strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
@@ -57,7 +57,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
     SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
-    std::unique_ptr<SearchIterator> createFilterSearch(FilterConstraint constraint) const override;
+    std::unique_ptr<SearchIterator> createFilterSearchImpl(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
     bool always_needs_unpack() const override;

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
@@ -136,7 +136,7 @@ WeightedSetTermBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &t
 }
 
 SearchIterator::UP
-WeightedSetTermBlueprint::createFilterSearch(FilterConstraint constraint) const
+WeightedSetTermBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     return create_or_filter(_terms, strict(), constraint);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.h
@@ -39,7 +39,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
 
     SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
-    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
+    SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override;
     std::unique_ptr<MatchingElementsSearch> create_matching_elements_search(const MatchingElementsFields &fields) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
 private:


### PR DESCRIPTION
blueprint enum values are re-purposed:
  before: identify how original query is optimized
  now: match iterators with originating blueprints

@toregge please review
