### PR TITLE
Revert revert of bump-jllama-major

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -122,7 +122,7 @@
         <junit.vespa.version>5.10.2</junit.vespa.version>
         <junit.platform.vespa.version>1.10.2</junit.platform.vespa.version>
         <junit4.vespa.version>4.13.2</junit4.vespa.version>
-        <kherud.llama.vespa.version>3.3.0</kherud.llama.vespa.version>
+        <kherud.llama.vespa.version>4.1.0</kherud.llama.vespa.version>
         <luben.zstd.vespa.version>1.5.6-4</luben.zstd.vespa.version>
         <lucene.vespa.version>9.11.1</lucene.vespa.version>
         <maven-archiver.vespa.version>3.6.2</maven-archiver.vespa.version>

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -37,7 +37,7 @@
 %global _vespa_gtest_version 1.16.0
 %global _vespa_protobuf_version 5.30.1
 %global _vespa_openblas_version 0.3.27
-%global _vespa_llama_version 3.3.0
+%global _vespa_llama_version 4.1.0
 %if 0%{?el8} || 0%{?el9} || 0%{?amzn2023}
 %global _use_vespa_abseil_cpp 1
 %global _use_vespa_gtest 1

--- a/model-integration/src/main/java/ai/vespa/llm/clients/LocalLLM.java
+++ b/model-integration/src/main/java/ai/vespa/llm/clients/LocalLLM.java
@@ -12,6 +12,7 @@ import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import de.kherud.llama.LlamaModel;
 import de.kherud.llama.ModelParameters;
+import de.kherud.llama.Pair;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,24 +53,24 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
     private final int maxPromptTokens;
     private final ContextOverflowPolicy.Enum contextOverflowPolicy;
     private final int contextSizePerRequest;
- 
+
     @Inject
     public LocalLLM(LlmLocalClientConfig config) {
-        
+
         // Only used if GPU is not used
         var defaultThreadCount = Math.max(Runtime.getRuntime().availableProcessors() - 2, 1);
         var modelFile = config.model().toFile().getAbsolutePath();
         var modelParams = new ModelParameters()
-                .setModelFilePath(modelFile)
-                .setContinuousBatching(true)
-                .setNParallel(config.parallelRequests())
-                .setNThreads(config.threads() <= 0 ? defaultThreadCount : config.threads())
-                .setNCtx(config.contextSize())
-                .setNGpuLayers(config.useGpu() ? config.gpuLayers() : 0);
-        
+                .setModel(modelFile)
+                .enableContBatching()
+                .setParallel(config.parallelRequests())
+                .setThreads(config.threads() <= 0 ? defaultThreadCount : config.threads())
+                .setCtxSize(config.contextSize())
+                .setGpuLayers(config.useGpu() ? config.gpuLayers() : 0);
+
         if (config.seed() != -1)
-            modelParams.setSeed(config.seed());    
-        
+            modelParams.setSeed(config.seed());
+
         // Load model
         long startLoad = System.nanoTime();
         model = new LlamaModel(modelParams);
@@ -84,11 +85,11 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
                 config.maxQueueSize() > 0 ? new ArrayBlockingQueue<>(config.maxQueueSize()) : new SynchronousQueue<>(),
                 new ThreadPoolExecutor.AbortPolicy()
         );
-        
-        // Staring all threads manually because we are using `executor.getQueue().offer(...)` to add tasks 
+
+        // Starting all threads manually because we are using `executor.getQueue().offer(...)` to add tasks
         // instead of higher-level methods like `executor.submit(...)` that automatically start threads when needed.
         executor.prestartAllCoreThreads();
-        
+
         // Setting other config parameters
         maxQueueWait = config.maxQueueWait();
         maxEnqueueWait = config.maxEnqueueWait();
@@ -98,14 +99,14 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
         logger.fine(() -> String.format("Context size per request: %d", contextSizePerRequest));
         contextOverflowPolicy = config.contextOverflowPolicy();
     }
