### PR TITLE
Reduce time to wait before resetting restart penalty

### DIFF
--- a/configd/src/apps/sentinel/service.cpp
+++ b/configd/src/apps/sentinel/service.cpp
@@ -321,7 +321,7 @@ Service::youExited(int status)
         if (diff < MAX_RESTART_PENALTY) {
             incrementRestartPenalty();
         }
-        if (diff > 10 * MAX_RESTART_PENALTY) {
+        if (diff > 5 * MAX_RESTART_PENALTY) {
             resetRestartPenalty();
         }
         if (diff < _restartPenalty) {


### PR DESCRIPTION
Today a service that has been restarted will have a restart penalty until the service has been running 10 * MAX_RESTART_PENALTY, reduce this to 5 * MAX_RESTART_PENALTY, should be enough.