### PR TITLE
Refactor temp directory creation using Files.createTempDirectory

### DIFF
--- a/application/src/main/java/com/yahoo/application/Application.java
+++ b/application/src/main/java/com/yahoo/application/Application.java
@@ -214,14 +214,12 @@ public final class Application implements AutoCloseable {
          * @throws IOException if the temporary directory could not be created
          */
         private static File makeTempDir(String prefix, String suffix) throws IOException {
-            File tmpDir = File.createTempFile(prefix, suffix, getTempDir());
-            if (!tmpDir.delete()) {
-                throw new RuntimeException("Could not delete temp directory: " + tmpDir);
+            try {
+                final File tmp = Files.createTempDirectory(prefix + suffix).toFile();
+                return tmp;
+            } catch (IOException e) {
+                throw new IOException("Could not create temp directory: " + prefix + suffix, e);
             }
-            if (!tmpDir.mkdirs()) {
-                throw new RuntimeException("Could not create temp directory: " + tmpDir);
-            }
-            return tmpDir;
         }
 
         /**


### PR DESCRIPTION
This PR refactors the makeTempDir method to use Java 7’s Files.createTempDirectory() API instead of the older pattern involving File.createTempFile(), manual deletion, and directory creation, which is potentially vulnerable

Reference
Something similar done here as well https://github.com/samtools/htsjdk/commit/269ba3fa507b9bab2dce54bf786d46b575db5527

Appreciate your time in reviewing this, thanks!

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
