### PR TITLE
Move from `proto3` to Protobuf Edition 2023 for the Storage API

### DIFF
--- a/storage/src/vespa/storageapi/mbusprot/protobuf/common.proto
+++ b/storage/src/vespa/storageapi/mbusprot/protobuf/common.proto
@@ -1,9 +1,14 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-syntax = "proto3";
+edition = "2023";
+// Preserve proto3 default field presence semantics
+option features.field_presence = IMPLICIT;
 
 option cc_enable_arenas = true;
 
 package storage.mbusprot.protobuf;
+
+import "google/protobuf/cpp_features.proto";
+option features.(pb.cpp).string_type = VIEW;
 
 // Note: we use a *Request/*Response naming convention rather than *Command/*Reply,
 // as the former is the gRPC convention and that's where we intend to move.

--- a/storage/src/vespa/storageapi/mbusprot/protobuf/feed.proto
+++ b/storage/src/vespa/storageapi/mbusprot/protobuf/feed.proto
@@ -1,11 +1,16 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-syntax = "proto3";
+edition = "2023";
+// Preserve proto3 default field presence semantics
+option features.field_presence = IMPLICIT;
 
 option cc_enable_arenas = true;
 
 package storage.mbusprot.protobuf;
 
 import "common.proto";
+
+import "google/protobuf/cpp_features.proto";
+option features.(pb.cpp).string_type = VIEW;
 
 message TestAndSetCondition {
     bytes selection = 1;

--- a/storage/src/vespa/storageapi/mbusprot/protobuf/inspect.proto
+++ b/storage/src/vespa/storageapi/mbusprot/protobuf/inspect.proto
@@ -1,12 +1,16 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
-syntax = "proto3";
+edition = "2023";
+// Preserve proto3 default field presence semantics
+option features.field_presence = IMPLICIT;
 
 option cc_enable_arenas = true;
 
 package storage.mbusprot.protobuf;
 
 import "common.proto";
+
+import "google/protobuf/cpp_features.proto";
+option features.(pb.cpp).string_type = VIEW;
 
 message StatBucketRequest {
     Bucket bucket             = 1;

--- a/storage/src/vespa/storageapi/mbusprot/protobuf/maintenance.proto
+++ b/storage/src/vespa/storageapi/mbusprot/protobuf/maintenance.proto
@@ -1,11 +1,16 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-syntax = "proto3";
+edition = "2023";
+// Preserve proto3 default field presence semantics
+option features.field_presence = IMPLICIT;
 
 option cc_enable_arenas = true;
 
 package storage.mbusprot.protobuf;
 
 import "common.proto";
+
+import "google/protobuf/cpp_features.proto";
+option features.(pb.cpp).string_type = VIEW;
 
 message DeleteBucketRequest {
     Bucket     bucket               = 1;

--- a/storage/src/vespa/storageapi/mbusprot/protobuf/visiting.proto
+++ b/storage/src/vespa/storageapi/mbusprot/protobuf/visiting.proto
@@ -1,11 +1,16 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-syntax = "proto3";
+edition = "2023";
+// Preserve proto3 default field presence semantics
+option features.field_presence = IMPLICIT;
 
 option cc_enable_arenas = true;
 
 package storage.mbusprot.protobuf;
 
 import "common.proto";
+
+import "google/protobuf/cpp_features.proto";
+option features.(pb.cpp).string_type = VIEW;
 
 message ClientVisitorParameter {
     bytes key   = 1;


### PR DESCRIPTION
@toregge please review. These changes will be the default in some future Protobuf version, so might as well do it now. This also cleans up remnants of API workarounds for when `vespalib::string` roamed the earth.
@arnej27959 FYI

Moving to the 2023 edition lets us specify that fields of type `string` and `byte` can be exposed as `string_view` instead of `std::string` instances. This makes such fields much more compatible with arena allocation. Some minor changes have been made to the codecs to use `string_view` setters as a result.

To avoid any changes to wire payloads for default fields, retain the proto3 implicit field presence semantics for now. Explicit field presence can be toggled on a per-field basis.

There shall be no changes to any protocol semantics.
