### PR TITLE
feat(indexing-language): don't annotate if text is likely binary data

### DIFF
--- a/config-model/src/test/derived/advanced/ilscripts.cfg
+++ b/config-model/src/test/derived/advanced/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "advanced"
 ilscript[].docfield[] "debug_src"
 ilscript[].docfield[] "attributes_src"

--- a/config-model/src/test/derived/advanced/ilscripts.cfg
+++ b/config-model/src/test/derived/advanced/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "advanced"
 ilscript[].docfield[] "debug_src"
 ilscript[].docfield[] "attributes_src"

--- a/config-model/src/test/derived/annotationsimplicitstruct/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsimplicitstruct/ilscripts.cfg
@@ -1,6 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "annotationsimplicitstruct"

--- a/config-model/src/test/derived/annotationsimplicitstruct/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsimplicitstruct/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsimplicitstruct"

--- a/config-model/src/test/derived/annotationsinheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsinheritance/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsinheritance"

--- a/config-model/src/test/derived/annotationsinheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsinheritance/ilscripts.cfg
@@ -1,6 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "annotationsinheritance"

--- a/config-model/src/test/derived/annotationsinheritance2/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsinheritance2/ilscripts.cfg
@@ -1,6 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "annotationsinheritance2"

--- a/config-model/src/test/derived/annotationsinheritance2/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsinheritance2/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsinheritance2"

--- a/config-model/src/test/derived/annotationsreference/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsreference/ilscripts.cfg
@@ -1,6 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "annotationsreference"

--- a/config-model/src/test/derived/annotationsreference/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationsreference/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsreference"

--- a/config-model/src/test/derived/annotationssimple/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationssimple/ilscripts.cfg
@@ -1,4 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationssimple"

--- a/config-model/src/test/derived/annotationssimple/ilscripts.cfg
+++ b/config-model/src/test/derived/annotationssimple/ilscripts.cfg
@@ -1,6 +1,6 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "annotationssimple"

--- a/config-model/src/test/derived/arrays/ilscripts.cfg
+++ b/config-model/src/test/derived/arrays/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "arrays"
 ilscript[].docfield[] "tags"
 ilscript[].docfield[] "ratings"

--- a/config-model/src/test/derived/arrays/ilscripts.cfg
+++ b/config-model/src/test/derived/arrays/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "arrays"
 ilscript[].docfield[] "tags"
 ilscript[].docfield[] "ratings"

--- a/config-model/src/test/derived/attributeprefetch/ilscripts.cfg
+++ b/config-model/src/test/derived/attributeprefetch/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "prefetch"
 ilscript[].docfield[] "singlebyte"
 ilscript[].docfield[] "multibyte"

--- a/config-model/src/test/derived/attributeprefetch/ilscripts.cfg
+++ b/config-model/src/test/derived/attributeprefetch/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "prefetch"
 ilscript[].docfield[] "singlebyte"
 ilscript[].docfield[] "multibyte"

--- a/config-model/src/test/derived/attributes/ilscripts.cfg
+++ b/config-model/src/test/derived/attributes/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "attributes"
 ilscript[].docfield[] "a1"
 ilscript[].docfield[] "a2"

--- a/config-model/src/test/derived/attributes/ilscripts.cfg
+++ b/config-model/src/test/derived/attributes/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "attributes"
 ilscript[].docfield[] "a1"
 ilscript[].docfield[] "a2"

--- a/config-model/src/test/derived/bolding_dynamic_summary/ilscripts.cfg
+++ b/config-model/src/test/derived/bolding_dynamic_summary/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "test"
 ilscript[].docfield[] "str_1"
 ilscript[].docfield[] "str_2"

--- a/config-model/src/test/derived/bolding_dynamic_summary/ilscripts.cfg
+++ b/config-model/src/test/derived/bolding_dynamic_summary/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "test"
 ilscript[].docfield[] "str_1"
 ilscript[].docfield[] "str_2"

--- a/config-model/src/test/derived/complex/ilscripts.cfg
+++ b/config-model/src/test/derived/complex/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "complex"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "location"

--- a/config-model/src/test/derived/complex/ilscripts.cfg
+++ b/config-model/src/test/derived/complex/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "complex"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "location"

