### PR TITLE
support ONNX Float16_t (converting to/from float)

### DIFF
--- a/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
@@ -17,12 +17,23 @@ LOG_SETUP(".eval.onnx_wrapper");
 
 using vespalib::make_string_short::fmt;
 
+struct OnnxFp16 : public Ort::Float16_t {
+    OnnxFp16() : Ort::Float16_t() {}
+    OnnxFp16(float v) : Ort::Float16_t(v) {}
+    OnnxFp16(double v) : Ort::Float16_t(float(v)) {}
+    explicit operator double() const noexcept { return ToFloat(); }
+    explicit operator vespalib::BFloat16() const noexcept { return ToFloat(); }
+    explicit operator vespalib::eval::Int8Float() const noexcept { return ToFloat(); }
+};
+
 // as documented in onnxruntime_cxx_api.h :
 namespace Ort {
 template <>
 struct TypeToTensorType<vespalib::BFloat16> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16; };
 template <>
 struct TypeToTensorType<vespalib::eval::Int8Float> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8; };
+template <>
+struct TypeToTensorType<OnnxFp16> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16; };
 }
 
 namespace vespalib::eval {
@@ -41,6 +52,7 @@ struct TypifyOnnxElementType {
         case Onnx::ElementType::UINT16:   return f(Result<uint16_t>());
         case Onnx::ElementType::UINT32:   return f(Result<uint32_t>());
         case Onnx::ElementType::UINT64:   return f(Result<uint64_t>());
+        case Onnx::ElementType::FLOAT16:  return f(Result<OnnxFp16>());
         case Onnx::ElementType::BFLOAT16: return f(Result<BFloat16>());
         case Onnx::ElementType::FLOAT:    return f(Result<float>());
         case Onnx::ElementType::DOUBLE:   return f(Result<double>());
@@ -148,6 +160,7 @@ Onnx::ElementType make_element_type(ONNXTensorElementDataType element_type) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:   return Onnx::ElementType::UINT16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:   return Onnx::ElementType::UINT32;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:   return Onnx::ElementType::UINT64;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:  return Onnx::ElementType::FLOAT16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: return Onnx::ElementType::BFLOAT16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:    return Onnx::ElementType::FLOAT;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:   return Onnx::ElementType::DOUBLE;
@@ -334,6 +347,7 @@ Onnx::WirePlanner::best_cell_type(Onnx::ElementType type)
     case Onnx::ElementType::UINT8:    [[fallthrough]];
     case Onnx::ElementType::INT16:    [[fallthrough]];
     case Onnx::ElementType::UINT16:   [[fallthrough]];
+    case Onnx::ElementType::FLOAT16:  [[fallthrough]];
     case Onnx::ElementType::FLOAT:    return CellType::FLOAT;
     case Onnx::ElementType::INT32:    [[fallthrough]];
     case Onnx::ElementType::INT64:    [[fallthrough]];

--- a/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
@@ -17,14 +17,18 @@ LOG_SETUP(".eval.onnx_wrapper");
 
 using vespalib::make_string_short::fmt;
 
-struct OnnxFp16 : public Ort::Float16_t {
-    OnnxFp16() : Ort::Float16_t() {}
-    OnnxFp16(float v) : Ort::Float16_t(v) {}
-    OnnxFp16(double v) : Ort::Float16_t(float(v)) {}
+namespace vespalib {
+
+struct Float16 : public Ort::Float16_t {
+    Float16() : Ort::Float16_t() {}
+    Float16(float v) : Ort::Float16_t(v) {}
+    Float16(double v) : Ort::Float16_t(float(v)) {}
     explicit operator double() const noexcept { return ToFloat(); }
-    explicit operator vespalib::BFloat16() const noexcept { return ToFloat(); }
+    explicit operator BFloat16() const noexcept { return ToFloat(); }
     explicit operator vespalib::eval::Int8Float() const noexcept { return ToFloat(); }
 };
+
+} // namespace vespalib
 
 // as documented in onnxruntime_cxx_api.h :
 namespace Ort {
@@ -33,7 +37,7 @@ struct TypeToTensorType<vespalib::BFloat16> { static constexpr ONNXTensorElement
 template <>
 struct TypeToTensorType<vespalib::eval::Int8Float> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8; };
 template <>
-struct TypeToTensorType<OnnxFp16> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16; };
+struct TypeToTensorType<vespalib::Float16> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16; };
 }
 
 namespace vespalib::eval {
@@ -52,7 +56,7 @@ struct TypifyOnnxElementType {
         case Onnx::ElementType::UINT16:   return f(Result<uint16_t>());
         case Onnx::ElementType::UINT32:   return f(Result<uint32_t>());
         case Onnx::ElementType::UINT64:   return f(Result<uint64_t>());
-        case Onnx::ElementType::FLOAT16:  return f(Result<OnnxFp16>());
+        case Onnx::ElementType::FLOAT16:  return f(Result<Float16>());
         case Onnx::ElementType::BFLOAT16: return f(Result<BFloat16>());
         case Onnx::ElementType::FLOAT:    return f(Result<float>());
         case Onnx::ElementType::DOUBLE:   return f(Result<double>());

--- a/eval/src/vespa/eval/onnx/onnx_wrapper.h
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.h
@@ -47,7 +47,7 @@ public:
     };
 
     // supported onnx element types
-    enum class ElementType { INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64, BFLOAT16, FLOAT, DOUBLE };
+    enum class ElementType { INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64, FLOAT16, BFLOAT16, FLOAT, DOUBLE };
 
     // information about a single input or output tensor
     struct TensorInfo {


### PR DESCRIPTION
@havardpe please review

with this change we can analyze a model using IEEE fp16 type:

$ vespa-analyze-onnx-model model_fp16.onnx 
unspecified option[0](optimize model), fallback: true
vm_size: 167376 kB, vm_rss: 42364 kB, malloc_peak: 0 kb, malloc_curr: 792 (before loading model)
vm_size: 1281332 kB, vm_rss: 1164632 kB, malloc_peak: 0 kb, malloc_curr: 1114748 (after loading model)
model meta-data:
  input[0]: 'input_ids' long[batch_size][sequence_length]
  input[1]: 'attention_mask' long[batch_size][sequence_length]
  output[0]: 'token_embeddings' OnnxFp16[batch_size][sequence_length][1024]
  output[1]: 'sentence_embedding' OnnxFp16[batch_size][1024]
unspecified option[1](symbolic size 'batch_size'), fallback: 1
unspecified option[2](symbolic size 'sequence_length'), fallback: 1
[2025-05-05 12:27:26.658709] 519307/29422 (.eval.onnx_wrapper) warning: input 'input_ids' with element type 'long' is bound to vespa value with cell type 'double'; adding explicit conversion step (this conversion might be lossy)
[2025-05-05 12:27:26.658901] 519307/29422 (.eval.onnx_wrapper) warning: input 'attention_mask' with element type 'long' is bound to vespa value with cell type 'double'; adding explicit conversion step (this conversion might be lossy)
[2025-05-05 12:27:26.658955] 519307/29422 (.eval.onnx_wrapper) warning: output 'token_embeddings' with element type 'OnnxFp16' is bound to vespa value with cell type 'float'; adding explicit conversion step (this conversion might be lossy)
[2025-05-05 12:27:26.658979] 519307/29422 (.eval.onnx_wrapper) warning: output 'sentence_embedding' with element type 'OnnxFp16' is bound to vespa value with cell type 'float'; adding explicit conversion step (this conversion might be lossy)
test setup:
  input[0]: tensor(d0[1],d1[1]) -> long[1][1]
  input[1]: tensor(d0[1],d1[1]) -> long[1][1]
  output[0]: OnnxFp16[1][1][1024] -> tensor<float>(d0[1],d1[1],d2[1024])
  output[1]: OnnxFp16[1][1024] -> tensor<float>(d0[1],d1[1024])
unspecified option[3](max concurrent evaluations), fallback: 1
vm_size: 1281332 kB, vm_rss: 1164632 kB, malloc_peak: 0 kb, malloc_curr: 1114748 (no evaluations yet)
vm_size: 1386384 kB, vm_rss: 1270216 kB, malloc_peak: 0 kb, malloc_curr: 1219800 (concurrent evaluations: 1)
estimated model evaluation time: 339.404 ms
