### PR TITLE
Gather memory usage in vespalib from statm

### DIFF
--- a/searchcore/src/tests/proton/server/disk_mem_usage_filter/disk_mem_usage_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_filter/disk_mem_usage_filter_test.cpp
@@ -19,7 +19,7 @@ struct DiskMemUsageFilterTest : public ::testing::Test
     DiskMemUsageFilterTest()
         : _filter(HwInfo(HwInfo::Disk(100, false, false), HwInfo::Memory(1000), HwInfo::Cpu(0)))
     {
-        _filter.set_resource_usage(TransientResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 299, 300, 42), 20);
+        _filter.set_resource_usage(TransientResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 300), 20);
     }
 
     void testWrite(const std::string &exp) {
@@ -42,7 +42,7 @@ struct DiskMemUsageFilterTest : public ::testing::Test
 
     void triggerMemoryLimit()
     {
-        _filter.set_resource_usage(TransientResourceUsage(), vespalib::ProcessMemoryStats(897, 898, 899, 900, 43), _filter.getDiskUsedSize());
+        _filter.set_resource_usage(TransientResourceUsage(), vespalib::ProcessMemoryStats(897, 898, 900), _filter.getDiskUsedSize());
     }
 };
 
@@ -53,9 +53,9 @@ TEST_F(DiskMemUsageFilterTest, default_filter_allows_write)
 
 TEST_F(DiskMemUsageFilterTest, stats_are_wired_through)
 {
-    EXPECT_EQ(42u, _filter.getMemoryStats().getMappingsCount());
+    EXPECT_EQ(297u, _filter.getMemoryStats().getVirt());
     triggerMemoryLimit();
-    EXPECT_EQ(43u, _filter.getMemoryStats().getMappingsCount());
+    EXPECT_EQ(897u, _filter.getMemoryStats().getVirt());
 }
 
 void
@@ -96,8 +96,8 @@ TEST_F(DiskMemUsageFilterTest, memory_limit_can_be_reached)
               "action: \"add more content nodes\", "
               "reason: \"memory used (0.9) > memory limit (0.8)\", "
               "stats: { "
-              "mapped: { virt: 897, rss: 898}, "
-              "anonymous: { virt: 899, rss: 900}, "
+              "virt: 897, "
+              "rss: { mapped: 898, anonymous: 900}, "
               "physicalMemory: 1000, memoryUsed: 0.9, memoryLimit: 0.8}}");
     assertResourceUsage(0.9, 0.8, 1.125, _filter.usageState().memoryState());
 }
@@ -111,8 +111,8 @@ TEST_F(DiskMemUsageFilterTest, both_disk_limit_and_memory_limit_can_be_reached)
               "action: \"add more content nodes\", "
               "reason: \"memory used (0.9) > memory limit (0.8)\", "
               "stats: { "
-              "mapped: { virt: 897, rss: 898}, "
-              "anonymous: { virt: 899, rss: 900}, "
+              "virt: 897, "
+              "rss: { mapped: 898, anonymous: 900}, "
               "physicalMemory: 1000, memoryUsed: 0.9, memoryLimit: 0.8}}, "
               "diskLimitReached: { "
               "action: \"add more content nodes\", "

--- a/searchcore/src/vespa/searchcore/proton/metrics/resource_usage_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/resource_usage_metrics.cpp
@@ -39,7 +39,6 @@ ResourceUsageMetrics::ResourceUsageMetrics(metrics::MetricSet *parent)
       memory("memory", {}, "The relative amount of memory used by this content node (transient usage not included, value in the range [0, 1]). Same value as reported to the cluster controller", this),
       disk_usage("disk", this),
       memory_usage("memory", this),
-      memoryMappings("memory_mappings", {}, "The number of mapped memory areas", this),
       openFileDescriptors("open_file_descriptors", {}, "The number of open files", this),
       feedingBlocked("feeding_blocked", {}, "Whether feeding is blocked due to resource limits being reached (value is either 0 or 1)", this),
       mallocArena("malloc_arena", {}, "Size of malloc arena", this),

