### PR TITLE
 Add initial-inflight-factor option to vespa-feed-client to mitigate the slow start

### DIFF
--- a/vespa-feed-client-api/abi-spec.json
+++ b/vespa-feed-client-api/abi-spec.json
@@ -168,6 +168,7 @@
       "public abstract ai.vespa.feed.client.FeedClientBuilder setEndpointUris(java.util.List)",
       "public abstract ai.vespa.feed.client.FeedClientBuilder setProxy(java.net.URI)",
       "public abstract ai.vespa.feed.client.FeedClientBuilder setCompression(ai.vespa.feed.client.FeedClientBuilder$Compression)",
+      "public abstract ai.vespa.feed.client.FeedClientBuilder setInitialInflightFactor(int)",
       "public abstract ai.vespa.feed.client.FeedClient build()"
     ],
     "fields" : [

--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
@@ -152,6 +152,14 @@ public interface FeedClientBuilder {
 
     enum Compression { auto, none, gzip }
 
+    /**
+     * Sets the initial inflight factor for this client.
+     *
+     * This determines the initial targetInflight,
+     * which is {@code minInflight * initialInflightFactor}.
+     */
+    FeedClientBuilder setInitialInflightFactor(int factor);
+
     /** Constructs instance of {@link FeedClient} from builder configuration */
     FeedClient build();
 

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliArguments.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliArguments.java
@@ -62,6 +62,7 @@ class CliArguments {
     private static final String PROXY_OPTION = "proxy";
     private static final String COMPRESSION = "compression";
     private static final String LOG_CONFIG_OPTION = "log-config";
+    private static final String INITIAL_INFLIGHT_FACTOR_OPTION = "initial-inflight-factor";
 
     private final CommandLine arguments;
 
@@ -227,6 +228,8 @@ class CliArguments {
         }
     }
 
+    OptionalInt initialInflightFactor() throws CliArgumentsException { return intValue(INITIAL_INFLIGHT_FACTOR_OPTION); }
+
     private Optional<String> stringValue(String option) { return Optional.ofNullable(arguments.getOptionValue(option)); }
 
     private OptionalDouble doubleValue(String option) throws CliArgumentsException {
@@ -384,6 +387,12 @@ class CliArguments {
                                       "VESPA_HOME/conf/vespa-feed-client/logging.properties")
                         .hasArg()
                         .type(File.class)
+                        .build())
+                .addOption(Option.builder()
+                        .longOpt(INITIAL_INFLIGHT_FACTOR_OPTION)
+                        .desc("Multiplier for minInflight to determine the initial targetInflight")
+                        .hasArg()
+                        .type(Number.class)
                         .build());
     }
 

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
@@ -176,6 +176,7 @@ public class CliClient {
         cliArgs.doomSeconds().ifPresent(doom -> builder.setCircuitBreaker(new GracePeriodCircuitBreaker(Duration.ofSeconds(10),
                                                                                                         Duration.ofSeconds(doom))));
         cliArgs.proxy().ifPresent(builder::setProxy);
+        cliArgs.initialInflightFactor().ifPresent(builder::setInitialInflightFactor);
         return builder.build();
     }
 

--- a/vespa-feed-client-cli/src/test/java/ai/vespa/feed/client/impl/CliArgumentsTest.java
+++ b/vespa-feed-client-cli/src/test/java/ai/vespa/feed/client/impl/CliArgumentsTest.java
@@ -45,7 +45,8 @@ class CliArgumentsTest {
                 "--show-errors",
                 "--show-all",
                 "--max-failure-seconds", "30",
-                "--proxy", "https://myproxy:1234"});
+                "--proxy", "https://myproxy:1234",
+                "--initial-inflight-factor", "64"});
         assertEquals(URI.create("https://vespa.ai:4443/"), args.endpoint());
         assertEquals(Paths.get("feed.json"), args.inputFile().get());
         assertEquals(10, args.connections().getAsInt());
