### PR TITLE
Change exit code when no pom files found

### DIFF
--- a/.buildkite/replace-vespa-version-in-poms.sh
+++ b/.buildkite/replace-vespa-version-in-poms.sh
@@ -19,7 +19,7 @@ fi
 
 if [[ -z $(find -L "$DIR" -name "pom.xml") ]]; then
     echo "No pom.xml files found in $DIR"
-    exit 0
+    exit 1
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
Do not merge, this is just to verify that BATS tests are running and failing.