### PR TITLE
Track number of flushes for each flush strategy.

### DIFF
--- a/searchcore/src/tests/proton/flushengine/flush_history/flush_history_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/flush_history/flush_history_test.cpp
@@ -3,10 +3,15 @@
 #include <vespa/searchcore/proton/flushengine/flush_history.h>
 #include <vespa/searchcore/proton/flushengine/flush_history_view.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <ios>
 
 using proton::flushengine::FlushHistory;
 using proton::flushengine::FlushHistoryEntry;
 using proton::flushengine::FlushHistoryView;
+using proton::flushengine::FlushStrategyHistoryEntry;
+using std::chrono::steady_clock;
+
+using FlushCounts = FlushStrategyHistoryEntry::FlushCounts;
 
 using namespace std::literals::chrono_literals;
 
@@ -26,6 +31,102 @@ make_names(const std::vector<Entry>& entries) {
         result.emplace_back(entry.name());
     }
     return result;
+}
+
+std::vector<FlushCounts>
+make_flush_counts(const std::vector<FlushStrategyHistoryEntry>& entries) {
+    std::vector<FlushCounts> result;
+    result.reserve(entries.size());
+    for (auto& entry : entries) {
+        result.emplace_back(entry.flush_counts());
+    }
+    return result;
+}
+
+std::vector<FlushCounts>
+make_finished_flush_counts(const FlushHistoryView& view)
+{
+    return make_flush_counts(view.finished_strategies());
+}
+
+std::vector<FlushCounts>
+make_draining_flush_counts(const FlushHistoryView& view)
+{
+    return make_flush_counts(view.draining_strategies());
+}
+
+FlushCounts
+make_active_flush_counts(const FlushHistoryView& view)
+{
+    return view.active_strategy().flush_counts();;
+}
+
+struct TSS {
+    bool switch_time_set;
+    bool finish_time_set;
+    bool last_flush_time_set;
+    TSS(bool switch_time_set_in, bool finish_time_set_in, bool last_flush_time_set_in)
+        : switch_time_set(switch_time_set_in),
+          finish_time_set(finish_time_set_in),
+          last_flush_time_set(last_flush_time_set_in)
+    {
+
+    }
+    bool operator==(const TSS&) const noexcept = default;
+};
+
+void PrintTo(const TSS& tss, std::ostream* os)
+{
+    *os << "{ switched=" << std::boolalpha << tss.switch_time_set << ", finished=" << tss.finish_time_set
+    << ", flushed=" << tss.last_flush_time_set << " }";
+}
+
+
+TSS
+make_tss(const FlushStrategyHistoryEntry& entry)
+{
+    return TSS(entry.switch_time() != steady_clock::time_point(),
+               entry.finish_time() != steady_clock::time_point(),
+               entry.last_flush_finish_time() != steady_clock::time_point());
+}
+
+std::vector<TSS>
+make_tss(const std::vector<FlushStrategyHistoryEntry>& entries)
+{
+    std::vector<TSS> result;
+    result.reserve(entries.size());
+    for (auto& entry : entries) {
+        result.emplace_back(make_tss(entry));
+    }
+    return result;
+}
+
+std::vector<TSS>
+make_finished_tss(const FlushHistoryView& view)
+{
+    return make_tss(view.finished_strategies());
+}
+
+std::vector<TSS>
+make_draining_tss(const FlushHistoryView& view)
+{
+    return make_tss(view.draining_strategies());
+}
+
+TSS
+make_active_tss(const FlushHistoryView& view)
+{
+    return make_tss(view.active_strategy());
+}
+
+}
+
+namespace proton::flushengine {
+
+void PrintTo(const FlushCounts& counts, std::ostream* os)
+{
+    *os << "FlushCounts(" << counts._started << "," << counts._finished << "," <<
+    counts._inherited << "," << counts._inherited_finished << ")";
 }
 
 }
