### PR TITLE
feat(indexing-language): don't annotate if text is likely binary data

### DIFF
--- a/config-model/src/test/derived/advanced/ilscripts.cfg
+++ b/config-model/src/test/derived/advanced/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "advanced"
 ilscript[].docfield[] "debug_src"
 ilscript[].docfield[] "attributes_src"

--- a/config-model/src/test/derived/annotationsimplicitstruct/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsimplicitstruct/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsimplicitstruct"

--- a/config-model/src/test/derived/annotationsinheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsinheritance/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsinheritance"

--- a/config-model/src/test/derived/annotationsinheritance2/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsinheritance2/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsinheritance2"

--- a/config-model/src/test/derived/annotationsreference/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsreference/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsreference"

--- a/config-model/src/test/derived/annotationssimple/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationssimple/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationssimple"

--- a/config-model/src/test/derived/arrays/ilscripts.cfg
+++ b/config-model/src/test/derived/arrays/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "arrays"
 ilscript[].docfield[] "tags"
 ilscript[].docfield[] "ratings"

--- a/config-model/src/test/derived/attributeprefetch/ilscripts.cfg
+++ b/config-model/src/test/derived/attributeprefetch/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "prefetch"
 ilscript[].docfield[] "singlebyte"
 ilscript[].docfield[] "multibyte"

--- a/config-model/src/test/derived/attributes/ilscripts.cfg
+++ b/config-model/src/test/derived/attributes/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "attributes"
 ilscript[].docfield[] "a1"
 ilscript[].docfield[] "a2"

--- a/config-model/src/test/derived/bolding_dynamic_summary/ilscripts.cfg
+++ b/config-model/src/test/derived/bolding_dynamic_summary/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "test"
 ilscript[].docfield[] "str_1"
 ilscript[].docfield[] "str_2"

--- a/config-model/src/test/derived/complex/ilscripts.cfg
+++ b/config-model/src/test/derived/complex/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "complex"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "location"

--- a/config-model/src/test/derived/emptydefault/ilscripts.cfg
+++ b/config-model/src/test/derived/emptydefault/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "emptydefault"
 ilscript[].docfield[] "one"
 ilscript[].docfield[] "two"

--- a/config-model/src/test/derived/exactmatch/ilscripts.cfg
+++ b/config-model/src/test/derived/exactmatch/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "exactmatch"
 ilscript[].docfield[] "tag"
 ilscript[].docfield[] "screweduserids"

--- a/config-model/src/test/derived/hnsw_index/ilscripts.cfg
+++ b/config-model/src/test/derived/hnsw_index/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "test"
 ilscript[].docfield[] "t1"
 ilscript[].docfield[] "t2"

--- a/config-model/src/test/derived/id/ilscripts.cfg
+++ b/config-model/src/test/derived/id/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "id"
 ilscript[].docfield[] "uri"
 ilscript[].content[] "clear_state | guard { input uri | summary uri | index uri; }"

--- a/config-model/src/test/derived/indexing_script_order/ilscripts.cfg
+++ b/config-model/src/test/derived/indexing_script_order/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "specialorder"
 ilscript[].docfield[] "a"
 ilscript[].docfield[] "b"

--- a/config-model/src/test/derived/indexswitches/ilscripts.cfg
+++ b/config-model/src/test/derived/indexswitches/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "indexswitches"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "descr"

--- a/config-model/src/test/derived/inheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/inheritance/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "child"
 ilscript[].docfield[] "onlygrandparent"
 ilscript[].docfield[] "overridden"

--- a/config-model/src/test/derived/language/ilscripts.cfg
+++ b/config-model/src/test/derived/language/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "language"
 ilscript[].docfield[] "language"
 ilscript[].docfield[] "title"

--- a/config-model/src/test/derived/lowercase/ilscripts.cfg
+++ b/config-model/src/test/derived/lowercase/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "lowercase"
 ilscript[].docfield[] "single_field_source"
 ilscript[].docfield[] "array_field_source"

