### PR TITLE
build(release): Migrate from Nexus to Central Maven Repository

### DIFF
--- a/.buildkite/settings-publish.xml
+++ b/.buildkite/settings-publish.xml
@@ -8,6 +8,12 @@
             <username>${env.OSSRH_USER}</username>
             <password>${env.OSSRH_TOKEN}</password>
         </server>
+        <server>
+            <id>central</id>
+            <username>${env.MVN_CENTRAL_USER}</username>
+            <password>${env.MVN_CENTRAL_TOKEN}</password>
+        </server>
+
     </servers>
 
     <profiles>


### PR DESCRIPTION
- Update the release script to use the Central Maven Publishing plugin instead of the Nexus Staging plugin
- Add a new server configuration for the Central Maven Repository in the Maven settings file
- Remove the obsolete Nexus-specific configuration