### PR TITLE
Add support for emitting mimalloc stats to malloc explorer 

### DIFF
--- a/searchcore/src/tests/proton/server/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/CMakeLists.txt
@@ -7,6 +7,7 @@ vespa_add_executable(searchcore_proton_server_gtest_test_app TEST
     feeddebugger_test.cpp
     feedstates_test.cpp
     health_adapter_test.cpp
+    malloc_explorer_test.cpp
     memory_flush_config_updater_test.cpp
     memoryconfigstore_test.cpp
     move_operation_limiter_test.cpp

--- a/searchcore/src/tests/proton/server/malloc_explorer_test.cpp
+++ b/searchcore/src/tests/proton/server/malloc_explorer_test.cpp
@@ -1,0 +1,52 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchcore/proton/server/malloc_info_explorer.h>
+#include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <atomic>
+#include <cassert>
+#include <string>
+#include <dlfcn.h>
+
+namespace {
+std::atomic<bool> override_stats = false;
+}
+
+extern "C" {
+
+using mi_output_fun = void(const char* msg, void* aux_arg);
+using mi_stats_fun_ptr = void(*)(mi_output_fun*, void*);
+
+// Override the symbol exported by mimalloc shared library with our own (which is in
+// the test executable and thus has precedence), causing the state explorer to get mocked
+// string data emitted. To be a good citizen we forward to the real backing call when
+// the test code is _not_ executing... just in case!
+void mi_stats_print_out(mi_output_fun* out_fn, void* arg) {
+#ifdef RTLD_NEXT // "reserved for future use" under POSIX, but implemented functionally under glibc
+    static const auto maybe_real_stats = reinterpret_cast<mi_stats_fun_ptr>(dlsym(RTLD_NEXT, "mi_stats_print_out"));
+    assert(maybe_real_stats != mi_stats_print_out); // No infinite recursion please
+#else
+    const mi_stats_fun_ptr maybe_real_stats = nullptr;
+#endif
+    if (override_stats) {
+        // Ensure we handle multiple output calls as part of one stats call
+        out_fn("here ", arg);
+        out_fn("be ", arg);
+        out_fn("dragons!", arg);
+    } else if (maybe_real_stats) {
+        // Test is running _with_ mimalloc o_o, delegate to it...
+        maybe_real_stats(out_fn, arg);
+    }
+}
+
+} // extern "C"
+
+TEST(MallocExplorerTest, mimalloc_internal_stats_are_emitted) {
+    proton::MallocInfoExplorer explorer;
+    vespalib::Slime result;
+    vespalib::slime::SlimeInserter inserter(result);
+    override_stats = true;
+    explorer.get_state(inserter, true);
+    override_stats = false;
+    EXPECT_EQ(result["raw_internal_info"].asString(), "here be dragons!");
+}

--- a/searchcore/src/vespa/searchcore/proton/server/malloc_info_explorer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/malloc_info_explorer.h
@@ -13,7 +13,7 @@ namespace proton {
  *   1. Implementation independent info via `mallinfo()` or `mallinfo2()` (if supported
  *      by the platform).
  *   2. Malloc-implementation specific information for implementations we know about.
- *      Currently only covers vespamalloc.
+ *      Currently only covers vespamalloc and mimalloc.
  */
 class MallocInfoExplorer : public vespalib::StateExplorer {
 public:


### PR DESCRIPTION
@johansolbakken please review
@toregge FYI

As with `vespamalloc`, `mimalloc` has an API for getting a human readable snapshot of internal allocation statistics. We currently expose this information for `vespamalloc` via `/state/v1/custom/component/mallocinfo`. This PR adds the same support for `mimalloc`.

As with the `vespamalloc` stats support, this uses weak symbol resolving to detect the presence of a particular malloc library and to invoke its statistics dumping API.