### PR TITLE
DocumentScanIterator should start checking on highest used lid

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
@@ -11,7 +11,7 @@ using Iterator = IDocumentMetaStore::Iterator;
 
 DocumentScanIterator::DocumentScanIterator(const IDocumentMetaStore &metaStore)
     : _metaStore(metaStore),
-      _lastLid(_metaStore.getCommittedDocIdLimit()),
+      _lastLid(_metaStore.getLidUsageStats().getHighestUsedLid() + 1),
       _itrValid(true)
 {
 }


### PR DESCRIPTION
When the scan starts a lid limit it needs to check all lids down to highest actually-used, wasting lots of time - especially if the job gets blocked and keep restarting.
@toregge please review
@vekterli @bjormel FYI
