### PR TITLE
Add experimental streaming JSONL output to the Document V1 API handler

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/BufferedContentChannelResponseWriter.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/BufferedContentChannelResponseWriter.java
@@ -1,0 +1,89 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.yahoo.jdisc.Response;
+import com.yahoo.jdisc.handler.BufferedContentChannel;
+import com.yahoo.jdisc.handler.CompletionHandler;
+import com.yahoo.jdisc.handler.ContentChannel;
+import com.yahoo.jdisc.handler.ResponseHandler;
+import com.yahoo.vespa.http.server.Headers;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
+/**
+ * Abstraction around buffered/streaming writing to a {@link ResponseHandler}.
+ */
+class BufferedContentChannelResponseWriter implements ResponseWriter {
+
+    private static final Logger log = Logger.getLogger(BufferedContentChannelResponseWriter.class.getName());
+
+    private static final CompletionHandler FAILURE_LOGGING_COMPLETION_HANDLER = new CompletionHandler() {
+        @Override public void completed() { }
+        @Override public void failed(Throwable t) {
+            log.log(FINE, "Exception writing or closing response data", t);
+        }
+    };
+
+    private final BufferedContentChannel buffer = new BufferedContentChannel();
+    private final ResponseHandler handler;
+    private final Object lock = new Object();
+    private ContentChannel channel;
+
+    public BufferedContentChannelResponseWriter(ResponseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public void commit(int status, String contentType, boolean fullyApplied) throws IOException {
+        Response response = new Response(status);
+        if (contentType != null) {
+            response.headers().add("Content-Type", List.of(contentType));
+        }
+        if (!fullyApplied) {
+            response.headers().add(Headers.IGNORED_FIELDS, "true");
+        }
+        synchronized (lock) {
+            if (channel != null) {
+                throw new IllegalStateException("commit called multiple times on same response writer");
+            }
+            try {
+                channel = handler.handleResponse(response);
+                buffer.connectTo(channel);
+            } catch (RuntimeException e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    @Override
+    public void write(ByteBuffer buf, CompletionHandler completionHandlerOrNull) {
+        CompletionHandler handler = completionHandlerOrNull;
+        if (handler == null) {
+            handler = FAILURE_LOGGING_COMPLETION_HANDLER;
+        }
+        buffer.write(buf, handler);
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (lock) {
+            try {
+                if (channel == null) {
+                    log.log(WARNING, "Close called before response was committed, in " + getClass().getName());
+                    commit(Response.Status.INTERNAL_SERVER_ERROR, null, true);
+                }
+            } finally {
+                if (channel != null) {
+                    channel.close(FAILURE_LOGGING_COMPLETION_HANDLER);
+                }
+            }
+        }
+    }
+
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/ResponseWriter.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/ResponseWriter.java
@@ -1,0 +1,65 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.yahoo.jdisc.handler.CompletionHandler;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * <p>Reasonably simple async response writer interface that allows for buffered and streaming
+ * response semantics. The devil is in the details, so please read carefully!</p>
+ *
+ * <p>All writes performed <em>prior</em> to invoking {@link #commit(int, String, boolean)} will be
+ * enqueued (and then subsequently flushed at commit time). All writes performed <em>after</em>
+ * invoking {@link #commit(int, String, boolean)}  will be sent immediately without intermediate queuing.</p>
+ *
+ * <p>This means supporting buffered vs. streaming response semantics becomes a matter of deciding
+ * when to commit relative to performing the response payload writes. However, if this is used in a
+ * <em>non-streaming</em> context, great care must be taken to avoid a catch-22/deadlock scenario
+ * where invoking {@link #commit(int, String, boolean)} transitively depends on the invocation of
+ * one or more completion handlers already submitted via {@link #write(ByteBuffer, CompletionHandler)},
+ * as these will <em>not</em> be invoked prior to commit.</p>
+ *
+ * <p>Note that any and all response headers are sent at commit-time and cannot be changed after
+ * the fact. This also includes the HTTP status code.</p>
+ *
+ * @author vekterli
+ */
+interface ResponseWriter extends AutoCloseable {
+    /**
+     * Commit response status and headers, and flush all queued buffers from previous
+     * {@link #write(ByteBuffer, CompletionHandler)} calls in-order to the underlying transport.
+     * After commit, all subsequent writes will be dispatched directly to the underlying
+     * transport and will <em>not</em> be implicitly enqueued.
+     *
+     * @param status HTTP status code.
+     * @param contentType String to send verbatim as HTTP <code>Content-Type</code> header iff non-null.
+     * @param fullyApplied Whether the request this response was created for had all its fields
+     *                     recognized during processing. Should only be false if one or more request
+     *                     fields were ignored. Only really makes sense for mutating operations.
+     */
+    void commit(int status, String contentType, boolean fullyApplied) throws IOException;
+
+    /**
+     * Write data to the underlying transport, with an optional completion handler.
+     *
+     * <strong>Important:</strong> any provided completion handler will <em>not</em> be invoked
+     * before {@link #commit(int, String, boolean)} has been called on the same instance used for
+     * writing. See the class comments for why this matters.
+     *
+     * @param buffer Buffer containing data to be written verbatim to the underlying transport.
+     * @param completionHandlerOrNull Completion handler that will be invoked once the write has been
+     *                                dispatched to the receiver. <strong>Important:</strong> it is
+     *                                unspecified which thread this happens from, and the handler may
+     *                                be invoked by the same thread that called <code>write</code>
+     *                                <em>while</em> <code>write</code> is being called, i.e. recursively.
+     *                                If null, a default no-op completion handler will be substituted.
+     */
+    void write(ByteBuffer buffer, CompletionHandler completionHandlerOrNull);
+
+    /**
+     * Narrowing of exception specifier of {@link AutoCloseable#close()}.
+     */
+    void close() throws IOException;
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentId;
+import com.yahoo.jdisc.handler.CompletionHandler;
+import com.yahoo.messagebus.Trace;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Shared abstraction that can be used for both buffered and streaming response
+ * rendering of Document V1 responses.
+ */
+interface StreamableJsonResponse extends AutoCloseable {
+    void commit(int status, boolean fullyApplied) throws IOException;
+    void writeDocumentsArrayStart() throws IOException;
+    void writeDocumentsArrayEnd() throws IOException;
+    void writeDocumentValue(Document document, CompletionHandler completionHandler) throws IOException;
+    void writeDocumentRemoval(DocumentId id, CompletionHandler completionHandler) throws IOException;
+    void reportUpdatedContinuation(Supplier<String> token) throws IOException;
+    void writeEpilogueContinuation(String token) throws IOException;
+    void writeTrace(Trace trace) throws IOException;
+    void writeMessage(String message) throws IOException;
+    void writeDocumentCount(long count) throws IOException;
+    void close() throws IOException; // Narrowed exception specifier
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
@@ -1,0 +1,202 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentId;
+import com.yahoo.document.json.JsonWriter;
+import com.yahoo.jdisc.handler.CompletionHandler;
+import com.yahoo.messagebus.Trace;
+import com.yahoo.tensor.serialization.JsonFormat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.function.Supplier;
+
+/**
+ * <p>A streaming JSONL response writer where puts and removes are written in the
+ * Vespa JSONL feed format. Since the output also contains other non-put/remove
+ * entries, this is a strict <em>superset</em> of the feed format, and clients must
+ * take that into account.</p>
+ *
+ * <p>One major difference from the "restful" JSON responses (streaming or not) is
+ * that continuation tokens are emitted inline as they are updated by the visitor
+ * session, rather than being emitted once as part of the response epilogue. This
+ * means a client can continuously observe updated token values and simply remember
+ * the last one they have observed. Visiting can then restart from that point with
+ * minimal loss of progress.</p>
+ *
+ * @author vekterli
+ */
+class StreamingJsonLinesResponse implements StreamableJsonResponse {
+
+    private static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder()
+            .streamReadConstraints(StreamReadConstraints.builder()
+                    .maxStringLength(Integer.MAX_VALUE).build())
+                    // Do not insert a space between root-level objects
+                    .rootValueSeparator((String)null)
+            .build();
+
+    private static final int DEFAULT_STREAM_ALLOC_SIZE = 32; // TODO a reasonable default
+
+    private final ResponseWriter responseWriter;
+    private final JsonFormat.EncodeOptions tensorOptions;
+    private final Object lock = new Object();
+    private String pendingContinuation = null;
+
+    public StreamingJsonLinesResponse(ResponseWriter responseWriter, JsonFormat.EncodeOptions tensorOptions) {
+        this.responseWriter = responseWriter;
+        this.tensorOptions = tensorOptions;
+    }
+
+    @Override
+    public void commit(int status, boolean fullyApplied) throws IOException {
+        // TODO decide proper content type
+        responseWriter.commit(status, "application/jsonl; charset=UTF-8", fullyApplied);
+    }
+
+    @Override
+    public void writeDocumentsArrayStart() throws IOException {
+        // Ignored; not part of JSONL response format
+    }
+
+    @Override
+    public void writeDocumentsArrayEnd() throws IOException {
+        // Ignored; not part of JSONL response format
+    }
+
+    @FunctionalInterface
+    interface MyJsonWriter {
+        void writeInto(JsonGenerator json) throws IOException;
+    }
+
+    private void writeJsonLine(MyJsonWriter jsonWriter, CompletionHandler completionHandler) throws IOException {
+        ByteArrayOutputStream myOut = new ByteArrayOutputStream(DEFAULT_STREAM_ALLOC_SIZE);
+        try (JsonGenerator json = JSON_FACTORY.createGenerator(myOut)) {
+            jsonWriter.writeInto(json);
+            json.writeRaw('\n');
+        }
+        responseWriter.write(ByteBuffer.wrap(myOut.toByteArray()), completionHandler);
+    }
+
+    // Write JSONL line with no associated explicit completion handler
+    private void writeJsonLine(MyJsonWriter jsonWriter) throws IOException {
+        writeJsonLine(jsonWriter, null);
+    }
+
+    @Override
+    public void writeDocumentValue(Document document, CompletionHandler completionHandler) throws IOException {
+        writeJsonLine((json) -> {
+            json.writeStartObject();
+            json.writeStringField("put", document.getId().toString());
+            new JsonWriter(json, tensorOptions).writeFields(document);
+            json.writeEndObject();
+            appendUpdatedContinuationLineIfPresent(json);
+        }, completionHandler);
+    }
+
+    @Override
+    public void writeDocumentRemoval(DocumentId id, CompletionHandler completionHandler) throws IOException {
+        writeJsonLine((json) -> {
+            json.writeStartObject();
+            json.writeStringField("remove", id.toString());
+            json.writeEndObject();
+            appendUpdatedContinuationLineIfPresent(json);
+        }, completionHandler);
+    }
+
+    @Override
+    public void reportUpdatedContinuation(Supplier<String> token) throws IOException {
+        // Continuation token updates happen within the context of the main visitor session lock,
+        // so we cannot directly write the token here, or we risk forming a following locking cycle
+        // with the jDisc response queue lock:
+        //
+        //  thread 1: mbus doc callback -> write doc -> jDisc queue (lock A) -> completion handler -> session ack (lock B)
+        //  thread 2: mbus session (lock B) -> progress callback -> write -> jDisc queue (lock A)
+        //
+        // et voilà; deadlock heaven.
+        //
+        // Instead, buffer it up to write it with the next put/remove. If there are no more
+        // put/remove ops, we'll get the token in the epilogue write anyway. As a bonus, by doing
+        // it this way we avoid duplicate token updates upon session close, as that will otherwise
+        // first give a token update, then write the epilogue token (iff the session has not
+        // already completed).
+        String tokenStr = token.get();
+        synchronized (lock) {
+            // It's OK to overwrite any existing pending continuation token since updates are
+            // strictly ordered and later updates shall subsume previous updates.
+            pendingContinuation = tokenStr;
+        }
+    }
+
+    /**
+     * Iff there is a pending continuation token, append as own JSONL line.
+     * <em>At least</em> one line must already have been written to <code>json</code>.
+     * Caller must ensure the appended line gets terminated with a newline character;
+     * this function does not do this.
+     */
+    private void appendUpdatedContinuationLineIfPresent(JsonGenerator json) throws IOException {
+        // _must not_ write anything to the wire that can take the big jDisc response lock!
+        synchronized (lock) {
+            if (pendingContinuation != null) {
+                json.writeRaw('\n'); // End of previous JSON line
+                appendContinuationToken(json, pendingContinuation);
+                pendingContinuation = null;
+            }
+        }
+    }
+
+    private void appendContinuationToken(JsonGenerator json, String token) throws IOException {
+        json.writeStartObject();
+        json.writeStringField("continuation", token);
+        json.writeEndObject();
+    }
+
+    @Override
+    public void writeEpilogueContinuation(String token) throws IOException {
+        writeJsonLine((json) -> {
+            appendContinuationToken(json, token);
+        });
+        // TODO this is not called if the session is finished; should we emit an explicit
+        //  "session finished" (perhaps with visitor stats?) demarcation entry?
+    }
+
+    @Override
+    public void writeTrace(Trace trace) throws IOException {
+        writeJsonLine((json) -> {
+            json.writeStartObject();
+            json.writeObjectFieldStart("trace");
+            TraceJsonRenderer.writeTrace(json, trace.getRoot());
+            json.writeEndObject();
+            json.writeEndObject();
+        });
+    }
+
+    @Override
+    public void writeMessage(String message) throws IOException {
+        writeJsonLine((json) -> {
+            json.writeStartObject();
+            json.writeStringField("message", message);
+            json.writeEndObject();
+        });
+    }
+
+    @Override
+    public void writeDocumentCount(long count) throws IOException {
+        // TODO do we want this for streaming or do we want another kind of session summary?
+        writeJsonLine((json) -> {
+            json.writeStartObject();
+            json.writeNumberField("documentCount", count);
+            json.writeEndObject();
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        responseWriter.close();
+    }
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/TraceJsonRenderer.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/TraceJsonRenderer.java
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.yahoo.messagebus.TraceNode;
+
+import java.io.IOException;
+
+/**
+ * Simple wrapper for rendering trace trees as recursive JSON structures.
+ */
+class TraceJsonRenderer {
+
+    static void writeTrace(JsonGenerator json, TraceNode node) throws IOException {
+        if (node.hasNote()) {
+            json.writeStringField("message", node.getNote());
+        }
+        if (!node.isLeaf()) {
+            json.writeArrayFieldStart(node.isStrict() ? "trace" : "fork");
+            for (int i = 0; i < node.getNumChildren(); i++) {
+                json.writeStartObject();
+                writeTrace(json, node.getChild(i));
+                json.writeEndObject();
+            }
+            json.writeEndArray();
+        }
+    }
+
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/TraceJsonRenderer.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/TraceJsonRenderer.java
@@ -11,6 +11,8 @@ import java.io.IOException;
  */
 class TraceJsonRenderer {
 
+    private TraceJsonRenderer() {}
+
     static void writeTrace(JsonGenerator json, TraceNode node) throws IOException {
         if (node.hasNote()) {
             json.writeStringField("message", node.getNote());

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
@@ -1,0 +1,270 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentId;
+import com.yahoo.document.DocumentTypeManager;
+import com.yahoo.document.config.DocumentmanagerConfig;
+import com.yahoo.document.datatypes.TensorFieldValue;
+import com.yahoo.jdisc.handler.CompletionHandler;
+import com.yahoo.messagebus.Trace;
+import com.yahoo.messagebus.TraceNode;
+import com.yahoo.schema.derived.Deriver;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.serialization.JsonFormat;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author vekterli
+ */
+public class StreamingJsonLinesResponseTest {
+
+    // Simple indirection to make matching write() calls easier by auto-converting
+    // ByteBuffer content to UTF-8 strings.
+    interface StringifiedResponseWriter {
+        void commit(int status, String contentType, boolean fullyApplied) throws IOException;
+        void write(String buffer, CompletionHandler completionHandlerOrNull);
+        void close() throws IOException; // Narrowed exception specifier
+    }
+
+    static class StringifyingResponseWriterBridge implements ResponseWriter {
+        private final StringifiedResponseWriter target;
+
+        public StringifyingResponseWriterBridge(StringifiedResponseWriter target) {
+            this.target = target;
+        }
+
+        @Override
+        public void commit(int status, String contentType, boolean fullyApplied) throws IOException {
+            target.commit(status, contentType, fullyApplied);
+        }
+
+        @Override
+        public void write(ByteBuffer buffer, CompletionHandler completionHandlerOrNull) {
+            target.write(new String(buffer.array(), StandardCharsets.UTF_8), completionHandlerOrNull);
+        }
+
+        @Override
+        public void close() throws IOException {
+            target.close();
+        }
+    }
+
+    static class Fixture {
+        final StringifiedResponseWriter writer;
+        final StreamingJsonLinesResponse jsonlResponse;
+
+        final DocumentmanagerConfig docConfig = Deriver
+                .getDocumentManagerConfig("src/test/cfg/music.sd")
+                .ignoreundefinedfields(true).build();
+        final DocumentTypeManager manager = new DocumentTypeManager(docConfig);
+        final Document doc1 = new Document(manager.getDocumentType("music"), "id:ns:music::one");
+        final Document doc2 = new Document(manager.getDocumentType("music"), "id:ns:music::two");
+
+        Fixture(JsonFormat.EncodeOptions tensorOptions) {
+            writer = mock(StringifiedResponseWriter.class);
+            var bridge = new StringifyingResponseWriterBridge(writer);
+            jsonlResponse = new StreamingJsonLinesResponse(bridge, tensorOptions);
+        }
+
+        Fixture() {
+            this(new JsonFormat.EncodeOptions());
+        }
+    }
+
+    @Test
+    void commit_is_forwarded_to_writer_with_jsonl_content_type() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.commit(200, true);
+        verify(f.writer).commit(200, "application/jsonl; charset=UTF-8", true);
+    }
+
+    @Test
+    void close_is_forwarded_to_writer() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.close();
+        verify(f.writer).close();
+    }
+
+    @Test
+    void non_jsonl_supported_features_do_not_result_in_writes() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.writeDocumentsArrayStart();
+        f.jsonlResponse.writeDocumentsArrayEnd();
+        verify(f.writer, never()).write(anyString(), any());
+    }
+
+    @Test
+    void operations_are_written_as_json_lines_in_order() throws IOException {
+        var f = new Fixture();
+        f.doc1.setFieldValue("artist", "Boyzvoice");
+        f.jsonlResponse.writeDocumentValue(f.doc1, null);
+        f.jsonlResponse.writeDocumentValue(f.doc2, null);
+        f.jsonlResponse.writeDocumentRemoval(new DocumentId("id:ns:music::three"), null);
+
+        var inOrder = Mockito.inOrder(f.writer);
+        inOrder.verify(f.writer).write("{\"put\":\"id:ns:music::one\",\"fields\":{\"artist\":\"Boyzvoice\"}}\n", null);
+        inOrder.verify(f.writer).write("{\"put\":\"id:ns:music::two\",\"fields\":{}}\n", null);
+        inOrder.verify(f.writer).write("{\"remove\":\"id:ns:music::three\"}\n", null);
+    }
+
+    @Test
+    void inline_continuation_tokens_are_not_written_immediately() throws IOException {
+        // See deadlock danger comment in the implementation for a rationale on why
+        // we can't write to the underlying channel as part of the token update itself.
+        var f = new Fixture();
+        f.jsonlResponse.reportUpdatedContinuation(() -> "cooltoken2000");
+        verify(f.writer, never()).write(anyString(), any());
+    }
+
+    @Test
+    void inline_continuation_token_updates_are_written_as_part_of_next_put() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.reportUpdatedContinuation(() -> "cooltoken2000");
+        // Token update and put is coalesced into the same buffer write.
+        f.jsonlResponse.writeDocumentValue(f.doc1, null);
+        String expected = """
+                {"put":"id:ns:music::one","fields":{}}
+                {"continuation":"cooltoken2000"}
+                """;
+        verify(f.writer).write(expected, null);
+        // Writing another put should _not_ have the token
+        f.jsonlResponse.writeDocumentValue(f.doc2, null);
+        expected = """
+                {"put":"id:ns:music::two","fields":{}}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+    @Test
+    void inline_continuation_token_updates_are_written_as_part_of_next_remove() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.reportUpdatedContinuation(() -> "cooltoken3000");
+        f.jsonlResponse.writeDocumentRemoval(new DocumentId("id:ns:music::three"), null);
+        String expected = """
+                {"remove":"id:ns:music::three"}
+                {"continuation":"cooltoken3000"}
+                """;
+        verify(f.writer).write(expected, null);
+        f.jsonlResponse.writeDocumentRemoval(new DocumentId("id:ns:music::four"), null);
+        expected = """
+                {"remove":"id:ns:music::four"}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+    @Test
+    void multiple_continuation_token_updates_retain_newest_token_value() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.reportUpdatedContinuation(() -> "cooltoken2000");
+        f.jsonlResponse.reportUpdatedContinuation(() -> "cooltoken3000");
+        f.jsonlResponse.reportUpdatedContinuation(() -> "cooltoken4000");
+        f.jsonlResponse.writeDocumentValue(f.doc1, null);
+        String expected = """
+                {"put":"id:ns:music::one","fields":{}}
+                {"continuation":"cooltoken4000"}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+    @Test
+    void epilogue_continuation_token_is_written_immediately() throws IOException {
+        var f = new Fixture();
+        // Not written while session lock is held, so it's safe to write it immediately.
+        f.jsonlResponse.writeEpilogueContinuation("swagtoken");
+        verify(f.writer).write("{\"continuation\":\"swagtoken\"}\n", null);
+    }
+
+    private static void verifyCompletionHandlerUntouched(CompletionHandler handler) {
+        // We should not invoke the handler ourselves, only forward it
+        verify(handler, never()).completed();
+        verify(handler, never()).failed(any());
+    }
+
+    @Test
+    void put_completion_handler_is_forwarded_to_writer() throws IOException {
+        var f = new Fixture();
+        var myHandler = mock(CompletionHandler.class);
+        f.jsonlResponse.writeDocumentValue(f.doc1, myHandler);
+        verify(f.writer).write(anyString(), same(myHandler));
+        verifyCompletionHandlerUntouched(myHandler);
+    }
+
+    @Test
+    void remove_completion_handler_is_forwarded_to_writer() throws IOException {
+        var f = new Fixture();
+        var myHandler = mock(CompletionHandler.class);
+        f.jsonlResponse.writeDocumentRemoval(new DocumentId("id:ns:music::zoid"), myHandler);
+        verify(f.writer).write(anyString(), same(myHandler));
+        verifyCompletionHandlerUntouched(myHandler);
+    }
+
+    @Test
+    void provided_tensor_options_are_used_when_rendering_put() throws IOException {
+        var f = new Fixture(new JsonFormat.EncodeOptions(true)); // short form
+        f.doc1.setFieldValue("embedding", new TensorFieldValue(Tensor.from("tensor(x[3]):[1,2,3]")));
+        f.jsonlResponse.writeDocumentValue(f.doc1, null);
+        String expected = """
+                {"put":"id:ns:music::one","fields":{"embedding":{"type":"tensor(x[3])","values":[1.0,2.0,3.0]}}}
+                """;
+        verify(f.writer).write(expected, null);
+
+        f = new Fixture(new JsonFormat.EncodeOptions(true, false, true)); // hex form
+        f.doc1.setFieldValue("embedding", new TensorFieldValue(Tensor.from("tensor(x[3]):[4,5,6]")));
+        f.jsonlResponse.writeDocumentValue(f.doc1, null);
+        expected = """
+                {"put":"id:ns:music::one","fields":{"embedding":{"type":"tensor(x[3])","values":"401000000000000040140000000000004018000000000000"}}}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+    @Test
+    void trace_is_rendered_as_own_line() throws IOException {
+        var f = new Fixture();
+        var trace = new Trace(9);
+        trace.trace(7, "Poirot's deductions", false);
+        trace.getRoot().addChild(new TraceNode().setStrict(false)
+                .addChild("The butler did it")
+                .addChild("Weapon was a garden gnome"));
+        f.jsonlResponse.writeTrace(trace);
+        // TODO the nested "trace" objects aren't beautiful; reconsider format for JSONL.
+        //  Since trace nodes may technically output "message" objects at any level, need a wrapper.
+        String expected = """
+                {"trace":{"trace":[{"message":"Poirot's deductions"},{"fork":[{"message":"The butler did it"},{"message":"Weapon was a garden gnome"}]}]}}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+    @Test
+    void message_is_rendered_as_own_line() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.writeMessage("'ello, 'ello, this is London");
+        String expected = """
+                {"message":"'ello, 'ello, this is London"}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+    @Test
+    void document_count_is_rendered_as_own_line() throws IOException {
+        var f = new Fixture();
+        f.jsonlResponse.writeDocumentCount(123456);
+        String expected = """
+                {"documentCount":123456}
+                """;
+        verify(f.writer).write(expected, null);
+    }
+
+}


### PR DESCRIPTION
@bjorncs please review. The majority of added lines is comments or tests. No testing of actual wiring from the Document V1 handler yet, since the actual semantics for how to enable JSONL remain TBD. Changes to the existing `DocumentV1ApiHandler` code are intentionally kept to a minimum—more stuff can be factored out separately later.

This commit adds a streaming JSONL response writer where puts (i.e. document instances) and removes are written in the Vespa JSONL feed format. Since the output also contains other non-put/remove entries, this is a strict _superset_ of the feed format, and clients must take that into account.

One major difference from the "restful" JSON responses (streaming or not) is that continuation tokens are emitted inline as they are updated by the visitor session, rather than being emitted once as part of the response epilogue. This means a client can continuously observe updated token values and simply remember the last one they have observed. Visiting can then restart from that point with minimal loss of progress.

The actual structure/contents of the emitted JSONL lines are not yet set in stone, and this is therefore currently to be considered an entirely experimental feature that should not yet be used in production. Correspondingly, enabling this output format requires the use of an undocumented, magic HTTP parameter, which will **stop working** once the JSONL output format is set in stone.
