### PR TITLE
The imported target GTest::GTest has been deprecated since CMake 3.20.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # @author Vegard Sjonfjell
 # @author Eirik Nygaard
 # @author Arnstein Ressem
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 include(functions.cmake)
 list(APPEND CMAKE_MODULE_PATH

--- a/document/src/tests/select/CMakeLists.txt
+++ b/document/src/tests/select/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(document_select_test_app TEST
     select_test.cpp
     DEPENDS
     vespa_document
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME document_select_test_app COMMAND document_select_test_app)

--- a/document/src/tests/tensor_fieldvalue/partial_add/CMakeLists.txt
+++ b/document/src/tests/tensor_fieldvalue/partial_add/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(document_partial_add_test_app TEST
     partial_add_test.cpp
     DEPENDS
     vespa_document
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME document_partial_add_test_app COMMAND document_partial_add_test_app)

--- a/document/src/tests/tensor_fieldvalue/partial_modify/CMakeLists.txt
+++ b/document/src/tests/tensor_fieldvalue/partial_modify/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(document_partial_modify_test_app TEST
     partial_modify_test.cpp
     DEPENDS
     vespa_document
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME document_partial_modify_test_app COMMAND document_partial_modify_test_app)

--- a/document/src/tests/tensor_fieldvalue/partial_remove/CMakeLists.txt
+++ b/document/src/tests/tensor_fieldvalue/partial_remove/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(document_partial_remove_test_app TEST
     partial_remove_test.cpp
     DEPENDS
     vespa_document
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME document_partial_remove_test_app COMMAND document_partial_remove_test_app)

--- a/documentapi/src/tests/messages/CMakeLists.txt
+++ b/documentapi/src/tests/messages/CMakeLists.txt
@@ -8,6 +8,6 @@ vespa_add_executable(documentapi_messages_test_app TEST
     messages_app.cpp
     DEPENDS
     vespa_documentapi
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME documentapi_messages_test_app COMMAND documentapi_messages_test_app)

--- a/eval/src/tests/eval/addr_to_symbol/CMakeLists.txt
+++ b/eval/src/tests/eval/addr_to_symbol/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_addr_to_symbol_test_app TEST
     addr_to_symbol_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_addr_to_symbol_test_app COMMAND eval_addr_to_symbol_test_app)

--- a/eval/src/tests/eval/array_array_map/CMakeLists.txt
+++ b/eval/src/tests/eval/array_array_map/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_array_array_map_test_app TEST
     array_array_map_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_array_array_map_test_app COMMAND eval_array_array_map_test_app)

--- a/eval/src/tests/eval/cell_type_space/CMakeLists.txt
+++ b/eval/src/tests/eval/cell_type_space/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_cell_type_space_test_app TEST
     cell_type_space_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_cell_type_space_test_app COMMAND eval_cell_type_space_test_app)

--- a/eval/src/tests/eval/fast_value/CMakeLists.txt
+++ b/eval/src/tests/eval/fast_value/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_fast_value_test_app TEST
     fast_value_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_fast_value_test_app COMMAND eval_fast_value_test_app)

--- a/eval/src/tests/eval/gen_spec/CMakeLists.txt
+++ b/eval/src/tests/eval/gen_spec/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_gen_spec_test_app TEST
     gen_spec_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_gen_spec_test_app COMMAND eval_gen_spec_test_app)

--- a/eval/src/tests/eval/inline_operation/CMakeLists.txt
+++ b/eval/src/tests/eval/inline_operation/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_inline_operation_test_app TEST
     inline_operation_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_inline_operation_test_app COMMAND eval_inline_operation_test_app)

--- a/eval/src/tests/eval/int8float/CMakeLists.txt
+++ b/eval/src/tests/eval/int8float/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_int8float_test_app TEST
     int8float_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_int8float_test_app COMMAND eval_int8float_test_app)

--- a/eval/src/tests/eval/multiply_add/CMakeLists.txt
+++ b/eval/src/tests/eval/multiply_add/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_multiply_add_test_app TEST
     multiply_add_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_multiply_add_test_app COMMAND eval_multiply_add_test_app)

--- a/eval/src/tests/eval/nested_loop/CMakeLists.txt
+++ b/eval/src/tests/eval/nested_loop/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(eval_nested_loop_test_app TEST
     nested_loop_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_nested_loop_test_app COMMAND eval_nested_loop_test_app)
 vespa_add_executable(eval_nested_loop_bench_app TEST
@@ -12,5 +12,5 @@ vespa_add_executable(eval_nested_loop_bench_app TEST
     nested_loop_bench.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )

--- a/eval/src/tests/eval/reference_evaluation/CMakeLists.txt
+++ b/eval/src/tests/eval/reference_evaluation/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_reference_evaluation_test_app TEST
     reference_evaluation_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_reference_evaluation_test_app COMMAND eval_reference_evaluation_test_app)

--- a/eval/src/tests/eval/reference_operations/CMakeLists.txt
+++ b/eval/src/tests/eval/reference_operations/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_reference_operations_test_app TEST
     reference_operations_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_reference_operations_test_app COMMAND eval_reference_operations_test_app)

--- a/eval/src/tests/eval/simple_value/CMakeLists.txt
+++ b/eval/src/tests/eval/simple_value/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_simple_value_test_app TEST
     simple_value_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_simple_value_test_app COMMAND eval_simple_value_test_app)

--- a/eval/src/tests/eval/value_codec/CMakeLists.txt
+++ b/eval/src/tests/eval/value_codec/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_value_codec_test_app TEST
     value_codec_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_value_codec_test_app COMMAND eval_value_codec_test_app)

--- a/eval/src/tests/instruction/best_similarity_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/best_similarity_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_best_similarity_function_test_app TEST
     best_similarity_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_best_similarity_function_test_app COMMAND eval_best_similarity_function_test_app)

--- a/eval/src/tests/instruction/dense_hamming_distance/CMakeLists.txt
+++ b/eval/src/tests/instruction/dense_hamming_distance/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_dense_hamming_distance_test_app TEST
     dense_hamming_distance_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_dense_hamming_distance_test_app COMMAND eval_dense_hamming_distance_test_app)

--- a/eval/src/tests/instruction/dense_join_reduce_plan/CMakeLists.txt
+++ b/eval/src/tests/instruction/dense_join_reduce_plan/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_dense_join_reduce_plan_test_app TEST
     dense_join_reduce_plan_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_dense_join_reduce_plan_test_app COMMAND eval_dense_join_reduce_plan_test_app)

--- a/eval/src/tests/instruction/dense_simple_expand_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/dense_simple_expand_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_dense_simple_expand_function_test_app TEST
     dense_simple_expand_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_dense_simple_expand_function_test_app COMMAND eval_dense_simple_expand_function_test_app)

--- a/eval/src/tests/instruction/fast_rename_optimizer/CMakeLists.txt
+++ b/eval/src/tests/instruction/fast_rename_optimizer/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_fast_rename_optimizer_test_app TEST
     fast_rename_optimizer_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_fast_rename_optimizer_test_app COMMAND eval_fast_rename_optimizer_test_app)

--- a/eval/src/tests/instruction/generic_cell_cast/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_cell_cast/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_cell_cast_test_app TEST
     generic_cell_cast_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_cell_cast_test_app COMMAND eval_generic_cell_cast_test_app)

--- a/eval/src/tests/instruction/generic_concat/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_concat/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_concat_test_app TEST
     generic_concat_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_concat_test_app COMMAND eval_generic_concat_test_app)

--- a/eval/src/tests/instruction/generic_create/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_create/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_create_test_app TEST
     generic_create_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_create_test_app COMMAND eval_generic_create_test_app)

--- a/eval/src/tests/instruction/generic_join/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_join/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_join_test_app TEST
     generic_join_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_join_test_app COMMAND eval_generic_join_test_app)

--- a/eval/src/tests/instruction/generic_map/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_map/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_map_test_app TEST
     generic_map_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_map_test_app COMMAND eval_generic_map_test_app)

--- a/eval/src/tests/instruction/generic_merge/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_merge/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_merge_test_app TEST
     generic_merge_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_merge_test_app COMMAND eval_generic_merge_test_app)

--- a/eval/src/tests/instruction/generic_peek/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_peek/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_peek_test_app TEST
     generic_peek_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_peek_test_app NO_VALGRIND COMMAND eval_generic_peek_test_app)

--- a/eval/src/tests/instruction/generic_reduce/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_reduce/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_reduce_test_app TEST
     generic_reduce_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_reduce_test_app COMMAND eval_generic_reduce_test_app)

--- a/eval/src/tests/instruction/generic_rename/CMakeLists.txt
+++ b/eval/src/tests/instruction/generic_rename/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_generic_rename_test_app TEST
     generic_rename_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_generic_rename_test_app COMMAND eval_generic_rename_test_app)

--- a/eval/src/tests/instruction/index_lookup_table/CMakeLists.txt
+++ b/eval/src/tests/instruction/index_lookup_table/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_index_lookup_table_test_app TEST
     index_lookup_table_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_index_lookup_table_test_app COMMAND eval_index_lookup_table_test_app)

--- a/eval/src/tests/instruction/inplace_map_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/inplace_map_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_inplace_map_function_test_app TEST
     inplace_map_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_inplace_map_function_test_app COMMAND eval_inplace_map_function_test_app)

--- a/eval/src/tests/instruction/l2_distance/CMakeLists.txt
+++ b/eval/src/tests/instruction/l2_distance/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_l2_distance_test_app TEST
     l2_distance_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_l2_distance_test_app COMMAND eval_l2_distance_test_app)