@@ -53,15 +154,23 @@ FlushHistoryTest::~FlushHistoryTest() = default;
 TEST_F(FlushHistoryTest, empty_history)
 {
     auto view = _flush_history.make_view();
-    EXPECT_EQ(NORMAL_STRATEGY, view->strategy());
-    EXPECT_EQ(42, view->strategy_id());
-    EXPECT_FALSE(view->priority_strategy());
+    auto& active_strategy = view->active_strategy();
+    EXPECT_EQ(NORMAL_STRATEGY, active_strategy.name());
+    EXPECT_EQ(42, active_strategy.id());
+    EXPECT_FALSE(active_strategy.priority_strategy());
     EXPECT_EQ(3, view->max_concurrent_normal());
     EXPECT_TRUE(view->finished().empty());
     EXPECT_TRUE(view->active().empty());
     EXPECT_TRUE(view->pending().empty());
     EXPECT_TRUE(view->finished_strategies().empty());
+    ASSERT_TRUE(view->draining_strategies().empty());
     EXPECT_TRUE(view->last_strategies().empty());
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{{}}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(0, 0, 0, 0), make_active_flush_counts(*view));
+    EXPECT_EQ((std::vector<TSS>{}), make_finished_tss(*view));
+    EXPECT_EQ((std::vector<TSS>{}), make_draining_tss(*view));
+    EXPECT_EQ(TSS(false, false, false), make_active_tss(*view));
 }
 
 TEST_F(FlushHistoryTest, track_flushes)
@@ -76,9 +185,13 @@ TEST_F(FlushHistoryTest, track_flushes)
     auto view = _flush_history.make_view();
     EXPECT_EQ((SV{"handler2.a2", "handler1.a1"}), make_names(view->finished()));
     EXPECT_EQ(SV{"handler1.a3"}, make_names(view->active()));
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(3, 2, 0, 0), make_active_flush_counts(*view));
+    EXPECT_EQ(TSS(false, false, true), make_active_tss(*view));
 }
 
-TEST_F(FlushHistoryTest, trackes_pending_flushes)
+TEST_F(FlushHistoryTest, tracks_pending_flushes)
 {
     _flush_history.add_pending_flush(HANDLER1, "a1", 3s);
     _flush_history.add_pending_flush(HANDLER2, "a2", 1s);
@@ -92,6 +205,10 @@ TEST_F(FlushHistoryTest, trackes_pending_flushes)
     EXPECT_EQ(SV{"handler2.a2"}, make_names(view->finished()));
     EXPECT_EQ(SV{"handler1.a1"}, make_names(view->active()));
     EXPECT_EQ((SV{"handler2.a3", "handler1.a4"}), make_names(view->pending()));
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(2, 1, 0, 0), make_active_flush_counts(*view));
+    EXPECT_EQ(TSS(false, false, true), make_active_tss(*view));
 }
 
 TEST_F(FlushHistoryTest, pending_flushes_can_be_cleared)
@@ -100,15 +217,20 @@ TEST_F(FlushHistoryTest, pending_flushes_can_be_cleared)
     _flush_history.clear_pending_flushes();
     auto view = _flush_history.make_view();
     EXPECT_TRUE(view->pending().empty());
+    EXPECT_EQ(TSS(false, false, false), make_active_tss(*view));
 }
 
 TEST_F(FlushHistoryTest, active_priority_flush_strategy_can_be_detected)
 {
     _flush_history.set_strategy(ALL_STRATEGY, 43, true);
     auto view = _flush_history.make_view();
-    EXPECT_EQ(ALL_STRATEGY, view->strategy());
-    EXPECT_EQ(43, view->strategy_id());
-    EXPECT_TRUE(view->priority_strategy());
+    auto& active_strategy = view->active_strategy();
+    EXPECT_EQ(ALL_STRATEGY, active_strategy.name());
+    EXPECT_EQ(43, active_strategy.id());
+    EXPECT_TRUE(active_strategy.priority_strategy());
+    EXPECT_EQ((std::vector<TSS>{{true, true, false}}), make_finished_tss(*view));
+    EXPECT_EQ((std::vector<TSS>{}), make_draining_tss(*view));
+    EXPECT_EQ(TSS(false, false, false), make_active_tss(*view));
 }
 
 TEST_F(FlushHistoryTest, flush_strategy_can_be_changed)
@@ -121,20 +243,62 @@ TEST_F(FlushHistoryTest, flush_strategy_can_be_changed)
     _flush_history.start_flush(HANDLER1, "a3", 4s, 7);
     _flush_history.set_strategy(NORMAL_STRATEGY, 44, false);
     auto view = _flush_history.make_view();
