### PR TITLE
Use `constexpr` `std::bit_cast` for BFloat16 float<->u16 conversions

### DIFF
--- a/vespalib/src/tests/util/bfloat16_test.cpp
+++ b/vespalib/src/tests/util/bfloat16_test.cpp
@@ -108,6 +108,11 @@ TEST(BFloat16Test, traits_check) {
         EXPECT_TRUE(std::has_unique_object_representations<BFloat16>::value);
 }
 
+TEST(BFloat16Test, conversion_is_constexpr) {
+    static_assert(BFloat16(10).get_bits()  == 16672u);
+    static_assert(BFloat16(123).get_bits() == 17142u);
+}
+
 static std::string hexdump(const void *p, size_t sz) {
     char tmpbuf[10];
     if (sz == 2) {

--- a/vespalib/src/vespa/vespalib/util/bfloat16.h
+++ b/vespalib/src/vespa/vespalib/util/bfloat16.h
@@ -31,7 +31,7 @@ private:
     static constexpr uint16_t float_to_bits(float value) noexcept {
         TwoU16 both{0,0};
         static_assert(sizeof(TwoU16) == sizeof(float));
-        memcpy(&both, &value, sizeof(float));
+        both = std::bit_cast<TwoU16>(value);
         if constexpr (native_endian == std::endian::big) {
             return both.u1;
         } else {
@@ -53,7 +53,7 @@ private:
         }
         float result = 0.0;
         static_assert(sizeof(TwoU16) == sizeof(float));
-        memcpy(&result, &both, sizeof(float));
+        result = std::bit_cast<float>(both);
         return result;
     }
 public:


### PR DESCRIPTION
@arnej27959 please review

`memcpy` is not `constexpr`, so using it in a  `constexpr` function in an actual compile-time context will fail. Using `std::bit_cast` avoids this issue.
