### PR TITLE
Magnus/lsp illegal argument handling

### DIFF
--- a/integration/schema-language-server/clients/vscode/package-lock.json
+++ b/integration/schema-language-server/clients/vscode/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/hasbin": "^1.2.2",
         "@types/mocha": "^10.0.6",
-        "@types/node": "20.x",
+        "@types/node": "^20.19.9",
         "@types/vscode": "^1.72.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
@@ -963,12 +963,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.5.tgz",
-      "integrity": "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -5487,10 +5488,11 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/integration/schema-language-server/clients/vscode/package.json
+++ b/integration/schema-language-server/clients/vscode/package.json
@@ -11,7 +11,7 @@
   "categories": [
     "Programming Languages",
     "Snippets",
-    "Other" 
+    "Other"
   ],
   "keywords": [
     "Vespa",
@@ -19,7 +19,7 @@
     "YQL"
   ],
   "repository": {
-    "type": "git",  
+    "type": "git",
     "url": "https://github.com/vespa-engine/vespa"
   },
   "icon": "images/icon.png",
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@types/hasbin": "^1.2.2",
     "@types/mocha": "^10.0.6",
-    "@types/node": "20.x",
+    "@types/node": "^20.19.9",
     "@types/vscode": "^1.72.0",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",

--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -2053,14 +2053,7 @@ void onnxModelItem(OnnxModel onnxModel) :
                     lastConsumedToken.addIllegalArgumentException(ex);
                 }
             } 
-        | (path = uriItem()) 
-            {
-                try {
-                    onnxModel.setUri(path);
-                } catch (IllegalArgumentException ex) {
-                    lastConsumedToken.addIllegalArgumentException(ex);
-                }
-            } 
+        | (uriInOnnxModel(onnxModel)) 
         | <GPU_DEVICE> <COLON> num = integerElm() 
             {
                 try {
@@ -2148,6 +2141,23 @@ String uriItem() :
 
   (<URI> <COLON> ( <URI_PATH> ) { path = lastConsumedToken.toString(); } (<NL>)*) { return path; }
 ;
+
+void uriInOnnxModel(OnnxModel onnxModel) :
+{
+   String path;
+   Token uriToken;
+}
+
+  (<URI> { uriToken = lastConsumedToken; } <COLON> ( <URI_PATH> ) { path = lastConsumedToken.toString(); } (<NL>)*) 
+{ 
+    try {
+        onnxModel.setUri(path);
+    } catch (IllegalArgumentException ex) {
+        uriToken.addIllegalArgumentException(ex);
+    }
+  }
+;
+
 
 String rankingConstantErrorMessage(String name) : {}
 

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -48,6 +48,62 @@ INJECT GroupingParserLexer:
     }
 }
 
+/**
+ * By allowing tokens to store exceptions we create a more fault tolerant parser,
+ * preventing premature exit from parsing even though the user has errors in the document.
+ *
+ * ParseExceptions are syntactical errors, so storing them is mainly to provide a better indication on
+ * where the error occurred (rather than "there is some error in this document").
+ *
+ * IllegalArgumentExceptions come from the Parsed* classes in config-model, these are more semantic errors
+ * coming from invalid constructs that can be caught early during parsing. They do however not cover all errors that
+ * can occur in schemas when deploying an application.
+ */
+INJECT Token :
+{
+
+    public class ParseExceptionSource {
+        public ParseException parseException;
+        public int beginOffset;
+        public int endOffset;
+
+        ParseExceptionSource(ParseException e, int beginOffset, int endOffset) {
+            parseException = e;
+            this.beginOffset = beginOffset;
+            this.endOffset = endOffset;
+        }
+    }
+
+    private ParseExceptionSource parseExceptionSource;
+    public ParseExceptionSource getParseExceptionSource() { return parseExceptionSource; }
+
+    void addParseException(ParseException e, int beginOffset, int endOffset) {
+        parseExceptionSource = new ParseExceptionSource(e, beginOffset, endOffset);
+        setDirty(true);
+    }
+
+    void addParseException(ParseException e) {
+        addParseException(e, getBeginOffset(), getEndOffset());
+    }
+
+    public class IllegalArgumentExceptionSource {
+        public IllegalArgumentException illegalArgumentException;
+        public Token endToken;
+
+        IllegalArgumentExceptionSource(IllegalArgumentException e, Token endToken) {
+            illegalArgumentException = e;
+            this.endToken = endToken;
+        }
+    }
+
+    private IllegalArgumentException illegalArgumentException;
+    public IllegalArgumentException getIllegalArgumentException() { return illegalArgumentException; }
+
+    void addIllegalArgumentException(IllegalArgumentException e) {
+        illegalArgumentException = e;
+    }
+
+}
         
 TOKEN :
     <INTEGER: <DECIMAL> (["l","L"])? | <HEX> (["l","L"])? | <OCTAL> (["l","L"])?> |
