### PR TITLE
Separate root volume replacement and instance startup to different calls

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -294,7 +294,7 @@ public final class Node implements Nodelike {
      * If both given wantToRetire and wantToDeprovision are equal to the current values, the method is no-op.
      */
     public Node withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, Agent agent, Instant at) {
-        return withWantToRetire(wantToRetire, wantToDeprovision, status.wantToRebuild(), status.startingRebuild(), status.wantToUpgradeFlavor(), agent, at);
+        return withWantToRetire(wantToRetire, wantToDeprovision, status.wantToRebuild(), status.bootingAfterRebuild(), status.wantToUpgradeFlavor(), agent, at);
     }
 
     /**
@@ -303,13 +303,13 @@ public final class Node implements Nodelike {
      *
      * If all given values are equal to the current ones, the method is no-op.
      */
-    public Node withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean startingRebuild, boolean wantToUpgradeFlavor, Agent agent, Instant at) {
+    public Node withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean bootingAfterRebuild, boolean wantToUpgradeFlavor, Agent agent, Instant at) {
         if (wantToRetire == status.wantToRetire() &&
             wantToDeprovision == status.wantToDeprovision() &&
             wantToRebuild == status.wantToRebuild() &&
-            startingRebuild == status.startingRebuild() &&
+            bootingAfterRebuild == status.bootingAfterRebuild() &&
             wantToUpgradeFlavor == status.wantToUpgradeFlavor()) return this;
-        Node node = this.with(status.withWantToRetire(wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, wantToUpgradeFlavor));
+        Node node = this.with(status.withWantToRetire(wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, wantToUpgradeFlavor));
         if (wantToRetire)
             node = node.with(history.with(new History.Event(History.Event.Type.wantToRetire, agent, at)));
         return node;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -294,7 +294,7 @@ public final class Node implements Nodelike {
      * If both given wantToRetire and wantToDeprovision are equal to the current values, the method is no-op.
      */
     public Node withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, Agent agent, Instant at) {
-        return withWantToRetire(wantToRetire, wantToDeprovision, status.wantToRebuild(), status.wantToUpgradeFlavor(), agent, at);
+        return withWantToRetire(wantToRetire, wantToDeprovision, status.wantToRebuild(), status.startingRebuild(), status.wantToUpgradeFlavor(), agent, at);
     }
 
     /**
@@ -303,12 +303,13 @@ public final class Node implements Nodelike {
      *
      * If all given values are equal to the current ones, the method is no-op.
      */
-    public Node withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean wantToUpgradeFlavor, Agent agent, Instant at) {
+    public Node withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean startingRebuild, boolean wantToUpgradeFlavor, Agent agent, Instant at) {
         if (wantToRetire == status.wantToRetire() &&
             wantToDeprovision == status.wantToDeprovision() &&
             wantToRebuild == status.wantToRebuild() &&
+            startingRebuild == status.startingRebuild() &&
             wantToUpgradeFlavor == status.wantToUpgradeFlavor()) return this;
-        Node node = this.with(status.withWantToRetire(wantToRetire, wantToDeprovision, wantToRebuild, wantToUpgradeFlavor));
+        Node node = this.with(status.withWantToRetire(wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, wantToUpgradeFlavor));
         if (wantToRetire)
             node = node.with(history.with(new History.Event(History.Event.Type.wantToRetire, agent, at)));
         return node;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -78,8 +78,8 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
     /**
      * Returns the subset of nodes that are currently in the process of starting up during rebuild
      */
-    public NodeList startingRebuild() {
-        return matching(node -> node.status().startingRebuild());
+    public NodeList bootingAfterRebuild() {
+        return matching(node -> node.status().bootingAfterRebuild());
     }
 
     /** Returns the subset of nodes which are removable */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -75,6 +75,13 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
         });
     }
 
