### PR TITLE
Clean up ProcessMemoryStats test

### DIFF
--- a/vespalib/src/tests/util/process_memory_stats/CMakeLists.txt
+++ b/vespalib/src/tests/util/process_memory_stats/CMakeLists.txt
@@ -6,5 +6,4 @@ vespa_add_executable(vespalib_process_memory_stats_test_app TEST
     vespalib
     GTest::gtest
 )
-vespa_add_test(NAME vespalib_process_memory_stats_test_app COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/process_memory_stats_test.sh
-               DEPENDS vespalib_process_memory_stats_test_app)
+vespa_add_test(NAME vespalib_process_memory_stats_test_app COMMAND vespalib_process_memory_stats_test_app)

--- a/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
+++ b/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
@@ -4,7 +4,7 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/process_memory_stats.h>
 #include <vespa/vespalib/util/size_literals.h>
-#include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <fcntl.h>
@@ -15,12 +15,12 @@ using namespace vespalib;
 class ProcessMemoryStatsTest : public ::testing::Test
 {
 protected:
-    void SetUp() override {
-        std::remove("mapfile");
+    static void SetUpTestSuite() {
+        std::filesystem::remove("mapfile");
     }
 
-    void TearDown() override {
-        std::remove("mapfile");
+    static void TearDownTestSuite() {
+        std::filesystem::remove("mapfile");
     }
 
     static constexpr double SIZE_EPSILON = 0.01;

--- a/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
+++ b/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
@@ -4,34 +4,44 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/process_memory_stats.h>
 #include <vespa/vespalib/util/size_literals.h>
-#include <iostream>
+#include <cstdio>
 #include <fstream>
-#include <sys/mman.h>
+#include <iostream>
 #include <fcntl.h>
+#include <sys/mman.h>
 
 using namespace vespalib;
 
-namespace {
-
-constexpr double SIZE_EPSILON = 0.01;
-
-std::string toString(const ProcessMemoryStats &stats)
+class ProcessMemoryStatsTest : public ::testing::Test
 {
-    std::ostringstream os;
-    os << "Virtual("
-       << stats.getVirt() <<
-       "), Rss("
-       << stats.getMappedRss() + stats.getAnonymousRss() <<
-       "), MappedRss("
-       << stats.getMappedRss() <<
-       "), AnonymousRss("
-       << stats.getAnonymousRss() << ")";
-    return os.str();
-}
+protected:
+    void SetUp() override {
+        std::remove("mapfile");
+    }
 
-}
+    void TearDown() override {
+        std::remove("mapfile");
+    }
 
-TEST(ProcessMemoryStatsTest, simple_stats)
+    static constexpr double SIZE_EPSILON = 0.01;
+
+    static std::string toString(const ProcessMemoryStats &stats)
+    {
+        std::ostringstream os;
+        os << "Virtual("
+           << stats.getVirt() <<
+           "), Rss("
+           << stats.getMappedRss() + stats.getAnonymousRss() <<
+           "), MappedRss("
+           << stats.getMappedRss() <<
+           "), AnonymousRss("
+           << stats.getAnonymousRss() << ")";
+        return os.str();
+    }
+
+};
+
+TEST_F(ProcessMemoryStatsTest, simple_stats)
 {
     ProcessMemoryStats stats(ProcessMemoryStats::create(SIZE_EPSILON));
     std::cout << toString(stats) << std::endl;
@@ -40,7 +50,7 @@ TEST(ProcessMemoryStatsTest, simple_stats)
     EXPECT_LT(0u, stats.getAnonymousRss());
 }
 
-TEST(ProcessMemoryStatsTest, grow_anonymous_memory)
+TEST_F(ProcessMemoryStatsTest, grow_anonymous_memory)
 {
     ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON));
     std::cout << toString(stats1) << std::endl;
@@ -59,7 +69,7 @@ TEST(ProcessMemoryStatsTest, grow_anonymous_memory)
     munmap(mapAddr, mapLen);
 }
 
-TEST(ProcessMemoryStatsTest, grow_mapped_memory)
+TEST_F(ProcessMemoryStatsTest, grow_mapped_memory)
 {
     std::ofstream of("mapfile");
     size_t mapLen = 64_Ki;
@@ -83,7 +93,7 @@ TEST(ProcessMemoryStatsTest, grow_mapped_memory)
     munmap(mapAddr, mapLen);
 }
 
-TEST(ProcessMemoryStatsTest, order_samples)
+TEST_F(ProcessMemoryStatsTest, order_samples)
 {
     ProcessMemoryStats a(0,0,7);
     ProcessMemoryStats b(0,0,8);
@@ -91,7 +101,7 @@ TEST(ProcessMemoryStatsTest, order_samples)
     EXPECT_FALSE(b < a);
 }
 
-TEST(ProcessMemoryStatsTest, parse_statm)
+TEST_F(ProcessMemoryStatsTest, parse_statm)
 {
     // size resident shared text lib data dt
     std::string statm = "3332000 1917762 8060 1 0 2960491 0";

--- a/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.sh
+++ b/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-set -e
-rm -f mapfile
-$VALGRIND ./vespalib_process_memory_stats_test_app
-rm -f mapfile


### PR DESCRIPTION
Since the test is now using gtest, we do not need the shell script for deleting the temporary file `mapfile` anymore. Instead, we delete the file in the fixture class.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
