### PR TITLE
Also demote warning for _unknown_ acceleration target level

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
@@ -159,7 +159,7 @@ constexpr static uint32_t DEFAULT_LEVEL = NEON_FP16_DOTPROD;
         return NEON;
     }
 #endif
-    LOG(warning, "Unknown vectorization target level for " VESPA_HWACCEL_ARCH_NAME ": '%s'. Using %s.",
+    LOG(info, "Unknown vectorization target level for " VESPA_HWACCEL_ARCH_NAME ": '%s'. Using %s.",
         str.c_str(), level_u32_to_str(DEFAULT_LEVEL));
     return DEFAULT_LEVEL;
 }


### PR DESCRIPTION
@toregge (or @hmusum) please review

Avoids spurious warnings when tests are run on different platforms.

