### PR TITLE
fix(grouping-parser): enable unicode support

### DIFF
--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -12,6 +12,7 @@ options {
     USER_TOKEN_MANAGER = false;
     USER_CHAR_STREAM   = true;
     ERROR_REPORTING    = true;
+    UNICODE_INPUT      = true;
 }
 
 // --------------------------------------------------------------------------------

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
@@ -630,7 +630,8 @@ public class GroupingParserTestCase {
                 () -> assertParse("all(group(foo) filter(regex(\".*mysubstring.*\", foo)) each(output(count())))"),
                 () -> assertParse("all(group(foo) filter(regex(\"^myexactstring$\", foo)) each(output(count())))"),
                 () -> assertParse("all(group(foo) filter(regex(\"(stringinparentheses)?\", foo)) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(regex(\"[a-zA-Z_]+characterclass\", foo)) each(output(count())))"));
+                () -> assertParse("all(group(foo) filter(regex(\"[a-zA-Z_]+characterclass\", foo)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(regex(\"中文\", foo)) each(output(count())))"));
 
         assertAll("filter with alias",
                 () -> assertParse(


### PR DESCRIPTION
Allow unicode string literals, e.g. in regex for filter expression.