--- a/eval/src/tests/instruction/mapped_lookup/CMakeLists.txt
+++ b/eval/src/tests/instruction/mapped_lookup/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_mapped_lookup_test_app TEST
     mapped_lookup_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_mapped_lookup_test_app COMMAND eval_mapped_lookup_test_app)

--- a/eval/src/tests/instruction/mixed_112_dot_product/CMakeLists.txt
+++ b/eval/src/tests/instruction/mixed_112_dot_product/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_mixed_112_dot_product_test_app TEST
     mixed_112_dot_product_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_mixed_112_dot_product_test_app COMMAND eval_mixed_112_dot_product_test_app)

--- a/eval/src/tests/instruction/mixed_inner_product_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/mixed_inner_product_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_mixed_inner_product_function_test_app TEST
     mixed_inner_product_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_mixed_inner_product_function_test_app COMMAND eval_mixed_inner_product_function_test_app)

--- a/eval/src/tests/instruction/mixed_l2_distance/CMakeLists.txt
+++ b/eval/src/tests/instruction/mixed_l2_distance/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(eval_mixed_l2_distance_test_app TEST
     mixed_l2_distance_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_mixed_l2_distance_test_app COMMAND eval_mixed_l2_distance_test_app)

--- a/eval/src/tests/instruction/pow_as_map_optimizer/CMakeLists.txt
+++ b/eval/src/tests/instruction/pow_as_map_optimizer/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_pow_as_map_optimizer_test_app TEST
     pow_as_map_optimizer_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_pow_as_map_optimizer_test_app COMMAND eval_pow_as_map_optimizer_test_app)

--- a/eval/src/tests/instruction/simple_join_count/CMakeLists.txt
+++ b/eval/src/tests/instruction/simple_join_count/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_simple_join_count_test_app TEST
     simple_join_count_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_simple_join_count_test_app COMMAND eval_simple_join_count_test_app)

--- a/eval/src/tests/instruction/sparse_112_dot_product/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_112_dot_product/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_112_dot_product_test_app TEST
     sparse_112_dot_product_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_112_dot_product_test_app COMMAND eval_sparse_112_dot_product_test_app)

--- a/eval/src/tests/instruction/sparse_dot_product_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_dot_product_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_dot_product_function_test_app TEST
     sparse_dot_product_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_dot_product_function_test_app COMMAND eval_sparse_dot_product_function_test_app)

--- a/eval/src/tests/instruction/sparse_full_overlap_join_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_full_overlap_join_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_full_overlap_join_function_test_app TEST
     sparse_full_overlap_join_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_full_overlap_join_function_test_app COMMAND eval_sparse_full_overlap_join_function_test_app)

--- a/eval/src/tests/instruction/sparse_join_reduce_plan/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_join_reduce_plan/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_join_reduce_plan_test_app TEST
     sparse_join_reduce_plan_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_join_reduce_plan_test_app COMMAND eval_sparse_join_reduce_plan_test_app)

--- a/eval/src/tests/instruction/sparse_merge_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_merge_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_merge_function_test_app TEST
     sparse_merge_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_merge_function_test_app COMMAND eval_sparse_merge_function_test_app)

--- a/eval/src/tests/instruction/sparse_no_overlap_join_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_no_overlap_join_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_no_overlap_join_function_test_app TEST
     sparse_no_overlap_join_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_no_overlap_join_function_test_app COMMAND eval_sparse_no_overlap_join_function_test_app)

--- a/eval/src/tests/instruction/sparse_singledim_lookup/CMakeLists.txt
+++ b/eval/src/tests/instruction/sparse_singledim_lookup/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sparse_singledim_lookup_test_app TEST
     sparse_singledim_lookup_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sparse_singledim_lookup_test_app COMMAND eval_sparse_singledim_lookup_test_app)

--- a/eval/src/tests/instruction/sum_max_dot_product_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/sum_max_dot_product_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sum_max_dot_product_function_test_app TEST
     sum_max_dot_product_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sum_max_dot_product_function_test_app COMMAND eval_sum_max_dot_product_function_test_app)

--- a/eval/src/tests/instruction/sum_max_inv_hamming_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/sum_max_inv_hamming_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_sum_max_inv_hamming_function_test_app TEST
     sum_max_inv_hamming_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_sum_max_inv_hamming_function_test_app COMMAND eval_sum_max_inv_hamming_function_test_app)

--- a/eval/src/tests/instruction/universal_dot_product/CMakeLists.txt
+++ b/eval/src/tests/instruction/universal_dot_product/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_universal_dot_product_test_app TEST
     universal_dot_product_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_universal_dot_product_test_app COMMAND eval_universal_dot_product_test_app)

--- a/eval/src/tests/instruction/unpack_bits_function/CMakeLists.txt
+++ b/eval/src/tests/instruction/unpack_bits_function/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_unpack_bits_function_test_app TEST
     unpack_bits_function_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_unpack_bits_function_test_app COMMAND eval_unpack_bits_function_test_app)

--- a/eval/src/tests/streamed/value/CMakeLists.txt
+++ b/eval/src/tests/streamed/value/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_streamed_value_test_app TEST
     streamed_value_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_streamed_value_test_app COMMAND eval_streamed_value_test_app)

--- a/eval/src/tests/tensor/binary_format/CMakeLists.txt
+++ b/eval/src/tests/tensor/binary_format/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_tensor_binary_format_test_app TEST
     binary_format_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_tensor_binary_format_test_app COMMAND eval_tensor_binary_format_test_app)

--- a/eval/src/tests/tensor/instruction_benchmark/CMakeLists.txt
+++ b/eval/src/tests/tensor/instruction_benchmark/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(vespa-tensor-instructions-benchmark TEST
     INSTALL bin
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_tensor_instruction_test COMMAND vespa-tensor-instructions-benchmark --smoke-test)

--- a/eval/src/tests/tensor/onnx_wrapper/CMakeLists.txt
+++ b/eval/src/tests/tensor/onnx_wrapper/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(eval_onnx_wrapper_test_app TEST
     onnx_wrapper_test.cpp
     DEPENDS
     vespaeval
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME eval_onnx_wrapper_test_app COMMAND eval_onnx_wrapper_test_app)

--- a/fbench/src/test/authority/CMakeLists.txt
+++ b/fbench/src/test/authority/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(fbench_authority_test_app TEST
     DEPENDS
     fbench_util
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME fbench_authority_test_app COMMAND fbench_authority_test_app)

--- a/logd/src/tests/empty_forwarder/CMakeLists.txt
+++ b/logd/src/tests/empty_forwarder/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(logd_empty_forwarder_test_app TEST
     empty_forwarder_test.cpp
     DEPENDS
     logd
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME logd_empty_forwarder_test_app COMMAND logd_empty_forwarder_test_app)

--- a/logd/src/tests/proto_converter/CMakeLists.txt
+++ b/logd/src/tests/proto_converter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(logd_proto_converter_test_app TEST
     proto_converter_test.cpp
     DEPENDS
     logd
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME logd_proto_converter_test_app COMMAND logd_proto_converter_test_app)

--- a/logd/src/tests/rpc_forwarder/CMakeLists.txt
+++ b/logd/src/tests/rpc_forwarder/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(logd_rpc_forwarder_test_app TEST
     rpc_forwarder_test.cpp
     DEPENDS
     logd
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME logd_rpc_forwarder_test_app COMMAND logd_rpc_forwarder_test_app)

--- a/logd/src/tests/watcher/CMakeLists.txt
+++ b/logd/src/tests/watcher/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(logd_watcher_test_app TEST
     watcher_test.cpp
     DEPENDS
     logd
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME logd_watcher_test_app COMMAND logd_watcher_test_app)

--- a/metrics/src/tests/CMakeLists.txt
+++ b/metrics/src/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ vespa_add_executable(metrics_gtest_runner_app TEST
     gtest_runner.cpp
     DEPENDS
     vespa_metrics
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/persistence/CMakeLists.txt
+++ b/persistence/CMakeLists.txt
@@ -13,7 +13,7 @@ vespa_define_module(
     src/vespa/persistence/spi
 
     TEST_DEPENDS
-    GTest::GTest
+    GTest::gtest
 
     TESTS
     src/tests

--- a/persistence/src/vespa/persistence/CMakeLists.txt
+++ b/persistence/src/vespa/persistence/CMakeLists.txt
@@ -11,5 +11,5 @@ vespa_add_library(persistence_persistence_conformancetest
     $<TARGET_OBJECTS:persistence_conformancetest_lib>
     DEPENDS
     vespa_persistence
-    GTest::GTest
+    GTest::gtest
 )

--- a/searchcore/src/tests/index/disk_indexes/CMakeLists.txt
+++ b/searchcore/src/tests/index/disk_indexes/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcorespi_disk_indexes_test_app
     disk_indexes_test.cpp
     DEPENDS
     searchcorespi
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcorespi_disk_indexes_test_app COMMAND searchcorespi_disk_indexes_test_app)

--- a/searchcore/src/tests/index/index_disk_layout/CMakeLists.txt
+++ b/searchcore/src/tests/index/index_disk_layout/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcorespi_index_disk_layout_test_app
     index_disk_layout_test.cpp
     DEPENDS
     searchcorespi
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcorespi_index_disk_layout_test_app COMMAND searchcorespi_index_disk_layout_test_app)

--- a/searchcore/src/tests/proton/attribute/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/CMakeLists.txt
@@ -9,7 +9,7 @@ vespa_add_executable(searchcore_attribute_test_app TEST
     searchcore_pcommon
     searchcore_test
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attribute_test_app COMMAND searchcore_attribute_test_app)
 

