### PR TITLE
fix(matchobject): Redundant null check due to previous dereference

### DIFF
--- a/searchsummary/src/vespa/juniper/matchobject.cpp
+++ b/searchsummary/src/vespa/juniper/matchobject.cpp
@@ -212,7 +212,7 @@ QueryTerm* match_iterator::first_match(Token& token) {
     queryterm_hashtable::keytype keyval = termval;
     if (LOG_WOULD_LOG(spam)) {
         char utf8term[1024];
-        Fast_UnicodeUtil::utf8ncopy(utf8term, term, 1024, (term != nullptr ? len : 0));
+        Fast_UnicodeUtil::utf8ncopy(utf8term, term, 1024, len);
         LOG(spam, "term %s, len %ld, keyval 0x%x termval 0x%x", utf8term, len, keyval, termval);
     }
     _el = _table.FindRef(keyval);


### PR DESCRIPTION
https://github.com/vespa-engine/vespa/blob/9f2a2baa6522019c66733bca056a1213ed0682d5/searchsummary/src/vespa/juniper/matchobject.cpp#L215-L215

This rule finds comparisons of a pointer to null that occur after a reference of that pointer. It's likely either the check is not required and can be removed, or it should be moved to before the dereference so that a null pointer dereference does not occur.

```cpp
int f(MyList *list) {
	list->append(1);

	// ...

	if (list != NULL)
	{
		list->append(2);
	}
}
```
fix this problem is to remove the redundant null check at line 215. Since `term` cannot be null at this point (it has already been dereferenced), we should simply pass `len` as the fourth argument to `Fast_UnicodeUtil::utf8ncopy`, instead of the ternary `(term != nullptr ? len : 0)`. This change should be made only in the affected region (line 215) of `searchsummary/src/vespa/juniper/matchobject.cpp`.

#### References
[Null Dereference](https://www.owasp.org/index.php/Null_Dereference)
[CWE-476](https://cwe.mitre.org/data/definitions/476.html)