### PR TITLE
Use a shared log replay operation throttler across all document DBs

### DIFF
--- a/searchcore/src/tests/proton/server/feedstates_test.cpp
+++ b/searchcore/src/tests/proton/server/feedstates_test.cpp
@@ -17,6 +17,7 @@
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/buffer.h>
+#include <vespa/vespalib/util/shared_operation_throttler.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using document::BucketId;
@@ -95,7 +96,7 @@ protected:
     MemoryConfigStore config_store;
     bucketdb::BucketDBOwner _bucketDB;
     bucketdb::BucketDBHandler _bucketDBHandler;
-    ReplayThrottlingPolicy _replay_throttling_policy;
+    std::shared_ptr<vespalib::SharedOperationThrottler> _replay_throttler;
     MyIncSerialNum _inc_serial_num;
     ReplayTransactionLogState state;
 
@@ -112,9 +113,9 @@ FeedStatesTest::FeedStatesTest()
       config_store(),
       _bucketDB(),
       _bucketDBHandler(_bucketDB),
-      _replay_throttling_policy({}),
+      _replay_throttler(vespalib::SharedOperationThrottler::make_unlimited_throttler()),
       _inc_serial_num(9u),
-      state("doctypename", feed_view_ptr, _bucketDBHandler, replay_config, config_store, _replay_throttling_policy, _inc_serial_num)
+      state("doctypename", feed_view_ptr, _bucketDBHandler, replay_config, config_store, _replay_throttler, _inc_serial_num)
 {
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -126,7 +126,6 @@ private:
     ClusterStateHandler                              _clusterStateHandler;
     BucketHandler                                    _bucketHandler;
     index::IndexConfig                               _indexCfg;
-    std::unique_ptr<ReplayThrottlingPolicy>          _replay_throttling_policy;
     ConfigStore::UP                                  _config_store;
     MetricsWireService                              &_metricsWireService;
     DocumentDBTaggedMetrics                          _metrics;

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
@@ -469,13 +469,14 @@ void
 FeedHandler::replayTransactionLog(SerialNum flushedIndexMgrSerial, SerialNum flushedSummaryMgrSerial,
                                   SerialNum oldestFlushedSerial, SerialNum newestFlushedSerial,
                                   ConfigStore &config_store,
-                                  const ReplayThrottlingPolicy& replay_throttling_policy)
+                                  std::shared_ptr<vespalib::SharedOperationThrottler> shared_operation_throttler)
 {
     (void) newestFlushedSerial;
     assert(_activeFeedView);
     assert(_bucketDBHandler);
     auto state = make_shared<ReplayTransactionLogState>
-                          (getDocTypeName(), _activeFeedView, *_bucketDBHandler, _replayConfig, config_store, replay_throttling_policy, *this);
+                          (getDocTypeName(), _activeFeedView, *_bucketDBHandler, _replayConfig,
+                           config_store, std::move(shared_operation_throttler), *this);
     changeFeedState(state);
     // Resurrected attribute vector might cause oldestFlushedSerial to
     // be lower than _prunedSerialNum, so don't warn for now.

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
@@ -19,6 +19,7 @@
 
 namespace searchcorespi::index { struct IThreadingService; }
 namespace document { class DocumentTypeRepo; }
+namespace vespalib { class SharedOperationThrottler; }
 
 namespace proton {
 struct ConfigStore;
@@ -189,7 +190,7 @@ public:
                          SerialNum oldestFlushedSerial,
                          SerialNum newestFlushedSerial,
                          ConfigStore &config_store,
-                         const ReplayThrottlingPolicy& replay_throttling_policy);
+                         std::shared_ptr<vespalib::SharedOperationThrottler> shared_operation_throttler);
 
     /**
      * Called when a flush is done and allows pruning of the transaction log.

--- a/searchcore/src/vespa/searchcore/proton/server/feedstates.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedstates.h
@@ -55,7 +55,7 @@ public:
             bucketdb::IBucketDBHandler &bucketDBHandler,
             IReplayConfig &replay_config,
             FeedConfigStore &config_store,
-            const ReplayThrottlingPolicy &replay_throttling_policy,
+            std::shared_ptr<vespalib::SharedOperationThrottler> shared_operation_throttler,
             IIncSerialNum &inc_serial_num);
 
     ~ReplayTransactionLogState() override;

--- a/searchcore/src/vespa/searchcore/proton/server/idocumentdbowner.h
+++ b/searchcore/src/vespa/searchcore/proton/server/idocumentdbowner.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <cstdint>
 
+namespace vespalib { class SharedOperationThrottler; }
+
 namespace proton {
 
 class IDocumentDBReferenceRegistry;
@@ -23,6 +25,7 @@ public:
     virtual uint32_t getNumThreadsPerSearch() const = 0;
     virtual SessionManager & session_manager() = 0;
     virtual std::shared_ptr<MaintenanceJobTokenSource> get_lid_space_compaction_job_token_source() = 0;
+    virtual std::shared_ptr<vespalib::SharedOperationThrottler> shared_replay_throttler() const = 0;
     virtual std::shared_ptr<IDocumentDBReferenceRegistry> getDocumentDBReferenceRegistry() const = 0;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -135,6 +135,7 @@ private:
     std::set<BucketSpace>           _nodeUp;   // bucketspaces where node is up
     std::shared_ptr<search::diskindex::IPostingListCache> _posting_list_cache;
     std::shared_ptr<MaintenanceJobTokenSource> _lid_space_compaction_job_token_source;
+    std::shared_ptr<vespalib::SharedOperationThrottler> _shared_replay_throttler;
 
     std::shared_ptr<DocumentDBConfigOwner>
     addDocumentDB(const DocTypeName & docTypeName, BucketSpace bucketSpace, const std::string & configid,
@@ -153,6 +154,7 @@ private:
     std::shared_ptr<IDocumentDBReferenceRegistry> getDocumentDBReferenceRegistry() const override;
     SessionManager & session_manager() override;
     std::shared_ptr<MaintenanceJobTokenSource> get_lid_space_compaction_job_token_source() override;
+    std::shared_ptr<vespalib::SharedOperationThrottler> shared_replay_throttler() const override;
     // Returns true if the node is up in _any_ bucket space
     bool updateNodeUp(BucketSpace bucketSpace, bool nodeUpInBucketSpace);
     void closeDocumentDBs(vespalib::ThreadStackExecutorBase & executor);

--- a/searchcore/src/vespa/searchcore/proton/test/dummydbowner.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/dummydbowner.cpp
@@ -4,13 +4,15 @@
 #include <vespa/searchcore/proton/reference/document_db_reference_registry.h>
 #include <vespa/searchcore/proton/matching/sessionmanager.h>
 #include <vespa/searchcore/proton/server/maintenance_job_token_source.h>
+#include <vespa/vespalib/util/shared_operation_throttler.h>
 
 namespace proton {
 
 DummyDBOwner::DummyDBOwner()
     : _registry(std::make_shared<DocumentDBReferenceRegistry>()),
       _sessionManager(std::make_unique<SessionManager>(10)),
-      _lid_space_compaction_job_token_source(std::make_shared<MaintenanceJobTokenSource>())
+      _lid_space_compaction_job_token_source(std::make_shared<MaintenanceJobTokenSource>()),
+      _shared_replay_throttler(vespalib::SharedOperationThrottler::make_unlimited_throttler())
 {}
 DummyDBOwner::~DummyDBOwner() = default;
 
@@ -28,6 +30,12 @@ std::shared_ptr<MaintenanceJobTokenSource>
 DummyDBOwner::get_lid_space_compaction_job_token_source()
 {
     return _lid_space_compaction_job_token_source;
+}
+
+std::shared_ptr<vespalib::SharedOperationThrottler>
+DummyDBOwner::shared_replay_throttler() const
+{
+    return _shared_replay_throttler;
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/dummydbowner.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummydbowner.h
@@ -11,6 +11,7 @@ struct DummyDBOwner : IDocumentDBOwner {
     std::shared_ptr<IDocumentDBReferenceRegistry> _registry;
     std::unique_ptr<SessionManager> _sessionManager;
     std::shared_ptr<MaintenanceJobTokenSource> _lid_space_compaction_job_token_source;
+    std::shared_ptr<vespalib::SharedOperationThrottler> _shared_replay_throttler;
 
     DummyDBOwner();
     ~DummyDBOwner() override;
@@ -22,6 +23,7 @@ struct DummyDBOwner : IDocumentDBOwner {
     std::shared_ptr<IDocumentDBReferenceRegistry> getDocumentDBReferenceRegistry() const override;
     SessionManager & session_manager() override;
     std::shared_ptr<MaintenanceJobTokenSource> get_lid_space_compaction_job_token_source() override;
+    std::shared_ptr<vespalib::SharedOperationThrottler> shared_replay_throttler() const override;
 };
 
 } // namespace proton


### PR DESCRIPTION
@toregge please review.

This centralizes control over log replay concurrency and (soon) resource usage, preventing different document types from running ahead at their own leisure.

This also adds _propagation_ of estimated operation resource usage for all sub-operations of `DocumentOperation`, but there is not yet any _enforcement_ of resource usage limits across operations. Want to observe the impacts of simply centralizing the throttling before adding anything more.

