### PR TITLE
make clang happy

### DIFF
--- a/fnet/src/vespa/fnet/transport.cpp
+++ b/fnet/src/vespa/fnet/transport.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/rendezvous.h>
+#include <vespa/vespalib/util/rendezvous.hpp>
 #include <vespa/vespalib/util/backtrace.h>
 #include <xxhash.h>
 

--- a/fnet/src/vespa/fnet/transport_debugger.cpp
+++ b/fnet/src/vespa/fnet/transport_debugger.cpp
@@ -2,6 +2,7 @@
 
 #include "transport_debugger.h"
 #include <vespa/vespalib/util/require.h>
+#include <vespa/vespalib/util/rendezvous.hpp>
 #include <cassert>
 
 namespace fnet {

--- a/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.cpp
@@ -3,6 +3,7 @@
 #include "match_loop_communicator.h"
 #include <vespa/searchlib/features/first_phase_rank_lookup.h>
 #include <vespa/vespalib/util/priority_queue.h>
+#include <vespa/vespalib/util/rendezvous.hpp>
 
 using search::features::FirstPhaseRankLookup;
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -18,6 +18,7 @@
 #include <vespa/searchlib/fef/test/plugin/setup.h>
 #include <vespa/searchlib/common/allocatedbitvector.h>
 #include <vespa/vespalib/data/slime/inserter.h>
+#include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/limited_thread_bundle_wrapper.h>
 #include <cinttypes>
 

--- a/searchcore/src/vespa/searchcore/proton/matching/partial_result.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/partial_result.cpp
@@ -2,6 +2,7 @@
 
 #include "partial_result.h"
 #include <cstring>
+#include <cassert>
 
 namespace proton::matching {
 

--- a/vespalib/src/vespa/vespalib/test/thread_meets.h
+++ b/vespalib/src/vespa/vespalib/test/thread_meets.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vespa/vespalib/util/rendezvous.h>
+#include <vespa/vespalib/util/rendezvous.hpp>
 
 namespace vespalib::test {
 

--- a/vespalib/src/vespa/vespalib/util/dual_merge_director.cpp
+++ b/vespalib/src/vespa/vespalib/util/dual_merge_director.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "dual_merge_director.h"
+#include <vespa/vespalib/util/rendezvous.hpp>
 
 namespace vespalib {
 

--- a/vespalib/src/vespa/vespalib/util/rendezvous.h
+++ b/vespalib/src/vespa/vespalib/util/rendezvous.h
@@ -123,5 +123,3 @@ public:
 };
 
 } // namespace vespalib
-
-#include "rendezvous.hpp"


### PR DESCRIPTION
* only include rendezvous.hpp where it's actually needed
* needed <cassert> one extra place

@havardpe or @toregge please review