@@ -70,6 +71,7 @@ class CliArgumentsTest {
         assertFalse(args.showProgress());
         assertEquals(Compression.gzip, args.compression());
         assertEquals(URI.create("https://myproxy:1234"), args.proxy().orElse(null));
+        assertEquals(64, args.initialInflightFactor().getAsInt());
     }
 
     @Test

--- a/vespa-feed-client-cli/src/test/resources/help.txt
+++ b/vespa-feed-client-cli/src/test/resources/help.txt
@@ -23,6 +23,9 @@ Vespa feed client
     --header <arg>                        HTTP header on the form 'Name:
                                           value'
     --help
+    --initial-inflight-factor <arg>       Multiplier for minInflight to
+                                          determine the initial
+                                          targetInflight
     --log-config <arg>                    Specify a path to a Java Util
                                           Logging properties file.
                                           Overrides the default

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/DynamicThrottler.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/DynamicThrottler.java
@@ -28,7 +28,7 @@ public class DynamicThrottler extends StaticThrottler {
 
     public DynamicThrottler(FeedClientBuilderImpl builder) {
         super(builder);
-        targetInflight = new AtomicLong(minInflight);
+        targetInflight = new AtomicLong(minInflight * Math.min(builder.initialInflightFactor, 256)); // maxInflight = 256 * minInflight;
     }
 
     @Override

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/DynamicThrottler.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/DynamicThrottler.java
@@ -28,7 +28,9 @@ public class DynamicThrottler extends StaticThrottler {
 
     public DynamicThrottler(FeedClientBuilderImpl builder) {
         super(builder);
-        targetInflight = new AtomicLong(minInflight * Math.min(builder.initialInflightFactor, 256)); // maxInflight = 256 * minInflight;
+        long calculatedInflight = minInflight * builder.initialInflightFactor;
+        long cappedInflight = Math.min(calculatedInflight, maxInflight);
+        targetInflight = new AtomicLong(cappedInflight);
     }
 
     @Override

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/FeedClientBuilderImpl.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/FeedClientBuilderImpl.java
@@ -59,6 +59,7 @@ public class FeedClientBuilderImpl implements FeedClientBuilder {
     URI proxy;
     Duration connectionTtl = Duration.ZERO;
     LongSupplier nanoClock = System::nanoTime;
+    int initialInflightFactor = 1;
 
     public FeedClientBuilderImpl() { }
 
@@ -254,6 +255,13 @@ public class FeedClientBuilderImpl implements FeedClientBuilder {
 
     FeedClientBuilderImpl setNanoClock(LongSupplier nanoClock) {
         this.nanoClock = requireNonNull(nanoClock);
+        return this;
+    }
+
+    @Override
+    public FeedClientBuilderImpl setInitialInflightFactor(int factor) {
+        if (factor < 1) throw new IllegalArgumentException("Initial inflight factor must be at least 1, but was " + factor);
+        this.initialInflightFactor = factor;
         return this;
     }
 


### PR DESCRIPTION
## Is your feature request related to a problem? Please describe.
The feed client experiences a slow start because the default initial target inflight value is too low in our environment, causing a 2-3 minute delay in the time it takes to reach optimal throughput.


## Describe the solution you'd like
I would like an option called "initial-inflight-factor" that allows us to configure a higher initial target inflight.
This would help the feed client ramp up more quickly and avoid performance bottlenecks at startup.

```
    --initial-inflight-factor <arg>       Multiplier for minInflight to
                                          determine the initial
                                          targetInflight
```

```
$ vespa-feed-client \
  --initial-inflight-factor 64 \
  --file /path/to/json/file \
  --endpoint https://container-endpoint:443/
```


## Describe alternatives you've considered
One alternative we considered was setting the number of "connections" to 512 in order to mitigate the slow start.
However, this approach consumes significant machine resources.


```
$ vespa-feed-client \
  --connections 512 \
  --file /path/to/json/file \
  --endpoint https://container-endpoint:443/
```


## Additional context
In our environment, we set the initial-inflight-factor to 64.
