### PR TITLE
Add support for IN operator in json select queries

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -648,7 +648,6 @@ public class SelectParser implements Parser {
                     field + "' has both");
         }
 
-        Collection<Inspector> values = children.values();
         Item item = null;
         if (index.isString()) {
            StringInItem stringInItem = new StringInItem(field);


### PR DESCRIPTION
Previously, the in operator could be used in yql queries but not in select queries.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
