### PR TITLE
feat: Add project names to all POM files

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>application</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/bundle-plugin-test/integration-test/pom.xml
+++ b/bundle-plugin-test/integration-test/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>integration-test</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>

--- a/bundle-plugin-test/pom.xml
+++ b/bundle-plugin-test/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <groupId>com.yahoo.vespa.bundle-plugin</groupId>
   <artifactId>bundle-plugin-test</artifactId>
   <version>8-SNAPSHOT</version>

--- a/bundle-plugin-test/test-bundles/pom.xml
+++ b/bundle-plugin-test/test-bundles/pom.xml
@@ -11,6 +11,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>test-bundles</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/clustercontroller-apps/pom.xml
+++ b/clustercontroller-apps/pom.xml
@@ -8,6 +8,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>clustercontroller-apps</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>container-plugin</packaging>

--- a/clustercontroller-reindexer/pom.xml
+++ b/clustercontroller-reindexer/pom.xml
@@ -9,6 +9,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>clustercontroller-reindexer</artifactId>

--- a/clustercontroller-utils/pom.xml
+++ b/clustercontroller-utils/pom.xml
@@ -9,6 +9,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>clustercontroller-utils</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>container-plugin</packaging>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>component</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/config-application-package/pom.xml
+++ b/config-application-package/pom.xml
@@ -9,6 +9,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>config-application-package</artifactId>
     <packaging>container-plugin</packaging>
     <version>8-SNAPSHOT</version>

--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>config-model</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>config</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/configserver-flags/pom.xml
+++ b/configserver-flags/pom.xml
@@ -11,6 +11,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>configserver-flags</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>container-plugin</packaging>

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>configserver</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -12,6 +12,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-dev</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-disc</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>

--- a/container-documentapi/pom.xml
+++ b/container-documentapi/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-documentapi</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/container-messagebus/pom.xml
+++ b/container-messagebus/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-messagebus</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>

--- a/container-onnxruntime/pom.xml
+++ b/container-onnxruntime/pom.xml
@@ -14,6 +14,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip> <!-- Javadoc plugin fails because of no source code in module -->
     </properties>

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-search-and-docproc</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-search</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -13,6 +13,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>container-test</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>jar</packaging>

--- a/docprocs/pom.xml
+++ b/docprocs/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>docprocs</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/documentapi-dependencies/pom.xml
+++ b/documentapi-dependencies/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>documentapi-dependencies</artifactId>
   <packaging>pom</packaging>
   <version>8-SNAPSHOT</version>

--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>documentapi</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/fileacquirer/pom.xml
+++ b/fileacquirer/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>fileacquirer</artifactId>
   <version>8-SNAPSHOT</version>
   <dependencies>

--- a/fsa/pom.xml
+++ b/fsa/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>fsa</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/hosted-api/pom.xml
+++ b/hosted-api/pom.xml
@@ -11,6 +11,7 @@
         <version>8-SNAPSHOT</version>
 	<relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>hosted-api</artifactId>
     <description>Miscellaneous for tenant client -- hosted Vespa controller communication</description>
 

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -11,6 +11,7 @@
         <version>8-SNAPSHOT</version>
 	<relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <packaging>container-plugin</packaging>
     <artifactId>http-client</artifactId>
     <description>HTTP client wrapper around an Apache http client 5</description>

--- a/http-utils/pom.xml
+++ b/http-utils/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>http-utils</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/integration/intellij/pom.xml
+++ b/integration/intellij/pom.xml
@@ -8,6 +8,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>vespa-intellij</artifactId> <!-- Not used - plugin is build by gradle -->
     <version>1.6.1</version> <!-- See copy-zip below, which depends on this being the same as the v. in build.gradle.kts -->
     <description>

--- a/jdisc-cloud-aws/pom.xml
+++ b/jdisc-cloud-aws/pom.xml
@@ -11,6 +11,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>jdisc-cloud-aws</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>container-plugin</packaging>

