### PR TITLE
Revert "fix(deps): update jetty monorepo to v12.0.23"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -113,7 +113,7 @@
         <java-jwt.vespa.version>4.4.0</java-jwt.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.0.23</jetty.vespa.version>
+        <jetty.vespa.version>12.0.22</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>
         <jimfs.vespa.version>1.3.0</jimfs.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#34410

This change broke some timeout behavior as seen in system test feed_when_container_oom.rb
Best to revert pending closer investigation 
