### PR TITLE
Only allow the first failing thread to enter `mimalloc` error handler

### DIFF
--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -171,6 +171,7 @@ vespa_define_module(
     src/tests/util/generationhandler_stress
     src/tests/util/hamming
     src/tests/util/md5
+    src/tests/util/mimalloc
     src/tests/valgrind
     src/tests/visit_ranges
     src/tests/wakeup

--- a/vespalib/src/tests/util/mimalloc/.gitignore
+++ b/vespalib/src/tests/util/mimalloc/.gitignore
@@ -1,0 +1,1 @@
+vespalib_mimalloc_intercept_test_app

--- a/vespalib/src/tests/util/mimalloc/CMakeLists.txt
+++ b/vespalib/src/tests/util/mimalloc/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_mimalloc_intercept_test_app TEST
+    SOURCES
+    mimalloc_intercept_test.cpp
+    DEPENDS
+    vespalib
+    GTest::gtest
+)
+vespa_add_test(NAME vespalib_mimalloc_intercept_test_app COMMAND vespalib_mimalloc_intercept_test_app)

--- a/vespalib/src/tests/util/mimalloc/mimalloc_intercept_test.cpp
+++ b/vespalib/src/tests/util/mimalloc/mimalloc_intercept_test.cpp
@@ -15,7 +15,7 @@ __attribute__((noinline)) void my_fake_mi_error_message(int err);
 __attribute__((noinline)) void my_fake_mi_malloc_generic(int err);
 
 // The error handler skips a few frames of the stack top due to assumptions on the internal
