### PR TITLE
Add simple utility functions for integer over/underflow checking

### DIFF
--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -20,6 +20,7 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     mmap_file_allocator_factory_test.cpp
     mmap_file_allocator_test.cpp
     nexus_test.cpp
+    overflow_test.cpp
     printabletest.cpp
     ptrholder.cpp
     random_test.cpp

--- a/vespalib/src/tests/util/overflow_test.cpp
+++ b/vespalib/src/tests/util/overflow_test.cpp
@@ -1,0 +1,48 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/overflow.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <cstdint>
+
+using namespace ::testing;
+
+namespace vespalib {
+
+TEST(OverflowTest, add_overflow_is_detected) {
+    EXPECT_FALSE(add_would_overflow<uint8_t>(uint8_t{100}, uint8_t{155}));
+    EXPECT_FALSE(add_would_overflow<uint8_t>(100, 155));
+    EXPECT_FALSE(add_would_overflow<uint8_t>(uint8_t{0}, uint8_t{255}));
+    EXPECT_TRUE( add_would_overflow<uint8_t>(uint8_t{101}, uint8_t{155}));
+    EXPECT_TRUE( add_would_overflow<uint8_t>(101, 155)); // also works with implicit int operands and intermediate result
+    EXPECT_FALSE(add_would_overflow<int32_t>(int32_t{INT32_MAX}, int32_t{0}));
+    EXPECT_TRUE( add_would_overflow<int32_t>(int32_t{INT32_MAX}, int32_t{1}));
+    EXPECT_FALSE(add_would_overflow<int64_t>(int64_t{INT64_MAX}, int64_t{0}));
+    EXPECT_FALSE(add_would_overflow<int64_t>(INT64_MAX, 0));
+    EXPECT_TRUE( add_would_overflow<int64_t>(int64_t{INT64_MAX}, int64_t{1}));
+    EXPECT_TRUE( add_would_overflow<int64_t>(INT64_MAX, 1));
+    EXPECT_TRUE( add_would_overflow<uint64_t>(uint64_t{UINT64_MAX}, uint64_t{1}));
+
+    EXPECT_TRUE( add_would_overflow<int32_t>(INT32_MIN, -1));
+}
+
+TEST(OverflowTest, sub_underflow_is_detected) {
+    EXPECT_FALSE(sub_would_underflow<uint8_t>(uint8_t{100}, uint8_t{100}));
+    EXPECT_TRUE( sub_would_underflow<uint8_t>(uint8_t{100}, uint8_t{101}));
+    EXPECT_FALSE(sub_would_underflow<uint64_t>(uint64_t{1}, uint64_t{0}));
+    EXPECT_TRUE( sub_would_underflow<uint64_t>(uint64_t{0}, uint64_t{1}));
+    EXPECT_FALSE(sub_would_underflow<int64_t>(int64_t{0}, int64_t{1}));
+    EXPECT_FALSE(sub_would_underflow<int64_t>(int64_t{-1}, int64_t{INT64_MAX}));
+    EXPECT_TRUE( sub_would_underflow<int64_t>(int64_t{-2}, int64_t{INT64_MAX}));
+
+    EXPECT_TRUE( sub_would_underflow<int32_t>(INT32_MAX, -1));
+}
+
+TEST(OverflowTest, mul_overflow_is_detected) {
+    EXPECT_FALSE(mul_would_overflow<uint8_t>(uint8_t{50}, uint8_t{5}));
+    EXPECT_TRUE( mul_would_overflow<uint8_t>(uint8_t{50}, uint8_t{6}));
+    EXPECT_FALSE(mul_would_overflow<int64_t>(int64_t{INT64_MAX}, int64_t{1}));
+    EXPECT_TRUE( mul_would_overflow<int64_t>(int64_t{INT64_MAX}, int64_t{2}));
+    EXPECT_TRUE( mul_would_overflow<int64_t>(int64_t{INT64_MAX}, int64_t{INT64_MAX}));
+}
+
+}

--- a/vespalib/src/vespa/vespalib/util/overflow.h
+++ b/vespalib/src/vespa/vespalib/util/overflow.h
@@ -1,0 +1,36 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <concepts>
+
+namespace vespalib {
+
+// Note: all these over/underflow checks require the expected result
+// type to be explicitly provided. This is because implicit integer type
+// promotions can have unexpected semantics (e.g. u8 + u8 will be promoted
+// via `int` and thus _not_ be considered an overflow case).
+
+// Well-defined overflow checking for addition of two integers
+template <std::integral R, std::integral T0, std::integral T1>
+[[nodiscard]] inline constexpr bool
+add_would_overflow(T0 lhs, T1 rhs) noexcept {
+    return __builtin_add_overflow_p(lhs, rhs, R{});
+}
+
+// Well-defined underflow checking for subtraction of two integers
+template <std::integral R, std::integral T0, std::integral T1>
+[[nodiscard]] inline constexpr bool
+sub_would_underflow(T0 lhs, T1 rhs) noexcept {
+    // The intrinsic calls this overflow, but we'll refer to it as underflow
+    return __builtin_sub_overflow_p(lhs, rhs, R{});
+}
+
+// Well-defined overflow checking for multiplication of two integers
+template <std::integral R, std::integral T0, std::integral T1>
+[[nodiscard]] inline constexpr bool
+mul_would_overflow(T0 lhs, T1 rhs) noexcept {
+    return __builtin_mul_overflow_p(lhs, rhs, R{});
+}
+
+}


### PR DESCRIPTION
@toregge please review

Defers to GCC/Clang add/sub/mul overflow predicate intrinsics.
