### PR TITLE
chore(deps): switch from OSSH to Maven Central

### DIFF
--- a/.buildkite/release-java-artifacts.sh
+++ b/.buildkite/release-java-artifacts.sh
@@ -16,7 +16,7 @@ fi
 readonly VESPA_RELEASE="$1"
 
 # shellcheck shell=bash disable=SC1083
-QUERY_VERSION_HTTP_CODE=$(curl --write-out %{http_code} --silent --location --output /dev/null "https://oss.sonatype.org/content/repositories/releases/com/yahoo/vespa/parent/${VESPA_RELEASE}/parent-${VESPA_RELEASE}.pom")
+QUERY_VERSION_HTTP_CODE=$(curl --write-out %{http_code} --silent --location --output /dev/null "https://repo.maven.apache.org/maven2/com/yahoo/vespa/parent/${VESPA_RELEASE}/parent-${VESPA_RELEASE}.pom")
 if [[ "200" == "$QUERY_VERSION_HTTP_CODE" ]]; then
   echo "Vespa version $VESPA_RELEASE is already promoted, exiting"
   exit 0
@@ -126,9 +126,9 @@ export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED"
 LOGFILE=$(mktemp)
 # shellcheck disable=2086
 $MVN $MVN_OPTS --settings="$SOURCE_DIR/.buildkite/settings-publish.xml" \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.14:deploy-staged-repository \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
     -DrepositoryDirectory="$TMP_STAGING" \
-    -DnexusUrl=https://oss.sonatype.org \
+    -DnexusUrl=https://ossrh-staging-api.central.sonatype.com \
     -DserverId=ossrh \
     -DautoReleaseAfterClose=false \
     -DstagingProgressTimeoutMinutes=10 \
@@ -137,9 +137,8 @@ $MVN $MVN_OPTS --settings="$SOURCE_DIR/.buildkite/settings-publish.xml" \
 STG_REPO=$(grep 'Staging repository at http' "$LOGFILE" | head -1 | awk -F/ '{print $NF}')
 # shellcheck disable=2086
 $MVN $MVN_OPTS --settings="$SOURCE_DIR/.buildkite/settings-publish.xml" -N \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.14:rc-release \
-    -DnexusUrl=https://oss.sonatype.org/ \
+    org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:rc-release \
+    -DnexusUrl=https://ossrh-staging-api.central.sonatype.com \
     -DserverId=ossrh \
     -DstagingProgressTimeoutMinutes=10 \
     -DstagingRepositoryId="$STG_REPO"
-

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -180,10 +180,10 @@
         <maven-compiler-plugin.vespa.version>3.13.0</maven-compiler-plugin.vespa.version>
         <maven-core.vespa.version>3.9.8</maven-core.vespa.version>
         <maven-dependency-plugin.vespa.version>3.7.1</maven-dependency-plugin.vespa.version>
-        <maven-deploy-plugin.vespa.version>3.1.2</maven-deploy-plugin.vespa.version>
+        <maven-deploy-plugin.vespa.version>3.1.4</maven-deploy-plugin.vespa.version>
         <maven-enforcer-plugin.vespa.version>3.5.0</maven-enforcer-plugin.vespa.version>
         <maven-failsafe-plugin.vespa.version>3.3.1</maven-failsafe-plugin.vespa.version>
-        <maven-gpg-plugin.vespa.version>3.2.5</maven-gpg-plugin.vespa.version>
+        <maven-gpg-plugin.vespa.version>3.2.7</maven-gpg-plugin.vespa.version>
         <maven-install-plugin.vespa.version>3.1.2</maven-install-plugin.vespa.version>
         <maven-jar-plugin.vespa.version>3.4.2</maven-jar-plugin.vespa.version>
         <maven-javadoc-plugin.vespa.version>3.8.0</maven-javadoc-plugin.vespa.version>
@@ -237,7 +237,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/hosted-tenant-base/pom.xml
+++ b/hosted-tenant-base/pom.xml
@@ -497,7 +497,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## What

- Updates the Nexus URL from `oss.sonatype.org` to `ossrh-staging-api.central.sonatype.com`
- Updates the versions of several Maven plugins used in the project, including:
  - maven-deploy-plugin from 3.1.2 to 3.1.4
  - maven-gpg-plugin from 3.2.5 to 3.2.7

## Why

* Move from OSSH to Maven Central, former is on the process of going EOL.

## References

* [What is different between Central Portal and Legacy OSSRH?](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/)
* [Publishing By Using the Portal OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/)