### PR TITLE
Gather memory usage from another source

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
@@ -38,7 +38,6 @@ public class SystemPoller {
     private static final Logger log = Logger.getLogger(SystemPoller.class.getName());
     private static final int memoryTypeVirtual = 0;
     private static final int memoryTypeResident = 1;
-    private static final long pageSize = getPageSize();
     private static final MetricId CPU = MetricId.toMetricId("cpu");
     private static final MetricId CPU_UTIL = MetricId.toMetricId("cpu_util");
     private static final MetricId MEMORY_VIRT = MetricId.toMetricId("memory_virt");
@@ -112,6 +111,10 @@ public class SystemPoller {
      * @return array[0] = memoryResident, array[1] = memoryVirtual (kB units)
      */
     static long[] getMemoryUsage(VespaService service) {
+        return getMemoryUsage(service, getPageSize());
+    }
+
+    static long[] getMemoryUsage(VespaService service, int pageSize) {
         String s;
         int pid = service.getPid();
 
@@ -122,21 +125,21 @@ public class SystemPoller {
             return new long[2];
         }
         try {
-            return getMemoryUsage(s);
+            return getMemoryUsage(s, pageSize);
         } catch (IOException ex) {
             log.log(Level.FINE, "Unable to read line from statm file", ex);
             return new long[2];
         }
     }
 
-    static long[] getMemoryUsage(String s) throws IOException{
+    static long[] getMemoryUsage(String s, int pageSize) throws IOException{
         long[] size = new long[2];
         // statm line: "size rss shared text lib data dt"
-        // all values are number of pages, return values from this method are in kibibytes
+        // all values are number of pages, return values from this method are values in bytes
         var statmPutputs = s.split(" ");
-        size[memoryTypeVirtual] = Long.parseLong(statmPutputs[0]) * pageSize / 1024;
+        size[memoryTypeVirtual] = Long.parseLong(statmPutputs[0]) * pageSize;
         // Returning rss, we don't consider shared memory here
-        size[memoryTypeResident] = Long.parseLong(statmPutputs[1]) * pageSize / 1024;
+        size[memoryTypeResident] = Long.parseLong(statmPutputs[1]) * pageSize;
 
         return size;
     }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
@@ -104,11 +104,11 @@ public class SystemPoller {
     }
 
     /**
-     * Return memory usage for a given process, both resident and virtual is
+     * Return memory usage in bytes for a given process, both resident and virtual is
      * returned.
      *
      * @param service The instance to get memory usage for
-     * @return array[0] = memoryResident, array[1] = memoryVirtual (kB units)
+     * @return array[0] = memoryResident, array[1] = memoryVirtual (both in bytes)
      */
     static long[] getMemoryUsage(VespaService service) {
         return getMemoryUsage(service, getPageSize());

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
@@ -303,7 +303,7 @@ public class SystemPoller {
 
     private static int getPageSize() {
         try {
-            return Integer.parseInt(new ProcessExecuter().exec("getconfig PAGESIZE").getSecond().trim());
+            return Integer.parseInt(new ProcessExecuter().exec("getconf PAGESIZE").getSecond().trim());
         } catch (IOException e) {
             log.log(WARNING, "Getting page size failed, using fallback value 4096");
             return 4096;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPollerProvider.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPollerProvider.java
@@ -17,7 +17,7 @@ public class SystemPollerProvider implements Provider<SystemPoller> {
      * @param services   The list of VespaService instances to monitor for System metrics
      * @param monitoringConfig   The interval in seconds between each polling.
      */
-    public SystemPollerProvider (VespaServices services, MonitoringConfig monitoringConfig) {
+    public SystemPollerProvider(VespaServices services, MonitoringConfig monitoringConfig) {
         if (runningOnLinux()) {
             Duration interval = Duration.ofMinutes(monitoringConfig.intervalMinutes());
             poller = new SystemPoller(services.getVespaServices(), interval);

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/SystemPollerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/SystemPollerTest.java
@@ -4,14 +4,12 @@ package ai.vespa.metricsproxy.service;
 import ai.vespa.metricsproxy.metric.Metric;
 import ai.vespa.metricsproxy.metric.Metrics;
 import ai.vespa.metricsproxy.metric.model.MetricId;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,13 +63,15 @@ public class SystemPollerTest {
                     "procs_blocked 0",
                     "softirq 32061301 0 4533497 8 5339359 1156384 0 37 10947075 0 10084941")
     };
+
+    // Test file for /proc/<pid>/statm
+    private static final String statm = "3332000 1917762 8060 1 0 2960491 0";
+
     private static final long [] PER_PROC_JIFFIES = {1691137, 1692185};
 
     @Test
     public void testSystemPoller() {
         DummyService s = new DummyService(0, "id");
-        List<VespaService> services = new ArrayList<>();
-        services.add(s);
 
         assertFalse(s.isAlive());
 
@@ -82,71 +82,11 @@ public class SystemPollerTest {
         assertEquals(0L, memusage[1]);
     }
 
-    private static final String smaps =
-            "00400000-004de000 r-xp 00000000 fe:01 670312                             /usr/bin/bash\n" +
-            "Size:                888 kB\n" +
-            "KernelPageSize:        4 kB\n" +
-            "MMUPageSize:           4 kB\n" +
-            "Rss:                 824 kB\n" +
-            "Pss:                 150 kB\n" +
-            "Shared_Clean:        824 kB\n" +
-            "Shared_Dirty:          0 kB\n" +
-            "Private_Clean:         0 kB\n" +
-            "Private_Dirty:         0 kB\n" +
-            "Referenced:          824 kB\n" +
-            "Anonymous:             0 kB\n" +
-            "LazyFree:              0 kB\n" +
-            "AnonHugePages:         0 kB\n" +
-            "ShmemPmdMapped:        0 kB\n" +
-            "FilePmdMapped:         0 kB\n" +
-            "Shared_Hugetlb:        0 kB\n" +
-            "Private_Hugetlb:       0 kB\n" +
-            "Swap:                  0 kB\n" +
-            "SwapPss:               0 kB\n" +
-            "Locked:                0 kB\n" +
-            "THPeligible:    0\n" +
-            "VmFlags: rd ex mr mw me dw \n" +
-            "006dd000-006de000 r--p 000dd000 fe:01 670312                             /usr/bin/bash\n" +
-            "Size:                  4 kB\n" +
-            "KernelPageSize:        4 kB\n" +
-            "MMUPageSize:           4 kB\n" +
-            "Rss:                   4 kB\n" +
-            "Pss:                   4 kB\n" +
-            "Shared_Clean:          0 kB\n" +
-            "Shared_Dirty:          0 kB\n" +
-            "Private_Clean:         4 kB\n" +
-            "Private_Dirty:         0 kB\n" +
-            "Referenced:            4 kB\n" +
-            "Anonymous:             4 kB\n" +
-            "LazyFree:              0 kB\n" +
-            "AnonHugePages:         0 kB\n" +
-            "ShmemPmdMapped:        0 kB\n" +
-            "FilePmdMapped:         0 kB\n" +
-            "Shared_Hugetlb:        0 kB\n" +
-            "Private_Hugetlb:       0 kB\n" +
-            "Swap:                  0 kB\n" +
-            "SwapPss:               0 kB\n" +
-            "Locked:                0 kB\n" +
-            "THPeligible:    0\n" +
-            "VmFlags: rd mr mw me dw ac \n";
-
     @Test
-    public void testSmapsParsing() throws IOException {
-        BufferedReader br = new BufferedReader(new StringReader(smaps));
-        long[] memusage = SystemPoller.getMemoryUsage(br);
-        assertEquals(913408L, memusage[0]);
-        assertEquals(847872L, memusage[1]);
-    }
-
-    @Ignore
-    @Test
-    public void benchmarkSmapsParsing() throws IOException {
-        for (int i=0; i < 100000; i++) {
-            BufferedReader br = new BufferedReader(new StringReader(smaps));
-            long[] memusage = SystemPoller.getMemoryUsage(br);
-            assertEquals(913408L, memusage[0]);
-            assertEquals(847872L, memusage[1]);
-        }
+    public void testStatmParsing() throws IOException {
+        long[] memusage = SystemPoller.getMemoryUsage(statm);
+        assertEquals(13328000, memusage[0]);
+        assertEquals(7671048L, memusage[1]);
     }
 
     @Test

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/SystemPollerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/SystemPollerTest.java
@@ -84,9 +84,9 @@ public class SystemPollerTest {
 
     @Test
     public void testStatmParsing() throws IOException {
-        long[] memusage = SystemPoller.getMemoryUsage(statm);
-        assertEquals(13328000, memusage[0]);
-        assertEquals(7671048L, memusage[1]);
+        long[] memusage = SystemPoller.getMemoryUsage(statm, 1);
+        assertEquals(3332000L, memusage[0]);
+        assertEquals(1917762L, memusage[1]);
     }
 
     @Test


### PR DESCRIPTION
Avoid expensive lookup of memory usage from `/proc/<pid>/smaps`, using `/proc/<pid>/statm` is cheaper