### PR TITLE
Unify test-and-set "document does not exist" error message

### DIFF
--- a/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
+++ b/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
@@ -1073,7 +1073,7 @@ TEST_F(TwoPhaseUpdateOperationTest, safe_path_condition_with_missing_doc_and_no_
                           "BucketId(0x0000000000000000), "
                           "timestamp 0, timestamp of updated doc: 0) "
                           "ReturnCode(TEST_AND_SET_CONDITION_FAILED, "
-                                     "Document did not exist)",
+                                     "Document does not exist)",
               _sender.getLastReply(true));
 
     EXPECT_EQ(metrics().updates.failures.notfound.getValue(), 0); // Not counted as "not found" failure when TaS is present

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -547,7 +547,7 @@ TwoPhaseUpdateOperation::handleSafePathReceivedGet(DistributorStripeMessageSende
         docToUpdate = reply.getDocument();
         setUpdatedForTimestamp(receivedTimestamp);
     } else if (hasTasCondition() && !shouldCreateIfNonExistent()) {
-        replyWithTasFailure(sender, "Document did not exist");
+        replyWithTasFailure(sender, "Document does not exist");
         return;
     } else if (shouldCreateIfNonExistent()) {
         LOG(debug, "No existing documents found for %s, creating blank document to update",


### PR DESCRIPTION
@toregge please review

Now uses the same wording across the different sites that can generate such a response.


