### PR TITLE
Export new cluster controller-aggregated document metrics

### DIFF
--- a/metrics/src/main/java/ai/vespa/metrics/ClusterControllerMetrics.java
+++ b/metrics/src/main/java/ai/vespa/metrics/ClusterControllerMetrics.java
@@ -14,6 +14,8 @@ public enum ClusterControllerMetrics implements VespaMetrics {
     UP_COUNT("cluster-controller.up.count", Unit.NODE, "Number of content nodes up"),
     CLUSTER_STATE_CHANGE_COUNT("cluster-controller.cluster-state-change.count", Unit.NODE, "Number of nodes changing state"),
     NODES_NOT_CONVERGED("cluster-controller.nodes-not-converged", Unit.NODE, "Number of nodes not converging to the latest cluster state version"),
+    STORED_DOCUMENT_COUNT("cluster-controller.stored-document-count", Unit.DOCUMENT, "Total number of unique documents stored in the cluster"),
+    STORED_DOCUMENT_BYTES("cluster-controller.stored-document-bytes", Unit.BYTE, "Combined byte size of all unique documents stored in the cluster (not including replication)"),
     CLUSTER_BUCKETS_OUT_OF_SYNC_RATIO("cluster-controller.cluster-buckets-out-of-sync-ratio", Unit.FRACTION, "Ratio of buckets in the cluster currently in need of syncing"),
     BUSY_TICK_TIME_MS("cluster-controller.busy-tick-time-ms", Unit.MILLISECOND, "Time busy"),
     IDLE_TICK_TIME_MS("cluster-controller.idle-tick-time-ms", Unit.MILLISECOND, "Time idle"),

--- a/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
@@ -230,6 +230,8 @@ public class Vespa9VespaMetricSet {
         addMetric(metrics, ClusterControllerMetrics.UP_COUNT.max());
         addMetric(metrics, ClusterControllerMetrics.NODES_NOT_CONVERGED.max());
         addMetric(metrics, ClusterControllerMetrics.CLUSTER_BUCKETS_OUT_OF_SYNC_RATIO.max());
+        addMetric(metrics, ClusterControllerMetrics.STORED_DOCUMENT_COUNT.max());
+        addMetric(metrics, ClusterControllerMetrics.STORED_DOCUMENT_BYTES.max());
         addMetric(metrics, ClusterControllerMetrics.CLUSTER_STATE_CHANGE_COUNT.baseName());
         addMetric(metrics, ClusterControllerMetrics.BUSY_TICK_TIME_MS, EnumSet.of(max, sum, count));
         addMetric(metrics, ClusterControllerMetrics.IDLE_TICK_TIME_MS, EnumSet.of(max, sum, count));


### PR DESCRIPTION
@olaaun please review

Makes the following 2 metrics available:
 - `cluster-controller.stored-document-count`
 - `cluster-controller.stored-document-bytes`

