### PR TITLE
Map backend `REJECTED` error code to HTTP 400 in Document V1

### DIFF
--- a/documentapi/abi-spec.json
+++ b/documentapi/abi-spec.json
@@ -381,6 +381,7 @@
       "public static final enum com.yahoo.documentapi.Response$Outcome NOT_FOUND",
       "public static final enum com.yahoo.documentapi.Response$Outcome INSUFFICIENT_STORAGE",
       "public static final enum com.yahoo.documentapi.Response$Outcome TIMEOUT",
+      "public static final enum com.yahoo.documentapi.Response$Outcome REJECTED",
       "public static final enum com.yahoo.documentapi.Response$Outcome ERROR"
     ]
   },

--- a/documentapi/src/main/java/com/yahoo/documentapi/Response.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/Response.java
@@ -117,6 +117,13 @@ public class Response {
         /** The operation timed out before it reached its destination. */
         TIMEOUT,
 
+        /**
+         * The operation was explicitly rejected by the backend.
+         * Some possible causes are a malformed payload or the operation exceeding
+         * configured maximum size limits. See the error message for details.
+         */
+        REJECTED,
+
         /** The operation failed for some unknown reason. */
         ERROR
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
@@ -52,6 +52,7 @@ import static com.yahoo.documentapi.Response.Outcome.CONDITION_FAILED;
 import static com.yahoo.documentapi.Response.Outcome.ERROR;
 import static com.yahoo.documentapi.Response.Outcome.INSUFFICIENT_STORAGE;
 import static com.yahoo.documentapi.Response.Outcome.NOT_FOUND;
+import static com.yahoo.documentapi.Response.Outcome.REJECTED;
 import static com.yahoo.documentapi.Response.Outcome.SUCCESS;
 import static com.yahoo.documentapi.Response.Outcome.TIMEOUT;
 
@@ -274,17 +275,23 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
     }
 
     private static Response.Outcome toOutcome(Reply reply) {
-        if (reply.getErrorCodes().contains(DocumentProtocol.ERROR_NO_SPACE))
+        if (reply.getErrorCodes().contains(DocumentProtocol.ERROR_NO_SPACE)) {
             return INSUFFICIENT_STORAGE;
-        if (reply.getErrorCodes().contains(DocumentProtocol.ERROR_TEST_AND_SET_CONDITION_FAILED))
+        }
+        if (reply.getErrorCodes().contains(DocumentProtocol.ERROR_TEST_AND_SET_CONDITION_FAILED)) {
             return CONDITION_FAILED;
+        }
         if (   reply instanceof UpdateDocumentReply && ! ((UpdateDocumentReply) reply).wasFound()
             || reply instanceof RemoveDocumentReply && ! ((RemoveDocumentReply) reply).wasFound()
             || reply.getErrorCodes().contains(DocumentProtocol.ERROR_DOCUMENT_NOT_FOUND)) {
             return NOT_FOUND;
         }
-        if (reply.getErrorCodes().contains(ErrorCode.TIMEOUT))
+        if (reply.getErrorCodes().contains(DocumentProtocol.ERROR_REJECTED)) {
+            return REJECTED;
+        }
+        if (reply.getErrorCodes().contains(ErrorCode.TIMEOUT)) {
             return TIMEOUT;
+        }
         return ERROR;
     }
 

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -107,7 +107,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -1146,6 +1145,7 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
                     case CONDITION_FAILED -> jsonResponse.commit(Response.Status.PRECONDITION_FAILED);
                     case INSUFFICIENT_STORAGE -> jsonResponse.commit(Response.Status.INSUFFICIENT_STORAGE);
                     case TIMEOUT -> jsonResponse.commit(Response.Status.GATEWAY_TIMEOUT);
+                    case REJECTED -> jsonResponse.commit(Response.Status.BAD_REQUEST);
                     case ERROR -> {
                         log.log(FINE, () -> "Exception performing document operation: " + response.getTextMessage());
                         jsonResponse.commit(Status.INTERNAL_SERVER_ERROR);

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -1012,6 +1012,26 @@ public class DocumentV1ApiTest {
                        "}", response.readAll());
         assertEquals(412, response.getStatus());
 
+        // REJECTED is a 400
+        access.session.expect((id, parameters) -> {
+            parameters.responseHandler().get().handleResponse(new Response(0, "backend not configured for danseband", Response.Outcome.REJECTED));
+            return new Result();
+        });
+        response = driver.sendRequest("http://localhost/document/v1/space/music/group/a/three?create=true", PUT,
+                """
+                {
+                  "fields": {
+                    "artist": { "assign": "Ole Ivars" }
+                  }
+                }""");
+        assertSameJson("""
+                {
+                  "pathId": "/document/v1/space/music/group/a/three",
+                  "id": "id:space:music:g=a:three",
+                  "message": "backend not configured for danseband"
+                }""", response.readAll());
+        assertEquals(400, response.getStatus());
+
         // OPTIONS gets options
         access.session.expect((__, ___) -> { throw new AssertionError("Not supposed to happen"); });
         response = driver.sendRequest("https://localhost/document/v1/space/music/docid/one", OPTIONS);


### PR DESCRIPTION
@bjorncs please review. Should ideally also be tested at a MessageBus level (no code remapping unit tests currently appear to exist there), but we have an end-to-end system test of this that is currently failing due to the lack of such a mapping.
@hmusum FYI.

Adds a distinct `REJECTED` code to the `Outcome` enum, which is then mapped to a HTTP 400 response by the `DocumentV1ApiHandler`. Otherwise we would fall back to HTTP 500 for these, which is not semantically ideal.