-    EXPECT_EQ(NORMAL_STRATEGY, view->strategy());
-    EXPECT_EQ(44, view->strategy_id());
-    EXPECT_FALSE(view->priority_strategy());
+    ASSERT_EQ(2, view->draining_strategies().size());
+    auto& active_strategy = view->active_strategy();
+    EXPECT_EQ(NORMAL_STRATEGY, active_strategy.name());
+    EXPECT_EQ(44, active_strategy.id());
+    EXPECT_FALSE(active_strategy.priority_strategy());
     EXPECT_TRUE(view->finished().empty());
     ASSERT_EQ((SV{"handler1.a1", "handler2.a2", "handler1.a3"}), make_names(view->active()));
     EXPECT_EQ(NORMAL_STRATEGY, view->active()[0].strategy());
     EXPECT_EQ(ALL_STRATEGY, view->active()[1].strategy());
     EXPECT_EQ(ALL_STRATEGY, view->active()[2].strategy());
-    EXPECT_EQ((SV{NORMAL_STRATEGY, ALL_STRATEGY}), make_names(view->finished_strategies()));
-    EXPECT_FALSE(view->finished_strategies()[0].priority_strategy());
-    EXPECT_TRUE(view->finished_strategies()[1].priority_strategy());
-    EXPECT_EQ(42, view->finished_strategies()[0].id());
-    EXPECT_EQ(43, view->finished_strategies()[1].id());
+    EXPECT_EQ((SV{}), make_names(view->finished_strategies()));
+    EXPECT_EQ((SV{NORMAL_STRATEGY, ALL_STRATEGY}), make_names(view->draining_strategies()));
+    EXPECT_FALSE(view->draining_strategies()[0].priority_strategy());
+    EXPECT_TRUE(view->draining_strategies()[1].priority_strategy());
+    EXPECT_EQ(42, view->draining_strategies()[0].id());
+    EXPECT_EQ(43, view->draining_strategies()[1].id());
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{{1, 0, 0, 0}, {2, 0, 1, 0}}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(0, 0, 3, 0), make_active_flush_counts(*view));
     EXPECT_EQ((SV{ALL_STRATEGY, NORMAL_STRATEGY}), make_names(view->last_strategies()));
+    EXPECT_EQ((std::vector<TSS>{}), make_finished_tss(*view));
+    EXPECT_EQ((std::vector<TSS>{{true, false, false}, {true, false, false}}), make_draining_tss(*view));
+    EXPECT_EQ(TSS(false, false, false),make_active_tss(*view));
+    _flush_history.flush_done(6);
+    _flush_history.prune_done(6);
+    view = _flush_history.make_view();
+    EXPECT_EQ((SV{}), make_names(view->finished_strategies()));
+    EXPECT_EQ((SV{NORMAL_STRATEGY, ALL_STRATEGY}), make_names(view->draining_strategies()));
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{{1, 0, 0, 0}, {2, 1, 1, 0}}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(0, 0, 3, 1), make_active_flush_counts(*view));
+    EXPECT_EQ((std::vector<TSS>{}), make_finished_tss(*view));
+    EXPECT_EQ((std::vector<TSS>{{true, false, false}, {true, false, true}}), make_draining_tss(*view));
+    EXPECT_EQ(TSS(false, false, true), make_active_tss(*view));
+    _flush_history.flush_done(5);
+    _flush_history.prune_done(5);
+    view = _flush_history.make_view();
+    EXPECT_EQ((SV{NORMAL_STRATEGY}), make_names(view->finished_strategies()));
+    EXPECT_EQ((SV{ALL_STRATEGY}), make_names(view->draining_strategies()));
+    EXPECT_EQ((std::vector<FlushCounts>{{1, 1, 0, 0}}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{{2, 1, 1, 1}}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(0, 0, 3, 2), make_active_flush_counts(*view));
+    EXPECT_EQ((std::vector<TSS>{{true, true, true}}), make_finished_tss(*view));
+    EXPECT_EQ((std::vector<TSS>{{true, false, true}}), make_draining_tss(*view));
+    EXPECT_EQ(TSS(false, false, true), make_active_tss(*view));
+    _flush_history.flush_done(7);
+    _flush_history.prune_done(7);
+    view = _flush_history.make_view();
+    EXPECT_EQ((SV{NORMAL_STRATEGY, ALL_STRATEGY}), make_names(view->finished_strategies()));
+    EXPECT_EQ((SV{}), make_names(view->draining_strategies()));
+    EXPECT_EQ((std::vector<FlushCounts>{{1, 1, 0, 0}, {2, 2, 1, 1}}), make_finished_flush_counts(*view));
+    EXPECT_EQ((std::vector<FlushCounts>{}), make_draining_flush_counts(*view));
+    EXPECT_EQ(FlushCounts(0, 0, 3, 3), make_active_flush_counts(*view));
+    EXPECT_EQ((std::vector<TSS>{{true, true, true}, {true, true, true}}), make_finished_tss(*view));
+    EXPECT_EQ((std::vector<TSS>{}), make_draining_tss(*view));
+    EXPECT_EQ(TSS(false, false, true), make_active_tss(*view));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history.cpp
@@ -88,7 +88,7 @@ FlushHistory::prune_draining_strategies(time_point now)
             break;
         }
         strategy.set_finish_time(now);