--- a/config-model/src/test/derived/multiplesummaries/ilscripts.cfg
+++ b/config-model/src/test/derived/multiplesummaries/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "multiplesummaries"
 ilscript[].docfield[] "a"
 ilscript[].docfield[] "adynamic"

--- a/config-model/src/test/derived/music/ilscripts.cfg
+++ b/config-model/src/test/derived/music/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "music"
 ilscript[].docfield[] "bgndata"
 ilscript[].docfield[] "sales"

--- a/config-model/src/test/derived/newrank/ilscripts.cfg
+++ b/config-model/src/test/derived/newrank/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "newrank"
 ilscript[].docfield[] "bgndata"
 ilscript[].docfield[] "sales"

--- a/config-model/src/test/derived/orderilscripts/ilscripts.cfg
+++ b/config-model/src/test/derived/orderilscripts/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "orderilscripts"
 ilscript[].docfield[] "foo"
 ilscript[].content[] "clear_state | guard { input foo | summary bar; }"

--- a/config-model/src/test/derived/position_array/ilscripts.cfg
+++ b/config-model/src/test/derived/position_array/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "position_array"
 ilscript[].docfield[] "pos"
 ilscript[].content[] "clear_state | guard { input pos | for_each { zcurve } | attribute pos_zcurve; }"

--- a/config-model/src/test/derived/position_attribute/ilscripts.cfg
+++ b/config-model/src/test/derived/position_attribute/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "position_attribute"
 ilscript[].docfield[] "pos"
 ilscript[].content[] "clear_state | guard { input pos | zcurve | attribute pos_zcurve; }"

--- a/config-model/src/test/derived/position_extra/ilscripts.cfg
+++ b/config-model/src/test/derived/position_extra/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "position_extra"
 ilscript[].docfield[] "pos_str"
 ilscript[].content[] "clear_state | guard { input pos_str | to_pos | zcurve | attribute pos_ext_zcurve; }"

--- a/config-model/src/test/derived/prefixexactattribute/ilscripts.cfg
+++ b/config-model/src/test/derived/prefixexactattribute/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "prefixexactattribute"
 ilscript[].docfield[] "indexfield0"
 ilscript[].docfield[] "attributefield1"

--- a/config-model/src/test/derived/ranktypes/ilscripts.cfg
+++ b/config-model/src/test/derived/ranktypes/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "ranktypes"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "descr"

--- a/config-model/src/test/derived/schemainheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/schemainheritance/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "child"
 ilscript[].docfield[] "pf1"
 ilscript[].docfield[] "importedschema_ref"

--- a/config-model/src/test/derived/structanyorder/ilscripts.cfg
+++ b/config-model/src/test/derived/structanyorder/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsimplicitstruct"
 ilscript[].docfield[] "structfield"
 ilscript[].docfield[] "structarrayfield"

--- a/config-model/src/test/derived/tokenization/ilscripts.cfg
+++ b/config-model/src/test/derived/tokenization/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "tokenization"
 ilscript[].docfield[] "text"
 ilscript[].docfield[] "text_array"

--- a/config-model/src/test/derived/types/ilscripts.cfg
+++ b/config-model/src/test/derived/types/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "types"
 ilscript[].docfield[] "abyte"
 ilscript[].docfield[] "along"

--- a/config-model/src/test/derived/uri_array/ilscripts.cfg
+++ b/config-model/src/test/derived/uri_array/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "uri_array"
 ilscript[].docfield[] "my_uri"
 ilscript[].content[] "clear_state | guard { input my_uri | index my_uri; }"

--- a/config-model/src/test/derived/uri_wset/ilscripts.cfg
+++ b/config-model/src/test/derived/uri_wset/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "uri_wset"
 ilscript[].docfield[] "my_uri"
 ilscript[].content[] "clear_state | guard { input my_uri | index my_uri; }"

