### PR TITLE
chore: update dependency versions and add perfmark and okhttp

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -108,6 +108,7 @@
         <hdrhistogram.vespa.version>2.2.2</hdrhistogram.vespa.version>
         <huggingface.vespa.version>0.32.0</huggingface.vespa.version>
         <icu4j.vespa.version>75.1</icu4j.vespa.version>
+        <io-perfmark.vespa.version>0.27.0</io-perfmark.vespa.version>
         <java-jjwt.vespa.version>0.11.5</java-jjwt.vespa.version>
         <java-jwt.vespa.version>4.4.0</java-jwt.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
@@ -133,6 +134,7 @@
         <mojo-executor.vespa.version>2.4.0</mojo-executor.vespa.version>
         <netty.vespa.version>4.1.118.Final</netty.vespa.version>
         <netty-tcnative.vespa.version>2.0.65.Final</netty-tcnative.vespa.version>
+        <okhttp.vespa.version>4.12.0</okhttp.vespa.version>
         <onnxruntime.vespa.version>1.20.0</onnxruntime.vespa.version>
         <openai-java.vespa.version>0.34.0</openai-java.vespa.version>
         <opennlp.vespa.version>2.4.0</opennlp.vespa.version>

--- a/model-integration/pom.xml
+++ b/model-integration/pom.xml
@@ -37,11 +37,13 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
+        <version>${okhttp.vespa.version}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>logging-interceptor</artifactId>
+        <version>${okhttp.vespa.version}</version>
         <scope>compile</scope>
       </dependency>
       <!-- END: Transitive dependencies for openai-java -->
@@ -71,6 +73,7 @@
       <dependency>
         <groupId>io.perfmark</groupId>
         <artifactId>perfmark-api</artifactId>
+        <version>${io-perfmark.vespa.version}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Add io-perfmark 0.27.0 and okhttp 4.12.0 versions to dependency
management.