### PR TITLE
Change wait_strategy_id to mean the id for the related

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_id_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_id_notifier.cpp
@@ -48,10 +48,10 @@ FlushStrategyIdNotifier::close()
 }
 
 void
-FlushStrategyIdNotifier::wait_ge_strategy_id(uint32_t strategy_id)
+FlushStrategyIdNotifier::wait_gt_strategy_id(uint32_t strategy_id)
 {
     std::unique_lock guard(_lock);
-    while (_strategy_id < strategy_id && !_closed) {
+    while (_strategy_id <= strategy_id && !_closed) {
         _cond.wait(guard);
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_id_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_id_notifier.h
@@ -26,7 +26,7 @@ public:
     ~FlushStrategyIdNotifier();
     void set_strategy_id(uint32_t strategy_id);
     void close();
-    void wait_ge_strategy_id(uint32_t strategy_id);
+    void wait_gt_strategy_id(uint32_t strategy_id);
     [[nodiscard]] bool add_strategy_id_listener(std::shared_ptr<FlushStrategyIdListener> listener);
     void remove_strategy_id_listener(std::shared_ptr<FlushStrategyIdListener> listener);
 };

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -675,23 +675,21 @@ FlushEngine::set_strategy_helper(std::shared_ptr<IFlushStrategy> strategy)
         _strategy_changed = true;
         std::lock_guard<std::mutex> guard(_lock);
         _cond.notify_all();
-        return _priorityStrategy->get_id() + 1u; // switch to strategy then to next one
+        return _priorityStrategy->get_id();
     } else {
-        // wait_strategy_id is now the strategy id for _priorityStrategy
         if (reuse_strategy(*_priorityStrategy, *strategy)) {
-            return _priorityStrategy->get_id() + 1u;
+            return _priorityStrategy->get_id();
         } else {
             for (auto& old_strategy : _priority_strategy_queue) {
                 if (reuse_strategy(*old_strategy, *strategy)) {
-                    return old_strategy->get_id() + 1u;
+                    return old_strategy->get_id();
                 }
             }
             strategy->set_id((_priority_strategy_queue.empty() ?
                               _priorityStrategy->get_id() :
                               _priority_strategy_queue.back()->get_id()) + 1u);
             _priority_strategy_queue.push_back(std::move(strategy));
-            // switch to queued strategies then next one
-            return _priority_strategy_queue.back()->get_id() + 1;
+            return _priority_strategy_queue.back()->get_id();
         }
     }
 }
@@ -708,7 +706,7 @@ FlushEngine::setStrategy(IFlushStrategy::SP strategy)
      * prune() afterwards.
      */
     if (wait_strategy_id != 0u) {
-        notifier->wait_ge_strategy_id(wait_strategy_id);
+        notifier->wait_gt_strategy_id(wait_strategy_id);
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/set_flush_strategy_rpc_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/set_flush_strategy_rpc_handler.cpp
@@ -82,7 +82,7 @@ SetFlushStrategyRpcHandler::set_strategy_id(uint32_t strategy_id)
             return;
         }
         _strategy_id = strategy_id;
-        if (_strategy_id < _wait_strategy_id) {
+        if (_strategy_id <= _wait_strategy_id) {
             return;
         }
     }


### PR DESCRIPTION
flush strategy being set (possibly queued) or reused. The wait is for flush tasks initiated by that flush strategy or earlier ones.

@vekterli : please review