--- a/searchcore/src/vespa/searchcore/proton/metrics/resource_usage_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/resource_usage_metrics.h
@@ -36,7 +36,6 @@ struct ResourceUsageMetrics : metrics::MetricSet
     metrics::DoubleValueMetric memory;
     DetailedResourceMetrics disk_usage;
     DetailedResourceMetrics memory_usage;
-    metrics::LongValueMetric memoryMappings;
     metrics::LongValueMetric openFileDescriptors;
     metrics::LongValueMetric feedingBlocked;
     metrics::LongValueMetric mallocArena;

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_filter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_filter.cpp
@@ -20,8 +20,9 @@ makeMemoryStatsMessage(std::ostream &os,
                        uint64_t physicalMemory)
 {
     os << "stats: { ";
-    os << "mapped: { virt: " << memoryStats.getMappedVirt() << ", rss: " << memoryStats.getMappedRss() << "}, ";
-    os << "anonymous: { virt: " << memoryStats.getAnonymousVirt() << ", rss: " << memoryStats.getAnonymousRss() << "}, ";
+    os << "virt: " << memoryStats.getVirt() << ", ";
+    os << "rss: { mapped: " << memoryStats.getMappedRss() << ", ";
+    os << "anonymous: " << memoryStats.getAnonymousRss() << "}, ";
     os << "physicalMemory: " << physicalMemory << ", ";
     os << "memoryUsed: " << memoryUsed << ", ";
     os << "memoryLimit: " << memoryLimit << "}";

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -844,7 +844,6 @@ Proton::updateMetrics(const metrics::MetricLockGuard &)
         metrics.resourceUsage.memory_usage.total_util.set(dm_metrics.total_memory_utilization());
         metrics.resourceUsage.memory_usage.transient.set(dm_metrics.transient_memory_usage());
 
-        metrics.resourceUsage.memoryMappings.set(usageFilter.getMemoryStats().getMappingsCount());
         metrics.resourceUsage.openFileDescriptors.set(FastOS_File::count_open_files());
         metrics.resourceUsage.feedingBlocked.set((usageFilter.acceptWriteOperation() ? 0.0 : 1.0));
 #ifdef __linux__

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
@@ -20,9 +20,8 @@ convertDiskStatsToSlime(const vespalib::HwInfo &hwInfo, uint64_t diskUsedSizeByt
 void
 convertMemoryStatsToSlime(const vespalib::ProcessMemoryStats &stats, Cursor &object)
 {
-    object.setLong("mappedVirt", stats.getMappedVirt());
+    object.setLong("virt", stats.getVirt());
     object.setLong("mappedRss", stats.getMappedRss());
-    object.setLong("anonymousVirt", stats.getAnonymousVirt());
     object.setLong("anonymousRss", stats.getAnonymousRss());
 }
 

--- a/vespalib/src/tests/util/process_memory_stats/CMakeLists.txt
+++ b/vespalib/src/tests/util/process_memory_stats/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(vespalib_process_memory_stats_test_app TEST
     process_memory_stats_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_process_memory_stats_test_app COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/process_memory_stats_test.sh
                DEPENDS vespalib_process_memory_stats_test_app)

--- a/vespalib/src/tests/util/process_memory_stats/CMakeLists.txt
+++ b/vespalib/src/tests/util/process_memory_stats/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_executable(vespalib_process_memory_stats_test_app TEST
     process_memory_stats_test.cpp
     DEPENDS
     vespalib
+    GTest::GTest
 )
 vespa_add_test(NAME vespalib_process_memory_stats_test_app COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/process_memory_stats_test.sh
                DEPENDS vespalib_process_memory_stats_test_app)

--- a/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
+++ b/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/process_memory_stats.h>
 #include <vespa/vespalib/util/size_literals.h>
@@ -17,10 +18,14 @@ constexpr double SIZE_EPSILON = 0.01;
 std::string toString(const ProcessMemoryStats &stats)
 {
     std::ostringstream os;
-    os << "Mapped("
-       << stats.getMappedVirt() << "," << stats.getMappedRss() <<
-        "), Anonymous("
-       << stats.getAnonymousVirt() << "," << stats.getAnonymousRss() << ")";
+    os << "Virtual("
+       << stats.getVirt() <<
+       "), Rss("
+       << stats.getMappedRss() + stats.getAnonymousRss() <<
+       "), MappedRss("
+       << stats.getMappedRss() <<
+       "), AnonymousRss("
+       << stats.getAnonymousRss() << ")";
     return os.str();
 }
 
@@ -28,63 +33,99 @@ std::string toString(const ProcessMemoryStats &stats)
 
 TEST("Simple stats")
 {
-    ProcessMemoryStats stats(ProcessMemoryStats::create(SIZE_EPSILON));
-    std::cout << toString(stats) << std::endl;
-    EXPECT_LESS(0u, stats.getMappedVirt());
-    EXPECT_LESS(0u, stats.getMappedRss());
-    EXPECT_LESS(0u, stats.getAnonymousVirt());
-    EXPECT_LESS(0u, stats.getAnonymousRss());
+    auto lambda = [](ProcessMemoryStats::SamplingStrategy strategy) {
+        ProcessMemoryStats stats(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats) << std::endl;
+        EXPECT_LESS(0u, stats.getVirt());
+        EXPECT_LESS(0u, stats.getMappedRss());
+        EXPECT_LESS(0u, stats.getAnonymousRss());
+    };
+
+    std::cout << "smaps" << std::endl;
+    lambda(ProcessMemoryStats::SamplingStrategy::SMAPS);
+
+    std::cout << "statm" << std::endl;
+    lambda(ProcessMemoryStats::SamplingStrategy::STATM);
 }
 
 TEST("grow anonymous memory")
 {
-    ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON));
-    std::cout << toString(stats1) << std::endl;
-    size_t mapLen = 64_Ki;
-    void *mapAddr = mmap(nullptr, mapLen, PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
-    ProcessMemoryStats stats2(ProcessMemoryStats::create(0.01));
-    std::cout << toString(stats2) << std::endl;
-    EXPECT_LESS_EQUAL(stats1.getAnonymousVirt() + mapLen,
-                      stats2.getAnonymousVirt());
-    memset(mapAddr, 1, mapLen);
-    ProcessMemoryStats stats3(ProcessMemoryStats::create(SIZE_EPSILON));
-    std::cout << toString(stats3) << std::endl;
-    // Cannot check that resident grows if swap is enabled and system loaded
-    munmap(mapAddr, mapLen);
+    auto lambda = [](ProcessMemoryStats::SamplingStrategy strategy) {
+        ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats1) << std::endl;
+        size_t mapLen = 64_Ki;
+        void *mapAddr = mmap(nullptr, mapLen, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
+        ProcessMemoryStats stats2(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats2) << std::endl;
+        EXPECT_LESS_EQUAL(stats1.getVirt() + mapLen,
+                          stats2.getVirt());
+        memset(mapAddr, 1, mapLen);
+        ProcessMemoryStats stats3(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats3) << std::endl;
+        // Cannot check that resident grows if swap is enabled and system loaded
+        munmap(mapAddr, mapLen);
+    };
+
+    std::cout << "smaps" << std::endl;
+    lambda(ProcessMemoryStats::SamplingStrategy::SMAPS);
+
+    std::cout << "statm" << std::endl;
+    lambda(ProcessMemoryStats::SamplingStrategy::STATM);
 }
 
 TEST("grow mapped memory")
 {
-    std::ofstream of("mapfile");
-    size_t mapLen = 64_Ki;
-    std::vector<char> buf(mapLen, 4);
-    of.write(&buf[0], buf.size());
-    of.close();
-    int mapfileFileDescriptor = open("mapfile", O_RDONLY, 0666);
-    EXPECT_LESS_EQUAL(0, mapfileFileDescriptor);
-    ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON));
-    std::cout << toString(stats1) << std::endl;
-    void *mapAddr = mmap(nullptr, mapLen, PROT_READ, MAP_SHARED,
-                         mapfileFileDescriptor, 0);
-    EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
-    ProcessMemoryStats stats2(ProcessMemoryStats::create(SIZE_EPSILON));
-    std::cout << toString(stats2) << std::endl;
-    EXPECT_LESS_EQUAL(stats1.getMappedVirt() + mapLen, stats2.getMappedVirt());
-    EXPECT_EQUAL(0, memcmp(mapAddr, &buf[0], mapLen));
-    ProcessMemoryStats stats3(ProcessMemoryStats::create(SIZE_EPSILON));
-    std::cout << toString(stats3) << std::endl;
-    // Cannot check that resident grows if swap is enabled and system loaded
-    munmap(mapAddr, mapLen);
+    auto lambda = [](ProcessMemoryStats::SamplingStrategy strategy) {
+        std::ofstream of("mapfile");
+        size_t mapLen = 64_Ki;
+        std::vector<char> buf(mapLen, 4);
+        of.write(&buf[0], buf.size());
+        of.close();
+        int mapfileFileDescriptor = open("mapfile", O_RDONLY, 0666);
+        EXPECT_LESS_EQUAL(0, mapfileFileDescriptor);
+        ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats1) << std::endl;
+        void *mapAddr = mmap(nullptr, mapLen, PROT_READ, MAP_SHARED,
+                             mapfileFileDescriptor, 0);
+        EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
+        ProcessMemoryStats stats2(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats2) << std::endl;
+        EXPECT_LESS_EQUAL(stats1.getVirt() + mapLen, stats2.getVirt());
+        EXPECT_EQUAL(0, memcmp(mapAddr, &buf[0], mapLen));
+        ProcessMemoryStats stats3(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
+        std::cout << toString(stats3) << std::endl;
+        // Cannot check that resident grows if swap is enabled and system loaded
+        munmap(mapAddr, mapLen);
+    };
+
+    std::cout << "smaps" << std::endl;
+    lambda(ProcessMemoryStats::SamplingStrategy::SMAPS);
+
+    std::cout << "statm" << std::endl;
+    lambda(ProcessMemoryStats::SamplingStrategy::STATM);
 }
 
 TEST("order samples")
 {
-    ProcessMemoryStats a(0,0,0,7,0);
-    ProcessMemoryStats b(0,0,0,8,0);
+    ProcessMemoryStats a(0,0,7);
+    ProcessMemoryStats b(0,0,8);
     EXPECT_TRUE(a < b);
     EXPECT_FALSE(b < a);
+}
+
+TEST("parseStatm")
+{
+    // size resident shared text lib data dt
+    std::string statm = "3332000 1917762 8060 1 0 2960491 0";
+    std::string_view view(statm);
+    asciistream stream(view);
+
+    ProcessMemoryStats stats = ProcessMemoryStats::parseStatm(stream);
+    EXPECT_EQUAL(3332000 * ProcessMemoryStats::PAGE_SIZE, stats.getVirt());
+    EXPECT_EQUAL((1917762 - 8060) * ProcessMemoryStats::PAGE_SIZE, stats.getAnonymousRss());
+    EXPECT_EQUAL(8060 * ProcessMemoryStats::PAGE_SIZE, stats.getMappedRss());
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
+++ b/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
@@ -1,7 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/asciistream.h>
-#include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/process_memory_stats.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <iostream>
@@ -31,14 +31,14 @@ std::string toString(const ProcessMemoryStats &stats)
 
 }
 
