### PR TITLE
Simplify nginx template configuration logic.

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/DataplaneProxyService.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/DataplaneProxyService.java
@@ -220,15 +220,8 @@ public final class DataplaneProxyService extends AbstractComponent {
         try {
             String nginxTemplate = Files.readString(configTemplate);
 
-            String remoteExpr      = useAzureProxy ? "$remote_addr" : "$proxy_protocol_addr - $remote_addr";
-            String proxySuffix     = useAzureProxy ? "" : "proxy_protocol";
-            String proxyOn         = useAzureProxy ? "" : "proxy_protocol on;";
-            String proxySetHeaders = useAzureProxy ? "proxy_set_header X-Forwarded-For $http_x_forwarded_for;\n proxy_set_header X-Forwarded-Port $server_port;\n proxy_set_header X-Real-IP $remote_addr;" : "proxy_set_header X-Forwarded-For $proxy_protocol_addr;\n proxy_set_header X-Forwarded-Port $proxy_protocol_port;";
-
-            nginxTemplate = replace(nginxTemplate, "remote_addr_expr", remoteExpr);
+            String proxySuffix = useAzureProxy ? "" : "proxy_protocol";
             nginxTemplate = replace(nginxTemplate, "proxy_protocol_suffix", proxySuffix);
-            nginxTemplate = replace(nginxTemplate, "proxy_protocol_on", proxyOn);
-            nginxTemplate = replace(nginxTemplate, "proxy_set_headers", proxySetHeaders);
 
             nginxTemplate = replace(nginxTemplate, "client_cert", clientCert.toString());
             nginxTemplate = replace(nginxTemplate, "client_key", clientKey.toString());

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/DataplaneProxyServiceTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/DataplaneProxyServiceTest.java
@@ -162,10 +162,7 @@ public class DataplaneProxyServiceTest {
         Files.createDirectories(templatePath.getParent());
         String template =
                 """
-                        remote_expr:${remote_addr_expr}
                         proxy_suffix:${proxy_protocol_suffix}
-                        proxy_on:${proxy_protocol_on}
-                        proxy_headers:${proxy_set_headers}
                         client_cert:${client_cert}
                         client_key:${client_key}
                         server_cert:${server_cert}
@@ -189,10 +186,7 @@ public class DataplaneProxyServiceTest {
 
         String out = DataplaneProxyService.nginxConfig(templatePath, clientCert, clientKey, serverCert, serverKey, 1111, 2222, List.of("one", "two"), fs.getPath("/opt/vespa"), true);
 
-        assertTrue(out.contains("remote_expr:$remote_addr"), "Should use $remote_addr when on Azure");
         assertTrue(out.contains("proxy_suffix:"), "Suffix must be empty on Azure");
-        assertTrue(out.contains("proxy_on:"), "proxy_protocol on; must be removed on Azure");
-        assertTrue(out.contains("proxy_headers:proxy_set_header X-Forwarded-For $http_x_forwarded_for;"), "Should set Azure-specific X-Forwarded-For header");
         assertTrue(out.contains("one vespatoken;"), "Should map first endpoint");
         assertTrue(out.contains("two vespatoken;"), "Should map second endpoint");
     }
@@ -204,10 +198,7 @@ public class DataplaneProxyServiceTest {
         Files.createDirectories(templatePath.getParent());
         String template =
                 """
-                        remote_expr:${remote_addr_expr}
                         proxy_suffix:${proxy_protocol_suffix}
-                        proxy_on:${proxy_protocol_on}
-                        proxy_headers:${proxy_set_headers}
                         """;
         Files.writeString(templatePath, template);
 
@@ -216,10 +207,7 @@ public class DataplaneProxyServiceTest {
 
         String out = DataplaneProxyService.nginxConfig(templatePath, dummy, dummy, dummy, dummy, 1, 2, List.of("e"), fs.getPath("/pfx"), false);
 
-        assertTrue(out.contains("remote_expr:$proxy_protocol_addr - $remote_addr"), "Should include proxy_protocol_addr when not on Azure");
         assertTrue(out.contains("proxy_suffix:proxy_protocol"), "Should add 'proxy_protocol' suffix when not on Azure");
-        assertTrue(out.contains("proxy_on:proxy_protocol on;"), "Should enable proxy_protocol on when not on Azure");
-        assertTrue(out.contains("proxy_headers:proxy_set_header X-Forwarded-For $proxy_protocol_addr;"), "Should set proxy_protocol-based X-Forwarded-For header");
     }
 
     private DataplaneProxyService dataplaneProxyService(DataplaneProxyService.ProxyCommands proxyCommands) throws IOException {


### PR DESCRIPTION
Removed unnecessary logic for handling Azure-specific nginx configurations in `DataplaneProxyService`. Updated tests to reflect these simplifications by eliminating references to unused template placeholders and assertions.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
