### PR TITLE
fix: arbitrary file access during archive extraction zipslip

### DIFF
--- a/client/go/internal/vespa/application.go
+++ b/client/go/internal/vespa/application.go
@@ -254,7 +254,11 @@ func (ap *ApplicationPackage) Unzip(test bool) (string, error) {
 	}
 	defer f.Close()
 	for _, f := range f.File {
+		// Normalize the file path and ensure it stays within the temp directory
 		dst := filepath.Join(tmp, f.Name)
+		if !strings.HasPrefix(filepath.Clean(dst), filepath.Clean(tmp)+string(os.PathSeparator)) {
+			return "", fmt.Errorf("illegal file path in archive: %s", f.Name)
+		}
 		if f.FileInfo().IsDir() {
 			if err := os.Mkdir(dst, f.FileInfo().Mode()); err != nil {
 				return "", err

--- a/config-application-package/src/main/java/com/yahoo/config/application/ConfigDefinitionDir.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/ConfigDefinitionDir.java
@@ -31,7 +31,13 @@ public class ConfigDefinitionDir {
         for (Bundle.DefEntry def : bundle.getDefEntries()) {
             checkUserDefConflict(bundle, def, bundlesAdded);
             String defFilename = def.defNamespace + "." + def.defName + ".def";
-            OutputStream out = new FileOutputStream(new File(defDir, defFilename));
+            File outFile = new File(defDir, defFilename);
+            // Zip Slip fix: ensure output file path is within defDir
+            if (!outFile.toPath().normalize().startsWith(defDir.toPath().normalize())) {
+                throw new IllegalArgumentException("Refusing to write config definition outside of " + defDir.getAbsolutePath() +
+                        " (got " + outFile.getAbsolutePath() + ")");
+            }
+            OutputStream out = new FileOutputStream(outFile);
             out.write(def.contents.getBytes());
             out.close();
         }

--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/SchemaValidators.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/SchemaValidators.java
@@ -169,7 +169,13 @@ public class SchemaValidators {
 
     private static void writeContentsToFile(File outDir, String outFile, InputStream inputStream) throws IOException {
         String contents = IOUtils.readAll(new InputStreamReader(inputStream));
-        File out = new File(outDir, outFile);
+
+        // Validate and sanitize the output path
+        File out = new File(outDir, outFile).getCanonicalFile();
+        if (!out.getPath().startsWith(outDir.getCanonicalPath() + File.separator)) {
+            throw new IOException("Invalid file path: " + outFile);
+        }
+
         IOUtils.writeFile(out, contents, false);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/CompressedApplicationInputStream.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/CompressedApplicationInputStream.java
@@ -91,6 +91,9 @@ public class CompressedApplicationInputStream implements AutoCloseable {
                 tmpStream.close();
                 log.log(Level.FINE, "Creating output file: " + file.path());
                 Path dstFile = dir.resolve(file.path().toString()).normalize();
+                if (!dstFile.startsWith(dir.normalize())) {
+                    throw new IOException("Entry attempts to write outside the target directory: " + dstFile);
+                }
                 Files.createDirectories(dstFile.getParent());
                 Files.move(tmpFile, dstFile);
                 tmpFile = createTempFile(dir);

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaLanguageServer.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaLanguageServer.java
@@ -271,7 +271,11 @@ public class SchemaLanguageServer implements LanguageServer, LanguageClientAware
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
                 if (!entry.isDirectory() && entry.getName().startsWith(documentationPath.getFileName().toString())) {
-                    Path destination = documentationPath.getParent().resolve(entry.getName());
+                    Path extractionDir = documentationPath.getParent();
+                    Path destination = extractionDir.resolve(entry.getName()).normalize();
+                    if (!destination.startsWith(extractionDir)) {
+                        throw new IOException("Zip entry is outside of the target dir: " + entry.getName());
+                    }
                     Files.createDirectories(destination.getParent());
                     try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(entry.getName())) {
                         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/UnpackRNGFiles.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/UnpackRNGFiles.java
@@ -42,7 +42,12 @@ public class UnpackRNGFiles {
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
                 if (!entry.isDirectory() && entry.getName().endsWith(".rng") && entry.getName().startsWith("resources/schema")) {
-                    Path writePath = serverPath.resolve(entry.getName());
+                    Path writePath = serverPath.resolve(entry.getName()).normalize();
+                    Path targetDir = serverPath.resolve("resources").resolve("schema").normalize();
+                    if (!writePath.startsWith(targetDir)) {
+                        // Potential Zip Slip attack, skip this entry
+                        continue;
+                    }
                     try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(entry.getName())) {
                         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
                         String content = reader.lines().collect(Collectors.joining(System.lineSeparator()));


### PR DESCRIPTION
https://github.com/vespa-engine/vespa/blob/754d57d8221bde68b8915f2c2f1effef912cc769/application-model/src/main/java/com/yahoo/vespa/archive/ArchiveStreamReader.java#L57-L57

https://github.com/vespa-engine/vespa/blob/754d57d8221bde68b8915f2c2f1effef912cc769/config-application-package/src/main/java/com/yahoo/config/model/application/provider/Bundle.java#L127-L127

https://github.com/vespa-engine/vespa/blob/9f2a2baa6522019c66733bca056a1213ed0682d5/config-application-package/src/main/java/com/yahoo/config/model/application/provider/SchemaValidators.java#L121-L121

https://github.com/vespa-engine/vespa/blob/9f2a2baa6522019c66733bca056a1213ed0682d5/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceCompressor.java#L73-L77

https://github.com/vespa-engine/vespa/blob/9f2a2baa6522019c66733bca056a1213ed0682d5/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaLanguageServer.java#L274-L274

https://github.com/vespa-engine/vespa/blob/9f2a2baa6522019c66733bca056a1213ed0682d5/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/UnpackRNGFiles.java#L46-L46

https://github.com/vespa-engine/vespa/blob/479b9acb863226f5082a7a0b3495172ab81dc657/client/go/internal/vespa/application.go#L256-L267


Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

fix this vulnerability, the code should ensure that any file path constructed from the archive entry name stays within the intended output directory. This is best achieved by:

- Resolving the output path (`serverPath.resolve(entry.getName())`), normalizing it, and checking that it starts with the intended output directory (`serverPath` or its intended subdirectory) using `Path.startsWith`.
- Only write the file if this check passes; otherwise, skip or throw an exception.
- This change should be made in the block where the output path is constructed and used for writing (lines 45–49).
- Add any necessary imports (`java.nio.file.Paths` is already available via `Path`).
- No changes to existing functionality are needed except for the added path validation.
- Check that the resulting path is within the intended extraction directory by comparing it to the temporary directory (`tmp`) using `filepath.HasPrefix` or similar logic.
- Validate that the normalized file path starts with the normalized path of the output directory using `Path.startsWith(..)`.
- Normalize the destination path resulting from `documentationPath.getParent().resolve(entry.getName())`.
- Verify that the normalized path starts with the canonical extraction directory (`documentationPath.getParent()`).
- Only proceed to create directories and write files if the check passes; otherwise, skip the entry or throw an exception.
- In `ConfigDefinitionDir.java` within the `checkAndCopyUserDefs` method, add code to check the normalized output path against `defDir.toPath().normalize()`.
- If the check fails, throw an `IllegalArgumentException`.


#### References
[Zip Slip Vulnerability](https://docs.openrewrite.org/recipes/java/security/zipslip)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)