### PR TITLE
fix: add missing <name> tags to POM files

### DIFF
--- a/bundle-plugin-test/test-bundles/artifact-version-for-exports-dep/pom.xml
+++ b/bundle-plugin-test/test-bundles/artifact-version-for-exports-dep/pom.xml
@@ -18,6 +18,7 @@
              impossible with the maven-versions-plugin, and cumbersome with factorylib. -->
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
   <dependencies>
   </dependencies>
   <build>

--- a/bundle-plugin-test/test-bundles/artifact-version-for-exports/pom.xml
+++ b/bundle-plugin-test/test-bundles/artifact-version-for-exports/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>artifact-version-for-exports</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa.bundle-plugin</groupId>

--- a/bundle-plugin-test/test-bundles/export-packages-lib/pom.xml
+++ b/bundle-plugin-test/test-bundles/export-packages-lib/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>export-packages-lib</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
 
   <build>
     <plugins>

--- a/bundle-plugin-test/test-bundles/main/pom.xml
+++ b/bundle-plugin-test/test-bundles/main/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>main</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa.bundle-plugin</groupId>

--- a/bundle-plugin-test/test-bundles/non-public-api-usage/pom.xml
+++ b/bundle-plugin-test/test-bundles/non-public-api-usage/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>non-public-api-usage</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
 
   <dependencies>
     <dependency>

--- a/bundle-plugin-test/test-bundles/vespa-jar-using-non-public-api/pom.xml
+++ b/bundle-plugin-test/test-bundles/vespa-jar-using-non-public-api/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>vespa-jar-using-non-public-api</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>
+  <name>${project.artifactId}</name>
 
   <dependencies>
     <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -15,6 +15,7 @@
   <artifactId>client</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
 
   <dependencies>
     <dependency>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -15,6 +15,7 @@
     <artifactId>cloud-tenant-base-dependencies-enforcer</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/config-bundle/pom.xml
+++ b/config-bundle/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>config-bundle</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/config-model-fat/pom.xml
+++ b/config-model-fat/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>config-model-fat</artifactId>
   <packaging>bundle</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>config-proxy</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/container-apache-http-client-bundle/pom.xml
+++ b/container-apache-http-client-bundle/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>container-apache-http-client-bundle</artifactId>
     <packaging>jar</packaging>
     <version>8-SNAPSHOT</version>
+    <name>${project.artifactId}</name>
 
     <parent>
         <groupId>com.yahoo.vespa</groupId>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>container-core</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
 
   <dependencies>
 

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -15,6 +15,7 @@
     <artifactId>container-dependencies-enforcer</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/container-llama/pom.xml
+++ b/container-llama/pom.xml
@@ -7,6 +7,7 @@
   <artifactId>container-llama</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <parent>
     <groupId>com.yahoo.vespa</groupId>
     <artifactId>parent</artifactId>

--- a/container-spifly/pom.xml
+++ b/container-spifly/pom.xml
@@ -7,6 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>container-spifly</artifactId>
     <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>parent</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -16,6 +16,7 @@
   <artifactId>container</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/docproc/pom.xml
+++ b/docproc/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>docproc</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <!-- PROVIDED scope -->
     <dependency>

--- a/fat-model-dependencies/pom.xml
+++ b/fat-model-dependencies/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>fat-model-dependencies</artifactId>
   <packaging>pom</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/hosted-zone-api/pom.xml
+++ b/hosted-zone-api/pom.xml
@@ -10,6 +10,7 @@
   </parent>
   <artifactId>hosted-zone-api</artifactId>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
 
   <dependencies>
     <!-- provided -->

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>maven-plugins</artifactId>
     <packaging>pom</packaging>
     <version>8-SNAPSHOT</version>
+    <name>${project.artifactId}</name>
     <description>Parent artifact for Vespa maven plugins.</description>
     <url>http://yahoo.github.io/vespa</url>
 

--- a/messagebus/pom.xml
+++ b/messagebus/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>messagebus</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/model-integration/pom.xml
+++ b/model-integration/pom.xml
@@ -14,6 +14,7 @@
   <artifactId>model-integration</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
 
   <dependencyManagement>
     <dependencies>