-TEST("Simple stats")
+TEST(ProcessMemoryStatsTest, simple_stats)
 {
     auto lambda = [](ProcessMemoryStats::SamplingStrategy strategy) {
         ProcessMemoryStats stats(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
         std::cout << toString(stats) << std::endl;
-        EXPECT_LESS(0u, stats.getVirt());
-        EXPECT_LESS(0u, stats.getMappedRss());
-        EXPECT_LESS(0u, stats.getAnonymousRss());
+        EXPECT_LT(0u, stats.getVirt());
+        EXPECT_LT(0u, stats.getMappedRss());
+        EXPECT_LT(0u, stats.getAnonymousRss());
     };
 
     std::cout << "smaps" << std::endl;
@@ -48,7 +48,7 @@ TEST("Simple stats")
     lambda(ProcessMemoryStats::SamplingStrategy::STATM);
 }
 
-TEST("grow anonymous memory")
+TEST(ProcessMemoryStatsTest, grow_anonymous_memory)
 {
     auto lambda = [](ProcessMemoryStats::SamplingStrategy strategy) {
         ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
@@ -56,11 +56,11 @@ TEST("grow anonymous memory")
         size_t mapLen = 64_Ki;
         void *mapAddr = mmap(nullptr, mapLen, PROT_READ | PROT_WRITE,
                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
+        EXPECT_NE(reinterpret_cast<void *>(-1), mapAddr);
         ProcessMemoryStats stats2(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
         std::cout << toString(stats2) << std::endl;
-        EXPECT_LESS_EQUAL(stats1.getVirt() + mapLen,
-                          stats2.getVirt());
+        EXPECT_LE(stats1.getVirt() + mapLen,
+                  stats2.getVirt());
         memset(mapAddr, 1, mapLen);
         ProcessMemoryStats stats3(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
         std::cout << toString(stats3) << std::endl;
@@ -75,7 +75,7 @@ TEST("grow anonymous memory")
     lambda(ProcessMemoryStats::SamplingStrategy::STATM);
 }
 
-TEST("grow mapped memory")
+TEST(ProcessMemoryStatsTest, grow_mapped_memory)
 {
     auto lambda = [](ProcessMemoryStats::SamplingStrategy strategy) {
         std::ofstream of("mapfile");
@@ -84,16 +84,16 @@ TEST("grow mapped memory")
         of.write(&buf[0], buf.size());
         of.close();
         int mapfileFileDescriptor = open("mapfile", O_RDONLY, 0666);
-        EXPECT_LESS_EQUAL(0, mapfileFileDescriptor);
+        EXPECT_LE(0, mapfileFileDescriptor);
         ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
         std::cout << toString(stats1) << std::endl;
         void *mapAddr = mmap(nullptr, mapLen, PROT_READ, MAP_SHARED,
                              mapfileFileDescriptor, 0);
-        EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
+        EXPECT_NE(reinterpret_cast<void *>(-1), mapAddr);
         ProcessMemoryStats stats2(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
         std::cout << toString(stats2) << std::endl;
-        EXPECT_LESS_EQUAL(stats1.getVirt() + mapLen, stats2.getVirt());
-        EXPECT_EQUAL(0, memcmp(mapAddr, &buf[0], mapLen));
+        EXPECT_LE(stats1.getVirt() + mapLen, stats2.getVirt());
+        EXPECT_EQ(0, memcmp(mapAddr, &buf[0], mapLen));
         ProcessMemoryStats stats3(ProcessMemoryStats::create(SIZE_EPSILON, strategy));
         std::cout << toString(stats3) << std::endl;
         // Cannot check that resident grows if swap is enabled and system loaded
@@ -107,7 +107,7 @@ TEST("grow mapped memory")
     lambda(ProcessMemoryStats::SamplingStrategy::STATM);
 }
 
-TEST("order samples")
+TEST(ProcessMemoryStatsTest, order_samples)
 {
     ProcessMemoryStats a(0,0,7);
     ProcessMemoryStats b(0,0,8);
@@ -115,7 +115,7 @@ TEST("order samples")
     EXPECT_FALSE(b < a);
 }
 
-TEST("parseStatm")
+TEST(ProcessMemoryStatsTest, parse_statm)
 {
     // size resident shared text lib data dt
     std::string statm = "3332000 1917762 8060 1 0 2960491 0";
@@ -123,9 +123,9 @@ TEST("parseStatm")
     asciistream stream(view);
 
     ProcessMemoryStats stats = ProcessMemoryStats::parseStatm(stream);
-    EXPECT_EQUAL(3332000 * ProcessMemoryStats::PAGE_SIZE, stats.getVirt());
-    EXPECT_EQUAL((1917762 - 8060) * ProcessMemoryStats::PAGE_SIZE, stats.getAnonymousRss());
-    EXPECT_EQUAL(8060 * ProcessMemoryStats::PAGE_SIZE, stats.getMappedRss());
+    EXPECT_EQ(3332000 * ProcessMemoryStats::PAGE_SIZE, stats.getVirt());
+    EXPECT_EQ((1917762 - 8060) * ProcessMemoryStats::PAGE_SIZE, stats.getAnonymousRss());
+    EXPECT_EQ(8060 * ProcessMemoryStats::PAGE_SIZE, stats.getMappedRss());
 }
 
-TEST_MAIN() { TEST_RUN_ALL(); }
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.cpp
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.cpp
@@ -1,16 +1,14 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "process_memory_stats.h"
+#include "exceptions.h"
 #include <vespa/vespalib/stllike/asciistream.h>
-#include <algorithm>
-#include <vector>
-#include <cinttypes>
 #include <vespa/vespalib/util/size_literals.h>
+#include <algorithm>
+#include <cinttypes>
+#include <vector>
 
 #include <vespa/log/log.h>
-
-#include "exceptions.h"
-
 LOG_SETUP(".vespalib.util.process_memory_stats");
 
 namespace vespalib {

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.cpp
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.cpp
@@ -152,19 +152,19 @@ ProcessMemoryStats::parseStatm(asciistream &statm)
 {
     ProcessMemoryStats ret;
     try {
-        // the first three values in smaps are size, resident, and shared
+        // the first three values in statm are size, resident, and shared
         // the values in statm are measured in numbers of pages
         uint64_t size, resident, shared;
         statm >> size >> resident >> shared;
 
-        // we only get the total program size via smaps (no distinction between anonymous and non-anonymous)
-        // VmSize (in status) = size (in smaps)
+        // we only get the total program size via statm (no distinction between anonymous and non-anonymous)
+        // VmSize (in status) = size (in statm)
         ret._virt = size * PAGE_SIZE;
 
-        // RssAnon (in status) = resident - shared (in smaps)
+        // RssAnon (in status) = resident - shared (in statm)
         ret._anonymous_rss = (resident - shared) * PAGE_SIZE;
 
-        // RssFile + RssShmem (in status) = shared (in smaps)
+        // RssFile + RssShmem (in status) = shared (in statm)
         ret._mapped_rss = shared * PAGE_SIZE;
 
     } catch (const IllegalArgumentException& e) {

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.h
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.h
@@ -34,7 +34,7 @@ public:
 
     ProcessMemoryStats();
     /**
-     * Sample memory stats for the current process based on reading the file /proc/self/smaps.
+     * Sample memory stats for the current process based on reading the file /proc/self/statm.
      *
      * Samples are taken until two consecutive memory stats are similar given the size epsilon.
      * This ensures a somewhat consistent memory stats snapshot.

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.h
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.h
@@ -14,20 +14,11 @@ class asciistream;
  */
 class ProcessMemoryStats
 {
-public:
-    enum SamplingStrategy {
-        SMAPS,
-        STATM
-    };
-
-private:
     uint64_t _virt; // virtual size
     uint64_t _mapped_rss;  // resident size
     uint64_t _anonymous_rss;  // resident size
 
-    static ProcessMemoryStats createStatsFromSmaps();
     static ProcessMemoryStats createStatsFromStatm();
-    static ProcessMemoryStats sample(SamplingStrategy strategy);
 
 public:
     static size_t PAGE_SIZE;
@@ -39,7 +30,7 @@ public:
      * Samples are taken until two consecutive memory stats are similar given the size epsilon.
      * This ensures a somewhat consistent memory stats snapshot.
      */
-    static ProcessMemoryStats create(double epsilon, SamplingStrategy strategy = STATM);
+    static ProcessMemoryStats create(double epsilon);
     uint64_t getVirt() const { return _virt; }
     uint64_t getMappedRss() const { return _mapped_rss; }
     uint64_t getAnonymousRss() const { return _anonymous_rss; }

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.h
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.h
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include <string>
-#include <functional>
 
 namespace vespalib {
 

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.h
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.h
@@ -4,24 +4,34 @@
 
 #include <cstdint>
 #include <string>
+#include <functional>
 
 namespace vespalib {
 
+class asciistream;
 /*
  * Class for linux specific way to get memory stats for current process.
  */
 class ProcessMemoryStats
 {
-    uint64_t _mapped_virt; // virtual size
+public:
+    enum SamplingStrategy {
+        SMAPS,
+        STATM
+    };
+
+private:
+    uint64_t _virt; // virtual size
     uint64_t _mapped_rss;  // resident size
-    uint64_t _anonymous_virt; // virtual size
     uint64_t _anonymous_rss;  // resident size
-    uint64_t _mappings_count; // number of mappings
-                              // (limited by sysctl vm.max_map_count)
 
     static ProcessMemoryStats createStatsFromSmaps();
+    static ProcessMemoryStats createStatsFromStatm();
+    static ProcessMemoryStats sample(SamplingStrategy strategy);
 
 public:
+    static size_t PAGE_SIZE;
+
     ProcessMemoryStats();
     /**
      * Sample memory stats for the current process based on reading the file /proc/self/smaps.
@@ -29,18 +39,17 @@ public:
      * Samples are taken until two consecutive memory stats are similar given the size epsilon.
      * This ensures a somewhat consistent memory stats snapshot.
      */
-    static ProcessMemoryStats create(double epsilon);
-    uint64_t getMappedVirt() const { return _mapped_virt; }
+    static ProcessMemoryStats create(double epsilon, SamplingStrategy strategy = STATM);
+    uint64_t getVirt() const { return _virt; }
     uint64_t getMappedRss() const { return _mapped_rss; }
-    uint64_t getAnonymousVirt() const { return _anonymous_virt; }
     uint64_t getAnonymousRss() const { return _anonymous_rss; }
-    uint64_t getMappingsCount() const { return _mappings_count; }
     bool similarTo(const ProcessMemoryStats &rhs, double epsilon) const;
     std::string toString() const;
     bool operator < (const ProcessMemoryStats & rhs) const { return _anonymous_rss < rhs._anonymous_rss; }
 
     /** for unit tests only */
-    ProcessMemoryStats(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+    ProcessMemoryStats(uint64_t, uint64_t, uint64_t);
+    static ProcessMemoryStats parseStatm(asciistream &statm);
 };
 
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Instead of using `/proc/self/smaps`, gather the memory usage in ProcessMemoryStats from `/proc/self/statm`, which is faster but also less accurate. In addition to being less accurate, the data obtained from `/proc/self/statm` is less detailed (no number of memory mappings, no distinction of anonymous vs mapped virtual memory), which is why some of the getters were renamed or removed. This led to some changes in other places. Since the values obtained from `/proc/self/smaps` and `/proc/self/statm` are almost identical (difference of 5MB observed in system tests), this pull request just removes the `/proc/self/smaps` code.