### PR TITLE
Revert "fix(deps): update grpc-java monorepo to v1.73.0"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -102,7 +102,7 @@
         <felix.vespa.version>7.0.5</felix.vespa.version>
         <felix.log.vespa.version>1.3.0</felix.log.vespa.version>
         <findbugs.vespa.version>3.0.2</findbugs.vespa.version> <!-- Should be kept in sync with guava -->
-        <grpc.vespa.version>1.73.0</grpc.vespa.version>
+        <grpc.vespa.version>1.72.0</grpc.vespa.version>
         <gson.vespa.version>2.12.1</gson.vespa.version>
         <hamcrest.vespa.version>3.0</hamcrest.vespa.version>
         <hdrhistogram.vespa.version>2.2.2</hdrhistogram.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#34389

This seems to have broken something:
`Could not initialize class com.strongdm.api.plumbing.Spec`
StrongDM API is constructed with gRPC.