@@ -242,7 +243,7 @@
     </exclusions>
     </dependency>
 
-     <!-- include com.fasterxml.jackson.databind -->
+    <!-- include com.fasterxml.jackson.databind -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/node-repository/pom.xml
+++ b/node-repository/pom.xml
@@ -14,6 +14,7 @@
     <artifactId>node-repository</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>container-plugin</packaging>
+    <name>${project.artifactId}</name>
     <description>Keeps track of node assignment in a multi-application setup.</description>
 
     <dependencies>

--- a/opennlp-linguistics/pom.xml
+++ b/opennlp-linguistics/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>opennlp-linguistics</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>vespa</artifactId>
     <packaging>pom</packaging>
     <version>8-SNAPSHOT</version>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>Aggregator pom for vespa.</description>
     <url>https://github.com/vespa-engine</url>
 

--- a/socket_test/pom.xml
+++ b/socket_test/pom.xml
@@ -8,6 +8,7 @@
     <groupId>com.yahoo.vespa</groupId>
     <artifactId>socket_test</artifactId>
     <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
     <parent>
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>parent</artifactId>

--- a/standalone-container/pom.xml
+++ b/standalone-container/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>standalone-container</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/tenant-cd-commons/pom.xml
+++ b/tenant-cd-commons/pom.xml
@@ -8,6 +8,7 @@
     <groupId>com.yahoo.vespa</groupId>
     <artifactId>tenant-cd-commons</artifactId>
     <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
 
     <parent>
         <groupId>com.yahoo.vespa</groupId>

--- a/vespa-athenz/pom.xml
+++ b/vespa-athenz/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>vespa-athenz</artifactId>
     <packaging>container-plugin</packaging>
     <version>8-SNAPSHOT</version>
+    <name>${project.artifactId}</name>
 
     <parent>
         <groupId>com.yahoo.vespa</groupId>

--- a/vespa-dependencies-enforcer/pom.xml
+++ b/vespa-dependencies-enforcer/pom.xml
@@ -15,6 +15,7 @@
     <artifactId>vespa-dependencies-enforcer</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/vespa-enforcer-extensions/pom.xml
+++ b/vespa-enforcer-extensions/pom.xml
@@ -7,6 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>vespa-enforcer-extensions</artifactId>
     <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>parent</artifactId>

--- a/vespa-feed-client-api/pom.xml
+++ b/vespa-feed-client-api/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>vespa-feed-client-api</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
 
   <dependencies>
     <!-- compile scope -->

--- a/vespa-osgi-testrunner/pom.xml
+++ b/vespa-osgi-testrunner/pom.xml
@@ -13,6 +13,7 @@
 
     <artifactId>vespa-osgi-testrunner</artifactId>
     <packaging>container-plugin</packaging>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/vespaclient-core/pom.xml
+++ b/vespaclient-core/pom.xml
@@ -11,6 +11,7 @@
   </parent>
   <artifactId>vespaclient-core</artifactId>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/vespaclient-java/pom.xml
+++ b/vespaclient-java/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>vespaclient-java</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
     <dependencies>
         <dependency>
             <!-- Due to com.yahoo.search.query.profile.DumpTool ... -->

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>zookeeper-server-parent</artifactId>
   <packaging>pom</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <modules>
     <module>zookeeper-server-common</module>
     <module>zookeeper-server</module>

--- a/zookeeper-server/zookeeper-server-common/pom.xml
+++ b/zookeeper-server/zookeeper-server-common/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>zookeeper-server-common</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/zookeeper-server/zookeeper-server/pom.xml
+++ b/zookeeper-server/zookeeper-server/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>zookeeper-server-3.9.3</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <properties>
     <zookeeper.version>3.9.3</zookeeper.version>
   </properties>


### PR DESCRIPTION
## What

* add missing <name> tags to POM files

## Why

* Ensures all pom.xml files have a <name> tag for Maven Central compliance.
* Resolves a publishing issue on Maven Central.