### PR TITLE
More `NULL` -> `nullptr` cleanups

### DIFF
--- a/config/src/tests/configfetcher/configfetcher_test.cpp
+++ b/config/src/tests/configfetcher/configfetcher_test.cpp
@@ -60,7 +60,7 @@ TEST(ConfigFetcherTest, requireThatConfigUpdatesArePerformed)
         fetcher.subscribe<MyConfig>("test1", &cb, spec);
         fetcher.start();
         ASSERT_TRUE(cb._configured);
-        ASSERT_TRUE(cb._config.get() != NULL);
+        ASSERT_TRUE(cb._config.get() != nullptr);
         ASSERT_EQ("my", cb._config->defName());
         ASSERT_EQ("foo", cb._config->myField);
 

--- a/config/src/tests/legacysubscriber/legacysubscriber_test.cpp
+++ b/config/src/tests/legacysubscriber/legacysubscriber_test.cpp
@@ -38,7 +38,7 @@ TEST(LegacySubscriberTest, requireThatFileLegacyWorks)
     MyCallback<MyConfig> cb;
     s.subscribe<MyConfig>(ConfigIdGenerator::id("file", "test1.cfg"), &cb);
     ASSERT_TRUE(cb._configured);
-    ASSERT_TRUE(cb._config.get() != NULL);
+    ASSERT_TRUE(cb._config.get() != nullptr);
     ASSERT_EQ("bar", cb._config->myField);
 }
 
@@ -48,7 +48,7 @@ TEST(LegacySubscriberTest, requireThatDirLegacyWorks)
     MyCallback<MyConfig> cb;
     s.subscribe<MyConfig>(ConfigIdGenerator::id("dir","testdir"), &cb);
     ASSERT_TRUE(cb._configured);
-    ASSERT_TRUE(cb._config.get() != NULL);
+    ASSERT_TRUE(cb._config.get() != nullptr);
     ASSERT_EQ("bar", cb._config->myField);
 }
 
@@ -63,11 +63,11 @@ TEST(LegacySubscriberTest, requireThatDirMultiFileLegacyWorks)
     s2.subscribe<BarConfig>(ConfigIdGenerator::id("dir", "testdir/foobar"), &cb2);
 
     ASSERT_TRUE(cb1._configured);
-    ASSERT_TRUE(cb1._config.get() != NULL);
+    ASSERT_TRUE(cb1._config.get() != nullptr);
     ASSERT_EQ("bar", cb1._config->fooValue);
 
     ASSERT_TRUE(cb2._configured);
-    ASSERT_TRUE(cb2._config.get() != NULL);
+    ASSERT_TRUE(cb2._config.get() != nullptr);
     ASSERT_EQ("foo", cb2._config->barValue);
 }
 
@@ -77,13 +77,13 @@ TEST(LegacySubscriberTest, requireThatFileLegacyWorksMultipleTimes)
     MyCallback<MyConfig> cb;
     s.subscribe<MyConfig>(ConfigIdGenerator::id("file", "test1.cfg"), &cb);
     ASSERT_TRUE(cb._configured);
-    ASSERT_TRUE(cb._config.get() != NULL);
+    ASSERT_TRUE(cb._config.get() != nullptr);
     ASSERT_EQ("bar", cb._config->myField);
     cb._configured = false;
     LegacySubscriber s2;
     s2.subscribe<MyConfig>(ConfigIdGenerator::id("file", "test1.cfg"), &cb);
     ASSERT_TRUE(cb._configured);
-    ASSERT_TRUE(cb._config.get() != NULL);
+    ASSERT_TRUE(cb._config.get() != nullptr);
     ASSERT_EQ("bar", cb._config->myField);
 }
 
@@ -93,7 +93,7 @@ TEST(LegacySubscriberTest, requireThatRawLegacyWorks)
     MyCallback<MyConfig> cb;
     s.subscribe<MyConfig>("raw:myField \"bar\"\n", &cb);
     ASSERT_TRUE(cb._configured);
-    ASSERT_TRUE(cb._config.get() != NULL);
+    ASSERT_TRUE(cb._config.get() != nullptr);
     ASSERT_EQ("bar", cb._config->myField);
 }
 

--- a/config/src/tests/subscriber/subscriber_test.cpp
+++ b/config/src/tests/subscriber/subscriber_test.cpp
@@ -55,7 +55,7 @@ namespace {
 
     void verifyConfig(const std::string & expected, std::unique_ptr<BazConfig> cfg)
     {
-        ASSERT_TRUE(cfg.get() != NULL);
+        ASSERT_TRUE(cfg.get() != nullptr);
         ASSERT_EQ(expected, cfg->bazValue);
     }
 

--- a/config/src/vespa/config/helper/legacysubscriber.cpp
+++ b/config/src/vespa/config/helper/legacysubscriber.cpp
@@ -15,7 +15,7 @@ LegacySubscriber::~LegacySubscriber() {}
 void
 LegacySubscriber::close()
 {
-    if (_fetcher.get() != NULL)
+    if (_fetcher.get() != nullptr)
         _fetcher->close();
 }
 

--- a/configutil/src/lib/configstatus.cpp
+++ b/configutil/src/lib/configstatus.cpp
@@ -127,7 +127,7 @@ ConfigStatus::ConfigStatus(Flags flags, const config::ConfigUri &uri)
         std::cerr << e.getMessage() << std::endl;
     }
 
