### PR TITLE
remove casts no longer needed

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/routable_factories_8.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/routable_factories_8.cpp
@@ -690,7 +690,7 @@ std::shared_ptr<IRoutableFactory> RoutableFactories80::visitor_info_message_fact
     return make_codec<VisitorInfoMessage, protobuf::VisitorInfoRequest>(
         [](const VisitorInfoMessage& src, protobuf::VisitorInfoRequest& dest) {
             set_bucket_id_vector(*dest.mutable_finished_buckets(), src.getFinishedBuckets());
-            dest.set_error_message(static_cast<std::string_view>(src.getErrorMessage()));
+            dest.set_error_message(src.getErrorMessage());
         },
         [](const protobuf::VisitorInfoRequest& src) {
             auto msg = std::make_unique<VisitorInfoMessage>();
@@ -899,7 +899,7 @@ std::shared_ptr<IRoutableFactory> RoutableFactories80::stat_bucket_message_facto
 std::shared_ptr<IRoutableFactory> RoutableFactories80::stat_bucket_reply_factory() {
     return make_codec<StatBucketReply, protobuf::StatBucketResponse>(
         [](const StatBucketReply& src, protobuf::StatBucketResponse& dest) {
-            dest.set_results(static_cast<std::string_view>(src.getResults()));
+            dest.set_results(src.getResults());
         },
         [](const protobuf::StatBucketResponse& src) {
             auto reply = std::make_unique<StatBucketReply>();
@@ -916,7 +916,7 @@ std::shared_ptr<IRoutableFactory> RoutableFactories80::stat_bucket_reply_factory
 std::shared_ptr<IRoutableFactory> RoutableFactories80::wrong_distribution_reply_factory() {
     return make_codec<WrongDistributionReply, protobuf::WrongDistributionResponse>(
         [](const WrongDistributionReply& src, protobuf::WrongDistributionResponse& dest) {
-            dest.mutable_cluster_state()->set_state_string(static_cast<std::string_view>(src.getSystemState()));
+            dest.mutable_cluster_state()->set_state_string(src.getSystemState());
         },
         [](const protobuf::WrongDistributionResponse& src) {
             auto reply = std::make_unique<WrongDistributionReply>();

--- a/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.cpp
@@ -210,7 +210,7 @@ void StorageApiRpcService::encode_rpc_v1_response(FRT_RPCRequest& request, api::
     // TODO skip encoding header altogether if no relevant fields set?
     protobuf::ResponseHeader hdr;
     if (reply.getTrace().getLevel() > 0) {
-        hdr.set_trace_payload(static_cast<std::string_view>(reply.getTrace().encode()));
+        hdr.set_trace_payload(reply.getTrace().encode());
     }
     // TODO consistent naming...
     encode_header_into_rpc_params(hdr, *ret);


### PR DESCRIPTION
@vekterli please review - probably leftovers from when we used vespalib::string
