### PR TITLE
Add post command hook

### DIFF
--- a/.buildkite/plugins/factory-reporter/hooks/post-command
+++ b/.buildkite/plugins/factory-reporter/hooks/post-command
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#
+# This script is run after the command has completed, and updates the job run status in factory.
+#
+set -eo pipefail
+
+PIPELINE="$BUILDKITE_PLUGIN_FACTORY_REPORTER_PIPELINE_ID"
+
+if [[ $SKIP_BUILDKITE_PLUGINS == "true" ]]; then
+    echo "SKIP_BUILDKITE_PLUGINS is set. Skipping factory reporter"
+    exit 0
+fi
+if [[ -z $PIPELINE ]]; then
+    echo "No pipeline ID found, skipping factory reporter"
+    exit 0
+fi
+
+if [[ $BUILDKITE_PULL_REQUEST == "false" ]]; then
+  FACTORY_COMMAND=$(buildkite-agent meta-data get factory-command)
+  JOB_JSON=$($FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "success")
+  echo "Output from updating job run : $JOB_JSON"
+fi

--- a/.buildkite/plugins/factory-reporter/hooks/pre-command
+++ b/.buildkite/plugins/factory-reporter/hooks/pre-command
@@ -26,6 +26,13 @@ if [[ $BUILDKITE_PULL_REQUEST == "false" ]]; then
     echo "start-seconds already set, skipping"
   fi
 
+  if command -v factory-command &> /dev/null; then
+    FACTORY_COMMAND="factory-command"
+  else
+    FACTORY_COMMAND="$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/factory-command.sh"
+  fi
+  buildkite-agent meta-data set factory-command "$FACTORY_COMMAND"
+
   JOB_JSON=$($BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/factory-command.sh update-buildkite-job-run $START_SECONDS $PIPELINE "running")
   echo "Output from updating job run : $JOB_JSON"
 

--- a/.buildkite/plugins/factory-reporter/hooks/pre-exit
+++ b/.buildkite/plugins/factory-reporter/hooks/pre-exit
@@ -24,10 +24,11 @@ fi
 
 if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS != 0 )); then
   START_SECONDS=$(buildkite-agent meta-data get start-seconds || echo 0)
-  $BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/factory-command.sh update-buildkite-job-run $START_SECONDS $PIPELINE failure
+  FACTORY_COMMAND=$(buildkite-agent meta-data get factory-command)
+  $FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE failure
 
   # Only update build status if the job type is 'build'
   if [[ $JOB_TYPE == "build" ]]; then
-    $BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/factory-command.sh update-build-status $PIPELINE failure "Build failed"
+    $FACTORY_COMMAND update-build-status $PIPELINE failure "Build failed"
   fi
 fi

--- a/.buildkite/plugins/factory-reporter/plugin.yml
+++ b/.buildkite/plugins/factory-reporter/plugin.yml
@@ -13,7 +13,7 @@ configuration:
       description: "Is this the first step? Yes: Create a build, No: Update the build"
     job-type:
         type: string
-        description: "The type of job being reported (e.g., 'build', 'release'). Defaults to 'build'."
+        description: "The type of job being reported (e.g., 'build', 'release', 'test'). Defaults to 'build'."
         default: 'build'
   additionalProperties: false
   required:
@@ -23,5 +23,7 @@ configuration:
 hooks:
   pre-command:
     command: "hooks/pre-command"
+  post-command:
+    command: "hooks/post-command"
   pre-exit:
     command: "hooks/pre-exit"

--- a/.buildkite/plugins/factory-reporter/plugin.yml
+++ b/.buildkite/plugins/factory-reporter/plugin.yml
@@ -19,3 +19,9 @@ configuration:
   required:
     - pipeline-id
     - first-step
+
+hooks:
+  pre-command:
+    command: "hooks/pre-command"
+  pre-exit:
+    command: "hooks/pre-exit"


### PR DESCRIPTION
## What
Always report job run state from the factory-reporter plugin hooks, instead of in individual pipelines.

## Why
More consistent, and makes it easier to report job states also from vespaai buildkite pipelines.
