### PR TITLE
fix(lsp): Prevent vscode task from starting in watch mode

### DIFF
--- a/integration/schema-language-server/clients/vscode/.vscode/tasks.json
+++ b/integration/schema-language-server/clients/vscode/.vscode/tasks.json
@@ -1,32 +1,16 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-            "label": "default",
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
+    "version": "2.0.0",
+    "tasks": [
+        {
             "label": "langserver",
-			"type": "npm",
-			"script": "vscode:prepublish",
+            "type": "npm",
+            "script": "vscode:prepublish",
             "group": {
-                "kind": "build"
+                "kind": "build",
+                "isDefault": true
             },
-            "dependsOn": [
-                "default"
-            ]
-		}
-	]
+        }
+    ]
 }


### PR DESCRIPTION
Prevent vscode from watching files while developing.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
