### PR TITLE
avoid entire fill phase when selecting only matchfeatures

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -12,6 +12,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * PartialSummaryHandler is a helper class to help handling of fill()
@@ -28,6 +30,7 @@ import java.util.Set;
  * @author arnej
  */
 public class PartialSummaryHandler {
+    private static final Logger log = Logger.getLogger(PartialSummaryHandler.class.getName());
 
     /** resolve summary class to use when none provided */
     public static String resolveSummaryClass(Result result) {
@@ -75,6 +78,11 @@ public class PartialSummaryHandler {
     // does this Hit need to be filled
     public boolean needFill(Hit hit) {
         return needsMoreFill(hit.getFilled());
+    }
+
+    // is the entire Result already filled as needed
+    public boolean resultAlreadyFilled() {
+        return ! needsMoreFill(resultHasFilled);
     }
 
     // what is the currently-effective DocsumDefinition
@@ -196,6 +204,8 @@ public class PartialSummaryHandler {
             else if (isFieldListRequest(wantClass)) {
                 var fieldSet = parseFieldList(wantClass);
                 knownSummaryClasses.put(wantClass, fieldSet);
+            } else {
+                log.log(Level.WARNING, "unknown summary class: " + wantClass);
             }
         }
         var set = knownSummaryClasses.get(wantClass);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InvokerResult.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InvokerResult.java
@@ -45,11 +45,12 @@ public class InvokerResult {
             if (hit.hasSortData()) {
                 fh.setSortData(hit.getSortData(), sorting);
             }
-            if (hit.hasMatchFeatures()) {
-                fh.setField("matchfeatures", hit.getMatchFeatures());
-            }
             fh.setQuery(query);
             fh.setFillable();
+            if (hit.hasMatchFeatures()) {
+                fh.setField("matchfeatures", hit.getMatchFeatures());
+                fh.setFilled("[f:matchfeatures]");
+            }
             fh.setCached(false);
             result.hits().add(fh);
         }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
@@ -82,6 +82,10 @@ public class RpcProtobufFillInvoker extends FillInvoker {
     @Override
     protected void sendFillRequest(Result result, String summaryClass) {
         partialSummaryHandler.wantToFill(result, summaryClass);
+        if (partialSummaryHandler.resultAlreadyFilled()) {
+            result.getQuery().trace(false, 3, "Skipping fill of ", summaryClass, " as result is already filled");
+            return;
+        }
         ListMap<Integer, FastHit> hitsByNode = hitsByNode(result);
         int queueSize = Math.max(hitsByNode.size(), resourcePool.knownNodeIds().size());
         responses = new LinkedBlockingQueue<>(queueSize);
@@ -113,6 +117,7 @@ public class RpcProtobufFillInvoker extends FillInvoker {
 
     @Override
     protected void getFillResults(Result result, String summaryClass) {
+        if (partialSummaryHandler.resultAlreadyFilled()) return;
         try {
             processResponses(result, summaryClass);
             result.hits().setSorted(false);


### PR DESCRIPTION
note: this also skips fill when fetching a subset of fields already filled.

@bratseth please review
@havardpe FYI

this also skips extra fills if you fill first a,b,c,d and then later fill a,c fields.