### PR TITLE
adjust policy for CurrentIndexSetup

### DIFF
--- a/searchlib/src/tests/expression/current_index_setup/current_index_setup_test.cpp
+++ b/searchlib/src/tests/expression/current_index_setup/current_index_setup_test.cpp
@@ -33,11 +33,26 @@ TEST(CurrentIndexSetupTest, unbound_struct_usage_can_be_captured) {
         EXPECT_EQ(setup.resolve("foo.a"), &foo_idx);
         EXPECT_EQ(setup.resolve("bar.a"), nullptr);
         EXPECT_EQ(setup.resolve("bar.b"), nullptr);
-        EXPECT_EQ(setup.resolve("plain"), nullptr);
     }
     EXPECT_EQ(setup.resolve("baz.a"), nullptr);
     EXPECT_TRUE(usage.has_single_unbound_struct());
     EXPECT_EQ(usage.get_unbound_struct_name(), "bar");
+}
+
+TEST(CurrentIndexSetupTest, unbound_plain_can_be_captured) {
+    CurrentIndexSetup setup;
+    CurrentIndexSetup::Usage usage;
+    CurrentIndex foo_idx;
+    setup.bind("foo", foo_idx);
+    EXPECT_FALSE(usage.has_single_unbound_struct());
+    {
+        CurrentIndexSetup::Usage::Bind capture_guard(setup, usage);
+        EXPECT_EQ(setup.resolve("foo.a"), &foo_idx);
+        EXPECT_EQ(setup.resolve("plain"), nullptr);
+    }
+    EXPECT_EQ(setup.resolve("baz.a"), nullptr);
+    EXPECT_TRUE(usage.has_single_unbound_struct());
+    EXPECT_EQ(usage.get_unbound_struct_name(), "plain");
 }
 
 TEST(CurrentIndexSetupTest, multi_unbound_struct_conflict_can_be_captured) {

--- a/searchlib/src/vespa/searchlib/expression/current_index_setup.cpp
+++ b/searchlib/src/vespa/searchlib/expression/current_index_setup.cpp
@@ -49,10 +49,7 @@ const CurrentIndex *
 CurrentIndexSetup::resolve(std::string_view field_name) const
 {
     size_t pos = field_name.rfind('.');
-    if (pos > field_name.size()) {
-        return nullptr;
-    }
-    auto struct_name = field_name.substr(0, pos);
+    auto struct_name = (pos > field_name.size()) ? field_name : field_name.substr(0, pos);
     auto entry = _bound.find(struct_name);
     if (entry == _bound.end()) {
         if (_usage != nullptr) {


### PR DESCRIPTION
This allows binding an index to a plain array<string> to allow filtering of groups to work.  May impact some strange corner cases where new behavior will be more consistent with array<struct> after this change.

@havardpe please review
Note: naming should change also, unbound_struct to unbound_array maybe?