### PR TITLE
Use zone from DeployState, part 2

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1041,7 +1041,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                 .getApplicationPackage()
                 .getDeploymentSpec()
                 .zoneEndpoint(context.properties().applicationId().instance(),
-                              context.properties().zone(),
+                              context.getDeployState().zone(),
                               cluster,
                               context.featureFlags().useNonPublicEndpointForTest());
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -341,8 +341,8 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                 .applicationPackage(applicationPackage)
                 .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties().setMultitenant(true)
-                                                .setHostedVespa(true)
-                                                .setZone(new Zone(environment, RegionName.from(region))))
+                                                .setHostedVespa(true))
+                .zone(new Zone(environment, RegionName.from(region)))
                 .build());
         assertEquals(2, model.hostSystem().getHosts().size());
         assertEquals(1, provisioner.provisionedClusters().size());


### PR DESCRIPTION
Avoid using zone from properties, trying to remove having a zone method for both deploy state and properties. Part 1 was in https://github.com/vespa-engine/vespa/pull/34109