### PR TITLE
Expose stable cluster document and byte count metrics from cluster controller

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentClusterStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentClusterStats.java
@@ -15,24 +15,41 @@ import java.util.Set;
  */
 public class ContentClusterStats implements Iterable<ContentNodeStats> {
 
+    private final long documentCountTotal;
+    private final long bytesTotal;
     // Maps a content node index to the content node's stats.
     private final Map<Integer, ContentNodeStats> mapToNodeStats;
 
-    public ContentClusterStats(Set<Integer> storageNodes) {
+    public ContentClusterStats(long documentCountTotal, long bytesTotal, Set<Integer> storageNodes) {
+        this.documentCountTotal = documentCountTotal;
+        this.bytesTotal = bytesTotal;
         mapToNodeStats = new HashMap<>(storageNodes.size());
         for (Integer index : storageNodes) {
             mapToNodeStats.put(index, new ContentNodeStats(index));
         }
     }
 
-    public ContentClusterStats(Map<Integer, ContentNodeStats> mapToNodeStats) {
+    public ContentClusterStats(Set<Integer> storageNodes) {
+        this(0, 0, storageNodes);
+    }
+
+    public ContentClusterStats(long documentCountTotal, long bytesTotal, Map<Integer, ContentNodeStats> mapToNodeStats) {
+        this.documentCountTotal = documentCountTotal;
+        this.bytesTotal = bytesTotal;
         this.mapToNodeStats = mapToNodeStats;
+    }
+
+    public ContentClusterStats(Map<Integer, ContentNodeStats> mapToNodeStats) {
+        this(0, 0, mapToNodeStats);
     }
 
     @Override
     public Iterator<ContentNodeStats> iterator() {
         return mapToNodeStats.values().iterator();
     }
+
+    public long getDocumentCountTotal() { return documentCountTotal; }
+    public long getBytesTotal() { return bytesTotal; }
 
     public ContentNodeStats getNodeStats(Integer index) { return mapToNodeStats.get(index);}
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -573,10 +573,13 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
     }
 
     private void updateMasterClusterSyncMetrics() {
-        var stats = stateVersionTracker.getAggregatedClusterStats().getAggregatedStats();
-        if (stats.hasUpdatesFromAllDistributors()) {
-            GlobalBucketSyncStatsCalculator.clusterBucketsOutOfSyncRatio(stats.getGlobalStats())
+        var stats = stateVersionTracker.getAggregatedClusterStats();
+        var aggrStats = stats.getAggregatedStats();
+        if (aggrStats.hasUpdatesFromAllDistributors()) {
+            GlobalBucketSyncStatsCalculator.clusterBucketsOutOfSyncRatio(aggrStats.getGlobalStats())
                     .ifPresent(metricUpdater::updateClusterBucketsOutOfSyncRatio);
+            metricUpdater.updateClusterDocumentMetrics(
+                    stats.getAggregatedDocumentCountTotal(), stats.getAggregatedBytesTotal());
         }
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -29,6 +29,7 @@ public class MetricUpdater {
     public MetricUpdater(MetricReporter metricReporter, Timer timer, int controllerIndex, String clusterName) {
         this.metricReporter = new ComponentMetricReporter(metricReporter, "cluster-controller.");
         this.metricReporter.addDimension("controller-index", String.valueOf(controllerIndex));
+        this.metricReporter.addDimension("cluster", clusterName);
         this.metricReporter.addDimension("clusterid", clusterName);
         this.timer = timer;
     }
@@ -53,8 +54,6 @@ public class MetricUpdater {
     public void updateClusterStateMetrics(ContentCluster cluster, ClusterState state,
                                           ResourceUsageStats resourceUsage, Instant lastStateBroadcastTimePoint) {
         Map<String, String> dimensions = new HashMap<>();
-        dimensions.put("cluster", cluster.getName());
-        dimensions.put("clusterid", cluster.getName());
         Instant now = timer.getCurrentWallClockTime();
         // NodeInfo::getClusterStateVersionBundleAcknowledged() returns -1 if the node has not yet ACKed a
         // cluster state version. Check for this version explicitly if we've yet to publish a state. This
@@ -123,6 +122,11 @@ public class MetricUpdater {
 
     public void updateClusterBucketsOutOfSyncRatio(double ratio) {
         metricReporter.set("cluster-buckets-out-of-sync-ratio", ratio);
+    }
+
+    public void updateClusterDocumentMetrics(long docsTotal, long bytesTotal) {
+        metricReporter.set("stored-document-count", docsTotal);
+        metricReporter.set("stored-document-bytes", bytesTotal);
     }
 
     public void addTickTime(long millis, boolean didWork) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/Distributor.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/Distributor.java
@@ -13,9 +13,13 @@ import java.util.List;
  */
 public class Distributor {
 
+    @JsonProperty("global-stats")
+    private DistributorGlobalStats globalStats = DistributorGlobalStats.EMPTY;
     @JsonProperty("storage-nodes")
     private List<StorageNode> storageNodes = new ArrayList<>();
 
+    public Long documentCountTotalOrNull() { return globalStats.storedDocumentCount(); }
+    public Long bytesTotalOrNull() { return globalStats.storedDocumentBytes(); }
     public List<StorageNode> getStorageNodes() { return storageNodes; }
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/DistributorGlobalStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/DistributorGlobalStats.java
@@ -1,0 +1,18 @@
+package com.yahoo.vespa.clustercontroller.core.hostinfo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Cross-node/bucket-space/replica statistics from a particular distributor.
+ *
+ * Fields are nullable to be able to distinguish between a node being on a version that
+ * does not send the fields vs. a node that sends the fields with zero values.
+ *
+ * @param storedDocumentCount Number of documents stored across all bucket spaces on all
+ *                            content node replicas controlled by the distributor.
+ * @param storedDocumentBytes Combined byte size of the documents reported by storedDocumentCount.
+ */
+public record DistributorGlobalStats(@JsonProperty("stored-document-count") Long storedDocumentCount,
+                                     @JsonProperty("stored-document-bytes") Long storedDocumentBytes) {
+    public static final DistributorGlobalStats EMPTY = new DistributorGlobalStats(null, null);
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/StorageNodeStatsBridge.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/StorageNodeStatsBridge.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.clustercontroller.core.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Class used to create a StorageNodeStatsContainer from HostInfo.
@@ -20,7 +21,9 @@ public class StorageNodeStatsBridge {
         for (StorageNode storageNode : distributor.getStorageNodes()) {
             mapToNodeStats.put(storageNode.getIndex(), new ContentNodeStats(storageNode));
         }
-        return new ContentClusterStats(mapToNodeStats);
+        long docsTotal  = Optional.ofNullable(distributor.documentCountTotalOrNull()).orElse(0L);
+        long bytesTotal = Optional.ofNullable(distributor.bytesTotalOrNull()).orElse(0L);
+        return new ContentClusterStats(docsTotal, bytesTotal, mapToNodeStats);
     }
 
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsAggregatorTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterStatsAggregatorTest.java
@@ -173,4 +173,25 @@ public class ClusterStatsAggregatorTest {
                 .add("global", 15 + 17, 6 + 8));
     }
 
+    @Test
+    void aggregator_tracks_total_document_count_and_byte_size_across_distributors() {
+        Fixture f = new Fixture(distributorNodes(0, 1), contentNodes(0));
+        f.update(0, new ContentClusterStatsBuilder().add(0, "default").withDocumentCountTotal(100).withBytesTotal(2000));
+        assertFalse(f.hasUpdatesFromAllDistributors());
+        f.update(1, new ContentClusterStatsBuilder().add(0, "default").withDocumentCountTotal(200).withBytesTotal(3000));
+        assertTrue(f.hasUpdatesFromAllDistributors());
+
+        assertEquals(300, f.aggregator.getAggregatedDocumentCountTotal());
+        assertEquals(5000, f.aggregator.getAggregatedBytesTotal());
+
+        f.update(0, new ContentClusterStatsBuilder().add(0, "default").withDocumentCountTotal(150).withBytesTotal(2020));
+        assertTrue(f.hasUpdatesFromAllDistributors());
+        assertEquals(350, f.aggregator.getAggregatedDocumentCountTotal());
+        assertEquals(5020, f.aggregator.getAggregatedBytesTotal());
+
+        f.update(1, new ContentClusterStatsBuilder().add(0, "default").withDocumentCountTotal(210).withBytesTotal(2900));
+        assertEquals(360, f.aggregator.getAggregatedDocumentCountTotal());
+        assertEquals(4920, f.aggregator.getAggregatedBytesTotal());
+    }
+
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ContentClusterStatsBuilder.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ContentClusterStatsBuilder.java
@@ -11,6 +11,9 @@ public class ContentClusterStatsBuilder {
 
     private final Map<Integer, ContentNodeStatsBuilder> stats = new HashMap<>();
 
+    private long documentCountTotal = 0;
+    private long bytesTotal = 0;
+
     public ContentClusterStatsBuilder add(int nodeIndex, String bucketSpace, long bucketsTotal, long bucketsPending) {
         return add(nodeIndex, bucketSpace, ContentNodeStats.BucketSpaceStats.of(bucketsTotal, bucketsPending));
     }
@@ -38,10 +41,20 @@ public class ContentClusterStatsBuilder {
         return this;
     }
 
+    public ContentClusterStatsBuilder withDocumentCountTotal(long docCount) {
+        this.documentCountTotal = docCount;
+        return this;
+    }
+
+    public ContentClusterStatsBuilder withBytesTotal(long bytesTotal) {
+        this.bytesTotal = bytesTotal;
+        return this;
+    }
+
     ContentClusterStats build() {
         Map<Integer, ContentNodeStats> nodeToStatsMap = new HashMap<>();
         stats.forEach((nodeIndex, nodeStatsBuilder) ->
                 nodeToStatsMap.put(nodeIndex, nodeStatsBuilder.build()));
-        return new ContentClusterStats(nodeToStatsMap);
+        return new ContentClusterStats(documentCountTotal, bytesTotal, nodeToStatsMap);
     }
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
@@ -219,4 +219,14 @@ public class MetricReporterTest {
         f.advanceTimeAndVerifyMetrics(Duration.ofMillis(10001), 0, 0);
     }
 
+    @Test
+    void metrics_are_emitted_for_cluster_document_stats() {
+        Fixture f = new Fixture();
+        f.metricUpdater.updateClusterDocumentMetrics(12345, 6789000);
+
+        // Metric dimensions are set indirectly via the metric updater's default context
+        verify(f.mockReporter).set(eq("cluster-controller.stored-document-count"), eq(12345L), any());
+        verify(f.mockReporter).set(eq("cluster-controller.stored-document-bytes"), eq(6789000L), any());
+    }
+
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/HostInfoTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/HostInfoTest.java
@@ -29,6 +29,8 @@ public class HostInfoTest {
     void testEmptyJson() {
         HostInfo hostInfo = HostInfo.createHostInfo("{}");
         assertNull(hostInfo.getVtag().getVersionOrNull());
+        assertNull(hostInfo.getDistributor().documentCountTotalOrNull());
+        assertNull(hostInfo.getDistributor().bytesTotalOrNull());
         assertTrue(hostInfo.getDistributor().getStorageNodes().isEmpty());
         assertTrue(hostInfo.getContentNode().getResourceUsage().isEmpty());
         assertTrue(hostInfo.getMetrics().getMetrics().isEmpty());
@@ -69,6 +71,7 @@ public class HostInfoTest {
         assertEquals(Optional.ofNullable(resourceUsage.get("disk")).map(ResourceUsage::getUsage).orElse(0.0), 0.6, 0.00001);
         assertEquals(Optional.ofNullable(resourceUsage.get("disk")).map(ResourceUsage::getName).orElse("missing"), "a cool disk");
         assertNull(resourceUsage.get("flux-capacitor"));
+        assertEquals(123456, hostInfo.getDistributor().documentCountTotalOrNull());
     }
 
     @Test
@@ -109,5 +112,7 @@ public class HostInfoTest {
         assertTrue(storageNodeByIndex.containsKey(5));
         assertEquals(5, storageNodeByIndex.get(5).getIndex().intValue());
         assertEquals(9, storageNodeByIndex.get(5).getMinCurrentReplicationFactorOrNull().intValue());
+
+        assertEquals(1337, hostInfo.getDistributor().documentCountTotalOrNull());
     }
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/StorageNodeStatsBridgeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/hostinfo/StorageNodeStatsBridgeTest.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
@@ -34,6 +35,8 @@ public class StorageNodeStatsBridgeTest {
         HostInfo hostInfo = HostInfo.createHostInfo(data);
 
         ContentClusterStats clusterStats = StorageNodeStatsBridge.generate(hostInfo.getDistributor());
+        assertEquals(123456, clusterStats.getDocumentCountTotal());
+        assertEquals(789012345, clusterStats.getBytesTotal());
         Iterator<ContentNodeStats> itr = clusterStats.iterator();
         { // content node 0
             ContentNodeStats stats = itr.next();

--- a/protocols/getnodestate/distributor.json
+++ b/protocols/getnodestate/distributor.json
@@ -1,5 +1,9 @@
 {
     "distributor": {
+        "global-stats": {
+            "stored-document-count": 1337,
+            "stored-document-bytes": 456789
+        },
         "storage-nodes": [
             {
                 "node-index": 0,

--- a/protocols/getnodestate/host_info.json
+++ b/protocols/getnodestate/host_info.json
@@ -72,6 +72,10 @@
         "version": "5.32.76"
     },
     "distributor": {
+        "global-stats": {
+            "stored-document-count": 123456,
+            "stored-document-bytes": 789012345
+        },
         "storage-nodes": [
             {
                 "node-index": 0,

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -735,7 +735,7 @@ MyBmNode::merge_node_stats(std::vector<BmNodeStats>& node_stats, storage::lib::C
         {
             std::lock_guard<std::mutex> guard(_lock);
             if (_bucket_spaces_stats_provider) {
-                per_node_bucket_spaces_stats = _bucket_spaces_stats_provider->getBucketSpacesStats();
+                per_node_bucket_spaces_stats = _bucket_spaces_stats_provider->per_node_bucket_spaces_stats();
             }
         }
         if (per_node_bucket_spaces_stats.has_value()) {

--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -124,7 +124,11 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
     }
 
     BucketSpacesStatsProvider::PerNodeBucketSpacesStats stripe_bucket_spaces_stats() {
-        return _stripe->getBucketSpacesStats();
+        return _stripe->per_node_bucket_spaces_stats();
+    }
+
+    DistributorGlobalStats stripe_distributor_global_stats() {
+        return _stripe->distributor_global_stats();
     }
 
     bool stripe_handle_message(const std::shared_ptr<api::StorageMessage>& msg) {
@@ -787,6 +791,9 @@ TEST_F(DistributorStripeTest, entering_recovery_mode_resets_bucket_space_stats)
 
     assert_invalid_stats_for_all_spaces(stats, 0);
     assert_invalid_stats_for_all_spaces(stats, 2);
+
+    const auto g_stats = stripe_distributor_global_stats();
+    EXPECT_FALSE(g_stats.valid());
 }
 
 TEST_F(DistributorStripeTest, stale_reads_config_is_propagated_to_external_operation_handler)

--- a/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.cpp
+++ b/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.cpp
@@ -11,6 +11,8 @@ operator<<(std::ostream& out, const BucketSpaceStats& stats)
     return out;
 }
 
+bool BucketSpaceStats::operator==(const BucketSpaceStats& rhs) const noexcept = default;
+
 void
 merge_bucket_spaces_stats(BucketSpacesStatsProvider::BucketSpacesStats& dest,
                           const BucketSpacesStatsProvider::BucketSpacesStats& src)

--- a/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.h
+++ b/storage/src/vespa/storage/distributor/bucket_spaces_stats_provider.h
@@ -10,10 +10,42 @@
 namespace storage::distributor {
 
 /**
+ * Distributor-global statistics across bucket spaces and content nodes.
+ */
+class DistributorGlobalStats {
+    bool     _valid;
+    uint64_t _documents_total;
+    uint64_t _bytes_total;
+public:
+    constexpr DistributorGlobalStats() noexcept
+        : _valid(false),
+          _documents_total(0),
+          _bytes_total(0)
+    {}
+    constexpr DistributorGlobalStats(uint64_t documents_total, uint64_t bytes_total) noexcept
+        : _valid(true),
+          _documents_total(documents_total),
+          _bytes_total(bytes_total)
+    {}
+
+    [[nodiscard]] constexpr static DistributorGlobalStats make_invalid() noexcept { return {}; }
+    [[nodiscard]] constexpr static DistributorGlobalStats make_empty_but_valid() noexcept { return {0, 0}; }
+
+    [[nodiscard]] bool valid() const noexcept { return _valid; }
+    [[nodiscard]] uint64_t documents_total() const noexcept { return _documents_total; }
+    [[nodiscard]] uint64_t bytes_total() const noexcept { return _bytes_total; }
+    bool operator==(const DistributorGlobalStats&) const noexcept = default;
+    void merge(const DistributorGlobalStats& rhs) noexcept {
+        _valid = _valid && rhs._valid;
+        _documents_total += rhs._documents_total;
+        _bytes_total += rhs._bytes_total;
+    }
+};
+
+/**
  * Statistics for a single bucket space on a content node.
  */
 class BucketSpaceStats {
-private:
     bool   _valid;
     size_t _bucketsTotal;
     size_t _bucketsPending;
@@ -35,11 +67,7 @@ public:
     size_t bucketsTotal() const noexcept { return _bucketsTotal; }
     size_t bucketsPending() const noexcept { return _bucketsPending; }
 
-    bool operator==(const BucketSpaceStats& rhs) const noexcept {
-        return (_valid == rhs._valid) &&
-                (_bucketsTotal == rhs._bucketsTotal) &&
-                (_bucketsPending == rhs._bucketsPending);
-    }
+    bool operator==(const BucketSpaceStats& rhs) const noexcept;
 
     void merge(const BucketSpaceStats& rhs) noexcept {
         _valid = _valid && rhs._valid;
@@ -61,7 +89,8 @@ public:
     using PerNodeBucketSpacesStats = std::unordered_map<uint16_t, BucketSpacesStats>;
 
     virtual ~BucketSpacesStatsProvider() = default;
-    virtual PerNodeBucketSpacesStats getBucketSpacesStats() const = 0;
+    [[nodiscard]] virtual PerNodeBucketSpacesStats per_node_bucket_spaces_stats() const = 0;
+    [[nodiscard]] virtual DistributorGlobalStats distributor_global_stats() const = 0;
 };
 
 void merge_bucket_spaces_stats(BucketSpacesStatsProvider::BucketSpacesStats& dest,

--- a/storage/src/vespa/storage/distributor/distributor_host_info_reporter.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_host_info_reporter.cpp
@@ -80,9 +80,16 @@ void
 DistributorHostInfoReporter::report(vespalib::JsonStream& output)
 {
     auto minReplica = _minReplicaProvider.getMinReplica();
-    auto bucketSpacesStats = _bucketSpacesStatsProvider.getBucketSpacesStats();
+    auto bucketSpacesStats = _bucketSpacesStatsProvider.per_node_bucket_spaces_stats();
+    auto global_stats = _bucketSpacesStatsProvider.distributor_global_stats();
 
     output << "distributor" << Object();
+    if (global_stats.valid()) {
+        output << "global-stats" << Object()
+               << "stored-document-count" << global_stats.documents_total()
+               << "stored-document-bytes" << global_stats.bytes_total()
+               << End();
+    }
     {
         output << "storage-nodes" << Array();
         outputStorageNodes(output, minReplica, bucketSpacesStats);

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -449,6 +449,7 @@ DistributorStripe::invalidate_internal_db_dependent_stats()
     {
         std::lock_guard guard(_metricLock);
         invalidate_bucket_spaces_stats(guard);
+        _global_stats = DistributorGlobalStats::make_invalid();
         invalidate_min_replica_stats(guard);
     }
 }
@@ -661,10 +662,17 @@ DistributorStripe::getMinReplica() const
 }
 
 BucketSpacesStatsProvider::PerNodeBucketSpacesStats
-DistributorStripe::getBucketSpacesStats() const
+DistributorStripe::per_node_bucket_spaces_stats() const
 {
     std::lock_guard guard(_metricLock);
     return _bucketSpacesStats;
+}
+
+DistributorGlobalStats
+DistributorStripe::distributor_global_stats() const
+{
+    std::lock_guard guard(_metricLock);
+    return _global_stats;
 }
 
 SimpleMaintenanceScanner::PendingMaintenanceStats
@@ -750,6 +758,7 @@ DistributorStripe::updateInternalMetricsForCompletedScan()
         _must_send_updated_host_info = true;
     }
     _bucketSpacesStats = std::move(new_space_stats);
+    _global_stats = DistributorGlobalStats(_bucketDbStats._docCount, _bucketDbStats._byteCount);
     maybe_update_bucket_db_memory_usage_stats();
 }
 

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -223,7 +223,8 @@ private:
      */
     MinReplicaMap getMinReplica() const override;
 
-    PerNodeBucketSpacesStats getBucketSpacesStats() const override;
+    PerNodeBucketSpacesStats per_node_bucket_spaces_stats() const override;
+    DistributorGlobalStats distributor_global_stats() const override;
 
     SimpleMaintenanceScanner::PendingMaintenanceStats pending_maintenance_stats() const;
 
@@ -369,6 +370,7 @@ private:
      */
     SimpleMaintenanceScanner::PendingMaintenanceStats _maintenanceStats;
     BucketSpacesStatsProvider::PerNodeBucketSpacesStats _bucketSpacesStats;
+    DistributorGlobalStats _global_stats;
     BucketDBMetricUpdater::Stats _bucketDbStats;
     std::unique_ptr<OwnershipTransferSafeTimePointCalculator> _ownershipSafeTimeCalc;
     std::chrono::steady_clock::duration _db_memory_sample_interval;

--- a/storage/src/vespa/storage/distributor/top_level_distributor.cpp
+++ b/storage/src/vespa/storage/distributor/top_level_distributor.cpp
@@ -393,11 +393,21 @@ TopLevelDistributor::getMinReplica() const
 }
 
 BucketSpacesStatsProvider::PerNodeBucketSpacesStats
-TopLevelDistributor::getBucketSpacesStats() const
+TopLevelDistributor::per_node_bucket_spaces_stats() const
 {
     BucketSpacesStatsProvider::PerNodeBucketSpacesStats result;
     for (const auto& stripe : _stripes) {
-        merge_per_node_bucket_spaces_stats(result, stripe->getBucketSpacesStats());
+        merge_per_node_bucket_spaces_stats(result, stripe->per_node_bucket_spaces_stats());
+    }
+    return result;
+}
+
+DistributorGlobalStats
+TopLevelDistributor::distributor_global_stats() const
+{
+    auto result = DistributorGlobalStats::make_empty_but_valid();
+    for (const auto& stripe : _stripes) {
+        result.merge(stripe->distributor_global_stats());
     }
     return result;
 }

--- a/storage/src/vespa/storage/distributor/top_level_distributor.h
+++ b/storage/src/vespa/storage/distributor/top_level_distributor.h
@@ -149,7 +149,8 @@ private:
      */
     MinReplicaMap getMinReplica() const override;
 
-    PerNodeBucketSpacesStats getBucketSpacesStats() const override;
+    PerNodeBucketSpacesStats per_node_bucket_spaces_stats() const override;
+    DistributorGlobalStats distributor_global_stats() const override;
 
     /**
      * Atomically publish internal metrics to external ideal state metrics.


### PR DESCRIPTION
@hakonhall please review cluster controller changes in particular (756d7e57b09d4896580503deea2ddcf4d81a07ea)
@toregge please review distributor changes in particular (32604189e26012087400847638d9c1f4106f88f8)

Report back aggregated cross-node and cross-bucket space document counts and byte sizes from the distributors to the cluster controller. By having aggregation that is cluster state version/transition-aware, the controller can report consistent values for total document counts and byte sizes.

This is unlike distributed gathering of distributor metrics, which risks sampling from different nodes on different sides of a state transition, causing seemingly inconsistent values to be observed (becoming consistent again once all sampling takes place on the same side of the transition edge).

The new host info values reported are the same as those emitted by the distributor via the existing docs/bytes stored-metrics. They are communicated to the controller using the existing host info `distributor` object, adding a new `global-stats` object underneath.

Two new metrics are added on the cluster controller:
  - `cluster-controller.stored-document-count`
  - `cluster-controller.stored-document-bytes`

Also unify `MetricUpdater` default metric context to always include certain dimensions.
