### PR TITLE
fix(pom.xml): add packaging type to dummy pom.xml

### DIFF
--- a/.buildkite/release-java-artifacts-dummy-pom.xml
+++ b/.buildkite/release-java-artifacts-dummy-pom.xml
@@ -9,4 +9,5 @@
   <groupId>dummy</groupId>
   <artifactId>dummy</artifactId>
   <version>1.0.0</version>
+  <packaging>pom</packaging>
 </project>


### PR DESCRIPTION
>  If no packaging value has been specified, it will default to jar.
Source: [Packaging](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html)