--- a/searchcore/src/tests/proton/attribute/attribute_aspect_delayer/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/attribute_aspect_delayer/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchcore_attribute_aspect_delayer_test_app TEST
     DEPENDS
     searchcore_attribute
     searchcore_pcommon
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attribute_aspect_delayer_test_app COMMAND searchcore_attribute_aspect_delayer_test_app)

--- a/searchcore/src/tests/proton/attribute/attribute_directory/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/attribute_directory/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_attribute_directory_test_app TEST
     attribute_directory_test.cpp
     DEPENDS
     searchcore_attribute
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attribute_directory_test_app COMMAND searchcore_attribute_directory_test_app)

--- a/searchcore/src/tests/proton/attribute/attribute_transient_memory_calculator/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/attribute_transient_memory_calculator/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchcore_attribute_transient_memory_calculator_test_app T
     DEPENDS
     searchcore_attribute
     searchcore_pcommon
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attribute_transient_memory_calculator_test_app COMMAND searchcore_attribute_transient_memory_calculator_test_app)

--- a/searchcore/src/tests/proton/attribute/attribute_usage_stats/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/attribute_usage_stats/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_attribute_usage_stats_test_app TEST
     attribute_usage_stats_test.cpp
     DEPENDS
     searchcore_attribute
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attribute_usage_stats_test_app COMMAND searchcore_attribute_usage_stats_test_app)

--- a/searchcore/src/tests/proton/attribute/attributes_state_explorer/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/attributes_state_explorer/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchcore_attributes_state_explorer_test_app TEST
     searchcore_attribute
     searchcore_pcommon
     searchcore_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attributes_state_explorer_test_app COMMAND searchcore_attributes_state_explorer_test_app)

--- a/searchcore/src/tests/proton/common/alloc_config/CMakeLists.txt
+++ b/searchcore/src/tests/proton/common/alloc_config/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_alloc_config_test_app TEST
     alloc_config_test.cpp
     DEPENDS
     searchcore_pcommon
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_alloc_config_test_app COMMAND searchcore_alloc_config_test_app)

--- a/searchcore/src/tests/proton/common/operation_rate_tracker/CMakeLists.txt
+++ b/searchcore/src/tests/proton/common/operation_rate_tracker/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_operation_rate_tracker_test_app TEST
     operation_rate_tracker_test.cpp
     DEPENDS
     searchcore_pcommon
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_operation_rate_tracker_test_app COMMAND searchcore_operation_rate_tracker_test_app)

--- a/searchcore/src/tests/proton/common/timer/CMakeLists.txt
+++ b/searchcore/src/tests/proton/common/timer/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_common_timer_test_app TEST
     timer_test.cpp
     DEPENDS
     searchcore_pcommon
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_common_timer_test_app COMMAND searchcore_common_timer_test_app)

--- a/searchcore/src/tests/proton/documentdb/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentdb/CMakeLists.txt
@@ -50,6 +50,6 @@ vespa_add_executable(searchcore_proton_documentdb_gtest_test_app TEST
     searchcore_server
     searchcore_feedoperation
     searchcore_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_proton_documentdb_gtest_test_app COMMAND searchcore_proton_documentdb_gtest_test_app)

--- a/searchcore/src/tests/proton/documentmetastore/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentmetastore/CMakeLists.txt
@@ -8,6 +8,6 @@ vespa_add_executable(searchcore_documentmetastore_test_app TEST
     searchcore_bucketdb
     searchcore_attribute
     searchcore_feedoperation
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_documentmetastore_test_app COMMAND searchcore_documentmetastore_test_app)

--- a/searchcore/src/tests/proton/documentmetastore/lid_allocator/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentmetastore/lid_allocator/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchcore_lid_allocator_test_app TEST
     lid_allocator_test.cpp
     DEPENDS
     searchcore_documentmetastore
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_lid_allocator_test_app COMMAND searchcore_lid_allocator_test_app)
 

--- a/searchcore/src/tests/proton/documentmetastore/lid_state_vector/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentmetastore/lid_state_vector/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchcore_lid_state_vector_test_app TEST
     lid_state_vector_test.cpp
     DEPENDS
     searchcore_documentmetastore
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_lid_state_vector_test_app COMMAND searchcore_lid_state_vector_test_app)
 

--- a/searchcore/src/tests/proton/index/CMakeLists.txt
+++ b/searchcore/src/tests/proton/index/CMakeLists.txt
@@ -8,7 +8,7 @@ vespa_add_executable(searchcore_indexmanager_test_app TEST
     searchcore_index
     searchcore_flushengine
     searchcore_pcommon
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(NAME searchcore_indexmanager_test_app
@@ -44,7 +44,7 @@ vespa_add_executable(searchcore_indexcollection_test_app TEST
     indexcollection_test.cpp
     DEPENDS
     searchcore_index
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(NAME searchcore_indexcollection_test_app

--- a/searchcore/src/tests/proton/matching/handle_recorder/CMakeLists.txt
+++ b/searchcore/src/tests/proton/matching/handle_recorder/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchcore_matching_handle_recorder_test_app TEST
     handle_recorder_test.cpp
     DEPENDS
     searchcore_matching
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_matching_handle_recorder_test_app COMMAND searchcore_matching_handle_recorder_test_app)

--- a/searchcore/src/tests/proton/matching/request_context/CMakeLists.txt
+++ b/searchcore/src/tests/proton/matching/request_context/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_matching_request_context_test_app TEST
     request_context_test.cpp
     DEPENDS
     searchcore_matching
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_matching_request_context_test_app COMMAND searchcore_matching_request_context_test_app)

--- a/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/CMakeLists.txt
+++ b/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_unpacking_iterators_optimizer_test_app TEST
     unpacking_iterators_optimizer_test.cpp
     DEPENDS
     searchcore_matching
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_unpacking_iterators_optimizer_test_app COMMAND searchcore_unpacking_iterators_optimizer_test_app)

--- a/searchcore/src/tests/proton/proton_configurer/CMakeLists.txt
+++ b/searchcore/src/tests/proton/proton_configurer/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_proton_configurer_test_app TEST
     proton_configurer_test.cpp
     DEPENDS
     searchcore_server
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_proton_configurer_test_app COMMAND searchcore_proton_configurer_test_app)

--- a/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/CMakeLists.txt
+++ b/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/CMakeLists.txt
@@ -7,6 +7,6 @@ vespa_add_executable(searchcore_attribute_reprocessing_initializer_test_app TEST
     searchcore_attribute
     searchcore_pcommon
     searchcore_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_attribute_reprocessing_initializer_test_app COMMAND searchcore_attribute_reprocessing_initializer_test_app)

--- a/searchcore/src/tests/proton/server/disk_mem_usage_filter/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_filter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_disk_mem_usage_filter_test_app TEST
     disk_mem_usage_filter_test.cpp
     DEPENDS
     searchcore_server
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_disk_mem_usage_filter_test_app COMMAND searchcore_disk_mem_usage_filter_test_app)

--- a/searchcore/src/tests/proton/server/disk_mem_usage_metrics/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_metrics/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_disk_mem_usage_metrics_test_app TEST
     disk_mem_usage_metrics_test.cpp
     DEPENDS
     searchcore_server
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_disk_mem_usage_metrics_test_app COMMAND searchcore_disk_mem_usage_metrics_test_app)

--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchcore_disk_mem_usage_sampler_test_app TEST
     DEPENDS
     searchcore_test
     searchcore_server
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_disk_mem_usage_sampler_test_app COMMAND searchcore_disk_mem_usage_sampler_test_app)

--- a/searchcore/src/tests/proton/server/initialize_threads_calculator/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/initialize_threads_calculator/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcore_initialize_threads_calculator_test_app TEST
     initialize_threads_calculator_test.cpp
     DEPENDS
     searchcore_server
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_initialize_threads_calculator_test_app COMMAND searchcore_initialize_threads_calculator_test_app)

--- a/searchcore/src/tests/proton/server/memoryflush/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/memoryflush/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchcore_memoryflush_test_app TEST
     searchcore_server
     searchcore_flushengine
     searchcore_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_memoryflush_test_app COMMAND searchcore_memoryflush_test_app)

--- a/searchcore/src/tests/proton/server/shared_threading_service/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/shared_threading_service/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchcore_shared_threading_service_test_app TEST
     DEPENDS
     searchcore_test
     searchcore_server
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcore_shared_threading_service_test_app COMMAND searchcore_shared_threading_service_test_app)

--- a/searchlib/src/apps/tests/CMakeLists.txt
+++ b/searchlib/src/apps/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ vespa_add_executable(searchlib_document_weight_attribute_lookup_stress_test_app
     document_weight_attribute_lookup_stress_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_document_weight_attribute_lookup_stress_test_app COMMAND searchlib_document_weight_attribute_lookup_stress_test_app BENCHMARK)

--- a/searchlib/src/tests/attribute/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_attribute_test_app TEST
     attribute_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_test_app COMMAND searchlib_attribute_test_app COST 250)

--- a/searchlib/src/tests/attribute/attribute_header/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/attribute_header/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_attribute_header_test_app TEST
     attribute_header_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_header_test_app COMMAND searchlib_attribute_header_test_app)

--- a/searchlib/src/tests/attribute/dfa_fuzzy_matcher/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/dfa_fuzzy_matcher/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_attribute_dfa_fuzzy_matcher_test_app TEST
     dfa_fuzzy_matcher_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_dfa_fuzzy_matcher_test_app COMMAND searchlib_attribute_dfa_fuzzy_matcher_test_app)

--- a/searchlib/src/tests/attribute/direct_multi_term_blueprint/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/direct_multi_term_blueprint/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_direct_multi_term_blueprint_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_direct_multi_term_blueprint_test_app COMMAND searchlib_direct_multi_term_blueprint_test_app)

