### PR TITLE
feat(validation): add EmbedExpressionValidator to check embedder IDs

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidator.java
@@ -1,0 +1,70 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation;
+
+import com.yahoo.vespa.indexinglanguage.ExpressionVisitor;
+import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Validates that all embedder ids specified in 'embed' expressions references an existing component.
+ *
+ * @author bjorncs
+ */
+public class EmbedExpressionValidator implements Validator {
+
+    private static final Logger log = Logger.getLogger(EmbedExpressionValidator.class.getName());
+
+    @Override
+    public void validate(Validation.Context context) {
+        // Collect all embedder ids from EmbedExpression instances in all schemas
+        var fieldToEmbedderId = new HashMap<String, String>();
+        context.model().getContentClusters().forEach((__, contentCluster) -> {
+            if (!contentCluster.getSearch().hasSearchCluster()) return;
+
+            contentCluster.getSearch().getSearchCluster().schemas().forEach((___, schema) -> {
+                schema.fullSchema().allFields()
+                        .forEach(field -> {
+                            if (field.isImportedField() || field.getIndexingScript().isEmpty()) return;
+
+                            var visitor = new ExpressionVisitor() {
+                                @Override
+                                protected void doVisit(Expression e) {
+                                    if (e instanceof EmbedExpression ee) {
+                                        ee.requestedEmbedderId().ifPresent(id -> {
+                                            var fieldName = field.getName();
+                                            log.log(Level.FINE, () -> "Found embedder '%s' for field '%s'".formatted(id, fieldName));
+                                            fieldToEmbedderId.put(fieldName, id);
+                                        });
+                                    }
+                                }
+                            };
+                            visitor.visit(field.getIndexingScript());
+                        });
+            });
+        });
+
+        // Collect all component ids from the model
+        var allComponentIds = new HashSet<String>();
+        context.model().getContainerClusters().forEach((__, containerCluster) ->
+                containerCluster.getAllComponents()
+                        .forEach(component -> {
+                            var id = component.getComponentId().getName();
+                            log.log(Level.FINE, () -> "Found component id '%s'".formatted(id));
+                            allComponentIds.add(id);
+                        }));
+
+        // Validate that all embedder ids are present as components
+        fieldToEmbedderId.forEach((fieldName, requestedEmbedderId) -> {
+            if (!allComponentIds.contains(requestedEmbedderId)) {
+                context.illegal(
+                        ("The 'embed' expression for field '%s' refers to an embedder with id '%s'. " +
+                                "No component with that id is configured.").formatted(fieldName, requestedEmbedderId));
+            }
+        });
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -111,6 +111,7 @@ public class Validation {
         new PagedAttributesRemoteStorageValidator().validate(execution);
         new TenantSecretValidator().validate(execution);
         new HnswValidator().validate(execution);
+        new EmbedExpressionValidator().validate(execution);
     }
 
     private static void validateFirstTimeDeployment(Execution execution) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidatorTest.java
@@ -59,6 +59,7 @@ class EmbedExpressionValidatorTest {
                 new EmbedExpressionValidator(),
                 new VespaModel(deployState),
                 deployState,
-                "The 'embed' expression for field 'embedding' refers to an embedder with id 'non_existing_embedder'. No component with that id is configured.");
+                "The 'embed' expression for field 'embedding' in schema 'test' refers to an embedder " +
+                        "with id 'non_existing_embedder'. No component with that id is configured.");
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidatorTest.java
@@ -1,0 +1,64 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation;
+
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.model.test.MockApplicationPackage;
+import com.yahoo.vespa.model.VespaModel;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author bjorncs
+ */
+class EmbedExpressionValidatorTest {
+
+    @Test
+    void testNonExistingEmbedderCausesIllegalEntry() throws IOException, SAXException {
+        // Create a schema that uses the 'embed' expression with a non-existing embedder ID
+        var schema = """
+                schema test {
+                  field embedding type tensor(x[768]) {
+                    indexing: input content | embed non_existing_embedder | attribute
+                  }
+                  document test {
+                    field content type string {
+                      indexing: summary | index
+                    }
+                  }
+                }
+                """;
+
+        // Create a services.xml file that doesn't define the embedder component
+        var services = """
+                <?xml version="1.0" encoding="utf-8" ?>
+                <services version="1.0">
+                  <container id="default" version="1.0">
+                    <search/>
+                    <document-api/>
+                  </container>
+                  <content id="test" version="1.0">
+                    <redundancy>1</redundancy>
+                    <documents>
+                      <document type="test" mode="index"/>
+                    </documents>
+                    <nodes count="1"/>
+                  </content>
+                </services>
+                """;
+
+        var deployState = new DeployState.Builder()
+                .applicationPackage(new MockApplicationPackage.Builder()
+                        .withServices(services)
+                        .withSchemas(List.of(schema))
+                        .build())
+                .build();
+        ValidationTester.expect(
+                new EmbedExpressionValidator(),
+                new VespaModel(deployState),
+                deployState,
+                "The 'embed' expression for field 'embedding' refers to an embedder with id 'non_existing_embedder'. No component with that id is configured.");
+    }
+}

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 
 /**
@@ -29,15 +30,20 @@ public class EmbedExpression extends Expression  {
 
     private final Linguistics linguistics;
     private final SelectedComponent<Embedder> embedder;
+    private final String requestedEmbedderId;
 
     /** The destination the embedding will be written to on the form [schema name].[field name] */
     private String destination;
 
     public EmbedExpression(Linguistics linguistics, Map<String, Embedder> embedders, String embedderId, List<String> embedderArguments) {
         this.linguistics = linguistics;
+        this.requestedEmbedderId = embedderId;
         embedder = new SelectedComponent<>("embedder", embedders, embedderId, true, embedderArguments,
                                            Embedder.FailingEmbedder::new);
     }
+
+    /** @return the requested embedder id. This will diverge from the selected embedder's id when executed in config-model */
+    public Optional<String> requestedEmbedderId() { return Optional.of(requestedEmbedderId).filter(s -> !s.isEmpty()); }
 
     @Override
     public DataType setInputType(DataType inputType, TypeContext context) {


### PR DESCRIPTION
Introduce EmbedExpressionValidator to ensure all embedder IDs used in
'embed' expressions reference existing components in the model. This
prevents misconfigurations where embed expressions refer to non-existent
components.