### PR TITLE
Add support for `and`, `or` and `not` predicates to filter in grouping

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -2636,6 +2636,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.grouping.request.AndPredicate" : {
+    "superClass" : "com.yahoo.search.grouping.request.FilterExpression",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.util.List)",
+      "public java.util.List getArgs()",
+      "public java.lang.String toString()",
+      "public com.yahoo.search.grouping.request.FilterExpression copy()"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.grouping.request.ArrayAtLookup" : {
     "superClass" : "com.yahoo.search.grouping.request.DocumentValue",
     "interfaces" : [ ],
@@ -3772,6 +3786,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.grouping.request.NotPredicate" : {
+    "superClass" : "com.yahoo.search.grouping.request.FilterExpression",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(com.yahoo.search.grouping.request.FilterExpression)",
+      "public com.yahoo.search.grouping.request.FilterExpression getExpression()",
+      "public java.lang.String toString()",
+      "public com.yahoo.search.grouping.request.FilterExpression copy()"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.grouping.request.NowFunction" : {
     "superClass" : "com.yahoo.search.grouping.request.FunctionNode",
     "interfaces" : [ ],
@@ -3796,6 +3824,20 @@
       "public com.yahoo.search.grouping.request.OrFunction copy()",
       "public static com.yahoo.search.grouping.request.OrFunction newInstance(java.util.List)",
       "public bridge synthetic com.yahoo.search.grouping.request.GroupingExpression copy()"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.search.grouping.request.OrPredicate" : {
