### PR TITLE
destroy Nexus vote on thread exit

### DIFF
--- a/vespalib/src/vespa/vespalib/test/nexus.cpp
+++ b/vespalib/src/vespa/vespalib/test/nexus.cpp
@@ -4,6 +4,8 @@
 
 namespace vespalib::test {
 
-Nexus::~Nexus() = default;
+Nexus::~Nexus() {
+    _vote.destroy();
+}
 
 }

--- a/vespalib/src/vespa/vespalib/util/rendezvous.h
+++ b/vespalib/src/vespa/vespalib/util/rendezvous.h
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <condition_variable>
 #include <vector>
+#include <atomic>
 
 namespace vespalib {
 
@@ -30,6 +31,13 @@ private:
     size_t                  _gen;
     std::vector<IN *>       _in;
     std::vector<OUT *>      _out;
+    std::atomic<bool>       _destroyed;
+    size_t                  _destroyed_at;
+
+    /**
+     * Check if destroyed. Might throw IllegalStateException
+     **/
+    void check_destroyed(size_t my_gen, const std::unique_lock<std::mutex> &guard) const;
 
     /**
      * Function called to perform the actual inter-thread state
@@ -77,6 +85,14 @@ public:
      **/
     Rendezvous(size_t n);
     virtual ~Rendezvous();
+
+    /**
+     * Destroy this Rendezvous. This will cause any calls to the
+     * rendezvous function to fail with an exception. This function
+     * can be used to avoid barrier deadlocks caused by early thread
+     * unwinding.
+     **/
+    void destroy();
 
     /**
      * @return number of participants


### PR DESCRIPTION
return first exception from Nexus::run
underlying rendezvous now supports destruction

@toregge please review
@arnej27959 FYI