-// mimalloc call-path, so to avoid getting an empty stack trace, emulate these here.
+// mimalloc call-path, so to get `my_failing_function` in the stack trace, emulate this here.
 
 void my_fake_mi_error_message(int err) {
     vespalib::terminate_on_mi_malloc_failure(err, nullptr);

--- a/vespalib/src/tests/util/mimalloc/mimalloc_intercept_test.cpp
+++ b/vespalib/src/tests/util/mimalloc/mimalloc_intercept_test.cpp
@@ -1,0 +1,78 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/mimalloc_intercept.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <absl/debugging/symbolize.h>
+#include <cerrno>
+
+// Utility to force the compiler to assume functions have side effects. Otherwise,
+// it simply cannot resist the temptation to optimize/inline across even functions
+// declared as __attribute__((noipa)).
+// See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+#define VESPA_ENFORCE_FN_SIDE_EFFECTS asm("")
+
+using namespace ::testing;
+
+namespace vespalib {
+
+// Disable all inter-process optimizations for these very simple forwarding functions.
+__attribute__((noipa)) void my_failing_function(int err);
+__attribute__((noipa)) void my_fake_mi_error_message(int err);
+__attribute__((noipa)) void my_fake_mi_malloc_generic(int err);
+
+// The error handler skips a few frames of the stack top due to assumptions on the internal
+// mimalloc call-path, so to get `my_failing_function` in the stack trace, emulate this here.
+
+void my_fake_mi_error_message(int err) {
+    terminate_on_mi_malloc_failure(err, nullptr);
+    VESPA_ENFORCE_FN_SIDE_EFFECTS;
+}
+
+void my_fake_mi_malloc_generic(int err) {
+    my_fake_mi_error_message(err);
+    VESPA_ENFORCE_FN_SIDE_EFFECTS;
+}
+
+void my_failing_function(int err) {
+    my_fake_mi_malloc_generic(err);
+    VESPA_ENFORCE_FN_SIDE_EFFECTS;
+}
+
+TEST(MiMallocErrorHandlerDeathTest, oom_condition_quick_exits_with_stack_trace) {
+    EXPECT_EXIT({ my_failing_function(ENOMEM); }, ExitedWithCode(66),
+                "mimalloc has reported an OOM condition; exiting process.*my_failing_function");
+}
+
+TEST(MiMallocErrorHandlerDeathTest, mimalloc_eagain_aborts_with_double_free_message) {
+    EXPECT_EXIT({ my_failing_function(EAGAIN); }, KilledBySignal(SIGABRT),
+                "mimalloc has reported an invariant violation: double-free");
+}
+
+TEST(MiMallocErrorHandlerDeathTest, mimalloc_efault_aborts_with_corruption_message) {
+    EXPECT_EXIT({ my_failing_function(EFAULT); }, KilledBySignal(SIGABRT),
+                "mimalloc has reported an invariant violation: corrupted free-list or metadata");
+}
+
+TEST(MiMallocErrorHandlerDeathTest, mimalloc_eoverflow_aborts_with_too_large_allocation_message) {
+    EXPECT_EXIT({ my_failing_function(EOVERFLOW); }, KilledBySignal(SIGABRT),
+                "mimalloc has reported an invariant violation: too large allocation request");
+}
+
+TEST(MiMallocErrorHandlerDeathTest, mimalloc_einval_aborts_with_invalid_ptr_message) {
+    EXPECT_EXIT({ my_failing_function(EINVAL); }, KilledBySignal(SIGABRT),
+                "mimalloc has reported an invariant violation: trying to free or reallocate an invalid pointer");
+}
+
+TEST(MiMallocErrorHandlerDeathTest, mimalloc_unknown_errno_aborts_with_unknown_error_and_errno) {
+    EXPECT_EXIT({ my_failing_function(EPERM); }, KilledBySignal(SIGABRT),
+                // \d seems to be broken for GTest regexes (see https://github.com/google/googletest/issues/3084)...
+                R"(mimalloc has reported an invariant violation: \(unknown error\) \(errno .+\))");
+}
+
+} // ns vespalib
+
+int main(int argc, char* argv[]) {
+    absl::InitializeSymbolizer(argv[0]);
+    InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/vespalib/src/vespa/vespalib/util/mimalloc_intercept.cpp
+++ b/vespalib/src/vespa/vespalib/util/mimalloc_intercept.cpp
@@ -31,8 +31,6 @@ namespace vespalib {
 
 namespace {
 
-// `noipa` this function to ensure it gets a stack frame that we can count.
-// See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html for its use vs. `noinline`
 __attribute__((noreturn))
 void terminate_on_mi_malloc_failure_once(int err, [[maybe_unused]] void* arg) {
     // From https://microsoft.github.io/mimalloc/group__extended.html:

--- a/vespalib/src/vespa/vespalib/util/mimalloc_intercept.cpp
+++ b/vespalib/src/vespa/vespalib/util/mimalloc_intercept.cpp
@@ -33,7 +33,7 @@ namespace {
 
 // `noipa` this function to ensure it gets a stack frame that we can count.
 // See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html for its use vs. `noinline`
-__attribute__((noipa, noreturn))
+__attribute__((noreturn))
 void terminate_on_mi_malloc_failure_once(int err, [[maybe_unused]] void* arg) {
     // From https://microsoft.github.io/mimalloc/group__extended.html:
     // "The possible error codes are:
@@ -61,7 +61,9 @@ void terminate_on_mi_malloc_failure_once(int err, [[maybe_unused]] void* arg) {
         // binaries where we already init the symbolizer, so triggering a core for other
         // (presumably less beefy) processes is not necessarily a problem.
         constexpr int max_frames = 32;
-        constexpr int skip_frames = 4; // this frame + terminate_on_mi_malloc_failure + _mi_error_message + _mi_malloc_generic
+        // Don't make any assumptions on which frames can be omitted from the stack trace.
+        // This is both dependent on compiler optimizations and the underlying mimalloc code.
+        constexpr int skip_frames = 0;
         void* frames[max_frames];
         int depth = absl::GetStackTrace(frames, max_frames, skip_frames);
         for (int i = 0; i < depth; ++i) {

--- a/vespalib/src/vespa/vespalib/util/mimalloc_intercept.h
+++ b/vespalib/src/vespa/vespalib/util/mimalloc_intercept.h
@@ -7,7 +7,7 @@ namespace vespalib {
 // Implementation of the `mimalloc_register_error` function callback which
 // prints a stack trace and quick-exits the process on OOM, or invokes abort()
 // upon all other reported failure conditions.
-__attribute__((noipa, noreturn))
+__attribute__((noreturn))
 void terminate_on_mi_malloc_failure(int err, void* fwd_arg);
 
 }

--- a/vespalib/src/vespa/vespalib/util/mimalloc_intercept.h
+++ b/vespalib/src/vespa/vespalib/util/mimalloc_intercept.h
@@ -1,0 +1,13 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace vespalib {
+
+// Implementation of the `mimalloc_register_error` function callback which
+// prints a stack trace and quick-exits the process on OOM, or invokes abort()
+// upon all other reported failure conditions.
+__attribute__((noipa, noreturn))
+void terminate_on_mi_malloc_failure(int err, void* fwd_arg);
+
+}


### PR DESCRIPTION
@johansolbakken please review
@toregge FYI

When `malloc` starts failing in one thread due to process OOM conditions, it's highly likely that other threads will also fail around the same time (assuming their own thread-local free-lists aren't sufficient).

To avoid getting jumbled, interleaved output on `stderr` from a bunch of threads racing to the finish line of printing errors and triggering a process exit, only allow a single thread into the error handler. The rest shall obediently wait forever until the process is terminated by that one thread (where "forever" is expected to be on the order of microseconds in reality).

This also adds death tests for the existing error handler functionality. Testing of only allowing the first thread to enter is not included here since it's inherently a race condition (which results in either killing the process or hanging the thread, neither outcomes being the most test-friendly) and therefore hard to test deterministically.