### PR TITLE
Emit events on lid space compaction start and restart edges

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/common/eventlogger.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/eventlogger.cpp
@@ -201,6 +201,41 @@ EventLogger::populateDocumentFieldComplete(const string &fieldName, int64_t docu
 }
 
 void
+EventLogger::lidSpaceCompactionStart(const string &subDbName,
+                                     uint32_t lidBloat, uint32_t allowedLidBloat,
+                                     double lidBloatFactor, double allowedLidBloatFactor,
+                                     uint32_t lidLimit, uint32_t lowestFreeLid)
+{
+    JSONStringer jstr;
+    jstr.beginObject();
+    jstr.appendKey("documentsubdb").appendString(subDbName)
+        .appendKey("lidbloat").appendInt64(lidBloat)
+        .appendKey("allowedlidbloat").appendInt64(allowedLidBloat)
+        .appendKey("lidbloatfactor").appendDouble(lidBloatFactor)
+        .appendKey("allowedlidbloatfactor").appendDouble(allowedLidBloatFactor)
+        .appendKey("lidlimit").appendInt64(lidLimit)
+        .appendKey("lowestfreelid").appendInt64(lowestFreeLid);
+    jstr.endObject();
+    EV_STATE("lidspace.compaction.start", jstr.str().c_str());
+}
+
+void
+EventLogger::lidSpaceCompactionRestart(const string &subDbName,
+                                       uint32_t usedLids, uint32_t allowedLidBloat,
+                                       uint32_t highestUsedLid, uint32_t lowestFreeLid)
+{
+    JSONStringer jstr;
+    jstr.beginObject();
+    jstr.appendKey("documentsubdb").appendString(subDbName)
+        .appendKey("usedlids").appendInt64(usedLids)
+        .appendKey("allowedlidbloat").appendInt64(allowedLidBloat)
+        .appendKey("highestusedlid").appendInt64(highestUsedLid)
+        .appendKey("lowestfreelid").appendInt64(lowestFreeLid);
+    jstr.endObject();
+    EV_STATE("lidspace.compaction.restart", jstr.str().c_str());
+}
+
+void
 EventLogger::lidSpaceCompactionComplete(const string &subDbName, uint32_t lidLimit)
 {
     JSONStringer jstr;

--- a/searchcore/src/vespa/searchcore/proton/common/eventlogger.h
+++ b/searchcore/src/vespa/searchcore/proton/common/eventlogger.h
@@ -21,6 +21,13 @@ public:
     static void populateAttributeComplete(const std::vector<string> &names, int64_t documentsVisisted);
     static void populateDocumentFieldStart(const string &fieldName);
     static void populateDocumentFieldComplete(const string &fieldName, int64_t documentsVisisted);
+    static void lidSpaceCompactionStart(const string &subDbName,
+                                        uint32_t lidBloat, uint32_t allowedLidBloat,
+                                        double lidBloatFactor, double allowedLidBloatFactor,
+                                        uint32_t lidLimit, uint32_t lowestFreeLid);
+    static void lidSpaceCompactionRestart(const string &subDbName,
+                                          uint32_t usedLids, uint32_t allowedLidBloat,
+                                          uint32_t highestUsedLid, uint32_t lowestFreeLid);
     static void lidSpaceCompactionComplete(const string &subDbName, uint32_t lidLimit);
     static void reprocessDocumentsStart(const string &subDb, double visitCost);
     static void reprocessDocumentsProgress(const string &subDb, double progress, double visitCost);

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
@@ -229,6 +229,8 @@ CompactionJob::run()
         }
         LidUsageStats stats = _handler->getLidStatus();
         if (shouldRestartScanDocuments(stats)) {
+            EventLogger::lidSpaceCompactionRestart(_handler->getName(), stats.getUsedLids(), _cfg.getAllowedLidBloat(),
+                                                   stats.getHighestUsedLid(), stats.getLowestFreeLid());
             _scanItr = _handler->getIterator();
         } else {
             _scanItr.reset();
@@ -244,6 +246,9 @@ CompactionJob::run()
         compactLidSpace(stats);
     } else if (hasTooMuchLidBloat(stats)) {
         assert(!_scanItr);
+        EventLogger::lidSpaceCompactionStart(_handler->getName(), stats.getLidBloat(), _cfg.getAllowedLidBloat(),
+                                             stats.getLidBloatFactor(), _cfg.getAllowedLidBloatFactor(),
+                                             stats.getLidLimit(), stats.getLowestFreeLid());
         _scanItr = _handler->getIterator();
         return scanDocuments(stats);
     }


### PR DESCRIPTION
@arnej27959 please review
@toregge FYI

Includes the relevant active stats and config values used to determine if compaction start/restart should be triggered. Complements the existing _completion_ edge event.

Example `searchnode` output from the lid compaction system test:
```
EVENT   searchnode       proton.proton.common.eventlogger	state/1 name="lidspace.compaction.start" value="{"documentsubdb":"test.0.ready","lidbloat":40000,"allowedlidbloat":1,"lidbloatfactor":0.3999960000399996,"allowedlidbloatfactor":0.0,"lidlimit":100001,"lowestfreelid":1}"
INFO    searchnode       proton.searchcorespi.index.indexmaintainer	compactLidSpace(60001, 180259)
EVENT   searchnode       proton.proton.common.eventlogger	state/1 name="lidspace.compaction.complete" value="{"documentsubdb":"test.0.ready","lidlimit":60001}"
```