--- a/config-model/src/test/java/com/yahoo/schema/derived/AbstractExportingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/derived/AbstractExportingTestCase.java
@@ -150,8 +150,9 @@ public abstract class AbstractExportingTestCase extends AbstractSchemaTestCase {
     }
 
     static void assertEqualFiles(String correctFileName, String checkFileName, boolean orderMatters) throws IOException {
-        // Set updateOnAssert to true if you want update the files with correct answer.
-        assertConfigFiles(correctFileName, checkFileName, orderMatters, false);
+        // Set the system property 'updateExpectedFiles' to true to update the expected files
+        // Example: mvn verify -DupdateExpectedFiles=true
+        assertConfigFiles(correctFileName, checkFileName, orderMatters, Boolean.getBoolean("updateExpectedFiles"));
     }
 
     void deleteContent(File dir) {

--- a/configdefinitions/src/vespa/ilscripts.def
+++ b/configdefinitions/src/vespa/ilscripts.def
@@ -11,7 +11,7 @@ fieldmatchmaxlength int default=1000000
 # The maximum allowed ratio of replacement characters before skipping annotation processing
 maxReplacementCharactersRatio double default=0.1
 # The maximum number of replacement characters to allow before skipping annotation processing
-maxReplacementCharacters int default=10
+maxReplacementCharacters int default=1000
 
 ilscript[].doctype    string
 ilscript[].docfield[] string

--- a/configdefinitions/src/vespa/ilscripts.def
+++ b/configdefinitions/src/vespa/ilscripts.def
@@ -7,6 +7,12 @@ maxtermoccurrences int default=10000
 maxtokenlength int default=1000
 fieldmatchmaxlength int default=1000000
 
+# Note on replacement character thresholds: both must be exceeded to skip annotation processing. See LinguisticsAnnotator for details.
+# The maximum allowed ratio of replacement characters before skipping annotation processing
+maxReplacementCharactersRatio double default=0.1
+# The maximum number of replacement characters to allow before skipping annotation processing
+maxReplacementCharacters int default=10
+
 ilscript[].doctype    string
 ilscript[].docfield[] string
 ilscript[].content[]  string

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/AnnotatorConfig.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/AnnotatorConfig.java
@@ -20,16 +20,22 @@ public class AnnotatorConfig implements Cloneable {
     private int maxTermOccurrences;
     private int maxTokenLength;
     private int maxTokenizeLength;
+    private double maxReplacementCharactersRatio;
+    private int maxReplacementCharacters;
 
     public static final int DEFAULT_MAX_TERM_OCCURRENCES;
     private static final int DEFAULT_MAX_TOKEN_LENGTH;
     private static final int DEFAULT_MAX_TOKENIZE_LENGTH;
+    private static final double DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO;
+    private static final int DEFAULT_MAX_REPLACEMENT_CHARACTERS;
 
     static {
         IlscriptsConfig defaults = new IlscriptsConfig(new IlscriptsConfig.Builder());
         DEFAULT_MAX_TERM_OCCURRENCES = defaults.maxtermoccurrences();
         DEFAULT_MAX_TOKEN_LENGTH = defaults.maxtokenlength();
         DEFAULT_MAX_TOKENIZE_LENGTH = defaults.fieldmatchmaxlength();
+        DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO = defaults.maxReplacementCharactersRatio();
+        DEFAULT_MAX_REPLACEMENT_CHARACTERS = defaults.maxReplacementCharacters();
     }
 
     public AnnotatorConfig() {
@@ -40,6 +46,8 @@ public class AnnotatorConfig implements Cloneable {
         maxTermOccurrences = DEFAULT_MAX_TERM_OCCURRENCES;
         maxTokenLength = DEFAULT_MAX_TOKEN_LENGTH;
         maxTokenizeLength = DEFAULT_MAX_TOKENIZE_LENGTH;
+        maxReplacementCharactersRatio = DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO;
+        maxReplacementCharacters = DEFAULT_MAX_REPLACEMENT_CHARACTERS;
     }
 
     public AnnotatorConfig(AnnotatorConfig other) {
@@ -50,6 +58,8 @@ public class AnnotatorConfig implements Cloneable {
         maxTermOccurrences = other.maxTermOccurrences;
         maxTokenLength = other.maxTokenLength;
         maxTokenizeLength = other.maxTokenizeLength;
+        maxReplacementCharactersRatio = other.maxReplacementCharactersRatio;
+        maxReplacementCharacters = other.maxReplacementCharacters;
     }
 
     public Language getLanguage() {
@@ -113,6 +123,12 @@ public class AnnotatorConfig implements Cloneable {
 
     public static int getDefaultMaxTokenLength() { return DEFAULT_MAX_TOKEN_LENGTH; }
 
+    public double getMaxReplacementCharactersRatio() { return maxReplacementCharactersRatio; }
+    public AnnotatorConfig setMaxReplacementCharactersRatio(double ratio) { this.maxReplacementCharactersRatio = ratio; return this;}
+
+    public int getMaxReplacementCharacters() { return maxReplacementCharacters; }
+    public AnnotatorConfig setMaxReplacementCharacters(int count) { this.maxReplacementCharacters = count; return this; }
+
     public AnnotatorConfig setMaxTokenizeLength(int maxTokenizeLength) {
         this.maxTokenizeLength = maxTokenizeLength;
         return this;
@@ -134,6 +150,14 @@ public class AnnotatorConfig implements Cloneable {
         return maxTermOccurrences != DEFAULT_MAX_TERM_OCCURRENCES;
     }
 
+    public boolean hasNonDefaultMaxReplacementCharactersRatio() {
+        return maxReplacementCharactersRatio != DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO;
+    }
+
+    public boolean hasNonDefaultMaxReplacementCharacters() {
+        return maxReplacementCharacters != DEFAULT_MAX_REPLACEMENT_CHARACTERS;
+    }
+
     public LinguisticsParameters asLinguisticsParameters() {
         return new LinguisticsParameters(language, stemMode, removeAccents, lowercase);
     }
@@ -148,13 +172,16 @@ public class AnnotatorConfig implements Cloneable {
         if (maxTermOccurrences != other.maxTermOccurrences) return false;
         if (maxTokenLength != other.maxTokenLength) return false;
         if (maxTokenizeLength != other.maxTokenizeLength) return false;
+        if (maxReplacementCharactersRatio != other.maxReplacementCharactersRatio) return false;
+        if (maxReplacementCharacters != other.maxReplacementCharacters) return false;
         return true;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getClass(), language.hashCode(), stemMode.hashCode(),
-                            removeAccents, lowercase, maxTermOccurrences, maxTokenLength, maxTokenizeLength);
+                            removeAccents, lowercase, maxTermOccurrences, maxTokenLength, maxTokenizeLength,
+                            maxReplacementCharactersRatio, maxReplacementCharacters);
     }
 
     @Override
@@ -176,6 +203,10 @@ public class AnnotatorConfig implements Cloneable {
             ret.append(" max-token-length:" + getMaxTokenLength());
         if (hasNonDefaultMaxTermOccurrences())
             ret.append(" max-occurrences:" + getMaxTermOccurrences());
+        if (hasNonDefaultMaxReplacementCharactersRatio())
+            ret.append(" max-replacement-characters-ratio:").append(getMaxReplacementCharactersRatio());
+        if (hasNonDefaultMaxReplacementCharacters())
+            ret.append(" max-replacement-characters:").append(getMaxReplacementCharacters());
         return ret.toString();
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
@@ -155,9 +155,10 @@ public class LinguisticsAnnotator {
 
     // Use the ratio of Unicode replacement characters as heuristic if the text is likely representing binary data
     // https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
-    private static boolean isLikelyBinaryData(String text) {
+    private boolean isLikelyBinaryData(String text) {
         var replacementCharCount = text.chars().filter(c -> c == 0xFFFD).count();
-        if (replacementCharCount > 10 && replacementCharCount > text.length() * 0.1D) {
+        if (replacementCharCount > config.getMaxReplacementCharacters()
+                && replacementCharCount > text.length() * config.getMaxReplacementCharactersRatio()) {
             log.log(Level.FINE, () ->
                     "Text contains %d replacement characters, which is more than 10%% of %d"
                             .formatted(replacementCharCount, text.length()));

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
@@ -160,8 +160,11 @@ public class LinguisticsAnnotator {
         if (replacementCharCount > config.getMaxReplacementCharacters()
                 && replacementCharCount > text.length() * config.getMaxReplacementCharactersRatio()) {
             log.log(Level.FINE, () ->
-                    "Text contains %d replacement characters, which is more than 10%% of %d"
-                            .formatted(replacementCharCount, text.length()));
+            {
+                var ratioAsPercent = (int) Math.round(config.getMaxReplacementCharactersRatio() * 100);
+                return "Text contains %d replacement characters, which is more than %d%% of %d"
+                        .formatted(replacementCharCount, ratioAsPercent, text.length());
+            });
             return true;
         }
         return false;

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotatorTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotatorTestCase.java
@@ -6,24 +6,22 @@ import com.yahoo.document.annotation.AnnotationTypes;
 import com.yahoo.document.annotation.SpanTree;
 import com.yahoo.document.annotation.SpanTrees;
 import com.yahoo.document.datatypes.StringFieldValue;
-import com.yahoo.language.Language;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.LinguisticsParameters;
-import com.yahoo.language.process.StemMode;
 import com.yahoo.language.process.Token;
 import com.yahoo.language.process.TokenType;
 import com.yahoo.language.process.Tokenizer;
 import com.yahoo.language.simple.SimpleLinguistics;
 import com.yahoo.language.simple.SimpleToken;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 
-
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -261,6 +259,16 @@ public class LinguisticsAnnotatorTestCase {
             }
             assertAnnotations(expected, input.toString(), tokens);
         }
+    }
+
+    @Test
+    public void requireThatHighRatioOfReplacementCharactersAreNotAnnotated() {
+        Predicate<String> isAnnotationsProduced =
+                txt -> new LinguisticsAnnotator(new SimpleLinguistics(), new AnnotatorConfig())
+                        .annotate(new StringFieldValue(txt));
+        assertTrue(isAnnotationsProduced.test("\uFFFD".repeat(10) + "a".repeat(90))); // Up to 10 replacement characters allowed
+        assertTrue(isAnnotationsProduced.test("\uFFFD".repeat(11) + "a".repeat(100))); // Up to 10% being replacement characters allowed
+        assertFalse(isAnnotationsProduced.test("\uFFFD".repeat(11) + "a".repeat(90))); // Above both limits, so no annotations
     }
 
     // --------------------------------------------------------------------------------

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotatorTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotatorTestCase.java
@@ -263,8 +263,12 @@ public class LinguisticsAnnotatorTestCase {
 
     @Test
     public void requireThatHighRatioOfReplacementCharactersAreNotAnnotated() {
+        var config = new AnnotatorConfig()
+                .setMaxReplacementCharacters(10)
+                .setMaxReplacementCharactersRatio(0.1d);
+
         Predicate<String> isAnnotationsProduced =
-                txt -> new LinguisticsAnnotator(new SimpleLinguistics(), new AnnotatorConfig())
+                txt -> new LinguisticsAnnotator(new SimpleLinguistics(), config)
                         .annotate(new StringFieldValue(txt));
         assertTrue(isAnnotationsProduced.test("\uFFFD".repeat(10) + "a".repeat(90))); // Up to 10 replacement characters allowed
         assertTrue(isAnnotationsProduced.test("\uFFFD".repeat(11) + "a".repeat(100))); // Up to 10% being replacement characters allowed


### PR DESCRIPTION
Use number of replacement characters as proxy