### PR TITLE
Reduce attribute address space limits

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ResourceLimits.java
@@ -42,7 +42,7 @@ public class ResourceLimits implements FleetcontrollerConfig.Producer, ProtonCon
         // storage/src/vespa/storage/persistence/filestorage/service_layer_host_info_reporter.cpp
         builder.cluster_feed_block_limit.put("memory", memoryLimit.orElse(0.8));
         builder.cluster_feed_block_limit.put("disk", diskLimit.orElse(0.75));
-        builder.cluster_feed_block_limit.put("attribute-address-space", 0.9);
+        builder.cluster_feed_block_limit.put("attribute-address-space", 0.89);
         builder.cluster_feed_block_noise_level(lowWatermarkDifference.orElse(0.0));
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
@@ -115,7 +115,7 @@ public class FleetControllerClusterTest {
         assertEquals(3, limits.size());
         assertEquals(expDisk, limits.get("disk"), DELTA);
         assertEquals(expMemory, limits.get("memory"), DELTA);
-        assertEquals(0.9, limits.get("attribute-address-space"), DELTA);
+        assertEquals(0.89, limits.get("attribute-address-space"), DELTA);
     }
 
     private FleetcontrollerConfig getConfigForResourceLimitsTuning(Double diskLimit, Double memoryLimit) {

--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -421,7 +421,7 @@ initialize.threads int default = 0
 
 ## Portion of max address space used in components in attribute vectors
 ## before put and update operations in feed is blocked.
-writefilter.attribute.address_space_limit double default = 0.92
+writefilter.attribute.address_space_limit double default = 0.91
 
 ## Portion of physical memory that can be resident memory in anonymous mapping
 ## by the proton process before put and update portion of feed is blocked.


### PR DESCRIPTION
Reduce from 0.92 to 0.91 for searchnode and from 0.90 to 0.89 for cluster controller, limits seem to be a little too high today