### PR TITLE
Increase max number of unconsumed request content reads

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -148,6 +148,11 @@ public class ConnectorFactory {
 
         httpConfig.setHttpCompliance(newHttpCompliance(connectorConfig));
 
+        // Sets the maximum amount of reads that can be done by the HttpStream.
+        // if the content is not fully consumed by the application.
+        // Overriding to a higher value to avoid unnecessary connection resets on application layer back-pressure.
+        httpConfig.setMaxUnconsumedRequestContentReads(64);
+
         // TODO Vespa 9 Use default URI compliance (LEGACY == old Jetty 9.4 compliance)
         httpConfig.setUriCompliance(UriCompliance.LEGACY);
         if (isSslEffectivelyEnabled(connectorConfig)) {


### PR DESCRIPTION
Allow for more unconsumed reads per stream to avoid unneccesary connection resets.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
