### PR TITLE
Ignore output to stdout

### DIFF
--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerApplication.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerApplication.java
@@ -43,6 +43,8 @@ import org.w3c.dom.Element;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -154,6 +156,10 @@ public class StandaloneContainerApplication implements Application {
         try {
             com.yahoo.container.Container.get().setCustomFileAcquirer(distributedFiles);
             com.yahoo.container.Container.get().disableUrlDownloader();
+            // Ignore output to stdout
+            System.setOut(new PrintStream(new OutputStream() {
+                public void write(int b) { }
+            }));
             configuredApplication.start();
         } catch (Exception e) {
             com.yahoo.container.Container.resetInstance();


### PR DESCRIPTION
Avoid filling log with stdout output from dependencies that unfortunately write to stdout in some situations. We will not get output to stdout from our own code, but that should use proper logging anyway, so I don't think this should be an issue. Trying to change this with standalone container first.