-    
+
     @Override
     public void deconstruct() {
         model.close();
         executor.shutdownNow();
         scheduler.shutdownNow();
     }
-    
+
     private de.kherud.llama.InferenceParameters setInferenceParameters(Prompt prompt, InferenceParameters options) {
         var inferParams = new de.kherud.llama.InferenceParameters(prompt.asString().stripLeading());
 
@@ -117,24 +118,29 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
         options.ifPresent(InferenceParameters.OPTION_TOP_P, (v) -> inferParams.setTopP(Integer.parseInt(v)));
         options.ifPresent(InferenceParameters.OPTION_N_PREDICT, (v) -> inferParams.setNPredict(Integer.parseInt(v)));
         options.ifPresent(InferenceParameters.OPTION_REPEAT_PENALTY, (v) -> inferParams.setRepeatPenalty(Float.parseFloat(v)));
+        options.ifPresent(InferenceParameters.OPTION_PRESENCE_PENALTY, (v) -> inferParams.setPresencePenalty(Float.parseFloat(v)));
         options.ifPresent(InferenceParameters.OPTION_SEED, (v) -> inferParams.setSeed(Integer.parseInt(v)));
         options.ifPresent(InferenceParameters.OPTION_JSON_SCHEMA, (v) -> {
             var grammar = JsonSchemaToGrammar.convert(v);
             inferParams.setGrammar(grammar);
         });
-        
+
         inferParams.setUseChatTemplate(true);
+        Pair<String, String> msg = new Pair<>("user", prompt.asString().stripLeading());
+        inferParams.setMessages("", List.of(msg));
+        String applied = model.applyTemplate(inferParams);
+        inferParams.setPrompt(applied);
         return inferParams;
-    } 
-    
+    }
+
 
     @Override
     public List<Completion> complete(Prompt prompt, InferenceParameters options) {
         StringBuilder result = new StringBuilder();
-        var future = completeWithOffer(prompt, options, 
+        var future = completeWithOffer(prompt, options,
                 completion -> result.append(completion.text()), maxEnqueueWait);
         Completion.FinishReason reason;
-    
+
         try {
             reason = future.get();
         } catch (InterruptedException e) {
@@ -149,7 +155,7 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
                 throw new LanguageModelException(500, "Error while generating completion.", cause);
             }
         }
-        
+
         List<Completion> completions = new ArrayList<>();
         completions.add(new Completion(result.toString(), reason));
         return completions;
@@ -159,7 +165,7 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
             Prompt prompt, InferenceParameters options, Consumer<Completion> consumer) {
         return completeWithOffer(prompt, options, consumer, 0);
     }