+    "superClass" : "com.yahoo.search.grouping.request.FilterExpression",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.util.List)",
+      "public java.util.List getArgs()",
+      "public java.lang.String toString()",
+      "public com.yahoo.search.grouping.request.FilterExpression copy()"
     ],
     "fields" : [ ]
   },

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/AndPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/AndPredicate.java
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.grouping.request;
+
+import com.yahoo.api.annotations.Beta;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a logical conjunction (AND) of filter expressions used to match grouping elements.
+ *
+ * @author johsol
+ */
+@Beta
+public class AndPredicate extends FilterExpression {
+    private final List<FilterExpression> args;
+
+    public AndPredicate(List<FilterExpression> args) {
+        if (args == null || args.size() < 2) {
+            throw new IllegalArgumentException("AndPredicate requires args to contain at least two elements.");
+        }
+        this.args = args;
+    }
+
+    public List<FilterExpression> getArgs() {
+        return args;
+    }
+
+    @Override
+    public String toString() {
+        return "and(" + args.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    @Override
+    public FilterExpression copy() {
+        return new AndPredicate(args.stream().map(FilterExpression::copy).toList());
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.grouping.request;
+
+import com.yahoo.api.annotations.Beta;
+
+import java.util.Objects;
+
+/**
+ * Represents a logical negation (NOT) of a filter expression used to exclude grouping elements.
+ *
+ * @author johsol
+ */
+@Beta
+public class NotPredicate extends FilterExpression {
+    private final FilterExpression expression;
+
+    public NotPredicate(FilterExpression expression) {
+        Objects.requireNonNull(expression, "Expression cannot be null");
+        this.expression = expression;
+    }
+
+    public FilterExpression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public String toString() {
+        return "not(%s)".formatted(expression);
+    }
+
+    @Override
+    public FilterExpression copy() {
+        return new NotPredicate(expression.copy());
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/OrPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/OrPredicate.java
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.grouping.request;
+
+import com.yahoo.api.annotations.Beta;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a logical disjunction (OR) of filter expressions used to match grouping elements.
+ *
+ * @author johsol
+ */
+@Beta
+public class OrPredicate extends FilterExpression {
+    private final List<FilterExpression> args;
+
+    public OrPredicate(List<FilterExpression> args) {
+        if (args == null || args.size() < 2) {
+            throw new IllegalArgumentException("OrPredicate requires args to contain at least two elements.");
+        }
+        this.args = args;
+    }
+
+    public List<FilterExpression> getArgs() {
+        return args;
+    }
+
+    @Override
+    public String toString() {
+        return "or(" + args.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    @Override
+    public FilterExpression copy() {
+        return new OrPredicate(args.stream().map(FilterExpression::copy).toList());
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
@@ -5,6 +5,7 @@ import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.grouping.request.AddFunction;
 import com.yahoo.search.grouping.request.AggregatorNode;
 import com.yahoo.search.grouping.request.AndFunction;
+import com.yahoo.search.grouping.request.AndPredicate;
 import com.yahoo.search.grouping.request.ArrayAtLookup;
 import com.yahoo.search.grouping.request.AttributeFunction;
 import com.yahoo.search.grouping.request.AttributeMapLookupValue;
@@ -61,9 +62,11 @@ import com.yahoo.search.grouping.request.ModFunction;
 import com.yahoo.search.grouping.request.MonthOfYearFunction;
 import com.yahoo.search.grouping.request.MulFunction;
 import com.yahoo.search.grouping.request.NegFunction;
+import com.yahoo.search.grouping.request.NotPredicate;
 import com.yahoo.search.grouping.request.NormalizeSubjectFunction;
 import com.yahoo.search.grouping.request.NowFunction;
 import com.yahoo.search.grouping.request.OrFunction;
+import com.yahoo.search.grouping.request.OrPredicate;
 import com.yahoo.search.grouping.request.PredefinedFunction;
 import com.yahoo.search.grouping.request.RawValue;
 import com.yahoo.search.grouping.request.RegexPredicate;
@@ -103,6 +106,7 @@ import com.yahoo.searchlib.aggregation.XorAggregationResult;
 import com.yahoo.searchlib.expression.AddFunctionNode;
 import com.yahoo.searchlib.expression.AggregationRefNode;
 import com.yahoo.searchlib.expression.AndFunctionNode;
+import com.yahoo.searchlib.expression.AndPredicateNode;
 import com.yahoo.searchlib.expression.ArrayAtLookupNode;
 import com.yahoo.searchlib.expression.AttributeMapLookupNode;
 import com.yahoo.searchlib.expression.AttributeNode;
@@ -130,9 +134,11 @@ import com.yahoo.searchlib.expression.ModuloFunctionNode;
 import com.yahoo.searchlib.expression.MultiArgFunctionNode;
 import com.yahoo.searchlib.expression.MultiplyFunctionNode;
 import com.yahoo.searchlib.expression.NegateFunctionNode;
+import com.yahoo.searchlib.expression.NotPredicateNode;
 import com.yahoo.searchlib.expression.NormalizeSubjectFunctionNode;
 import com.yahoo.searchlib.expression.NumElemFunctionNode;
 import com.yahoo.searchlib.expression.OrFunctionNode;
+import com.yahoo.searchlib.expression.OrPredicateNode;
 import com.yahoo.searchlib.expression.RangeBucketPreDefFunctionNode;
 import com.yahoo.searchlib.expression.RawBucketResultNode;
 import com.yahoo.searchlib.expression.RawBucketResultNodeVector;
@@ -255,6 +261,14 @@ class ExpressionConverter {
     public FilterExpressionNode toFilterExpressionNode(FilterExpression expression) {
         if (expression instanceof RegexPredicate rp) {
             return new RegexPredicateNode(rp.getPattern(), toExpressionNode(rp.getExpression()));
+        }  else if (expression instanceof NotPredicate np) {
+            return new NotPredicateNode(toFilterExpressionNode(np.getExpression()));
+        } else if (expression instanceof OrPredicate op) {
+            var args = op.getArgs().stream().map(this::toFilterExpressionNode).toList();
+            return new OrPredicateNode(args);
+        } else if (expression instanceof AndPredicate ap) {
+            var args = ap.getArgs().stream().map(this::toFilterExpressionNode).toList();
+            return new AndPredicateNode(args);
         } else {
             throw new IllegalInputException(
                     "Can not convert '%s' to a filter expression.".formatted(expression.getClass().getSimpleName()));

--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -24,6 +24,7 @@ PARSER_BEGIN(GroupingParser)
 
 package com.yahoo.search.grouping.request.parser;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.LinkedList;
 import com.yahoo.javacc.UnicodeUtilities;
@@ -131,6 +132,7 @@ TOKEN :
     <MOD: "mod"> |
     <MUL: "mul"> |
     <NEG: "neg"> |
+    <NOT: "not"> |
     <NORMALIZESUBJECT: "normalizesubject"> |
     <NOW: "now"> |
     <OR: "or"> |
@@ -327,7 +329,10 @@ FilterExpression filterExp(GroupingOperation grp) :
     FilterExpression exp;
 }
 {
-    exp = regexPredicate(grp)
+    ( (exp = regexPredicate(grp)) |
+      (exp = notPredicate(grp))   |
+      (exp = orPredicate(grp))    |
+      (exp = andPredicate(grp)))
     { return exp; }
 }
 
@@ -955,6 +960,35 @@ RegexPredicate regexPredicate(GroupingOperation grp) :
     { return new RegexPredicate(pattern, exp); }
 }
 
+NotPredicate notPredicate(GroupingOperation grp) :
+{
+    FilterExpression exp;
+}
+{
+    <NOT> lbrace() exp = filterExp(grp) rbrace()
+    { return new NotPredicate(exp); }
+}
+
+OrPredicate orPredicate(GroupingOperation grp) :
+{
+    FilterExpression exp;
+    List<FilterExpression> args = new ArrayList<FilterExpression>();
+}
+{
+    <OR> lbrace() ( exp = filterExp(grp) { args.add(exp); } ( comma() exp = filterExp(grp) { args.add(exp); } )+ ) rbrace()
+    { return new OrPredicate(args); }
+}
+
+AndPredicate andPredicate(GroupingOperation grp) :
+{
+    FilterExpression exp;
+    List<FilterExpression> args = new ArrayList<FilterExpression>();
+}
+{
+    <AND> lbrace() ( exp = filterExp(grp) { args.add(exp); } ( comma() exp = filterExp(grp) { args.add(exp); } )+ ) rbrace()
+    { return new AndPredicate(args); }
+}
+
 void bucket(GroupingOperation grp, BucketResolver resolver) :
 {
     ConstantValue from, to = null;
@@ -1068,6 +1102,7 @@ String identifier() :
         <MOD> |
         <MUL> |
         <NEG> |
+        <NOT> |
         <NORMALIZESUBJECT> |
         <NOW> |
         <OR> |

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
@@ -107,6 +107,7 @@ public class GroupingParserTestCase {
                 "mod",
                 "mul",
                 "neg",
+                "not",
                 "normalizesubject",
                 "now",
                 "or",
@@ -637,6 +638,12 @@ public class GroupingParserTestCase {
                 () -> assertParse(
                         "all(group($myalias=foo) filter(regex(\".*mysubstring.*\", $myalias)) each(output(count())))",
                         "all(group(foo) filter(regex(\".*mysubstring.*\", foo)) each(output(count())))"));
+
+        assertAll("filter with predicates",
+                () -> assertParse("all(group(foo) filter(not(regex(\"mybar\", foo))) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(or(regex(\"mybar\", foo), regex(\"mybaz\", foo), regex(\"myfoo\", boz))) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(and(regex(\"mybar\", foo), regex(\"mybaz\", foo), regex(\"myfoo\", boz))) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(and(or(regex(\"mybar\", foo), not(regex(\"mybaz\", foo))), regex(\"myfoo\", boz))) each(output(count())))"));
     }
 
     // --------------------------------------------------------------------------------

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
@@ -17,11 +17,14 @@ import com.yahoo.searchlib.aggregation.GroupingLevel;
 import com.yahoo.searchlib.aggregation.HitsAggregationResult;
 import com.yahoo.searchlib.aggregation.SumAggregationResult;
 import com.yahoo.searchlib.expression.AddFunctionNode;
+import com.yahoo.searchlib.expression.AndPredicateNode;
 import com.yahoo.searchlib.expression.AttributeMapLookupNode;
 import com.yahoo.searchlib.expression.AttributeNode;
 import com.yahoo.searchlib.expression.ConstantNode;
 import com.yahoo.searchlib.expression.ExpressionNode;
 import com.yahoo.searchlib.expression.FilterExpressionNode;
+import com.yahoo.searchlib.expression.NotPredicateNode;
+import com.yahoo.searchlib.expression.OrPredicateNode;
 import com.yahoo.searchlib.expression.RegexPredicateNode;
 import com.yahoo.searchlib.expression.StrCatFunctionNode;
 import com.yahoo.searchlib.expression.StringResultNode;
@@ -33,6 +36,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -831,6 +835,18 @@ public class RequestBuilderTestCase {
                 "[[{ Attribute, filter = [Regex [Attribute]] }, { Attribute, result = [Count] }]]");
     }
 
+    @Test
+    void require_that_filter_predicate_layout_is_correct() {
+        assertLayout("all(group(a) filter(not(regex(\".*suffix$\", a))) each(output(count())))",
+                "[[{ Attribute, filter = [Not [Regex [Attribute]]], result = [Count] }]]");
+        assertLayout("all(group(a) filter(or(regex(\".*suffix$\", a),regex(\".*suffix$\", b))) each(output(count())))",
+                "[[{ Attribute, filter = [Or [Regex [Attribute], Regex [Attribute]]], result = [Count] }]]");
+        assertLayout("all(group(a) filter(and(regex(\".*suffix$\", a),regex(\".*suffix$\", b))) each(output(count())))",
+                "[[{ Attribute, filter = [And [Regex [Attribute], Regex [Attribute]]], result = [Count] }]]");
+        assertLayout("all(group(a) filter(and(or(regex(\".*suffix$\", a),regex(\".*suffix$\", b)), not(regex(\".*suffix$\", c)))) each(output(count())))",
+                "[[{ Attribute, filter = [And [Or [Regex [Attribute], Regex [Attribute]], Not [Regex [Attribute]]]], result = [Count] }]]");
+    }
+
     private static void assertTotalGroupsAndSummaries(long expected, String query) {
         assertTotalGroupsAndSummaries(expected, Long.MAX_VALUE, query);
     }
@@ -1088,6 +1104,15 @@ public class RequestBuilderTestCase {
             if (filterExp instanceof RegexPredicateNode rpn) {
                 var simpleName = rpn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
                 return "Regex [%s]".formatted(simpleName);
+            } else if (filterExp instanceof NotPredicateNode npn) {
+                var simpleName = npn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
+                return "Not [%s]".formatted(simpleName);
+            } else if (filterExp instanceof OrPredicateNode opn) {
+                var simpleName = opn.getArgs().stream().map(LayoutWriter::toSimpleName).collect(Collectors.joining(", "));
+                return "Or [%s]".formatted(simpleName);
+            } else if (filterExp instanceof AndPredicateNode apn) {
+                var simpleName = apn.getArgs().stream().map(LayoutWriter::toSimpleName).collect(Collectors.joining(", "));
+                return "And [%s]".formatted(simpleName);
             }
             return filterExp.getClass().getSimpleName();
         }

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -12,6 +12,7 @@ FAULT_TOLERANT=true;
 SMART_NODE_CREATION=false; // Will create a tree node for every rule
 
 INJECT GroupingParser:
+    import java.util.ArrayList;
     import java.util.List;
     import java.util.LinkedList;
     import com.yahoo.javacc.UnicodeUtilities;
@@ -131,6 +132,7 @@ TOKEN :
     <MUL: "mul"> |
     <NEG: "neg"> |
     <NORMALIZESUBJECT: "normalizesubject"> |
+    <NOT: "not"> |
     <NOW: "now"> |
     <OR: "or"> |
     <ORDER: "order"> |
@@ -321,7 +323,10 @@ FilterExpression filterExp(GroupingOperation grp) :
 {
     FilterExpression exp;
 }
-    ( exp = regexPredicate(grp) )
+    ( (exp = regexPredicate(grp)) |
+      (exp = notPredicate(grp))   |
+      (exp = orPredicate(grp))    |
+      (exp = andPredicate(grp)))
     { return exp; }
 ;
 
@@ -948,6 +953,32 @@ RegexPredicate regexPredicate(GroupingOperation grp) :
     { return new RegexPredicate(pattern, exp); }
 ;
 
+NotPredicate notPredicate(GroupingOperation grp) :
+{
+    FilterExpression exp;
+}
+    ( <NOT> lbraceElm exp = filterExp(grp) rbraceElm )
+    { return new NotPredicate(exp); }
+;
+
+OrPredicate orPredicate(GroupingOperation grp) :
+{
+    FilterExpression exp;
+    List<FilterExpression> args = new ArrayList<FilterExpression>();
+}
+    ( <OR> lbraceElm ( exp = filterExp(grp) { args.add(exp); } ( commaElm exp = filterExp(grp) { args.add(exp); } )+ ) rbraceElm )
+    { return new OrPredicate(args); }
+;
+
+AndPredicate andPredicate(GroupingOperation grp) :
+{
+    FilterExpression exp;
+    List<FilterExpression> args = new ArrayList<FilterExpression>();
+}
+    ( <AND> lbraceElm ( exp = filterExp(grp) { args.add(exp); } ( commaElm exp = filterExp(grp) { args.add(exp); } )+ ) rbraceElm )
+    { return new AndPredicate(args); }
+;
+
 bucketElm(GroupingOperation grp, BucketResolver resolver) :
 {
     ConstantValue from, to = null;
@@ -1058,6 +1089,7 @@ String identifierStr :
         <MUL> |
         <NEG> |
         <NORMALIZESUBJECT> |
+        <NOT> |
         <NOW> |
         <OR> |
         <ORDER> |

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaTextDocumentService.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaTextDocumentService.java
@@ -203,6 +203,8 @@ public class SchemaTextDocumentService implements TextDocumentService {
                 EventFormattingContext context = eventContextCreator.createContext(params);
                 return SchemaFormatting.computeFormattingEdits(context);
             } catch (InvalidContextException ignore) {
+            } catch (Exception e) {
+                logger.error("Error during formatting request: " + e.getMessage());
             }
             return List.of();
         });
@@ -215,6 +217,8 @@ public class SchemaTextDocumentService implements TextDocumentService {
                 EventRangeFormattingContext context = eventContextCreator.createContext(params);
                 return SchemaFormatting.computeRangeFormattingEdits(context);
             } catch (InvalidContextException ignore) {
+            } catch (Exception e) {
+                logger.error("Error during range formatting request: " + e.getMessage());
             }
             return List.of();
         });

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/context/EventFormattingContext.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/context/EventFormattingContext.java
@@ -6,6 +6,7 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import ai.vespa.schemals.SchemaMessageHandler;
 import ai.vespa.schemals.index.SchemaIndex;
 import ai.vespa.schemals.schemadocument.SchemaDocumentScheduler;
+import ai.vespa.schemals.schemadocument.DocumentManager.DocumentType;
 
 public class EventFormattingContext extends EventDocumentContext {
 
@@ -15,6 +16,11 @@ public class EventFormattingContext extends EventDocumentContext {
             SchemaMessageHandler messageHandler, TextDocumentIdentifier documentIdentifier, FormattingOptions formattingOptions)
             throws InvalidContextException {
         super(scheduler, schemaIndex, messageHandler, documentIdentifier);
+
+        if (this.document.getDocumentType() == DocumentType.YQL) {
+            throw new InvalidContextException("Formatting not supported for yql (yet).");
+        }
+
         this.formattingOptions = formattingOptions;
     }
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/context/InvalidContextException.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/context/InvalidContextException.java
@@ -4,4 +4,8 @@ public class InvalidContextException extends Exception {
     public InvalidContextException() {
         super();
     }
+
+    public InvalidContextException(String message) {
+        super(message);
+    }
 }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/YQLCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/YQLCompletion.java
@@ -9,6 +9,7 @@ import ai.vespa.schemals.context.EventCompletionContext;
 import ai.vespa.schemals.lsp.common.completion.CompletionProvider;
 import ai.vespa.schemals.lsp.yqlplus.completion.provider.GroupOperationCompletion;
 import ai.vespa.schemals.lsp.yqlplus.completion.provider.GroupingExpressionProvider;
+import ai.vespa.schemals.lsp.yqlplus.completion.provider.GroupingFilterProvider;
 import ai.vespa.schemals.lsp.yqlplus.completion.provider.RootCompletion;
 import ai.vespa.schemals.lsp.yqlplus.completion.provider.RootGroupingCompletion;
 
@@ -21,7 +22,8 @@ public class YQLCompletion {
         new RootCompletion(),
         new RootGroupingCompletion(),
         new GroupOperationCompletion(),
-        new GroupingExpressionProvider()
+        new GroupingExpressionProvider(),
+        new GroupingFilterProvider()
     };
 
     public static ArrayList<CompletionItem> getCompletionItems(EventCompletionContext context, PrintStream errorLogger) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/provider/GroupOperationCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/provider/GroupOperationCompletion.java
@@ -32,7 +32,7 @@ public class GroupOperationCompletion implements CompletionProvider {
         add(CompletionUtils.constructSnippet("output", "output($1)$0"));
         add(CompletionUtils.constructSnippet("precision", "precision(${1:number})$0"));
         add(CompletionUtils.constructSnippet("where", "where($1)$0"));
-        add(CompletionUtils.constructSnippet("filter", "filter(regex(\"$1\", $2))$0"));
+        add(CompletionUtils.constructSnippet("filter", "filter($0)"));
     }};
 
     private final static List<CompletionItem> allEachCompletionItems = new ArrayList<>() {{

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/provider/GroupingFilterProvider.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/provider/GroupingFilterProvider.java
@@ -1,0 +1,37 @@
+package ai.vespa.schemals.lsp.yqlplus.completion.provider;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+
+import ai.vespa.schemals.context.EventCompletionContext;
+import ai.vespa.schemals.lsp.common.completion.CompletionProvider;
+import ai.vespa.schemals.lsp.common.completion.CompletionUtils;
+import ai.vespa.schemals.parser.grouping.ast.expElm;
+import ai.vespa.schemals.parser.grouping.ast.filterExp;
+import ai.vespa.schemals.tree.CSTUtils;
+import ai.vespa.schemals.tree.Node;
+
+public class GroupingFilterProvider implements CompletionProvider {
+
+    @Override
+    public List<CompletionItem> getCompletionItems(EventCompletionContext context) {
+        Node node = CSTUtils.getLastCleanNode(context.document.getRootYQLNode(), context.position);
+
+        if (node == null) {
+            return List.of();
+        }
+
+        // Match: inside filter, but not expression
+        if (CSTUtils.findASTClassAncestor(node, expElm.class) != null) return List.of();
+        if (CSTUtils.findASTClassAncestor(node, filterExp.class) == null) return List.of();
+
+        return List.of(
+            CompletionUtils.constructSnippet("regex", "regex(\"$1\", $2)"),
+            CompletionUtils.constructSnippet("and", "and($0)"),
+            CompletionUtils.constructSnippet("or", "or($0)"),
+            CompletionUtils.constructSnippet("not", "not($0)")
+        );
+    }
+}

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/semantictokens/VespaGroupingSemanticTokenConfig.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/semantictokens/VespaGroupingSemanticTokenConfig.java
@@ -84,6 +84,7 @@ class VespaGroupingSemanticToken {
         put(AT.class, SemanticTokenTypes.Keyword);
 
         put(ADD.class, simpleExpressions);
+        put(AND.class, simpleExpressions);
         put(ALIAS.class, simpleExpressions); // TODO: Verify that this is a function
         put(ATTRIBUTE.class, simpleExpressions);
         put(AVG.class, simpleExpressions);
@@ -100,6 +101,7 @@ class VespaGroupingSemanticToken {
         put(MUL.class, simpleExpressions);
         put(NEG.class, simpleExpressions);
         put(NORMALIZESUBJECT.class, simpleExpressions);
+        put(NOT.class, simpleExpressions);
         put(NOW.class, simpleExpressions);
         put(OR.class, simpleExpressions);
         put(PREDEFINED.class, simpleExpressions);

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/YQLParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/YQLParserTest.java
@@ -195,6 +195,7 @@ public class YQLParserTest {
             "select * from sources * where ({stem: false}(foo contains \"a\" and bar contains \"b\")) or foo contains ({stem: false}\"c\")",
             "select * from sources * where foo contains @animal and foo contains phrase(@animal, @syntaxExample, @animal)",
             "select * from sources * where sddocname contains 'purchase' | all(group(customer) each(output(sum(price))))",
+            "select * from sources * where true | all(group(customer) filter(and(regex(\"foo\", bar), or(not(regex(\"baz\", a)), regex(\"b\", b)))) each(output(sum(price))))",
         };
 
         Stream<String> queryStream = Stream.concat(Arrays.stream(queries), Arrays.stream(groupingQueries));

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/AndPredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/AndPredicateNode.java
@@ -1,0 +1,59 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.expression;
+
+import com.yahoo.vespa.objects.Deserializer;
+import com.yahoo.vespa.objects.ObjectVisitor;
+import com.yahoo.vespa.objects.Serializer;
+
+import java.util.List;
+
+/**
+ * Protocol class for {@code AndPredicate}.
+ *
+ * @author johsol
+ */
+public class AndPredicateNode extends MultiArgPredicateNode {
+
+    public static final int classId = registerClass(0x4000 + 177, AndPredicateNode.class, AndPredicateNode::new);
+
+    public AndPredicateNode() {}
+
+    public AndPredicateNode(List<FilterExpressionNode> args) {
+        super(args);
+    }
+
+    @Override
+    protected int onGetClassId() {
+        return classId;
+    }
+
+    @Override
+    public FilterExpressionNode clone() {
+        return new AndPredicateNode(getArgs().stream().map(FilterExpressionNode::clone).toList());
+    }
+
+    @Override
+    protected void onSerialize(Serializer buf) {
+        super.onSerialize(buf);
+    }
+
+    @Override
+    protected void onDeserialize(Deserializer buf) {
+        super.onDeserialize(buf);
+    }
+
+    @Override
+    public void visitMembers(ObjectVisitor visitor) {
+        super.visitMembers(visitor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/MultiArgPredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/MultiArgPredicateNode.java
@@ -1,0 +1,88 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.expression;
+
+import com.yahoo.vespa.objects.Deserializer;
+import com.yahoo.vespa.objects.ObjectVisitor;
+import com.yahoo.vespa.objects.Serializer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Protocol class for descendants of {@code FilterExpressionNode} that has several {@code FilterExpressionNode} as children.
+ *
+ * @author johsol
+ */
+public abstract class MultiArgPredicateNode extends FilterExpressionNode {
+
+    public static final int classId = registerClass(0x4000 + 175, MultiArgPredicateNode.class);
+    private List<FilterExpressionNode> args = new ArrayList<>();
+
+    public MultiArgPredicateNode() {}
+
+    public MultiArgPredicateNode(List<FilterExpressionNode> args) {
+        this.args = args;
+    }
+
+    public final MultiArgPredicateNode addArg(FilterExpressionNode arg) {
+        Objects.requireNonNull(arg, "Can not add null arg");
+        args.add(arg);
+        return this;
+    }
+
+    public FilterExpressionNode getArg(int i) {
+        return args.get(i);
+    }
+
+    public int getNumArgs() {
+        return args.size();
+    }
+
+    public List<FilterExpressionNode> getArgs() {
+        return args;
+    }
+
+    @Override
+    protected int onGetClassId() {
+        return classId;
+    }
+
+    @Override
+    protected void onSerialize(Serializer buf) {
+        int numArgs = args.size();
+        buf.putInt(null, numArgs);
+        for (FilterExpressionNode node : args) {
+            serializeOptional(buf, node);
+        }
+    }
+
+    @Override
+    protected void onDeserialize(Deserializer buf) {
+        args.clear();
+        int numArgs = buf.getInt(null);
+        for (int i = 0; i < numArgs; i++) {
+            FilterExpressionNode node = (FilterExpressionNode)deserializeOptional(buf);
+            args.add(node);
+        }
+    }
+
+    @Override
+    public void visitMembers(ObjectVisitor visitor) {
+        super.visitMembers(visitor);
+        visitor.visit("args", args);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MultiArgPredicateNode rhs = (MultiArgPredicateNode)o;
+        return args.equals(rhs.args);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(args);
+    }
+}

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/NotPredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/NotPredicateNode.java
@@ -1,0 +1,70 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.expression;
+
+import com.yahoo.vespa.objects.Deserializer;
+import com.yahoo.vespa.objects.ObjectVisitor;
+import com.yahoo.vespa.objects.Serializer;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Protocol class for {@code NotPredicate}.
+ *
+ * @author johsol
+ */
+public class NotPredicateNode extends FilterExpressionNode {
+
+    public static final int classId = registerClass(0x4000 + 174, NotPredicateNode.class, NotPredicateNode::new);
+
+    private FilterExpressionNode expression;
+
+    public NotPredicateNode() {}
+
+    public NotPredicateNode(FilterExpressionNode expression) {
+        this.expression = expression;
+    }
+
+    public Optional<FilterExpressionNode> getExpression() {
+        return Optional.ofNullable(expression);
+    }
+
+    @Override
+    protected int onGetClassId() {
+        return classId;
+    }
+
+    @Override
+    public FilterExpressionNode clone() {
+        return new NotPredicateNode(expression != null ? expression.clone() : null);
+    }
+
+    @Override
+    protected void onSerialize(Serializer buf) {
+        serializeOptional(buf, expression);
+    }
+
+    @Override
+    protected void onDeserialize(Deserializer buf) {
+        expression = (FilterExpressionNode)deserializeOptional(buf);
+    }
+
+    @Override
+    public void visitMembers(ObjectVisitor visitor) {
+        super.visitMembers(visitor);
+        visitor.visit("expression", expression);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NotPredicateNode that = (NotPredicateNode) o;
+        return Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expression);
+    }
+}

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/OrPredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/OrPredicateNode.java
@@ -1,0 +1,60 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.expression;
+
+import com.yahoo.vespa.objects.Deserializer;
+import com.yahoo.vespa.objects.ObjectVisitor;
+import com.yahoo.vespa.objects.Serializer;
+
+import java.util.List;
+
+/**
+ * Protocol class for {@code OrPredicate}.
+ *
+ * @author johsol
+ */
+public class OrPredicateNode extends MultiArgPredicateNode {
+
+    public static final int classId = registerClass(0x4000 + 176, OrPredicateNode.class, OrPredicateNode::new);
+
+    public OrPredicateNode() {
+    }
+
+    public OrPredicateNode(List<FilterExpressionNode> args) {
+        super(args);
+    }
+
+    @Override
+    public FilterExpressionNode clone() {
+        return new OrPredicateNode(getArgs().stream().map(FilterExpressionNode::clone).toList());
+    }
+
+    @Override
+    protected int onGetClassId() {
+        return classId;
+    }
+
+    @Override
+    protected void onSerialize(Serializer buf) {
+        super.onSerialize(buf);
+    }
+
+    @Override
+    protected void onDeserialize(Deserializer buf) {
+        super.onDeserialize(buf);
+    }
+
+    @Override
+    public void visitMembers(ObjectVisitor visitor) {
+        super.visitMembers(visitor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/searchlib/src/tests/expression/filter_predicate_node/filter_predicate_node_test.cpp
+++ b/searchlib/src/tests/expression/filter_predicate_node/filter_predicate_node_test.cpp
@@ -1,68 +1,171 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/expression/and_predicate_node.h>
 #include <vespa/searchlib/expression/constantnode.h>
 #include <vespa/searchlib/expression/stringresultnode.h>
 #include <vespa/searchlib/expression/filter_predicate_node.h>
+#include <vespa/searchlib/expression/not_predicate_node.h>
+#include <vespa/searchlib/expression/or_predicate_node.h>
 #include <vespa/searchlib/expression/regex_predicate_node.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace search::expression;
 
-struct Fixture {
-    std::unique_ptr<StringResultNode> _input;
+/**
+ * Defines methods for declaratively creating filter expression trees.
+ */
+class FilterPredicateNodesTest : public ::testing::Test {
     std::unique_ptr<FilterPredicateNode> _node;
 
-    Fixture();
-    ~Fixture();
+protected:
+    FilterPredicateNodesTest();
 
-    Fixture& setup_doc(const char * field_value);
-    // Fixture& setup_doc(std::vector<std::string> field_value);
-    Fixture& setup_node(std::string regex_value);
-    bool evaluate();
+    ~FilterPredicateNodesTest() override;
+
+public:
+    [[nodiscard]] bool evaluate() const;
+
+    FilterPredicateNodesTest& set_node(std::unique_ptr<FilterPredicateNode> node);
+
+    static std::unique_ptr<FilterPredicateNode> make_regex(const std::string& regex_value,
+                                                           std::unique_ptr<ExpressionNode> result_node);
+
+    static std::unique_ptr<FilterPredicateNode> make_not(std::unique_ptr<FilterPredicateNode> filter_node);
+
+    template<typename... Nodes>
+    static std::unique_ptr<FilterPredicateNode> make_or(Nodes... nodes);
+
+    template<typename... Nodes>
+    static std::unique_ptr<FilterPredicateNode> make_and(Nodes... nodes);
+
+    static std::unique_ptr<ExpressionNode> make_result(const std::string& value);
 };
 
-Fixture::Fixture() : _input(), _node() {}
-Fixture::~Fixture() = default;
+FilterPredicateNodesTest::FilterPredicateNodesTest() = default;
 
+FilterPredicateNodesTest::~FilterPredicateNodesTest() = default;
 
-Fixture&
-Fixture::setup_doc(const char * field_value)
-{
-    _input = std::make_unique<StringResultNode>(field_value);
-    return *this;
-}
-
-Fixture&
-Fixture::setup_node(std::string regex_value)
-{
-    _node = std::make_unique<RegexPredicateNode>(regex_value,
-                                                 std::make_unique<ConstantNode>(
-                                                         ResultNode::UP(_input->clone())));
-    return *this;
-}
-
-bool
-Fixture::evaluate()
-{
+bool FilterPredicateNodesTest::evaluate() const {
     return _node->allow(42, 17.25);
 }
 
+FilterPredicateNodesTest& FilterPredicateNodesTest::set_node(std::unique_ptr<FilterPredicateNode> node) {
+    _node = std::move(node);
+    return *this;
+}
 
-class RegexFilterTest : public Fixture, public ::testing::Test
-{
-protected:
-    RegexFilterTest();
-    ~RegexFilterTest() override;
-};
+std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_regex(const std::string& regex_value,
+                                                                          std::unique_ptr<ExpressionNode> result_node) {
+    return std::make_unique<RegexPredicateNode>(regex_value, std::move(result_node));
+}
 
-RegexFilterTest::RegexFilterTest() = default;
-RegexFilterTest::~RegexFilterTest() = default;
+std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_not(std::unique_ptr<FilterPredicateNode> filter_node) {
+    return std::make_unique<NotPredicateNode>(std::move(filter_node));
+}
 
-TEST_F(RegexFilterTest, test_regex_match)
-{
-    EXPECT_TRUE(setup_doc("foobar").setup_node("foo.*").evaluate());
-    EXPECT_FALSE(setup_doc("foobar").setup_node("foo").evaluate());
-    EXPECT_FALSE(setup_doc("foobar").setup_node("bar").evaluate());
+template<typename... Nodes>
+std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_or(Nodes... nodes) {
+    auto or_predicate = std::make_unique<OrPredicateNode>();
+    (or_predicate->args().emplace_back(std::move(nodes)), ...);
+    return or_predicate;
+}
+
+template<typename... Nodes>
+std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_and(Nodes... nodes) {
+    auto and_predicate = std::make_unique<AndPredicateNode>();
+    (and_predicate->args().emplace_back(std::move(nodes)), ...);
+    return and_predicate;
+}
+
+std::unique_ptr<ExpressionNode> FilterPredicateNodesTest::make_result(const std::string& value) {
+    return std::make_unique<ConstantNode>(std::make_unique<StringResultNode>(value));
+}
+
+TEST_F(FilterPredicateNodesTest, test_regex_match) {
+    EXPECT_TRUE(set_node(make_regex("foo.*", make_result("foobar"))).evaluate());
+    EXPECT_FALSE(set_node(make_regex("foo", make_result("foobar"))).evaluate());
+    EXPECT_FALSE(set_node(make_regex("bar", make_result("foobar"))).evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_not_predicate) {
+    EXPECT_FALSE(set_node(make_not(make_regex("foo.*", make_result("foobar")))).evaluate());
+    EXPECT_TRUE(set_node(make_not(make_regex("foo", make_result("foobar")))).evaluate());
+    EXPECT_TRUE(set_node(make_not(make_regex("bar", make_result("foobar")))).evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_or_no_match) {
+    EXPECT_FALSE(
+        set_node(make_or(
+            make_regex("foo", make_result("foobar")),
+            make_regex("bar", make_result("foobar")))).
+        evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_or_one_match) {
+    EXPECT_TRUE(
+        set_node(make_or(
+            make_regex("foo", make_result("foobar")),
+            make_regex("foobar", make_result("foobar")))).
+        evaluate());
+    EXPECT_TRUE(
+        set_node(make_or(
+            make_regex("foobar", make_result("foobar")),
+            make_regex("bar", make_result("foobar")))).
+        evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_or_three_arguments) {
+    EXPECT_TRUE(
+        set_node(make_or(
+            make_regex("foo", make_result("foobar")),
+            make_regex("foobar", make_result("foobar")),
+            make_regex("baz", make_result("foobar")))).
+        evaluate());
+    EXPECT_FALSE(
+        set_node(make_or(
+            make_regex("foo", make_result("foobar")),
+            make_regex("bar", make_result("foobar")),
+            make_regex("baz", make_result("foobar")))).
+        evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_and_no_match) {
+    EXPECT_FALSE(
+        set_node(make_and(
+            make_regex("foo", make_result("foobar")),
+            make_regex("bar", make_result("foobar")))).
+        evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_and_one_match) {
+    EXPECT_FALSE(
+        set_node(make_and(
+            make_regex("foobar", make_result("foobar")),
+            make_regex("bar", make_result("foobar")))).
+        evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_and_all_match) {
+    EXPECT_TRUE(
+        set_node(make_and(
+            make_regex("foo", make_result("foo")),
+            make_regex("bar", make_result("bar")))).
+        evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_and_three_arguments) {
+    EXPECT_TRUE(
+        set_node(make_and(
+            make_regex("foo", make_result("foo")),
+            make_regex("bar", make_result("bar")),
+            make_regex("baz", make_result("baz")))).
+        evaluate());
+    EXPECT_FALSE(
+        set_node(make_and(
+            make_regex("foo", make_result("foo")),
+            make_regex("bar", make_result("bar")),
+            make_regex("baz", make_result("foobar")))).
+        evaluate());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/common/identifiable.h
+++ b/searchlib/src/vespa/searchlib/common/identifiable.h
@@ -180,3 +180,7 @@
 #define CID_search_SparseSketch                             SEARCHLIB_CID(171)
 #define CID_search_expression_RegexPredicateNode            SEARCHLIB_CID(172)
 // #define CID_search_expression_TruePredicateNode             SEARCHLIB_CID(173)
+#define CID_search_expression_NotPredicateNode              SEARCHLIB_CID(174)
+#define CID_search_expression_MultiArgPredicateNode         SEARCHLIB_CID(175)
+#define CID_search_expression_OrPredicateNode               SEARCHLIB_CID(176)
+#define CID_search_expression_AndPredicateNode              SEARCHLIB_CID(177)

--- a/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
@@ -39,5 +39,9 @@ vespa_add_library(searchlib_expression OBJECT
     floatresultnode.cpp
     integerresultnode.cpp
     regex_predicate_node.cpp
+    not_predicate_node.cpp
+    multi_arg_predicate_node.cpp
+    or_predicate_node.cpp
+    and_predicate_node.cpp
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/expression/and_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/and_predicate_node.cpp
@@ -19,10 +19,10 @@ AndPredicateNode::AndPredicateNode(const AndPredicateNode&) = default;
 AndPredicateNode& AndPredicateNode::operator=(const AndPredicateNode&) = default;
 
 bool AndPredicateNode::allow(const DocId docId, const HitRank rank) {
-    return std::ranges::all_of(args(), [docId, rank](auto arg){ return arg->allow(docId, rank); });
+    return std::ranges::all_of(args(), [docId, rank](auto& arg){ return arg->allow(docId, rank); });
 }
 
 bool AndPredicateNode::allow(const document::Document& doc, const HitRank rank) {
-    return std::ranges::all_of(args(), [&doc, rank](auto arg){ return arg->allow(doc, rank); });
+    return std::ranges::all_of(args(), [&doc, rank](auto& arg){ return arg->allow(doc, rank); });
 }
 } // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/and_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/and_predicate_node.cpp
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "and_predicate_node.h"
+#include "resultnode.h"
+
+#include <algorithm>
+
+namespace search::expression {
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+IMPLEMENT_IDENTIFIABLE_NS2(search, expression, AndPredicateNode, MultiArgPredicateNode);
+
+AndPredicateNode::AndPredicateNode() noexcept = default;
+
+AndPredicateNode::~AndPredicateNode() = default;
+
+AndPredicateNode::AndPredicateNode(const AndPredicateNode&) = default;
+
+AndPredicateNode& AndPredicateNode::operator=(const AndPredicateNode&) = default;
+
+bool AndPredicateNode::allow(const DocId docId, const HitRank rank) {
+    return std::ranges::all_of(args(), [docId, rank](auto arg){ return arg->allow(docId, rank); });
+}
+
+bool AndPredicateNode::allow(const document::Document& doc, const HitRank rank) {
+    return std::ranges::all_of(args(), [&doc, rank](auto arg){ return arg->allow(doc, rank); });
+}
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/and_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/and_predicate_node.h
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "expressiontree.h"
+#include "filter_predicate_node.h"
+#include "multi_arg_predicate_node.h"
+
+namespace search::expression {
+
+/**
+ * Implements logical AND filter used in grouping expressions.
+ **/
+class AndPredicateNode : public MultiArgPredicateNode {
+public:
+    AndPredicateNode() noexcept;
+    ~AndPredicateNode() override;
+    AndPredicateNode(const AndPredicateNode&);
+    AndPredicateNode& operator=(const AndPredicateNode&);
+
+    [[nodiscard]] AndPredicateNode* clone() const override { return new AndPredicateNode(*this); }
+
+    DECLARE_IDENTIFIABLE_NS2(search, expression, AndPredicateNode);
+
+    bool allow(DocId docId, HitRank rank) override;
+    bool allow(const document::Document&, HitRank) override;
+};
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/filter_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/filter_predicate_node.h
@@ -11,6 +11,8 @@ namespace search::expression {
 class FilterPredicateNode : public vespalib::Identifiable
 {
 public:
+    using IP = vespalib::IdentifiablePtr<FilterPredicateNode>;
+
     DECLARE_IDENTIFIABLE_ABSTRACT_NS2(search, expression, FilterPredicateNode);
     virtual FilterPredicateNode * clone() const = 0;
     //virtual bool valid() const = 0;

--- a/searchlib/src/vespa/searchlib/expression/multi_arg_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/multi_arg_predicate_node.cpp
@@ -1,0 +1,56 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "multi_arg_predicate_node.h"
+#include "resultvector.h"
+
+#include <vespa/vespalib/objects/serializer.hpp>
+#include <vespa/vespalib/objects/deserializer.hpp>
+#include <vespa/vespalib/util/exceptions.h>
+
+namespace search::expression {
+
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS2(search, expression, MultiArgPredicateNode, FilterPredicateNode);
+
+MultiArgPredicateNode::MultiArgPredicateNode() noexcept = default;
+
+MultiArgPredicateNode::~MultiArgPredicateNode() = default;
+
+MultiArgPredicateNode::MultiArgPredicateNode(const MultiArgPredicateNode&) = default;
+
+MultiArgPredicateNode& MultiArgPredicateNode::operator=(const MultiArgPredicateNode&) = default;
+
+MultiArgPredicateNode::MultiArgPredicateNode(const std::vector<FilterPredicateNode::IP>& input) {
+    for (const auto& node : input) {
+        _args.emplace_back(node->clone());
+    }
+}
+
+Serializer& MultiArgPredicateNode::onSerialize(Serializer& os) const {
+    return os << _args;
+}
+
+Deserializer& MultiArgPredicateNode::onDeserialize(Deserializer& is) {
+    is >> _args;
+
+    if (std::ranges::any_of(_args, [](const auto& arg){ return arg.get() == nullptr; })) {
+        throw vespalib::IllegalArgumentException("Filter predicate node received non-present argument node.");
+    }
+
+    return is;
+}
+
+void MultiArgPredicateNode::visitMembers(vespalib::ObjectVisitor& visitor) const {
+    visit(visitor, "args", _args);
+}
+
+void MultiArgPredicateNode::selectMembers(const vespalib::ObjectPredicate& predicate,
+                                                vespalib::ObjectOperation& operation) {
+    FilterPredicateNode::selectMembers(predicate, operation);
+    for(auto& _arg : _args) {
+        _arg->select(predicate, operation);
+    }
+}
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/multi_arg_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/multi_arg_predicate_node.h
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "expressiontree.h"
+#include "filter_predicate_node.h"
+
+namespace search::expression {
+
+/**
+ * Abstract base class for predicate nodes with multiple children.
+ **/
+class MultiArgPredicateNode : public FilterPredicateNode {
+    using FilterPredicateNodeVector = std::vector<FilterPredicateNode::IP>;
+    FilterPredicateNodeVector _args;
+
+public:
+    MultiArgPredicateNode() noexcept;
+    ~MultiArgPredicateNode() override;
+    MultiArgPredicateNode(const MultiArgPredicateNode&);
+    MultiArgPredicateNode& operator=(const MultiArgPredicateNode&);
+
+    explicit MultiArgPredicateNode(const std::vector<FilterPredicateNode::IP>& input);
+
+    DECLARE_IDENTIFIABLE_ABSTRACT_NS2(search, expression, MultiArgPredicateNode);
+    DECLARE_NBO_SERIALIZE;
+
+    void visitMembers(vespalib::ObjectVisitor& visitor) const override;
+    void selectMembers(const vespalib::ObjectPredicate& predicate,
+                       vespalib::ObjectOperation& operation) override;
+
+    [[nodiscard]] FilterPredicateNodeVector& args() noexcept { return _args; }
+    [[nodiscard]] const FilterPredicateNodeVector& args() const noexcept { return _args; }
+};
+}

--- a/searchlib/src/vespa/searchlib/expression/not_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/not_predicate_node.cpp
@@ -1,0 +1,60 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "not_predicate_node.h"
+
+#include <vespa/vespalib/util/exceptions.h>
+
+#include "resultnode.h"
+#include "resultvector.h"
+
+namespace search::expression {
+
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+IMPLEMENT_IDENTIFIABLE_NS2(search, expression, NotPredicateNode, FilterPredicateNode);
+
+NotPredicateNode::NotPredicateNode() noexcept = default;
+
+NotPredicateNode::~NotPredicateNode() = default;
+
+NotPredicateNode::NotPredicateNode(const NotPredicateNode&) = default;
+
+NotPredicateNode& NotPredicateNode::operator=(const NotPredicateNode&) = default;
+
+NotPredicateNode::NotPredicateNode(std::unique_ptr<FilterPredicateNode> input)
+  : _expression(std::move(input))
+{
+}
+
+Serializer& NotPredicateNode::onSerialize(Serializer& os) const {
+    return os << _expression;
+}
+
+Deserializer& NotPredicateNode::onDeserialize(Deserializer& is) {
+    is >> _expression;
+
+    if (_expression.get() == nullptr) {
+        throw vespalib::IllegalArgumentException("Filter predicate node received non-present argument node.");
+    }
+
+    return is;
+}
+
+bool NotPredicateNode::allow(DocId docId, HitRank rank) {
+    return !_expression->allow(docId, rank);
+}
+
+bool NotPredicateNode::allow(const document::Document& doc, HitRank rank) {
+    return !_expression->allow(doc, rank);
+}
+
+void NotPredicateNode::visitMembers(vespalib::ObjectVisitor& visitor) const {
+    visit(visitor, "expression", _expression);
+}
+
+void NotPredicateNode::selectMembers(const vespalib::ObjectPredicate& predicate,
+                                           vespalib::ObjectOperation& operation) {
+    _expression->select(predicate, operation);
+}
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/not_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/not_predicate_node.h
@@ -1,0 +1,36 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "expressiontree.h"
+#include "filter_predicate_node.h"
+
+namespace search::expression {
+
+/**
+ * Implements logical NOT filter used in grouping expressions for negating sub filter expressions.
+ **/
+class NotPredicateNode : public FilterPredicateNode {
+    FilterPredicateNode::IP _expression;
+
+public:
+    NotPredicateNode() noexcept;
+    ~NotPredicateNode() override;
+    NotPredicateNode(const NotPredicateNode&);
+    NotPredicateNode& operator=(const NotPredicateNode&);
+
+    [[nodiscard]] NotPredicateNode* clone() const override { return new NotPredicateNode(*this); }
+
+    // for unit testing::
+    explicit NotPredicateNode(std::unique_ptr<FilterPredicateNode> input);
+
+    DECLARE_IDENTIFIABLE_NS2(search, expression, NotPredicateNode);
+    DECLARE_NBO_SERIALIZE;
+
+    bool allow(DocId docId, HitRank rank) override;
+    bool allow(const document::Document&, HitRank) override;
+    void visitMembers(vespalib::ObjectVisitor& visitor) const override;
+    void selectMembers(const vespalib::ObjectPredicate& predicate,
+                       vespalib::ObjectOperation& operation) override;
+};
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/or_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/or_predicate_node.cpp
@@ -1,0 +1,30 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "or_predicate_node.h"
+#include "resultnode.h"
+
+#include <algorithm>
+
+namespace search::expression {
+
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+IMPLEMENT_IDENTIFIABLE_NS2(search, expression, OrPredicateNode, MultiArgPredicateNode);
+
+OrPredicateNode::OrPredicateNode() noexcept = default;
+
+OrPredicateNode::~OrPredicateNode() = default;
+
+OrPredicateNode::OrPredicateNode(const OrPredicateNode&) = default;
+
+OrPredicateNode& OrPredicateNode::operator=(const OrPredicateNode&) = default;
+
+bool OrPredicateNode::allow(const DocId docId, const HitRank rank) {
+    return std::ranges::any_of(args(), [docId, rank](auto arg){ return arg->allow(docId, rank); });
+}
+
+bool OrPredicateNode::allow(const document::Document& doc, const HitRank rank) {
+    return std::ranges::any_of(args(), [&doc, rank](auto arg){ return arg->allow(doc, rank); });
+}
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/or_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/or_predicate_node.cpp
@@ -20,11 +20,11 @@ OrPredicateNode::OrPredicateNode(const OrPredicateNode&) = default;
 OrPredicateNode& OrPredicateNode::operator=(const OrPredicateNode&) = default;
 
 bool OrPredicateNode::allow(const DocId docId, const HitRank rank) {
-    return std::ranges::any_of(args(), [docId, rank](auto arg){ return arg->allow(docId, rank); });
+    return std::ranges::any_of(args(), [docId, rank](auto& arg){ return arg->allow(docId, rank); });
 }
 
 bool OrPredicateNode::allow(const document::Document& doc, const HitRank rank) {
-    return std::ranges::any_of(args(), [&doc, rank](auto arg){ return arg->allow(doc, rank); });
+    return std::ranges::any_of(args(), [&doc, rank](auto& arg){ return arg->allow(doc, rank); });
 }
 
 } // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/or_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/or_predicate_node.h
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "expressiontree.h"
+#include "filter_predicate_node.h"
+#include "multi_arg_predicate_node.h"
+
+namespace search::expression {
+
+/**
+ * Implements logical OR filter used in grouping expressions.
+ **/
+class OrPredicateNode : public MultiArgPredicateNode {
+public:
+    OrPredicateNode() noexcept;
+    ~OrPredicateNode() override;
+    OrPredicateNode(const OrPredicateNode&);
+    OrPredicateNode& operator=(const OrPredicateNode&);
+
+    [[nodiscard]] OrPredicateNode* clone() const override { return new OrPredicateNode(*this); }
+
+    DECLARE_IDENTIFIABLE_NS2(search, expression, OrPredicateNode);
+
+    bool allow(DocId docId, HitRank rank) override;
+    bool allow(const document::Document&, HitRank) override;
+};
+
+} // namespace search::expression


### PR DESCRIPTION
This commit adds three rules in `filterExp` to the grouping parser.

In Java public API it extends the public interface with `NotPredicate`,
`AndPredicate` and `OrPredicate`.

And, it extends identifiable with 4 new node types:
`MultiArgPredicateNode`, `OrPredicateNode`, `AndPredicateNode` and
`NotPredicateNode` in Java and C++.

@vekterli please review
@arnej27959 FYI