### PR TITLE
Propagate approximate message size from Document API <-> Storage API

### DIFF
--- a/storage/src/tests/storageserver/documentapiconvertertest.cpp
+++ b/storage/src/tests/storageserver/documentapiconvertertest.cpp
@@ -115,12 +115,14 @@ TEST_F(DocumentApiConverterTest, put) {
     documentapi::PutDocumentMessage putmsg(doc);
     putmsg.setTimestamp(1234);
     putmsg.setCondition(my_condition);
+    putmsg.setApproxSize(13371337);
 
     auto cmd = toStorageAPI<api::PutCommand>(putmsg);
     EXPECT_EQ(defaultBucket, cmd->getBucket());
     ASSERT_EQ(cmd->getDocument().get(), doc.get());
     EXPECT_EQ(cmd->getCondition(), my_condition);
     EXPECT_FALSE(cmd->get_create_if_non_existent());
+    EXPECT_EQ(cmd->getApproxByteSize(), 13371337);
 
     std::unique_ptr<mbus::Reply> reply = putmsg.createReply();
     ASSERT_TRUE(reply.get());
@@ -132,6 +134,7 @@ TEST_F(DocumentApiConverterTest, put) {
     EXPECT_EQ(mbusPut->getTimestamp(), 1234);
     EXPECT_EQ(mbusPut->getCondition(), my_condition);
     EXPECT_FALSE(mbusPut->get_create_if_non_existent());
+    EXPECT_EQ(mbusPut->getApproxSize(), 13371337);
 }
 
 TEST_F(DocumentApiConverterTest, put_with_create) {
@@ -167,6 +170,7 @@ TEST_F(DocumentApiConverterTest, update) {
         updateMsg.setOldTimestamp(1234);
         updateMsg.setNewTimestamp(5678);
         updateMsg.setCondition(my_condition);
+        updateMsg.setApproxSize(13371337);
         EXPECT_FALSE(updateMsg.has_cached_create_if_missing());
         EXPECT_EQ(updateMsg.create_if_missing(), create_if_missing);
 
@@ -178,6 +182,7 @@ TEST_F(DocumentApiConverterTest, update) {
         EXPECT_EQ(my_condition, updateCmd->getCondition());
         EXPECT_FALSE(updateCmd->has_cached_create_if_missing());
         EXPECT_EQ(updateCmd->create_if_missing(), create_if_missing);
+        EXPECT_EQ(updateCmd->getApproxByteSize(), 13371337);
 
         auto mbusReply = updateMsg.createReply();
         ASSERT_TRUE(mbusReply.get());
@@ -189,6 +194,7 @@ TEST_F(DocumentApiConverterTest, update) {
         EXPECT_EQ(api::Timestamp(5678), mbusUpdate->getNewTimestamp());
         EXPECT_EQ(my_condition, mbusUpdate->getCondition());
         EXPECT_EQ(mbusUpdate->create_if_missing(), create_if_missing);
+        EXPECT_EQ(mbusUpdate->getApproxSize(), 13371337);
 
         // Cached value of create_if_missing should override underlying update's value
         updateCmd->set_cached_create_if_missing(!create_if_missing);

--- a/storage/src/vespa/storage/storageserver/documentapiconverter.cpp
+++ b/storage/src/vespa/storage/storageserver/documentapiconverter.cpp
@@ -44,6 +44,7 @@ DocumentApiConverter::toStorageAPI(documentapi::DocumentMessage& fromMsg)
         auto to = std::make_unique<api::PutCommand>(bucket, from.stealDocument(), from.getTimestamp());
         to->setCondition(from.getCondition());
         to->set_create_if_non_existent(from.get_create_if_non_existent());
+        to->setApproxByteSize(from.getApproxSize());
         toMsg = std::move(to);
         break;
     }
@@ -54,6 +55,7 @@ DocumentApiConverter::toStorageAPI(documentapi::DocumentMessage& fromMsg)
         auto to = std::make_unique<api::UpdateCommand>(bucket, from.stealDocumentUpdate(), from.getNewTimestamp());
         to->setOldTimestamp(from.getOldTimestamp());
         to->setCondition(from.getCondition());
+        to->setApproxByteSize(from.getApproxSize());
         if (from.has_cached_create_if_missing()) {
             to->set_cached_create_if_missing(from.create_if_missing());
         }
@@ -210,6 +212,7 @@ DocumentApiConverter::toDocumentAPI(api::StorageCommand& fromMsg)
         to->setTimestamp(from.getTimestamp());
         to->setCondition(from.getCondition());
         to->set_create_if_non_existent(from.get_create_if_non_existent());
+        to->setApproxSize(from.getApproxByteSize());
         toMsg = std::move(to);
         break;
     }
@@ -223,6 +226,7 @@ DocumentApiConverter::toDocumentAPI(api::StorageCommand& fromMsg)
         if (from.has_cached_create_if_missing()) {
             to->set_cached_create_if_missing(from.create_if_missing());
         }
+        to->setApproxSize(from.getApproxByteSize());
         toMsg = std::move(to);
         break;
     }


### PR DESCRIPTION
@toregge please review
@hmusum FYI

The size of a message's payload is approximated by using the uncompressed wire size as a proxy for the true size (which may require expensive deserialization to know). Some wiring was missing in the protocol conversion component that caused the size to not be propagated internally.

Required for https://github.com/vespa-engine/system-test/pull/4421 to work.