### PR TITLE
rewrite partial fill logic with better semantics

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumDefinition.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumDefinition.java
@@ -5,6 +5,7 @@ import com.yahoo.data.access.Inspector;
 import com.yahoo.search.schema.DocumentSummary;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -30,6 +31,18 @@ public class DocsumDefinition {
                                      .map(field -> DocsumField.create(field.name(), field.type().asString()))
                                      .collect(Collectors.toUnmodifiableMap(DocsumField::getName, field -> field));
     }
+
+    // make a partial copy
+    DocsumDefinition(String name, DocsumDefinition all, Set<String> keepFields) {
+        this.name = name;
+        this.dynamic = all.dynamic;
+        this.fields = all.fields().entrySet()
+                .stream()
+                .filter(entry -> keepFields.contains(entry.getKey()))
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+
 
     public String name() { return name; }
     public Map<String, DocsumField> fields() { return fields; }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastHit.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/FastHit.java
@@ -561,10 +561,13 @@ public class FastHit extends Hit {
          * or a summary added later in this hit
          */
         private boolean shadowed(String name) {
-            if (hit.hasField(name)) return true;
+            if (hit.hasField(name)) {
+                return true;
+            }
             for (int i = 0; i < hit.summaries.size() - index; i++) {
-                if (hit.summaries.get(i).type.fields().containsKey(name))
+                if (hit.summaries.get(i).type.fields().containsKey(name)) {
                     return true;
+                }
             }
             return false;
         }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/IndexedBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/IndexedBackend.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.fastsearch;
 
+import com.yahoo.prelude.fastsearch.PartialSummaryHandler;
 import com.yahoo.prelude.querytransform.QueryRewrite;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -103,7 +104,7 @@ public class IndexedBackend extends VespaBackend {
         if (result.isFilled(summaryClass)) return;
 
         Query query = result.getQuery();
-        traceQuery(getName(), DispatchPhase.FILL, query, query.getOffset(), query.getHits(), 1, quotedSummaryClass(summaryClass));
+        traceQuery(getName(), DispatchPhase.FILL, query, query.getOffset(), query.getHits(), 1, quotedSummaryClass(query, summaryClass));
 
         try (FillInvoker invoker = getFillInvoker(result)) {
             invoker.fill(result, summaryClass);
@@ -140,8 +141,10 @@ public class IndexedBackend extends VespaBackend {
         return dispatcher.getFillInvoker(result, this);
     }
 
-    private static Optional<String> quotedSummaryClass(String summaryClass) {
-        return Optional.of(summaryClass == null ? "[null]" : "'" + summaryClass + "'");
+    private static Optional<String> quotedSummaryClass(Query q, String summaryClass) {
+        return Optional.of(PartialSummaryHandler
+                           .quotedSummaryClassName(summaryClass,
+                                                   q.getPresentation().getSummaryFields()));
     }
 
     public String toString() {

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -1,0 +1,229 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.fastsearch;
+
+import com.yahoo.prelude.fastsearch.DocumentDatabase;
+import com.yahoo.prelude.fastsearch.DocsumDefinitionSet;
+
+import com.yahoo.search.Result;
+import com.yahoo.search.result.Hit;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * PartialSummaryHandler is a helper class to help handling of fill()
+ * requests which only cover some of the possible summary fields.
+ *
+ * Usage:
+ * 1) construct from DocumentDatabase (it needs the DocsumDefinitionSet)
+ * 2) call wantToFill to specify intent
+ * 3) use askForSummary and askForFields for making the backend request
+ * 4) use needFill to see if the Hit actually needs filling
+ * 5) use effectiveDocsumDef for decoding the backend response
+ * 6) use markFilled to mark the Hit with what actually got filled
+ *
+ * @author arnej
+ */
+public class PartialSummaryHandler {
+
+    /** resolve summary class to use when none provided */
+    public static String resolveSummaryClass(Result result) {
+        // TODO: consider using "[presentation]" instead
+        return result.getQuery().getPresentation().getSummary();
+    }
+
+    private final DocsumDefinitionSet docsumDefinitions;
+    private DocsumDefinition effectiveDocsumDef = null;
+    private final Map<String, Set<String>> knownSummaryClasses = new HashMap<>();
+    private String summaryFromQuery = null;
+    private String summaryRequestedInFill = null;
+    private String askForSummary = null;
+    private String fillMarker = null;
+    private Set<String> fieldsFromQuery = null;
+    private Set<String> resultHasFilled = null;
+    private Set<String> askForFields = null;
+
+    public PartialSummaryHandler(DocumentDatabase docDb) {
+        this.docsumDefinitions = docDb.getDocsumDefinitionSet();
+    }
+
+    // for unit testing:
+    public PartialSummaryHandler(Map<String, Set<String>> knownSummaryClasses) {
+        this.docsumDefinitions = null;
+        this.knownSummaryClasses.putAll(knownSummaryClasses);
+    }
+
+    public void wantToFill(Result result, String summaryClass) {
+        this.summaryRequestedInFill = summaryClass;
+        analyzeResult(result);
+        // NOTE: ordering here is important, there are dependencies between these steps:
+        computeAskForSum();
+        computeAskForFields();
+        computeFillMarker();
+        computeEffectiveDocsumDef();
+    }
+
+    // which summary class we should ask the backend for:
+    public String askForSummary() { return askForSummary; }
+
+    // if requesting a specific set of fields, which ones, otherwise null
+    public Set<String> askForFields() { return askForFields; }
+
+    // does this Hit need to be filled
+    public boolean needFill(Hit hit) {
+        return needsMoreFill(hit.getFilled());
+    }
+
+    // what is the currently-effective DocsumDefinition
+    public DocsumDefinition effectiveDocsumDef() {
+        if (effectiveDocsumDef == null) {
+            if (docsumDefinitions == null) {
+                throw new IllegalStateException("missing docsumDefinitions");
+            }
+            throw new IllegalStateException("docsumDefinition missing for summary=" + askForSummary);
+        }
+        return effectiveDocsumDef;
+    }
+
+    // mark the Hit with how it actually got filled
+    public void markFilled(Hit hit) {
+        hit.setFilled(fillMarker);
+    }
+
+    private void analyzeResult(Result result) {
+        this.resultHasFilled = result.hits().getFilled();
+        var presentation = result.getQuery().getPresentation();
+        // TODO: summaryFromQuery is currently not used
+        this.summaryFromQuery = presentation.getSummary();
+        this.fieldsFromQuery = presentation.getSummaryFields();
+    }
+
+    private static boolean isFieldListRequest(String summaryClass) {
+        return summaryClass != null && summaryClass.startsWith("[f:");
+    }
+
+    private static boolean isDefaultRequest(String summaryClass) {
+        return summaryClass == null || summaryClass.equals("default");
+    }
+
+    private void computeAskForSum() {
+        this.askForSummary = summaryRequestedInFill;
+        if (isFieldListRequest(summaryRequestedInFill)) {
+            this.askForSummary = "default";
+        }
+    }
+
+    private void computeAskForFields() {
+        this.askForFields = null;
+        if (isFieldListRequest(summaryRequestedInFill)) {
+            var fieldSet = parseFieldList(summaryRequestedInFill);
+            if (! fieldSet.isEmpty()) {
+                this.askForFields = fieldSet;
+            }
+        } else if (isDefaultRequest(summaryRequestedInFill)) {
+            if (! fieldsFromQuery.isEmpty()) {
+                this.askForFields = fieldsFromQuery;
+            }
+        }
+    }
+
+    private void computeFillMarker() {
+        this.fillMarker = askForSummary;
+        if (askForFields != null) {
+            fillMarker = syntheticName(askForFields);
+        }
+    }
+
+    private static String syntheticName(Set<String> summaryFields) {
+        var buf = new StringBuilder();
+        for (String field : summaryFields) {
+            buf.append(buf.length() == 0 ? "[f:" : ",");
+            buf.append(field);
+        }
+        buf.append(']');
+        return buf.toString();
+    }
+
+    public static String quotedSummaryClassName(String summaryClass, Set<String> summaryFields) {
+        if (isDefaultRequest(summaryClass) && ! summaryFields.isEmpty()) {
+            return syntheticName(summaryFields);
+        } else if (summaryClass == null) {
+            return "[null]";
+        } else {
+            return "'" + summaryClass + "'";
+        }
+    }
+
+    private void computeEffectiveDocsumDef() {
+        if ((docsumDefinitions != null) && docsumDefinitions.hasDocsum(askForSummary)) {
+            effectiveDocsumDef = docsumDefinitions.getDocsum(askForSummary);
+            if (askForFields != null) {
+                effectiveDocsumDef = new DocsumDefinition(fillMarker, effectiveDocsumDef, askForFields);
+            }
+        }
+    }
+
+    private Set<String> parseFieldList(String fieldList) {
+        if (fieldList.startsWith("[f:") && fieldList.endsWith("]")) {
+            String content = fieldList.substring(3, fieldList.length() - 1);
+            String[] parts = content.split(",");
+            return Set.copyOf(Arrays.asList(parts));
+        }
+        return Set.of();
+    }
+
+    private Set<String> getFieldsForClass(String wantClass) {
+        if (! knownSummaryClasses.containsKey(wantClass)) {
+            if (docsumDefinitions != null && docsumDefinitions.hasDocsum(wantClass)) {
+                var docsumDef = docsumDefinitions.getDocsum(wantClass);
+                var fields = docsumDef.fields().keySet();
+                var fieldSet = Set.copyOf(fields);
+                knownSummaryClasses.put(wantClass, fieldSet);
+            }
+            else if (isFieldListRequest(wantClass)) {
+                var fieldSet = parseFieldList(wantClass);
+                knownSummaryClasses.put(wantClass, fieldSet);
+            }
+        }
+        var set = knownSummaryClasses.get(wantClass);
+        if (set != null) {
+            return set;
+        } else {
+            return Set.of();
+        }
+    }
+
+    private boolean needsMoreFill(Set<String> alreadyFilled) {
+        // unfillable?
+        if (alreadyFilled == null) return false;
+
+        // do we already have the entire thing?
+        if (alreadyFilled.contains(askForSummary)) return false;
+        // do we already have the entire subset?
+        if (alreadyFilled.contains(fillMarker)) return false;
+
+        // no, see what we have got:
+        var gotFields = new HashSet<String>();
+        for (var hasSummary : alreadyFilled) {
+            var hasSome = getFieldsForClass(hasSummary);
+            for (String field : hasSome) {
+                gotFields.add(field);
+            }
+        }
+
+        // check if got covers all that we want:
+        var wantFields = (askForFields == null ? getFieldsForClass(askForSummary) : askForFields);
+        for (String field : wantFields) {
+            if (! gotFields.contains(field)) {
+                // need this field
+                return true;
+            }
+        }
+        // we have everything needed
+        return false;
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/Searcher.java
+++ b/container-search/src/main/java/com/yahoo/search/Searcher.java
@@ -2,6 +2,7 @@
 package com.yahoo.search;
 
 import com.yahoo.component.ComponentId;
+import com.yahoo.prelude.fastsearch.PartialSummaryHandler;
 import com.yahoo.processing.Processor;
 import com.yahoo.processing.Response;
 import com.yahoo.search.searchchain.Execution;
@@ -156,7 +157,7 @@ public abstract class Searcher extends Processor {
      */
     public final void ensureFilled(Result result, String summaryClass, Execution execution) {
         if (summaryClass == null)
-            summaryClass = result.getQuery().getPresentation().getSummary();
+            summaryClass = PartialSummaryHandler.resolveSummaryClass(result);
 
         if ( ! result.isFilled(summaryClass)) {
             fill(result, summaryClass, execution);

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -91,10 +91,10 @@ public class SearchHandler extends LoggingRequestHandler {
     private static final String fallbackSearchChain = "vespa";
 
     private final CompiledQueryProfileRegistry queryProfileRegistry;
-    
+
     /** If present, responses from this will set the HTTP response header with this key to the host name of this */
     private final Optional<String> hostResponseHeaderKey;
-    
+
     private final String selfHostname = HostName.getLocalhost();
     private final Map<String, Embedder> embedders;
     private final ExecutionFactory executionFactory;
@@ -348,6 +348,7 @@ public class SearchHandler extends LoggingRequestHandler {
         Result result = execution.search(query);
 
         ensureQuerySet(result, query);
+        // TODO: consider fill(result, "[presentation]") instead
         execution.fill(result, result.getQuery().getPresentation().getSummary());
 
         traceExecutionTimes(query, result);
@@ -553,5 +554,3 @@ public class SearchHandler extends LoggingRequestHandler {
     }
 
 }
-
-

--- a/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
@@ -8,6 +8,7 @@ import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.Ping;
 import com.yahoo.prelude.Pong;
 import com.yahoo.language.process.SpecialTokenRegistry;
+import com.yahoo.prelude.fastsearch.PartialSummaryHandler;
 import com.yahoo.prelude.fastsearch.VespaBackend;
 import com.yahoo.processing.Processor;
 import com.yahoo.processing.Request;
@@ -519,7 +520,7 @@ public class Execution extends com.yahoo.processing.execution.Execution {
      * instead of "foo".
      *
      * @deprecated use fill(Result, String)
-     * 
+     *
      * @param result the result to fill
      */
     @Deprecated  // TODO Remove on Vespa 9.
@@ -540,11 +541,13 @@ public class Execution extends com.yahoo.processing.execution.Execution {
      * @param result the result to fill
      */
     public void fill(Result result) {
-        fill(result, result.getQuery().getPresentation().getSummary());
+        fill(result, PartialSummaryHandler.resolveSummaryClass(result));
     }
 
     /** Calls fill on the next searcher in this chain. If there is no next, nothing is done. */
     public void fill(Result result, String summaryClass) {
+        if (summaryClass == null)
+            summaryClass = PartialSummaryHandler.resolveSummaryClass(result);
         timer.sampleFill(nextIndex(), context.getDetailedDiagnostics());
         Searcher current = (Searcher)next(); // TODO: Allow but skip processors which are not searchers
         if (current == null) return;

--- a/container-search/src/main/java/com/yahoo/search/yql/FieldFilter.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/FieldFilter.java
@@ -54,7 +54,9 @@ public class FieldFilter extends Searcher {
                 var field = fields.next();
                 if ( ! result.getQuery().getPresentation().getSummaryFields().contains(field.getKey()) &&
                      ! syntheticFields.contains(field.getKey()))
+                {
                     fields.remove();
+                }
             }
         }
     }

--- a/container-search/src/test/java/com/yahoo/search/yql/FieldFilterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/FieldFilterTestCase.java
@@ -76,8 +76,7 @@ public class FieldFilterTestCase {
         execution.fill(result);
         assertEquals(2, result.getConcreteHitCount());
         assertEquals(Set.of(FIELD_B), result.hits().get(0).fieldKeys());
-        assertEquals(Set.of(FIELD_B, "matchfeatures", "rankfeatures", "summaryfeatures"),
-                     result.hits().get(1).fieldKeys());
+        assertEquals(Set.of(FIELD_B), result.hits().get(1).fieldKeys());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlFieldAndSourceTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlFieldAndSourceTestCase.java
@@ -88,8 +88,9 @@ public class YqlFieldAndSourceTestCase {
         Result result = execution.search(query);
         execution.fill(result);
         assertEquals(1, result.getConcreteHitCount());
-        assertTrue(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
+        assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
         assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        assertTrue(result.hits().get(0).isFilled("[f:" + FIELD1 + "]"));
     }
 
     @Test
@@ -100,7 +101,10 @@ public class YqlFieldAndSourceTestCase {
         assertEquals(1, result.getConcreteHitCount());
         assertTrue(result.hits().get(0).isFilled(THIRD_OPTION));
         assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
-        assertTrue(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        assertFalse(result.hits().get(0).isFilled("[f:" + FIELD2 + "]"));
+        execution.fill(result);
+        assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
+        assertTrue(result.hits().get(0).isFilled("[f:" + FIELD2 + "]"));
     }
 
     @Test
@@ -111,7 +115,8 @@ public class YqlFieldAndSourceTestCase {
         assertEquals(1, result.getConcreteHitCount());
         assertFalse(result.hits().get(0).isFilled(THIRD_OPTION));
         assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
-        assertTrue(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        assertTrue(result.hits().get(0).isFilled("[f:" + FIELD2 + "]"));
     }
 
     @Test
@@ -121,8 +126,9 @@ public class YqlFieldAndSourceTestCase {
         execution.fill(result, null);
         assertEquals(1, result.getConcreteHitCount());
         assertFalse(result.hits().get(0).isFilled(THIRD_OPTION));
-        assertTrue(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
+        assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
         assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        assertTrue(result.hits().get(0).isFilled("[f:" + FIELD3 + "]"));
     }
 
     @Test
@@ -143,8 +149,12 @@ public class YqlFieldAndSourceTestCase {
         execution.fill(result, THIRD_OPTION);
         assertEquals(1, result.getConcreteHitCount());
         assertTrue(result.hits().get(0).isFilled(THIRD_OPTION));
-        assertTrue(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
+        assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
         assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        execution.fill(result, "default");
+        assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
+        assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
+        assertTrue(result.hits().get(0).isFilled("[f:" + FIELD1 + "]"));
     }
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -12,11 +12,11 @@ class GetDocsumArgs
 {
 private:
     using FieldSet = vespalib::hash_set<std::string>;
-    std::string   _resultClassName;
+    std::string        _resultClassName;
     bool               _dumpFeatures;
     bool               _locations_possible;
     std::vector<char>  _stackDump;
-    std::string   _location;
+    std::string        _location;
     vespalib::duration _timeout;
     fef::Properties    _highlightTerms;
     FieldSet           _fields;


### PR DESCRIPTION
Before this, doing fill(result, "foo") could result in only getting parts of the "foo" document-summary if you also had "select a,b,c ..." in your YQL statement.

Now, only fill(result, "default") or equivalent will trigger the special only-some-field fetching.  Also, the hits will be marked with hit.setFilled("[f:a,b,c]") so that it doesn't lie about what we actually have.

We probably want to redefine some semantics so it's possible to see the difference between at least some of these:
* execution.fill(result)
* execution.fill(result, null)
* execution.fill(result, result.getQuery().getPresentation().getSummary())
* execution.fill(result, "mysummary")

NOTE: no unit tests yet, some semantics are still open for change