### PR TITLE
get MD5 from bytes directly

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationFile.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationFile.java
@@ -207,7 +207,7 @@ public class FilesApplicationFile extends ApplicationFile {
             if (file.isDirectory()) {
                 return new MetaData(ContentStatusNew, "");
             } else {
-                return new MetaData(ContentStatusNew, ConfigUtils.getMd5(IOUtils.readAll(createReader())));
+                return new MetaData(ContentStatusNew, ConfigUtils.getMd5(IOUtils.readFileBytes(file)));
             }
         } catch (IOException | IllegalArgumentException e) {
             return null;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationFile.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationFile.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.config.server.zookeeper;
 import com.yahoo.json.Jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.config.application.api.ApplicationFile;
+import com.yahoo.io.HexDump;
 import com.yahoo.io.IOUtils;
 import com.yahoo.path.Path;
 import com.yahoo.text.Utf8;
@@ -187,7 +188,7 @@ class ZKApplicationFile extends ApplicationFile {
         if (zkApp.exists(metaPath)) {
             return getMetaDataFromZk(metaPath);
         }
-        return new MetaData(ContentStatusNew, isDirectory() ? "" : ConfigUtils.getMd5(zkApp.getData(getZKPath(path))));
+        return new MetaData(ContentStatusNew, isDirectory() ? "" : ConfigUtils.getMd5(zkApp.getBytes(getZKPath(path))));
     }
 
     private MetaData getMetaDataFromZk(Path metaPath) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/ContentHandlerTestBase.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/ContentHandlerTestBase.java
@@ -65,7 +65,7 @@ public abstract class ContentHandlerTestBase extends SessionHandlerTest {
         assertStatus("/foo/?return=status&recursive=true",
                 "[{\"status\":\"new\",\"md5\":\"\",\"name\":\"" + baseUrl + "foo/bar\"}," +
                         "{\"status\":\"new\",\"md5\":\"9a0364b9e99bb480dd25e1f0284c8555\",\"name\":\"" + baseUrl + "foo/bar/file-without-extension\"}," +
-                        "{\"status\":\"new\",\"md5\":\"dd9f9fbaf9adb96fd7be2f9bbe562714\",\"name\":\"" + baseUrl + "foo/bar/test.jar\"}," +
+                        "{\"status\":\"new\",\"md5\":\"56f62ad750881d2f8276136896ff84fb\",\"name\":\"" + baseUrl + "foo/bar/test.jar\"}," +
                         "{\"status\":\"new\",\"md5\":\"c157a79031e1c40f85931829bc5fc552\",\"name\":\"" + baseUrl + "foo/test1.json\"}," +
                         "{\"status\":\"new\",\"md5\":\"258622b1688250cb619f3c9ccaefb7eb\",\"name\":\"" + baseUrl + "foo/test2.txt\"}]");
     }

--- a/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
+++ b/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
@@ -406,7 +406,7 @@ public abstract class IOUtils {
         try (BufferedReader buffered = new BufferedReader(reader)) {
             int c;
             while ((c = buffered.read()) != -1)
-                sb.appendCodePoint(c);
+                sb.append((char)c);
         }
         return sb.toString();
     }


### PR DESCRIPTION
the old code would convert from binary data to string, back to bytes, and then perform MD5.  This gave different results depending on LC_CTYPE settings.  Use the raw bytes directly to get the same MD5 as "md5sum ./src/test/apps/content/foo/bar/test.jar"

NOTE: this will (obviously) change the MD5 checksums generated - it seems likely to me that it could have bad effects, so we need to discuss it and go over scenarios before merging.  But the current situation is bad in any case.

