### PR TITLE
Reduce max number of document inverters for a memory index from 4 to 3.

### DIFF
--- a/searchlib/src/vespa/searchlib/memoryindex/memory_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/memory_index.cpp
@@ -63,7 +63,7 @@ MemoryIndex::MemoryIndex(const Schema& schema,
       _pushThreads(pushThreads),
       _fieldIndexes(std::make_unique<FieldIndexCollection>(_schema, inspector)),
       _inverter_context(std::make_unique<DocumentInverterContext>(_schema, _invertThreads, _pushThreads, *_fieldIndexes)),
-      _inverters(std::make_unique<DocumentInverterCollection>(*_inverter_context, 4)),
+      _inverters(std::make_unique<DocumentInverterCollection>(*_inverter_context, 3)),
       _frozen(false),
       _maxDocId(0), // docId 0 is reserved
       _numDocs(0),


### PR DESCRIPTION
@vekterli : please review
