### PR TITLE
handle indexing statements with optional inputs

### DIFF
--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
@@ -43,7 +43,7 @@ public class DocumentScript {
         expression.resolve(documentType);
     }
 
-    public Expression getExpression() { return expression; }
+    public ScriptExpression getExpression() { return expression; }
 
     public Document execute(FieldValuesFactory fieldValuesFactory, Document document) {
         for (var i = document.iterator(); i.hasNext(); ) {

--- a/docprocs/src/test/cfg/documentmanager.cfg
+++ b/docprocs/src/test/cfg/documentmanager.cfg
@@ -3,13 +3,10 @@ doctype[0].name "document"
 doctype[0].idx 10000
 doctype[0].contentstruct 10001
 doctype[0].primitivetype[0].idx 10002
-doctype[0].primitivetype[0].internalid 0
 doctype[0].primitivetype[0].name "int"
 doctype[0].primitivetype[1].idx 10003
-doctype[0].primitivetype[1].internalid 5
 doctype[0].primitivetype[1].name "double"
 doctype[0].primitivetype[2].idx 10004
-doctype[0].primitivetype[2].internalid 2
 doctype[0].primitivetype[2].name "string"
 doctype[0].annotationtype[0].idx 10005
 doctype[0].annotationtype[0].name "proximity_break"
@@ -126,7 +123,6 @@ doctype[2].idx 10018
 doctype[2].inherits[0].idx 10000
 doctype[2].contentstruct 10019
 doctype[2].primitivetype[0].idx 10020
-doctype[2].primitivetype[0].internalid 1
 doctype[2].primitivetype[0].name "float"
 doctype[2].wsettype[0].idx 10021
 doctype[2].wsettype[0].elementtype 10004
@@ -392,7 +388,6 @@ doctype[4].idx 10025
 doctype[4].inherits[0].idx 10000
 doctype[4].contentstruct 10026
 doctype[4].primitivetype[0].idx 10028
-doctype[4].primitivetype[0].internalid 4
 doctype[4].primitivetype[0].name "long"
 doctype[4].arraytype[0].idx 10027
 doctype[4].arraytype[0].elementtype 10028

--- a/docprocs/src/test/cfg/documentmanager_inherit.cfg
+++ b/docprocs/src/test/cfg/documentmanager_inherit.cfg
@@ -3,13 +3,10 @@ doctype[0].name "document"
 doctype[0].idx 10000
 doctype[0].contentstruct 10001
 doctype[0].primitivetype[0].idx 10002
-doctype[0].primitivetype[0].internalid 0
 doctype[0].primitivetype[0].name "int"
 doctype[0].primitivetype[1].idx 10003
-doctype[0].primitivetype[1].internalid 5
 doctype[0].primitivetype[1].name "double"
 doctype[0].primitivetype[2].idx 10004
-doctype[0].primitivetype[2].internalid 2
 doctype[0].primitivetype[2].name "string"
 doctype[0].annotationtype[0].idx 10005
 doctype[0].annotationtype[0].name "proximity_break"
@@ -53,7 +50,6 @@ doctype[1].idx 10014
 doctype[1].inherits[0].idx 10000
 doctype[1].contentstruct 10015
 doctype[1].primitivetype[0].idx 10016
-doctype[1].primitivetype[0].internalid 1
 doctype[1].primitivetype[0].name "float"
 doctype[1].structtype[0].idx 10015
 doctype[1].structtype[0].name newssummary_summary.header

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
@@ -76,4 +76,24 @@ public class ScriptManagerTestCase {
         }
         assertNull(scriptMgr.getScript(new DocumentType("unknown")));
     }
+
+    @Test
+    public void requireThatInputFieldsCanBeOptional() {
+        var typeMgr = DocumentTypeManager.fromFile("src/test/cfg/documentmanager_inherit.cfg");
+        DocumentType docType = typeMgr.getDocumentType("newsarticle");
+        assertNotNull(docType);
+        IlscriptsConfig.Builder config = new IlscriptsConfig.Builder();
+        config.ilscript(new IlscriptsConfig.Ilscript.Builder().doctype("newsarticle")
+                        .content("(input uri || \"\") | attribute city")
+                        .content("clear_state | guard { (input uri || \"\") | set_language; input weight | attribute weight; }")
+                        .content("input title | index title"));
+        ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(config), null,
+                                                    Chunker.throwsOnUse.asMap(),
+                                                    Embedder.throwsOnUse.asMap(),
+                                                    FieldGenerator.throwsOnUse.asMap());
+        assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "title"));
+        assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "weight"));
+        assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "uri"));
+    }
+
 }


### PR DESCRIPTION
* an indexing statement that has just one required input but also some optional input can also be considered as a single-input statement.

this is to make it possible (but not easy) to allow partial update clearing (aka assign null) for fields with extra set_language wrappers.
