### PR TITLE
Don't set max_feed_op_batch_size config (same as default value)

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
@@ -80,7 +80,6 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
             maintenanceThrottleBuilder.max_window_size(maxContentNodeMaintenanceOpConcurrency);
             builder.maintenance_operation_throttler(maintenanceThrottleBuilder);
         }
-        builder.max_feed_op_batch_size(64); // TODO: Remove when default in config definition is 64
     }
 
 }


### PR DESCRIPTION
Default value set to 64 in https://github.com/vespa-engine/vespa/pull/34083