@@ -950,7 +1006,15 @@ RegexPredicate regexPredicate(GroupingOperation grp) :
     GroupingExpression exp;
 }
     ( <REGEX> lbraceElm pattern = stringElm commaElm exp = expElm(grp) rbraceElm )
-    { return new RegexPredicate(pattern, exp); }
+    { 
+        try {
+            return new RegexPredicate(pattern, exp); 
+        } catch (IllegalArgumentException ex) {
+            // This can happen if the regex is not valid
+            lastConsumedToken.addIllegalArgumentException(ex);
+            return new RegexPredicate("", exp);
+        }
+    }
 ;
 
 NotPredicate notPredicate(GroupingOperation grp) :

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -244,12 +244,13 @@ UNPARSED :
   <MULTI_LINE_COMMENT: "/*" (~["*"])* "*" (~["*","/"] (~["*"])* "*" | "*")* "/" >
 ;
 
-
-// --------------------------------------------------------------------------------
-//
-// Production rules.
-//
-// --------------------------------------------------------------------------------
+/*
+ * --------------------------------------------------------------------------------
+ *
+ * Production rules.
+ *
+ * -------------------------------------------------------------------------------
+ */
 
 List<GroupingOperation> requestList :
 {
@@ -1004,14 +1005,15 @@ RegexPredicate regexPredicate(GroupingOperation grp) :
 {
     String pattern;
     GroupingExpression exp;
+    Token stringToken;
 }
-    ( <REGEX> lbraceElm pattern = stringElm commaElm exp = expElm(grp) rbraceElm )
+    ( <REGEX> lbraceElm pattern = stringElm { stringToken = lastConsumedToken; } commaElm exp = expElm(grp) rbraceElm )
     { 
         try {
             return new RegexPredicate(pattern, exp); 
         } catch (IllegalArgumentException ex) {
             // This can happen if the regex is not valid
-            lastConsumedToken.addIllegalArgumentException(ex);
+            stringToken.addIllegalArgumentException(ex);
             return new RegexPredicate("", exp);
         }
     }

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -55,7 +55,7 @@ INJECT GroupingParserLexer:
  * ParseExceptions are syntactical errors, so storing them is mainly to provide a better indication on
  * where the error occurred (rather than "there is some error in this document").
  *
- * IllegalArgumentExceptions come from the Parsed* classes in config-model, these are more semantic errors
+ * IllegalArgumentExceptions come from the returned classes from for example container-search, these are more semantic errors
  * coming from invalid constructs that can be caught early during parsing. They do however not cover all errors that
  * can occur in schemas when deploying an application.
  */

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/RankProfileDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/RankProfileDocument.java
@@ -65,6 +65,7 @@ public class RankProfileDocument implements DocumentManager {
     @Override
     public ParseContext getParseContext() {
         ParseContext context = new ParseContext(content, logger, fileURI, schemaIndex, this.scheduler);
+        context.useGeneralIdentifers();
         context.useRankProfileIdentifiers();
         return context;
     }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocument.java
@@ -79,6 +79,7 @@ public class SchemaDocument implements DocumentManager {
     @Override
     public ParseContext getParseContext() {
         ParseContext context = new ParseContext(content, this.logger, this.fileURI, this.schemaIndex, this.scheduler);
+        context.useGeneralIdentifers();
         context.useDocumentIdentifiers();
         return context;
     }
@@ -269,7 +270,11 @@ public class SchemaDocument implements DocumentManager {
             SchemaRankingExpressionParser.embedCST(context, node, diagnostics);
         }
 
-        for (Identifier<SchemaNode> identifier : context.identifiers()) {
+        for (Identifier<SchemaNode> identifier : context.schemaIdentifiers()) {
+            identifier.identify(node, diagnostics);
+        }
+
+        for (Identifier<ai.vespa.schemals.tree.Node> identifier : context.generalIdentifiers()) {
             identifier.identify(node, diagnostics);
         }
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/YQLDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/YQLDocument.java
@@ -70,7 +70,8 @@ public class YQLDocument implements DocumentManager {
     @Override
     public ParseContext getParseContext() {
         ParseContext context = new ParseContext(fileContent, logger, fileURI, schemaIndex, scheduler);
-        context.useVespaGroupingIdentifiers();
+        context.useGeneralIdentifers();
+        context.useYqlAndGroupingIdentifiers();
         return context;
     }
 
@@ -251,6 +252,10 @@ public class YQLDocument implements DocumentManager {
     private static void traverseCST(YQLNode node, ParseContext context, ArrayList<Diagnostic> diagnostics) {
 
         for (Identifier<YQLNode> identifier : context.YQLIdentifiers()) {
+            identifier.identify(node, diagnostics);
+        }
+
+        for (Identifier<ai.vespa.schemals.tree.Node> identifier : context.generalIdentifiers()) {
             identifier.identify(node, diagnostics);
         }
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/common/IdentifyIllegalArgumentNodes.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/common/IdentifyIllegalArgumentNodes.java
@@ -1,0 +1,59 @@
+package ai.vespa.schemals.schemadocument.parser.common;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+import ai.vespa.schemals.common.SchemaDiagnostic;
+import ai.vespa.schemals.context.ParseContext;
+import ai.vespa.schemals.schemadocument.parser.Identifier;
+import ai.vespa.schemals.tree.Node;
+import ai.vespa.schemals.tree.Node.LanguageType;
+
+public class IdentifyIllegalArgumentNodes extends Identifier<Node> {
+
+    public IdentifyIllegalArgumentNodes(ParseContext context) {
+        super(context);
+    }
+
+    @Override
+    public void identify(Node node, List<Diagnostic> diagnostics) {
+        if (node.getLanguageType() == LanguageType.SCHEMA
+            && (node.getSchemaNode().getOriginalSchemaNode() instanceof ai.vespa.schemals.parser.Token))
+        {
+            ai.vespa.schemals.parser.Token nodeAsToken 
+                = (ai.vespa.schemals.parser.Token)node.getSchemaNode().getOriginalSchemaNode();
+
+            maybeAddToDiagnostics(
+                diagnostics,
+                node,
+                nodeAsToken.getIllegalArgumentException()
+            );
+        }
+
+        if (node.getLanguageType() == LanguageType.GROUPING 
+            && (node.getYQLNode().getOriginalGroupingNode() instanceof ai.vespa.schemals.parser.grouping.Token)) 
+        {
+            ai.vespa.schemals.parser.grouping.Token nodeAsGroupingToken 
+                = (ai.vespa.schemals.parser.grouping.Token)node.getYQLNode().getOriginalGroupingNode();
+
+            maybeAddToDiagnostics(
+                diagnostics,
+                node,
+                nodeAsGroupingToken.getIllegalArgumentException()
+            );
+        }
+    }
+
+    private void maybeAddToDiagnostics(List<Diagnostic> diagnostics, Node node, Exception ex) {
+        if (ex == null) return;
+
+        diagnostics.add(new SchemaDiagnostic.Builder()
+            .setRange(node.getRange())
+            .setMessage(ex.getMessage())
+            .setSeverity(DiagnosticSeverity.Error)
+            .build()
+        );
+    }
+}

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/schema/IdentifyDirtySchemaNodes.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/schema/IdentifyDirtySchemaNodes.java
@@ -61,17 +61,7 @@ public class IdentifyDirtySchemaNodes extends Identifier<SchemaNode> {
                 .build());
         }
 
-        IllegalArgumentException illegalArgumentException = nodeAsToken.getIllegalArgumentException();
-
-        if (illegalArgumentException != null) {
-            diagnostics.add(new SchemaDiagnostic.Builder()
-                .setRange(node.getRange())
-                .setMessage(illegalArgumentException.getMessage())
-                .setSeverity(DiagnosticSeverity.Error)
-                .build());
-        }
-
-        if (parseException == null && illegalArgumentException == null) {
+        if (parseException == null && nodeAsToken.getIllegalArgumentException() == null) {
             pureDirtyNodeIdentifier.identify(node, diagnostics);
         }
     }

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.TestFactory;
 
 import com.yahoo.io.IOUtils;
 
-import ai.vespa.schemals.common.ClientLogger;
 import ai.vespa.schemals.common.FileUtils;
 import ai.vespa.schemals.context.ParseContext;
 import ai.vespa.schemals.index.SchemaIndex;
@@ -29,6 +28,7 @@ public class SchemaParserTest {
 
     ParseResult parseString(String input, String fileName) throws Exception {
         ParseContext context = Utils.createTestContext(input, fileName);
+        context.useGeneralIdentifers();
         context.useDocumentIdentifiers();
         return SchemaDocument.parseContent(context);
     }

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/YQLParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/YQLParserTest.java
@@ -22,6 +22,7 @@ public class YQLParserTest {
 
     ParseResult parseString(String input, String fileName) throws Exception {
         ParseContext context = Utils.createTestContext(input, fileName);
+        context.useGeneralIdentifers();
         context.useYqlAndGroupingIdentifiers();
         return YQLDocument.parseContent(context);
     }

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/YQLParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/YQLParserTest.java
@@ -6,11 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 import ai.vespa.schemals.context.ParseContext;
@@ -24,7 +22,7 @@ public class YQLParserTest {
 
     ParseResult parseString(String input, String fileName) throws Exception {
         ParseContext context = Utils.createTestContext(input, fileName);
-        context.useVespaGroupingIdentifiers();
+        context.useYqlAndGroupingIdentifiers();
         return YQLDocument.parseContent(context);
     }
 
@@ -209,6 +207,7 @@ public class YQLParserTest {
     Stream<DynamicTest> InvalidQuery() throws Exception {
         var queries = new TestWithError[] {
             new TestWithError(1, "seletc *"),
+            new TestWithError(1, "select * from sources * where true | all(group(foo) filter(regex(\"*\", field)))"),
             // new TestWithError(1, "select * from sources * where true | all(group(a) order(attr * count()) each(output(count())) )"),
         };
 

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/testutils/TestSchemaMessageHandler.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/testutils/TestSchemaMessageHandler.java
@@ -1,6 +1,5 @@
 package ai.vespa.schemals.testutils;
 
-import java.io.StringWriter;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/testutils/TestSchemaProgressHandler.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/testutils/TestSchemaProgressHandler.java
@@ -3,7 +3,6 @@ package ai.vespa.schemals.testutils;
 import java.util.UUID;
 
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageClient;
 
 import ai.vespa.schemals.SchemaProgressHandler;
 


### PR DESCRIPTION
Fixed bug where parser would crash if an invalid regex was given in grouping filter(regex(...)).
Generalized handling of illegal arguments in the parsers.
Minor change to uri element in onnx-model (which is not supported so there is always an illegal argument).