### PR TITLE
Signal visiting completion edge in (experimental) JSONL response format

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
@@ -12,13 +12,15 @@ import com.fasterxml.jackson.core.io.SerializedString;
 class JsonNames {
     private JsonNames() {}
 
-    static final SerializedString CONTINUATION   = new SerializedString("continuation");
-    static final SerializedString DOCUMENTS      = new SerializedString("documents");
-    static final SerializedString DOCUMENT_COUNT = new SerializedString("documentCount");
-    static final SerializedString ID             = new SerializedString("id");
-    static final SerializedString MESSAGE        = new SerializedString("message");
-    static final SerializedString PATH_ID        = new SerializedString("pathId");
-    static final SerializedString PUT            = new SerializedString("put");
-    static final SerializedString REMOVE         = new SerializedString("remove");
-    static final SerializedString TRACE          = new SerializedString("trace");
+    static final SerializedString CONTINUATION     = new SerializedString("continuation");
+    static final SerializedString DOCUMENTS        = new SerializedString("documents");
+    static final SerializedString DOCUMENT_COUNT   = new SerializedString("documentCount");
+    static final SerializedString ID               = new SerializedString("id");
+    static final SerializedString MESSAGE          = new SerializedString("message");
+    static final SerializedString PATH_ID          = new SerializedString("pathId");
+    static final SerializedString PERCENT_FINISHED = new SerializedString("percentFinished");
+    static final SerializedString PUT              = new SerializedString("put");
+    static final SerializedString REMOVE           = new SerializedString("remove");
+    static final SerializedString TOKEN            = new SerializedString("token");
+    static final SerializedString TRACE            = new SerializedString("trace");
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonResponse.java
@@ -321,15 +321,19 @@ class JsonResponse implements StreamableJsonResponse {
     }
 
     @Override
-    public void reportUpdatedContinuation(Supplier<String> token) throws IOException {
+    public void reportUpdatedContinuation(Supplier<VisitorContinuation> continuationSupplier) throws IOException {
         // Not supported by the restful Document V1 format; only a single epilogue
         // continuation token may be emitted.
     }
 
     @Override
-    public synchronized void writeEpilogueContinuation(String token) throws IOException {
-        json.writeFieldName(JsonNames.CONTINUATION);
-        json.writeString(token);
+    public synchronized void writeEpilogueContinuation(VisitorContinuation continuation) throws IOException {
+        if (continuation.hasRemaining()) {
+            json.writeFieldName(JsonNames.CONTINUATION);
+            json.writeString(continuation.token());
+        }
+        // Else: no explicit completion signal for the REST-ful response format;
+        // it is implied by the _absence_ of a continuation token field.
     }
 
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
@@ -19,8 +19,11 @@ interface StreamableJsonResponse extends AutoCloseable {
     void writeDocumentsArrayEnd() throws IOException;
     void writeDocumentValue(Document document, CompletionHandler completionHandler) throws IOException;
     void writeDocumentRemoval(DocumentId id, CompletionHandler completionHandler) throws IOException;
-    void reportUpdatedContinuation(Supplier<String> token) throws IOException;
-    void writeEpilogueContinuation(String token) throws IOException;
+    // The implementation MUST NOT assume the Supplier is safe to invoke at any other
+    // time than during the synchronous invocation of this method. This is because the
+    // underlying supplied resource may require locking for safe access.
+    void reportUpdatedContinuation(Supplier<VisitorContinuation> continuationSupplier) throws IOException;
+    void writeEpilogueContinuation(VisitorContinuation continuation) throws IOException;
     void writeTrace(Trace trace) throws IOException;
     void writeMessage(String message) throws IOException;
     void writeDocumentCount(long count) throws IOException;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/VisitorContinuation.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/VisitorContinuation.java
@@ -1,0 +1,19 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.restapi.resource;
+
+/**
+ * Wrapper around an opaque visitor continuation token string and its completion
+ * progress as a percentage. A continuation representing that visiting is complete
+ * (i.e. no more buckets to visit) should have a token value of null and a completion
+ * percentage of 100. Conversely, any continuation representing unfinished visiting
+ * must have a non-null token value and a completion percentage less than 100.
+ *
+ * @author vekterli
+ */
+record VisitorContinuation(String token, double percentFinished) {
+
+    static final VisitorContinuation FINISHED = new VisitorContinuation(null, 100.0);
+
+    boolean hasRemaining() { return token != null; }
+
+}


### PR DESCRIPTION
@bjorncs please review

Extend the returned `continuation` object to encompass both the opaque `token` string field and a `percentFinished` field. This allows clients to deduce their progress through the bucket space without having to know anything about the underlying continuation token internals.

When a visitor session completes with no more buckets to visit, emit a continuation _without_ the `token` field and with a `percentFinished` value of 100. This makes it easier to write a reactive client that observes incoming JSONL lines.

This does not change any semantics for the RESTful JSON response.

As before, it should be noted that the exact naming and structure is not yet set in stone.