### PR TITLE
8.363.17 is obsolete, do not publish

### DIFF
--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -38,7 +38,7 @@ cd $DLDIR
 
 readonly DNF="dnf -y -q --forcearch $RPMARCH"
 
-$DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa --showduplicates 'vespa*' | grep "Available Packages" -A 100000 | tail -n +2 | sed '/\.src\ */d' | sed -E "s/\.($RPMARCH|noarch)\ */-/" | awk '{print $1}' | grep -v '.src$' > $COPR_PACKAGES
+$DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa --showduplicates 'vespa*' | grep "Available Packages" -A 100000 | tail -n +2 | sed '/\.src\ */d' | sed -E "s/\.($RPMARCH|noarch)\ */-/" | awk '{print $1}' | grep -v 8.363.17 | grep -v '.src$' > $COPR_PACKAGES
 
 echo "Packages on Copr:"
 cat $COPR_PACKAGES


### PR DESCRIPTION
We've stopped building the opensource RPM on copr, so 8.363.17 remains as the last built verion there. Avoid publishing it to cloudsmith as it will just be deleted by the GC job.

@gjoranv or @esolitos please review & merge

