### PR TITLE
Use preserialized JSON field name strings for Document V1 output

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -67,7 +67,6 @@ import com.yahoo.messagebus.DynamicThrottlePolicy;
 import com.yahoo.messagebus.Message;
 import com.yahoo.messagebus.StaticThrottlePolicy;
 import com.yahoo.messagebus.Trace;
-import com.yahoo.messagebus.TraceNode;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.restapi.Path;
 import com.yahoo.search.query.ParameterParser;
@@ -809,21 +808,25 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
         }
 
         synchronized void writePathId(String path) throws IOException {
-            json.writeStringField("pathId", path);
+            json.writeFieldName(JsonNames.PATH_ID);
+            json.writeString(path);
         }
 
         @Override
         public synchronized void writeMessage(String message) throws IOException {
-            json.writeStringField("message", message);
+            json.writeFieldName(JsonNames.MESSAGE);
+            json.writeString(message);
         }
 
         @Override
         public synchronized void writeDocumentCount(long count) throws IOException {
-            json.writeNumberField("documentCount", count);
+            json.writeFieldName(JsonNames.DOCUMENT_COUNT);
+            json.writeNumber(count);
         }
 
         synchronized void writeDocId(DocumentId id) throws IOException {
-            json.writeStringField("id", id.toString());
+            json.writeFieldName(JsonNames.ID);
+            json.writeString(id.toString());
         }
 
         @Override
@@ -851,7 +854,8 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
 
         @Override
         public synchronized void writeDocumentsArrayStart() throws IOException {
-            json.writeArrayFieldStart("documents");
+            json.writeFieldName(JsonNames.DOCUMENTS);
+            json.writeStartArray();
         }
 
         private interface DocumentWriter {
@@ -875,7 +879,8 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
             writeDocument(myOut -> {
                 try (JsonGenerator myJson = jsonFactory.createGenerator(myOut)) {
                     myJson.writeStartObject();
-                    myJson.writeStringField("remove", id.toString());
+                    myJson.writeFieldName(JsonNames.REMOVE);
+                    myJson.writeString(id.toString());
                     myJson.writeEndObject();
                 }
             }, completionHandler);
@@ -966,7 +971,8 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
 
         @Override
         public synchronized void writeEpilogueContinuation(String token) throws IOException {
-            json.writeStringField("continuation", token);
+            json.writeFieldName(JsonNames.CONTINUATION);
+            json.writeString(token);
         }
 
     }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
@@ -1,0 +1,24 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+import com.fasterxml.jackson.core.io.SerializedString;
+
+/**
+ * Pre-serialized JSON field name strings to avoid implicit conversion from
+ * <code>String</code> on every field key write.
+ *
+ * @author vekterli
+ */
+class JsonNames {
+    private JsonNames() {}
+
+    static final SerializedString CONTINUATION   = new SerializedString("continuation");
+    static final SerializedString DOCUMENTS      = new SerializedString("documents");
+    static final SerializedString DOCUMENT_COUNT = new SerializedString("documentCount");
+    static final SerializedString ID             = new SerializedString("id");
+    static final SerializedString MESSAGE        = new SerializedString("message");
+    static final SerializedString PATH_ID        = new SerializedString("pathId");
+    static final SerializedString PUT            = new SerializedString("put");
+    static final SerializedString REMOVE         = new SerializedString("remove");
+    static final SerializedString TRACE          = new SerializedString("trace");
+}

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
@@ -92,7 +92,8 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
     public void writeDocumentValue(Document document, CompletionHandler completionHandler) throws IOException {
         writeJsonLine((json) -> {
             json.writeStartObject();
-            json.writeStringField("put", document.getId().toString());
+            json.writeFieldName(JsonNames.PUT);
+            json.writeString(document.getId().toString());
             new JsonWriter(json, tensorOptions).writeFields(document);
             json.writeEndObject();
             appendUpdatedContinuationLineIfPresent(json);
@@ -103,7 +104,8 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
     public void writeDocumentRemoval(DocumentId id, CompletionHandler completionHandler) throws IOException {
         writeJsonLine((json) -> {
             json.writeStartObject();
-            json.writeStringField("remove", id.toString());
+            json.writeFieldName(JsonNames.REMOVE);
+            json.writeString(id.toString());
             json.writeEndObject();
             appendUpdatedContinuationLineIfPresent(json);
         }, completionHandler);
@@ -152,7 +154,8 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
 
     private void appendContinuationToken(JsonGenerator json, String token) throws IOException {
         json.writeStartObject();
-        json.writeStringField("continuation", token);
+        json.writeFieldName(JsonNames.CONTINUATION);
+        json.writeString(token);
         json.writeEndObject();
     }
 
@@ -169,7 +172,8 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
     public void writeTrace(Trace trace) throws IOException {
         writeJsonLine((json) -> {
             json.writeStartObject();
-            json.writeObjectFieldStart("trace");
+            json.writeFieldName(JsonNames.TRACE);
+            json.writeStartObject();
             TraceJsonRenderer.writeTrace(json, trace.getRoot());
             json.writeEndObject();
             json.writeEndObject();
@@ -180,7 +184,8 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
     public void writeMessage(String message) throws IOException {
         writeJsonLine((json) -> {
             json.writeStartObject();
-            json.writeStringField("message", message);
+            json.writeFieldName(JsonNames.MESSAGE);
+            json.writeString(message);
             json.writeEndObject();
         });
     }
@@ -190,7 +195,8 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
         // TODO do we want this for streaming or do we want another kind of session summary?
         writeJsonLine((json) -> {
             json.writeStartObject();
-            json.writeNumberField("documentCount", count);
+            json.writeFieldName(JsonNames.DOCUMENT_COUNT);
+            json.writeNumber(count);
             json.writeEndObject();
         });
     }


### PR DESCRIPTION
@bjorncs please review

Avoids having to do the same UTF-8 encoding/character escaping work over and over for every static field name string written.
