### PR TITLE
chore(flags): bump expiry of temporary flag `require-operator-mode`

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -339,7 +339,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag REQUIRE_OPERATOR_MODE = defineFeatureFlag(
             "require-operator-mode", false,
-            List.of("eirik"), "2025-05-27", "2025-06-25",
+            List.of("eirik"), "2025-05-27", "2025-07-25",
             "Wheter operator mode is required to access hostedOperator functionality",
             "Takes effect immediately"
     );

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -339,7 +339,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag REQUIRE_OPERATOR_MODE = defineFeatureFlag(
             "require-operator-mode", false,
-            List.of("eirik"), "2025-05-27", "2025-07-25",
+            List.of("eirik"), "2025-05-27", "2025-09-25",
             "Wheter operator mode is required to access hostedOperator functionality",
             "Takes effect immediately"
     );


### PR DESCRIPTION
## What

* Bump the require-operator-mode Flag expiry

## Why

* Allows time to migrate off the flag.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
