### PR TITLE
Prepare for missing value policy in sort blob writers.

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -45,6 +45,7 @@ using search::QueryTermSimple;
 using search::TuneFileAttributes;
 using search::attribute::SearchContext;
 using search::attribute::SearchContextParams;
+using search::common::sortspec::MissingPolicy;
 using search::fef::MatchData;
 using search::fef::MatchDataLayout;
 using search::fef::TermFieldMatchData;
@@ -1979,7 +1980,7 @@ TEST(DocumentMetaStoreTest, serialize_for_sort)
     EXPECT_EQ(12u, SZ);
     EXPECT_EQ(SZ, dms.getFixedWidth());
     uint8_t asc_dest[SZ];
-    auto asc_writer = dms.make_sort_blob_writer(true, nullptr);
+    auto asc_writer = dms.make_sort_blob_writer(true, nullptr, MissingPolicy::DEFAULT, std::string_view());
     EXPECT_EQ(0, asc_writer->write(3, asc_dest, sizeof(asc_dest)));
     EXPECT_EQ(-1, asc_writer->write(1, asc_dest, sizeof(asc_dest) - 1));
     document::GlobalId gid;
@@ -1993,7 +1994,7 @@ TEST(DocumentMetaStoreTest, serialize_for_sort)
     EXPECT_EQ(0, memcmp(asc_dest, gid.get(), SZ));
 
     uint8_t desc_dest[SZ];
-    auto desc_writer = dms.make_sort_blob_writer(false, nullptr);
+    auto desc_writer = dms.make_sort_blob_writer(false, nullptr, MissingPolicy::DEFAULT, std::string_view());
     EXPECT_EQ(SZ, desc_writer->write(2, desc_dest, sizeof(desc_dest)));
     for (size_t i(0); i < SZ; i++) {
         EXPECT_EQ(0xff - asc_dest[i], desc_dest[i]);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -1139,7 +1139,9 @@ DocumentMetaStoreSortBlobWriter<ascending>::write(uint32_t docid, void* buf, lon
 }
 
 std::unique_ptr<search::attribute::ISortBlobWriter>
-DocumentMetaStore::make_sort_blob_writer(bool ascending, const search::common::BlobConverter*) const
+DocumentMetaStore::make_sort_blob_writer(bool ascending, const search::common::BlobConverter*,
+                                         search::common::sortspec::MissingPolicy,
+                                         std::string_view) const
 {
     if (ascending) {
         return std::make_unique<DocumentMetaStoreSortBlobWriter<true>>(*this);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -272,7 +272,10 @@ public:
     void setTrackDocumentSizes(bool trackDocumentSizes) { _trackDocumentSizes = trackDocumentSizes; }
     void foreach(const search::IGidToLidMapperVisitor &visitor) const override;
     bool is_sortable() const noexcept override;
-    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const override;
+    std::unique_ptr<search::attribute::ISortBlobWriter>
+    make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
+                          search::common::sortspec::MissingPolicy policy,
+                          std::string_view missing_value) const override;
 };
 
 }

--- a/searchlib/src/tests/attribute/raw_attribute/raw_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/raw_attribute/raw_attribute_test.cpp
@@ -23,6 +23,7 @@ using search::attribute::Config;
 using search::attribute::EmptySearchContext;
 using search::attribute::SearchContextParams;
 using search::attribute::SingleRawAttribute;
+using search::common::sortspec::MissingPolicy;
 using vespalib::Issue;
 
 using namespace std::literals;
