### PR TITLE
Add system name parameter to factory-command create-release

### DIFF
--- a/.buildkite/factory-command.sh
+++ b/.buildkite/factory-command.sh
@@ -38,9 +38,11 @@ case $COMMAND in
     "$FACTORY_API/builds"
     ;;
   create-release)
+    SYSTEM_NAME=$1
+    if [[ -z $SYSTEM_NAME ]]; then SYSTEM_NAME="opensource"; fi
     $CURL -H "Authorization: Bearer $TOKEN" -d "{
         \"startSeconds\": $(date +%s),
-        \"systemName\": \"opensource\"
+        \"systemName\": \"$SYSTEM_NAME\"
     }" \
     "$FACTORY_API/releases"
     ;;

--- a/.buildkite/factory-command.sh
+++ b/.buildkite/factory-command.sh
@@ -68,10 +68,12 @@ case $COMMAND in
     ;;
   update-released-time)
     VERSION=$1
-    if [[ -z $VERSION ]]; then echo "Usage: $0 $COMMAND <version>"; exit 1; fi
+    SYSTEM_NAME=$2
+    if [[ -z $SYSTEM_NAME ]]; then SYSTEM_NAME="opensource"; fi
+    if [[ -z $VERSION ]]; then echo "Usage: $0 $COMMAND <version> [<systemName>]"; exit 1; fi
     $CURL -H "Authorization: Bearer $TOKEN" -d "{
         \"releasedSeconds\": $(date +%s),
-        \"systemName\": \"opensource\"
+        \"systemName\": \"${SYSTEM_NAME}\"
     }" \
     "$FACTORY_API/releases/$VERSION"
     ;;


### PR DESCRIPTION
- To allow calling it from the promote-to-pubilc gh workflow (uses 'public', while buildkite uses 'opensource')

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
