### PR TITLE
fix(release-java-artifacts): use Central Portal API for deployment instead mvn plugins

### DIFF
--- a/.buildkite/release-java-artifacts.sh
+++ b/.buildkite/release-java-artifacts.sh
@@ -184,9 +184,11 @@ cd "$REPO_ROOT"
 find . -name "$VESPA_RELEASE" -type d | sed 's,^./,,' | xargs -n 1 -P $NUM_PROC -I '{}' bash -c "sign_module {}"
 
 # Create a zip file of all the staged artifacts
+(
 cd "$TMP_STAGING"
 ZIP_FILE=$(mktemp).zip
 zip -r "$ZIP_FILE" .
+)
 
 # Upload the bundle using the Central Portal API
 echo "Uploading deployment bundle using Central Portal API"
@@ -206,4 +208,4 @@ fi
 echo "Got deployment ID: $DEPLOYMENT_ID"
 wait_deployment_reaching_status "PUBLISHED" "$DEPLOYMENT_ID"
 
-echo "Staging repository $DEPLOYMENT_ID published successfully"
+echo "Deployment $DEPLOYMENT_ID published successfully"

--- a/.buildkite/release-java-artifacts.sh
+++ b/.buildkite/release-java-artifacts.sh
@@ -184,10 +184,10 @@ cd "$REPO_ROOT"
 find . -name "$VESPA_RELEASE" -type d | sed 's,^./,,' | xargs -n 1 -P $NUM_PROC -I '{}' bash -c "sign_module {}"
 
 # Create a zip file of all the staged artifacts
-(
-cd "$TMP_STAGING"
 ZIP_FILE=$(mktemp).zip
-zip -r "$ZIP_FILE" .
+(
+  cd "$TMP_STAGING"
+  zip -r "$ZIP_FILE" .
 )
 
 # Upload the bundle using the Central Portal API


### PR DESCRIPTION
The changes in this commit replace the Nexus Staging Maven Plugin with the Central Portal API for publishing Java artifacts. This simplifies the deployment process and removes the need for the Nexus Staging Maven Plugin, which had issues with JDK 17. The key changes are:

- Create a zip file of all the staged artifacts
- Upload the bundle using the Central Portal API
- Wait for the deployment to reach the "PUBLISHED" status
- Remove the Nexus Staging Maven Plugin-related code