### PR TITLE
Reapply: defer `int8` (`Int8Float`) dot product calculation to vectorized kernel

### DIFF
--- a/eval/src/vespa/eval/eval/CMakeLists.txt
+++ b/eval/src/vespa/eval/eval/CMakeLists.txt
@@ -17,6 +17,7 @@ vespa_add_library(eval_eval OBJECT
     feature_name_extractor.cpp
     function.cpp
     gbdt.cpp
+    inline_operation.cpp
     int8float.cpp
     interpreted_function.cpp
     key_gen.cpp

--- a/eval/src/vespa/eval/eval/inline_operation.cpp
+++ b/eval/src/vespa/eval/eval/inline_operation.cpp
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "inline_operation.h"
+#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+
+namespace vespalib::eval::operation {
+
+// These are the ironically de-inlined operations of `inline_operation.h` that may benefit
+// from being in an explicit translation unit. In particular, this is for operations that
+// use our own vectorized kernels, trading off inlining with not having to call getAccelerator()
+// for each invocation of apply(), as well as hiding the iaccelerated header details.
+
+namespace {
+
+// Same pattern as in `mixed_l2_distance.cpp`
+static const auto &accel = hwaccelerated::IAccelerated::getAccelerator();
+
+}
+
+double DotProduct<Int8Float, Int8Float>::apply(const Int8Float *lhs, const Int8Float *rhs, size_t count) {
+    // Do a few pre-flight checks before daring to touch the buffer as-if int8_t*...
+    static_assert(sizeof(Int8Float)  == sizeof(int8_t));
+    static_assert(alignof(Int8Float) == alignof(int8_t));
+    static_assert(std::has_unique_object_representations_v<Int8Float>);
+
+    const auto *lhs_as_i8 = reinterpret_cast<const int8_t*>(lhs);
+    const auto *rhs_as_i8 = reinterpret_cast<const int8_t*>(rhs);
+    return static_cast<double>(accel.dotProduct(lhs_as_i8, rhs_as_i8, count));
+}
+
+}

--- a/eval/src/vespa/eval/eval/inline_operation.h
+++ b/eval/src/vespa/eval/eval/inline_operation.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "int8float.h"
 #include "operation.h"
 #include <vespa/vespalib/util/typify.h>
 #include <cblas.h>
@@ -172,6 +173,11 @@ struct DotProduct<double,double> {
     static double apply(const double * lhs, const double * rhs, size_t count) {
         return cblas_ddot(count, lhs, 1, rhs, 1);
     }
+};
+
+template <>
+struct DotProduct<Int8Float, Int8Float> {
+    static double apply(const Int8Float *lhs, const Int8Float *rhs, size_t count);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
@havardpe please review. This is an unmodified re-run of #34180, but now with 100% less expected `SIGILL` due to Valgrind trying to execute instructions it knows nothing about.

Since `Int8Float` is just a truncated version of the integer part of a `float` there's no exponent/mantissa distinction to worry about, i.e. we can cheekily reinterpret the whole thing as an array of `int8_t` and pass it on to the vectorized implementation. This is effectively identical to what's already done for vectorized tensor L2 distance evals.

Since we now have CPU feature detection and target selection on aarch64, this will work with Valgrind even without NEON `dotproduct` support.
