### PR TITLE
chore(messagebus): increase maxPendingCount to 4096

### DIFF
--- a/container-messagebus/src/main/resources/configdefinitions/container.jdisc.container-mbus.def
+++ b/container-messagebus/src/main/resources/configdefinitions/container.jdisc.container-mbus.def
@@ -20,7 +20,7 @@ transport_events_before_wakeup int default=1
 
 # Everying below is deprecated and will go away very soon.
 # Dynamic throttling is used, and works better than anything else.
-maxpendingcount int default=2048
+maxpendingcount int default=4096
 
 #The amount of input data that the service can process concurrently
 maxConcurrentFactor double default=0.2 range=[0.0-1.0]

--- a/messagebus/src/main/java/com/yahoo/messagebus/MessageBusParams.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/MessageBusParams.java
@@ -25,7 +25,7 @@ public class MessageBusParams {
      */
     public MessageBusParams() {
         retryPolicy = new RetryTransientErrorsPolicy();
-        maxPendingCount = 1024;
+        maxPendingCount = 4096;
         config = null;
     }
 


### PR DESCRIPTION
Based on the config definition comment it’s not in use. Let’s see if it has any impact in the CI environment.