### PR TITLE
Allow mirroring copr rpms manually, not only on schedule. MERGEOK

### DIFF
--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -69,18 +69,22 @@ echo
 UPLOAD_FAILED=false
 echo "GitHub event: $GITHUB_EVENT_NAME"
 
-if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-  for rpm in $(ls *.rpm); do
-    echo "Uploading $rpm ..."
-    if ! $MYDIR/upload-rpm-to-cloudsmith.sh $rpm ; then
+for rpm in *.rpm; do
+  [ -e "$rpm" ] || continue
+  echo "Uploading $rpm ..."
+  if [ "${DRY_RUN:-false}" != "true" ]; then
+    $MYDIR/upload-rpm-to-cloudsmith.sh $rpm
+    if [ $? -ne 0 ]; then
       echo "Could not upload $rpm"
       UPLOAD_FAILED=true
     else
       echo "$rpm uploaded"
     fi
-  done
-  echo
-fi
+  else
+    echo "DRY_RUN: Skipping upload of $rpm"
+  fi
+done
+echo
 
 if $UPLOAD_FAILED; then
   echo "Some RPMs failed to upload"

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -2,6 +2,12 @@ name: Mirror Copr RPMs to archive
 
 on:
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run only non-destructive commands, skipping the destructive ones'
+        required: false
+        type: boolean
+        default: true
 
   pull_request:
     paths:
@@ -13,6 +19,9 @@ on:
 
   schedule:
    - cron: '0 6 * * *'
+
+env:
+  DRY_RUN: ${{ (inputs.dry-run || github.event_name == 'pull_request') && 'true' || '' }}
 
 jobs:
   mirror-copr-rpms-to-archive:


### PR DESCRIPTION
- Add a 'dry-run' input param to skip the mirroring itself.

FYI: @glebashnik 
