### PR TITLE
avoid extra fill() round-trips

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -157,6 +157,16 @@ public class PartialSummaryHandler {
         }
     }
 
+    public static String enoughFields(String summaryClass, Result result) {
+        var summaryFields = result.getQuery().getPresentation().getSummaryFields();
+        if (isDefaultRequest(summaryClass) && ! summaryFields.isEmpty()) {
+            // it's enough to have the string we would use as fillMarker
+            return syntheticName(summaryFields);
+        } else {
+            return summaryClass;
+        }
+    }
+
     private void computeEffectiveDocsumDef() {
         if ((docsumDefinitions != null) && docsumDefinitions.hasDocsum(askForSummary)) {
             effectiveDocsumDef = docsumDefinitions.getDocsum(askForSummary);


### PR DESCRIPTION
This is a bit of a hack until more semantics are changed / more cleanup done.  Should make actual behavior OK as before, at least in the simple cases.

@bjormel FYI
