### PR TITLE
Tokenize early in linguistics mode

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
@@ -205,9 +205,9 @@ public class StemmingSearcher extends Searcher {
         if (segments.isEmpty()) return blockAsItem;
 
         String indexName = current.getIndexName();
-        Substring substring = getOffsets(current);
+        Substring origin = getOffsets(current);
         if (segments.size() == 1) {
-            TaggableItem w = singleWordSegment(current, segments.get(0), index, substring, context.insidePhrase);
+            TaggableItem w = singleWordSegment(current, segments.get(0), index, origin, context.insidePhrase);
             setMetaData(current, context.reverseConnectivity, w);
             return (Item)w;
         }
@@ -218,7 +218,7 @@ public class StemmingSearcher extends Searcher {
             composite = chooseComposite(current, ((Item) current).getParent(), indexName);
 
         for (StemList segment : segments) {
-            TaggableItem w = singleWordSegment(current, segment, index, substring, context.insidePhrase);
+            TaggableItem w = singleWordSegment(current, segment, index, origin, context.insidePhrase);
 
             if (composite instanceof AndSegmentItem) {
                 setSignificanceAndDocumentFrequency(w, current);
@@ -299,7 +299,7 @@ public class StemmingSearcher extends Searcher {
     private TaggableItem singleWordSegment(BlockItem current,
                                            StemList segment,
                                            Index index,
-                                           Substring substring,
+                                           Substring origin,
                                            boolean insidePhrase) {
         String indexName = current.getIndexName();
         if (!insidePhrase && ((index.getLiteralBoost() || index.getStemMode() == StemMode.ALL))) {
@@ -308,12 +308,12 @@ public class StemmingSearcher extends Searcher {
             for (String term : segment) {
                 terms.add(new Alternative(term, 0.7d));
             }
-            WordAlternativesItem alternatives = new WordAlternativesItem(indexName, current.isFromQuery(), substring, terms);
+            WordAlternativesItem alternatives = new WordAlternativesItem(indexName, current.isFromQuery(), origin, terms);
             if (alternatives.getAlternatives().size() > 1) {
                 return alternatives;
             }
         }
-        return singleStemSegment((Item) current, segment.get(0), indexName, substring);
+        return singleStemSegment((Item) current, segment.get(0), indexName, origin);
     }
 
     private void setMetaData(BlockItem current, Map<Item, TaggableItem> reverseConnectivity, TaggableItem replacement) {
@@ -328,8 +328,8 @@ public class StemmingSearcher extends Searcher {
     }
 
     private WordItem singleStemSegment(Item blockAsItem, String stem, String indexName,
-                                       Substring substring) {
-        WordItem replacement = new WordItem(stem, indexName, true, substring);
+                                       Substring origin) {
+        WordItem replacement = new WordItem(stem, indexName, true, origin);
         replacement.setStemmed(true);
         copyAttributes(blockAsItem, replacement);
         return replacement;

--- a/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
@@ -1279,6 +1279,24 @@ public class QueryTestCase {
     }
 
     @Test
+    void testLinguisticsModeWithSingleTerm() {
+        var profile = new QueryProfile("test");
+        profile.set("model.type", "linguistics", null);
+        profile.set("model.type.isYqlDefault", "true", null);
+        var query = new Query(httpEncode("?yql=select * from sources * where default contains 'Cars'"),
+                              profile.compile(null));
+        Result r = new Execution(new Chain<>(new MinimalQueryInserter()), Execution.Context.createContextStub()).search(query);
+        assertEquals("select * from sources * where default contains ({stem: false, normalizeCase: false, accentDrop: false}\"car\")",
+                     query.yqlRepresentation());
+
+        var word = (WordItem)query.getModel().getQueryTree().getRoot();
+        // Further token processing is disabled due to type=linguistics applied by default to all terms
+        assertTrue(word.isStemmed());
+        assertFalse(word.isNormalizable());
+        assertTrue(word.isLowercased());
+    }
+
+    @Test
     void testLinguisticsModeWithPhraseSegment() {
         var profile = new QueryProfile("test");
         profile.set("model.type", "linguistics", null);


### PR DESCRIPTION
Since 'linguistics' mode will do all token processing in one pass, tokenization should be invoked instead of segmentation, as segmentation returns the original form of each token, anticipating further processing.