--- a/config-model/src/test/derived/emptydefault/ilscripts.cfg
+++ b/config-model/src/test/derived/emptydefault/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "emptydefault"
 ilscript[].docfield[] "one"
 ilscript[].docfield[] "two"

--- a/config-model/src/test/derived/emptydefault/ilscripts.cfg
+++ b/config-model/src/test/derived/emptydefault/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "emptydefault"
 ilscript[].docfield[] "one"
 ilscript[].docfield[] "two"

--- a/config-model/src/test/derived/exactmatch/ilscripts.cfg
+++ b/config-model/src/test/derived/exactmatch/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "exactmatch"
 ilscript[].docfield[] "tag"
 ilscript[].docfield[] "screweduserids"

--- a/config-model/src/test/derived/exactmatch/ilscripts.cfg
+++ b/config-model/src/test/derived/exactmatch/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "exactmatch"
 ilscript[].docfield[] "tag"
 ilscript[].docfield[] "screweduserids"

--- a/config-model/src/test/derived/hnsw_index/ilscripts.cfg
+++ b/config-model/src/test/derived/hnsw_index/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "test"
 ilscript[].docfield[] "t1"
 ilscript[].docfield[] "t2"

--- a/config-model/src/test/derived/hnsw_index/ilscripts.cfg
+++ b/config-model/src/test/derived/hnsw_index/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "test"
 ilscript[].docfield[] "t1"
 ilscript[].docfield[] "t2"

--- a/config-model/src/test/derived/id/ilscripts.cfg
+++ b/config-model/src/test/derived/id/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "id"
 ilscript[].docfield[] "uri"
 ilscript[].content[] "clear_state | guard { input uri | summary uri | index uri; }"

--- a/config-model/src/test/derived/id/ilscripts.cfg
+++ b/config-model/src/test/derived/id/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "id"
 ilscript[].docfield[] "uri"
 ilscript[].content[] "clear_state | guard { input uri | summary uri | index uri; }"

--- a/config-model/src/test/derived/indexing_script_order/ilscripts.cfg
+++ b/config-model/src/test/derived/indexing_script_order/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "specialorder"
 ilscript[].docfield[] "a"
 ilscript[].docfield[] "b"

--- a/config-model/src/test/derived/indexing_script_order/ilscripts.cfg
+++ b/config-model/src/test/derived/indexing_script_order/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "specialorder"
 ilscript[].docfield[] "a"
 ilscript[].docfield[] "b"

--- a/config-model/src/test/derived/indexswitches/ilscripts.cfg
+++ b/config-model/src/test/derived/indexswitches/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "indexswitches"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "descr"

--- a/config-model/src/test/derived/indexswitches/ilscripts.cfg
+++ b/config-model/src/test/derived/indexswitches/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "indexswitches"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "descr"

--- a/config-model/src/test/derived/inheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/inheritance/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "child"
 ilscript[].docfield[] "onlygrandparent"
 ilscript[].docfield[] "overridden"

--- a/config-model/src/test/derived/inheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/inheritance/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "child"
 ilscript[].docfield[] "onlygrandparent"
 ilscript[].docfield[] "overridden"

--- a/config-model/src/test/derived/language/ilscripts.cfg
+++ b/config-model/src/test/derived/language/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "language"
 ilscript[].docfield[] "language"
 ilscript[].docfield[] "title"

--- a/config-model/src/test/derived/language/ilscripts.cfg
+++ b/config-model/src/test/derived/language/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "language"
 ilscript[].docfield[] "language"
 ilscript[].docfield[] "title"

--- a/config-model/src/test/derived/lowercase/ilscripts.cfg
+++ b/config-model/src/test/derived/lowercase/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "lowercase"
 ilscript[].docfield[] "single_field_source"
 ilscript[].docfield[] "array_field_source"

--- a/config-model/src/test/derived/lowercase/ilscripts.cfg
+++ b/config-model/src/test/derived/lowercase/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "lowercase"
 ilscript[].docfield[] "single_field_source"
 ilscript[].docfield[] "array_field_source"

--- a/config-model/src/test/derived/multiplesummaries/ilscripts.cfg
+++ b/config-model/src/test/derived/multiplesummaries/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "multiplesummaries"
 ilscript[].docfield[] "a"
 ilscript[].docfield[] "adynamic"

