### PR TITLE
Stop using legacy flavor names

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
@@ -305,16 +305,9 @@ public class NodesSpecification {
 
     private static Pair<NodeResources, NodeResources> nodeResources(ModelElement nodesElement) {
         ModelElement resources = nodesElement.child("resources");
-        if (resources != null) {
-            return nodeResourcesFromResourcesElement(resources);
-        }
-        else if (nodesElement.stringAttribute("flavor") != null) { // legacy fallback
-            var flavorResources = NodeResources.fromLegacyName(nodesElement.stringAttribute("flavor"));
-            return new Pair<>(flavorResources, flavorResources);
-        }
-        else {
-            return new Pair<>(NodeResources.unspecified(), NodeResources.unspecified());
-        }
+        return resources == null
+                ? new Pair<>(NodeResources.unspecified(), NodeResources.unspecified())
+                : nodeResourcesFromResourcesElement(resources);
     }
 
     private static Pair<NodeResources, NodeResources> nodeResourcesFromResourcesElement(ModelElement element) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeFlavors.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeFlavors.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * All the flavors configured in this zone (i.e this should be called HostFlavors).
@@ -39,18 +38,13 @@ public class NodeFlavors {
         return new ArrayList<>(configuredFlavors.values());
     }
 
-    /** Returns a flavor by name, or empty if there is no flavor with this name and it cannot be created on the fly. */
+    /** Returns a flavor by name, or empty if there is no flavor with this name. */
     public Optional<Flavor> getFlavor(String name) {
-        if (configuredFlavors.containsKey(name))
-            return Optional.of(configuredFlavors.get(name));
-
-        NodeResources nodeResources = NodeResources.fromLegacyName(name);
-        return Optional.of(new Flavor(nodeResources));
+        return Optional.ofNullable(configuredFlavors.get(name));
     }
 
     /**
-     * Returns the flavor with the given name or throws an IllegalArgumentException if it does not exist
-     * and cannot be created on the fly.
+     * Returns the flavor with the given name or throws an IllegalArgumentException if it does not exist.
      */
     public Flavor getFlavorOrThrow(String flavorName) {
         return getFlavor(flavorName).orElseThrow(() -> new IllegalArgumentException("Unknown flavor '" + flavorName + "'"));

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
@@ -542,6 +542,7 @@ public class NodeResources {
      *
      * @throws IllegalArgumentException if the given string cannot be parsed as a serial form of this
      */
+    // TODO: Remove this when oldest config model in use is 8.518
     public static NodeResources fromLegacyName(String name) {
         if ( ! name.startsWith("d-"))
             throw new IllegalArgumentException("A node specification string must start by 'd-' but was '" + name + "'");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -238,7 +238,7 @@ public class RetiredExpirerTest {
         String ipv4 = "127.0.1.4";
         nameResolver.addRecord(retiredNode.hostname(), ipv4);
         Node node = Node.create(retiredNode.hostname(), IP.Config.ofEmptyPool(ipv4), retiredNode.hostname(),
-                                tester.asFlavor("default", NodeType.config), NodeType.config).build();
+                                tester.asFlavor("default"), NodeType.config).build();
         var nodes = List.of(node);
         nodes = nodeRepository.nodes().addNodes(nodes, Agent.system);
         nodes = nodeRepository.nodes().deallocate(nodes, Agent.system, getClass().getSimpleName());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
@@ -40,7 +40,7 @@ public class AclProvisioningTest {
 
     @Test
     public void trusted_nodes_for_allocated_node() {
-        NodeList configServers = tester.makeConfigServers(3, "d-1-4-10", Version.fromString("6.123.456"));
+        NodeList configServers = tester.makeConfigServers(3, "default", Version.fromString("6.123.456"));
 
         // Populate repo
         tester.makeReadyNodes(10, new NodeResources(1, 4, 10, 1));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
@@ -435,25 +435,6 @@ public class DynamicAllocationTest {
     }
 
     @Test
-    public void switching_from_legacy_flavor_syntax_to_resources_does_not_cause_reallocation() {
-        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).flavorsConfig(flavorsConfig()).build();
-        tester.makeReadyNodes(2, new Flavor(new NodeResources(5, 20, 1400, 3)), NodeType.host, 10, true);
-        tester.activateTenantHosts();
-
-        ApplicationId application = ProvisioningTester.applicationId();
-        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("test")).vespaVersion("1").build();
-
-        List<HostSpec> hosts1 = tester.prepare(application, cluster, Capacity.from(new ClusterResources(2, 1, NodeResources.fromLegacyName("d-2-8-500")), false, true));
-        tester.activate(application, hosts1);
-
-        NodeResources resources = new NodeResources(1.5, 8, 500, 0.3);
-        List<HostSpec> hosts2 = tester.prepare(application, cluster, Capacity.from(new ClusterResources(2, 1, resources)));
-        tester.activate(application, hosts2);
-
-        assertEquals(hosts1, hosts2);
-    }
-
-    @Test
     public void prefer_exclusive_network_switch() {
         // Hosts are provisioned, without switch information
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).flavorsConfig(flavorsConfig()).build();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -412,7 +412,7 @@ public class ProvisioningTester {
     }
 
     public List<Node> makeReadyNodes(int n, String flavor, NodeType type) {
-        return makeReadyNodes(n, asFlavor(flavor, type), Optional.empty(), type, 0);
+        return makeReadyNodes(n, asFlavor(flavor), Optional.empty(), type, 0);
     }
     public List<Node> makeReadyNodes(int n, NodeResources resources, NodeType type) {
         return makeReadyNodes(n, new Flavor(resources), Optional.empty(), type, 0);
@@ -429,7 +429,7 @@ public class ProvisioningTester {
     }
 
     public List<Node> makeProvisionedNodes(int n, String flavor, NodeType type, int ipAddressPoolSize, boolean dualStack) {
-        return makeProvisionedNodes(n, asFlavor(flavor, type), Optional.empty(), type, ipAddressPoolSize, dualStack);
+        return makeProvisionedNodes(n, asFlavor(flavor), Optional.empty(), type, ipAddressPoolSize, dualStack);
     }
     public List<Node> makeProvisionedNodes(int n, Flavor flavor, Optional<TenantName> reservedTo, NodeType type, int ipAddressPoolSize, boolean dualStack) {
         return makeProvisionedNodes(n, (index) -> "host-" + index + ".yahoo.com", flavor, reservedTo, type, ipAddressPoolSize, dualStack);
@@ -519,14 +519,14 @@ public class ProvisioningTester {
     }
 
     public List<Node> makeReadyNodes(int n, String flavor, NodeType type, int ipAddressPoolSize) {
-        return makeReadyNodes(n, asFlavor(flavor, type), Optional.empty(), type, ipAddressPoolSize);
+        return makeReadyNodes(n, asFlavor(flavor), Optional.empty(), type, ipAddressPoolSize);
     }
     public List<Node> makeReadyNodes(int n, Flavor flavor, Optional<TenantName> reservedTo, NodeType type, int ipAddressPoolSize) {
         return makeReadyNodes(n, flavor, reservedTo, type, ipAddressPoolSize, false);
     }
 
     public List<Node> makeReadyNodes(int n, String flavor, NodeType type, int ipAddressPoolSize, boolean dualStack) {
-        return makeReadyNodes(n, asFlavor(flavor, type), type, ipAddressPoolSize, dualStack);
+        return makeReadyNodes(n, asFlavor(flavor), type, ipAddressPoolSize, dualStack);
     }
     public List<Node> makeReadyNodes(int n, Flavor flavor, NodeType type, int ipAddressPoolSize, boolean dualStack) {
         return makeReadyNodes(n, flavor, Optional.empty(), type, ipAddressPoolSize, dualStack);
@@ -538,16 +538,9 @@ public class ProvisioningTester {
         return move(Node.State.ready, nodes);
     }
 
-    public Flavor asFlavor(String flavorString, NodeType type) {
-        Optional<Flavor> flavor = nodeFlavors.getFlavor(flavorString);
-        if (flavor.isEmpty()) {
-            // TODO: Remove the need for this by always adding hosts with a given capacity
-            if (type == NodeType.tenant) // Tenant nodes can have any (docker) flavor
-                flavor = Optional.of(new Flavor(NodeResources.fromLegacyName(flavorString)));
-            else
-                throw new IllegalArgumentException("No flavor '" + flavorString + "'");
-        }
-        return flavor.get();
+    public Flavor asFlavor(String flavorString) {
+        return nodeFlavors.getFlavor(flavorString)
+                          .orElseThrow(() -> new IllegalArgumentException("No flavor '" + flavorString + "'"));
     }
 
     /** Create one or more child nodes on a single host starting with index 1 */

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -1189,7 +1189,7 @@ public class NodesV2ApiTest {
     private static String asDockerNodeJson(String hostname, NodeType nodeType, String parentHostname, String... ipAddress) {
         return "{\"hostname\":\"" + hostname + "\", \"parentHostname\":\"" + parentHostname + "\"," +
                createIpAddresses(ipAddress) +
-               "\"id\":\"" + hostname + "\",\"flavor\":\"d-1-1-100\"" +
+               "\"id\":\"" + hostname + "\",\"resources\":{\"vcpu\": 1.0, \"memoryGb\": 1.0, \"diskGb\": 100.0, \"bandwidthGbps\": 0.3, \"architecture\": \"any\"}" +
                (nodeType != NodeType.tenant ? ",\"type\":\"" + nodeType +  "\"" : "") +
                "}";
     }


### PR DESCRIPTION
"Magic" legacy flavor names, e.g. d-2-8-50 was used to create node resources with the cpu, memory and disk specified. Stop using these, keep the method handling this until config models still using this are no longer in use.