### PR TITLE
Remove confusing and duplicate handling of zone in DeployState

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1381,7 +1381,7 @@
       "public abstract com.yahoo.config.provision.AthenzDomain tenantSecretDomain()",
       "public abstract java.lang.String athenzDnsSuffix()",
       "public abstract boolean hostedVespa()",
-      "public abstract com.yahoo.config.provision.Zone zone()",
+      "public com.yahoo.config.provision.Zone zone()",
       "public abstract java.util.Set endpoints()",
       "public abstract boolean isBootstrap()",
       "public abstract boolean isFirstTimeDeployment()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -135,7 +135,7 @@ public interface ModelContext {
         AthenzDomain tenantSecretDomain();
         String athenzDnsSuffix();
         boolean hostedVespa();
-        Zone zone();
+        default Zone zone() { return Zone.defaultZone(); } // TODO: remove when not used by config models anymore (8.516)
         Set<ContainerEndpoint> endpoints();
         boolean isBootstrap();
         boolean isFirstTimeDeployment();

--- a/config-model/src/main/java/com/yahoo/config/model/ConfigModelContext.java
+++ b/config-model/src/main/java/com/yahoo/config/model/ConfigModelContext.java
@@ -9,15 +9,10 @@ import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AnyConfigProducer;
 import com.yahoo.config.model.producer.TreeConfigProducer;
-import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterInfo;
-import com.yahoo.config.provision.ClusterInfo.Builder;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.model.VespaModel;
 