--- a/config-model/src/test/derived/multiplesummaries/ilscripts.cfg
+++ b/config-model/src/test/derived/multiplesummaries/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "multiplesummaries"
 ilscript[].docfield[] "a"
 ilscript[].docfield[] "adynamic"

--- a/config-model/src/test/derived/music/ilscripts.cfg
+++ b/config-model/src/test/derived/music/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "music"
 ilscript[].docfield[] "bgndata"
 ilscript[].docfield[] "sales"

--- a/config-model/src/test/derived/music/ilscripts.cfg
+++ b/config-model/src/test/derived/music/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "music"
 ilscript[].docfield[] "bgndata"
 ilscript[].docfield[] "sales"

--- a/config-model/src/test/derived/newrank/ilscripts.cfg
+++ b/config-model/src/test/derived/newrank/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "newrank"
 ilscript[].docfield[] "bgndata"
 ilscript[].docfield[] "sales"

--- a/config-model/src/test/derived/newrank/ilscripts.cfg
+++ b/config-model/src/test/derived/newrank/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "newrank"
 ilscript[].docfield[] "bgndata"
 ilscript[].docfield[] "sales"

--- a/config-model/src/test/derived/orderilscripts/ilscripts.cfg
+++ b/config-model/src/test/derived/orderilscripts/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "orderilscripts"
 ilscript[].docfield[] "foo"
 ilscript[].content[] "clear_state | guard { input foo | summary bar; }"

--- a/config-model/src/test/derived/orderilscripts/ilscripts.cfg
+++ b/config-model/src/test/derived/orderilscripts/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "orderilscripts"
 ilscript[].docfield[] "foo"
 ilscript[].content[] "clear_state | guard { input foo | summary bar; }"

--- a/config-model/src/test/derived/position_array/ilscripts.cfg
+++ b/config-model/src/test/derived/position_array/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "position_array"
 ilscript[].docfield[] "pos"
 ilscript[].content[] "clear_state | guard { input pos | for_each { zcurve } | attribute pos_zcurve; }"

--- a/config-model/src/test/derived/position_array/ilscripts.cfg
+++ b/config-model/src/test/derived/position_array/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "position_array"
 ilscript[].docfield[] "pos"
 ilscript[].content[] "clear_state | guard { input pos | for_each { zcurve } | attribute pos_zcurve; }"

--- a/config-model/src/test/derived/position_attribute/ilscripts.cfg
+++ b/config-model/src/test/derived/position_attribute/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "position_attribute"
 ilscript[].docfield[] "pos"
 ilscript[].content[] "clear_state | guard { input pos | zcurve | attribute pos_zcurve; }"

--- a/config-model/src/test/derived/position_attribute/ilscripts.cfg
+++ b/config-model/src/test/derived/position_attribute/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "position_attribute"
 ilscript[].docfield[] "pos"
 ilscript[].content[] "clear_state | guard { input pos | zcurve | attribute pos_zcurve; }"

--- a/config-model/src/test/derived/position_extra/ilscripts.cfg
+++ b/config-model/src/test/derived/position_extra/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "position_extra"
 ilscript[].docfield[] "pos_str"
 ilscript[].content[] "clear_state | guard { input pos_str | to_pos | zcurve | attribute pos_ext_zcurve; }"

--- a/config-model/src/test/derived/position_extra/ilscripts.cfg
+++ b/config-model/src/test/derived/position_extra/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "position_extra"
 ilscript[].docfield[] "pos_str"
 ilscript[].content[] "clear_state | guard { input pos_str | to_pos | zcurve | attribute pos_ext_zcurve; }"

--- a/config-model/src/test/derived/prefixexactattribute/ilscripts.cfg
+++ b/config-model/src/test/derived/prefixexactattribute/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "prefixexactattribute"
 ilscript[].docfield[] "indexfield0"
 ilscript[].docfield[] "attributefield1"

--- a/config-model/src/test/derived/prefixexactattribute/ilscripts.cfg
+++ b/config-model/src/test/derived/prefixexactattribute/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "prefixexactattribute"
 ilscript[].docfield[] "indexfield0"
 ilscript[].docfield[] "attributefield1"

--- a/config-model/src/test/derived/ranktypes/ilscripts.cfg
+++ b/config-model/src/test/derived/ranktypes/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "ranktypes"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "descr"

