### PR TITLE
Add app, instance and arch dims for customer rpm flag

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -178,9 +178,9 @@ public class PermanentFlags {
 
     public static final UnboundJacksonFlag<CustomerRpmServiceList> CUSTOMER_RPM_SERVICES = defineJacksonFlag(
             "customer-rpm-services", CustomerRpmServiceList.empty(), CustomerRpmServiceList.class,
-            "Specifies customer rpm services to run on enclave hosts.",
+            "Specifies customer rpm services to run on enclave tenant hosts.",
             "Takes effect on next host admin tick.",
-            TENANT_ID);
+            TENANT_ID, APPLICATION, INSTANCE_ID, ARCHITECTURE);
 
     private static final String VERSION_QUALIFIER_REGEX = "[a-zA-Z0-9_-]+";
     private static final Pattern QUALIFIER_PATTERN = Pattern.compile("^" + VERSION_QUALIFIER_REGEX + "$");


### PR DESCRIPTION
This setup assumes that missing/empty dimension value for no filtering is possible (or alternatively that we can use an empty blacklist).

E.g we can assume that a setup like this is possible:
- Flag config `(tenant_a, <no value>, <no value>, x86_64)`
- Applies to `(tenant_a, some_app, some_instance, x86_64)`

Could you confirm @hakonhall ?