### PR TITLE
Improve transaction log replay resource usage tracking

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.cpp
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/updateoperation.cpp
@@ -61,7 +61,9 @@ UpdateOperation::serialize(vespalib::nbostream &os) const
 {
     assertValidBucketId(_upd->getId());
     DocumentOperation::serialize(os);
+    const size_t old_size = os.size();
     serializeUpdate(os);
+    _serializedDocSize = os.size() - old_size;
 }
 
 
@@ -70,7 +72,9 @@ UpdateOperation::deserialize(vespalib::nbostream &is, const DocumentTypeRepo &re
 {
     DocumentOperation::deserialize(is, repo);
     try {
+        const size_t old_size = is.size();
         deserializeUpdate(std::move(is), repo);
+        _serializedDocSize = old_size - is.size();
     } catch (document::DocumentTypeNotFoundException &e) {
         LOG(warning, "Failed deserialize update operation using unknown document type '%s'",
             e.getDocumentTypeName().c_str());

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -438,6 +438,12 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
 
     _executor.sync();
     waitForOnlineState();
+    if (replay_throttle_policy.get_params()) {
+        LOG(info, "Estimated maximum memory usage during transaction log replay was %" PRIu64
+                " bytes. Soft limit was %" PRIu64 " bytes",
+            _shared_replay_throttler->max_resource_usage(),
+            replay_throttle_policy.get_params()->resource_usage_soft_limit);
+    }
     _rpcHooks->set_online();
 
     _flushEngine->start();

--- a/vespalib/src/vespa/vespalib/util/shared_operation_throttler.h
+++ b/vespalib/src/vespa/vespalib/util/shared_operation_throttler.h
@@ -100,6 +100,8 @@ public:
 
     [[nodiscard]] virtual uint64_t current_resource_usage() const noexcept = 0;
 
+    [[nodiscard]] virtual uint64_t max_resource_usage() const noexcept = 0;
+
     struct DynamicThrottleParams {
         uint32_t window_size_increment      = 20;
         uint32_t min_window_size            = 20;


### PR DESCRIPTION
@toregge please review. This avoids updates being tracked as using 0 bytes, and adds visibility of replay resource usage during startup.
