### PR TITLE
Add Aarch64 SVE/SVE2 auto-vectorization targets

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
@@ -3,7 +3,7 @@
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(ACCEL_FILES "x64_generic.cpp" "avx2.cpp" "avx3.cpp" "avx3_dl.cpp")
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-  set(ACCEL_FILES "neon.cpp" "neon_fp16_dotprod.cpp")
+  set(ACCEL_FILES "neon.cpp" "neon_fp16_dotprod.cpp" "sve.cpp" "sve2.cpp")
 else()
   message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
@@ -21,6 +21,8 @@ set_source_files_properties(avx3_dl.cpp           PROPERTIES COMPILE_FLAGS "-O3 
 
 set_source_files_properties(neon.cpp              PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a")
 set_source_files_properties(neon_fp16_dotprod.cpp PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a+fp16+dotprod+crypto -mtune=neoverse-n1")
+set_source_files_properties(sve.cpp               PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a+sve -mtune=neoverse-n1")
+set_source_files_properties(sve2.cpp              PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a+sve2 -mtune=neoverse-n1")
 
 set(BLA_VENDOR OpenBLAS)
 vespa_add_target_package_dependency(vespa_hwaccelerated BLAS)

--- a/vespalib/src/vespa/vespalib/hwaccelerated/sve.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/sve.cpp
@@ -1,0 +1,4 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#define VESPA_HWACCEL_INCLUDE_DEFINITIONS 1
+#include "sve.h"

--- a/vespalib/src/vespa/vespalib/hwaccelerated/sve.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/sve.h
@@ -1,0 +1,9 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#define VESPA_HWACCEL_TARGET_TYPE SveAccelerator
+#define VESPA_HWACCEL_TARGET_NAME "SVE"
+#include "generic-inl.h"
+#undef VESPA_HWACCEL_TARGET_TYPE
+#undef VESPA_HWACCEL_TARGET_NAME

--- a/vespalib/src/vespa/vespalib/hwaccelerated/sve2.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/sve2.cpp
@@ -1,0 +1,4 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#define VESPA_HWACCEL_INCLUDE_DEFINITIONS 1
+#include "sve2.h"

--- a/vespalib/src/vespa/vespalib/hwaccelerated/sve2.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/sve2.h
@@ -1,0 +1,9 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#define VESPA_HWACCEL_TARGET_TYPE Sve2Accelerator
+#define VESPA_HWACCEL_TARGET_NAME "SVE2"
+#include "generic-inl.h"
+#undef VESPA_HWACCEL_TARGET_TYPE
+#undef VESPA_HWACCEL_TARGET_NAME


### PR DESCRIPTION
@toregge please review

As with the x64 AVX3_DL target, these are disabled by default but available for benchmarking. Want an auto-vectorized baseline to compare against. For simplicity, always assume transitive CPU feature support requirements `SVE2` → `SVE` → `NEON_FP16_DOTPROD`.

When running our acceleration benchmark suite with these changes on a Google Axion system with SVE2 support, I don't actually observe any performance benefits vs. the default `NEON_FP16_DOTPROD` target. In fact, `int8` squared euclidean distance has a slight performance _regression_.

It is possible that our generic, high-ish level implementation—which does its best to lovingly seduce the compiler into generating vectorized code—is not the best fit for SIMD engines where the vector width is only known at runtime (vs. fixed-size at compile time, like with AVX/NEON). Either that or I'm using it wrong(tm).