-        _finished_strategies.push_back(strategy);
+        _finished_strategies.push_back(std::move(strategy));
         _draining_strategies.erase(_draining_strategies.begin());
     }
 }
@@ -100,7 +100,8 @@ FlushHistory::strategy_flush_done(uint32_t strategy_id, time_point now)
     if (it != _draining_strategies.end()) {
         auto &starting_strategy = it->second;
         starting_strategy.finish_flush(strategy_id, now);
-        for (++it; it != _draining_strategies.end(); ++it) {
+        ++it;
+        for (; it != _draining_strategies.end(); ++it) {
             it->second.finish_flush(strategy_id, now);
         }
         auto lit = _last_strategies.find(starting_strategy.name());

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history.h
@@ -24,23 +24,23 @@ class FlushHistory {
     duration                                 _keep_duration;
     size_t                                   _keep_entries;
     size_t                                   _keep_entries_max; // limit at which _keep_duration is ignored
-    std::string                              _strategy;
     const uint32_t                           _strategy_id_base;
-    uint32_t                                 _strategy_id;
-    bool                                     _priority_strategy;
-    time_point                               _strategy_start_time;
     const uint32_t                           _max_concurrent_normal;
     uint32_t                                 _pending_id;
     std::deque<FlushHistoryEntry>            _finished;
     std::map<uint32_t, FlushHistoryEntry>    _active;
     std::map<std::string, FlushHistoryEntry> _pending;
     std::deque<FlushStrategyHistoryEntry>    _finished_strategies;
+    std::map<uint32_t, FlushStrategyHistoryEntry>    _draining_strategies; // non-active strategies with active flushes
+    FlushStrategyHistoryEntry                        _active_strategy;
     std::map<std::string, FlushStrategyHistoryEntry> _last_strategies;
 
     std::string build_name(const std::string& handler_name, const std::string& target_name);
 
     void prune_finished();
     void prune_finished_strategies();
+    void prune_draining_strategies(time_point now);
+    void strategy_flush_done(uint32_t strategy_id, time_point now);
 public:
     FlushHistory(std::string strategy, uint32_t stategy_id, uint32_t max_concurrent_normal);
     FlushHistory(const FlushHistory&) = delete;

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history.h
@@ -27,13 +27,35 @@ class FlushHistory {
     const uint32_t                           _strategy_id_base;
     const uint32_t                           _max_concurrent_normal;
     uint32_t                                 _pending_id;
+
+    /*
+     * History of flushes.
+     *
+     * For a priority flush strategy, a flush history entry starts at _pending, moves to _active when it is scheduled,
+     * and later _finished when the flush has completed. The oldest entries in _finished can be removed due to pruning.
+     *
+     * For a normal flush strategy, a flush history entry starts at _active since selection of new flush targets is
+     * deferred to when a new flush can be scheduled.
+     */
     std::deque<FlushHistoryEntry>            _finished;
     std::map<uint32_t, FlushHistoryEntry>    _active;
     std::map<std::string, FlushHistoryEntry> _pending;
-    std::deque<FlushStrategyHistoryEntry>    _finished_strategies;
-    std::map<uint32_t, FlushStrategyHistoryEntry>    _draining_strategies; // non-active strategies with active flushes
+
+    /*
+     * History of flush strategies.
+     *
+     * A flush strategy history entry starts at _active_strategy. When a new flush strategy is activated, the
+     * flush strategy history entry for the deactivated flush strategy is copied to both _draining_strategies and
+     * _last_strategies (overwriting any previous entry in _last_strategies with same name). The entries in
+     * _draining_strategies that don't have active flushes are moved to _finished_strategies.
+     * The oldest entries in _finished_strategies can be removed due to pruning.
+     *
+     * Currently, the flush history does not reflect the queued flush strategies.
+     */
+    std::deque<FlushStrategyHistoryEntry>            _finished_strategies;
+    std::map<uint32_t, FlushStrategyHistoryEntry>    _draining_strategies; // inactive flush strategies with active flushes
     FlushStrategyHistoryEntry                        _active_strategy;
-    std::map<std::string, FlushStrategyHistoryEntry> _last_strategies;
+    std::map<std::string, FlushStrategyHistoryEntry> _last_strategies; // last inactive flush strategy for each name
 
     std::string build_name(const std::string& handler_name, const std::string& target_name);
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_entry.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_entry.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "flush_history_entry.h"
+#include "flush_strategy_history_entry.h"
 
 namespace proton::flushengine {
 
@@ -17,6 +18,14 @@ FlushHistoryEntry::FlushHistoryEntry(std::string name_in, std::string strategy_i
       _prune_time(),
       _last_flush_duration(last_flush_duration_in),
       _id(id_in)
+{
+
+}
+
+FlushHistoryEntry::FlushHistoryEntry(std::string name_in, const FlushStrategyHistoryEntry& strategy_entry,
+                                     time_point create_time_in, duration last_flush_duration_in, uint32_t id_in)
+    : FlushHistoryEntry(std::move(name_in), strategy_entry.name(), strategy_entry.id(),
+                        strategy_entry.priority_strategy(), create_time_in, last_flush_duration_in, id_in)
 {
 
 }

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_entry.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_entry.h
@@ -7,6 +7,8 @@
 
 namespace proton::flushengine {
 
+class FlushStrategyHistoryEntry;
+
 /*
  * A recent flush operation that can be shown in the state explorer.
  */
@@ -30,6 +32,8 @@ public:
     FlushHistoryEntry(std::string name_in, std::string strategy_in, uint32_t strategy_id_in,
                       bool priority_strategy_in, time_point create_time_in,
                       duration last_flush_duration_in, uint32_t id_in);
+    FlushHistoryEntry(std::string name_in, const FlushStrategyHistoryEntry& strategy_entry,
+                      time_point create_time_in, duration last_flush_duration_in, uint32_t id_in);
     FlushHistoryEntry(const FlushHistoryEntry &);
     FlushHistoryEntry(FlushHistoryEntry &&) noexcept;
     ~FlushHistoryEntry();

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_view.cpp
@@ -4,27 +4,23 @@
 
 namespace proton::flushengine {
 
-FlushHistoryView::FlushHistoryView(std::string strategy_in,
-                                   uint32_t strategy_id_base_in,
-                                   uint32_t strategy_id_in,
-                                   bool priority_strategy_in,
-                                   time_point strategy_start_time_in,
+FlushHistoryView::FlushHistoryView(uint32_t strategy_id_base_in,
                                    uint32_t max_concurrent_normal_in,
                                    std::vector<FlushHistoryEntry> finished_in,
                                    std::vector<FlushHistoryEntry> active_in,
                                    std::vector<FlushHistoryEntry> pending_in,
                                    std::vector<FlushStrategyHistoryEntry> finished_strategies_in,
+                                   std::vector<FlushStrategyHistoryEntry> draining_strategies_in,
+                                   FlushStrategyHistoryEntry active_strategy_in,
                                    std::vector<FlushStrategyHistoryEntry> last_strategies_in)
-    : _strategy(std::move(strategy_in)),
-      _strategy_id_base(strategy_id_base_in),
-      _strategy_id(strategy_id_in),
-      _priority_strategy(priority_strategy_in),
-      _strategy_start_time(strategy_start_time_in),
+    : _strategy_id_base(strategy_id_base_in),
       _max_concurrent_normal(max_concurrent_normal_in),
       _finished(std::move(finished_in)),
       _active(std::move(active_in)),
       _pending(std::move(pending_in)),
       _finished_strategies(std::move(finished_strategies_in)),
+      _draining_strategies(std::move(draining_strategies_in)),
+      _active_strategy(std::move(active_strategy_in)),
       _last_strategies(std::move(last_strategies_in))
 {
 }

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_view.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_history_view.h
@@ -14,28 +14,24 @@ namespace proton::flushengine {
 class FlushHistoryView {
     using time_point = std::chrono::steady_clock::time_point;
 
-    std::string                            _strategy;
     uint32_t                               _strategy_id_base;
-    uint32_t                               _strategy_id;
-    bool                                   _priority_strategy;
-    time_point                             _strategy_start_time;
     uint32_t                               _max_concurrent_normal;
     std::vector<FlushHistoryEntry>         _finished;
     std::vector<FlushHistoryEntry>         _active;
     std::vector<FlushHistoryEntry>         _pending;
     std::vector<FlushStrategyHistoryEntry> _finished_strategies;
+    std::vector<FlushStrategyHistoryEntry> _draining_strategies; // strategies or strategy with active flush
+    FlushStrategyHistoryEntry              _active_strategy;
     std::vector<FlushStrategyHistoryEntry> _last_strategies;
 public:
-    FlushHistoryView(std::string strategy_in,
-                     uint32_t strategy_id_base_in,
-                     uint32_t strategy_id_in,
-                     bool priority_strategy_in,
-                     time_point strategy_start_time_in,
+    FlushHistoryView(uint32_t strategy_id_base_in,
                      uint32_t max_concurrent_normal_in,
                      std::vector<FlushHistoryEntry> finished_in,
                      std::vector<FlushHistoryEntry> active_in,
                      std::vector<FlushHistoryEntry> pending_in,
                      std::vector<FlushStrategyHistoryEntry> finished_strategies_in,
+                     std::vector<FlushStrategyHistoryEntry> draining_strategies_in,
+                     FlushStrategyHistoryEntry active_strategy_in,
                      std::vector<FlushStrategyHistoryEntry> last_strategies_in);
     FlushHistoryView(const FlushHistoryView&);
     FlushHistoryView(FlushHistoryView&&) noexcept;
@@ -43,16 +39,14 @@ public:
     FlushHistoryView& operator=(const FlushHistoryView&);
     FlushHistoryView& operator=(FlushHistoryView&&) noexcept;
 
-    const std::string& strategy() const noexcept { return _strategy; }
     uint32_t strategy_id_base() const noexcept { return _strategy_id_base; }
-    uint32_t strategy_id() const noexcept { return _strategy_id; }
-    bool priority_strategy() const noexcept { return _priority_strategy; }
-    time_point strategy_start_time() const noexcept { return _strategy_start_time; }
     uint32_t max_concurrent_normal() const noexcept { return _max_concurrent_normal; }
     const std::vector<FlushHistoryEntry>& finished() const noexcept { return _finished; }
     const std::vector<FlushHistoryEntry>& active() const noexcept { return _active; }
     const std::vector<FlushHistoryEntry>& pending() const noexcept { return _pending; }
     const std::vector<FlushStrategyHistoryEntry>& finished_strategies() const noexcept { return _finished_strategies; }
+    const std::vector<FlushStrategyHistoryEntry>& draining_strategies() const noexcept { return _draining_strategies; }
+    const FlushStrategyHistoryEntry& active_strategy() const noexcept { return _active_strategy; }
     const std::vector<FlushStrategyHistoryEntry>& last_strategies() const noexcept { return _last_strategies; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_history_entry.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_history_entry.cpp
@@ -5,12 +5,16 @@
 namespace proton::flushengine {
 
 FlushStrategyHistoryEntry::FlushStrategyHistoryEntry(std::string name_in, uint32_t id_in,
-                                     bool priority_strategy_in, time_point start_time_in, time_point finish_time_in)
+                                     bool priority_strategy_in, time_point start_time_in,
+                                     uint32_t inherited_flushes_in)
     : _name(std::move(name_in)),
       _id(id_in),
       _priority_strategy(priority_strategy_in),
       _start_time(start_time_in),
-      _finish_time(finish_time_in)
+      _switch_time(),
+      _finish_time(),
+      _last_flush_finish_time(),
+      _flush_counts(inherited_flushes_in)
 {
 }
 
@@ -21,5 +25,23 @@ FlushStrategyHistoryEntry::~FlushStrategyHistoryEntry() = default;
 
 FlushStrategyHistoryEntry& FlushStrategyHistoryEntry::operator=(const FlushStrategyHistoryEntry &) = default;
 FlushStrategyHistoryEntry& FlushStrategyHistoryEntry::operator=(FlushStrategyHistoryEntry &&) noexcept = default;
+
+void
+FlushStrategyHistoryEntry::start_flush() noexcept
+{
+    ++_flush_counts._started;
+}
+
+void
+FlushStrategyHistoryEntry::finish_flush(uint32_t strategy_id, time_point now) noexcept
+{
+    if (strategy_id < _id) {
+        ++_flush_counts._inherited_finished;
+        _last_flush_finish_time = now;
+    } else if (strategy_id == _id) {
+        ++_flush_counts._finished;
+        _last_flush_finish_time = now;
+    }
+}
 
 }

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_history_entry.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_strategy_history_entry.h
@@ -16,17 +16,21 @@ class FlushStrategyHistoryEntry {
     using duration = steady_clock::duration;
 
 public:
+    /*
+     * Flush counts for a flush strategy. The remaining active flushes when the flush strategy was created
+     * is tracked in _inherited, with _inherited_finished being incremented when those flushes complete.
+     */
     struct FlushCounts {
-        uint32_t    _started;
-        uint32_t    _finished;
-        uint32_t    _inherited;
-        uint32_t    _inherited_finished;
+        uint32_t    _started;            // # flushes started by this flush strategy
+        uint32_t    _finished;           // # flushes started by this flush strategy that have finished
+        uint32_t    _inherited;          // # flushes started by an earlier flush strategy
+        uint32_t    _inherited_finished; // # flushes started by an earlier flush strategy that have finished
 
-        FlushCounts(uint32_t inherited)
-        : FlushCounts(0, 0, inherited, 0)
+        constexpr explicit FlushCounts(uint32_t inherited) noexcept
+            : FlushCounts(0, 0, inherited, 0)
         {
         }
-        FlushCounts(uint32_t started, uint32_t finished, uint32_t inherited, uint32_t inherited_finished)
+        constexpr FlushCounts(uint32_t started, uint32_t finished, uint32_t inherited, uint32_t inherited_finished) noexcept
             : _started(started),
               _finished(finished),
               _inherited(inherited),

--- a/searchcore/src/vespa/searchcore/proton/server/prepare_restart2_rpc_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/prepare_restart2_rpc_handler.cpp
@@ -125,8 +125,10 @@ add_previous_flush_strategy(JsonStream& stream, const FlushHistoryView& view, co
     stream << "previous" << Object();
     stream << "strategy" << entry.name();
     stream << "start_time" << as_system_microseconds(entry.start_time());
-    stream << "finish_time" << as_system_microseconds(entry.finish_time());
-    // Note: above finish time is when strategy scheduled last flush job, not when that job completed.
+    stream << "switch_time" << as_system_microseconds(entry.switch_time());
+    if (entry.finish_time() != steady_clock::time_point()) {
+        stream << "finish_time" << as_system_microseconds(entry.finish_time());
+    }
     stream << "id" << entry.id();
     add_active_flush(stream, view, entry.id());
     add_finished_flush(stream, view, entry.id());
@@ -137,12 +139,13 @@ void
 add_current_flush_strategy(JsonStream& stream, const FlushHistoryView& view)
 {
     stream << "current" << Object();
-    stream << "strategy" << view.strategy();
-    stream << "start_time" << as_system_microseconds(view.strategy_start_time());
-    stream << "id" << view.strategy_id();
-    add_active_flush(stream, view, view.strategy_id());
-    add_finished_flush(stream, view, view.strategy_id());
-    add_pending_flush(stream, view, view.strategy_id());
+    auto& active_strategy = view.active_strategy();
+    stream << "strategy" << active_strategy.name();
+    stream << "start_time" << as_system_microseconds(active_strategy.start_time());
+    stream << "id" << active_strategy.id();
+    add_active_flush(stream, view, active_strategy.id());
+    add_finished_flush(stream, view, active_strategy.id());
+    add_pending_flush(stream, view, active_strategy.id());
     stream << End();
 }
 


### PR DESCRIPTION
Add a draining state for flush strategies that are no longer active but have ongoing flushes started by the flush strategy or inherited from an earlier flush strategy.

@vekterli : please review
