### PR TITLE
Stop considering feed blocked status per group in dispatcher

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -26,7 +26,6 @@ public class Group {
     private volatile boolean hasFullCoverage = true;
     private volatile long activeDocuments = 0;
     private volatile long targetActiveDocuments = 0;
-    private volatile boolean isBlockingWrites = false;
     private volatile boolean isBalanced = true;
 
     public Group(int id, List<Node> nodes) {
@@ -74,7 +73,6 @@ public class Group {
         long activeDocs = calculateActiveDocs(workingNodes);
         activeDocuments = activeDocs;
         targetActiveDocuments = workingNodes.stream().mapToLong(Node::getTargetActiveDocuments).sum();
-        isBlockingWrites = nodes.stream().anyMatch(Node::isBlockingWrites);
         int numWorkingNodes = workingNodes.size();
         if (numWorkingNodes > 0) {
             long average = activeDocs / numWorkingNodes;
@@ -104,9 +102,6 @@ public class Group {
 
     /** Returns the target active documents on this group. If unknown, 0 is returned. */
     long targetActiveDocuments() { return targetActiveDocuments; }
-
-    /** Returns whether any node in this group is currently blocking write operations */
-    public boolean isBlockingWrites() { return isBlockingWrites; }
 
     /** Returns whether the nodes in the group have about the same number of documents */
     public boolean isBalanced() { return isBalanced; }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
@@ -24,7 +24,6 @@ public class Node {
     private volatile long targetActiveDocuments = 0;
     private volatile boolean statusIsKnown = false;
     private volatile boolean working = true;
-    private volatile boolean isBlockingWrites = false;
 
     public Node(String clusterName, int key, String hostname, int group) {
         this.clusterName = clusterName;
@@ -84,10 +83,6 @@ public class Node {
     /** Returns the active documents on this node. If unknown, 0 is returned. */
     long getActiveDocuments() { return activeDocuments; }
     long getTargetActiveDocuments() { return targetActiveDocuments; }
-
-    public void setBlockingWrites(boolean isBlockingWrites) { this.isBlockingWrites = isBlockingWrites; }
-
-    boolean isBlockingWrites() { return isBlockingWrites; }
 
     @Override
     public int hashCode() { return Objects.hash(hostname, key, group); }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -311,7 +311,6 @@ public class SearchCluster implements NodeManager<Node> {
                 if (pong.activeDocuments().isPresent()) {
                     node.setActiveDocuments(pong.activeDocuments().get());
                     node.setTargetActiveDocuments(pong.targetActiveDocuments().get());
-                    node.setBlockingWrites(pong.isBlockingWrites());
                 }
                 clusterMonitor.responded(node);
             }


### PR DESCRIPTION
Since feed blocked is for the whole cluster it does not make sense to consider individual groups and their feed blocked status, simplify accordingly.