### PR TITLE
Move small popcount branches first in function

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
@@ -25,14 +25,15 @@ Avx3DlAccelerator::populationCount(const uint64_t* a, size_t sz) const noexcept 
     // It can therefore specialize the implementations.
     // Empirically on GCC 14.2, each increasing trip count uses less and less POPCNT and more
     // and more VPOPCNT, culminating with the arbitrary trip count implementation.
-    if (sz <= 8) [[unlikely]] {
+    if (sz <= 8) {
         return helper::populationCount(a, sz);
-    } else if (sz <= 16) [[unlikely]] {
+    } else if (sz <= 16) {
         return helper::populationCount(a, sz);
-    } else if (sz <= 32) [[unlikely]] {
+    } else if (sz <= 32) {
+        return helper::populationCount(a, sz);
+    } else {
         return helper::populationCount(a, sz);
     }
-    return helper::populationCount(a, sz);
 }
 
 double


### PR DESCRIPTION
@toregge please review. More experiments will likely follow. Need to run some more varied (and larger) benchmarks, not just microbenchmarks where everything is hot in the cache and the branch predictor is having the time of its life.

With larger inputs the extra branching overhead should diminish relative to the cost of actually processing the input itself, but this may be inverted with small inputs.
