### PR TITLE
Revert "only wire inside multivalue expressions"

### DIFF
--- a/searchlib/src/vespa/searchlib/aggregation/grouping.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/grouping.cpp
@@ -151,18 +151,8 @@ struct ResolveCurrentIndex : vespalib::ObjectOperation, vespalib::ObjectPredicat
                 docField.setCurrentIndex(setup.resolve(docField.getFieldName()));
             }
         }
-        // ignore not-multivalue ExpressionNode (see below)
     }
-
     bool check(const vespalib::Identifiable &obj) const override {
-        if (obj.inherits(ExpressionNode::classId)) {
-            const auto& expr = static_cast<const ExpressionNode &>(obj);
-            const auto * res = expr.getResult();
-            if (res && ! res->inherits(ResultNodeVector::classId)) {
-                // not multivalue, execute() will ignore it
-                return true;
-            }
-        }
         return obj.inherits(AttributeNode::classId)
                 || obj.inherits(DocumentFieldNode::classId);
     }
@@ -325,10 +315,6 @@ Grouping::configureStaticStuff(const ConfigureStaticParams & params)
         select(confDoc, confDoc);
     }
 
-    // prepare result types of expressions
-    ExpressionTree::Configure treeConf;
-    select(treeConf, treeConf);
-
     if (params._enableNestedMultivalueGrouping) {
         CurrentIndexSetup setup;
         ResolveCurrentIndex resolver(setup);
@@ -339,7 +325,7 @@ Grouping::configureStaticStuff(const ConfigureStaticParams & params)
         selectGroups(resolver, resolver, _root, 0, _lastLevel, 0);
     }
 
-    // redo prepare, wiring of current-index may change result types
+    ExpressionTree::Configure treeConf;
     select(treeConf, treeConf);
 
     AggregationResult::Configure aggrConf;


### PR DESCRIPTION
Reverts vespa-engine/vespa#34135

this triggered various system test failures / coredumps.  We need to do something more complicated...