--- a/searchlib/src/tests/attribute/direct_posting_store/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/direct_posting_store/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_direct_posting_store_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_direct_posting_store_test_app COMMAND searchlib_direct_posting_store_test_app)

--- a/searchlib/src/tests/attribute/enum_attribute_compaction/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/enum_attribute_compaction/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_enum_attribute_compaction_test_app TEST
     enum_attribute_compaction_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_enum_attribute_compaction_test_app COMMAND searchlib_enum_attribute_compaction_test_app COST 100)

--- a/searchlib/src/tests/attribute/enum_comparator/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/enum_comparator/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_enum_comparator_test_app TEST
     enum_comparator_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_enum_comparator_test_app COMMAND searchlib_enum_comparator_test_app)

--- a/searchlib/src/tests/attribute/enumstore/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/enumstore/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_enumstore_test_app TEST
     enumstore_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_enumstore_test_app COMMAND searchlib_enumstore_test_app)

--- a/searchlib/src/tests/attribute/extendattributes/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/extendattributes/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_extendattribute_test_app TEST
     extendattribute_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_extendattribute_test_app COMMAND searchlib_extendattribute_test_app)

--- a/searchlib/src/tests/attribute/multi_term_or_filter_search/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/multi_term_or_filter_search/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_multi_term_or_filter_search_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_multi_term_or_filter_search_test_app COMMAND searchlib_multi_term_or_filter_search_test_app)

--- a/searchlib/src/tests/attribute/multi_value_mapping/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/multi_value_mapping/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_multi_value_mapping_test_app TEST
     multi_value_mapping_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_multi_value_mapping_test_app COMMAND searchlib_multi_value_mapping_test_app)

--- a/searchlib/src/tests/attribute/multi_value_read_view/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/multi_value_read_view/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_attribute_multi_value_read_view_test_app TEST
     multi_value_read_view_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_multi_value_read_view_test_app COMMAND searchlib_attribute_multi_value_read_view_test_app)

--- a/searchlib/src/tests/attribute/posting_store/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/posting_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_posting_store_test_app TEST
     posting_store_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_posting_store_test_app COMMAND searchlib_posting_store_test_app COST 30)

--- a/searchlib/src/tests/attribute/postinglistattribute/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/postinglistattribute/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_postinglistattribute_test_app TEST
     postinglistattribute_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_postinglistattribute_test_app COMMAND searchlib_postinglistattribute_test_app)

--- a/searchlib/src/tests/attribute/raw_attribute/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/raw_attribute/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_raw_attribute_test_app TEST
     raw_attribute_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_raw_attribute_test_app COMMAND searchlib_raw_attribute_test_app)

--- a/searchlib/src/tests/attribute/reference_attribute/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/reference_attribute/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_reference_attribute_test_app TEST
     reference_attribute_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_reference_attribute_test_app COMMAND searchlib_reference_attribute_test_app)

--- a/searchlib/src/tests/attribute/save_target/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/save_target/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_attribute_save_target_test_app TEST
     attribute_save_target_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_save_target_test_app COMMAND searchlib_attribute_save_target_test_app)

--- a/searchlib/src/tests/attribute/searchable/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/searchable/CMakeLists.txt
@@ -21,6 +21,6 @@ vespa_add_executable(searchlib_attribute_blueprint_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_blueprint_test_app COMMAND searchlib_attribute_blueprint_test_app)

--- a/searchlib/src/tests/attribute/searchcontextelementiterator/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/searchcontextelementiterator/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_attribute_searchcontextelementiterator_test_app T
     searchcontextelementiterator_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_attribute_searchcontextelementiterator_test_app COMMAND searchlib_attribute_searchcontextelementiterator_test_app)

--- a/searchlib/src/tests/attribute/sort_blob_writers/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/sort_blob_writers/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_sort_blob_writers_test_app TEST
     sort_blob_writers_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_sort_blob_writers_test_app COMMAND searchlib_sort_blob_writers_test_app)

--- a/searchlib/src/tests/common/geogcd/CMakeLists.txt
+++ b/searchlib/src/tests/common/geogcd/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_geo_gcd_test_app TEST
     geo_gcd_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_geo_gcd_test_app COMMAND searchlib_geo_gcd_test_app)

--- a/searchlib/src/tests/common/location/CMakeLists.txt
+++ b/searchlib/src/tests/common/location/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_geo_location_test_app TEST
     geo_location_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_geo_location_test_app COMMAND searchlib_geo_location_test_app)

--- a/searchlib/src/tests/common/location_iterator/CMakeLists.txt
+++ b/searchlib/src/tests/common/location_iterator/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchlib_location_iterator_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_location_iterator_test_app COMMAND searchlib_location_iterator_test_app)

--- a/searchlib/src/tests/common/matching_elements/CMakeLists.txt
+++ b/searchlib/src/tests/common/matching_elements/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_common_matching_elements_test_app TEST
     matching_elements_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_common_matching_elements_test_app COMMAND searchlib_common_matching_elements_test_app)

--- a/searchlib/src/tests/common/matching_elements_fields/CMakeLists.txt
+++ b/searchlib/src/tests/common/matching_elements_fields/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_common_matching_elements_fields_test_app TEST
     matching_elements_fields_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_common_matching_elements_fields_test_app COMMAND searchlib_common_matching_elements_fields_test_app)

--- a/searchlib/src/tests/common/resultset/CMakeLists.txt
+++ b/searchlib/src/tests/common/resultset/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_resultset_test_app TEST
     resultset_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_resultset_test_app COMMAND searchlib_resultset_test_app)

--- a/searchlib/src/tests/diskindex/field_length_scanner/CMakeLists.txt
+++ b/searchlib/src/tests/diskindex/field_length_scanner/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_field_length_scanner_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_field_length_scanner_test_app COMMAND searchlib_field_length_scanner_test_app)

--- a/searchlib/src/tests/diskindex/fusion/CMakeLists.txt
+++ b/searchlib/src/tests/diskindex/fusion/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_fusion_test_app TEST
     fusion_test.cpp
     DEPENDS
     searchlib_test
-    GTest::GTest
+    GTest::gtest
     AFTER
     searchlib_vespa-index-inspect_app
 )

--- a/searchlib/src/tests/engine/proto_converter/CMakeLists.txt
+++ b/searchlib/src/tests/engine/proto_converter/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_engine_proto_converter_test_app TEST
     proto_converter_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_engine_proto_converter_test_app COMMAND searchlib_engine_proto_converter_test_app)
 if(Protobuf_VERSION VERSION_LESS_EQUAL 3.12.4)

--- a/searchlib/src/tests/engine/proto_rpc_adapter/CMakeLists.txt
+++ b/searchlib/src/tests/engine/proto_rpc_adapter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_engine_proto_rpc_adapter_test_app TEST
     proto_rpc_adapter_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_engine_proto_rpc_adapter_test_app COMMAND searchlib_engine_proto_rpc_adapter_test_app)

--- a/searchlib/src/tests/expression/current_index_setup/CMakeLists.txt
+++ b/searchlib/src/tests/expression/current_index_setup/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_current_index_setup_test_app TEST
     current_index_setup_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_current_index_setup_test_app COMMAND searchlib_current_index_setup_test_app)

--- a/searchlib/src/tests/features/bm25/CMakeLists.txt
+++ b/searchlib/src/tests/features/bm25/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchlib_features_bm25_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_features_bm25_test_app COMMAND searchlib_features_bm25_test_app)

--- a/searchlib/src/tests/features/elementwise/CMakeLists.txt
+++ b/searchlib/src/tests/features/elementwise/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchlib_features_elementwise_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_features_elementwise_test_app COMMAND searchlib_features_elementwise_test_app)

--- a/searchlib/src/tests/features/first_phase_rank/CMakeLists.txt
+++ b/searchlib/src/tests/features/first_phase_rank/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchlib_features_first_phase_rank_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_features_first_phase_rank_test_app COMMAND searchlib_features_first_phase_rank_test_app)

--- a/searchlib/src/tests/fef/featurenamebuilder/CMakeLists.txt
+++ b/searchlib/src/tests/fef/featurenamebuilder/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_featurenamebuilder_test_app TEST
     featurenamebuilder_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_featurenamebuilder_test_app COMMAND searchlib_featurenamebuilder_test_app)

--- a/searchlib/src/tests/fef/resolver/CMakeLists.txt
+++ b/searchlib/src/tests/fef/resolver/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_resolver_test_app TEST
     resolver_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_resolver_test_app COMMAND searchlib_resolver_test_app)

--- a/searchlib/src/tests/fef/termmatchdatamerger/CMakeLists.txt
+++ b/searchlib/src/tests/fef/termmatchdatamerger/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_termmatchdatamerger_test_app TEST
     termmatchdatamerger_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_termmatchdatamerger_test_app COMMAND searchlib_termmatchdatamerger_test_app)

--- a/searchlib/src/tests/index/field_length_calculator/CMakeLists.txt
+++ b/searchlib/src/tests/index/field_length_calculator/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_field_length_calculator_test_app TEST
     field_length_calculator_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_field_length_calculator_test_app COMMAND searchlib_field_length_calculator_test_app)

--- a/searchlib/src/tests/memoryindex/compact_words_store/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/compact_words_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_compact_words_store_test_app TEST
     compact_words_store_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_compact_words_store_test_app COMMAND searchlib_compact_words_store_test_app)

