### PR TITLE
Fallback to less vectorized popcount for short vectors on AVX3_DL 

### DIFF
--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -28,7 +28,8 @@ benchmark_fn(Fn f, size_t sz, size_t count) {
         sumOfSums += sum;
     }
     duration elapsed = steady_clock::now() - start;
-    printf("sum=%f of N=%zu and vector length=%zu took %" PRId64 "\n", sumOfSums, count, sz, count_ms(elapsed));
+    printf("sum=%f of N=%zu and vector length=%zu took %.1f ms\n", sumOfSums, count, sz,
+           std::chrono::duration<double, std::milli>(elapsed).count());
 }
 
 void


### PR DESCRIPTION
@havardpe please review 👀

Empirical measurements show that firing up the whole pile of massively compiler-unrolled AVX-512 `VPOPCNT` machinery for short vectors is actually detrimental to performance. We therefore specialize the code generation for short vectors.

This uses some sneaky tricks with calling the same inlined function across multiple distinct branches explicitly predicated on the size of the vector (and therefore the max loop trip count), allowing the compiler to generate specialized implementations since it knows the bounds.

Empirically on GCC 14.2, each increasing trip count case uses less and less `POPCNT` and more and more `VPOPCNT`, culminating with the arbitrary trip count implementation. Clang 20 has a similar approach, but I have not benchmarked the resulting code. [Godbolt with GCC+Clang](https://godbolt.org/z/MaYxMxjds).

Here's a benchmark graph showing baseline AVX3 (`POPCNT` only), AVX3_DL (`VPOPCNT`) and the hybrid approach with specializations for short vectors (all sample points are for 100,000,000 iterations):

<img width="566" alt="avx3_popcount_all" src="https://github.com/user-attachments/assets/02bc7cb8-ed03-49c1-beea-3b1b360cba57" />

Zooming in on vectors with element counts <= 32 we see that the hybrid approach is very close to being strictly better:

<img width="642" alt="avx3_popcount_32" src="https://github.com/user-attachments/assets/e5e2a626-839b-4942-9b1f-ed7b218a804b" />

In addition, improve the printed timing resolution of benchmark runs by printing as millisecond floats instead of integers.