### PR TITLE
more usage of PartialSummaryHandler:

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/IndexedBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/IndexedBackend.java
@@ -78,7 +78,7 @@ public class IndexedBackend extends VespaBackend {
                 // contain the data we need. If we fetch the default
                 // one we end up fetching docsums twice unless the
                 // user also requested the default one.
-                fill(result, query.getPresentation().getSummary()); // ARGH
+                fill(result, PartialSummaryHandler.resolveSummaryClass(result)); // ARGH
             }
             return result;
         } catch (TimeoutException e) {

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
@@ -226,15 +226,9 @@ public abstract class VespaBackend {
                 return null;
             } else {
                 var db = getDocumentDatabase(query);
-                if (db != null && ! db.getDocsumDefinitionSet().hasDocsum(summaryClass)) {
-                    // intentional reference compare, true when execution.fill(result) was called:
-                    if (summaryClass == query.getPresentation().getSummary()) {
-                        // problem comes from the query:
-                        throw new IllegalInputException("invalid presentation.summary=" + summaryClass);
-                    } else {
-                        // problem comes from a Searcher doing fill with explicit summaryClass:
-                        throw new IllegalArgumentException("invalid fill() with summaryClass=" + summaryClass);
-                    }
+                if (db != null) {
+                    var partialSummaryHandler = new PartialSummaryHandler(db);
+                    partialSummaryHandler.validateSummaryClass(summaryClass, query);
                 }
             }
         }

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -349,7 +349,7 @@ public class SearchHandler extends LoggingRequestHandler {
 
         ensureQuerySet(result, query);
         // TODO: consider fill(result, "[presentation]") instead
-        execution.fill(result, result.getQuery().getPresentation().getSummary());
+        execution.fill(result);
 
         traceExecutionTimes(query, result);
         traceVespaVersion(query);

--- a/container-search/src/main/java/com/yahoo/search/searchchain/AsyncExecution.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/AsyncExecution.java
@@ -116,7 +116,7 @@ public class AsyncExecution {
     public FutureResult searchAndFill(Query query) {
         return getFutureResult(execution.context().executor(), () -> {
             Result result = execution.search(query);
-            execution.fill(result, query.getPresentation().getSummary());
+            execution.fill(result);
             return result;
         }, query);
     }

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
@@ -141,7 +141,7 @@ public class StreamingBackend extends VespaBackend {
                                                                      "streaming.groupname or streaming.selection"));
         }
         try {
-            ensureLegalSummaryClass(query, query.getPresentation().getSummary());
+            ensureLegalSummaryClass(query, PartialSummaryHandler.PRESENTATION);
         } catch (IllegalInputException e) {
             return new Result(query, ErrorMessage.createIllegalQuery(Exceptions.toMessageString(e)));
         }


### PR DESCRIPTION
* move summary class validation
* avoid fill with explicit query.getPresentation().getSummary()
* prepare to change fill(result) to use [presentation]

@bjorncs / @bratseth please review
