### PR TITLE
fix(metrics-proxy): specify JVM heap settings in `MetricsProxyContainer` instead of the parent cluster object

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -10,6 +10,7 @@ import ai.vespa.metricsproxy.rpc.RpcConnector;
 import ai.vespa.metricsproxy.rpc.RpcConnectorConfig;
 import ai.vespa.metricsproxy.service.VespaServices;
 import ai.vespa.metricsproxy.service.VespaServicesConfig;
+import ai.vespa.utils.BytesQuantity;
 import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.ApplicationId;
@@ -153,14 +154,13 @@ public class MetricsProxyContainer extends Container implements
     @Override
     public void getConfig(QrStartConfig.Builder builder) {
         cluster.getConfig(builder);
-
         if (clusterMembership.isPresent()) {
             boolean adminCluster = clusterMembership.get().cluster().type() == ClusterSpec.Type.admin;
-            int maxHeapSize = adminCluster ? 96 : 256;
-            builder.jvm
-                    .gcopts(jvmGCOptions)
-                    .heapsize(maxHeapSize);
-            if (adminCluster) builder.jvm.minHeapsize(maxHeapSize);
+            int heapSize = adminCluster ? 96 : 320;
+            builder.jvm.heapsize(heapSize);
+            builder.jvm.minHeapsize(heapSize);
+            builder.jvm.compressedClassSpaceSize(0);
+            builder.jvm.baseMaxDirectMemorySize((int)BytesQuantity.ofMB(128).toBytes());
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -28,7 +28,6 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.admin.Admin;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.admin.monitoring.Monitoring;
@@ -192,15 +191,6 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         }
     }
 
-    @Override
-    public void getConfig(QrStartConfig.Builder builder) {
-        super.getConfig(builder);
-        
-        builder.jvm
-                .minHeapsize(256)
-                .heapsize(256);
-    }
-    
     protected boolean messageBusEnabled() { return false; }
 
     private MetricSet getAdditionalDefaultMetrics() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -9,14 +9,10 @@ import ai.vespa.metricsproxy.http.yamas.YamasHandler;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
 import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import com.yahoo.component.ComponentSpecification;
-import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
-import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
-import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames;
 import com.yahoo.vespa.model.container.Container;
@@ -44,7 +40,6 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.g
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getMetricsNodesConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getModel;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.servicesWithAdminOnly;
-import static com.yahoo.vespa.model.container.ContainerCluster.G1GC;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -134,21 +129,6 @@ public class MetricsProxyContainerClusterTest {
         var accessLog = getAccessLogComponent(hostedModel.getAdmin().getMetricsProxyCluster());
         assertNotNull(accessLog);
         assertEquals("logs/vespa/access/JsonAccessLog.metrics-proxy.%Y%m%d%H%M%S", accessLog.getFileNamePattern());
-    }
-    
-    @Test
-    void configure_jvm_options() {
-        var state = new DeployState.Builder().properties(new TestProperties().setHostedVespa(true)).build();
-        var root = new MockRoot("foo", state);
-        var cluster = new MetricsProxyContainerCluster(root, "bar", state);
-        var configBuilder = new QrStartConfig.Builder();
-        cluster.getConfig(configBuilder);
-        var jvm = configBuilder.build().jvm();
-        assertEquals(1, jvm.availableProcessors());
-        assertEquals(256, jvm.minHeapsize());
-        assertEquals(256, jvm.heapsize());
-        assertEquals(0, jvm.heapSizeAsPercentageOfPhysicalMemory());
-        assertEquals(G1GC, jvm.gcopts());
     }
 
     private AccessLogComponent getAccessLogComponent(ContainerCluster<? extends Container> cluster) {


### PR DESCRIPTION
Increase heap size to 320MB. Override size for class space and direct memory.

FYI @glebashnik 