### PR TITLE
Don't reject feed blocked group if it has enough active documents

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -58,7 +58,7 @@ public class Group {
         return hasSufficientCoverage;
     }
 
-    void setHasSufficientCoverage(boolean sufficientCoverage) {
+    public void setHasSufficientCoverage(boolean sufficientCoverage) {
         hasSufficientCoverage = sufficientCoverage;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch.searchcluster;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -62,14 +61,17 @@ public class Group {
         hasSufficientCoverage = sufficientCoverage;
     }
 
-    public int workingNodes() {
-        return (int) nodes.stream().filter(node -> node.isWorking() == Boolean.TRUE).count();
+    public List<Node> workingNodes() {
+        return nodes.stream().filter(node -> node.isWorking() == Boolean.TRUE).toList();
+    }
+
+    public int workingNodesCount() {
+        return workingNodes().size();
     }
 
     public void aggregateNodeValues() {
-        List<Node> workingNodes = new ArrayList<>(nodes);
-        workingNodes.removeIf(node -> node.isWorking() != Boolean.TRUE);
-        long activeDocs = workingNodes.stream().mapToLong(Node::getActiveDocuments).sum();
+        List<Node> workingNodes = workingNodes();
+        long activeDocs = calculateActiveDocs(workingNodes);
         activeDocuments = activeDocs;
         targetActiveDocuments = workingNodes.stream().mapToLong(Node::getTargetActiveDocuments).sum();
         isBlockingWrites = nodes.stream().anyMatch(Node::isBlockingWrites);
@@ -91,8 +93,14 @@ public class Group {
         }
     }
 
+    private static long calculateActiveDocs(List<Node> workingNodes) {
+        return workingNodes.stream()
+                           .mapToLong(Node::getActiveDocuments)
+                           .sum();
+    }
+
     /** Returns the active documents on this group. If unknown, 0 is returned. */
-    long activeDocuments() { return activeDocuments; }
+    public long activeDocuments() { return activeDocuments; }
 
     /** Returns the target active documents on this group. If unknown, 0 is returned. */
     long targetActiveDocuments() { return targetActiveDocuments; }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -272,7 +272,7 @@ public class SearchCluster implements NodeManager<Node> {
                 log.info("Cluster " + clusterId + ": " + group + " has full coverage. " +
                          "Active documents: " + group.activeDocuments() + "/" + medianDocuments + ", " +
                          "Target active documents: " + group.targetActiveDocuments() + ", " +
-                         "working nodes: " + group.workingNodes() + "/" + group.nodes().size());
+                         "working nodes: " + group.workingNodesCount() + "/" + group.nodes().size());
             } else {
                 StringBuilder unresponsive = new StringBuilder();
                 for (var node : group.nodes()) {
@@ -282,7 +282,7 @@ public class SearchCluster implements NodeManager<Node> {
                 String message = "Cluster " + clusterId + ": " + group + " has reduced coverage: " +
                                  "Active documents: " + group.activeDocuments() + "/" + maxDocuments + ", " +
                                  "Target active documents: " + group.targetActiveDocuments() + ", " +
-                                 "working nodes: " + group.workingNodes() + "/" + group.nodes().size() +
+                                 "working nodes: " + group.workingNodesCount() + "/" + group.nodes().size() +
                                  ", unresponsive nodes: " + (unresponsive.toString().isEmpty() ? " none" : unresponsive);
                 if (nonWorkingNodeCount() == 1) // That is normal
                     log.info(message);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
@@ -39,4 +39,8 @@ public interface SearchGroups {
 
     boolean isPartialGroupCoverageSufficient(boolean currentCoverageSufficient, Collection<Node> nodes);
 
+    boolean hasBetterCoverageThan(long groupDocumentCount, long documentCount);
+
+    long maxDocumentCount();
+
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
@@ -40,23 +40,24 @@ public class SearchGroupsImpl implements SearchGroups {
             if (availabilityPolicy.prioritizeAvailability()) {
                 // To take a group *out of* rotation, require that it has less active documents than the median.
                 // This avoids scenarios where incorrect accounting in a single group takes all other groups offline.
-                double documentCoverage = 100.0 * (double) groupDocumentCount / medianDocumentCount;
-                return documentCoverage >= availabilityPolicy.minActiveDocsPercentage();
+                return hasBetterCoverageThan(groupDocumentCount, medianDocumentCount);
             }
             else {
                 // Only serve from groups that have the maximal coverage, prioritizing 100% coverage over availability
                 // when there is a conflict.
-                double documentCoverage = 100.0 * (double) groupDocumentCount / maxDocumentCount;
-                return documentCoverage >= availabilityPolicy.minActiveDocsPercentage();
-
+                return hasBetterCoverageThan(groupDocumentCount, maxDocumentCount);
             }
         }
         else {
             // to put a group *in* rotation, require that it has as many documents as the largest group,
             // to avoid taking groups in too early when the majority of the groups have just been added.
-            double documentCoverage = 100.0 * (double) groupDocumentCount / maxDocumentCount;
-            return documentCoverage >= availabilityPolicy.minActiveDocsPercentage();
+            return hasBetterCoverageThan(groupDocumentCount, maxDocumentCount);
         }
+    }
+
+    public boolean hasBetterCoverageThan(long groupDocumentCount, long documentCount) {
+        double documentCoverage = 100.0 * (double) groupDocumentCount / documentCount;
+        return documentCoverage >= availabilityPolicy.minActiveDocsPercentage();
     }
 
     public long medianDocumentCount() {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
@@ -158,7 +158,7 @@ public class DispatcherTest {
         cluster.group(0).nodes().get(0).setBlockingWrites(true);
         cluster.group(1).nodes().get(0).setBlockingWrites(true);
         cluster.pingIterationCompleted();
-        assertEquals(0,
+        assertEquals(2,
                 dispatcher.getSearchInvoker(new Query(), null).distributionKey().get().longValue(),
                 "Blocking group is used when multiple groups are blocking");
         dispatcher.deconstruct();


### PR DESCRIPTION
Prefer a feed blocked group before one without coverage (i.e. one that is in maintenance).

https://github.com/vespa-engine/vespa/issues/33755