-    if (_cfg.get() == NULL) {
+    if (_cfg.get() == nullptr) {
         std::cerr << "FATAL ERROR: failed to get model configuration." << std::endl;
         std::_Exit(1);
     }

--- a/configutil/src/tests/model_inspect/model_inspect_test.cpp
+++ b/configutil/src/tests/model_inspect/model_inspect_test.cpp
@@ -229,7 +229,7 @@ TEST(ModelInspectTest, action_no_command)
 {
     std::stringstream f1;
     ModelDummy f2(f1);
-    char *argv[] = { strdup("notacommand"), NULL, NULL };
+    char *argv[] = { strdup("notacommand"), nullptr, nullptr };
     ASSERT_EQ(1, f2.action(1, argv));
     ASSERT_EQ(1, f2.action(2, argv));
     ASSERT_EQ(1, f2.action(3, argv));
@@ -271,25 +271,25 @@ TEST(ModelInspectTest, action)
         free(arg[0]);
     }
     {
-        char *arg[] = { strdup("host"), NULL };
+        char *arg[] = { strdup("host"), nullptr };
         ASSERT_EQ(0, f2.action(2, arg));
         ASSERT_TRUE(f2._listHost);
         free(arg[0]);
     }
     {
-        char *arg[] = { strdup("cluster"), NULL };
+        char *arg[] = { strdup("cluster"), nullptr };
         ASSERT_EQ(0, f2.action(2, arg));
         ASSERT_TRUE(f2._listCluster);
         free(arg[0]);
     }
     {
-        char *arg[] = { strdup("service"), NULL };
+        char *arg[] = { strdup("service"), nullptr };
         ASSERT_EQ(0, f2.action(2, arg));
         ASSERT_TRUE(f2._listService);
         free(arg[0]);
     }
     {
-        char *arg[] = { strdup("configid"), NULL };
+        char *arg[] = { strdup("configid"), nullptr };
         ASSERT_EQ(0, f2.action(2, arg));
         ASSERT_TRUE(f2._listConfigId);
         free(arg[0]);
@@ -302,7 +302,7 @@ TEST(ModelInspectTest, action)
         free(arg[1]);
     }
     {
-        char *arg[] = { strdup("get-index-of"), NULL, NULL };
+        char *arg[] = { strdup("get-index-of"), nullptr, nullptr };
         ASSERT_EQ(0, f2.action(3, arg));
         ASSERT_TRUE(f2._getIndexOf);
         free(arg[0]);

--- a/document/src/tests/documenttypetestcase.cpp
+++ b/document/src/tests/documenttypetestcase.cpp
@@ -55,12 +55,12 @@ TEST(DocumentTypeTest, testInheritanceConfig)
         repo(readDocumenttypesConfig(TEST_PATH("data/inheritancetest.cfg")));
     {
         const DocumentType* type(repo.getDocumentType("music"));
-        EXPECT_TRUE(type != NULL);
+        EXPECT_TRUE(type != nullptr);
     }
 
     {
         const DocumentType* type(repo.getDocumentType("books"));
-        EXPECT_TRUE(type != NULL);
+        EXPECT_TRUE(type != nullptr);
     }
 }
 

--- a/document/src/tests/struct_anno/struct_anno_test.cpp
+++ b/document/src/tests/struct_anno/struct_anno_test.cpp
@@ -44,19 +44,19 @@ TEST(StructAnnoTest, require_that_struct_fields_can_contain_annotations)
     deserializer.read(doc);
 
     FieldValue::UP urlRef = doc.getValue("my_url");
-    ASSERT_TRUE(urlRef.get() != NULL);
+    ASSERT_TRUE(urlRef.get() != nullptr);
     const StructFieldValue *url = dynamic_cast<const StructFieldValue*>(urlRef.get());
-    ASSERT_TRUE(url != NULL);
+    ASSERT_TRUE(url != nullptr);
 
     FieldValue::UP strRef = url->getValue("scheme");
     const StringFieldValue *str = dynamic_cast<const StringFieldValue*>(strRef.get());
-    ASSERT_TRUE(str != NULL);
+    ASSERT_TRUE(str != nullptr);
 
     auto tree = std::move(str->getSpanTrees().front());
 
     EXPECT_EQ("my_tree", tree->getName());
     const SimpleSpanList *root = dynamic_cast<const SimpleSpanList*>(&tree->getRoot());
-    ASSERT_TRUE(root != NULL);
+    ASSERT_TRUE(root != nullptr);
     EXPECT_EQ(1u, root->size());
     SimpleSpanList::const_iterator it = root->begin();
     EXPECT_EQ(Span(0, 6), (*it++));

--- a/document/src/vespa/document/select/context.cpp
+++ b/document/src/vespa/document/select/context.cpp
@@ -7,29 +7,29 @@
 namespace document::select {
 
 Context::Context()
-    : _doc(NULL),
-      _docId(NULL),
-      _docUpdate(NULL),
+    : _doc(nullptr),
+      _docId(nullptr),
+      _docUpdate(nullptr),
       _variables()
 { }
 
 Context::Context(const Document& doc)
     : _doc(&doc),
-      _docId(NULL),
-      _docUpdate(NULL),
+      _docId(nullptr),
+      _docUpdate(nullptr),
       _variables()
 { }
 
 Context::Context(const DocumentId& docId)
-    : _doc(NULL),
+    : _doc(nullptr),
       _docId(&docId),
-      _docUpdate(NULL),
+      _docUpdate(nullptr),
       _variables()
 { }
 
 Context::Context(const DocumentUpdate& docUpdate)
-    : _doc(NULL),
-      _docId(NULL),
+    : _doc(nullptr),
+      _docId(nullptr),
       _docUpdate(&docUpdate),
       _variables()
 { }

--- a/document/src/vespa/document/select/doctype.cpp
+++ b/document/src/vespa/document/select/doctype.cpp
@@ -27,14 +27,14 @@ DocType::DocType(std::string_view doctype)
 ResultList
 DocType::contains(const Context &context) const
 {
-    if (context._doc != NULL) {
+    if (context._doc != nullptr) {
         const Document &doc = *context._doc;
         return
             ResultList(Result::get(
                 documentTypeEqualsName(doc.getType(),
                                        _doctype)));
     }
-    if (context._docId != NULL) {
+    if (context._docId != nullptr) {
         return ResultList(Result::get((context._docId->getDocType() == _doctype)));
     }
     const DocumentUpdate &upd(*context._docUpdate);
@@ -46,12 +46,12 @@ ResultList
 DocType::trace(const Context& context, std::ostream& out) const
 {
     ResultList result = contains(context);
-    if (context._doc != NULL) {
+    if (context._doc != nullptr) {
         const Document &doc = *context._doc;
         out << "DocType - Doc is type " << doc.getType()
             << ", wanted " << _doctype << ", returning "
             << result << ".\n";
-    } else if (context._docId != NULL) {
+    } else if (context._docId != nullptr) {
         out << "DocType - Doc is type (document id -- unknown type)"
             << ", wanted " << _doctype << ", returning "
             << result << ".\n";

--- a/documentapi/src/tests/messagebus/messagebus_test.cpp
+++ b/documentapi/src/tests/messagebus/messagebus_test.cpp
@@ -62,7 +62,7 @@ TEST_F(MessageBusTest, test_message)
     EXPECT_TRUE(blob.size() > 0);
 
     Routable::UP dec1 = protocol.decode(vespalib::Version(6,221), blob);
-    EXPECT_TRUE(dec1.get() != NULL);
+    EXPECT_TRUE(dec1.get() != nullptr);
     EXPECT_TRUE(dec1->isReply() == false);
     EXPECT_TRUE(dec1->getType() == DocumentProtocol::MESSAGE_UPDATEDOCUMENT);
 
@@ -83,13 +83,13 @@ TEST_F(MessageBusTest, test_protocol)
     EXPECT_TRUE(protocol.getName() == "document");
 
     IRoutingPolicy::UP policy = protocol.createPolicy(string("DocumentRouteSelector"), string("file:documentrouteselectorpolicy.cfg"));
-    EXPECT_TRUE(policy.get() != NULL);
+    EXPECT_TRUE(policy.get() != nullptr);
 
     policy = protocol.createPolicy(string(""),string(""));
-    EXPECT_TRUE(policy.get() == NULL);
+    EXPECT_TRUE(policy.get() == nullptr);
 
     policy = protocol.createPolicy(string("Balle"),string(""));
-    EXPECT_TRUE(policy.get() == NULL);
+    EXPECT_TRUE(policy.get() == nullptr);
 }
 
 TEST_F(MessageBusTest, get_document_message_is_not_sequenced)

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -105,13 +105,13 @@ int UrlReader::nextUrl(char *buf, int buflen)
     if (_leftOvers) {
         if ( _args._usePostMode && _args._singleQueryFile && _reader.GetFilePos() >= _args._queryfileEndOffset ) {
             // reached logical EOF
-            _leftOvers = NULL;
+            _leftOvers = nullptr;
             return -1;
         }
         int sz = std::min(_leftOversLen, buflen-1);
         strncpy(buf, _leftOvers, sz);
         buf[sz] = '\0';
-        _leftOvers = NULL;
+        _leftOvers = nullptr;
         return _leftOversLen;
     }
     int ll = findUrl(buf, buflen);

--- a/fbench/src/filterfile/filterfile.cpp
+++ b/fbench/src/filterfile/filterfile.cpp
@@ -82,7 +82,7 @@ main(int argc, char** argv)
 
     // filter the input
     char *line    = new char[bufsize];
-    assert(line != NULL);
+    assert(line != nullptr);
     int   res;
     char *tmp;
     char *url;
@@ -91,7 +91,7 @@ main(int argc, char** argv)
     int   idx;
     int   outIdx;
     char *buf     = new char[bufsize];
-    assert(buf != NULL);
+    assert(buf != nullptr);
     int   state; // 0=expect param name, 1=copy, 2=skip
     bool  gotQuery;
     memcpy(buf, prefix, prefixlen);
@@ -99,18 +99,18 @@ main(int argc, char** argv)
 
         // find field beginning
         tmp = strstr(line, beginToken);
-        startIdx = (tmp != NULL) ? (tmp - line) + beginTokenlen : 0;
+        startIdx = (tmp != nullptr) ? (tmp - line) + beginTokenlen : 0;
 
         // find url beginning
         url = strstr(line + startIdx, trigger);
-        if (url == NULL)
+        if (url == nullptr)
             continue;                                // CONTINUE
 
         // find field end
         tmp = strstr(line + startIdx, endToken);
-        if (tmp == NULL)
+        if (tmp == nullptr)
             tmp = strstr(line + startIdx, "\"");
-        endIdx = (tmp != NULL) ? (tmp - line) : strlen(line);
+        endIdx = (tmp != nullptr) ? (tmp - line) : strlen(line);
 
         // find params
         idx = (url - line) + triggerlen;

--- a/fbench/src/httpclient/httpclient.cpp
+++ b/fbench/src/httpclient/httpclient.cpp
@@ -51,7 +51,7 @@ HTTPClient::HTTPClient(vespalib::CryptoEngine::SP engine, const char *hostname, 
     _chunkLeft(0),
     _dataRead(0),
     _dataDone(false),
-    _reader(NULL)
+    _reader(nullptr)
 {
 }
 

--- a/fbench/src/httpclient/httpclient.h
+++ b/fbench/src/httpclient/httpclient.h
@@ -173,7 +173,7 @@ protected:
    * @param url the url you want to connect to
    **/
   bool Connect(const char *url, bool usePost = false,
-               const char *content = NULL, int contentLen = 0);
+               const char *content = nullptr, int contentLen = 0);
 
   /**
    * Read the next line of text from the data stream into 'buf'. If
@@ -342,11 +342,11 @@ public:
    * @return FetchStatus object which can be queried for status.
    * @param url the url to fetch.
    * @param file where to save the fetched document. If this parameter
-   *             is NULL, the content will be read and then discarded.
+   *             is nullptr, the content will be read and then discarded.
    * @param usePost whether to use POST in the request
    * @param content if usePost is true, the content to post
    * @param contentLen length of content in bytes
    **/
-  FetchStatus Fetch(const char *url, std::ostream *file = NULL,
-                    bool usePost = false, const char *content = NULL, int contentLen = 0);
+  FetchStatus Fetch(const char *url, std::ostream *file = nullptr,
+                    bool usePost = false, const char *content = nullptr, int contentLen = 0);
 };

--- a/fbench/src/test/httpclient_splitstring.cpp
+++ b/fbench/src/test/httpclient_splitstring.cpp
@@ -28,10 +28,10 @@ DebugHTTPClient::SplitLineTest(const char *input)
   printf("*** TEST HTTPClient::SplitString ***\n");
   printf("string:'%s'\n", str);
   rest = str;
-  while (rest != NULL) {
+  while (rest != nullptr) {
     rest = SplitString(rest, argc, argv, 5);
     printf("argc:'%d'\n", argc);
-    printf("rest:'%s'\n", (rest == NULL) ? "NULL" : rest);
+    printf("rest:'%s'\n", (rest == nullptr) ? "NULL" : rest);
     for(i = 0; i < argc; i++) {
       printf("  %d:'%s'\n", i, argv[i]);
     }

--- a/messagebus/src/tests/messagebus/messagebus.cpp
+++ b/messagebus/src/tests/messagebus/messagebus.cpp
@@ -307,18 +307,18 @@ TEST_F(MessageBusTest, test_routing_policy_cache)
     MessageBus &bus = client->server.mb;
 
     IRoutingPolicy::SP all = bus.getRoutingPolicy(SimpleProtocol::NAME, "All", "");
-    ASSERT_TRUE(all.get() != NULL);
+    ASSERT_TRUE(all.get() != nullptr);
 
     IRoutingPolicy::SP ref = bus.getRoutingPolicy(SimpleProtocol::NAME, "All", "");
-    ASSERT_TRUE(ref.get() != NULL);
+    ASSERT_TRUE(ref.get() != nullptr);
     ASSERT_TRUE(all.get() == ref.get());
 
     IRoutingPolicy::SP allArg = bus.getRoutingPolicy(SimpleProtocol::NAME, "All", "Arg");
-    ASSERT_TRUE(allArg.get() != NULL);
+    ASSERT_TRUE(allArg.get() != nullptr);
     ASSERT_TRUE(all.get() != allArg.get());
 
     IRoutingPolicy::SP refArg = bus.getRoutingPolicy(SimpleProtocol::NAME, "All", "Arg");
-    ASSERT_TRUE(refArg.get() != NULL);
+    ASSERT_TRUE(refArg.get() != nullptr);
     ASSERT_TRUE(allArg.get() == refArg.get());
 }
 

--- a/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
@@ -99,7 +99,7 @@ public:
         }
         Executor::Task::UP wrapper(new TaskWrapper(std::move(task), gate));
         Executor::Task::UP ok = _executor.execute(std::move(wrapper));
-        assert(ok.get() == NULL);
+        assert(ok.get() == nullptr);
     }
 };
 
@@ -291,7 +291,7 @@ TEST(AttributeFlushTest, require_that_updater_and_flusher_can_run_concurrently)
 {
     Fixture f;
     AttributeManager &am = f._m;
-    EXPECT_TRUE(f.addAttribute("a1").get() != NULL);
+    EXPECT_TRUE(f.addAttribute("a1").get() != nullptr);
     IFlushTarget::SP ft = am.getFlushable("a1");
     (static_cast<FlushableAttribute *>(ft.get()))->setCleanUpAfterFlush(false);
     UpdaterTask updaterTask(am);
@@ -343,12 +343,12 @@ TEST(AttributeFlushTest, require_that_flushable_attribute_manages_sync_token_inf
 
     IndexMetaInfo info("flush/a3");
     EXPECT_EQ(0u, fa->getFlushedSerialNum());
-    EXPECT_TRUE(fa->initFlush(0, std::make_shared<search::FlushToken>()).get() == NULL);
+    EXPECT_TRUE(fa->initFlush(0, std::make_shared<search::FlushToken>()).get() == nullptr);
     EXPECT_TRUE(!info.load());
 
     av->commit(CommitParam(10)); // last sync token = 10
     EXPECT_EQ(0u, fa->getFlushedSerialNum());
-    EXPECT_TRUE(fa->initFlush(10, std::make_shared<search::FlushToken>()).get() != NULL);
+    EXPECT_TRUE(fa->initFlush(10, std::make_shared<search::FlushToken>()).get() != nullptr);
     fa->initFlush(10, std::make_shared<search::FlushToken>())->run();
     EXPECT_EQ(10u, fa->getFlushedSerialNum());
     EXPECT_TRUE(info.load());

--- a/searchcore/src/vespa/searchcore/proton/index/index_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/index/index_writer.cpp
@@ -50,7 +50,7 @@ IndexWriter::removeDocs(search::SerialNum serialNum, LidVector lids)
         return;
     }
     for (search::DocumentIdT lid : lids) {
-        VLOG(getDebugLevel(lid, NULL), "Handle remove: serial(%" PRIu64 "), num_lids(%lu)", serialNum, lids.size());
+        VLOG(getDebugLevel(lid, nullptr), "Handle remove: serial(%" PRIu64 "), num_lids(%lu)", serialNum, lids.size());
     }
     _mgr->removeDocuments(std::move(lids), serialNum);
 }

--- a/searchcore/src/vespa/searchcore/proton/test/mock_summary_adapter.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_summary_adapter.h
@@ -15,7 +15,7 @@ struct MockSummaryAdapter : public ISummaryAdapter
     void remove(SerialNum, DocumentIdT) override {}
     void heartBeat(SerialNum) override {}
     const search::IDocumentStore &getDocumentStore() const override {
-        const search::IDocumentStore *store = NULL;
+        const search::IDocumentStore *store = nullptr;
         return *store;
     }
     std::unique_ptr<document::Document> get(DocumentIdT, const DocumentTypeRepo &) override {

--- a/searchsummary/src/tests/juniper/fakerewriter.cpp
+++ b/searchsummary/src/tests/juniper/fakerewriter.cpp
@@ -29,13 +29,13 @@ const char* FakeRewriter::Name() const {
 
 RewriteHandle* FakeRewriter::Rewrite(uint32_t langid, const char* term) {
     std::string t(term);
-    if (langid > 4) return NULL;
+    if (langid > 4) return nullptr;
     return new RewriteHandle(t, langid);
 }
 
 RewriteHandle* FakeRewriter::Rewrite(uint32_t langid, const char* term, size_t length) {
     std::string t(term, length);
-    if (langid > 4) return NULL;
+    if (langid > 4) return nullptr;
     return new RewriteHandle(t, langid);
 }
 
@@ -43,7 +43,7 @@ const char* FakeRewriter::NextTerm(RewriteHandle* exp, size_t& length) {
     std::string& t = exp->next();
     if (t.size() == 0) {
         delete exp;
-        return NULL;
+        return nullptr;
     }
     length = t.size();
     return t.c_str();

--- a/searchsummary/src/tests/juniper/latintokenizer.h
+++ b/searchsummary/src/tests/juniper/latintokenizer.h
@@ -65,7 +65,7 @@ public:
           : first(begin),
             second(end),
             _punctuation(punctuation) {}
-        Fast_Token() : first(NULL), second(NULL), _punctuation(false) {}
+        Fast_Token() : first(nullptr), second(nullptr), _punctuation(false) {}
         Fast_Token(const Fast_Token& other)
           : first(other.first),
             second(other.second),
@@ -126,9 +126,9 @@ private:
 
 template <typename IsSeparator, typename IsPunctuation>
 Fast_LatinTokenizer<IsSeparator, IsPunctuation>::Fast_LatinTokenizer()
-  : _org(NULL),
-    _next(NULL),
-    _end(NULL),
+  : _org(nullptr),
+    _next(nullptr),
+    _end(nullptr),
     _moreTokens(false),
     _isSeparator(),
     _isPunctuation() {}
@@ -143,9 +143,9 @@ Fast_LatinTokenizer<IsSeparator, IsPunctuation>::Fast_LatinTokenizer()
 
 template <typename IsSeparator, typename IsPunctuation>
 Fast_LatinTokenizer<IsSeparator, IsPunctuation>::Fast_LatinTokenizer(char* text)
-  : _org(NULL),
-    _next(NULL),
-    _end(NULL),
+  : _org(nullptr),
+    _next(nullptr),
+    _end(nullptr),
     _moreTokens(false),
     _isSeparator(),
     _isPunctuation() {
@@ -163,9 +163,9 @@ Fast_LatinTokenizer<IsSeparator, IsPunctuation>::Fast_LatinTokenizer(char* text)
 
 template <typename IsSeparator, typename IsPunctuation>
 Fast_LatinTokenizer<IsSeparator, IsPunctuation>::Fast_LatinTokenizer(char* text, size_t length)
-  : _org(NULL),
-    _next(NULL),
-    _end(NULL),
+  : _org(nullptr),
+    _next(nullptr),
+    _end(nullptr),
     _moreTokens(false),
     _isSeparator(),
     _isPunctuation() {
@@ -195,8 +195,8 @@ void Fast_LatinTokenizer<IsSeparator, IsPunctuation>::SetNewText(char* text) {
 
     _org = text;
     _next = text;
-    _moreTokens = text != NULL;
-    _end = NULL;
+    _moreTokens = text != nullptr;
+    _end = nullptr;
 }
 
 /**
@@ -213,8 +213,8 @@ void Fast_LatinTokenizer<IsSeparator, IsPunctuation>::SetNewText(char* text, siz
 
     _org = text;
     _next = text;
-    _moreTokens = text != NULL;
-    _end = (_next ? _next + length : NULL);
+    _moreTokens = text != nullptr;
+    _end = (_next ? _next + length : nullptr);
 }
 
 /**
@@ -229,7 +229,7 @@ void Fast_LatinTokenizer<IsSeparator, IsPunctuation>::SkipBlanks() {
 
     if (!_moreTokens) return;
     // Initialized with '\0' terminated buffer?
-    if (_end == NULL) {
+    if (_end == nullptr) {
         while (*_next != '\0' && _isSeparator(*_next)) { ++_next; }
         if (*_next == '\0') { _moreTokens = false; }
     }
@@ -271,7 +271,7 @@ Fast_LatinTokenizer<IsSeparator, IsPunctuation>::GetNextToken() {
     SkipBlanks();
 
     // Initialized with '\0' terminated buffer? Find the next blank or punctuation.
-    if (_end == NULL) {
+    if (_end == nullptr) {
         while (*_next != '\0' && !_isSeparator(*_next) && !_isPunctuation(*_next)) { ++_next; }
 
         // Initialized with specified buffer length.

--- a/searchsummary/src/tests/juniper/latintokenizertest.cpp
+++ b/searchsummary/src/tests/juniper/latintokenizertest.cpp
@@ -4,14 +4,14 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
-class Mapel_Pucntuation {
+class Maple_Punctuation {
 private:
     /** Member variables. */
     static bool* _lookup;
 
 public:
     /** Constructors */
-    Mapel_Pucntuation();
+    Maple_Punctuation();
 
     /** Punctuation predicate. */
     bool operator()(char c) const { return _lookup[static_cast<unsigned char>(c)]; }
@@ -30,13 +30,13 @@ public:
     bool operator()(char c) const { return _lookup[static_cast<unsigned char>(c)]; }
 };
 
-bool* Maple_Space::_lookup = NULL;
-bool* Mapel_Pucntuation::_lookup = NULL;
+bool* Maple_Space::_lookup = nullptr;
+bool* Maple_Punctuation::_lookup = nullptr;
 
-Mapel_Pucntuation::Mapel_Pucntuation() {
+Maple_Punctuation::Maple_Punctuation() {
 
     // Initialize lookup table.
-    if (_lookup == NULL) {
+    if (_lookup == nullptr) {
 
         _lookup = new bool[256];
 
@@ -69,7 +69,7 @@ Mapel_Pucntuation::Mapel_Pucntuation() {
 Maple_Space::Maple_Space() {
 
     // Initialize lookup table.
-    if (_lookup == NULL) {
+    if (_lookup == nullptr) {
 
         _lookup = new bool[256];
 
@@ -229,22 +229,22 @@ TEST(LatinTokenizerTest, testEndingLength) {
 
 TEST(LatinTokenizerTest, testNull) {
 
-    Fast_SimpleLatinTokenizer* lt = new Fast_SimpleLatinTokenizer(NULL);
+    Fast_SimpleLatinTokenizer* lt = new Fast_SimpleLatinTokenizer(nullptr);
 
     EXPECT_TRUE(!lt->MoreTokens());
 
-    EXPECT_TRUE(lt->GetOriginalText() == NULL);
+    EXPECT_TRUE(lt->GetOriginalText() == nullptr);
 
     delete lt;
 }
 
 TEST(LatinTokenizerTest, testNullLength) {
 
-    Fast_SimpleLatinTokenizer* lt = new Fast_SimpleLatinTokenizer(NULL, 0);
+    Fast_SimpleLatinTokenizer* lt = new Fast_SimpleLatinTokenizer(nullptr, 0);
 
     EXPECT_TRUE(!lt->MoreTokens());
 
-    EXPECT_TRUE(lt->GetOriginalText() == NULL);
+    EXPECT_TRUE(lt->GetOriginalText() == nullptr);
 
     delete lt;
 }
@@ -275,7 +275,7 @@ private:
     TPS& operator=(const TPS&);
 
 public:
-    TPS() : _myfunc(NULL) {}
+    TPS() : _myfunc(nullptr) {}
     void Init(int (*myfunc)(int c)) { _myfunc = myfunc; }
 
     bool operator()(char c) {
@@ -305,7 +305,7 @@ TEST(LatinTokenizerTest, testTypeparamObservers) {
 
 TEST(LatinTokenizerTest, testMapelURL) {
 
-    using MyTokenizer = Fast_LatinTokenizer<Maple_Space, Mapel_Pucntuation>;
+    using MyTokenizer = Fast_LatinTokenizer<Maple_Space, Maple_Punctuation>;
 
     std::string  text("http://search.msn.co.uk/results.asp?q= cfg=SMCBROWSE rn=1825822 dp=1873075 v=166:");
     MyTokenizer* tok = new MyTokenizer(const_cast<char*>(text.c_str()));

--- a/searchsummary/src/tests/juniper/matchobjectTest.cpp
+++ b/searchsummary/src/tests/juniper/matchobjectTest.cpp
@@ -73,7 +73,7 @@ TEST(MatchObjectTest, testTerm) {
 TEST(MatchObjectTest, testMatch) {
     // Check that we hit on the longest match first
     juniper::QueryParser p("AND(junipe,juniper)");
-    juniper::QueryHandle qh(p, NULL);
+    juniper::QueryHandle qh(p, nullptr);
 
     MatchObject*    mo = qh.MatchObj();
     juniper::Result res(*juniper::TestConfig, qh, "", 0);
@@ -118,7 +118,7 @@ TEST(MatchObjectTest, testMatch) {
                                     "extremelylongwordhit))");
         QueryHandle&      qh1(q._qhandle);
         juniper::Result   res1(*juniper::TestConfig, qh1, doc.c_str(), doc.size());
-        juniper::Summary* sum = res1.GetTeaser(NULL);
+        juniper::Summary* sum = res1.GetTeaser(nullptr);
         std::string       s(sum->Text());
         EXPECT_EQ(s, "A simple document with an <b>extremelylongwordhit</b> in the middle"
                        " of it that islong enough to allow...triggered "
@@ -141,7 +141,7 @@ TEST(MatchObjectTest, testMatchAnnotated) {
     TestQuery         q("AND(big,buy)");
     QueryHandle&      qh1(q._qhandle);
     juniper::Result   res1(*juniper::TestConfig, qh1, doc, strlen(doc));
-    juniper::Summary* sum = res1.GetTeaser(NULL);
+    juniper::Summary* sum = res1.GetTeaser(nullptr);
     std::string       s(sum->Text());
 
     EXPECT_EQ(s, "A <b>big</b> and ugly teaser about <b>"

--- a/searchsummary/src/tests/juniper/testenv.h
+++ b/searchsummary/src/tests/juniper/testenv.h
@@ -39,7 +39,7 @@ private:
 
 class TestQuery {
 public:
-    TestQuery(const char* qexp, const char* options = NULL);
+    TestQuery(const char* qexp, const char* options = nullptr);
     QueryParser _qparser;
     QueryHandle _qhandle;
 };

--- a/searchsummary/src/vespa/juniper/ITokenProcessor.h
+++ b/searchsummary/src/vespa/juniper/ITokenProcessor.h
@@ -14,7 +14,7 @@ public:
      *  by the processor.
      */
     struct Token {
-        Token() : token(NULL), bytepos(0), charpos(0), wordpos(0), bytelen(0), charlen(0), curlen(0) {}
+        Token() : token(nullptr), bytepos(0), charpos(0), wordpos(0), bytelen(0), charlen(0), curlen(0) {}
         const ucs4_t* token;   //!< a normalized UCS4 representation of the token
         off_t         bytepos; //!< Position in bytes from start of original text
         off_t         charpos; //!< Position in number of characters according to utf8 encoding

--- a/searchsummary/src/vespa/juniper/config.cpp
+++ b/searchsummary/src/vespa/juniper/config.cpp
@@ -33,12 +33,12 @@ Config::Config(const char* config_name, const Juniper& juniper)
     size_t               max_matches = atoi(GetProp("dynsum.max_matches", "3"));
     const char*          escape_markup = GetProp("dynsum.escape_markup", "auto");
     const char*          preserve_white_space = GetProp("dynsum.preserve_white_space", "off");
-    size_t               match_winsize = strtol(GetProp("matcher.winsize", "200"), NULL, 0);
+    size_t               match_winsize = strtol(GetProp("matcher.winsize", "200"), nullptr, 0);
     size_t               max_match_candidates = atoi(GetProp("matcher.max_match_candidates", "1000"));
     const char*          seps = GetProp("dynsum.separators", separators.c_str());
     const unsigned char* cons =
         reinterpret_cast<const unsigned char*>(GetProp("dynsum.connectors", separators.c_str()));
-    double proximity_factor = vespalib::locale::c::strtod(GetProp("proximity.factor", "0.25"), NULL);
+    double proximity_factor = vespalib::locale::c::strtod(GetProp("proximity.factor", "0.25"), nullptr);
     // Silently convert to something sensible
     if (proximity_factor > 1E8 || proximity_factor < 0) proximity_factor = 0.25;
 
@@ -69,8 +69,8 @@ const char* Config::GetProp(const char* name, const char* def) {
     if (_config_name == "juniper") {
         return _juniper.getProp().GetProperty(propstr.c_str(), def);
     } else {
-        const char* p = _juniper.getProp().GetProperty(propstr.c_str(), NULL);
-        if (p == NULL) {
+        const char* p = _juniper.getProp().GetProperty(propstr.c_str(), nullptr);
+        if (p == nullptr) {
             propstr = "juniper.";
             propstr.append(name);
             p = _juniper.getProp().GetProperty(propstr.c_str(), def);

--- a/searchsummary/src/vespa/juniper/hashbase.h
+++ b/searchsummary/src/vespa/juniper/hashbase.h
@@ -51,12 +51,12 @@ protected:
     };
 
     Fast_HashTableElement<Key, T>* SearchNext() {
-        Fast_HashTableElement<Key, T>* retVal = NULL;
+        Fast_HashTableElement<Key, T>* retVal = nullptr;
 
         for (++_index; _index < _hashTable->_tableSize; _index++) {
             retVal = _hashTable->_lookupTable[_index];
 
-            if (retVal != NULL) break;
+            if (retVal != nullptr) break;
         }
 
         return retVal;
@@ -67,18 +67,18 @@ public:
     inline Key GetCurrentKey() { return _runner->GetKey(); }
 
     inline void Next() {
-        if (_runner != NULL) {
+        if (_runner != nullptr) {
             _runner = _runner->GetNext();
 
-            if (_runner == NULL) { _runner = SearchNext(); }
+            if (_runner == nullptr) { _runner = SearchNext(); }
         }
     };
 
-    inline bool End() const { return _runner == NULL; };
+    inline bool End() const { return _runner == nullptr; };
     // becomes true when ++ on the last element
 
     inline void Rewind() {
-        _runner = NULL;
+        _runner = nullptr;
         _index = -1;
 
         _runner = SearchNext();
@@ -111,7 +111,7 @@ protected:
     }
 
 public:
-    Fast_HashTable() : _numElements(0), _lookupTable(NULL), _compare() {
+    Fast_HashTable() : _numElements(0), _lookupTable(nullptr), _compare() {
         using dummyDef = element;
         _lookupTable = new dummyDef*[_tableSize];
         memset(_lookupTable, 0, _tableSize * sizeof(element*));
@@ -124,26 +124,26 @@ public:
     inline void Clear() {
         if (_numElements == 0) return;
         for (int i = 0; i < _tableSize; i++) {
-            element *curr, *prev = NULL;
+            element *curr, *prev = nullptr;
 
-            for (curr = _lookupTable[i]; curr != NULL; curr = curr->GetNext()) {
-                if (prev != NULL) {
+            for (curr = _lookupTable[i]; curr != nullptr; curr = curr->GetNext()) {
+                if (prev != nullptr) {
                     delete prev;
                     _numElements--;
                     if (_numElements == 0) break;
                 }
                 prev = curr;
-                _lookupTable[i] = NULL;
+                _lookupTable[i] = nullptr;
             }
 
-            if (prev != NULL) delete prev;
+            if (prev != nullptr) delete prev;
         }
     }
 
     Key Insert(Key key, T item) {
         int pos = HashFunction(key);
 
-        if (_lookupTable[pos] == NULL || !_compare(item, _lookupTable[pos]->GetItem())) {
+        if (_lookupTable[pos] == nullptr || !_compare(item, _lookupTable[pos]->GetItem())) {
             _lookupTable[pos] = new element(key, _lookupTable[pos], item);
         } else {
             element* pel = _lookupTable[pos];
@@ -162,11 +162,11 @@ public:
 
     T Find(Key key) {
         T retVal;
-        retVal = NULL;
+        retVal = nullptr;
 
         int pos = HashFunction(key);
 
-        for (element* curr = _lookupTable[pos]; curr != NULL; curr = curr->GetNext()) {
+        for (element* curr = _lookupTable[pos]; curr != nullptr; curr = curr->GetNext()) {
             if (curr->GetKey() == key) {
                 retVal = curr->GetItem();
                 break;
@@ -179,20 +179,20 @@ public:
     element* FindRef(Key key) {
         int pos = HashFunction(key);
 
-        for (element* curr = _lookupTable[pos]; curr != NULL; curr = curr->GetNext())
+        for (element* curr = _lookupTable[pos]; curr != nullptr; curr = curr->GetNext())
             if (curr->GetKey() == key) return curr;
-        return NULL;
+        return nullptr;
     }
 
     T Remove(Key key) {
-        T retVal = NULL;
+        T retVal = nullptr;
 
         int pos = HashFunction(key);
 
         element* curr = _lookupTable[pos];
-        element* prev = NULL;
+        element* prev = nullptr;
 
-        for (; curr != NULL; curr = curr->GetNext()) {
+        for (; curr != nullptr; curr = curr->GetNext()) {
             if (curr->GetKey() == key) {
                 retVal = curr->GetItem();
                 break;
@@ -201,8 +201,8 @@ public:
             prev = curr;
         }
 
-        if (curr != NULL) {
-            if (prev != NULL) {
+        if (curr != nullptr) {
+            if (prev != nullptr) {
                 prev->SetNext(curr->GetNext());
             } else {
                 _lookupTable[pos] = curr->GetNext();
@@ -219,16 +219,16 @@ public:
     void RemoveItem(T item) {
         for (int i = 0; i < _tableSize; i++) {
             element* curr = _lookupTable[i];
-            element* prev = NULL;
+            element* prev = nullptr;
 
-            while (curr != NULL) {
+            while (curr != nullptr) {
                 if (item == curr->GetItem()) {
                     // Found item to delete
                     element* toBeDeleted = curr;
 
                     curr = curr->GetNext();
 
-                    if (prev != NULL) {
+                    if (prev != nullptr) {
                         prev->SetNext(curr);
                     } else {
                         _lookupTable[i] = curr;
@@ -247,10 +247,10 @@ public:
 
     void Print() {
         for (int i = 0; i < _tableSize; i++) {
-            if (_lookupTable[i] != NULL) {
+            if (_lookupTable[i] != nullptr) {
                 printf("[%i]", i);
 
-                for (element* curr = _lookupTable[i]; curr != NULL; curr = curr->GetNext()) {
+                for (element* curr = _lookupTable[i]; curr != nullptr; curr = curr->GetNext()) {
                     printf(" -> %u", curr->GetKey());
                 }
 

--- a/searchsummary/src/vespa/juniper/matchelem.h
+++ b/searchsummary/src/vespa/juniper/matchelem.h
@@ -39,7 +39,7 @@ public:
     // Set if this match element is part of a valid match
     inline bool valid() const { return _valid; }
 
-    virtual MatchCandidate* Complex() { return NULL; }
+    virtual MatchCandidate* Complex() { return nullptr; }
 
 protected:
     off_t _starttoken; // The token number at which this element starts

--- a/searchsummary/src/vespa/juniper/rpinterface.h
+++ b/searchsummary/src/vespa/juniper/rpinterface.h
@@ -162,7 +162,7 @@ long GetRelevancy(Result& result_handle);
  *    based on the same content and analysis.
  *  @return The generated Teaser object. This object is valid until result_handle is deleted.
  */
-Summary* GetTeaser(Result& result_handle, const Config* alt_config = NULL);
+Summary* GetTeaser(Result& result_handle, const Config* alt_config = nullptr);
 
 /** Retrieve log information based on the previous calls to this result handle.
  *  Note that for the log to be complete, the juniper log override entry in

--- a/searchsummary/src/vespa/juniper/simplemap.h
+++ b/searchsummary/src/vespa/juniper/simplemap.h
@@ -16,7 +16,7 @@ public:
         typename std::pair<typename std::map<_key, _val>::iterator, bool> p =
             _map.insert(std::make_pair(key, val));
         if (p.second) return p.first->second;
-        return NULL;
+        return nullptr;
     }
 
     _val find(_key key) {
@@ -24,7 +24,7 @@ public:
         if (it != _map.end())
             return it->second;
         else
-            return NULL;
+            return nullptr;
     }
 
     size_t size() { return _map.size(); }
@@ -36,7 +36,7 @@ public:
         typename std::map<_key, _val>::iterator it(_map.begin());
         for (; it != _map.end(); ++it) {
             delete (it->second);
-            it->second = NULL;
+            it->second = nullptr;
         }
     }
 

--- a/slobrok/src/vespa/slobrok/server/monitor.cpp
+++ b/slobrok/src/vespa/slobrok/server/monitor.cpp
@@ -28,7 +28,7 @@ Monitor::~Monitor()
 void
 Monitor::enable(FRT_Target *monitorTarget)
 {
-    assert(monitorTarget != NULL);
+    assert(monitorTarget != nullptr);
     Unschedule();
     disconnect();
     _enabled = true;

--- a/storage/src/vespa/storage/storageutil/bloomfilter.h
+++ b/storage/src/vespa/storage/storageutil/bloomfilter.h
@@ -9,7 +9,7 @@ private:
     BloomFilter& operator=(const BloomFilter &);
 
 public:
-        BloomFilter(int size, int hashes, uint32_t *buf = NULL);
+        BloomFilter(int size, int hashes, uint32_t *buf = nullptr);
         ~BloomFilter();
 
         bool check(const uint32_t *data, int len, bool add);

--- a/streamingvisitors/src/tests/hitcollector/hitcollector_test.cpp
+++ b/streamingvisitors/src/tests/hitcollector/hitcollector_test.cpp
@@ -348,13 +348,13 @@ TEST_F(HitCollectorTest, feature_set)
     EXPECT_EQ(sf->numDocs(), 3u);
     {
         const auto * f = sf->getFeaturesByDocId(1);
-        ASSERT_TRUE(f != NULL);
+        ASSERT_TRUE(f != nullptr);
         EXPECT_EQ(f[0].as_double(), 11); // 10 + docId
         EXPECT_EQ(f[1].as_double(), 31); // 30 + docId
     }
     {
         const auto * f = sf->getFeaturesByDocId(3);
-        ASSERT_TRUE(f != NULL);
+        ASSERT_TRUE(f != nullptr);
         EXPECT_TRUE(f[0].is_double());
         EXPECT_TRUE(!f[0].is_data());
         EXPECT_EQ(f[0].as_double(), 13);
@@ -372,12 +372,12 @@ TEST_F(HitCollectorTest, feature_set)
     }
     {
         const auto * f = sf->getFeaturesByDocId(4);
-        ASSERT_TRUE(f != NULL);
+        ASSERT_TRUE(f != nullptr);
         EXPECT_EQ(f[0].as_double(), 14);
         EXPECT_EQ(f[1].as_double(), 34);
     }
-    ASSERT_TRUE(sf->getFeaturesByDocId(0) == NULL);
-    ASSERT_TRUE(sf->getFeaturesByDocId(2) == NULL);
+    ASSERT_TRUE(sf->getFeaturesByDocId(0) == nullptr);
+    ASSERT_TRUE(sf->getFeaturesByDocId(2) == nullptr);
 
     SearchResult sr;
     hc.fillSearchResult(sr);

--- a/vespaclient/src/vespa/vespaclient/vesparoute/application.cpp
+++ b/vespaclient/src/vespa/vespaclient/vesparoute/application.cpp
@@ -64,7 +64,7 @@ Application::main(int argc, char **argv)
             throw InvalidConfigException(fmt("There is no routing table for protocol '%s'.", _params.getProtocol().c_str()));
         }
         for (const std::string & hop : _params.getHops()) {
-            if (table->getHop(hop) == NULL) {
+            if (table->getHop(hop) == nullptr) {
                 throw InvalidConfigException(fmt("There is no hop named '%s' for protocol '%s'.", hop.c_str(), _params.getProtocol().c_str()));
             }
         }
@@ -479,7 +479,7 @@ bool
 Application::isService(FRT_Supervisor &frt, const std::string &spec) const
 {
     FRT_Target *target = frt.GetTarget(spec.c_str());
-    if (target == NULL) {
+    if (target == nullptr) {
         return false;
     }
     FRT_RPCRequest *req = frt.AllocRPCRequest();
@@ -510,7 +510,7 @@ mbus::HopBlueprint
 Application::getHop(const std::string &str) const
 {
     const mbus::HopBlueprint *ret = _mbus->getRoutingTable(_params.getProtocol())->getHop(str);
-    if (ret == NULL) {
+    if (ret == nullptr) {
         return mbus::HopBlueprint(mbus::HopSpec("anonymous", str));
     }
     return *ret;
@@ -520,7 +520,7 @@ mbus::Route
 Application::getRoute(const std::string &str) const
 {
     const mbus::Route *ret = _mbus->getRoutingTable(_params.getProtocol())->getRoute(str);
-    if (ret != NULL) {
+    if (ret != nullptr) {
         return *ret;
     }
     return mbus::Route::parse(str);

--- a/vespalib/src/tests/benchmark/benchmark.cpp
+++ b/vespalib/src/tests/benchmark/benchmark.cpp
@@ -11,9 +11,9 @@ int main(int argc, char **argv) {
         size_t concurrency(1);
         size_t numRuns(1000);
         if (argc > 2) {
-            numRuns = strtoul(argv[2], NULL, 0);
+            numRuns = strtoul(argv[2], nullptr, 0);
             if (argc > 3) {
-                concurrency = strtoul(argv[3], NULL, 0);
+                concurrency = strtoul(argv[3], nullptr, 0);
             }
         }
         Benchmark::run(argv[1], numRuns, concurrency);

--- a/vespalib/src/tests/btree/btree_test.cpp
+++ b/vespalib/src/tests/btree/btree_test.cpp
@@ -172,11 +172,11 @@ void
 cleanup(GenerationHandler & g,
         ManagerType & m,
         BTreeNode::Ref n1Ref, NodeType * n1,
-        BTreeNode::Ref n2Ref = BTreeNode::Ref(), NodeType * n2 = NULL)
+        BTreeNode::Ref n2Ref = BTreeNode::Ref(), NodeType * n2 = nullptr)
 {
     assert(ManagerType::isValidRef(n1Ref));
     m.holdNode(n1Ref, n1);
-    if (n2 != NULL) {
+    if (n2 != nullptr) {
         assert(ManagerType::isValidRef(n2Ref));
         m.holdNode(n2Ref, n2);
     } else {

--- a/vespalib/src/tests/btree/btreeaggregation_test.cpp
+++ b/vespalib/src/tests/btree/btreeaggregation_test.cpp
@@ -203,11 +203,11 @@ void
 cleanup(GenerationHandler & g,
         ManagerType & m,
         BTreeNode::Ref n1Ref, NodeType * n1,
-        BTreeNode::Ref n2Ref = BTreeNode::Ref(), NodeType * n2 = NULL)
+        BTreeNode::Ref n2Ref = BTreeNode::Ref(), NodeType * n2 = nullptr)
 {
     assert(ManagerType::isValidRef(n1Ref));
     m.holdNode(n1Ref, n1);
-    if (n2 != NULL) {
+    if (n2 != nullptr) {
         assert(ManagerType::isValidRef(n2Ref));
         m.holdNode(n2Ref, n2);
     } else {

--- a/vespalib/src/tests/btree/frozenbtree_test.cpp
+++ b/vespalib/src/tests/btree/frozenbtree_test.cpp
@@ -77,9 +77,9 @@ FrozenBTreeTest::FrozenBTreeTest()
     : ::testing::Test(),
       _randomValues(),
       _sortedRandomValues(),
-      _generationHandler(NULL),
-      _allocator(NULL),
-      _tree(NULL),
+      _generationHandler(nullptr),
+      _allocator(nullptr),
+      _tree(nullptr),
       _randomGenerator()
 {
 }
@@ -89,9 +89,9 @@ FrozenBTreeTest::~FrozenBTreeTest() = default;
 void
 FrozenBTreeTest::allocTree()
 {
-    assert(_generationHandler == NULL);
-    assert(_allocator == NULL);
-    assert(_tree == NULL);
+    assert(_generationHandler == nullptr);
+    assert(_allocator == nullptr);
+    assert(_tree == nullptr);
     _generationHandler = new GenerationHandler;
     _allocator = new NodeAllocator();
     _tree = new Tree;
@@ -127,9 +127,9 @@ FrozenBTreeTest::freeTree(bool verbose)
     EXPECT_TRUE(_intTree->getNumInternalNodes() == 0 &&
                _intTree->getNumLeafNodes() == 0);
     delete _intTree;
-    _intTree = NULL;
+    _intTree = nullptr;
     delete _intKeyStore;
-    _intKeyStore = NULL;
+    _intKeyStore = nullptr;
 #endif
     (void) verbose;
     _tree->clear(*_allocator);
@@ -138,11 +138,11 @@ FrozenBTreeTest::freeTree(bool verbose)
     _generationHandler->incGeneration();
     _allocator->reclaim_memory(_generationHandler->get_oldest_used_generation());
     delete _tree;
-    _tree = NULL;
+    _tree = nullptr;
     delete _allocator;
-    _allocator = NULL;
+    _allocator = nullptr;
     delete _generationHandler;
-    _generationHandler = NULL;
+    _generationHandler = nullptr;
 }
 
 

--- a/vespalib/src/tests/guard/guard_test.cpp
+++ b/vespalib/src/tests/guard/guard_test.cpp
@@ -27,15 +27,15 @@ TEST(GuardTest, testFilePointer)
         EXPECT_TRUE(strcmp(tmp, "Hello") == 0);
     }
     {
-        FILE *pt = NULL;
+        FILE *pt = nullptr;
         {
             FilePointer file(fopen("filept.txt", "r"));
             EXPECT_TRUE(file.valid());
             pt = file;
         }
-        EXPECT_TRUE(pt != NULL);
+        EXPECT_TRUE(pt != nullptr);
         // char tmp[128];
-        // EXPECT_TRUE(fgets(tmp, sizeof(tmp), pt) == NULL);
+        // EXPECT_TRUE(fgets(tmp, sizeof(tmp), pt) == nullptr);
     }
     {
         FilePointer file(fopen("filept.txt", "w"));
@@ -51,10 +51,10 @@ TEST(GuardTest, testFilePointer)
 
         FILE *ref = file.fp();
         FILE *fp = file.release();
-        EXPECT_TRUE(fp != NULL);
+        EXPECT_TRUE(fp != nullptr);
         EXPECT_TRUE(fp == ref);
         EXPECT_TRUE(!file.valid());
-        EXPECT_TRUE(file.fp() == NULL);
+        EXPECT_TRUE(file.fp() == nullptr);
         fclose(fp);
     }
 }

--- a/vespalib/src/tests/objects/identifiable/identifiable_test.cpp
+++ b/vespalib/src/tests/objects/identifiable/identifiable_test.cpp
@@ -235,18 +235,18 @@ TEST_F(IdentifiableTest, test_identifiable)
     EXPECT_EQ(strcmp(rtcB.name(), "B"), 0);
 
     const Identifiable::RuntimeClass * rt(Identifiable::classFromId(0x1ab76245));
-    ASSERT_TRUE(rt == NULL);
+    ASSERT_TRUE(rt == nullptr);
     rt = Identifiable::classFromId(Abstract::classId);
-    ASSERT_TRUE(rt != NULL);
+    ASSERT_TRUE(rt != nullptr);
     Identifiable * u = rt->create();
-    ASSERT_TRUE(u == NULL);
+    ASSERT_TRUE(u == nullptr);
     rt = Identifiable::classFromId(A::classId);
-    ASSERT_TRUE(rt != NULL);
+    ASSERT_TRUE(rt != nullptr);
     rt = Identifiable::classFromId(B::classId);
-    ASSERT_TRUE(rt != NULL);
+    ASSERT_TRUE(rt != nullptr);
 
     Identifiable * o = rt->create();
-    ASSERT_TRUE(o != NULL);
+    ASSERT_TRUE(o != nullptr);
 
     const Identifiable::RuntimeClass & rtc = o->getClass();
     ASSERT_TRUE(rtc.id() == B::classId);
@@ -267,11 +267,11 @@ TEST_F(IdentifiableTest, test_identifiable)
     delete o;
 
     rt = Identifiable::classFromName("NotBNorA");
-    ASSERT_TRUE(rt == NULL);
+    ASSERT_TRUE(rt == nullptr);
     rt = Identifiable::classFromName("B");
-    ASSERT_TRUE(rt != NULL);
+    ASSERT_TRUE(rt != nullptr);
     o = rt->create();
-    ASSERT_TRUE(o != NULL);
+    ASSERT_TRUE(o != nullptr);
     const Identifiable::RuntimeClass & rtc2 = o->getClass();
     ASSERT_TRUE(rtc2.id() == B::classId);
     ASSERT_TRUE(strcmp(rtc2.name(), "B") == 0);
@@ -282,7 +282,7 @@ TEST_F(IdentifiableTest, test_identifiable)
     ASSERT_TRUE(o->getClass().id() == B::classId);
     delete o;
 
-    IdentifiablePtr<C> c0(NULL);
+    IdentifiablePtr<C> c0(nullptr);
     IdentifiablePtr<C> c1(new C(10));
     IdentifiablePtr<C> c2(new C(20));
 

--- a/vespalib/src/tests/util/ptrholder.cpp
+++ b/vespalib/src/tests/util/ptrholder.cpp
@@ -33,11 +33,11 @@ using HOLD = PtrHolder<DataRef>;
 TEST(PtrHolderTest, test_empty)
 {
     HOLD hold;
-    EXPECT_TRUE(hold.get().get() == NULL);
+    EXPECT_TRUE(hold.get().get() == nullptr);
     EXPECT_TRUE(!hold.hasValue());
     EXPECT_TRUE(!hold.hasNewValue());
     EXPECT_TRUE(!hold.latch());
-    EXPECT_TRUE(hold.get().get() == NULL);
+    EXPECT_TRUE(hold.get().get() == nullptr);
     EXPECT_TRUE(!hold.hasValue());
     EXPECT_TRUE(!hold.hasNewValue());
     hold.set(nullptr);

--- a/vespalib/src/vespa/vespalib/net/socket_options.cpp
+++ b/vespalib/src/vespa/vespalib/net/socket_options.cpp
@@ -24,7 +24,7 @@ bool set_bool_opt(int fd, int level, int name, bool value) {
 bool
 SocketOptions::set_blocking(int fd, bool value)
 {
-    int flags = fcntl(fd, F_GETFL, NULL);
+    int flags = fcntl(fd, F_GETFL, nullptr);
     if (flags != -1) {
         if (value) {
             flags &= ~O_NONBLOCK; // clear non-blocking flag

--- a/vespalib/src/vespa/vespalib/objects/identifiable.h
+++ b/vespalib/src/vespa/vespalib/objects/identifiable.h
@@ -33,8 +33,8 @@
   static  vespalib::Identifiable::RuntimeInfo  _RTInfo; \
   static  vespalib::Identifiable::RuntimeClass _RTClass; \
   static const std::type_info & typeId() { return typeid(cclass); } \
-  static bool tryCast(const vespalib::Identifiable * v) { return dynamic_cast<const cclass *>(v) != NULL; } \
-  static cclass *identifyClassAsIdentifiable() { return NULL; } /* no implementation */
+  static bool tryCast(const vespalib::Identifiable * v) { return dynamic_cast<const cclass *>(v) != nullptr; } \
+  static cclass *identifyClassAsIdentifiable() { return nullptr; } /* no implementation */
 
 #define DECLARE_IDENTIFIABLE_BASE_COMMON(cclass) \
   DECLARE_IDENTIFIABLE_STATIC_BASE_COMMON(cclass) \
@@ -108,28 +108,28 @@
 
 #define IMPLEMENT_IDENTIFIABLE_ABSTRACT(cclass, base)  \
   IMPLEMENT_IDENTIFIABLE_BASE(cclass, #cclass, base, IDENTIFIABLE_CLASSID(cclass), \
-                              NULL, cclass::typeId, cclass::tryCast, "")
+                              nullptr, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE(cclass, base) \
   IMPLEMENT_IDENTIFIABLE_CONCRET(cclass)           \
   IMPLEMENT_IDENTIFIABLE_BASE(cclass, #cclass, base, IDENTIFIABLE_CLASSID(cclass), \
                               cclass::createAsIdentifiable, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS(ns, cclass, base) \
   IMPLEMENT_IDENTIFIABLE_BASE(ns::cclass, #ns"::"#cclass, base, IDENTIFIABLE_CLASSID_NS(ns, cclass), \
-                              NULL, cclass::typeId, cclass::tryCast, "")
+                              nullptr, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE_NS(ns, cclass, base) \
   IMPLEMENT_IDENTIFIABLE_CONCRET(ns::cclass)           \
   IMPLEMENT_IDENTIFIABLE_BASE(ns::cclass, #ns"::"#cclass, base, IDENTIFIABLE_CLASSID_NS(ns, cclass), \
                               cclass::createAsIdentifiable, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS2(ns1, ns2, cclass, base) \
   IMPLEMENT_IDENTIFIABLE_BASE(ns1::ns2::cclass, #ns1"::"#ns2"::"#cclass, base, IDENTIFIABLE_CLASSID_NS2(ns1, ns2, cclass), \
-                              NULL, cclass::typeId, cclass::tryCast, "")
+                              nullptr, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE_NS2(ns1, ns2, cclass, base) \
   IMPLEMENT_IDENTIFIABLE_CONCRET(ns1::ns2::cclass)           \
   IMPLEMENT_IDENTIFIABLE_BASE(ns1::ns2::cclass, #ns1"::"#ns2"::"#cclass, base, IDENTIFIABLE_CLASSID_NS2(ns1, ns2, cclass), \
                               cclass::createAsIdentifiable, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS3(ns1, ns2, ns3, cclass, base) \
   IMPLEMENT_IDENTIFIABLE_BASE(ns1::ns2::ns3::cclass, #ns1"::"#ns2"::"#ns3"::"#cclass, base, IDENTIFIABLE_CLASSID_NS3(ns1, ns2, ns3, cclass), \
-                              NULL, cclass::typeId, cclass::tryCast, "")
+                              nullptr, cclass::typeId, cclass::tryCast, "")
 #define IMPLEMENT_IDENTIFIABLE_NS3(ns1, ns2, ns3, cclass, base) \
   IMPLEMENT_IDENTIFIABLE_CONCRET(ns1::ns2::ns3::cclass)           \
   IMPLEMENT_IDENTIFIABLE_BASE(ns1::ns2::ns3::cclass, #ns1"::"#ns2"::"#ns3"::"#cclass, base, IDENTIFIABLE_CLASSID_NS3(ns1, ns2, ns3, cclass), \
@@ -334,7 +334,7 @@ public:
      * It is symetric with the << operator, and does the same as >>, except instead of checking the id
      * it uses it to construct an object.
      * @param is The nbostream used for input.
-     * @return The object created and constructed by deserialize. NULL if there are any errors.
+     * @return The object created and constructed by deserialize. nullptr if there are any errors.
      */
     static UP create(Deserializer & is);
     static UP create(nbostream & is) { NBOSerializer nis(is); return create(nis); }
@@ -353,7 +353,7 @@ public:
      * It is symetric with the << operator
      * @param is The nbostream used for input.
      * @param obj The object that the stream will be deserialized into.
-     * @return The object created and constructed by deserialize. NULL if there are any errors.
+     * @return The object created and constructed by deserialize. nullptr if there are any errors.
      */
     friend Deserializer & operator >> (Deserializer & os, Identifiable & obj);
     friend nbostream & operator >> (nbostream & os, Identifiable & obj);

--- a/vespalib/src/vespa/vespalib/test/socket_options_verifier.h
+++ b/vespalib/src/vespa/vespalib/test/socket_options_verifier.h
@@ -30,7 +30,7 @@ struct SocketOptionsVerifier {
     int fd;
     SocketOptionsVerifier(int fd_in) : fd(fd_in) {}
     void verify_blocking(bool value) {
-        int flags = fcntl(fd, F_GETFL, NULL);
+        int flags = fcntl(fd, F_GETFL, nullptr);
         EXPECT_NE(flags, -1);
         EXPECT_EQ(((flags & O_NONBLOCK) == 0), value);
     }

--- a/vespalib/src/vespa/vespalib/trace/slime_trace_serializer.cpp
+++ b/vespalib/src/vespa/vespalib/trace/slime_trace_serializer.cpp
@@ -22,7 +22,7 @@ SlimeTraceSerializer::visit(const TraceNode & node)
 {
     assert(!_cursors.empty());
     Cursor * current(_cursors.top());
-    assert(current != NULL);
+    assert(current != nullptr);
     _cursors.pop();
     addTimestamp(*current, node);
     addPayload(*current, node);

--- a/vespalog/src/logger/llreader.cpp
+++ b/vespalog/src/logger/llreader.cpp
@@ -61,7 +61,7 @@ InputBuf::extend()
     _size *= 2;
     int pos = _bp - _buf;
     char *nbuf = (char *)realloc(_buf, _size);
-    if (nbuf == NULL) {
+    if (nbuf == nullptr) {
         free(_buf);
         throw MsgException("realloc failed");
     }

--- a/vespalog/src/vespa/log/bufferedlogger.cpp
+++ b/vespalog/src/vespa/log/bufferedlogger.cpp
@@ -202,7 +202,7 @@ BufferedLogger::BufferedLogger()
 
 BufferedLogger::~BufferedLogger()
 {
-    delete _backing; _backing = NULL;
+    delete _backing; _backing = nullptr;
 }
 
 namespace {

--- a/vespalog/src/vespa/log/control-file.h
+++ b/vespalog/src/vespa/log/control-file.h
@@ -21,7 +21,7 @@ private:
     enum Mode _mode;
     std::string _fileName;
     void ensureHeader();
-    bool hasPrefix() { return (_prefix != NULL &&
+    bool hasPrefix() { return (_prefix != nullptr &&
                                _prefix[0] != '\0' &&
                                _prefix[0] != ' ' &&
                                _prefix[0] != '\n'); }

--- a/vespalog/src/vespa/log/llparser.cpp
+++ b/vespalog/src/vespa/log/llparser.cpp
@@ -25,7 +25,7 @@ LLParser::LLParser()
 {
     assert(_target != nullptr);
     const char *envServ = getenv("VESPA_SERVICE_NAME");
-    if (envServ != NULL) {
+    if (envServ != nullptr) {
         _defService = envServ;
     }
     snprintf(_defPid, 10, "%d", (int)getpid());
@@ -87,7 +87,7 @@ LLParser::doInput(char *line)
     double logTime = 0.0;
     bool timefield = false;
     int pidfield = 0;
-    char *eod = NULL;
+    char *eod = nullptr;
 
     char *first = line;
     char *tab = strchr(first, '\t');	// time?
@@ -319,7 +319,7 @@ LLParser::makeMessage(const char *tmf, const char *hsf, const char *pdf,
     char tmbuffer[24];
     if (tmf[0] == '\0') {
         struct timeval tv;
-        gettimeofday(&tv, NULL);
+        gettimeofday(&tv, nullptr);
         snprintf(tmbuffer, 24, "%u.%06u",
                  static_cast<unsigned int>(tv.tv_sec),
                  static_cast<unsigned int>(tv.tv_usec));

--- a/vespamalloc/src/tests/allocfree/creatingmanythreads.cpp
+++ b/vespamalloc/src/tests/allocfree/creatingmanythreads.cpp
@@ -7,7 +7,7 @@ void * thread_alloc(void * arg)
 {
     char * v = new char [*static_cast<int *>(arg)];
     delete [] v;
-    return NULL;
+    return nullptr;
 }
 
 int main(int argc, char **argv) {
@@ -24,11 +24,11 @@ int main(int argc, char **argv) {
     for (int i(0); i < numThreads; ) {
         for (int j(0); (i < numThreads) && j < 10000; i++, j++) {
             pthread_t thread;
-            if (pthread_create(&thread, NULL, thread_alloc, &allocSize) != 0) {
+            if (pthread_create(&thread, nullptr, thread_alloc, &allocSize) != 0) {
                 LOG(error, "Failed to create thread");
                 return 1;
             }
-            if (pthread_join(thread, NULL) != 0) {
+            if (pthread_join(thread, nullptr) != 0) {
                 LOG(error, "Failed to join thread");
                 return 1;
             }

--- a/vespamalloc/src/tests/doubledelete/expectsignal.cpp
+++ b/vespamalloc/src/tests/doubledelete/expectsignal.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    int retval = strtol(argv[1], NULL, 0);
+    int retval = strtol(argv[1], nullptr, 0);
 
     fprintf(stderr, "argc=%d : Running '%s' expecting signal %d\n", argc, argv[2], retval);
 

--- a/vespamalloc/src/tests/overwrite/expectsignal.cpp
+++ b/vespamalloc/src/tests/overwrite/expectsignal.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    int retval = strtol(argv[1], NULL, 0);
+    int retval = strtol(argv[1], nullptr, 0);
 
     fprintf(stderr, "argc=%d : Running '%s' expecting signal %d\n", argc, argv[2], retval);
 

--- a/vespamalloc/src/tests/thread/thread.cpp
+++ b/vespamalloc/src/tests/thread/thread.cpp
@@ -63,12 +63,12 @@ TEST(ThreadTest, main) {
         pthread_t th;
         void *retval;
         if (strcmp(testType, "exit") == 0) {
-            EXPECT_EQ( pthread_create(&th, NULL, just_exit, NULL), 0);
+            EXPECT_EQ( pthread_create(&th, nullptr, just_exit, nullptr), 0);
         } else if (strcmp(testType, "cancel") == 0) {
-            EXPECT_EQ( pthread_create(&th, NULL, just_cancel, NULL), 0);
+            EXPECT_EQ( pthread_create(&th, nullptr, just_cancel, nullptr), 0);
             EXPECT_EQ( pthread_cancel(th), 0);
         } else {
-            EXPECT_EQ( pthread_create(&th, NULL, just_return, NULL), 0);
+            EXPECT_EQ( pthread_create(&th, nullptr, just_return, nullptr), 0);
         }
         EXPECT_EQ(pthread_join(th, &retval), 0);
     }

--- a/vespamalloc/src/vespamalloc/malloc/mallocdst16.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/mallocdst16.cpp
@@ -5,7 +5,7 @@ namespace vespamalloc {
 
 static Allocator * createAllocator()
 {
-    if (_GmemP == NULL) {
+    if (_GmemP == nullptr) {
         _GmemP = new (_Gmem) Allocator(1, 0x200000);
     }
     return _GmemP;

--- a/vespamalloc/src/vespamalloc/malloc/mallocdst16_nl.cpp
+++ b/vespamalloc/src/vespamalloc/malloc/mallocdst16_nl.cpp
@@ -5,7 +5,7 @@ namespace vespamalloc {
 
 static Allocator * createAllocator()
 {
-    if (_GmemP == NULL) {
+    if (_GmemP == nullptr) {
         _GmemP = new (_Gmem) Allocator(1, 0x7fffffffffffffffl);
     }
     return _GmemP;


### PR DESCRIPTION
@toregge please review.

With this, the final obviously greppable old-school `NULL`s shall have been purged from the C++ code base (aside from some comments and use in string literals). A few `NULL`s still remain in a couple of C files, but not touching those yet since `nullptr` is a C23 feature.