### PR TITLE
refactoring StreamingBackend

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
@@ -227,9 +227,12 @@ public abstract class VespaBackend {
             } else {
                 var db = getDocumentDatabase(query);
                 if (db != null && ! db.getDocsumDefinitionSet().hasDocsum(summaryClass)) {
+                    // intentional reference compare, true when execution.fill(result) was called:
                     if (summaryClass == query.getPresentation().getSummary()) {
+                        // problem comes from the query:
                         throw new IllegalInputException("invalid presentation.summary=" + summaryClass);
                     } else {
+                        // problem comes from a Searcher doing fill with explicit summaryClass:
                         throw new IllegalArgumentException("invalid fill() with summaryClass=" + summaryClass);
                     }
                 }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
@@ -20,7 +20,6 @@ import com.yahoo.search.result.Hit;
 import com.yahoo.searchlib.aggregation.Grouping;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,9 +44,9 @@ public abstract class VespaBackend {
     /** Default docsum class. null means "unset" and is the default value */
     private final String defaultDocsumClass;
 
-    /** Returns an iterator which returns all hits below this result **/
-    private static Iterator<Hit> hitIterator(Result result) {
-        return result.hits().unorderedDeepIterator();
+    /** Iterate over all hits below this result */
+    protected static Iterable<Hit> iterableHits(Result result) {
+        return () -> result.hits().unorderedDeepIterator();
     }
 
     /** The name of this source */
@@ -181,12 +180,12 @@ public abstract class VespaBackend {
         return result;
     }
 
+    // split by query
     private static List<Result> partitionHits(Result result, String summaryClass) {
         List<Result> parts = new ArrayList<>();
         TinyIdentitySet<Query> queryMap = new TinyIdentitySet<>(4);
 
-        for (Iterator<Hit> i = hitIterator(result); i.hasNext(); ) {
-            Hit hit = i.next();
+        for (Hit hit : iterableHits(result)) {
             if (hit instanceof FastHit fastHit) {
                 if ( ! fastHit.isFilled(summaryClass)) {
                     Query q = fastHit.getQuery();
@@ -228,7 +227,11 @@ public abstract class VespaBackend {
             } else {
                 var db = getDocumentDatabase(query);
                 if (db != null && ! db.getDocsumDefinitionSet().hasDocsum(summaryClass)) {
-                    throw new IllegalInputException("invalid presentation.summary=" + summaryClass);
+                    if (summaryClass == query.getPresentation().getSummary()) {
+                        throw new IllegalInputException("invalid presentation.summary=" + summaryClass);
+                    } else {
+                        throw new IllegalArgumentException("invalid fill() with summaryClass=" + summaryClass);
+                    }
                 }
             }
         }
@@ -319,82 +322,6 @@ public abstract class VespaBackend {
         if (query.getTrace().isTraceable(level + 2) && query.getTrace().getQuery()) {
             query.trace("YQL+ representation: " + query.yqlRepresentation(), level + 2);
         }
-    }
-
-    static class FillHitResult {
-        final boolean ok;
-        final String error;
-        FillHitResult(boolean ok) {
-            this(ok, null);
-        }
-        FillHitResult(boolean ok, String error) {
-            this.ok = ok;
-            this.error = error;
-        }
-    }
-
-    private FillHitResult fillHit(FastHit hit, DocsumPacket packet, String summaryClass) {
-        if (packet != null) {
-            byte[] docsumdata = packet.getData();
-            if (docsumdata.length > 0) {
-                return new FillHitResult(true, decodeSummary(summaryClass, hit, docsumdata));
-            }
-        }
-        return new FillHitResult(false);
-    }
-
-    static protected class FillHitsResult {
-        public final int skippedHits; // Number of hits not producing a summary.
-        public final String error; // Optional error message
-        FillHitsResult(int skippedHits, String error) {
-            this.skippedHits = skippedHits;
-            this.error = error;
-        }
-    }
-    /**
-     * Fills the hits.
-     *
-     * @return the number of hits that we did not return data for, and an optional error message.
-     *         when things are working normally we return 0.
-     */
-     protected FillHitsResult fillHits(Result result, DocsumPacket[] packets, String summaryClass) {
-        int skippedHits = 0;
-        String lastError = null;
-        int packetIndex = 0;
-        for (Iterator<Hit> i = hitIterator(result); i.hasNext();) {
-            Hit hit = i.next();
-
-            if (hit instanceof FastHit fastHit && ! hit.isFilled(summaryClass)) {
-                DocsumPacket docsum = packets[packetIndex];
-
-                packetIndex++;
-                FillHitResult fr = fillHit(fastHit, docsum, summaryClass);
-                if ( ! fr.ok ) {
-                    skippedHits++;
-                }
-                if (fr.error != null) {
-                    result.hits().addError(ErrorMessage.createTimeout(fr.error));
-                    skippedHits++;
-                    lastError = fr.error;
-                }
-            }
-        }
-        result.hits().setSorted(false);
-        return new FillHitsResult(skippedHits, lastError);
-    }
-
-    private String decodeSummary(String summaryClass, FastHit hit, byte[] docsumdata) {
-        DocumentDatabase db = getDocumentDatabase(hit.getQuery());
-        hit.setField(Hit.SDDOCNAME_FIELD, db.schema().name());
-        return decodeSummary(summaryClass, hit, docsumdata, db.getDocsumDefinitionSet());
-    }
-
-    private static String decodeSummary(String summaryClass, FastHit hit, byte[] docsumdata, DocsumDefinitionSet docsumSet) {
-        String error = docsumSet.lazyDecode(summaryClass, docsumdata, hit);
-        if (error == null) {
-            hit.setFilled(summaryClass);
-        }
-        return error;
     }
 
     public void shutDown() { }

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.streamingvisitors;
 
 import com.yahoo.document.select.parser.ParseException;
 import com.yahoo.messagebus.Trace;
+import com.yahoo.prelude.fastsearch.PartialSummaryHandler;
 import com.yahoo.prelude.fastsearch.TimeoutException;
 import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
@@ -19,6 +20,19 @@ import java.util.Set;
  * @author Ulf Carlin
  */
 interface Visitor {
+
+    record Context(String searchCluster,
+                   String schema,
+                   int traceLevelOverride,
+                   PartialSummaryHandler partialSummaryHandler)
+    {
+        Context(String searchCluster, String schema) {
+            this(searchCluster, schema, 0);
+        }
+        Context(String searchCluster, String schema, int traceLevelOverride) {
+            this(searchCluster, schema, traceLevelOverride, null);
+        }
+    }
 
     void doSearch() throws InterruptedException, ParseException, TimeoutException;
 

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VisitorFactory.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VisitorFactory.java
@@ -11,6 +11,6 @@ import com.yahoo.search.Query;
  */
 interface VisitorFactory {
 
-    Visitor createVisitor(Query query, String searchCluster, Route route, String schema, int traceLevelOverride);
+    Visitor createVisitor(Query query, Route route, Visitor.Context context);
 
 }

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingSearcherTestCase.java
@@ -157,8 +157,8 @@ public class StreamingSearcherTestCase {
         public MockVisitor lastCreatedVisitor;
 
         @Override
-        public Visitor createVisitor(Query query, String searchCluster, Route route, String documentType, int traceLevelOverride) {
-            lastCreatedVisitor = new MockVisitor(query, searchCluster, route, documentType, traceLevelOverride);
+        public Visitor createVisitor(Query query, Route route, Visitor.Context context) {
+            lastCreatedVisitor = new MockVisitor(query, context.searchCluster(), route, context.schema(), context.traceLevelOverride());
             return lastCreatedVisitor;
         }
     }

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingVisitorTest.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingVisitorTest.java
@@ -312,7 +312,8 @@ public class StreamingVisitorTest {
     }
 
     private void verifyVisitorOk(MockVisitorSessionFactory factory, QueryArguments qa, Route route, String searchCluster) throws Exception {
-        StreamingVisitor visitor = new StreamingVisitor(buildQuery(qa), searchCluster, route, "mytype", factory, 0);
+        var context = new Visitor.Context(searchCluster, "mytype", 0);
+        StreamingVisitor visitor = new StreamingVisitor(buildQuery(qa), route, factory, context);
         visitor.doSearch();
         verifyVisitorParameters(factory.getParams(), qa, searchCluster, "mytype", route);
         supplyResults(visitor);
@@ -320,7 +321,8 @@ public class StreamingVisitorTest {
     }
 
     private void verifyVisitorFails(MockVisitorSessionFactory factory, QueryArguments qa, Route route, String searchCluster) throws Exception {
-        StreamingVisitor visitor = new StreamingVisitor(buildQuery(qa), searchCluster, route, "mytype", factory, 0);
+        var context = new Visitor.Context(searchCluster, "mytype", 0);
+        StreamingVisitor visitor = new StreamingVisitor(buildQuery(qa), route, factory, context);
         try {
             visitor.doSearch();
             fail("Visitor did not fail");


### PR DESCRIPTION
* use Iterable / modern for loops
* differentiate between invalid query and invalid programmatic fill
* move helper classes and methods only used for streaming from VespaBackend to StreamingBackend
* pack some data used together into a Context, which can also carry around a PartialSummaryHandler (as yet unused)
* no functional changes

@bjorncs or @bratseth please review
