### PR TITLE
make filter wrapper class naming transparent for profiling tags

### DIFF
--- a/searchlib/src/tests/queryeval/wrappers/wrappers_test.cpp
+++ b/searchlib/src/tests/queryeval/wrappers/wrappers_test.cpp
@@ -91,7 +91,8 @@ TEST_F(WrapperTest, filter_wrapper)
     tfmda.add(&match);
     _data.unpackedDocId = 0;
     auto search = std::make_unique<FilterWrapper>(1);
-search->wrap(std::make_unique<DummyItr>(_data, search->tfmda()[0]));
+    search->wrap(std::make_unique<DummyItr>(_data, search->tfmda()[0]));
+    EXPECT_TRUE(search->getClassName().find("DummyItr") != std::string::npos);
     search->initFullRange();
     EXPECT_EQ(_data.unpackedDocId, 0u);
     EXPECT_TRUE(!search->seek(1u));

--- a/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
+++ b/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
@@ -61,6 +61,9 @@ public:
     Trinary is_strict() const override {
         return _wrapped_search->is_strict();
     }
+    std::string getClassName() const override {
+        return _wrapped_search->getClassName();
+    }
 };
 
 } // namespace

--- a/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
@@ -25,8 +25,8 @@ struct TaskGuard {
     ~TaskGuard() { profiler.complete(); }
 };
 
-std::string name_of(const auto &obj) {
-    return vespalib::getClassName(obj);
+std::string name_of(const SearchIterator &search) {
+    return search.getClassName();
 }
 
 std::unique_ptr<SearchIterator> create(Profiler &profiler,


### PR DESCRIPTION
just use the class name of the wrapped search for now. We might consider somethings like 'FW<inner_type>' in the future if needed.

@toregge please review