--- a/searchlib/src/tests/memoryindex/datastore/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/datastore/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_feature_store_test_app TEST
     feature_store_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_feature_store_test_app COMMAND searchlib_feature_store_test_app)
 vespa_add_executable(searchlib_word_store_test_app TEST
@@ -12,6 +12,6 @@ vespa_add_executable(searchlib_word_store_test_app TEST
     word_store_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_word_store_test_app COMMAND searchlib_word_store_test_app)

--- a/searchlib/src/tests/memoryindex/document_inverter/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/document_inverter/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_document_inverter_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_document_inverter_test_app COMMAND searchlib_document_inverter_test_app)

--- a/searchlib/src/tests/memoryindex/document_inverter_collection/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/document_inverter_collection/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_document_inverter_collection_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_document_inverter_collection_test_app COMMAND searchlib_document_inverter_collection_test_app)

--- a/searchlib/src/tests/memoryindex/field_index/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/field_index/CMakeLists.txt
@@ -5,7 +5,7 @@ vespa_add_executable(searchlib_field_index_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_field_index_test_app COMMAND searchlib_field_index_test_app COST 100)
 

--- a/searchlib/src/tests/memoryindex/field_index_remover/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/field_index_remover/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_field_index_remover_test_app TEST
     field_index_remover_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_field_index_remover_test_app COMMAND searchlib_field_index_remover_test_app)

--- a/searchlib/src/tests/memoryindex/field_inverter/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/field_inverter/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_field_inverter_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_field_inverter_test_app COMMAND searchlib_field_inverter_test_app)

--- a/searchlib/src/tests/memoryindex/memory_index/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/memory_index/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_memory_index_test_app TEST
     memory_index_test.cpp
     DEPENDS
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_memory_index_test_app COMMAND searchlib_memory_index_test_app)

--- a/searchlib/src/tests/memoryindex/url_field_inverter/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/url_field_inverter/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_url_field_inverter_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_url_field_inverter_test_app COMMAND searchlib_url_field_inverter_test_app)

--- a/searchlib/src/tests/postinglistbm/CMakeLists.txt
+++ b/searchlib/src/tests/postinglistbm/CMakeLists.txt
@@ -5,7 +5,7 @@ vespa_add_executable(searchlib_posting_list_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_posting_list_test_app NO_VALGRIND COMMAND searchlib_posting_list_test_app)
 

--- a/searchlib/src/tests/queryeval/equiv/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/equiv/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_equiv_test_app TEST
     equiv_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_equiv_test_app COMMAND searchlib_equiv_test_app)

--- a/searchlib/src/tests/queryeval/exact_nearest_neighbor/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/exact_nearest_neighbor/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_exact_nearest_neighbor_test_app TEST
     exact_nearest_neighbor_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_exact_nearest_neighbor_test_app COMMAND searchlib_exact_nearest_neighbor_test_app)

--- a/searchlib/src/tests/queryeval/fake_searchable/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/fake_searchable/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_fake_searchable_test_app TEST
     fake_searchable_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_fake_searchable_test_app COMMAND searchlib_fake_searchable_test_app)

--- a/searchlib/src/tests/queryeval/filter_search/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/filter_search/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_filter_search_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_filter_search_test_app COMMAND searchlib_filter_search_test_app)

--- a/searchlib/src/tests/queryeval/flow/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/flow/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_queryeval_flow_test_app TEST
     queryeval_flow_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_queryeval_flow_test_app COMMAND searchlib_queryeval_flow_test_app)

--- a/searchlib/src/tests/queryeval/global_filter/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/global_filter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_queryeval_global_filter_test_app TEST
     global_filter_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_queryeval_global_filter_test_app COMMAND searchlib_queryeval_global_filter_test_app)

--- a/searchlib/src/tests/queryeval/iterator_benchmark/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/CMakeLists.txt
@@ -10,6 +10,6 @@ vespa_add_executable(searchlib_iterator_benchmark_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 # Note: this should not be executed as a unit test, so the vespa_add_test() command is not specified.

--- a/searchlib/src/tests/queryeval/matching_elements_search/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/matching_elements_search/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchlib_matching_elements_search_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_matching_elements_search_test_app COMMAND searchlib_matching_elements_search_test_app)

--- a/searchlib/src/tests/queryeval/or_speed/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/or_speed/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_or_speed_test_app TEST
     or_speed_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_or_speed_test_app COMMAND searchlib_or_speed_test_app)

--- a/searchlib/src/tests/queryeval/profiled_iterator/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/profiled_iterator/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_queryeval_profiled_iterator_test_app TEST
     profiled_iterator_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_queryeval_profiled_iterator_test_app COMMAND searchlib_queryeval_profiled_iterator_test_app)

--- a/searchlib/src/tests/queryeval/wrappers/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/wrappers/CMakeLists.txt
@@ -6,6 +6,6 @@ vespa_add_executable(searchlib_wrappers_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_wrappers_test_app COMMAND searchlib_wrappers_test_app)

--- a/searchlib/src/tests/searchcommon/schema/CMakeLists.txt
+++ b/searchlib/src/tests/searchcommon/schema/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchcommon_schema_test_app TEST
     schema_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchcommon_schema_test_app NO_VALGRIND COMMAND searchcommon_schema_test_app)

--- a/searchlib/src/tests/sortspec/CMakeLists.txt
+++ b/searchlib/src/tests/sortspec/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_multilevelsort_test_app TEST
     multilevelsort_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_multilevelsort_test_app COMMAND searchlib_multilevelsort_test_app)

--- a/searchlib/src/tests/tensor/direct_tensor_store/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/direct_tensor_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_direct_tensor_store_test_app TEST
     direct_tensor_store_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_direct_tensor_store_test_app COMMAND searchlib_direct_tensor_store_test_app)

--- a/searchlib/src/tests/tensor/distance_calculator/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/distance_calculator/CMakeLists.txt
@@ -5,7 +5,7 @@ vespa_add_executable(searchlib_distance_calculator_test_app TEST
     DEPENDS
     vespa_searchlib
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_distance_calculator_test_app COMMAND searchlib_distance_calculator_test_app)
 

--- a/searchlib/src/tests/tensor/distance_functions/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/distance_functions/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_distance_functions_test_app TEST
     distance_functions_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_distance_functions_test_app COMMAND searchlib_distance_functions_test_app)
 

--- a/searchlib/src/tests/tensor/hnsw_best_neighbors/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/hnsw_best_neighbors/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_hnsw_best_neighbors_test_app TEST
     hnsw_best_neighbors_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_hnsw_best_neighbors_test_app COMMAND searchlib_hnsw_best_neighbors_test_app)

--- a/searchlib/src/tests/tensor/hnsw_index/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/hnsw_index/CMakeLists.txt
@@ -5,7 +5,7 @@ vespa_add_executable(searchlib_hnsw_index_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_hnsw_index_test_app COMMAND searchlib_hnsw_index_test_app)
 
@@ -14,5 +14,5 @@ vespa_add_executable(mt_stress_hnsw_app TEST
     stress_hnsw_mt.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )

--- a/searchlib/src/tests/tensor/hnsw_nodeid_mapping/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/hnsw_nodeid_mapping/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_hnsw_nodeid_mapping_test_app TEST
     hnsw_nodeid_mapping_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_hnsw_nodeid_mapping_test_app COMMAND searchlib_hnsw_nodeid_mapping_test_app)
 

--- a/searchlib/src/tests/tensor/hnsw_saver/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/hnsw_saver/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchlib_hnsw_save_load_test_app TEST
     DEPENDS
     searchlib_test
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_hnsw_save_load_test_app COMMAND searchlib_hnsw_save_load_test_app)

--- a/searchlib/src/tests/tensor/tensor_buffer_operations/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/tensor_buffer_operations/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_tensor_buffer_operations_test_app TEST
     tensor_buffer_operations_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_tensor_buffer_operations_test_app COMMAND searchlib_tensor_buffer_operations_test_app)

--- a/searchlib/src/tests/tensor/tensor_buffer_store/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/tensor_buffer_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_tensor_buffer_store_test_app TEST
     tensor_buffer_store_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_tensor_buffer_store_test_app COMMAND searchlib_tensor_buffer_store_test_app)

--- a/searchlib/src/tests/tensor/tensor_buffer_type_mapper/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/tensor_buffer_type_mapper/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_tensor_buffer_type_mapper_test_app TEST
     tensor_buffer_type_mapper_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_tensor_buffer_type_mapper_test_app COMMAND searchlib_tensor_buffer_type_mapper_test_app)

--- a/searchlib/src/tests/test/schema_builder/CMakeLists.txt
+++ b/searchlib/src/tests/test/schema_builder/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_schema_builder_test_app TEST
     schema_builder_test.cpp
     DEPENDS
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_schema_builder_test_app COMMAND searchlib_schema_builder_test_app)

--- a/searchlib/src/tests/test/string_field_builder/CMakeLists.txt
+++ b/searchlib/src/tests/test/string_field_builder/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_string_field_builder_test_app TEST
     string_field_builder_test.cpp
     DEPENDS
     searchlib_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_string_field_builder_test_app COMMAND searchlib_string_field_builder_test_app)

--- a/searchlib/src/tests/util/CMakeLists.txt
+++ b/searchlib/src/tests/util/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_rawbuf_test_app TEST
     rawbuf_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_rawbuf_test_app COMMAND searchlib_rawbuf_test_app)

--- a/searchlib/src/tests/util/folded_string_compare/CMakeLists.txt
+++ b/searchlib/src/tests/util/folded_string_compare/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_folded_string_compare_test_app TEST
     folded_string_compare_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_folded_string_compare_test_app COMMAND searchlib_folded_string_compare_test_app)

--- a/searchlib/src/tests/util/index_stats/CMakeLists.txt
+++ b/searchlib/src/tests/util/index_stats/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_index_stats_test_app TEST
     index_stats_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_index_stats_test_app COMMAND searchlib_index_stats_test_app)