--- a/jdisc-security-filters/pom.xml
+++ b/jdisc-security-filters/pom.xml
@@ -15,6 +15,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <dependencies>
         <!-- provided -->
         <dependency>

--- a/linguistics-components/pom.xml
+++ b/linguistics-components/pom.xml
@@ -10,6 +10,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>linguistics-components</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/linguistics/pom.xml
+++ b/linguistics/pom.xml
@@ -10,6 +10,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>linguistics</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/lucene-linguistics/pom.xml
+++ b/lucene-linguistics/pom.xml
@@ -10,6 +10,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
 
   <artifactId>lucene-linguistics</artifactId>
   <packaging>container-plugin</packaging>

--- a/metrics-proxy/pom.xml
+++ b/metrics-proxy/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>metrics-proxy</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/model-evaluation/pom.xml
+++ b/model-evaluation/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>model-evaluation</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>

--- a/provided-dependencies/pom.xml
+++ b/provided-dependencies/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>provided-dependencies</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/routing-generator/pom.xml
+++ b/routing-generator/pom.xml
@@ -9,6 +9,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
 
     <groupId>com.yahoo.vespa</groupId>
     <artifactId>routing-generator</artifactId>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>security-utils</artifactId>
   <packaging>bundle</packaging>
   <version>8-SNAPSHOT</version>

--- a/tenant-cd-api/pom.xml
+++ b/tenant-cd-api/pom.xml
@@ -17,6 +17,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
 
     <properties>
 

--- a/vespa-3party-bundles/pom.xml
+++ b/vespa-3party-bundles/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespa-3party-bundles</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/vespa-3party-jars/pom.xml
+++ b/vespa-3party-jars/pom.xml
@@ -11,6 +11,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
     <artifactId>vespa-3party-jars</artifactId>
     <version>8-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/vespa-application-maven-plugin/pom.xml
+++ b/vespa-application-maven-plugin/pom.xml
@@ -9,6 +9,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespa-application-maven-plugin</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>

--- a/vespa-feed-client-cli/pom.xml
+++ b/vespa-feed-client-cli/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespa-feed-client-cli</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/vespa-feed-client/pom.xml
+++ b/vespa-feed-client/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespa-feed-client</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/vespa-maven-plugin/pom.xml
+++ b/vespa-maven-plugin/pom.xml
@@ -10,6 +10,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespa-maven-plugin</artifactId>
   <description>Maven Plugin for deploying a Vespa application package</description>
   <packaging>maven-plugin</packaging>

--- a/vespa-testrunner-components/pom.xml
+++ b/vespa-testrunner-components/pom.xml
@@ -14,6 +14,7 @@
         <version>8-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+  <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/vespaclient-container-plugin/pom.xml
+++ b/vespaclient-container-plugin/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespaclient-container-plugin</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>container-plugin</packaging>

--- a/vespajlib/pom.xml
+++ b/vespajlib/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespajlib</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/zkfacade/pom.xml
+++ b/zkfacade/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>zkfacade</artifactId>
   <packaging>container-plugin</packaging>
   <version>8-SNAPSHOT</version>

--- a/zookeeper-client-common/pom.xml
+++ b/zookeeper-client-common/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>zookeeper-client-common</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>

--- a/zookeeper-command-line-client/pom.xml
+++ b/zookeeper-command-line-client/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>zookeeper-command-line-client</artifactId>
   <version>8-SNAPSHOT</version>
   <dependencies>

--- a/zookeeper-common/pom.xml
+++ b/zookeeper-common/pom.xml
@@ -8,6 +8,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>zookeeper-common</artifactId>
   <packaging>jar</packaging>
   <version>8-SNAPSHOT</version>


### PR DESCRIPTION
## What

* Adds a `<name>${project.artifactId}</name>` tag to every pom.xml which has `<parent>` and is missing `<name>`.

## Why

Fix maven central publishing 