### PR TITLE
Simplify popcount loop to make auto-vectorizer more happy

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
@@ -17,23 +17,15 @@ Avx3DlAccelerator::dotProduct(const double* af, const double* bf, size_t sz) con
 
 size_t
 Avx3DlAccelerator::populationCount(const uint64_t* a, size_t sz) const noexcept {
-    // Empirical measurements show that firing up the whole pile of massively compiler-unrolled
-    // AVX512 VPOPCNT machinery for short vectors is actually determinental to performance.
-    // We therefore specialize the code generation for short vectors.
-    // This sequence of apparent identical function calls may look odd, but for each distinct
-    // branch `helper::populationCount` is inline and the compiler knows the max loop trip count.
-    // It can therefore specialize the implementations.
-    // Empirically on GCC 14.2, each increasing trip count uses less and less POPCNT and more
-    // and more VPOPCNT, culminating with the arbitrary trip count implementation.
-    if (sz <= 8) {
-        return helper::populationCount(a, sz);
-    } else if (sz <= 16) {
-        return helper::populationCount(a, sz);
-    } else if (sz <= 32) {
-        return helper::populationCount(a, sz);
-    } else {
-        return helper::populationCount(a, sz);
+    // When targeting VPOPCNTDQ the compiler auto-vectorization somewhat ironically
+    // gets horribly confused when the code is explicitly written to do popcounts
+    // in parallel across elements. Just doing a plain, boring loop lets the auto-
+    // vectorizer understand the semantics of the loop much more easily.
+    size_t count = 0;
+    for (size_t i = 0; i < sz; ++i) {
+        count += std::popcount(a[i]);
     }
+    return count;
 }
 
 double


### PR DESCRIPTION
@havardpe please review. Before trying any artisanal hand-sculptured AVX-512 intrinsics, let's try the opposite first and do something far simpler than what was already there :eyes: [Godbolt link](https://godbolt.org/z/zPGjr8W4s)—note that Clang does a more impressive job than GCC and actually uses 4x parallel accumulators, which is the same "trick" as the AVX-512 intrinsics version uses.
@arnej27959 FYI

When targeting `VPOPCNTDQ` the compiler auto-vectorization somewhat ironically gets horribly confused when the code is explicitly written to do popcounts in parallel across elements. Just doing a plain, boring loop lets the auto-vectorizer understand the semantics of the loop much more easily. This avoids generating a massive pile of vector lane permutations as part of the loop body.