--- a/searchlib/src/tests/util/slime_output_raw_buf_adapter/CMakeLists.txt
+++ b/searchlib/src/tests/util/slime_output_raw_buf_adapter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchlib_slime_output_raw_buf_adapter_test_app TEST
     slime_output_raw_buf_adapter_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchlib_slime_output_raw_buf_adapter_test_app COMMAND searchlib_slime_output_raw_buf_adapter_test_app)

--- a/searchlib/src/tests/vespa-fileheader-inspect/CMakeLists.txt
+++ b/searchlib/src/tests/vespa-fileheader-inspect/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_vespa-fileheader-inspect_test_app TEST
     vespa-fileheader-inspect_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
     AFTER
     searchlib_vespa-fileheader-inspect_app
 )

--- a/searchlib/src/vespa/searchlib/test/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/test/CMakeLists.txt
@@ -23,7 +23,7 @@ vespa_add_library(searchlib_test
     vespa_searchlib
     searchlib_searchlib_test_features
     searchlib_searchlib_test_memoryindex
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_library(searchlib_test_gtest_migration OBJECT

--- a/searchlib/src/vespa/searchlib/test/features/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/test/features/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_library(searchlib_searchlib_test_features
     distance_closeness_fixture.cpp
     DEPENDS
     vespa_searchlib
-    GTest::GTest
+    GTest::gtest
 )

--- a/searchsummary/src/tests/docsummary/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_positionsdfw_test_app TEST
     positionsdfw_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_positionsdfw_test_app COMMAND searchsummary_positionsdfw_test_app)

--- a/searchsummary/src/tests/docsummary/annotation_converter/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/annotation_converter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_annotation_converter_test_app TEST
     annotation_converter_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_annotation_converter_test_app COMMAND searchsummary_annotation_converter_test_app)

--- a/searchsummary/src/tests/docsummary/attribute_combiner/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/attribute_combiner/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchsummary_attribute_combiner_test_app TEST
     DEPENDS
     vespa_searchsummary
     searchsummary_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_attribute_combiner_test_app COMMAND searchsummary_attribute_combiner_test_app)

--- a/searchsummary/src/tests/docsummary/attribute_tokens_dfw/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/attribute_tokens_dfw/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchsummary_attribute_tokens_dfw_test_app TEST
     DEPENDS
     vespa_searchsummary
     searchsummary_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_attribute_tokens_dfw_test_app COMMAND searchsummary_attribute_tokens_dfw_test_app)

--- a/searchsummary/src/tests/docsummary/attributedfw/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/attributedfw/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchsummary_attributedfw_test_app TEST
     DEPENDS
     vespa_searchsummary
     searchsummary_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_attributedfw_test_app COMMAND searchsummary_attributedfw_test_app)

--- a/searchsummary/src/tests/docsummary/document_id_dfw/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/document_id_dfw/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(searchsummary_document_id_dfw_test_app TEST
     DEPENDS
     vespa_searchsummary
     searchsummary_test
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_document_id_dfw_test_app COMMAND searchsummary_document_id_dfw_test_app)

--- a/searchsummary/src/tests/docsummary/matched_elements_filter/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/matched_elements_filter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_matched_elements_filter_test_app TEST
     matched_elements_filter_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_matched_elements_filter_test_app COMMAND searchsummary_matched_elements_filter_test_app)

--- a/searchsummary/src/tests/docsummary/query_term_filter_factory/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/query_term_filter_factory/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_query_term_filter_factory_test_app TEST
     query_term_filter_factory_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_query_term_filter_factory_test_app COMMAND searchsummary_query_term_filter_factory_test_app)

--- a/searchsummary/src/tests/docsummary/result_class/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/result_class/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_result_class_test_app TEST
     result_class_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_result_class_test_app COMMAND searchsummary_result_class_test_app)

--- a/searchsummary/src/tests/docsummary/slime_filler/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/slime_filler/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_slime_filler_test_app TEST
     slime_filler_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_slime_filler_test_app COMMAND searchsummary_slime_filler_test_app)

--- a/searchsummary/src/tests/docsummary/slime_filler_filter/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/slime_filler_filter/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_slime_filler_filter_test_app TEST
     slime_filler_filter_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_slime_filler_filter_test_app COMMAND searchsummary_slime_filler_filter_test_app)

--- a/searchsummary/src/tests/docsummary/slime_summary/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/slime_summary/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(searchsummary_slime_summary_test_app TEST
     slime_summary_test.cpp
     DEPENDS
     vespa_searchsummary
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME searchsummary_slime_summary_test_app COMMAND searchsummary_slime_summary_test_app)

--- a/slobrok/src/tests/local_rpc_monitor_map/CMakeLists.txt
+++ b/slobrok/src/tests/local_rpc_monitor_map/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(slobrok_local_rpc_monitor_map_test_app TEST
     local_rpc_monitor_map_test.cpp
     DEPENDS
     vespa_slobrok_slobrokserver
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME slobrok_local_rpc_monitor_map_test_app COMMAND slobrok_local_rpc_monitor_map_test_app)

--- a/slobrok/src/tests/rpc_mapping_monitor/CMakeLists.txt
+++ b/slobrok/src/tests/rpc_mapping_monitor/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(slobrok_rpc_mapping_monitor_test_app TEST
     rpc_mapping_monitor_test.cpp
     DEPENDS
     vespa_slobrok_slobrokserver
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME slobrok_rpc_mapping_monitor_test_app COMMAND slobrok_rpc_mapping_monitor_test_app)

--- a/slobrok/src/tests/service_map_history/CMakeLists.txt
+++ b/slobrok/src/tests/service_map_history/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(slobrok_service_map_history_test_app TEST
     service_map_history_test.cpp
     DEPENDS
     vespa_slobrok_slobrokserver
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME slobrok_service_map_history_test_app COMMAND slobrok_service_map_history_test_app)

--- a/slobrok/src/tests/service_map_mirror/CMakeLists.txt
+++ b/slobrok/src/tests/service_map_mirror/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(slobrok_service_map_mirror_test_app TEST
     service_map_mirror_test.cpp
     DEPENDS
     vespa_slobrok_slobrokserver
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME slobrok_service_map_mirror_test_app COMMAND slobrok_service_map_mirror_test_app)

--- a/slobrok/src/tests/union_service_map/CMakeLists.txt
+++ b/slobrok/src/tests/union_service_map/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(slobrok_union_service_map_test_app TEST
     union_service_map_test.cpp
     DEPENDS
     vespa_slobrok_slobrokserver
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME slobrok_union_service_map_test_app COMMAND slobrok_union_service_map_test_app)

