### PR TITLE
Jdisc request content logging

### DIFF
--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -75,7 +75,12 @@ AccessLog = element accesslog {
     attribute compressionType { string "gzip" | string "zstd" }? &
     attribute queueSize { xsd:nonNegativeInteger }? &
     attribute bufferSize { xsd:nonNegativeInteger }? &
-    attribute rotationInterval { string }?
+    attribute rotationInterval { string }? &
+    element request-content {
+        element samples-per-second { xsd:double { minInclusive = "0.0" maxInclusive = "100000" } } &
+        element path-prefix { string } &
+        element max-bytes { xsd:nonNegativeInteger }
+    }*
 }
 
 SecretStore = element secret-store {

--- a/config-model/src/test/schema-test-files/services.xml
+++ b/config-model/src/test/schema-test-files/services.xml
@@ -120,7 +120,19 @@
     </http>
 
     <accesslog type='json'
-           fileNamePattern='logs/vespa/access/access-json.%Y%m%d%H%M%S' compressOnRotation='true'  compressionType='zstd' queueSize='13' bufferSize='65536'/>
+           fileNamePattern='logs/vespa/access/access-json.%Y%m%d%H%M%S' compressOnRotation='true'  compressionType='zstd' queueSize='13' bufferSize='65536'>
+      <request-content>
+        <samples-per-second>0.2</samples-per-second>
+        <path-prefix>/search</path-prefix>
+        <max-bytes>65536</max-bytes>
+      </request-content>
+      <request-content>
+        <samples-per-second>0.5</samples-per-second>
+        <path-prefix>/document</path-prefix>
+        <max-bytes>32768</max-bytes>
+      </request-content>
+    </accesslog>
+
     <accesslog type='vespa'
            fileNamePattern='logs/vespa/access/access-vespa.%Y%m%d%H%M%S' />
 

--- a/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
+++ b/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
@@ -157,7 +157,9 @@ accessLog.remotePortHeaders[]         string
 
 # Path prefixes for which content should be logged
 accessLog.content[].pathPrefix  string
+# Maximum size of content to log, in bytes
 accessLog.content[].maxSize     long
+# Probabilistic sample rate, per second
 accessLog.content[].sampleRate  double
 
 compliance.httpViolations[] string

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/TracingOptions.java
@@ -2,10 +2,10 @@
 package com.yahoo.vespa.streamingvisitors;
 
 import com.yahoo.vespa.streamingvisitors.tracing.LoggingTraceExporter;
-import com.yahoo.vespa.streamingvisitors.tracing.MaxSamplesPerPeriod;
-import com.yahoo.vespa.streamingvisitors.tracing.MonotonicNanoClock;
-import com.yahoo.vespa.streamingvisitors.tracing.ProbabilisticSampleRate;
-import com.yahoo.vespa.streamingvisitors.tracing.SamplingStrategy;
+import ai.vespa.sampling.MaxSamplesPerPeriod;
+import ai.vespa.sampling.MonotonicNanoClock;
+import ai.vespa.sampling.ProbabilisticSampleRate;
+import ai.vespa.sampling.SamplingStrategy;
 import com.yahoo.vespa.streamingvisitors.tracing.SamplingTraceExporter;
 import com.yahoo.vespa.streamingvisitors.tracing.TraceExporter;
 

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporter.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporter.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors.tracing;
 
+import ai.vespa.sampling.SamplingStrategy;
+
 import java.util.function.Supplier;
 
 /**

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingSearcherTestCase.java
@@ -19,9 +19,8 @@ import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
 import com.yahoo.vdslib.VisitorStatistics;
-import com.yahoo.vespa.streamingvisitors.tracing.MockUtils;
-import com.yahoo.vespa.streamingvisitors.tracing.MonotonicNanoClock;
-import com.yahoo.vespa.streamingvisitors.tracing.SamplingStrategy;
+import ai.vespa.sampling.MonotonicNanoClock;
+import ai.vespa.sampling.SamplingStrategy;
 import com.yahoo.vespa.streamingvisitors.tracing.TraceExporter;
 import org.junit.jupiter.api.Test;
 
@@ -311,7 +310,8 @@ public class StreamingSearcherTestCase {
         StreamingBackend searcher;
 
         private TraceFixture(Long firstTimestamp, Long... additionalTimestamps) {
-            clock = MockUtils.mockedClockReturning(firstTimestamp, additionalTimestamps);
+            clock = mock(MonotonicNanoClock.class);
+            when(clock.nanoTimeNow()).thenReturn(firstTimestamp, additionalTimestamps);
             options = new TracingOptions(sampler, exporter, clock, 8, 2.0);
             factory = new MockVisitorFactory();
             searcher = new StreamingBackend(CLUSTER_PARAMS, "search-cluster-A", factory, "content-cluster-A", options);

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporterTest.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/tracing/SamplingTraceExporterTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors.tracing;
 
+import ai.vespa.sampling.SamplingStrategy;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -520,7 +520,7 @@ public class PermanentFlags {
             "log-request-content", List.of(), String.class,
             "Include request content in access log for paths starting with any of these prefixes",
             "Takes effect on next redeployment",
-            list -> list.stream().allMatch(s -> s.matches("^[a-zA-Z/.0-9-]+:(0(\\.\\d+)?|1(\\.0+)?):\\d+(B|kB|MB|GB)?$")),
+            list -> list.stream().allMatch(s -> s.matches("^[a-zA-Z/.0-9-]+:\\d+(?:\\.\\d+)?:\\d+(?:B|kB|MB|GB)?$")),
             INSTANCE_ID);
 
     public static final UnboundIntFlag ZOOKEEPER_JUTE_MAX_BUFFER = defineIntFlag(

--- a/vespajlib/src/main/java/ai/vespa/sampling/MaxSamplesPerPeriod.java
+++ b/vespajlib/src/main/java/ai/vespa/sampling/MaxSamplesPerPeriod.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 /**
  * Very basic sampling strategy which allows for sampling N requests within a fixed

--- a/vespajlib/src/main/java/ai/vespa/sampling/MonotonicNanoClock.java
+++ b/vespajlib/src/main/java/ai/vespa/sampling/MonotonicNanoClock.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 /**
  * Clock which returns a monotonically increasing timestamp from an undefined epoch.

--- a/vespajlib/src/main/java/ai/vespa/sampling/ProbabilisticSampleRate.java
+++ b/vespajlib/src/main/java/ai/vespa/sampling/ProbabilisticSampleRate.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;

--- a/vespajlib/src/main/java/ai/vespa/sampling/SamplingStrategy.java
+++ b/vespajlib/src/main/java/ai/vespa/sampling/SamplingStrategy.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 /**
  * A sampling strategy makes the high-level decision of whether or not a query

--- a/vespajlib/src/main/java/ai/vespa/sampling/package-info.java
+++ b/vespajlib/src/main/java/ai/vespa/sampling/package-info.java
@@ -1,0 +1,4 @@
+@ExportPackage
+package ai.vespa.sampling;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/vespajlib/src/test/java/ai/vespa/sampling/MaxSamplesPerPeriodTest.java
+++ b/vespajlib/src/test/java/ai/vespa/sampling/MaxSamplesPerPeriodTest.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 import org.junit.jupiter.api.Test;
 

--- a/vespajlib/src/test/java/ai/vespa/sampling/MockUtils.java
+++ b/vespajlib/src/test/java/ai/vespa/sampling/MockUtils.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 import java.util.Random;
 

--- a/vespajlib/src/test/java/ai/vespa/sampling/ProbabilisticSampleRateTest.java
+++ b/vespajlib/src/test/java/ai/vespa/sampling/ProbabilisticSampleRateTest.java
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.streamingvisitors.tracing;
+package ai.vespa.sampling;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
### Description

- Moved sampling classes to `ai.vespa.sampling` in `vespajlib`.
- Added support for `request-content` elements in access log configuration.
- Enabled sampling of request content with configurable parameters: samples per second, path prefix, and max bytes.