+    /**
+     * Returns the subset of nodes that are currently in the process of starting up during rebuild
+     */
+    public NodeList startingRebuild() {
+        return matching(node -> node.status().startingRebuild());
+    }
+
     /** Returns the subset of nodes which are removable */
     public NodeList removable() {
         return matching(node -> node.allocation().isPresent() && node.allocation().get().removable());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacer.java
@@ -35,17 +35,32 @@ public class DiskReplacer extends NodeRepositoryMaintainer {
 
     @Override
     protected double maintain() {
-        NodeList candidates = nodeRepository().nodes().list().rebuilding(true);
-        if (candidates.isEmpty()) {
-            return 0;
-        }
+        int attempts = 0;
         int failures = 0;
-        List<Node> rebuilding;
-        try (var locked = nodeRepository().nodes().lockAndGetAll(candidates.asList(), Optional.of(Duration.ofSeconds(10)))) {
-            rebuilding = locked.nodes().stream().map(NodeMutex::node).toList();
+        NodeList rebuildCandidates = nodeRepository().nodes().list().rebuilding(true);
+        try (var locked = nodeRepository().nodes().lockAndGetAll(rebuildCandidates.asList(), Optional.of(Duration.ofSeconds(10)))) {
+            List<Node> rebuilding = locked.nodes().stream().map(NodeMutex::node).toList();
             RebuildResult result = hostProvisioner.replaceRootDisk(rebuilding);
+            for (Node updated : result.successes()) {
+                if (!updated.status().wantToRebuild()) {
+                    nodeRepository().nodes().write(updated, () -> {});
+                }
+            }
+            for (var entry : result.failed().entrySet()) {
+                ++failures;
+                log.log(Level.WARNING, "Failed to replace root disk on " + entry.getKey() + ", will retry in " +
+                        interval() + ": " + Exceptions.toMessageString(entry.getValue()));
+            }
+            attempts += result.successes().size() + result.failed().size();
+        }
 
-            for (Node updated : result.rebuilt()) {
+        NodeList hostsStartingRebuild = nodeRepository().nodes().list().startingRebuild();
+
+        try (var locked = nodeRepository().nodes().lockAndGetAll(hostsStartingRebuild.asList(), Optional.of(Duration.ofSeconds(10)))) {
+            List<Node> starting = locked.nodes().stream().map(NodeMutex::node).toList();
+            RebuildResult startResult = hostProvisioner.startHosts(starting);
+
+            for (Node updated : startResult.successes()) {
                 if (!updated.status().wantToRebuild()) {
                     NodeList children = nodeRepository().nodes().list().childrenOf(updated);
                     restoreSnapshotsOf(children);
@@ -53,13 +68,15 @@ public class DiskReplacer extends NodeRepositoryMaintainer {
                 }
             }
 
-            for (var entry : result.failed().entrySet()) {
+            for (var entry : startResult.failed().entrySet()) {
                 ++failures;
-                log.log(Level.WARNING, "Failed to rebuild " + entry.getKey() + ", will retry in " +
-                                       interval() + ": " + Exceptions.toMessageString(entry.getValue()));
+                log.log(Level.WARNING, "Failed to start " + entry.getKey() + ", will retry in " +
+                        interval() + ": " + Exceptions.toMessageString(entry.getValue()));
             }
+            attempts += startResult.successes().size() + startResult.failed().size();
         }
-        return asSuccessFactorDeviation(rebuilding.size(), failures);
+
+        return asSuccessFactorDeviation(attempts, failures);
     }
 
     private void restoreSnapshotsOf(NodeList children) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -186,7 +186,7 @@ public class Nodes {
                         node = node.with(node.status().withWantToRetire(existing.get().status().wantToRetire(),
                                                                         false,
                                                                         rebuilding,
-                                                                        existing.get().status().startingRebuild(),
+                                                                        existing.get().status().bootingAfterRebuild(),
                                                                         existing.get().status().wantToUpgradeFlavor()));
                     }
                     nodesToRemove.add(existing.get());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
@@ -23,6 +23,7 @@ public class Status {
     private final boolean wantToRetire;
     private final boolean wantToDeprovision;
     private final boolean wantToRebuild;
+    private final boolean startingRebuild;
     private final boolean preferToRetire;
     private final boolean wantToFail;
     private final boolean wantToUpgradeFlavor;
@@ -37,6 +38,7 @@ public class Status {
                   boolean wantToRetire,
                   boolean wantToDeprovision,
                   boolean wantToRebuild,
+                  boolean startingRebuild,
                   boolean preferToRetire,
                   boolean wantToFail,
                   boolean wantToUpgradeFlavor,
@@ -61,6 +63,7 @@ public class Status {
         this.wantToRetire = wantToRetire;
         this.wantToDeprovision = wantToDeprovision;
         this.wantToRebuild = wantToRebuild;
+        this.startingRebuild = startingRebuild;
         this.preferToRetire = preferToRetire;
         this.wantToFail = wantToFail;
         this.osVersion = Objects.requireNonNull(osVersion, "OS version must be non-null");
@@ -68,35 +71,35 @@ public class Status {
     }
 
     /** Returns a copy of this with the reboot generation changed */
-    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns the reboot generation of this node */
     public Generation reboot() { return reboot; }
 
     /** Returns a copy of this with the vespa version changed */
-    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns the Vespa version installed on the node, if known */
     public Optional<Version> vespaVersion() { return vespaVersion; }
 
     /** Returns a copy of this with the container image changed */
-    public Status withContainerImage(DockerImage containerImage) { return new Status(reboot, vespaVersion, Optional.of(containerImage), failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withContainerImage(DockerImage containerImage) { return new Status(reboot, vespaVersion, Optional.of(containerImage), failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns the container image the node is running, if any */
     public Optional<DockerImage> containerImage() { return containerImage; }
 
-    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount + 1, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount + 1, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
-    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount - 1, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount - 1, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
-    public Status withFailCount(int value) { return new Status(reboot, vespaVersion, containerImage, value, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withFailCount(int value) { return new Status(reboot, vespaVersion, containerImage, value, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns how many times this node has been moved to the failed state. */
     public int failCount() { return failCount; }
 
     /** Returns a copy of this with the want to retire/deprovision/rebuild flags changed */
-    public Status withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean wantToUpgradeFlavor) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+    public Status withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean startingRebuild, boolean wantToUpgradeFlavor) {
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /**
@@ -113,6 +116,9 @@ public class Status {
     /** Returns whether this node should be rebuilt when possible. */
     public boolean wantToRebuild() { return wantToRebuild; }
 
+    /** Returns whether this node is currently starting a rebuild. */
+    public boolean startingRebuild() { return startingRebuild; }
+
     /**
      * Returns whether this node is requested to retire. Unlike {@link Status#wantToRetire()}, this is a soft
      * request to retire, which will not allow any replacement to increase node skew in the cluster.
@@ -126,7 +132,7 @@ public class Status {
 
     /** Returns a copy of this with want to fail set to the given value */
     public Status withWantToFail(boolean wantToFail) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns whether this node should be failed */
@@ -134,12 +140,12 @@ public class Status {
 
     /** Returns a copy of this with prefer-to-retire set to given value */
     public Status withPreferToRetire(boolean preferToRetire) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns a copy of this with the OS version set to given version */
     public Status withOsVersion(OsVersion version) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, version, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, version, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns the OS version of this node */
@@ -149,7 +155,7 @@ public class Status {
 
     /** Returns a copy of this with the firmwareVerifiedAt set to the given instant. */
     public Status withFirmwareVerifiedAt(Instant instant) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, Optional.of(instant), snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, Optional.of(instant), snapshot);
     }
 
     /** Returns the last time this node had firmware that was verified to be up to date. */
@@ -164,13 +170,13 @@ public class Status {
 
     /** Returns a copy of this with backup snapshot set to given value */
     public Status withSnapshot(Optional<Snapshot> snapshot) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns the initial status of a newly provisioned node */
     public static Status initial() {
         return new Status(Generation.initial(), Optional.empty(), Optional.empty(), 0, false,
-                          false, false, false, false, false, OsVersion.EMPTY, Optional.empty(), Optional.empty());
+                          false, false, false, false, false, false, OsVersion.EMPTY, Optional.empty(), Optional.empty());
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
@@ -23,7 +23,7 @@ public class Status {
     private final boolean wantToRetire;
     private final boolean wantToDeprovision;
     private final boolean wantToRebuild;
-    private final boolean startingRebuild;
+    private final boolean bootingAfterRebuild;
     private final boolean preferToRetire;
     private final boolean wantToFail;
     private final boolean wantToUpgradeFlavor;
@@ -38,7 +38,7 @@ public class Status {
                   boolean wantToRetire,
                   boolean wantToDeprovision,
                   boolean wantToRebuild,
-                  boolean startingRebuild,
+                  boolean bootingAfterRebuild,
                   boolean preferToRetire,
                   boolean wantToFail,
                   boolean wantToUpgradeFlavor,
@@ -63,7 +63,7 @@ public class Status {
         this.wantToRetire = wantToRetire;
         this.wantToDeprovision = wantToDeprovision;
         this.wantToRebuild = wantToRebuild;
-        this.startingRebuild = startingRebuild;
+        this.bootingAfterRebuild = bootingAfterRebuild;
         this.preferToRetire = preferToRetire;
         this.wantToFail = wantToFail;
         this.osVersion = Objects.requireNonNull(osVersion, "OS version must be non-null");
@@ -71,35 +71,35 @@ public class Status {
     }
 
     /** Returns a copy of this with the reboot generation changed */
-    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns the reboot generation of this node */
     public Generation reboot() { return reboot; }
 
     /** Returns a copy of this with the vespa version changed */
-    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns the Vespa version installed on the node, if known */
     public Optional<Version> vespaVersion() { return vespaVersion; }
 
     /** Returns a copy of this with the container image changed */
-    public Status withContainerImage(DockerImage containerImage) { return new Status(reboot, vespaVersion, Optional.of(containerImage), failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withContainerImage(DockerImage containerImage) { return new Status(reboot, vespaVersion, Optional.of(containerImage), failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns the container image the node is running, if any */
     public Optional<DockerImage> containerImage() { return containerImage; }
 
-    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount + 1, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount + 1, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
-    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount - 1, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount - 1, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
-    public Status withFailCount(int value) { return new Status(reboot, vespaVersion, containerImage, value, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
+    public Status withFailCount(int value) { return new Status(reboot, vespaVersion, containerImage, value, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot); }
 
     /** Returns how many times this node has been moved to the failed state. */
     public int failCount() { return failCount; }
 
     /** Returns a copy of this with the want to retire/deprovision/rebuild flags changed */
-    public Status withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean startingRebuild, boolean wantToUpgradeFlavor) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+    public Status withWantToRetire(boolean wantToRetire, boolean wantToDeprovision, boolean wantToRebuild, boolean bootingAfterRebuild, boolean wantToUpgradeFlavor) {
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /**
@@ -117,7 +117,7 @@ public class Status {
     public boolean wantToRebuild() { return wantToRebuild; }
 
     /** Returns whether this node is currently starting a rebuild. */
-    public boolean startingRebuild() { return startingRebuild; }
+    public boolean bootingAfterRebuild() { return bootingAfterRebuild; }
 
     /**
      * Returns whether this node is requested to retire. Unlike {@link Status#wantToRetire()}, this is a soft
@@ -132,7 +132,7 @@ public class Status {
 
     /** Returns a copy of this with want to fail set to the given value */
     public Status withWantToFail(boolean wantToFail) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns whether this node should be failed */
@@ -140,12 +140,12 @@ public class Status {
 
     /** Returns a copy of this with prefer-to-retire set to given value */
     public Status withPreferToRetire(boolean preferToRetire) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns a copy of this with the OS version set to given version */
     public Status withOsVersion(OsVersion version) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, version, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, version, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns the OS version of this node */
@@ -155,7 +155,7 @@ public class Status {
 
     /** Returns a copy of this with the firmwareVerifiedAt set to the given instant. */
     public Status withFirmwareVerifiedAt(Instant instant) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, Optional.of(instant), snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, Optional.of(instant), snapshot);
     }
 
     /** Returns the last time this node had firmware that was verified to be up to date. */
@@ -170,7 +170,7 @@ public class Status {
 
     /** Returns a copy of this with backup snapshot set to given value */
     public Status withSnapshot(Optional<Snapshot> snapshot) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, startingRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, wantToRebuild, bootingAfterRebuild, preferToRetire, wantToFail, wantToUpgradeFlavor, osVersion, firmwareVerifiedAt, snapshot);
     }
 
     /** Returns the initial status of a newly provisioned node */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -83,7 +83,7 @@ public class NodeSerializer {
     private static final String wantToRetireKey = "wantToRetire";
     private static final String wantToDeprovisionKey = "wantToDeprovision";
     private static final String wantToRebuildKey = "wantToRebuild";
-    private static final String startingRebuildKey = "startingRebuild";
+    private static final String bootingAfterRebuildKey = "bootingAfterRebuild";
     private static final String preferToRetireKey = "preferToRetire";
     private static final String wantToFailKey = "wantToFailKey"; // TODO: This should be changed to 'wantToFail'
     private static final String wantToUpgradeFlavorKey = "wantToUpgradeFlavor";
@@ -175,7 +175,7 @@ public class NodeSerializer {
         object.setBool(wantToDeprovisionKey, node.status().wantToDeprovision());
         object.setBool(wantToFailKey, node.status().wantToFail());
         object.setBool(wantToRebuildKey, node.status().wantToRebuild());
-        object.setBool(startingRebuildKey, node.status().startingRebuild());
+        object.setBool(bootingAfterRebuildKey, node.status().bootingAfterRebuild());
         object.setBool(wantToUpgradeFlavorKey, node.status().wantToUpgradeFlavor());
         node.allocation().ifPresent(allocation -> toSlime(allocation, object.setObject(instanceKey)));
         toSlime(node.history().events(), object.setArray(historyKey));
@@ -309,7 +309,7 @@ public class NodeSerializer {
                           object.field(wantToRetireKey).asBool(),
                           object.field(wantToDeprovisionKey).asBool(),
                           object.field(wantToRebuildKey).asBool(),
-                          object.field(startingRebuildKey).asBool(),
+                          object.field(bootingAfterRebuildKey).asBool(),
                           object.field(preferToRetireKey).asBool(),
                           object.field(wantToFailKey).asBool(),
                           object.field(wantToUpgradeFlavorKey).asBool(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -83,6 +83,7 @@ public class NodeSerializer {
     private static final String wantToRetireKey = "wantToRetire";
     private static final String wantToDeprovisionKey = "wantToDeprovision";
     private static final String wantToRebuildKey = "wantToRebuild";
+    private static final String startingRebuildKey = "startingRebuild";
     private static final String preferToRetireKey = "preferToRetire";
     private static final String wantToFailKey = "wantToFailKey"; // TODO: This should be changed to 'wantToFail'
     private static final String wantToUpgradeFlavorKey = "wantToUpgradeFlavor";
@@ -174,6 +175,7 @@ public class NodeSerializer {
         object.setBool(wantToDeprovisionKey, node.status().wantToDeprovision());
         object.setBool(wantToFailKey, node.status().wantToFail());
         object.setBool(wantToRebuildKey, node.status().wantToRebuild());
+        object.setBool(startingRebuildKey, node.status().startingRebuild());
         object.setBool(wantToUpgradeFlavorKey, node.status().wantToUpgradeFlavor());
         node.allocation().ifPresent(allocation -> toSlime(allocation, object.setObject(instanceKey)));
         toSlime(node.history().events(), object.setArray(historyKey));
@@ -307,6 +309,7 @@ public class NodeSerializer {
                           object.field(wantToRetireKey).asBool(),
                           object.field(wantToDeprovisionKey).asBool(),
                           object.field(wantToRebuildKey).asBool(),
+                          object.field(startingRebuildKey).asBool(),
                           object.field(preferToRetireKey).asBool(),
                           object.field(wantToFailKey).asBool(),
                           object.field(wantToUpgradeFlavorKey).asBool(),
@@ -417,7 +420,7 @@ public class NodeSerializer {
     }
 
     // ----------------- Enum <-> string mappings ----------------------------------------
-    
+
     /** Returns the event type, or null if this event type should be ignored */
     private History.Event.Type eventTypeFromString(String eventTypeString) {
         return switch (eventTypeString) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
@@ -80,7 +80,9 @@ public interface HostProvisioner {
      */
     default RebuildResult replaceRootDisk(Collection<Node> hosts) { return new RebuildResult(List.of(), Map.of()); }
 
-    record RebuildResult(List<Node> rebuilt, Map<Node, Exception> failed) { }
+    default RebuildResult startHosts(Collection<Node> hosts) { return new RebuildResult(List.of(), Map.of()); }
+
+    record RebuildResult(List<Node> successes, Map<Node, Exception> failed) { }
 
     /**
      * Returns the maintenance events scheduled for hosts in this zone, in given cloud accounts. Host events in the

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
@@ -76,13 +76,23 @@ public interface HostProvisioner {
 
     /** Replace the root (OS) disk of hosts. Implementations of this are expected to be idempotent.
      *
-     * @return the node objects for which updates were made
+     * @return the node objects for which updates were made. The hosts argument will be split to three disjoint subsets:
+     *  - nodes which were successfully updated, included in {@link RebuildResult#completed()}
+     *  - nodes which failed to be updated, included in {@link RebuildResult#failed()}
+     *  - nodes which were not updated yet, these should be retried later.
      */
     default RebuildResult replaceRootDisk(Collection<Node> hosts) { return new RebuildResult(List.of(), Map.of()); }
 
+    /** Boots instances which had their root volumes replaced. Implementations of this are expected to be idempotent.
+     *
+     * @return the node objects for which updates were made. The hosts argument will be split to three disjoint subsets:
+     *  - nodes which were successfully updated, included in {@link RebuildResult#completed()}
+     *  - nodes which failed to be updated, included in {@link RebuildResult#failed()}
+     *  - nodes which were not updated yet, these should be retried later.
+     */
     default RebuildResult startHosts(Collection<Node> hosts) { return new RebuildResult(List.of(), Map.of()); }
 
-    record RebuildResult(List<Node> successes, Map<Node, Exception> failed) { }
+    record RebuildResult(List<Node> completed, Map<Node, Exception> failed) { }
 
     /**
      * Returns the maintenance events scheduled for hosts in this zone, in given cloud accounts. Host events in the

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -63,6 +63,7 @@ public class NodePatcher {
     private static final String WANT_TO_RETIRE = "wantToRetire";
     private static final String WANT_TO_DEPROVISION = "wantToDeprovision";
     private static final String WANT_TO_REBUILD = "wantToRebuild";
+    private static final String STARTING_REBUILD = "startingRebuild";
     private static final String WANT_TO_UPGRADE_FLAVOR = "wantToUpgradeFlavor";
     private static final String REPORTS = "reports";
     private static final Set<String> RECURSIVE_FIELDS = Set.of(WANT_TO_RETIRE, WANT_TO_DEPROVISION);
@@ -223,6 +224,7 @@ public class NodePatcher {
             case WANT_TO_RETIRE:
             case WANT_TO_DEPROVISION:
             case WANT_TO_REBUILD:
+            case STARTING_REBUILD:
             case WANT_TO_UPGRADE_FLAVOR:
                 // These needs to be handled as one, because certain combinations are not allowed.
                 return node.withWantToRetire(asOptionalBoolean(root.field(WANT_TO_RETIRE))
@@ -232,6 +234,9 @@ public class NodePatcher {
                                              asOptionalBoolean(root.field(WANT_TO_REBUILD))
                                                      .filter(want -> !applyingAsChild)
                                                      .orElseGet(node.status()::wantToRebuild),
+                                            asOptionalBoolean(root.field(STARTING_REBUILD))
+                                                    .filter(want -> !applyingAsChild)
+                                                    .orElseGet(node.status()::startingRebuild),
                                              asOptionalBoolean(root.field(WANT_TO_UPGRADE_FLAVOR))
                                                      .filter(want -> !applyingAsChild)
                                                      .orElseGet(node.status()::wantToUpgradeFlavor),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -63,7 +63,7 @@ public class NodePatcher {
     private static final String WANT_TO_RETIRE = "wantToRetire";
     private static final String WANT_TO_DEPROVISION = "wantToDeprovision";
     private static final String WANT_TO_REBUILD = "wantToRebuild";
-    private static final String STARTING_REBUILD = "startingRebuild";
+    private static final String BOOTING_AFTER_REBUILD = "bootingAfterRebuild";
     private static final String WANT_TO_UPGRADE_FLAVOR = "wantToUpgradeFlavor";
     private static final String REPORTS = "reports";
     private static final Set<String> RECURSIVE_FIELDS = Set.of(WANT_TO_RETIRE, WANT_TO_DEPROVISION);
@@ -224,7 +224,7 @@ public class NodePatcher {
             case WANT_TO_RETIRE:
             case WANT_TO_DEPROVISION:
             case WANT_TO_REBUILD:
-            case STARTING_REBUILD:
+            case BOOTING_AFTER_REBUILD:
             case WANT_TO_UPGRADE_FLAVOR:
                 // These needs to be handled as one, because certain combinations are not allowed.
                 return node.withWantToRetire(asOptionalBoolean(root.field(WANT_TO_RETIRE))
@@ -234,9 +234,9 @@ public class NodePatcher {
                                              asOptionalBoolean(root.field(WANT_TO_REBUILD))
                                                      .filter(want -> !applyingAsChild)
                                                      .orElseGet(node.status()::wantToRebuild),
-                                            asOptionalBoolean(root.field(STARTING_REBUILD))
+                                            asOptionalBoolean(root.field(BOOTING_AFTER_REBUILD))
                                                     .filter(want -> !applyingAsChild)
-                                                    .orElseGet(node.status()::startingRebuild),
+                                                    .orElseGet(node.status()::bootingAfterRebuild),
                                              asOptionalBoolean(root.field(WANT_TO_UPGRADE_FLAVOR))
                                                      .filter(want -> !applyingAsChild)
                                                      .orElseGet(node.status()::wantToUpgradeFlavor),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -180,6 +180,7 @@ class NodesResponse extends SlimeJsonResponse {
         object.setBool("preferToRetire", node.status().preferToRetire());
         object.setBool("wantToDeprovision", node.status().wantToDeprovision());
         object.setBool("wantToRebuild", node.status().wantToRebuild());
+        object.setBool("bootingAfterRebuild", node.status().bootingAfterRebuild());
         object.setBool("wantToUpgradeFlavor", node.status().wantToUpgradeFlavor());
         object.setBool("down", node.history().isDown());
         toSlime(node.history().events(), object.setArray("history"));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -158,7 +158,7 @@ public class MockNodeRepository extends NodeRepository {
         nodes.add(node10);
 
         Node node55 = Node.create("node55", ipConfig(55), "host55.yahoo.com", resources(2, 8, 50, 1, fast, local), NodeType.tenant)
-                          .status(Status.initial().withWantToRetire(true, true, false, false))
+                          .status(Status.initial().withWantToRetire(true, true, false, false, false))
                 .cloudAccount(defaultCloudAccount).build();
         nodes.add(node55);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -259,7 +259,7 @@ public class NodeRepositoryTest {
 
         // Set host 2 properties and deprovision it
         try (var lock = tester.nodeRepository().nodes().lockAndGetRequired("host2")) {
-            Node host2 = lock.node().withWantToRetire(true, false, true, false, Agent.system, tester.nodeRepository().clock().instant());
+            Node host2 = lock.node().withWantToRetire(true, false, true, false, false, Agent.system, tester.nodeRepository().clock().instant());
             tester.nodeRepository().nodes().write(host2, lock);
         }
         tester.nodeRepository().nodes().removeRecursively("host2");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacerTest.java
@@ -60,7 +60,7 @@ public class DiskReplacerTest {
         assertTrue(nodes.stream().allMatch(node -> node.status().snapshot().isPresent() &&
                                                    node.status().snapshot().get().state() == Snapshot.State.created), "Snapshot restore is not yet triggered");
         assertEquals(0, tester.nodeRepository().nodes().list().rebuilding(true).size());
-        assertEquals(1, tester.nodeRepository().nodes().list().startingRebuild().size());
+        assertEquals(1, tester.nodeRepository().nodes().list().bootingAfterRebuild().size());
 
         hostProvisioner.completeInstanceStartupOf(host0);
         diskReplacer.maintain();
@@ -69,7 +69,7 @@ public class DiskReplacerTest {
         assertTrue(nodes.stream().allMatch(node -> node.status().snapshot().isPresent() &&
                 node.status().snapshot().get().state() == Snapshot.State.restoring), "Snapshot restore is triggered for all children");
         assertEquals(0, tester.nodeRepository().nodes().list().rebuilding(true).size());
-        assertEquals(0, tester.nodeRepository().nodes().list().startingRebuild().size());
+        assertEquals(0, tester.nodeRepository().nodes().list().bootingAfterRebuild().size());
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacerTest.java
@@ -52,14 +52,24 @@ public class DiskReplacerTest {
             tester.nodeRepository().snapshots().move(snapshot.id(), node.hostname(), Snapshot.State.created);
         });
 
-        // Rebuild completes
-        hostProvisioner.completeRebuildOf(host0);
+        // Root disk has completed replacement
+        hostProvisioner.completeDiskReplacementOf(host0);
         diskReplacer.maintain();
         nodes = tester.nodeRepository().nodes().list().childrenOf(host0).asList();
         assertFalse(nodes.isEmpty());
         assertTrue(nodes.stream().allMatch(node -> node.status().snapshot().isPresent() &&
-                                                   node.status().snapshot().get().state() == Snapshot.State.restoring), "Snapshot restore is triggered for all children");
+                                                   node.status().snapshot().get().state() == Snapshot.State.created), "Snapshot restore is not yet triggered");
         assertEquals(0, tester.nodeRepository().nodes().list().rebuilding(true).size());
+        assertEquals(1, tester.nodeRepository().nodes().list().startingRebuild().size());
+
+        hostProvisioner.completeInstanceStartupOf(host0);
+        diskReplacer.maintain();
+        nodes = tester.nodeRepository().nodes().list().childrenOf(host0).asList();
+        assertFalse(nodes.isEmpty());
+        assertTrue(nodes.stream().allMatch(node -> node.status().snapshot().isPresent() &&
+                node.status().snapshot().get().state() == Snapshot.State.restoring), "Snapshot restore is triggered for all children");
+        assertEquals(0, tester.nodeRepository().nodes().list().rebuilding(true).size());
+        assertEquals(0, tester.nodeRepository().nodes().list().startingRebuild().size());
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainerTest.java
@@ -930,7 +930,7 @@ public class HostCapacityMaintainerTest {
             parentHostname.ifPresent(builder::parentHostname);
             allocation.ifPresent(builder::allocation);
             if (hostname.equals("host2-1"))
-                builder.status(Status.initial().withWantToRetire(true, true, false, false));
+                builder.status(Status.initial().withWantToRetire(true, true, false, false, false));
             return builder.build();
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/os/OsVersionsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/os/OsVersionsTest.java
@@ -819,7 +819,7 @@ public class OsVersionsTest {
             Optional<Version> wantedOsVersion = node.status().osVersion().wanted();
             assertFalse(node + " is not retiring", node.status().wantToRetire());
             assertTrue(node + " is rebuilding", node.status().wantToRebuild());
-            node = node.withWantToRetire(false, false, false, false, Agent.system,
+            node = node.withWantToRetire(false, false, false, false, false, Agent.system,
                                          tester.clock().instant());
             return node.with(node.status().withOsVersion(node.status().osVersion().withCurrent(wantedOsVersion)));
         });

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -329,12 +329,13 @@ public class NodeSerializerTest {
     public void want_to_rebuild_and_upgrade_flavor() {
         Node node = nodeSerializer.fromJson(nodeSerializer.toJson(createNode()));
         assertFalse(node.status().wantToRebuild());
-        node = node.with(node.status().withWantToRetire(true, false, true, true));
+        node = node.with(node.status().withWantToRetire(true, false, true, true, true));
         node = nodeSerializer.fromJson(nodeSerializer.toJson(node));
         assertTrue(node.status().wantToRetire());
         assertFalse(node.status().wantToDeprovision());
         assertTrue(node.status().wantToRebuild());
         assertTrue(node.status().wantToUpgradeFlavor());
+        assertTrue(node.status().startingRebuild());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -335,7 +335,7 @@ public class NodeSerializerTest {
         assertFalse(node.status().wantToDeprovision());
         assertTrue(node.status().wantToRebuild());
         assertTrue(node.status().wantToUpgradeFlavor());
-        assertTrue(node.status().startingRebuild());
+        assertTrue(node.status().bootingAfterRebuild());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
@@ -57,6 +57,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
@@ -57,6 +57,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/controller1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/controller1.json
@@ -32,6 +32,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-container1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-container1.json
@@ -57,6 +57,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
@@ -59,6 +59,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-2.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": true,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-3.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-4.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": true,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node3.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node4.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node5.json
@@ -58,6 +58,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost1-with-firmware-data.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost1-with-firmware-data.json
@@ -60,6 +60,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost6.json
@@ -33,6 +33,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node1.json
@@ -56,6 +56,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node10.json
@@ -59,6 +59,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node11.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node11.json
@@ -32,6 +32,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node13.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node13.json
@@ -32,6 +32,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node14.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node14.json
@@ -32,6 +32,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node2.json
@@ -56,6 +56,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node3.json
@@ -31,6 +31,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
@@ -62,6 +62,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": true,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
@@ -59,6 +59,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
@@ -59,6 +59,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4.json
@@ -59,6 +59,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
@@ -32,6 +32,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
@@ -34,6 +34,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node55.json
@@ -31,6 +31,7 @@
   "preferToRetire": false,
   "wantToDeprovision": true,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node6.json
@@ -56,6 +56,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node7.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node7.json
@@ -31,6 +31,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node8.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node8.json
@@ -33,6 +33,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node9.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node9.json
@@ -33,6 +33,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/parent2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/parent2.json
@@ -36,6 +36,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/snapshot/node4.json
@@ -59,6 +59,7 @@
   "preferToRetire": false,
   "wantToDeprovision": false,
   "wantToRebuild": false,
+  "bootingAfterRebuild": false,
   "wantToUpgradeFlavor": false,
   "down": false,
   "history": [


### PR DESCRIPTION
Also adds new node status field indicating that rebuild steps have completed, and the instance should currently be started.

With internal PR

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
