### PR TITLE
Extend iterator constness when iterating over const children.

### DIFF
--- a/searchlib/src/vespa/searchlib/aggregation/group.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/group.cpp
@@ -445,11 +445,11 @@ Group::Value::prune(const Value & b, uint32_t lastLevel, uint32_t currentLevel) 
     auto keep = new ChildP[b.getChildrenSize()];
     size_t kept(0);
     auto mine = iterateAllChildren();
-    auto others = b.iterateChildren();
+    auto others = b.iterateConstChildren();
     auto px = mine.begin();
-    auto py = others.cbegin();
+    auto py = others.begin();
     // Assumes that both lists are ordered by group id
-    while (py != others.cend() && px != mine.end()) {
+    while (py != others.end() && px != mine.end()) {
         if ((*py)->cmpId(**px) > 0) {
             px++;
         } else if ((*py)->cmpId(**px) == 0) {
@@ -473,11 +473,11 @@ Group::Value::mergePartial(const GroupingLevelList &levels, uint32_t firstLevel,
                            uint32_t currentLevel, const Value & b)
 {
     auto mine = iterateChildren();
-    auto others = b.iterateChildren();
+    auto others = b.iterateConstChildren();
     auto px = mine.begin();
-    auto py = others.cbegin();
+    auto py = others.begin();
     // Assumes that both lists are ordered by group id
-    while (py != others.cend() && px != mine.end()) {
+    while (py != others.end() && px != mine.end()) {
         if ((*py)->cmpId(**px) > 0) {
             px++;
         } else if ((*py)->cmpId(**px) == 0) {

--- a/searchlib/src/vespa/searchlib/aggregation/group.h
+++ b/searchlib/src/vespa/searchlib/aggregation/group.h
@@ -39,6 +39,7 @@ public:
     using ChildP = Group *;
     using GroupList = ChildP *;
     using ChildrenIteratorHelper = std::span<ChildP>;
+    using ConstChildrenIteratorHelper = std::span<const Group* const>;
     struct GroupEqual {
         GroupEqual(const GroupList * v) : _v(v) { }
         bool operator()(uint32_t a, uint32_t b) { return (*_v)[a]->getId().cmpFast((*_v)[b]->getId()) == 0; }
@@ -112,6 +113,9 @@ public:
         }
         ChildrenIteratorHelper iterateAllChildren() const {
             return ChildrenIteratorHelper(_children, _children + getAllChildrenSize());
+        }
+        ConstChildrenIteratorHelper iterateConstChildren() const {
+            return ConstChildrenIteratorHelper(_children, _children + _childrenLength);
         }
 
         const AggregationResult & getAggregationResult(size_t i) const noexcept { return static_cast<const AggregationResult &>(*_aggregationResults[i]); }


### PR DESCRIPTION
@arnej27959 : please review
@vekterli : FYI

Note: AppleClang doesn't yet support cbegin()/cend() member functions on std::span, but using begin()/end() should be ok when template argument to std::span is a const type.


