### PR TITLE
chore(doc-v1-api): increase window size update rate in InstrumentedThrottlePolicy

### DIFF
--- a/configdefinitions/src/vespa/document-operation-executor.def
+++ b/configdefinitions/src/vespa/document-operation-executor.def
@@ -6,7 +6,7 @@ resendDelayMillis     int default=10
 
 # Bound on number of document operations to keep in queue — further operations are rejected.
 # Set to 0 to disable queue and dispatch directly to documentapi instead.
-maxThrottled          int default=1024
+maxThrottled          int default=256
 
 # Max age in seconds for operations in queue.
 maxThrottledAge       double default=3.0
@@ -15,4 +15,4 @@ maxThrottledAge       double default=3.0
 # - If 0>, the the number of bytes as an absolute value.
 # - If 0, allow infinite number of bytes (in other words disables the size restriction).
 # - If <0, the number of bytes as a ratio of the JVM's maximum heap size (e.g. -0.5 for 50% of max heap).
-maxThrottledBytes double default=-0.30
+maxThrottledBytes double default=-0.25

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/InstrumentedThrottlePolicy.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/InstrumentedThrottlePolicy.java
@@ -23,7 +23,11 @@ class InstrumentedThrottlePolicy extends DynamicThrottlePolicy {
     private final AtomicInteger previousMaxPending = new AtomicInteger(Integer.MIN_VALUE);
     private final Metric metric;
 
-    @Inject InstrumentedThrottlePolicy(Metric metric) { this.metric = metric; }
+    @Inject
+    InstrumentedThrottlePolicy(Metric metric) {
+        setResizeRate(2); // Increase the window size update rate by lowering resize rate...  ¯\_(ツ)_/¯
+        this.metric = metric;
+    }
 
     @Override
     public boolean canSend(Message message, int pendingCount) {


### PR DESCRIPTION
Set the resize rate to 2 to increase the window size update frequency. This change aims to improve the responsiveness of the
throttle policy by adjusting the rate at which the window size is updated.