@@ -111,8 +112,8 @@ TEST_F(RawAttributeTest, implements_serialize_for_sort) {
     memset(buf, 0, sizeof(buf));
     _attr->addDocs(10);
     _attr->commit();
-    auto asc_writer = _attr->make_sort_blob_writer(true, nullptr);
-    auto desc_writer = _attr->make_sort_blob_writer(false, nullptr);
+    auto asc_writer = _attr->make_sort_blob_writer(true, nullptr, MissingPolicy::DEFAULT, std::string_view());
+    auto desc_writer = _attr->make_sort_blob_writer(false, nullptr, MissingPolicy::DEFAULT, std::string_view());
     EXPECT_EQ(1, asc_writer->write(1, buf, sizeof(buf)));
     EXPECT_EQ(0, buf[0]);
     EXPECT_EQ(1, desc_writer->write(1, buf, sizeof(buf)));

--- a/searchlib/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchlib/src/vespa/searchcommon/attribute/iattributevector.h
@@ -5,6 +5,7 @@
 #include "basictype.h"
 #include "collectiontype.h"
 #include <vespa/searchcommon/common/iblobconverter.h>
+#include <vespa/searchlib/common/sortspec.h>
 #include <vespa/vespalib/datastore/atomic_entry_ref.h>
 #include <ostream>
 #include <span>
@@ -441,7 +442,9 @@ public:
      * Make a writer that is used for writing a serialized form of this attribute vector for sorting.
      * The serialized form can be used by memcmp() and sort order will be preserved.
      */
-    virtual std::unique_ptr<ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const = 0;
+    virtual std::unique_ptr<ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                   common::sortspec::MissingPolicy policy,
+                                                                   std::string_view missing_value) const = 0;
 
     /**
      * Virtual destructor to allow safe subclassing.

--- a/searchlib/src/vespa/searchlib/attribute/attrvector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attrvector.h
@@ -126,7 +126,9 @@ private:
     uint32_t get(DocId doc, WeightedInt * v, uint32_t sz)   const override { return getAllHelper<WeightedInt, largeint_t>(doc, v, sz); }
     uint32_t get(DocId doc, WeightedFloat * v, uint32_t sz) const override { return getAllHelper<WeightedFloat, double>(doc, v, sz); }
     bool is_sortable() const noexcept override;
-    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const override;
+    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
+                                                                              search::common::sortspec::MissingPolicy policy,
+                                                                              std::string_view missing_value) const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -223,6 +225,9 @@ private:
         return available;
     }
     bool is_sortable() const noexcept override;
-    std::unique_ptr<search::attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const override;
+    std::unique_ptr<search::attribute::ISortBlobWriter>
+    make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
+                          search::common::sortspec::MissingPolicy policy,
+                          std::string_view missing_value) const override;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/attrvector.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attrvector.hpp
@@ -119,10 +119,12 @@ public:
 
 template <typename F, typename B>
 std::unique_ptr<search::attribute::ISortBlobWriter>
-NumericDirectAttrVector<F, B>::make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const
+NumericDirectAttrVector<F, B>::make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
+                                                     search::common::sortspec::MissingPolicy policy,
+                                                     std::string_view missing_value) const
 {
     if (!F::IsMultiValue()) {
-        return search::NumericDirectAttribute<B>::make_sort_blob_writer(ascending, converter);
+        return search::NumericDirectAttribute<B>::make_sort_blob_writer(ascending, converter, policy, missing_value);
     }
     if (ascending) {
         return std::make_unique<NumericDirectSortBlobWriter<BaseType, true>>(this->_data, this->_idx);
@@ -185,10 +187,12 @@ StringDirectAttrVector<F>::is_sortable() const noexcept
 
 template <typename F>
 std::unique_ptr<search::attribute::ISortBlobWriter>
-StringDirectAttrVector<F>::make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter) const
+StringDirectAttrVector<F>::make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
+                                                 search::common::sortspec::MissingPolicy policy,
+                                                 std::string_view missing_value) const
 {
     if (!F::IsMultiValue()) {
-        return search::StringDirectAttribute::make_sort_blob_writer(ascending, converter);
+        return search::StringDirectAttribute::make_sort_blob_writer(ascending, converter, policy, missing_value);
     }
     if (ascending) {
         return std::make_unique<StringDirectSortBlobWriter<true>>(this->_buffer, this->_offsets, this->_idx, converter);

--- a/searchlib/src/vespa/searchlib/attribute/floatbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/floatbase.h
@@ -72,7 +72,9 @@ protected:
     virtual void fillValues(LoadedVector &) {}
     virtual void load_posting_lists(LoadedVector&) {}
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                      common::sortspec::MissingPolicy policy,
+                                                                      std::string_view missing_value) const override;
 
     const Change _defaultValue;
 private:

--- a/searchlib/src/vespa/searchlib/attribute/floatbase.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/floatbase.hpp
@@ -58,7 +58,11 @@ FloatingPointAttributeTemplate<T>::is_sortable() const noexcept
 
 template<typename T>
 std::unique_ptr<attribute::ISortBlobWriter>
-FloatingPointAttributeTemplate<T>::make_sort_blob_writer(bool ascending, const common::BlobConverter*) const {
+FloatingPointAttributeTemplate<T>::make_sort_blob_writer(bool ascending, const common::BlobConverter*,
+                                                         common::sortspec::MissingPolicy policy,
+                                                         std::string_view missing_value) const {
+    (void) policy;
+    (void) missing_value;
     if (ascending) {
         return std::make_unique<attribute::SingleNumericSortBlobWriter<FloatingPointAttributeTemplate<T>, true>>(*this);
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -301,9 +301,11 @@ public:
     }
 };
 
-std::unique_ptr<attribute::ISortBlobWriter>
-ImportedAttributeVectorReadGuard::make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const {
-    return std::make_unique<SortBlobWriter>(*this, _target_attribute.make_sort_blob_writer(ascending, converter));
+std::unique_ptr<ISortBlobWriter>
+ImportedAttributeVectorReadGuard::make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                        common::sortspec::MissingPolicy policy,
+                                                        std::string_view missing_value) const {
+    return std::make_unique<SortBlobWriter>(*this, _target_attribute.make_sort_blob_writer(ascending, converter, policy, missing_value));
 }
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -112,7 +112,9 @@ protected:
     }
 
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                           common::sortspec::MissingPolicy policy,
+                                                           std::string_view missing_value) const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/integerbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/integerbase.h
@@ -69,7 +69,9 @@ protected:
     virtual void fillValues(LoadedVector &) {}
     virtual void load_posting_lists(LoadedVector&) {}
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                      common::sortspec::MissingPolicy policy,
+                                                                      std::string_view missing_value) const override;
 
     const Change _defaultValue;
 private:

--- a/searchlib/src/vespa/searchlib/attribute/integerbase.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/integerbase.hpp
@@ -71,7 +71,11 @@ IntegerAttributeTemplate<T>::is_sortable() const noexcept
 
 template<typename T>
 std::unique_ptr<attribute::ISortBlobWriter>
-IntegerAttributeTemplate<T>::make_sort_blob_writer(bool ascending, const common::BlobConverter*) const {
+IntegerAttributeTemplate<T>::make_sort_blob_writer(bool ascending, const common::BlobConverter*,
+                                                   common::sortspec::MissingPolicy policy,
+                                                   std::string_view missing_value) const {
+    (void) policy;
+    (void) missing_value;
     if (ascending) {
         return std::make_unique<attribute::SingleNumericSortBlobWriter<IntegerAttributeTemplate<T>, true>>(*this);
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
@@ -55,7 +55,9 @@ protected:
     }
 
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                      common::sortspec::MissingPolicy policy,
+                                                                      std::string_view missing_value) const override;
 
 public:
     MultiValueNumericAttribute(const std::string & baseFileName, const AttributeVector::Config & c =

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
@@ -213,8 +213,12 @@ public:
 
 template <typename B, typename M>
 std::unique_ptr<attribute::ISortBlobWriter>
-MultiValueNumericAttribute<B, M>::make_sort_blob_writer(bool ascending, const common::BlobConverter*) const
+MultiValueNumericAttribute<B, M>::make_sort_blob_writer(bool ascending, const common::BlobConverter*,
+                                                        common::sortspec::MissingPolicy policy,
+                                                        std::string_view missing_value) const
 {
+    (void) policy;
+    (void) missing_value;
     if (ascending) {
         return std::make_unique<MultiNumericSortBlobWriter<MultiValueMapping, T, true>>(this->_mvMapping);
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
@@ -43,7 +43,9 @@ protected:
     using largeint_t = typename B::BaseClass::largeint_t;
 
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                      common::sortspec::MissingPolicy policy,
+                                                                      std::string_view missing_value) const override;
 public:
     MultiValueNumericEnumAttribute(const std::string & baseFileName, const AttributeVector::Config & cfg);
 

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.hpp
@@ -178,8 +178,12 @@ public:
 
 template <typename B, typename M>
 std::unique_ptr<attribute::ISortBlobWriter>
-MultiValueNumericEnumAttribute<B, M>::make_sort_blob_writer(bool ascending, const common::BlobConverter*) const
+MultiValueNumericEnumAttribute<B, M>::make_sort_blob_writer(bool ascending, const common::BlobConverter*,
+                                                            search::common::sortspec::MissingPolicy policy,
+                                                            std::string_view missing_value) const
 {
+    (void) policy;
+    (void) missing_value;
     if (ascending) {
         return std::make_unique<MultiNumericEnumSortBlobWriter<MultiValueMapping, EnumStore, T, true>>(this->_mvMapping, this->_enumStore);
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.h
@@ -43,7 +43,10 @@ protected:
     using WeightedString = StringAttribute::WeightedString;
     using generation_t = StringAttribute::generation_t;
 
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                      common::sortspec::MissingPolicy policy,
+                                                                      std::string_view missing_value) const override;
+
 public:
     MultiValueStringAttributeT(const std::string & name, const AttributeVector::Config & c);
     MultiValueStringAttributeT(const std::string & name);

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
@@ -94,8 +94,12 @@ public:
 
 template <typename B, typename M>
 std::unique_ptr<attribute::ISortBlobWriter>
-MultiValueStringAttributeT<B, M>::make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const
+MultiValueStringAttributeT<B, M>::make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                        search::common::sortspec::MissingPolicy policy,
+                                                        std::string_view missing_value) const
 {
+    (void) policy;
+    (void) missing_value;
     if (ascending) {
         return std::make_unique<MultiStringSortBlobWriter<MultiValueMapping, EnumStore, true>>(this->_mvMapping, this->_enumStore, converter);
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/not_implemented_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/not_implemented_attribute.cpp
@@ -120,7 +120,9 @@ NotImplementedAttribute::is_sortable() const noexcept
 }
 
 std::unique_ptr<attribute::ISortBlobWriter>
-NotImplementedAttribute::make_sort_blob_writer(bool, const common::BlobConverter*) const {
+NotImplementedAttribute::make_sort_blob_writer(bool, const common::BlobConverter*,
+                                               common::sortspec::MissingPolicy,
+                                               std::string_view) const {
     notImplemented();
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/not_implemented_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/not_implemented_attribute.h
@@ -30,7 +30,9 @@ struct NotImplementedAttribute : AttributeVector {
     std::vector<EnumHandle> findFoldedEnums(const char *value) const override;
 
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                                      common::sortspec::MissingPolicy policy,
+                                                                      std::string_view missing_value) const override;
     uint32_t clearDoc(DocId) override;
     uint32_t getEnum(DocId) const override;
     bool addDoc(DocId &) override;

--- a/searchlib/src/vespa/searchlib/attribute/raw_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/raw_attribute.cpp
@@ -81,8 +81,10 @@ RawAttribute::is_sortable() const noexcept
     return true;
 }
 
-std::unique_ptr<attribute::ISortBlobWriter>
-RawAttribute::make_sort_blob_writer(bool ascending, const common::BlobConverter*) const
+std::unique_ptr<ISortBlobWriter>
+RawAttribute::make_sort_blob_writer(bool ascending, const common::BlobConverter*,
+                                    common::sortspec::MissingPolicy,
+                                    std::string_view) const
 {
     if (ascending) {
         // Note: Template argument for the writer is "descending".

--- a/searchlib/src/vespa/searchlib/attribute/raw_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/raw_attribute.h
@@ -16,7 +16,9 @@ public:
     ~RawAttribute() override;
 
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter) const override;
+    std::unique_ptr<ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* converter,
+                                                           common::sortspec::MissingPolicy policy,
+                                                           std::string_view missing_value) const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
@@ -176,8 +176,12 @@ DescendingSortBlobWriter::write(uint32_t docid, void* ser_to, long available)
 }
 
 std::unique_ptr<attribute::ISortBlobWriter>
-StringAttribute::make_sort_blob_writer(bool ascending, const common::BlobConverter* bc) const
+StringAttribute::make_sort_blob_writer(bool ascending, const common::BlobConverter* bc,
+                                       common::sortspec::MissingPolicy policy,
+                                       std::string_view missing_value) const
 {
+    (void) policy;
+    (void) missing_value;
     if (ascending) {
         return std::make_unique<AscendingSortBlobWriter>(*this, bc);
     } else {

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -74,7 +74,9 @@ protected:
     bool get_match_is_cased() const noexcept;
     bool has_uncased_matching() const noexcept override;
     bool is_sortable() const noexcept override;
-    std::unique_ptr<attribute::ISortBlobWriter> make_sort_blob_writer(bool ascending, const common::BlobConverter* bc) const override;
+    std::unique_ptr<attribute::ISortBlobWriter>
+    make_sort_blob_writer(bool ascending, const common::BlobConverter* bc, common::sortspec::MissingPolicy policy,
+                          std::string_view missing_value) const override;
 private:
     virtual void load_posting_lists(LoadedVector& loaded);
     virtual void load_enum_store(LoadedVector& loaded);

--- a/searchlib/src/vespa/searchlib/common/sortresults.cpp
+++ b/searchlib/src/vespa/searchlib/common/sortresults.cpp
@@ -167,7 +167,9 @@ FastS_SortSpec::VectorRef::VectorRef(uint32_t type, const search::attribute::IAt
     : _type(type),
       _vector(vector),
       _converter(converter),
-      _writer((_vector != nullptr) ? _vector->make_sort_blob_writer(has_ascending_sort_order(), converter) : nullptr)
+      _writer((_vector != nullptr) ? _vector->make_sort_blob_writer(has_ascending_sort_order(), converter,
+                                                                    search::common::sortspec::MissingPolicy::DEFAULT,
+                                                                    std::string_view()) : nullptr)
 {
 }
 

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -210,7 +210,9 @@ void
 SearchVisitor::AttrInfo::make_sort_blob_writer()
 {
     if (_attr && _attr->get()->is_sortable()) {
-        _sort_blob_writer = _attr->get()->make_sort_blob_writer(_ascending, _converter);
+        _sort_blob_writer = _attr->get()->make_sort_blob_writer(_ascending, _converter,
+                                                                search::common::sortspec::MissingPolicy::DEFAULT,
+                                                                std::string_view());
     }
 }
 


### PR DESCRIPTION
This PR only extends the API.
Different policy implementations for handling missing values will follow in later PRs.

@toregge please review