--- a/storage/src/tests/bucketdb/CMakeLists.txt
+++ b/storage/src/tests/bucketdb/CMakeLists.txt
@@ -9,7 +9,7 @@ vespa_add_executable(storage_bucketdb_gtest_runner_app TEST
     DEPENDS
     vespa_storage
     storage_testcommon
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/common/CMakeLists.txt
+++ b/storage/src/tests/common/CMakeLists.txt
@@ -20,7 +20,7 @@ vespa_add_executable(storage_common_gtest_runner_app TEST
     DEPENDS
     storage_testcommon
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/common/hostreporter/CMakeLists.txt
+++ b/storage/src/tests/common/hostreporter/CMakeLists.txt
@@ -14,7 +14,7 @@ vespa_add_executable(storage_hostreporter_gtest_runner_app TEST
     DEPENDS
     vespa_storage
     storage_testhostreporter
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/frameworkimpl/status/CMakeLists.txt
+++ b/storage/src/tests/frameworkimpl/status/CMakeLists.txt
@@ -8,7 +8,7 @@ vespa_add_executable(storage_status_gtest_runner_app TEST
     DEPENDS
     vespa_storage
     storage_testcommon
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/persistence/CMakeLists.txt
+++ b/storage/src/tests/persistence/CMakeLists.txt
@@ -19,7 +19,7 @@ vespa_add_executable(storage_persistence_gtest_runner_app TEST
     DEPENDS
     vespa_storage
     storage_testpersistence_common
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/persistence/common/CMakeLists.txt
+++ b/storage/src/tests/persistence/common/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_library(storage_testpersistence_common TEST
     filestortestfixture.cpp
     persistenceproviderwrapper.cpp
     DEPENDS
-    GTest::GTest
+    GTest::gtest
     vespa_persistence
     storage_testcommon
 )

--- a/storage/src/tests/persistence/filestorage/CMakeLists.txt
+++ b/storage/src/tests/persistence/filestorage/CMakeLists.txt
@@ -18,7 +18,7 @@ vespa_add_executable(storage_filestorage_gtest_runner_app TEST
     vespa_storage
     storage_testhostreporter
     storage_testpersistence_common
-    GTest::GTest
+    GTest::gtest
     absl::failure_signal_handler
 )
 

--- a/storage/src/tests/storageapi/CMakeLists.txt
+++ b/storage/src/tests/storageapi/CMakeLists.txt
@@ -8,7 +8,7 @@ vespa_add_executable(storageapi_gtest_runner_app TEST
     storageapi_testmbusprot
     storageapi_testmessageapi
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/storageapi/buckets/CMakeLists.txt
+++ b/storage/src/tests/storageapi/buckets/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_library(storageapi_testbuckets
     bucketinfotest.cpp
     DEPENDS
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )

--- a/storage/src/tests/storageapi/mbusprot/CMakeLists.txt
+++ b/storage/src/tests/storageapi/mbusprot/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_library(storageapi_testmbusprot
     storageprotocoltest.cpp
     DEPENDS
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )

--- a/storage/src/tests/storageapi/messageapi/CMakeLists.txt
+++ b/storage/src/tests/storageapi/messageapi/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_library(storageapi_testmessageapi
     storage_message_address_test.cpp
     DEPENDS
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )

--- a/storage/src/tests/storageframework/CMakeLists.txt
+++ b/storage/src/tests/storageframework/CMakeLists.txt
@@ -8,7 +8,7 @@ vespa_add_executable(storageframework_gtest_runner_app TEST
     DEPENDS
     storageframework_testclock
     storageframework_testthread
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/storageframework/clock/CMakeLists.txt
+++ b/storage/src/tests/storageframework/clock/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_library(storageframework_testclock
     timetest.cpp
     DEPENDS
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )

--- a/storage/src/tests/storageframework/thread/CMakeLists.txt
+++ b/storage/src/tests/storageframework/thread/CMakeLists.txt
@@ -5,5 +5,5 @@ vespa_add_library(storageframework_testthread
     taskthreadtest.cpp
     DEPENDS
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )

--- a/storage/src/tests/storageserver/CMakeLists.txt
+++ b/storage/src/tests/storageserver/CMakeLists.txt
@@ -24,7 +24,7 @@ vespa_add_executable(storage_storageserver_gtest_runner_app TEST
     storage_testcommon
     storage_teststorageserver
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/storageserver/rpc/CMakeLists.txt
+++ b/storage/src/tests/storageserver/rpc/CMakeLists.txt
@@ -10,7 +10,7 @@ vespa_add_executable(storage_storageserver_rpc_gtest_runner_app TEST
     storage_testcommon
     storage_teststorageserver
     vespa_storage
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storage/src/tests/visiting/CMakeLists.txt
+++ b/storage/src/tests/visiting/CMakeLists.txt
@@ -10,7 +10,7 @@ vespa_add_executable(storage_visiting_gtest_runner_app TEST
     DEPENDS
     vespa_storage
     storage_teststorageserver
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/storageserver/src/tests/CMakeLists.txt
+++ b/storageserver/src/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ vespa_add_executable(storageserver_gtest_runner_app TEST
     DEPENDS
     storageserver_storageapp
     storage_testcommon
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(

--- a/streamingvisitors/src/tests/hitcollector/CMakeLists.txt
+++ b/streamingvisitors/src/tests/hitcollector/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(streamingvisitors_hitcollector_test_app TEST
     hitcollector_test.cpp
     DEPENDS
     vespa_streamingvisitors
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME streamingvisitors_hitcollector_test_app COMMAND streamingvisitors_hitcollector_test_app)

--- a/streamingvisitors/src/tests/matching_elements_filler/CMakeLists.txt
+++ b/streamingvisitors/src/tests/matching_elements_filler/CMakeLists.txt
@@ -5,6 +5,6 @@ vespa_add_executable(streamingvisitors_matching_elements_filler_test_app TEST
     DEPENDS
     searchlib_test
     vespa_streamingvisitors
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME streamingvisitors_matching_elements_filler_test_app COMMAND streamingvisitors_matching_elements_filler_test_app)

--- a/streamingvisitors/src/tests/nearest_neighbor_field_searcher/CMakeLists.txt
+++ b/streamingvisitors/src/tests/nearest_neighbor_field_searcher/CMakeLists.txt
@@ -6,7 +6,7 @@ vespa_add_executable(vsm_nearest_neighbor_field_searcher_test_app TEST
     vespa_searchlib
     searchlib_test
     vespa_streamingvisitors
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(NAME vsm_nearest_neighbor_field_searcher_test_app COMMAND vsm_nearest_neighbor_field_searcher_test_app)

--- a/streamingvisitors/src/tests/query_term_filter_factory/CMakeLists.txt
+++ b/streamingvisitors/src/tests/query_term_filter_factory/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(streamingvisitors_query_term_filter_factory_test_app TEST
     query_term_filter_factory_test.cpp
     DEPENDS
     vespa_streamingvisitors
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME streamingvisitors_query_term_filter_factory_test_app COMMAND streamingvisitors_query_term_filter_factory_test_app)

--- a/streamingvisitors/src/tests/rank_processor/CMakeLists.txt
+++ b/streamingvisitors/src/tests/rank_processor/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(streamingvisitors_rank_processor_test_app TEST
     rank_processor_test.cpp
     DEPENDS
     vespa_streamingvisitors
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME streamingvisitors_rank_processor_test_app COMMAND streamingvisitors_rank_processor_test_app)

--- a/streamingvisitors/src/tests/searchvisitor/CMakeLists.txt
+++ b/streamingvisitors/src/tests/searchvisitor/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(streamingvisitors_searchvisitor_test_app TEST
     searchvisitor_test.cpp
     DEPENDS
     vespa_streamingvisitors
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME streamingvisitors_searchvisitor_test_app COMMAND streamingvisitors_searchvisitor_test_app)

--- a/vdslib/src/tests/CMakeLists.txt
+++ b/vdslib/src/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ vespa_add_executable(vdslib_gtest_runner_app TEST
     vdslib_containertest
     vdslib_testdistribution
     vdslib_teststate
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test(NAME vdslib_gtest_runner_app COMMAND vdslib_gtest_runner_app COST 100)

--- a/vdslib/src/tests/container/CMakeLists.txt
+++ b/vdslib/src/tests/container/CMakeLists.txt
@@ -6,5 +6,5 @@ vespa_add_library(vdslib_containertest
     documentsummarytest.cpp
     DEPENDS
     vespa_vdslib
-    GTest::GTest
+    GTest::gtest
 )

--- a/vdslib/src/tests/distribution/CMakeLists.txt
+++ b/vdslib/src/tests/distribution/CMakeLists.txt
@@ -5,5 +5,5 @@ vespa_add_library(vdslib_testdistribution
     grouptest.cpp
     DEPENDS
     vespa_vdslib
-    GTest::GTest
+    GTest::gtest
 )

--- a/vdslib/src/tests/state/CMakeLists.txt
+++ b/vdslib/src/tests/state/CMakeLists.txt
@@ -7,5 +7,5 @@ vespa_add_library(vdslib_teststate
     nodestatetest.cpp
     DEPENDS
     vespa_vdslib
-    GTest::GTest
+    GTest::gtest
 )

--- a/vespalib/src/tests/btree/CMakeLists.txt
+++ b/vespalib/src/tests/btree/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(vespalib_btree_test_app TEST
     btree_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_btree_test_app COMMAND vespalib_btree_test_app COST 30)
 vespa_add_executable(vespalib_frozenbtree_test_app TEST

--- a/vespalib/src/tests/btree/btree-stress/CMakeLists.txt
+++ b/vespalib/src/tests/btree/btree-stress/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_btree_stress_test_app
     btree_stress_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_btree_stress_test_app NO_VALGRIND COMMAND vespalib_btree_stress_test_app --smoke-test)

--- a/vespalib/src/tests/btree/btree_store/CMakeLists.txt
+++ b/vespalib/src/tests/btree/btree_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_btree_store_test_app TEST
     btree_store_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_btree_store_test_app COMMAND vespalib_btree_store_test_app COST 30)

--- a/vespalib/src/tests/coro/active_work/CMakeLists.txt
+++ b/vespalib/src/tests/coro/active_work/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_active_work_test_app TEST
     active_work_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_active_work_test_app COMMAND vespalib_active_work_test_app)

--- a/vespalib/src/tests/coro/async_io/CMakeLists.txt
+++ b/vespalib/src/tests/coro/async_io/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_async_io_test_app TEST
     async_io_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_async_io_test_app COMMAND vespalib_async_io_test_app)

--- a/vespalib/src/tests/coro/detached/CMakeLists.txt
+++ b/vespalib/src/tests/coro/detached/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_detached_test_app TEST
     detached_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_detached_test_app COMMAND vespalib_detached_test_app)

--- a/vespalib/src/tests/coro/generator/CMakeLists.txt
+++ b/vespalib/src/tests/coro/generator/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(vespalib_generator_test_app TEST
     generator_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_executable(vespalib_generator_bench_app TEST
     SOURCES
@@ -12,6 +12,6 @@ vespa_add_executable(vespalib_generator_bench_app TEST
     hidden_sequence.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_generator_test_app COMMAND vespalib_generator_test_app)

--- a/vespalib/src/tests/coro/lazy/CMakeLists.txt
+++ b/vespalib/src/tests/coro/lazy/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_lazy_test_app TEST
     lazy_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_lazy_test_app COMMAND vespalib_lazy_test_app)

--- a/vespalib/src/tests/coro/received/CMakeLists.txt
+++ b/vespalib/src/tests/coro/received/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_received_test_app TEST
     received_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_received_test_app COMMAND vespalib_received_test_app)

--- a/vespalib/src/tests/coro/waiting_for/CMakeLists.txt
+++ b/vespalib/src/tests/coro/waiting_for/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_waiting_for_test_app TEST
     waiting_for_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_waiting_for_test_app COMMAND vespalib_waiting_for_test_app)

--- a/vespalib/src/tests/datastore/array_store/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/array_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_array_store_test_app TEST
     array_store_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_array_store_test_app COMMAND vespalib_array_store_test_app COST 100)

--- a/vespalib/src/tests/datastore/array_store_dynamic_type_mapper/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/array_store_dynamic_type_mapper/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_array_store_dynamic_type_mapper_test_app TEST
     array_store_dynamic_type_mapper_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_array_store_dynamic_type_mapper_test_app COMMAND vespalib_array_store_dynamic_type_mapper_test_app)

--- a/vespalib/src/tests/datastore/buffer_stats/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/buffer_stats/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_datastore_buffer_stats_test_app TEST
     buffer_stats_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_datastore_buffer_stats_test_app COMMAND vespalib_datastore_buffer_stats_test_app)

--- a/vespalib/src/tests/datastore/compact_buffer_candidates/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/compact_buffer_candidates/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_compact_buffer_candidates_test_app TEST
     compact_buffer_candidates_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_compact_buffer_candidates_test_app COMMAND vespalib_compact_buffer_candidates_test_app)

--- a/vespalib/src/tests/datastore/datastore/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/datastore/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_datastore_test_app TEST
     datastore_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_datastore_test_app COMMAND vespalib_datastore_test_app)

--- a/vespalib/src/tests/datastore/dynamic_array_buffer_type/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/dynamic_array_buffer_type/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_dynamic_array_buffer_type_test_app TEST
     dynamic_array_buffer_type_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_dynamic_array_buffer_type_test_app COMMAND vespalib_dynamic_array_buffer_type_test_app)

--- a/vespalib/src/tests/datastore/fixed_size_hash_map/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/fixed_size_hash_map/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_fixed_size_hash_map_test_app
     fixed_size_hash_map_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_fixed_size_hash_map_test_app COMMAND vespalib_fixed_size_hash_map_test_app)

--- a/vespalib/src/tests/datastore/free_list/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/free_list/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_datastore_free_list_test_app TEST
     free_list_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_datastore_free_list_test_app COMMAND vespalib_datastore_free_list_test_app)

--- a/vespalib/src/tests/datastore/sharded_hash_map/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/sharded_hash_map/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_sharded_hash_map_test_app
     sharded_hash_map_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_sharded_hash_map_test_app COMMAND vespalib_sharded_hash_map_test_app)

