### PR TITLE
BucketResultNode has ResultNode as actual parent,

### DIFF
--- a/searchlib/src/vespa/searchlib/expression/bucketresultnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/bucketresultnode.cpp
@@ -3,7 +3,7 @@
 
 namespace search::expression {
 
-IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS2(search, expression, BucketResultNode, vespalib::Identifiable);
+IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS2(search, expression, BucketResultNode, ResultNode);
 
 const std::string BucketResultNode::_toField("to");
 const std::string BucketResultNode::_fromField("from");


### PR DESCRIPTION
this needs to be registered in the identifiable RTTI data structures.

@havardpe please review
@toregge FYI
