### PR TITLE
split container-core tests

### DIFF
--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -460,21 +460,25 @@
           </execution>
         </executions>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>${test.hide}</redirectTestOutputToFile>
+        </configuration>
         <executions>
           <execution>
-            <id>default-test</id>
             <goals>
-              <goal>test</goal>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
-            <phase>integration-test</phase>
           </execution>
         </executions>
       </plugin>
-
     </plugins>
     <outputDirectory>${buildOutputDirectory}</outputDirectory>
   </build>

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/FilterIT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/FilterIT.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
  * @author Oyvind Bakksjo
  * @author bjorncs
  */
-public class FilterTestCase {
+public class FilterIT {
     @Test
     void requireThatRequestFilterIsNotRunOnUnboundPath() throws Exception {
         RequestFilterMockBase filter = mock(RequestFilterMockBase.class);

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/Http2IT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/Http2IT.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author bjorncs
  */
-class Http2Test {
+class Http2IT {
     @Test
     void requireThatServerCanRespondToHttp2Request(@TempDir Path tmpFolder) throws Exception {
         Path privateKeyFile = tmpFolder.resolve("private-key.pem");

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceIT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceIT.java
@@ -54,9 +54,9 @@ import static org.hamcrest.Matchers.matchesPattern;
 /**
  * @author Simon Thoresen Hult
  */
-public class HttpServerConformanceTest extends ServerProviderConformanceTest {
+public class HttpServerConformanceIT extends ServerProviderConformanceTest {
 
-    private static final Logger log = Logger.getLogger(HttpServerConformanceTest.class.getName());
+    private static final Logger log = Logger.getLogger(HttpServerConformanceIT.class.getName());
 
     private static final String REQUEST_CONTENT = "myRequestContent";
     private static final String RESPONSE_CONTENT = "myResponseContent";
@@ -66,7 +66,7 @@ public class HttpServerConformanceTest extends ServerProviderConformanceTest {
     private static CloseableHttpClient httpClient;
     private static ExecutorService executorService;
 
-    protected HttpServerConformanceTest() {
+    protected HttpServerConformanceIT() {
         super(false);
     }
 
@@ -93,7 +93,7 @@ public class HttpServerConformanceTest extends ServerProviderConformanceTest {
     @AfterAll
     public static void reportDiagnostics() {
         System.out.println(
-                "After " + HttpServerConformanceTest.class.getSimpleName()
+                "After " + HttpServerConformanceIT.class.getSimpleName()
                 + ": #threads=" + Thread.getAllStackTraces().size());
     }
 

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
@@ -110,7 +110,7 @@ import static org.mockito.Mockito.when;
  * @author Simon Thoresen Hult
  * @author bjorncs
  */
-public class HttpServerTest {
+public class HttpServerIT {
 
     @TempDir
     public File tmpFolder;

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServletIT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/JDiscHttpServletIT.java
@@ -29,7 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Simon Thoresen Hult
  */
-public class JDiscHttpServletTest {
+public class JDiscHttpServletIT {
 
     @Test
     void requireThatServerRespondsToAllMethods() throws Exception {

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/ProxyProtocolIT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/ProxyProtocolIT.java
@@ -44,9 +44,9 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author bjorncs
  */
 @Timeout(value = 60)
-class ProxyProtocolTest {
+class ProxyProtocolIT {
 
-    private static final Logger log = Logger.getLogger(ProxyProtocolTest.class.getName());
+    private static final Logger log = Logger.getLogger(ProxyProtocolIT.class.getName());
 
     private static Path privateKeyFile;
     private static Path certificateFile;

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/SslHandshakeMetricsIT.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/SslHandshakeMetricsIT.java
@@ -31,9 +31,9 @@ import static org.mockito.Mockito.verify;
 /**
  * @author bjorncs
  */
-class SslHandshakeMetricsTest {
+class SslHandshakeMetricsIT {
 
-    private static final Logger log = Logger.getLogger(SslHandshakeMetricsTest.class.getName());
+    private static final Logger log = Logger.getLogger(SslHandshakeMetricsIT.class.getName());
     private static Path privateKeyFile;
     private static Path certificateFile;
 


### PR DESCRIPTION
Integration tests now named FooIT and run by failsafe plugin.

@gjoranv please review
@bjorncs @bratseth FYI

after this it should be possible to do:
```
ulimit -n 65536
mvn -T 1C compile
mvn -T 1C test
```
and to run all the tests, `mvn -T 1C integration-test`