-    
+
     /**
      * Completes the given prompt, mostly asynchronously with or without a blocking wait.
      * It is used by both `complete()` and `completeAsync()` with different `offerTimeout` values.
@@ -170,20 +176,20 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
     private CompletableFuture<Completion.FinishReason> completeWithOffer(
             Prompt prompt, InferenceParameters options, Consumer<Completion> consumer, long offerTimeout) {
         var completionFuture = new CompletableFuture<Completion.FinishReason>();
-        
+
         var promptStr = prompt.asString().stripLeading();
         var promptTokens = model.encode(promptStr);
-        
+
         // Truncate prompt
         if (maxPromptTokens > 0 && promptTokens.length > maxPromptTokens) {
             promptTokens = Arrays.copyOfRange(promptTokens, 0, maxPromptTokens + 1);
             promptStr = model.decode(promptTokens);
             prompt = StringPrompt.from(promptStr);
         }
-        
+
         var numPromptTokens = promptTokens.length;
         var numRequestTokens = numPromptTokens + maxTokens;
-        logger.fine(() -> String.format("Prompt tokens: %d, max tokens: %d, request tokens: %d", 
+        logger.fine(() -> String.format("Prompt tokens: %d, max tokens: %d, request tokens: %d",
                 numPromptTokens, maxTokens, numRequestTokens));
 
         // Do something when context size is too small for this request
@@ -220,12 +226,12 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
                 completionFuture.completeExceptionally(new LanguageModelException(500, errorMessage, e));
             }
         }, null);
-        
+
         try {
-            var accepted = offerTimeout > 0 
-                    ? executor.getQueue().offer(future, offerTimeout, TimeUnit.MILLISECONDS) 
+            var accepted = offerTimeout > 0
+                    ? executor.getQueue().offer(future, offerTimeout, TimeUnit.MILLISECONDS)
                     : executor.getQueue().offer(future);
-                
+
             if (!accepted) {
                 String errorMessage = rejectedExecutionErrorMessage(
                         "Rejected completion due to timeout waiting to add the request to the executor queue");
@@ -239,7 +245,7 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
             completionFuture.completeExceptionally(new LanguageModelException(500, errorMessage));
             return completionFuture;
         }
-        
+
         if (maxQueueWait > 0) {
             scheduler.schedule(
                     () -> {
@@ -253,7 +259,7 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
                     }, maxQueueWait, TimeUnit.MILLISECONDS
             );
         }
-        
+
         return completionFuture;
     }
 

--- a/model-integration/src/test/java/ai/vespa/llm/clients/LocalLLMTest.java
+++ b/model-integration/src/test/java/ai/vespa/llm/clients/LocalLLMTest.java
@@ -6,15 +6,17 @@ import ai.vespa.llm.LanguageModelException;
 import ai.vespa.llm.completion.Completion;
 import ai.vespa.llm.completion.Prompt;
 import ai.vespa.llm.completion.StringPrompt;
-import com.sun.xml.bind.v2.util.EditDistance;
 import com.yahoo.config.ModelReference;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -237,8 +239,8 @@ public class LocalLLMTest {
                             "even when the journey feels endless.",
                     "Det er ikke viktig hvor langsomt du går, så lange du ikke stopper. " +
                             "Persistens og bestemthed er det som egentlig fører til succes. " +
-                            "Hver liten steg fremover bygger grunnlaget for å nå storhet, " +
-                            "selv når reisen føler seg uendelig."
+                            "Hver lille steg fremover bygger grunnlaget for å nå storhet, " +
+                            "selv når reisen føler seg uendelig lang."
             ),
             new LLMTask(
                     "Our greatest glory is not in never falling, but in rising every time we fall.",
@@ -254,17 +256,17 @@ public class LocalLLMTest {
             ),
             new LLMTask(
                     "Success depends upon previous preparation, and without such preparation there is sure to be failure.",
-                    "Suksess avhenger av forhåndsforberedelse, og uten denne er det sikkerhet for feil."
+                    "Suksess avhenger av forberedelse, og uten denne er det sikkerhet for feil."
             ),
             new LLMTask(
                     "The man who moves a mountain begins by carrying away small stones, " +
                             "then moves on to medium-sized rocks, gradually clears larger rocks and boulders, " +
                             "and finally overcomes the most formidable obstacles to achieve his goal, " +
                             "displaying extraordinary perseverance and determination.",
-                    "Mannen som flyttet berget starter med å bære borte små sten, " +
-                            "derefter flyttet han på med mellemstørre steiner, gradvis fjernet større steiner og stenblokker, " +
-                            "og sluttelig overkommet de mest formidable hindrerne for å nå sin mål, " +
-                            "med utmærkt tenasje og bestemthet."
+                    "Mannen som flyttet bjerget starter med å bære borte små sten, " +
+                            "og gradvis tar han borte større sten og boulders, " +
+                            "og slutter med å overkomme de største hindrene for å nå sin mål, " +
+                            "med uverdenslige evner og styrke."
             )
     );
     
@@ -324,22 +326,55 @@ public class LocalLLMTest {
                 System.err.println("Actual output: " + completionStr);
             }
             
-            // Using edit distance to compare output to account for small variations in LLM output.
-            // The threshold is an arbitrary small number.
-            // Using an edit distance method from arbitrary library among existing dependencies.
             if (expectOutput != null) {
-                var editDistance = EditDistance.editDistance(expectOutput, completionStr);
-                var maxEditDistance = expectOutput.length() * 0.05;
-                assertTrue(editDistance <= maxEditDistance, 
-                        "Expected output edit distance <= " + maxEditDistance + ", got " + editDistance);
+                var distance = tokenDistance(expectOutput, completionStr);
+                var maxDistance = 0.33;
+                assertTrue(distance < maxDistance, 
+                        "Expected token distance < " + maxDistance + ", got " + distance);
             }
             
             if (expectNotOutput != null) {
-                var editDistance = EditDistance.editDistance(expectNotOutput, completionStr);
-                var maxEditDistance = expectNotOutput.length() * 0.05;
-                assertTrue(editDistance >= maxEditDistance,
-                        "Expected output edit distance >= " + maxEditDistance + ", got " + editDistance);
+                var distance = tokenDistance(expectNotOutput, completionStr);
+                var maxDistance = 0.66;
+                assertTrue(distance >= maxDistance,
+                        "Expected token distance >= " + maxDistance + ", got " + distance);
             }
+        }
+        
+        private static double tokenDistance(String str1, String str2) {
+            var tokens1 = str1.split("\\s+");
+            var tokens2 = str2.split("\\s+");
+
+            if (tokens1.length == 0 && tokens2.length == 0) {
+                return 0.0;
+            }
+            
+            var counts1 = getTokenCounts(tokens1);
+            var counts2 = getTokenCounts(tokens2);
+
+            Set<String> allTokens = new HashSet<>();
+            allTokens.addAll(counts1.keySet());
+            allTokens.addAll(counts2.keySet());
+
+            int intersection = 0;
+
+            for (String token : allTokens) {
+                int count1 = counts1.getOrDefault(token, 0);
+                int count2 = counts2.getOrDefault(token, 0);
+                intersection += Math.min(count1, count2);
+            }
+            
+            return 1.0 - 2.0 * intersection / (tokens1.length + tokens2.length);
+        }
+
+        private static Map<String, Integer> getTokenCounts(String[] tokens) {
+            var counts = new HashMap<String, Integer>();
+            
+            for (String token : tokens) {
+                counts.put(token, counts.getOrDefault(token, 0) + 1);
+            }
+            
+            return counts;
         }
     }
 
@@ -502,19 +537,10 @@ public class LocalLLMTest {
         var futures = new ArrayList<CompletableFuture<Void>>();
 
         try {
-            for (var i : List.of(0, 2, 3, 4, 5)) {
+            for (var i : List.of(0, 1, 2, 3, 4, 5, 6)) {
                 futures.add(CompletableFuture.runAsync(
                         () -> new CompletionTest(llm, TASKS.get(i).input)
                                 .expectOutput(TASKS.get(i).output)
-                                .expectFinishReason(Completion.FinishReason.stop)
-                                .test()
-                ));
-            }
-
-            for (var i : List.of(1, 6)) {
-                futures.add(CompletableFuture.runAsync(
-                        () -> new CompletionTest(llm, TASKS.get(i).input)
-                                .expectNotOutput(TASKS.get(i).output)
                                 .expectFinishReason(Completion.FinishReason.stop)
                                 .test()
                 ));


### PR DESCRIPTION
This reverts commit 97d25065dc1b5ed3669c7b6fcc6488e67ad969e3, reversing changes made to ed037e4a75b452a29daf34d74d942e51da50d69e.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Reverting the reverted jllama update.
System feeding_generate_local_llm test timeouts were too tight, which are fixed now.
Local testing (on M3) show that new version has higher throughput but seem to have more variation in latency.