### PR TITLE
Don't set job run status to sucess when command status is non-zero.

### DIFF
--- a/.buildkite/plugins/factory-reporter/hooks/post-command
+++ b/.buildkite/plugins/factory-reporter/hooks/post-command
@@ -12,27 +12,34 @@ if [[ $SKIP_BUILDKITE_PLUGINS == "true" ]]; then
     echo "SKIP_BUILDKITE_PLUGINS is set. Skipping factory reporter"
     exit 0
 fi
+if [[ $BUILDKITE_PULL_REQUEST != "false" ]]; then
+    exit 0
+fi
 if [[ -z $PIPELINE ]]; then
     echo "No pipeline ID found, skipping factory reporter"
     exit 0
 fi
 
-if [[ $BUILDKITE_PULL_REQUEST == "false" ]]; then
+START_SECONDS=$(buildkite-agent meta-data get start-seconds)
+if [[ -z $START_SECONDS ]]; then
+  echo "Error: start-seconds not set as meta-data" >&2
+  exit 1
+fi
 
-  START_SECONDS=$(buildkite-agent meta-data get start-seconds)
-  if [[ -z $START_SECONDS ]]; then
-    echo "Error: start-seconds not set as meta-data" >&2
-    exit 1
-  fi
+FACTORY_COMMAND=$(buildkite-agent meta-data get factory-command)
+if [[ -z $FACTORY_COMMAND ]]; then
+  echo "Error: factory-command not set as meta-data" >&2
+  exit 1
+fi
+echo "Using factory command: $FACTORY_COMMAND"
 
-  FACTORY_COMMAND=$(buildkite-agent meta-data get factory-command)
-  if [[ -z $FACTORY_COMMAND ]]; then
-    echo "Error: factory-command not set as meta-data" >&2
-    exit 1
-  fi
-  echo "Using factory command: $FACTORY_COMMAND"
-
-
+# Update the job run status in factory
+# The case where BUILDKITE_COMMAND_EXIT_STATUS is non-zero is handled in the pre-exit hook.
+if [[ -z $BUILDKITE_COMMAND_EXIT_STATUS ]]; then
+  echo "BUILDKITE_COMMAND_EXIT_STATUS is not set, assuming failure"
+  JOB_JSON=$($FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "failure")
+  echo "Used factory-command to set job run failure: $JOB_JSON"
+elif (( $BUILDKITE_COMMAND_EXIT_STATUS == 0 )); then
   JOB_JSON=$($FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "success")
-  echo "Output from updating job run : $JOB_JSON"
+  echo "Used factory-command to set job run success: $JOB_JSON"
 fi

--- a/.buildkite/plugins/factory-reporter/hooks/post-command
+++ b/.buildkite/plugins/factory-reporter/hooks/post-command
@@ -42,4 +42,6 @@ if [[ -z "$BUILDKITE_COMMAND_EXIT_STATUS" ]]; then
 elif (( $BUILDKITE_COMMAND_EXIT_STATUS == 0 )); then
   JOB_JSON=$($FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "success")
   echo "Used factory-command to set job run success: $JOB_JSON"
+else
+  echo "BUILDKITE_COMMAND_EXIT_STATUS is non-zero. Pre-exit hook is expected to handle this case." >&2
 fi

--- a/.buildkite/plugins/factory-reporter/hooks/post-command
+++ b/.buildkite/plugins/factory-reporter/hooks/post-command
@@ -35,7 +35,7 @@ echo "Using factory command: $FACTORY_COMMAND"
 
 # Update the job run status in factory
 # The case where BUILDKITE_COMMAND_EXIT_STATUS is non-zero is handled in the pre-exit hook.
-if [[ -z $BUILDKITE_COMMAND_EXIT_STATUS ]]; then
+if [[ -z "$BUILDKITE_COMMAND_EXIT_STATUS" ]]; then
   echo "BUILDKITE_COMMAND_EXIT_STATUS is not set, assuming failure"
   JOB_JSON=$($FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "failure")
   echo "Used factory-command to set job run failure: $JOB_JSON"


### PR DESCRIPTION
- I wrongfully assumed that post-command would not run if the command failed. In this case, it's no big deal, though, as the pre-exit hook will shortly after set job status to failure.

