### PR TITLE
Add test source file missing from `CMakeLists.txt`

### DIFF
--- a/vdslib/src/tests/distribution/CMakeLists.txt
+++ b/vdslib/src/tests/distribution/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(vdslib_testdistribution
     SOURCES
     distributiontest.cpp
+    global_bucket_space_distribution_converter_test.cpp
     grouptest.cpp
     DEPENDS
     vespa_vdslib


### PR DESCRIPTION
@toregge please review.

Seemingly slipped between the cracks when the test was moved here from another module at some point. Luckily the unit tests have not been silently broken...
