### PR TITLE
Remove unused, deprecated method to get zone endpoint

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -521,7 +521,6 @@
       "public java.util.Map cloudAccounts()",
       "public com.yahoo.config.provision.Tags tags(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment)",
       "public java.util.Optional hostTTL(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
-      "public com.yahoo.config.provision.ZoneEndpoint zoneEndpoint(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.zone.ZoneId, com.yahoo.config.provision.ClusterSpec$Id)",
       "public com.yahoo.config.provision.ZoneEndpoint zoneEndpoint(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Zone, com.yahoo.config.provision.ClusterSpec$Id, boolean)",
       "public com.yahoo.config.provision.ZoneEndpoint zoneEndpoint(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.zone.ZoneId, com.yahoo.config.provision.ClusterSpec$Id, boolean)",
       "public java.lang.String xmlForm()",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
 
@@ -230,11 +229,6 @@ public final class DeploymentSpec {
     }
 
     Optional<Duration> hostTTL() { return hostTTL; }
-
-    // TODO: Used by models up to 8.502. Scheduled to be removed.
-    public ZoneEndpoint zoneEndpoint(InstanceName instance, ZoneId zone, ClusterSpec.Id cluster) {
-        return zoneEndpoint(instance, zone, cluster, false);
-    }
 
     // TODO: Used by models from 8.505.  Remove useNonPublicEndpointForTest argument once rolled out.
     public ZoneEndpoint zoneEndpoint(InstanceName instance, Zone zone, ClusterSpec.Id cluster, boolean useNonPublicEndpointForTest) {

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
@@ -650,15 +650,15 @@ public class DeploymentSpecWithoutInstanceTest {
 
         var zone = from(prod, RegionName.from("us-east"));
         assertEquals(ZoneEndpoint.defaultEndpoint,
-                     spec.zoneEndpoint(InstanceName.from("custom"), zone, ClusterSpec.Id.from("bax")));
+                     spec.zoneEndpoint(InstanceName.from("custom"), zone, ClusterSpec.Id.from("bax"), false));
         assertEquals(ZoneEndpoint.defaultEndpoint,
-                     spec.zoneEndpoint(InstanceName.from("default"), defaultId(), ClusterSpec.Id.from("bax")));
+                     spec.zoneEndpoint(InstanceName.from("default"), defaultId(), ClusterSpec.Id.from("bax"), false));
         assertEquals(ZoneEndpoint.defaultEndpoint,
-                     spec.zoneEndpoint(InstanceName.from("default"), zone, ClusterSpec.Id.from("bax")));
+                     spec.zoneEndpoint(InstanceName.from("default"), zone, ClusterSpec.Id.from("bax"), false));
 
         assertEquals(new ZoneEndpoint(false, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "barn"),
                                                            new AllowedUrn(AccessType.gcpServiceConnect, "nine"))),
-                     spec.zoneEndpoint(InstanceName.from("default"), zone, ClusterSpec.Id.from("froz")));
+                     spec.zoneEndpoint(InstanceName.from("default"), zone, ClusterSpec.Id.from("froz"), false));
     }
 
     @Test


### PR DESCRIPTION
Only tests was using this and no config models in use are using it anymore. Part 1, more to come.