-import java.time.Duration;
 import java.util.Comparator;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -86,7 +81,7 @@ public final class ConfigModelContext {
             .ifPresent(builder::hostTTL);
         spec.instance(properties().applicationId().instance())
             .flatMap(instance -> instance.bcp().groups().stream()
-                                         .filter(group -> group.memberRegions().contains(properties().zone().region()))
+                                         .filter(group -> group.memberRegions().contains(deployState.zone().region()))
                                          .map(Group::deadline)
                                          .min(Comparator.naturalOrder()))
             .ifPresent(builder::bcpDeadline);

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -14,7 +14,6 @@ import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DataplaneToken;
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 
 import java.net.URI;
@@ -37,7 +36,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private ApplicationId applicationId = ApplicationId.defaultId();
     private List<ConfigServerSpec> configServerSpecs = List.of();
     private boolean hostedVespa = false;
-    private Zone zone = Zone.defaultZone();
     private Set<ContainerEndpoint> endpoints = Set.of();
     private boolean useDedicatedNodeForLogserver = false;
     private String jvmGCOptions = null;
@@ -90,7 +88,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public AthenzDomain tenantSecretDomain() { return null; }
     @Override public String athenzDnsSuffix() { return null; }
     @Override public boolean hostedVespa() { return hostedVespa; }
-    @Override public Zone zone() { return zone; }
     @Override public Set<ContainerEndpoint> endpoints() { return endpoints; }
     @Override public String jvmGCOptions(Optional<ClusterSpec.Type> clusterType) { return jvmGCOptions; }
     @Override public boolean isBootstrap() { return false; }
@@ -216,11 +213,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setEndpointCertificateSecrets(Optional<EndpointCertificateSecrets> endpointCertificateSecrets) {
         this.endpointCertificateSecrets = endpointCertificateSecrets;
-        return this;
-    }
-
-    public TestProperties setZone(Zone zone) {
-        this.zone = zone;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/QuotaValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/QuotaValidator.java
@@ -47,7 +47,7 @@ public class QuotaValidator implements Validator {
 
     private void validateBudget(BigDecimal budget, Context context,
                                 CapacityPolicies capacityPolicies) {
-        var zone = context.deployState().getProperties().zone();
+        var zone = context.deployState().zone();
         var application = context.model().applicationPackage().getApplicationId();
 
         var maxSpend = 0.0;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -29,11 +29,9 @@ import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DataplaneToken;
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provision.ZoneEndpoint;
-import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.jdisc.DataplaneProxyService;
 import com.yahoo.container.logging.AccessLog;
@@ -1034,7 +1032,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                 .getApplicationPackage()
                 .getDeploymentSpec()
                 .zoneEndpoint(context.properties().applicationId().instance(),
-                              context.properties().zone(),
+                              context.getDeployState().zone(),
                               cluster,
                               context.featureFlags().useNonPublicEndpointForTest());
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/ClusterInfoTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ClusterInfoTest.java
@@ -251,11 +251,11 @@ public class ClusterInfoTest {
                                   .zone(new Zone(cloud, SystemName.Public, Environment.prod, RegionName.from(region)))
                                   .properties(new TestProperties().setHostedVespa(true)
                                                                   .setCloudAccount(account)
-                                                                  .setApplicationId(ApplicationId.from(TenantName.defaultName(), ApplicationName.defaultName(), InstanceName.from(instance)))
-                                                                  .setZone(new Zone(Environment.prod, RegionName.from(region))))
+                                                                  .setApplicationId(ApplicationId.from(TenantName.defaultName(), ApplicationName.defaultName(), InstanceName.from(instance))))
                                   .endpoints(Set.of(new ContainerEndpoint("testcontainer", ApplicationClusterEndpoint.Scope.zone, List.of("tc.example.com"))))
                                   .modelHostProvisioner(provisioner)
                                   .provisioned(provisioner.provisioned())
+                                  .zone(new Zone(Environment.prod, RegionName.from(region)))
                                   .build();
         new VespaModel(new NullConfigModelRegistry(), deployState);
         return deployState.provisioned().capacities();

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
@@ -27,15 +27,17 @@ public class QuotaValidatorTest {
 
     @Test
     void test_deploy_under_quota() {
-        var tester = new ValidationTester(8, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
-        tester.deploy(null, getServices(4), Environment.prod, null, CONTAINER_CLUSTER);
+        var zone = publicZone;
+        var tester = new ValidationTester(8, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
+        tester.deploy(null, getServices(4), zone, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void test_deploy_above_quota_clustersize() {
-        var tester = new ValidationTester(14, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
+        var zone = publicZone;
+        var tester = new ValidationTester(14, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
         try {
-            tester.deploy(null, getServices(11), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(11), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("Clusters testCluster exceeded max cluster size of 10", e.getMessage());
@@ -44,9 +46,10 @@ public class QuotaValidatorTest {
 
     @Test
     void test_deploy_above_quota_budget() {
-        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
+        var zone = publicZone;
+        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(10), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $1.63 but your remaining quota is $1.25: Contact support to upgrade your plan.", e.getMessage());
@@ -55,15 +58,17 @@ public class QuotaValidatorTest {
 
     @Test
     void test_deploy_within_quota_budget_because_in_dev() {
-        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(devZone));
-        tester.deploy(null, getServices(10), Environment.dev, null, CONTAINER_CLUSTER);
+        var zone = devZone;
+        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
+        tester.deploy(null, getServices(10), zone, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void test_deploy_above_quota_budget_in_publiccd() {
-        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota.withBudget(BigDecimal.ONE)).setZone(publicCdZone));
+        var zone = publicCdZone;
+        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota.withBudget(BigDecimal.ONE)), zone);
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(10), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("publiccd: The resources used cost $1.63 but your remaining quota is $1.00: Contact support to upgrade your plan.", e.getMessage());
@@ -72,9 +77,10 @@ public class QuotaValidatorTest {
 
     @Test
     void test_deploy_max_resources_above_quota() {
-        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicCdZone));
+        var zone = publicCdZone;
+        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(10), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("publiccd: The resources used cost $1.63 but your remaining quota is $1.25: Contact support to upgrade your plan.", e.getMessage());
@@ -84,12 +90,13 @@ public class QuotaValidatorTest {
 
     @Test
     void test_deploy_above_quota_budget_in_dev() {
+        var zone = devZone;
         var quota = Quota.unlimited().withBudget(BigDecimal.valueOf(0.01));
-        var tester = new ValidationTester(5, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(devZone));
+        var tester = new ValidationTester(5, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
 
         // There is downscaling to 1 node per cluster in dev
         try {
-            tester.deploy(null, getServices(2, false), Environment.dev, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(2, false), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $0.16 but your remaining quota is $0.01: Contact support to upgrade your plan.", e.getMessage());
@@ -97,7 +104,7 @@ public class QuotaValidatorTest {
 
         // Override so that we will get 2 nodes in content cluster
         try {
-            tester.deploy(null, getServices(2, true), Environment.dev, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(2, true), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $0.33 but your remaining quota is $0.01: Contact support to upgrade your plan.", e.getMessage());
@@ -106,10 +113,11 @@ public class QuotaValidatorTest {
 
     @Test
     void test_deploy_with_negative_budget() {
+        var zone = publicZone;
         var quota = Quota.unlimited().withBudget(BigDecimal.valueOf(-1));
-        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
+        var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota), zone);
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(null, getServices(10), zone, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $-.-- but your remaining quota is $--.--: Please free up some capacity.",

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/TenantSecretValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/TenantSecretValidatorTest.java
@@ -36,12 +36,12 @@ public class TenantSecretValidatorTest {
 
     @Test
     void passes_on_services_without_secrets() throws Exception {
-        runTenantSecretValidator(publicCdProperties(), servicesWithoutSecrets());
+        runTenantSecretValidator(new TestProperties().setHostedVespa(true), servicesWithoutSecrets());
     }
 
     @Test
     void passes_on_existing_vault_and_secret() throws Exception {
-        TestProperties properties = publicCdProperties();
+        TestProperties properties = new TestProperties().setHostedVespa(true);
         properties.setTenantVaults(List.of(new TenantVault("vId1", "vault1", "",
                                                            List.of(new TenantVault.Secret("sId1", "secret1")))));
         runTenantSecretValidator(properties, servicesWithSecrets());
@@ -49,53 +49,53 @@ public class TenantSecretValidatorTest {
 
     @Test
     void fails_on_non_existent_vault() {
-        TestProperties properties = publicCdProperties();
+        TestProperties properties = new TestProperties().setHostedVespa(true);
         properties.setTenantVaults(List.of(new TenantVault("unusedVault", "_", "", List.of())));
 
         var exception = assertThrows(IllegalArgumentException.class,
-                                     () -> runTenantSecretValidator(properties, servicesWithSecrets()));
+                                     () -> runTenantSecretValidator(properties, servicesWithSecrets(), publicCdZone));
         assertEquals("Vault 'vault1' does not exist, or application does not have access to it", exception.getMessage());
     }
 
     @Test
     void fails_on_non_existent_secret() {
-        TestProperties properties = publicCdProperties();
+        TestProperties properties = new TestProperties().setHostedVespa(true);
         properties.setTenantVaults(List.of(new TenantVault("vId1", "vault1", "",
                                                            List.of(new TenantVault.Secret("unusedSecret", "_")))));
 
         var exception = assertThrows(IllegalArgumentException.class,
-                                     () -> runTenantSecretValidator(properties, servicesWithSecrets()));
+                                     () -> runTenantSecretValidator(properties, servicesWithSecrets(), publicCdZone));
         assertEquals("Secret 'secret1' is not defined in vault 'vault1'", exception.getMessage());
     }
 
     @Test
     void does_not_run_on_self_hosted() throws Exception {
         var properties = new TestProperties().setHostedVespa(false);
-        runTenantSecretValidator(properties, servicesWithSecrets());
+        runTenantSecretValidator(properties, servicesWithSecrets(), Zone.defaultZone());
     }
 
     @Test
     void does_not_run_on_hosted_non_public() throws Exception {
-        var properties = new TestProperties().setHostedVespa(true).setZone(new Zone(SystemName.cd, Environment.prod, RegionName.defaultName()));
-        runTenantSecretValidator(properties, servicesWithSecrets());
+        var properties = new TestProperties().setHostedVespa(true);
+        runTenantSecretValidator(properties, servicesWithSecrets(), new Zone(SystemName.cd, Environment.prod, RegionName.defaultName()));
     }
 
     private void runTenantSecretValidator(TestProperties properties, String services) throws IOException, SAXException {
+        runTenantSecretValidator(properties, services, Zone.defaultZone());
+    }
+
+    private void runTenantSecretValidator(TestProperties properties, String services, Zone zone) throws IOException, SAXException {
         ApplicationPackage app = new MockApplicationPackage.Builder()
                 .withServices(services)
                 .build();
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(app)
-                .zone(properties.zone())
+                .zone(zone)
                 .properties(properties)
                 .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
         ValidationTester.validate(new TenantSecretValidator(), model, deployState);
-    }
-
-    private TestProperties publicCdProperties() {
-        return new TestProperties().setHostedVespa(true).setZone(publicCdZone);
     }
 
     private String servicesWithoutSecrets() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UriBindingsValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UriBindingsValidatorTest.java
@@ -32,7 +32,7 @@ public class UriBindingsValidatorTest {
     Zone publicCdZone = new Zone(SystemName.PublicCd, Environment.prod, RegionName.defaultName());
 
     @Test
-    void fails_on_user_handler_binding_with_port() throws IOException, SAXException {
+    void fails_on_user_handler_binding_with_port() {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
             runUriBindingValidator(true, createServicesXmlWithHandler("http://*:4443/my-handler"));
         });
@@ -51,7 +51,7 @@ public class UriBindingsValidatorTest {
     }
 
     @Test
-    void fails_on_user_handler_binding_with_hostname() throws IOException, SAXException {
+    void fails_on_user_handler_binding_with_hostname() {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
             runUriBindingValidator(true, createServicesXmlWithHandler("http://myhostname/my-handler"));
         });
@@ -59,7 +59,7 @@ public class UriBindingsValidatorTest {
     }
 
     @Test
-    void fails_on_user_handler_binding_with_non_http_scheme() throws IOException, SAXException {
+    void fails_on_user_handler_binding_with_non_http_scheme() {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
             runUriBindingValidator(true, createServicesXmlWithHandler("ftp://*/my-handler"));
         });
@@ -67,7 +67,7 @@ public class UriBindingsValidatorTest {
     }
 
     @Test
-    void fails_on_invalid_filter_binding() throws IOException, SAXException {
+    void fails_on_invalid_filter_binding() {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
             runUriBindingValidator(true, createServicesXmlWithRequestFilterChain("https://*:4443/my-request-filer-chain"));
         });
@@ -79,6 +79,7 @@ public class UriBindingsValidatorTest {
         runUriBindingValidator(true, createServicesXmlWithHandler("http://*/my-handler"));
     }
 
+    @Test
     void allows_user_binding_with_wildcard_port() throws IOException, SAXException {
         runUriBindingValidator(true, createServicesXmlWithHandler("http://*:*/my-handler"));
     }
@@ -89,20 +90,22 @@ public class UriBindingsValidatorTest {
     }
 
     private void runUriBindingValidator(boolean isHosted, String servicesXml) throws IOException, SAXException {
-        runUriBindingValidator(new TestProperties().setZone(publicCdZone).setHostedVespa(isHosted), servicesXml, (__, message) -> {});
-    }
-    private void runUriBindingValidator(boolean isHosted, String servicesXml, Zone zone, DeployLogger deployLogger) throws IOException, SAXException {
-        runUriBindingValidator(new TestProperties().setZone(zone).setHostedVespa(isHosted), servicesXml, deployLogger);
+        runUriBindingValidator(new TestProperties().setHostedVespa(isHosted), servicesXml, publicCdZone, (__, message) -> {});
     }
 
-    private void runUriBindingValidator(TestProperties testProperties, String servicesXml, DeployLogger deployLogger) throws IOException, SAXException {
+    private void runUriBindingValidator(boolean isHosted, String servicesXml, Zone zone, DeployLogger deployLogger) throws IOException, SAXException {
+        runUriBindingValidator(new TestProperties().setHostedVespa(isHosted), servicesXml, zone, deployLogger);
+    }
+
+    private void runUriBindingValidator(TestProperties testProperties, String servicesXml,
+                                        Zone zone, DeployLogger deployLogger) throws IOException, SAXException {
         ApplicationPackage app = new MockApplicationPackage.Builder()
                 .withServices(servicesXml)
                 .build();
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(app)
                 .deployLogger(deployLogger)
-                .zone(testProperties.zone())
+                .zone(zone)
                 .properties(testProperties)
                 .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .build();

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationTester.java
@@ -48,25 +48,25 @@ public class ValidationTester {
     }
 
     /** Creates a validation tester with number of nodes available and the given test properties */
-    public ValidationTester(int nodeCount, boolean sharedHosts, TestProperties properties) {
-        this(new InMemoryProvisioner(nodeCount, sharedHosts), properties);
+    public ValidationTester(int nodeCount, boolean sharedHosts, TestProperties properties, Zone zone) {
+        this(new InMemoryProvisioner(nodeCount, sharedHosts), properties, zone);
     }
 
     /** Creates a validation tester with a given host provisioner */
     public ValidationTester(InMemoryProvisioner hostProvisioner) {
-        this(hostProvisioner, new TestProperties().setHostedVespa(true));
+        this(hostProvisioner, new TestProperties().setHostedVespa(true), Zone.defaultZone());
     }
 
     /** Creates a validation tester with a number of nodes available */
     public ValidationTester(int nodeCount) {
-        this(new InMemoryProvisioner(nodeCount, false), new TestProperties().setHostedVespa(true));
+        this(new InMemoryProvisioner(nodeCount, false), new TestProperties().setHostedVespa(true), Zone.defaultZone());
     }
 
     /** Creates a validation tester with a given host provisioner */
-    public ValidationTester(InMemoryProvisioner hostProvisioner, TestProperties testProperties) {
+    public ValidationTester(InMemoryProvisioner hostProvisioner, TestProperties testProperties, Zone zone) {
         this.hostProvisioner = hostProvisioner;
         this.properties = testProperties;
-        hostProvisioner.setEnvironment(testProperties.zone().environment());
+        hostProvisioner.setEnvironment(zone.environment());
     }
 
     /**
@@ -74,14 +74,14 @@ public class ValidationTester {
      *
      * @param previousModel the previous model, or null if no previous
      * @param services the services file content
-     * @param environment the environment this deploys to
+     * @param zone the zone this deploys to
      * @param validationOverrides the validation overrides file content, or null if none
      * @param containerCluster container cluster(s) which are declared in services
      * @return the new model and any change actions
      */
     public Pair<VespaModel, List<ConfigChangeAction>> deploy(VespaModel previousModel,
                                                              String services,
-                                                             Environment environment,
+                                                             Zone zone,
                                                              String validationOverrides,
                                                              String... containerCluster) {
         Instant now = LocalDate.parse("2000-01-01", DateTimeFormatter.ISO_DATE).atStartOfDay().atZone(ZoneOffset.UTC).toInstant();
@@ -98,9 +98,7 @@ public class ValidationTester {
                                                                                                List.of(name + ".example.com")))
                                                             .collect(Collectors.toSet());
         DeployState.Builder deployStateBuilder = new DeployState.Builder()
-                                                             .zone(new Zone(SystemName.defaultSystem(),
-                                                                            environment,
-                                                                            RegionName.defaultName()))
+                                                             .zone(zone)
                                                              .endpoints(containerEndpoints)
                                                              .applicationPackage(newApp)
                                                              .properties(properties)

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentClusterRemovalValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentClusterRemovalValidatorTest.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.application.api.ValidationOverrides;
-import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
@@ -17,13 +17,15 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ContentClusterRemovalValidatorTest {
 
+    private static final Zone zone = Zone.defaultZone();
+
     private final ValidationTester tester = new ValidationTester(8);
 
     @Test
     void testContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), zone, null, "contentClusterId.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices("newContentClusterId"), Environment.prod, null, "newContentClusterId.indexing");
+            tester.deploy(previous, getServices("newContentClusterId"), zone, null, "newContentClusterId.indexing");
             fail("Expected exception due to content cluster id change");
         }
         catch (IllegalArgumentException expected) {
@@ -35,8 +37,8 @@ public class ContentClusterRemovalValidatorTest {
 
     @Test
     void testOverridingContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        var result = tester.deploy(previous, getServices("newContentClusterId"), Environment.prod, removalOverride, "newContentClusterId.indexing"); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), zone, null, "contentClusterId.indexing").getFirst();
+        var result = tester.deploy(previous, getServices("newContentClusterId"), zone, removalOverride, "newContentClusterId.indexing"); // Allowed due to override
         assertEquals(result.getFirst().getContainerClusters().values().stream()
                            .flatMap(cluster -> cluster.getContainers().stream())
                            .map(container -> container.getServiceInfo())

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.application.api.ValidationOverrides;
-import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
@@ -20,13 +20,15 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ContentTypeRemovalValidatorTest {
 
+    private static final Zone zone = Zone.defaultZone();
+
     @Test
     void testContentTypeRemovalValidation() {
         ValidationTester tester = new ValidationTester();
 
-        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null, "test.indexing").getFirst();
+        VespaModel previous = tester.deploy(null, getServices("music"), zone, null, "test.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices("book"), Environment.prod, null, "test.indexing");
+            tester.deploy(previous, getServices("book"), zone, null, "test.indexing");
             fail("Expected exception due to removal of schema 'music");
         }
         catch (IllegalArgumentException expected) {
@@ -41,8 +43,8 @@ public class ContentTypeRemovalValidatorTest {
     void testOverridingContentTypeRemovalValidation() {
         ValidationTester tester = new ValidationTester();
 
-        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null, "test.indexing").getFirst();
-        tester.deploy(previous, getServices("book"), Environment.prod, removalOverride, "test.indexing"); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices("music"), zone, null, "test.indexing").getFirst();
+        tester.deploy(previous, getServices("book"), zone, removalOverride, "test.indexing"); // Allowed due to override
     }
 
     private static String getServices(String documentType) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidatorTest.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import org.junit.jupiter.api.Test;
@@ -13,6 +13,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Test that global attribute changes are detected by change validator.
  */
 public class GlobalDocumentChangeValidatorTest {
+
+    private static final Zone zone = Zone.defaultZone();
 
     @Test
     void testChangeGlobalAttribute() {
@@ -26,9 +28,9 @@ public class GlobalDocumentChangeValidatorTest {
 
     private void testChangeGlobalAttribute(boolean allowed, boolean oldGlobal, boolean newGlobal, String validationOverrides) {
         ValidationTester tester = new ValidationTester();
-        VespaModel oldModel = tester.deploy(null, getServices(oldGlobal), Environment.prod, validationOverrides, "default.indexing").getFirst();
+        VespaModel oldModel = tester.deploy(null, getServices(oldGlobal), zone, validationOverrides, "default.indexing").getFirst();
         try {
-            var actions = tester.deploy(oldModel, getServices(newGlobal), Environment.prod, validationOverrides, "default.indexing").getSecond();
+            var actions = tester.deploy(oldModel, getServices(newGlobal), zone, validationOverrides, "default.indexing").getSecond();
             assertTrue(allowed);
             assertEquals(validationOverrides == null ? 0 : 1, actions.size());
             if (validationOverrides != null) assertEquals(ClusterSpec.Id.from("default"), actions.get(0).clusterId());

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/IndexingModeChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/IndexingModeChangeValidatorTest.java
@@ -5,6 +5,9 @@ import com.yahoo.config.application.api.ValidationOverrides.ValidationException;
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.api.ConfigChangeReindexAction;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import org.junit.jupiter.api.Test;
@@ -21,13 +24,16 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class IndexingModeChangeValidatorTest {
 
+    private final Zone zone = Zone.defaultZone();
+    private final Zone devZone = new Zone(SystemName.main, Environment.dev, RegionName.defaultName());
+
     @Test
     void testChangingIndexModeFromIndexedToStreamingWhenDisallowedButInDev() {
         ValidationTester tester = new ValidationTester();
 
         VespaModel oldModel =
-                tester.deploy(null, getServices("index"), Environment.dev, "<validation-overrides />").getFirst();
-        List<ConfigChangeAction> actions = tester.deploy(oldModel, getServices("streaming"), Environment.dev, "<calidation-overrides />").getSecond();
+                tester.deploy(null, getServices("index"), devZone, "<validation-overrides />").getFirst();
+        List<ConfigChangeAction> actions = tester.deploy(oldModel, getServices("streaming"), devZone, "<calidation-overrides />").getSecond();
         assertReindexingChange("Document type 'music' in cluster 'default-content' changed indexing mode from 'indexed' to 'streaming'", actions);
     }
 
@@ -36,9 +42,9 @@ public class IndexingModeChangeValidatorTest {
         ValidationTester tester = new ValidationTester();
 
         VespaModel oldModel =
-                tester.deploy(null, getServices("index"), Environment.prod, "<validation-overrides />").getFirst();
+                tester.deploy(null, getServices("index"), zone, "<validation-overrides />").getFirst();
         try {
-            tester.deploy(oldModel, getServices("streaming"), Environment.prod, "<calidation-overrides />").getSecond();
+            tester.deploy(oldModel, getServices("streaming"), zone, "<calidation-overrides />").getSecond();
             fail("Should throw on disallowed config change action");
         }
         catch (ValidationException e) {
@@ -54,9 +60,9 @@ public class IndexingModeChangeValidatorTest {
         ValidationTester tester = new ValidationTester();
 
         VespaModel oldModel =
-                tester.deploy(null, getServices("index"), Environment.prod, validationOverrides).getFirst();
+                tester.deploy(null, getServices("index"), zone, validationOverrides).getFirst();
         List<ConfigChangeAction> changeActions =
-                tester.deploy(oldModel, getServices("streaming"), Environment.prod, validationOverrides).getSecond();
+                tester.deploy(oldModel, getServices("streaming"), zone, validationOverrides).getSecond();
 
         assertReindexingChange( // allowed=true due to validation override
                 "Document type 'music' in cluster 'default-content' changed indexing mode from 'indexed' to 'streaming'",
@@ -68,9 +74,9 @@ public class IndexingModeChangeValidatorTest {
         ValidationTester tester = new ValidationTester();
 
         VespaModel oldModel =
-                tester.deploy(null, getServices("index"), Environment.prod, validationOverrides).getFirst();
+                tester.deploy(null, getServices("index"), zone, validationOverrides).getFirst();
         List<ConfigChangeAction> changeActions =
-                tester.deploy(oldModel, getServices("store-only"), Environment.prod, validationOverrides).getSecond();
+                tester.deploy(oldModel, getServices("store-only"), zone, validationOverrides).getSecond();
 
         assertReindexingChange( // allowed=true due to validation override
                 "Document type 'music' in cluster 'default-content' changed indexing mode from 'indexed' to 'store-only'",

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyChangeValidatorTest.java
@@ -1,7 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
-import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class RedundancyChangeValidatorTest {
 
+    private static final Zone zone = Zone.defaultZone();
+
     private static final String redundancyOverride =
             "<validation-overrides>\n" +
             "    <allow until='2000-01-03'>redundancy-one</allow>\n" +
@@ -24,8 +26,8 @@ public class RedundancyChangeValidatorTest {
     public void testChangingRedundancyToOne() {
         try {
             var tester = new ValidationTester(6);
-            VespaModel previous = tester.deploy(null, getServices("test", 2), Environment.prod, null, "test.indexing").getFirst();
-            tester.deploy(previous, getServices("test", 1), Environment.prod, null, "test.indexing");
+            VespaModel previous = tester.deploy(null, getServices("test", 2), zone, null, "test.indexing").getFirst();
+            tester.deploy(previous, getServices("test", 1), zone, null, "test.indexing");
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
@@ -41,11 +43,11 @@ public class RedundancyChangeValidatorTest {
     @Test
     public void testChangingRedundancyToOneWithValidationOverride() {
         var tester = new ValidationTester(6);
-        VespaModel previous = tester.deploy(null, getServices("test", 2), Environment.prod, null, "test.indexing").getFirst();
-        previous = tester.deploy(previous, getServices("test", 1), Environment.prod, redundancyOverride, "test.indexing").getFirst();
+        VespaModel previous = tester.deploy(null, getServices("test", 2), zone, null, "test.indexing").getFirst();
+        previous = tester.deploy(previous, getServices("test", 1), zone, redundancyOverride, "test.indexing").getFirst();
 
         // Staying at one does not require an override
-        tester.deploy(previous, getServices("test", 1), Environment.prod, null, "test.indexing");
+        tester.deploy(previous, getServices("test", 1), zone, null, "test.indexing");
     }
 
     private static String getServices(String contentClusterId, int redundancy) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
@@ -6,6 +6,9 @@ import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
@@ -21,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ResourcesReductionValidatorTest {
 
     private static final String CONTAINER_CLUSTER = "default.indexing";
+    private static final Zone zone = Zone.defaultZone();
+    private static final Zone devZone = new Zone(SystemName.main, Environment.dev, RegionName.defaultName());
 
     private final NodeResources hostResources = new NodeResources(64, 128, 1000, 10);
     private final InMemoryProvisioner provisioner           = new InMemoryProvisioner(30, hostResources, true, InMemoryProvisioner.defaultHostResources);
@@ -32,17 +37,17 @@ public class ResourcesReductionValidatorTest {
     void ok_when_reduction_by_over_50_percent_in_hosted_dev() {
         var fromResources = new NodeResources(8, 64, 800, 1);
         var toResources = new NodeResources(8, 16, 800, 1);
-        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.dev, null, CONTAINER_CLUSTER).getFirst();
-        tester.deploy(previous, contentServices(6, toResources), Environment.dev, null, CONTAINER_CLUSTER);
+        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), devZone, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(6, toResources), devZone, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void fail_when_reduction_by_over_50_percent() {
         var fromResources = new NodeResources(8, 64, 800, 1);
         var toResources = new NodeResources(8, 16, 800, 1);
-        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), zone, null, CONTAINER_CLUSTER).getFirst();
         try {
-            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(previous, contentServices(6, toResources), zone, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         } catch (IllegalArgumentException expected) {
             assertResourceReductionException(expected, "from 64.0 to 16.0 memory GiB per node");
@@ -53,9 +58,9 @@ public class ResourcesReductionValidatorTest {
     void fail_when_reducing_multiple_resources_by_over_50_percent() {
         var fromResources = new NodeResources(8, 64, 800, 1);
         var toResources = new NodeResources(3, 16, 200, 1);
-        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), zone, null, CONTAINER_CLUSTER).getFirst();
         try {
-            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(previous, contentServices(6, toResources), zone, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         } catch (IllegalArgumentException expected) {
             assertResourceReductionException(expected, "from 8.0 to 3.0 vcpu per node");
@@ -64,28 +69,28 @@ public class ResourcesReductionValidatorTest {
 
     @Test
     void small_resource_decrease_is_allowed() {
-        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(1.5, 64, 800, 1)), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-        tester.deploy(previous, contentServices(6, new NodeResources(.5, 48, 600, 1)), Environment.prod, null, CONTAINER_CLUSTER);
+        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(1.5, 64, 800, 1)), zone, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(6, new NodeResources(.5, 48, 600, 1)), zone, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void reorganizing_resources_is_allowed() {
-        VespaModel previous = tester.deploy(null, contentServices(12, new NodeResources(2, 10, 100, 1)), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-        tester.deploy(previous, contentServices(4, new NodeResources(6, 30, 300, 1)), Environment.prod, null, CONTAINER_CLUSTER);
+        VespaModel previous = tester.deploy(null, contentServices(12, new NodeResources(2, 10, 100, 1)), zone, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(4, new NodeResources(6, 30, 300, 1)), zone, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void overriding_resource_decrease() {
-        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(8, 64, 800, 1)), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-        tester.deploy(previous, contentServices(6, new NodeResources(8, 16, 800, 1)), Environment.prod, resourcesReductionOverride, CONTAINER_CLUSTER); // Allowed due to override
+        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(8, 64, 800, 1)), zone, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(6, new NodeResources(8, 16, 800, 1)), zone, resourcesReductionOverride, CONTAINER_CLUSTER); // Allowed due to override
     }
 
     @Test
     void reduction_is_detected_when_going_from_unspecified_resources_container() {
         NodeResources toResources = defaultResources.withDiskGb(defaultResources.diskGb() / 5);
         try {
-            VespaModel previous = tester.deploy(null, containerServices(6, null), Environment.prod, null).getFirst();
-            tester.deploy(previous, containerServices(6, toResources), Environment.prod, null);
+            VespaModel previous = tester.deploy(null, containerServices(6, null), zone, null).getFirst();
+            tester.deploy(previous, containerServices(6, toResources), zone, null);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -97,8 +102,8 @@ public class ResourcesReductionValidatorTest {
     void reduction_is_detected_when_going_to_unspecified_resources_container() {
         NodeResources fromResources = defaultResources.withVcpu(defaultResources.vcpu() * 3);
         try {
-            VespaModel previous = tester.deploy(null, containerServices(6, fromResources), Environment.prod, null).getFirst();
-            tester.deploy(previous, containerServices(6, null), Environment.prod, null);
+            VespaModel previous = tester.deploy(null, containerServices(6, fromResources), zone, null).getFirst();
+            tester.deploy(previous, containerServices(6, null), zone, null);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -110,8 +115,8 @@ public class ResourcesReductionValidatorTest {
     void reduction_is_detected_when_going_from_unspecified_resources_content() {
         NodeResources toResources = defaultResources.withDiskGb(defaultResources.diskGb() / 5);
         try {
-            VespaModel previous = tester.deploy(null, contentServices(6, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null, CONTAINER_CLUSTER);
+            VespaModel previous = tester.deploy(null, contentServices(6, null), zone, null, CONTAINER_CLUSTER).getFirst();
+            tester.deploy(previous, contentServices(6, toResources), zone, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         } catch (IllegalArgumentException expected) {
             assertResourceReductionException(expected, "from 50.0 to 10.0 disk Gb per node");
@@ -122,8 +127,8 @@ public class ResourcesReductionValidatorTest {
     void reduction_is_detected_when_going_to_unspecified_resources_content() {
         NodeResources fromResources = defaultResources.withVcpu(defaultResources.vcpu() * 3);
         try {
-            VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-            tester.deploy(previous, contentServices(6, null), Environment.prod, null, CONTAINER_CLUSTER);
+            VespaModel previous = tester.deploy(null, contentServices(6, fromResources), zone, null, CONTAINER_CLUSTER).getFirst();
+            tester.deploy(previous, contentServices(6, null), zone, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -137,8 +142,8 @@ public class ResourcesReductionValidatorTest {
         int toNodes = 14;
         try {
             ValidationTester tester = new ValidationTester(33);
-            VespaModel previous = tester.deploy(null, contentServices(fromNodes, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-            tester.deploy(previous, contentServices(toNodes, null), Environment.prod, null, CONTAINER_CLUSTER);
+            VespaModel previous = tester.deploy(null, contentServices(fromNodes, null), zone, null, CONTAINER_CLUSTER).getFirst();
+            tester.deploy(previous, contentServices(toNodes, null), zone, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -151,9 +156,9 @@ public class ResourcesReductionValidatorTest {
     void testSizeReductionValidationSelfhosted() {
         var tester = new ValidationTester(provisionerSelfHosted);
 
-        VespaModel previous = tester.deploy(null, contentServices(10, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        VespaModel previous = tester.deploy(null, contentServices(10, null), zone, null, CONTAINER_CLUSTER).getFirst();
         try {
-            tester.deploy(previous, contentServices(4, null), Environment.prod, null, CONTAINER_CLUSTER);
+            tester.deploy(previous, contentServices(4, null), zone, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -169,23 +174,23 @@ public class ResourcesReductionValidatorTest {
     void testSizeReductionValidationMinimalDecreaseIsAllowed() {
         ValidationTester tester = new ValidationTester(30);
 
-        VespaModel previous = tester.deploy(null, contentServices(3, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-        tester.deploy(previous, contentServices(2, null), Environment.prod, null, CONTAINER_CLUSTER);
+        VespaModel previous = tester.deploy(null, contentServices(3, null), zone, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(2, null), zone, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void testOverridingSizeReductionValidation() {
         ValidationTester tester = new ValidationTester(33);
 
-        VespaModel previous = tester.deploy(null, contentServices(30, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
-        tester.deploy(previous, contentServices(14, null), Environment.prod, resourcesReductionOverride, CONTAINER_CLUSTER); // Allowed due to override
+        VespaModel previous = tester.deploy(null, contentServices(30, null), zone, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(14, null), zone, resourcesReductionOverride, CONTAINER_CLUSTER); // Allowed due to override
     }
 
     @Test
     void testRedundancyIncreaseValidation() {
-        VespaModel previous = tester.deploy(null, getServices(1, 3, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        VespaModel previous = tester.deploy(null, getServices(1, 3, 1), zone, null, "contentClusterId.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices(3, 3, 1), Environment.prod, null, "contentClusterId.indexing");
+            tester.deploy(previous, getServices(3, 3, 1), zone, null, "contentClusterId.indexing");
             fail("Expected exception due to redundancy increase");
         }
         catch (IllegalArgumentException expected) {
@@ -200,23 +205,23 @@ public class ResourcesReductionValidatorTest {
 
     @Test
     void testNoRedundancyIncreaseValidationErrorWhenIncreasingGroupsAndNodes() {
-        VespaModel previous = tester.deploy(null, getServices(1, 2, 2), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        tester.deploy(previous, getServices(1, 4, 4), Environment.prod, null, "contentClusterId.indexing");
+        VespaModel previous = tester.deploy(null, getServices(1, 2, 2), zone, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(1, 4, 4), zone, null, "contentClusterId.indexing");
     }
 
     @Test
     void testRedundancyIncreaseValidationWithGroups() {
         // Changing redundancy from 1 to 2 is allowed when having 2 nodes in 2 groups versus 3 nodes in 1 group
         // (effective redundancy for the cluster is 2 in both cases)
-        VespaModel previous = tester.deploy(null, getServices(1, 2, 2), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        tester.deploy(previous, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing");
+        VespaModel previous = tester.deploy(null, getServices(1, 2, 2), zone, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(2, 3, 1), zone, null, "contentClusterId.indexing");
     }
 
     @Test
     void testRedundancyDecreaseWithTooLargeNodeDecrease() {
         try {
-            VespaModel previous = tester.deploy(null, getServices(3, 7, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
-            tester.deploy(previous, getServices(2, 2, 1), Environment.prod, null, "contentClusterId.indexing");
+            VespaModel previous = tester.deploy(null, getServices(3, 7, 1), zone, null, "contentClusterId.indexing").getFirst();
+            tester.deploy(previous, getServices(2, 2, 1), zone, null, "contentClusterId.indexing");
             fail("Expected exception");
         }
         catch (IllegalArgumentException expected) {
@@ -230,8 +235,8 @@ public class ResourcesReductionValidatorTest {
 
     @Test
     void testOverridingContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        tester.deploy(previous, getServices(3, 3, 1), Environment.prod, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices(2, 3, 1), zone, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(3, 3, 1), zone, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
     }
 
     private static String getServices(int redundancy, int nodes, int groups) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/RedundancyOnFirstDeploymentValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/RedundancyOnFirstDeploymentValidatorTest.java
@@ -5,6 +5,9 @@ import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
@@ -17,14 +20,17 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class RedundancyOnFirstDeploymentValidatorTest {
 
+    private static final Zone zone = Zone.defaultZone();
+
     private final ValidationTester tester = new ValidationTester(7, false,
                                                                  new TestProperties().setFirstTimeDeployment(true)
-                                                                                     .setHostedVespa(true));
+                                                                                     .setHostedVespa(true),
+                                                                 zone);
 
     @Test
     void testRedundancyOnFirstDeploymentValidation() {
         try {
-            tester.deploy(null, getServices(1), Environment.prod, null, "contentClusterId.indexing");
+            tester.deploy(null, getServices(1), zone, null, "contentClusterId.indexing");
             fail("Expected exception due to redundancy 1");
         }
         catch (IllegalArgumentException expected) {
@@ -38,7 +44,7 @@ public class RedundancyOnFirstDeploymentValidatorTest {
 
     @Test
     void testOverridingRedundancyOnFirstDeploymentValidation() {
-        tester.deploy(null, getServices(1), Environment.prod, redundancyOneOverride, "contentClusterId.indexing"); // Allowed due to override
+        tester.deploy(null, getServices(1), zone, redundancyOneOverride, "contentClusterId.indexing"); // Allowed due to override
     }
 
     private static String getServices(int redundancy) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -341,8 +341,8 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                 .applicationPackage(applicationPackage)
                 .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties().setMultitenant(true)
-                                                .setHostedVespa(true)
-                                                .setZone(new Zone(environment, RegionName.from(region))))
+                                                .setHostedVespa(true))
+                .zone(new Zone(environment, RegionName.from(region)))
                 .build());
         assertEquals(2, model.hostSystem().getHosts().size());
         assertEquals(1, provisioner.provisionedClusters().size());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -423,9 +422,6 @@ public class ModelContextImpl implements ModelContext {
 
         @Override
         public boolean hostedVespa() { return hostedVespa; }
-
-        @Override
-        public Zone zone() { return zone; }
 
         @Override
         public Set<ContainerEndpoint> endpoints() { return endpoints; }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -90,7 +89,6 @@ public class ModelContextImplTest {
         assertEquals(ApplicationId.defaultId(), context.properties().applicationId());
         assertTrue(context.properties().configServerSpecs().isEmpty());
         assertTrue(context.properties().multitenant());
-        assertNotNull(context.properties().zone());
         assertFalse(context.properties().hostedVespa());
         assertEquals(endpoints, context.properties().endpoints());
         assertFalse(context.properties().isFirstTimeDeployment());


### PR DESCRIPTION
Zone could be set and used both in DeployState and in ModelContext.Properties. This is confusing and might lead to bugs, only get and set zone in DeployState.