### PR TITLE
Revert "try to initialize coverage as early as possible" MERGEOK

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -235,11 +235,6 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
     vespalib::Timer total_matching_time;
     MatchingStats my_stats;
     SearchReply::UP reply = std::make_unique<SearchReply>();
-    Coverage & coverage = reply->coverage;
-    coverage.setCovered(0);
-    coverage.setActive(metaStore.getNumActiveLids());
-    coverage.setTargetActive(bucketdb.getNumActiveDocs());
-
     bool isDoomExplicit = false;
     { // we want to measure full set-up and tear-down time as part of
       // collateral time
@@ -283,7 +278,6 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
             return reply;
         }
         if (mtf->get_request_context().getDoom().soft_doom()) {
-            coverage.degradeTimeout();
             vespalib::Issue::report("Search request soft doomed during query setup and initialization.");
             return reply;
         }
@@ -313,6 +307,7 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
                                                           _distributionKey, numParts);
         my_stats = MatchMaster::getStats(std::move(master));
         reply = std::move(result->_reply);
+        Coverage & coverage = reply->coverage;
         updateCoverage(coverage, mtf->match_limiter(), my_stats, metaStore, bucketdb);
 
         LOG(debug, "numThreadsPerSearch = %zu. Configured = %d, estimated hits=%d, totalHits=%" PRIu64 ", rankprofile=%s",


### PR DESCRIPTION
@toregge or @bratseth please review

Reverts vespa-engine/vespa#34448

Valgrind not happy in the summer heat
```

[ RUN      ] MatchingTest.require_that_matching_is_performed_with_multi_threaded_matcher
--
  | ==169686== Invalid write of size 8
  | ==169686==    at 0x4A745C: updateCoverage (matcher.cpp:210)
  | ==169686==    by 0x4A745C: proton::matching::Matcher::match(search::engine::SearchRequest const&, vespalib::ThreadBundle&, proton::matching::ISearchContext&, search::attribute::IAttributeContext&, proton::matching::SessionManager&, search::IDocumentMetaStore const&, proton::bucketdb::BucketDBOwner const&, proton::matching::SearchSession::OwnershipBundle&&) (matcher.cpp:316)
  | ==169686==    by 0x480B0A: performSearch (matching_test.cpp:454)
  | ==169686==    by 0x480B0A: MatchingTest_require_that_matching_is_performed_with_multi_threaded_matcher_Test::TestBody() (matching_test.cpp:604)
  | ==169686==    by 0x417A34C: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x416AA9D: testing::Test::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x416AC24: testing::TestInfo::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x416AE1E: testing::TestSuite::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x41726D3: testing::internal::UnitTestImpl::RunAllTests() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x4172AB4: testing::UnitTest::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x46FF60: RUN_ALL_TESTS (gtest.h:2334)
  | ==169686==    by 0x46FF60: main (matching_test.cpp:1354)
  | ==169686==  Address 0x17fce4f8 is 104 bytes inside a block of size 280 free'd
  | ==169686==    at 0x4C3D2F8: operator delete(void*, unsigned long) (vg_replace_malloc.c:1101)
  | ==169686==    by 0x4A69FA: operator() (unique_ptr.h:93)
  | ==169686==    by 0x4A69FA: reset (unique_ptr.h:205)
  | ==169686==    by 0x4A69FA: operator= (unique_ptr.h:185)
  | ==169686==    by 0x4A69FA: operator= (unique_ptr.h:237)
  | ==169686==    by 0x4A69FA: operator= (unique_ptr.h:409)
  | ==169686==    by 0x4A69FA: proton::matching::Matcher::match(search::engine::SearchRequest const&, vespalib::ThreadBundle&, proton::matching::ISearchContext&, search::attribute::IAttributeContext&, proton::matching::SessionManager&, search::IDocumentMetaStore const&, proton::bucketdb::BucketDBOwner const&, proton::matching::SearchSession::OwnershipBundle&&) (matcher.cpp:315)
  | ==169686==    by 0x480B0A: performSearch (matching_test.cpp:454)
  | ==169686==    by 0x480B0A: MatchingTest_require_that_matching_is_performed_with_multi_threaded_matcher_Test::TestBody() (matching_test.cpp:604)
  | ==169686==    by 0x417A34C: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x416AA9D: testing::Test::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x416AC24: testing::TestInfo::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x416AE1E: testing::TestSuite::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x41726D3: testing::internal::UnitTestImpl::RunAllTests() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x4172AB4: testing::UnitTest::Run() (in /opt/vespa-deps/lib64/libgtest.so.1.16.0)
  | ==169686==    by 0x46FF60: RUN_ALL_TESTS (gtest.h:2334)
  | ==169686==    by 0x46FF60: main (matching_test.cpp:1354)
```