### PR TITLE
more decimals in tensor output

### DIFF
--- a/eval/src/vespa/eval/eval/tensor_spec.cpp
+++ b/eval/src/vespa/eval/eval/tensor_spec.cpp
@@ -282,7 +282,7 @@ TensorSpec::to_string() const
 {
     std::string out = make_string("spec(%s) {\n", _type.c_str());
     for (const auto &cell: _cells) {
-        out.append(make_string("  %s: %g\n", addr_to_compact_string(cell.first).c_str(), cell.second.value));
+        out.append(make_string("  %s: %.9g\n", addr_to_compact_string(cell.first).c_str(), cell.second.value));
     }
     out.append("}");
     return out;


### PR DESCRIPTION
This should ensure we have enough to round-trip a float (and will make sure all our existing examples in the tensor playground look nice in the refreshed UI)