### PR TITLE
Install vespa-print-default with wrapper

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -36,6 +36,7 @@ install_symlink(libexec/vespa/vespa-wrapper bin/vespa-rpc-invoke)
 install_symlink(libexec/vespa/vespa-wrapper bin/vespa-sentinel-cmd)
 install_symlink(libexec/vespa/vespa-wrapper bin/vespa-route)
 install_symlink(libexec/vespa/vespa-wrapper bin/vespa-transactionlog-inspect)
+install_symlink(libexec/vespa/vespa-wrapper bin/vespa-print-default)
 
 install_symlink(libexec/vespa/vespa-wrapper sbin/vespa-distributord)
 install_symlink(libexec/vespa/vespa-wrapper sbin/vespa-proton)

--- a/defaults/src/apps/printdefault/CMakeLists.txt
+++ b/defaults/src/apps/printdefault/CMakeLists.txt
@@ -2,7 +2,7 @@
 vespa_add_executable(defaults_vespa-print-default_app
     SOURCES
     printdefault.cpp
-    OUTPUT_NAME vespa-print-default
+    OUTPUT_NAME vespa-print-default-bin
     INSTALL bin
     DEPENDS
     vespadefaults


### PR DESCRIPTION
This should fix `vespa-print-default` so that it actually uses defaults from environment variables in /opt/vespa/conf/vespa/default-env.txt