### PR TITLE
Add --data parameter to provide document data on command line

### DIFF
--- a/client/go/internal/cli/cmd/document.go
+++ b/client/go/internal/cli/cmd/document.go
@@ -22,10 +22,11 @@ import (
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/document"
 )
 
-func addDocumentFlags(cli *CLI, cmd *cobra.Command, printCurl *bool, timeoutSecs, waitSecs *int, headers *[]string) {
+func addDocumentFlags(cli *CLI, cmd *cobra.Command, printCurl *bool, timeoutSecs, waitSecs *int, headers *[]string, data *string) {
 	cmd.PersistentFlags().BoolVarP(printCurl, "verbose", "v", false, "Print the equivalent curl command for the document operation")
 	cmd.PersistentFlags().IntVarP(timeoutSecs, "timeout", "T", 60, "Timeout for the document request in seconds")
 	cmd.PersistentFlags().StringSliceVarP(headers, "header", "", nil, "Add a header to the HTTP request, on the format 'Header: Value'. This can be specified multiple times")
+	cmd.PersistentFlags().StringVarP(data, "data", "d", "", "Document data to use instead of reading from file or stdin")
 	cli.bindWaitFlag(cmd, 0, waitSecs)
 }
 
@@ -63,19 +64,31 @@ func documentClient(cli *CLI, timeoutSecs int, waiter *Waiter, printCurl bool, h
 	return client, docService, nil
 }
 
-func sendOperation(op document.Operation, args []string, timeoutSecs int, waiter *Waiter, printCurl bool, cli *CLI, headers []string) error {
+func sendOperation(op document.Operation, args []string, timeoutSecs int, waiter *Waiter, printCurl bool, cli *CLI, headers []string, data string) error {
 	client, service, err := documentClient(cli, timeoutSecs, waiter, printCurl, headers)
 	if err != nil {
 		return err
 	}
 	id := ""
-	filename := args[0]
-	if len(args) > 1 {
-		id = args[0]
-		filename = args[1]
+	if len(args) == 0 && data == "" {
+		return fmt.Errorf("Must provide either a file name or use the --data parameter")
 	}
+
+	var filename string
+	if data == "" {
+		filename = args[0]
+		if len(args) > 1 {
+			id = args[0]
+			filename = args[1]
+		}
+	} else if len(args) == 1 {
+		id = args[0]
+	}
+
 	var r io.ReadCloser
-	if filename == "-" {
+	if data != "" {
+		r = io.NopCloser(strings.NewReader(data))
+	} else if filename == "-" {
 		r = io.NopCloser(cli.Stdin)
 	} else {
 		f, err := os.Open(filename)
@@ -165,6 +178,7 @@ func newDocumentCmd(cli *CLI) *cobra.Command {
 		timeoutSecs int
 		waitSecs    int
 		headers     []string
+		data        string
 	)
 	cmd := &cobra.Command{
 		Use:   "document json-file",
@@ -182,13 +196,14 @@ should be used instead of this.`,
 		Example:           `$ vespa document src/test/resources/A-Head-Full-of-Dreams.json`,
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.RangeArgs(0, 1),
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			waiter := cli.waiter(time.Duration(waitSecs)*time.Second, cmd)
-			return sendOperation(-1, args, timeoutSecs, waiter, printCurl, cli, headers)
+			return sendOperation(-1, args, timeoutSecs, waiter, printCurl, cli, headers, data)
 		},
 	}
-	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers)
+	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers, &data)
 	return cmd
 }
 
@@ -198,6 +213,7 @@ func newDocumentPutCmd(cli *CLI) *cobra.Command {
 		timeoutSecs int
 		waitSecs    int
 		headers     []string
+		data        string
 	)
 	cmd := &cobra.Command{
 		Use:   "put [id] json-file",
@@ -207,18 +223,20 @@ If the document already exists, all its values will be replaced by this document
 If the document id is specified both as an argument and in the file the argument takes precedence.
 
 If json-file is a single dash ('-'), the document will be read from standard input.
+Alternatively, you can use the --data parameter to provide the document data directly.
 `,
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.RangeArgs(0, 2),
 		Example: `$ vespa document put src/test/resources/A-Head-Full-of-Dreams.json
-$ vespa document put id:mynamespace:music::a-head-full-of-dreams src/test/resources/A-Head-Full-of-Dreams.json`,
+$ vespa document put id:mynamespace:music::a-head-full-of-dreams src/test/resources/A-Head-Full-of-Dreams.json
+$ vespa document put id:mynamespace:music::a-head-full-of-dreams --data '{"fields":{"title":"My Title","artist":"My Artist"}}'`,
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			waiter := cli.waiter(time.Duration(waitSecs)*time.Second, cmd)
-			return sendOperation(document.OperationPut, args, timeoutSecs, waiter, printCurl, cli, headers)
+			return sendOperation(document.OperationPut, args, timeoutSecs, waiter, printCurl, cli, headers, data)
 		},
 	}
-	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers)
+	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers, &data)
 	return cmd
 }
 
@@ -228,23 +246,24 @@ func newDocumentUpdateCmd(cli *CLI) *cobra.Command {
 		timeoutSecs int
 		waitSecs    int
 		headers     []string
+		data        string
 	)
 	cmd := &cobra.Command{
 		Use:   "update [id] json-file",
 		Short: "Modifies some fields of an existing document",
 		Long: `Updates the values of the fields given in a json file as specified in the file.
 If the document id is specified both as an argument and in the file the argument takes precedence.`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.RangeArgs(0, 2),
 		Example: `$ vespa document update src/test/resources/A-Head-Full-of-Dreams-Update.json
 $ vespa document update id:mynamespace:music::a-head-full-of-dreams src/test/resources/A-Head-Full-of-Dreams.json`,
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			waiter := cli.waiter(time.Duration(waitSecs)*time.Second, cmd)
-			return sendOperation(document.OperationUpdate, args, timeoutSecs, waiter, printCurl, cli, headers)
+			return sendOperation(document.OperationUpdate, args, timeoutSecs, waiter, printCurl, cli, headers, data)
 		},
 	}
-	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers)
+	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers, &data)
 	return cmd
 }
 
@@ -254,6 +273,7 @@ func newDocumentRemoveCmd(cli *CLI) *cobra.Command {
 		timeoutSecs int
 		waitSecs    int
 		headers     []string
+		data        string
 	)
 	cmd := &cobra.Command{
 		Use:   "remove id | json-file",
@@ -280,11 +300,11 @@ $ vespa document remove id:mynamespace:music::a-head-full-of-dreams`,
 				result := client.Send(doc)
 				return printResult(cli, operationResult(false, doc, service, result), false)
 			} else {
-				return sendOperation(document.OperationRemove, args, timeoutSecs, waiter, printCurl, cli, headers)
+				return sendOperation(document.OperationRemove, args, timeoutSecs, waiter, printCurl, cli, headers, data)
 			}
 		},
 	}
-	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers)
+	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers, &data)
 	return cmd
 }
 
@@ -296,6 +316,7 @@ func newDocumentGetCmd(cli *CLI) *cobra.Command {
 		waitSecs       int
 		fieldSet       string
 		headers        []string
+		data           string
 	)
 	cmd := &cobra.Command{
 		Use:               "get id(s)",
@@ -312,7 +333,7 @@ $ vespa document get id:mynamespace:music::song-1 id:mynamespace:music::song-2`,
 	}
 	cmd.Flags().StringVar(&fieldSet, "field-set", "", "Fields to include when reading document")
 	cmd.Flags().BoolVar(&ignoreNotFound, "ignore-missing", false, "Do not treat non-existent document as an error")
-	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers)
+	addDocumentFlags(cli, cmd, &printCurl, &timeoutSecs, &waitSecs, &headers, &data)
 	return cmd
 }
 

--- a/client/go/internal/cli/cmd/document_test.go
+++ b/client/go/internal/cli/cmd/document_test.go
@@ -97,6 +97,34 @@ func TestDocumentSendPutFromStdin(t *testing.T) {
 	assertFieldsEqual(t, doc, body)
 }
 
+func TestDocumentSendPutWithData(t *testing.T) {
+	client := &mock.HTTPClient{}
+	cli, stdout, stderr := newTestCLI(t)
+	cli.httpClient = client
+	doc, err := os.ReadFile("testdata/A-Head-Full-of-Dreams-Put.json")
+	require.Nil(t, err)
+	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "document", "put", "--data", string(doc)))
+	assert.Equal(t, "Success: put id:mynamespace:music::a-head-full-of-dreams\n", stdout.String())
+	assert.Equal(t, "", stderr.String())
+	body, err := io.ReadAll(client.LastRequest.Body)
+	require.Nil(t, err)
+	assertFieldsEqual(t, doc, body)
+}
+
+func TestDocumentSendPutWithDataAndId(t *testing.T) {
+	client := &mock.HTTPClient{}
+	cli, stdout, stderr := newTestCLI(t)
+	cli.httpClient = client
+	doc, err := os.ReadFile("testdata/A-Head-Full-of-Dreams-Without-Operation.json")
+	require.Nil(t, err)
+	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "document", "put", "id:mynamespace:music::a-head-full-of-dreams", "--data", string(doc)))
+	assert.Equal(t, "Success: put id:mynamespace:music::a-head-full-of-dreams\n", stdout.String())
+	assert.Equal(t, "", stderr.String())
+	body, err := io.ReadAll(client.LastRequest.Body)
+	require.Nil(t, err)
+	assertFieldsEqual(t, doc, body)
+}
+
 func TestDocumentSendMissingId(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	assert.NotNil(t, cli.Run("-t", "http://127.0.0.1:8080", "document", "put", "testdata/A-Head-Full-of-Dreams-Without-Operation.json"))


### PR DESCRIPTION
@sarzhann : Humble attempt at adding `--data` parameter to provide document data on command line. Please review carefully.

CC: @kkraune 