--- a/vespalib/src/tests/datastore/unique_store/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/unique_store/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_unique_store_test_app TEST
     unique_store_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_unique_store_test_app COMMAND vespalib_unique_store_test_app)

--- a/vespalib/src/tests/datastore/unique_store_dictionary/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/unique_store_dictionary/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_unique_store_dictionary_test_app TEST
     unique_store_dictionary_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_unique_store_dictionary_test_app COMMAND vespalib_unique_store_dictionary_test_app)

--- a/vespalib/src/tests/datastore/unique_store_string_allocator/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/unique_store_string_allocator/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_unique_store_string_allocator_test_app TEST
     unique_store_string_allocator_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_unique_store_string_allocator_test_app COMMAND vespalib_unique_store_string_allocator_test_app)

--- a/vespalib/src/tests/detect_type_benchmark/CMakeLists.txt
+++ b/vespalib/src/tests/detect_type_benchmark/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_executable(vespalib_detect_type_benchmark_app TEST
     detect_type_benchmark.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )

--- a/vespalib/src/tests/execution_profiler/CMakeLists.txt
+++ b/vespalib/src/tests/execution_profiler/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_execution_profiler_test_app TEST
     execution_profiler_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_execution_profiler_test_app COMMAND vespalib_execution_profiler_test_app)

--- a/vespalib/src/tests/executor_idle_tracking/CMakeLists.txt
+++ b/vespalib/src/tests/executor_idle_tracking/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_executor_idle_tracking_test_app TEST
     executor_idle_tracking_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_executor_idle_tracking_test_app COMMAND vespalib_executor_idle_tracking_test_app)

--- a/vespalib/src/tests/fastos/CMakeLists.txt
+++ b/vespalib/src/tests/fastos/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(fastos_file_test_app TEST
     file_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME fastos_file_test_app COMMAND fastos_file_test_app)

--- a/vespalib/src/tests/fuzzy/CMakeLists.txt
+++ b/vespalib/src/tests/fuzzy/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(vespalib_fuzzy_matcher_test_app TEST
         fuzzy_matcher_test.cpp
         DEPENDS
         vespalib
-        GTest::GTest
+        GTest::gtest
         )
 vespa_add_test(NAME vespalib_fuzzy_matcher_test_app COMMAND vespalib_fuzzy_matcher_test_app)
 
@@ -13,7 +13,7 @@ vespa_add_executable(vespalib_levenshtein_distance_test_app TEST
         levenshtein_distance_test.cpp
         DEPENDS
         vespalib
-        GTest::GTest
+        GTest::gtest
         )
 vespa_add_test(NAME vespalib_levenshtein_distance_test_app COMMAND vespalib_levenshtein_distance_test_app)
 
@@ -22,6 +22,6 @@ vespa_add_executable(vespalib_levenshtein_dfa_test_app TEST
     levenshtein_dfa_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_levenshtein_dfa_test_app COMMAND vespalib_levenshtein_dfa_test_app)

--- a/vespalib/src/tests/fuzzy/table_dfa/CMakeLists.txt
+++ b/vespalib/src/tests/fuzzy/table_dfa/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_fuzzy_table_dfa_test_app TEST
         table_dfa_test.cpp
         DEPENDS
         vespalib
-        GTest::GTest
+        GTest::gtest
         )
 vespa_add_test(NAME vespalib_fuzzy_table_dfa_test_app COMMAND vespalib_fuzzy_table_dfa_test_app)

--- a/vespalib/src/tests/issue/CMakeLists.txt
+++ b/vespalib/src/tests/issue/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_issue_test_app TEST
     issue_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_issue_test_app COMMAND vespalib_issue_test_app)

--- a/vespalib/src/tests/overload/CMakeLists.txt
+++ b/vespalib/src/tests/overload/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_overload_test_app TEST
     overload_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_overload_test_app COMMAND vespalib_overload_test_app)

--- a/vespalib/src/tests/process/CMakeLists.txt
+++ b/vespalib/src/tests/process/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_process_test_app TEST
     process_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_process_test_app COMMAND vespalib_process_test_app COST 30)

--- a/vespalib/src/tests/rw_spin_lock/CMakeLists.txt
+++ b/vespalib/src/tests/rw_spin_lock/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_rw_spin_lock_test_app TEST
     rw_spin_lock_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_rw_spin_lock_test_app NO_VALGRIND COMMAND vespalib_rw_spin_lock_test_app)

--- a/vespalib/src/tests/signalhandler/CMakeLists.txt
+++ b/vespalib/src/tests/signalhandler/CMakeLists.txt
@@ -16,7 +16,7 @@ vespa_add_executable(vespalib_signalhandler_test_app TEST
     DEPENDS
     vespalib
     vespalib_signalhandler_test_my_shared_library
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_signalhandler_test_app NO_VALGRIND COMMAND vespalib_signalhandler_test_app)
 vespa_add_executable(vespalib_victim_app

--- a/vespalib/src/tests/stllike/CMakeLists.txt
+++ b/vespalib/src/tests/stllike/CMakeLists.txt
@@ -46,7 +46,7 @@ vespa_add_executable(vespalib_replace_variable_test_app TEST
     replace_variable_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_replace_variable_test_app COMMAND vespalib_replace_variable_test_app)
 vespa_add_executable(vespalib_lrucache_test_app TEST
@@ -54,7 +54,7 @@ vespa_add_executable(vespalib_lrucache_test_app TEST
     lrucache.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_lrucache_test_app COMMAND vespalib_lrucache_test_app)
 vespa_add_executable(vespalib_cache_test_app TEST

--- a/vespalib/src/tests/unwind_message/CMakeLists.txt
+++ b/vespalib/src/tests/unwind_message/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_unwind_message_test_app TEST
     unwind_message_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_unwind_message_test_app COMMAND vespalib_unwind_message_test_app)

--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -37,7 +37,7 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     DEPENDS
     vespalib
     onnxruntime
-    GTest::GTest
+    GTest::gtest
 )
 
 vespa_add_test( NAME vespalib_util_gtest_runner_test_app COMMAND vespalib_util_gtest_runner_test_app)

--- a/vespalib/src/tests/util/generationhandler_stress/CMakeLists.txt
+++ b/vespalib/src/tests/util/generationhandler_stress/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_generation_handler_stress_test_app
     generation_handler_stress_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_generation_handler_stress_test_app NO_VALGRIND COMMAND vespalib_generation_handler_stress_test_app --smoke-test)

--- a/vespalib/src/tests/util/hamming/CMakeLists.txt
+++ b/vespalib/src/tests/util/hamming/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(vespalib_hamming_test_app TEST
     hamming_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_hamming_test_app COMMAND vespalib_hamming_test_app)
 

--- a/vespalib/src/tests/visit_ranges/CMakeLists.txt
+++ b/vespalib/src/tests/visit_ranges/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalib_visit_ranges_test_app TEST
     visit_ranges_test.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalib_visit_ranges_test_app COMMAND vespalib_visit_ranges_test_app)

--- a/vespalib/src/tests/wakeup/CMakeLists.txt
+++ b/vespalib/src/tests/wakeup/CMakeLists.txt
@@ -4,5 +4,5 @@ vespa_add_executable(vespalib_wakeup_bench_app TEST
     wakeup_bench.cpp
     DEPENDS
     vespalib
-    GTest::GTest
+    GTest::gtest
 )

--- a/vespalog/src/test/log_message/CMakeLists.txt
+++ b/vespalog/src/test/log_message/CMakeLists.txt
@@ -4,6 +4,6 @@ vespa_add_executable(vespalog_log_message_test_app TEST
     log_message_test.cpp
     DEPENDS
     vespalog
-    GTest::GTest
+    GTest::gtest
 )
 vespa_add_test(NAME vespalog_log_message_test_app COMMAND vespalog_log_message_test_app)


### PR DESCRIPTION
Use the imported target GTest::gtest instead (added in CMake 3.20). Require CMake 3.20 or newer.

@boeker : please review
