### PR TITLE
fix(ci): add 'job-type' as property

### DIFF
--- a/.buildkite/plugins/factory-reporter/README.md
+++ b/.buildkite/plugins/factory-reporter/README.md
@@ -26,4 +26,6 @@ The id of the pipeline
 
 Set to true if this is the first step in the pipeline
 
+### `job-type` (Optional, string)
 
+The type of job. Defaults to `build`.

--- a/.buildkite/plugins/factory-reporter/plugin.yml
+++ b/.buildkite/plugins/factory-reporter/plugin.yml
@@ -14,6 +14,7 @@ configuration:
     job-type:
         type: string
         description: "The type of job being reported (e.g., 'build', 'release'). Defaults to 'build'."
+        default: 'build'
   additionalProperties: false
   required:
     - pipeline-id

--- a/.buildkite/plugins/factory-reporter/plugin.yml
+++ b/.buildkite/plugins/factory-reporter/plugin.yml
@@ -11,6 +11,9 @@ configuration:
     first-step:
       type: boolean
       description: "Is this the first step? Yes: Create a build, No: Update the build"
+    job-type:
+        type: string
+        description: "The type of job being reported (e.g., 'build', 'release'). Defaults to 'build'."
   additionalProperties: false
   required:
     - pipeline-id


### PR DESCRIPTION
## What
Add `job-type` as config property in the factory-reporter plugin.

## Why
Required to allow using it as config to the plugin (forgotten in #34175 )