--- a/config-model/src/test/derived/ranktypes/ilscripts.cfg
+++ b/config-model/src/test/derived/ranktypes/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "ranktypes"
 ilscript[].docfield[] "title"
 ilscript[].docfield[] "descr"

--- a/config-model/src/test/derived/schemainheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/schemainheritance/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "child"
 ilscript[].docfield[] "pf1"
 ilscript[].docfield[] "importedschema_ref"

--- a/config-model/src/test/derived/schemainheritance/ilscripts.cfg
+++ b/config-model/src/test/derived/schemainheritance/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "child"
 ilscript[].docfield[] "pf1"
 ilscript[].docfield[] "importedschema_ref"

--- a/config-model/src/test/derived/structanyorder/ilscripts.cfg
+++ b/config-model/src/test/derived/structanyorder/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "annotationsimplicitstruct"
 ilscript[].docfield[] "structfield"
 ilscript[].docfield[] "structarrayfield"

--- a/config-model/src/test/derived/structanyorder/ilscripts.cfg
+++ b/config-model/src/test/derived/structanyorder/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "annotationsimplicitstruct"
 ilscript[].docfield[] "structfield"
 ilscript[].docfield[] "structarrayfield"

--- a/config-model/src/test/derived/tokenization/ilscripts.cfg
+++ b/config-model/src/test/derived/tokenization/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "tokenization"
 ilscript[].docfield[] "text"
 ilscript[].docfield[] "text_array"

--- a/config-model/src/test/derived/tokenization/ilscripts.cfg
+++ b/config-model/src/test/derived/tokenization/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "tokenization"
 ilscript[].docfield[] "text"
 ilscript[].docfield[] "text_array"

--- a/config-model/src/test/derived/types/ilscripts.cfg
+++ b/config-model/src/test/derived/types/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "types"
 ilscript[].docfield[] "abyte"
 ilscript[].docfield[] "along"

--- a/config-model/src/test/derived/types/ilscripts.cfg
+++ b/config-model/src/test/derived/types/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "types"
 ilscript[].docfield[] "abyte"
 ilscript[].docfield[] "along"

--- a/config-model/src/test/derived/uri_array/ilscripts.cfg
+++ b/config-model/src/test/derived/uri_array/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "uri_array"
 ilscript[].docfield[] "my_uri"
 ilscript[].content[] "clear_state | guard { input my_uri | index my_uri; }"

--- a/config-model/src/test/derived/uri_array/ilscripts.cfg
+++ b/config-model/src/test/derived/uri_array/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "uri_array"
 ilscript[].docfield[] "my_uri"
 ilscript[].content[] "clear_state | guard { input my_uri | index my_uri; }"

--- a/config-model/src/test/derived/uri_wset/ilscripts.cfg
+++ b/config-model/src/test/derived/uri_wset/ilscripts.cfg
@@ -1,8 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
-maxReplacementCharactersRatio 0.1
-maxReplacementCharacters 1000
+maxReplacementCharactersRatio 0.3
+maxReplacementCharacters 10000
 ilscript[].doctype "uri_wset"
 ilscript[].docfield[] "my_uri"
 ilscript[].content[] "clear_state | guard { input my_uri | index my_uri; }"

--- a/config-model/src/test/derived/uri_wset/ilscripts.cfg
+++ b/config-model/src/test/derived/uri_wset/ilscripts.cfg
@@ -1,6 +1,8 @@
 maxtermoccurrences 10000
 maxtokenlength 1000
 fieldmatchmaxlength 1000000
+maxReplacementCharactersRatio 0.1
+maxReplacementCharacters 1000
 ilscript[].doctype "uri_wset"
 ilscript[].docfield[] "my_uri"
 ilscript[].content[] "clear_state | guard { input my_uri | index my_uri; }"

