### PR TITLE
Change MMAP madvise default to SEQUENTIAL for search.

### DIFF
--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -181,9 +181,8 @@ search.io enum {NORMAL, DIRECTIO, MMAP } default=MMAP restart
 ## Multiple optional options for use with mmap
 search.mmap.options[] enum {POPULATE, HUGETLB} restart
 
-## Advise to give to os when mapping memory.
-## TODO Check if default should be random
-search.mmap.advise enum {NORMAL, RANDOM, SEQUENTIAL} default=NORMAL restart
+## Advise to give to os when memory mapping disk index posting list files used for search.
+search.mmap.advise enum {NORMAL, RANDOM, SEQUENTIAL} default=SEQUENTIAL restart
 
 ## Max number of threads allowed to handle large queries concurrently
 ## Positive number means there is a limit, 0 or negative means no limit.


### PR DESCRIPTION
Benchmarking of lexical search using a Wikipedia dataset has shown that madvise SEQUENTIAL for disk index posting list files results in lower 99 percentile query latencies and better utilization of the I/O subsystem.

This setting has already been the default since Vespa 8.503.27 due to overrides in the config model.

@vekterli please review
@toregge FYI