### PR TITLE
Implement /state/v1/version in vespalib

### DIFF
--- a/vespalib/src/tests/state_server/state_server_test.cpp
+++ b/vespalib/src/tests/state_server/state_server_test.cpp
@@ -390,7 +390,7 @@ TEST_FFFF("require that config resource works as expected",
                  get_json(f4, host_tag, config_path, empty_params));
 }
 
-TEST_FFFF("require that version resource works as expected",
+TEST_FFFF("version resource yields current version number",
           SimpleHealthProducer(), SimpleMetricsProducer(), SimpleComponentConfigProducer(),
           StateApi(f1, f2, f3))
 {

--- a/vespalib/src/tests/state_server/state_server_test.cpp
+++ b/vespalib/src/tests/state_server/state_server_test.cpp
@@ -310,7 +310,8 @@ TEST_FFFF("require that top-level urls are generated correctly",
     EXPECT_EQUAL("{\"resources\":["
                  "{\"url\":\"http://HOST/state/v1/health\"},"
                  "{\"url\":\"http://HOST/state/v1/metrics\"},"
-                 "{\"url\":\"http://HOST/state/v1/config\"}]}",
+                 "{\"url\":\"http://HOST/state/v1/config\"},"
+                 "{\"url\":\"http://HOST/state/v1/version\"}]}",
                  get_json(f4, host_tag, root_path, empty_params));
     EXPECT_EQUAL(get_json(f4, host_tag, root_path, empty_params),
                  get_json(f4, host_tag, short_root_path, empty_params));
@@ -325,6 +326,7 @@ TEST_FFFF("require that top-level resource list can be extended",
                  "{\"url\":\"http://HOST/state/v1/health\"},"
                  "{\"url\":\"http://HOST/state/v1/metrics\"},"
                  "{\"url\":\"http://HOST/state/v1/config\"},"
+                 "{\"url\":\"http://HOST/state/v1/version\"},"
                  "{\"url\":\"http://HOST/state/v1/custom\"}]}",
                  get_json(f4, host_tag, root_path, empty_params));
 }


### PR DESCRIPTION
Previously, only some services supported /state/v1/version. This commit adds support for it to the remaining services.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
