### PR TITLE
feat: Add capability to proxy vespa cli tools - executables

### DIFF
--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -180,6 +180,7 @@ For detailed description of flags and configuration, see 'vespa help config'.
 			// and executes the corresponding vespa-<cmd> binary with those arguments.
 
 			// Find the index of the subcommand in os.Args (so we can pass through all user arguments and flags)
+			// This is a hack to get the subcommand flags and arguments since Cobra doesn't provide undefined flags
 			var subcmdIdx int
 			for i, arg := range os.Args {
 				if i == 0 {


### PR DESCRIPTION
This pull request enhances the command execution logic in the Vespa CLI by enabling support for external commands and support tools. The changes ensure a smoother user experience by allowing the CLI to seamlessly handle both internal and external commands.

### Enhancements to command execution:

* Modified the `RunE` function in `root.go` to support external commands (`vespa-<cmd>`). If an internal command is not found, the CLI now searches for an external executable matching the command name in the system's `$PATH` and executes it. This includes setting up proper input/output redirection and error handling.

### Improvements to flag handling:

* Added `FParseErrWhitelist.UnknownFlags = true` to the root command configuration, allowing the CLI to ignore unknown flags and pass them to external commands. This ensures compatibility with external command-specific flags.I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

### Example usage
```shell
$ vespa support diagnostics sysinfo --dest-dir ~/test-diag

System diagnostics written to /Users/onur/test-diag/diag-sysinfo.zip
```

```shell
$ vespa unknown-command -asdasd asdads

Usage:
  vespa [flags]
  vespa [command]

Available Commands:
 ...

Error: unknown command 'unknown-command' (no internal command, and failed to find 'vespa-unknown-command' in $PATH)
```