--- a/config-model/src/test/java/com/yahoo/schema/derived/AbstractExportingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/derived/AbstractExportingTestCase.java
@@ -150,8 +150,9 @@ public abstract class AbstractExportingTestCase extends AbstractSchemaTestCase {
     }
 
     static void assertEqualFiles(String correctFileName, String checkFileName, boolean orderMatters) throws IOException {
-        // Set updateOnAssert to true if you want update the files with correct answer.
-        assertConfigFiles(correctFileName, checkFileName, orderMatters, false);
+        // Set the system property 'updateExpectedFiles' to true to update the expected files
+        // Example: mvn verify -DupdateExpectedFiles=true
+        assertConfigFiles(correctFileName, checkFileName, orderMatters, Boolean.getBoolean("updateExpectedFiles"));
     }
 
     void deleteContent(File dir) {

--- a/configdefinitions/src/vespa/ilscripts.def
+++ b/configdefinitions/src/vespa/ilscripts.def
@@ -9,9 +9,9 @@ fieldmatchmaxlength int default=1000000
 
 # Note on replacement character thresholds: both must be exceeded to skip annotation processing. See LinguisticsAnnotator for details.
 # The maximum allowed ratio of replacement characters before skipping annotation processing
-maxReplacementCharactersRatio double default=0.1
+maxReplacementCharactersRatio double default=0.3
 # The maximum number of replacement characters to allow before skipping annotation processing
-maxReplacementCharacters int default=1000
+maxReplacementCharacters int default=10000
 
 ilscript[].doctype    string
 ilscript[].docfield[] string

--- a/configdefinitions/src/vespa/ilscripts.def
+++ b/configdefinitions/src/vespa/ilscripts.def
@@ -7,6 +7,12 @@ maxtermoccurrences int default=10000
 maxtokenlength int default=1000
 fieldmatchmaxlength int default=1000000
 
+# Note on replacement character thresholds: both must be exceeded to skip annotation processing. See LinguisticsAnnotator for details.
+# The maximum allowed ratio of replacement characters before skipping annotation processing
+maxReplacementCharactersRatio double default=0.1
+# The maximum number of replacement characters to allow before skipping annotation processing
+maxReplacementCharacters int default=1000
+
 ilscript[].doctype    string
 ilscript[].docfield[] string
 ilscript[].content[]  string

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
@@ -45,13 +45,13 @@ public class DocumentScript {
 
     public ScriptExpression getExpression() { return expression; }
 
-    public Document execute(FieldValuesFactory fieldValuesFactory, Document document) {
+    public Document execute(FieldValuesFactory fieldValuesFactory, Document document, boolean isReindexing) {
         for (var i = document.iterator(); i.hasNext(); ) {
             Map.Entry<Field, FieldValue> entry = i.next();
             requireThatFieldIsDeclaredInDocument(entry.getKey());
             removeAnyLinguisticsSpanTree(entry.getValue());
         }
-        return expression.execute(fieldValuesFactory, document);
+        return expression.execute(fieldValuesFactory, document, isReindexing);
     }
 
     public DocumentUpdate execute(FieldValuesFactory fieldValuesFactory, DocumentUpdate update) {

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
@@ -1,8 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.docprocs.indexing;
 
-import java.util.ArrayList;
-import java.util.List;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
@@ -30,6 +28,8 @@ import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -130,7 +130,7 @@ public class IndexingProcessor extends DocumentProcessor {
             buffer.flip();
             inputDocument = documentTypeManager.createDocument(buffer);
         }
-        Document output = script.execute(fieldValuesFactory, inputDocument);
+        Document output = script.execute(fieldValuesFactory, inputDocument, isReindexingOperation(input));
         if (output == null) return;
 
         out.add(new DocumentPut(input, output));
@@ -160,6 +160,12 @@ public class IndexingProcessor extends DocumentProcessor {
             // Ideally, this should be handled by dependency injection, however for now this workaround is necessary.
         }
         return map;
+    }
+
+    private static boolean isReindexingOperation(DocumentPut op) {
+        // All reindexing operation will have a special expression value in the test and set condition.
+        // Below value must match the constant in storage/src/vespa/storage/common/reindexing_constants.cpp.
+        return op.getCondition().getSelection().equals("@@__vespa_internal_allow_through_bucket_lock");
     }
 
 }

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
@@ -165,7 +165,7 @@ public class IndexingProcessor extends DocumentProcessor {
     private static boolean isReindexingOperation(DocumentPut op) {
         // All reindexing operation will have a special expression value in the test and set condition.
         // Below value must match the constant in storage/src/vespa/storage/common/reindexing_constants.cpp.
-        return op.getCondition().getSelection().equals("@@__vespa_internal_allow_through_bucket_lock");
+        return op.getCondition().getSelection().startsWith("@@__vespa_internal_allow_through_bucket_lock");
     }
 
 }

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -237,7 +237,7 @@ public class DocumentScriptTestCase {
         docType.addField("myField", fieldValue.getDataType());
         Document doc = new Document(docType, "id:ns:myDocumentType::");
         doc.setFieldValue("myField", fieldValue.clone());
-        doc = newScript(docType).execute(fieldValuesFactory, doc, isReindexingOperation(input));
+        doc = newScript(docType).execute(fieldValuesFactory, doc, false);
         return doc.getFieldValue("myField");
     }
 
@@ -347,7 +347,7 @@ public class DocumentScriptTestCase {
     }
 
     private static Document execute(Document document) {
-        return newScript(document.getDataType()).execute(new FieldValuesFactory(), document, isReindexingOperation(input));
+        return newScript(document.getDataType()).execute(new FieldValuesFactory(), document, false);
     }
 
     private static DocumentUpdate execute(DocumentUpdate update) {

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -237,7 +237,7 @@ public class DocumentScriptTestCase {
         docType.addField("myField", fieldValue.getDataType());
         Document doc = new Document(docType, "id:ns:myDocumentType::");
         doc.setFieldValue("myField", fieldValue.clone());
-        doc = newScript(docType).execute(fieldValuesFactory, doc);
+        doc = newScript(docType).execute(fieldValuesFactory, doc, isReindexingOperation(input));
         return doc.getFieldValue("myField");
     }
 
@@ -347,7 +347,7 @@ public class DocumentScriptTestCase {
     }
 
     private static Document execute(Document document) {
-        return newScript(document.getDataType()).execute(new FieldValuesFactory(), document);
+        return newScript(document.getDataType()).execute(new FieldValuesFactory(), document, isReindexingOperation(input));
     }
 
     private static DocumentUpdate execute(DocumentUpdate update) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContext.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContext.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.collections.LazyMap;
+import com.yahoo.document.DocumentId;
 import com.yahoo.document.FieldPath;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.language.Language;
@@ -11,6 +12,7 @@ import com.yahoo.language.detect.Detection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Simon Thoresen Hult
@@ -22,6 +24,9 @@ public class ExecutionContext {
     private FieldValue currentValue;
     private Language language;
     private final Map<Object, Object> cache = LazyMap.newHashMap();
+    // Document id is practical for logging and informative error messages
+    private DocumentId documentId;
+    private boolean isReindexingOperation;
 
     public ExecutionContext() {
         this(null);
@@ -110,10 +115,19 @@ public class ExecutionContext {
         return detected;
     }
 
+    public boolean isReindexingOperation() { return isReindexingOperation; }
+    public ExecutionContext setReindexingOperation() { isReindexingOperation = true; return this; }
+
+    public Optional<DocumentId> getDocumentId() { return Optional.ofNullable(documentId); }
+    public ExecutionContext setDocumentId(DocumentId id) { documentId = Objects.requireNonNull(id); return this; }
+
     /** Clears all state in this except the cache. */
     public ExecutionContext clear() {
+        // Why is language not cleared?
         variables.clear();
         currentValue = null;
+        documentId = null;
+        isReindexingOperation = false;
         return this;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/TokenizeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/TokenizeExpression.java
@@ -5,7 +5,6 @@ import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.language.Language;
 import com.yahoo.language.Linguistics;
-import com.yahoo.language.process.StemMode;
 import com.yahoo.vespa.indexinglanguage.linguistics.AnnotatorConfig;
 import com.yahoo.vespa.indexinglanguage.linguistics.LinguisticsAnnotator;
 
@@ -52,7 +51,7 @@ public final class TokenizeExpression extends Expression {
         if (lang != null)
             configWithLanguage.setLanguage(lang);
         LinguisticsAnnotator annotator = new LinguisticsAnnotator(linguistics, configWithLanguage);
-        annotator.annotate(output);
+        annotator.annotate(output, context.getDocumentId().orElse(null), context.isReindexingOperation());
     }
 
     @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/AnnotatorConfig.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/AnnotatorConfig.java
@@ -20,16 +20,22 @@ public class AnnotatorConfig implements Cloneable {
     private int maxTermOccurrences;
     private int maxTokenLength;
     private int maxTokenizeLength;
+    private double maxReplacementCharactersRatio;
+    private int maxReplacementCharacters;
 
     public static final int DEFAULT_MAX_TERM_OCCURRENCES;
     private static final int DEFAULT_MAX_TOKEN_LENGTH;
     private static final int DEFAULT_MAX_TOKENIZE_LENGTH;
+    private static final double DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO;
+    private static final int DEFAULT_MAX_REPLACEMENT_CHARACTERS;
 
     static {
         IlscriptsConfig defaults = new IlscriptsConfig(new IlscriptsConfig.Builder());
         DEFAULT_MAX_TERM_OCCURRENCES = defaults.maxtermoccurrences();
         DEFAULT_MAX_TOKEN_LENGTH = defaults.maxtokenlength();
         DEFAULT_MAX_TOKENIZE_LENGTH = defaults.fieldmatchmaxlength();
+        DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO = defaults.maxReplacementCharactersRatio();
+        DEFAULT_MAX_REPLACEMENT_CHARACTERS = defaults.maxReplacementCharacters();
     }
 
     public AnnotatorConfig() {
@@ -40,6 +46,8 @@ public class AnnotatorConfig implements Cloneable {
         maxTermOccurrences = DEFAULT_MAX_TERM_OCCURRENCES;
         maxTokenLength = DEFAULT_MAX_TOKEN_LENGTH;
         maxTokenizeLength = DEFAULT_MAX_TOKENIZE_LENGTH;
+        maxReplacementCharactersRatio = DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO;
+        maxReplacementCharacters = DEFAULT_MAX_REPLACEMENT_CHARACTERS;
     }
 
     public AnnotatorConfig(AnnotatorConfig other) {
@@ -50,6 +58,8 @@ public class AnnotatorConfig implements Cloneable {
         maxTermOccurrences = other.maxTermOccurrences;
         maxTokenLength = other.maxTokenLength;
         maxTokenizeLength = other.maxTokenizeLength;
+        maxReplacementCharactersRatio = other.maxReplacementCharactersRatio;
+        maxReplacementCharacters = other.maxReplacementCharacters;
     }
 
     public Language getLanguage() {
@@ -113,6 +123,12 @@ public class AnnotatorConfig implements Cloneable {
 
     public static int getDefaultMaxTokenLength() { return DEFAULT_MAX_TOKEN_LENGTH; }
 
+    public double getMaxReplacementCharactersRatio() { return maxReplacementCharactersRatio; }
+    public AnnotatorConfig setMaxReplacementCharactersRatio(double ratio) { this.maxReplacementCharactersRatio = ratio; return this;}
+
+    public int getMaxReplacementCharacters() { return maxReplacementCharacters; }
+    public AnnotatorConfig setMaxReplacementCharacters(int count) { this.maxReplacementCharacters = count; return this; }
+
     public AnnotatorConfig setMaxTokenizeLength(int maxTokenizeLength) {
         this.maxTokenizeLength = maxTokenizeLength;
         return this;
@@ -134,6 +150,14 @@ public class AnnotatorConfig implements Cloneable {
         return maxTermOccurrences != DEFAULT_MAX_TERM_OCCURRENCES;
     }
 
+    public boolean hasNonDefaultMaxReplacementCharactersRatio() {
+        return maxReplacementCharactersRatio != DEFAULT_MAX_REPLACEMENT_CHARACTERS_RATIO;
+    }
+
+    public boolean hasNonDefaultMaxReplacementCharacters() {
+        return maxReplacementCharacters != DEFAULT_MAX_REPLACEMENT_CHARACTERS;
+    }
+
     public LinguisticsParameters asLinguisticsParameters() {
         return new LinguisticsParameters(language, stemMode, removeAccents, lowercase);
     }
@@ -148,13 +172,16 @@ public class AnnotatorConfig implements Cloneable {
         if (maxTermOccurrences != other.maxTermOccurrences) return false;
         if (maxTokenLength != other.maxTokenLength) return false;
         if (maxTokenizeLength != other.maxTokenizeLength) return false;
+        if (maxReplacementCharactersRatio != other.maxReplacementCharactersRatio) return false;
+        if (maxReplacementCharacters != other.maxReplacementCharacters) return false;
         return true;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getClass(), language.hashCode(), stemMode.hashCode(),
-                            removeAccents, lowercase, maxTermOccurrences, maxTokenLength, maxTokenizeLength);
+                            removeAccents, lowercase, maxTermOccurrences, maxTokenLength, maxTokenizeLength,
+                            maxReplacementCharactersRatio, maxReplacementCharacters);
     }
 
     @Override
@@ -176,6 +203,10 @@ public class AnnotatorConfig implements Cloneable {
             ret.append(" max-token-length:" + getMaxTokenLength());
         if (hasNonDefaultMaxTermOccurrences())
             ret.append(" max-occurrences:" + getMaxTermOccurrences());
+        if (hasNonDefaultMaxReplacementCharactersRatio())
+            ret.append(" max-replacement-characters-ratio:").append(getMaxReplacementCharactersRatio());
+        if (hasNonDefaultMaxReplacementCharacters())
+            ret.append(" max-replacement-characters:").append(getMaxReplacementCharacters());
         return ret.toString();
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
@@ -36,6 +36,9 @@ import static com.yahoo.language.LinguisticsCase.toLowerCase;
 public class LinguisticsAnnotator {
 
     private static final Logger log = Logger.getLogger(LinguisticsAnnotator.class.getName());
+    // Temporary environment variable to disable this check
+    private static final boolean binaryCheckDisabled =
+            Boolean.parseBoolean(System.getenv("VESPA_DISABLE_LINGUISTICS_BINARY_CHECK"));
 
     static {
         class RateLimitingLogFilter implements Filter {
@@ -180,8 +183,7 @@ public class LinguisticsAnnotator {
      * @return true if the text is likely binary data and is a reindexing operation, false otherwise
      */
     private boolean checkLikelyBinaryData(String text, DocumentId docId, boolean isReindexingOperation) {
-        // Temporary environment variable to disable this check
-        if (System.getenv("VESPA_DISABLE_LINGUISTICS_BINARY_CHECK") != null) return false;
+        if (binaryCheckDisabled) return false;
 
         var maxRatio = config.getMaxReplacementCharactersRatio();
         var maxCharacters = config.getMaxReplacementCharacters();

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
@@ -98,7 +98,7 @@ public class LinguisticsAnnotator {
                        ? text.getString()
                        : Text.substringByCodepoints(text.getString(), 0, config.getMaxTokenizeLength());
 
-        if (isLikelyBinaryData(input, docId, isReindexingOperation)) return false;
+        if (checkLikelyBinaryData(input, docId, isReindexingOperation)) return false;
 
         Iterable<Token> tokens = tokenizer.tokenize(input, config.asLinguisticsParameters());
         TermOccurrences termOccurrences = new TermOccurrences(config.getMaxTermOccurrences());
@@ -176,9 +176,10 @@ public class LinguisticsAnnotator {
      * Use the ratio of Unicode replacement characters as heuristic if the text is likely representing binary data
      *
      * @see <a href="https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character">...</a>
-     * @throws IllegalArgumentException if text is likely binary data and not a reindexing operation
+     * @throws IllegalArgumentException if text is likely binary data and is <strong>not</strong> a reindexing operation
+     * @return true if the text is likely binary data and is a reindexing operation, false otherwise
      */
-    private boolean isLikelyBinaryData(String text, DocumentId docId, boolean isReindexingOperation) {
+    private boolean checkLikelyBinaryData(String text, DocumentId docId, boolean isReindexingOperation) {
         var maxRatio = config.getMaxReplacementCharactersRatio();
         var maxCharacters = config.getMaxReplacementCharacters();
         // Skip if both thresholds are disabled

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
@@ -180,6 +180,9 @@ public class LinguisticsAnnotator {
      * @return true if the text is likely binary data and is a reindexing operation, false otherwise
      */
     private boolean checkLikelyBinaryData(String text, DocumentId docId, boolean isReindexingOperation) {
+        // Temporary environment variable to disable this check
+        if (System.getenv("VESPA_DISABLE_LINGUISTICS_BINARY_CHECK") != null) return false;
+
         var maxRatio = config.getMaxReplacementCharactersRatio();
         var maxCharacters = config.getMaxReplacementCharacters();
         // Skip if both thresholds are disabled


### PR DESCRIPTION
Skip tokenization if it's a reindexing operation with some heavily throttled logging. If not, fail hard with an exception.

Extended the previous PR with detection of reindexing operations (https://github.com/vespa-engine/vespa/pull/34398). The threshold are the same as before.

FYI @bratseth @hmusum 