### PR TITLE
Test BATS gh action: Change exit code when no pom files found

### DIFF
--- a/.buildkite/replace-vespa-version-in-poms.sh
+++ b/.buildkite/replace-vespa-version-in-poms.sh
@@ -19,7 +19,7 @@ fi
 
 if [[ -z $(find -L "$DIR" -name "pom.xml") ]]; then
     echo "No pom.xml files found in $DIR"
-    exit 0
+    exit 1
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
This is just to verify that the bats tests are running for PRs that modify shell scripts.
