### PR TITLE
Carry oveer the weight of the source term to the composite

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/PhraseItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/PhraseItem.java
@@ -107,9 +107,7 @@ public class PhraseItem extends CompositeIndexedItem {
             addIndexedItem(index, (IndexedItem) item);
         } else if (item instanceof IntItem) {
             addIndexedItem(index, convertIntToWord(item));
-        } else if (item instanceof PhraseItem) {
-            PhraseItem phrase = (PhraseItem) item;
-
+        } else if (item instanceof PhraseItem phrase) {
             for (Iterator<Item> i = phrase.getItemIterator(); i.hasNext();) {
                 addIndexedItem(index++, (WordItem) i.next());
             }
@@ -189,10 +187,8 @@ public class PhraseItem extends CompositeIndexedItem {
     /**
      * Returns a subitem as a block item,
      *
-     * @param index
-     *            the (0-base) index of the item to return
-     * @throws IndexOutOfBoundsException
-     *             if there is no subitem at index
+     * @param index the (0-base) index of the item to return
+     * @throws IndexOutOfBoundsException if there is no subitem at index
      */
     public BlockItem getBlockItem(int index) {
         return (BlockItem) getItem(index);
@@ -211,11 +207,9 @@ public class PhraseItem extends CompositeIndexedItem {
         for (Iterator<Item> i = getItemIterator(); i.hasNext();) {
             Item subitem = i.next();
 
-            if (subitem instanceof PhraseSegmentItem) {
-                PhraseSegmentItem seg = (PhraseSegmentItem) subitem;
-
+            if (subitem instanceof PhraseSegmentItem segment) {
                 // "What encode does, minus what encodeThis does"
-                itemCount += seg.encodeContent(buffer);
+                itemCount += segment.encodeContent(buffer);
             } else {
                 itemCount += subitem.encode(buffer);
             }
@@ -241,14 +235,10 @@ public class PhraseItem extends CompositeIndexedItem {
         for (Iterator<Item> i = getItemIterator(); i.hasNext();) {
             Item item = i.next();
 
-            if (item instanceof WordItem) {
-                WordItem wordItem = (WordItem) item;
-
+            if (item instanceof WordItem wordItem) {
                 buffer.append(wordItem.getWord());
-            } else if (item instanceof PhraseSegmentItem) {
-                PhraseSegmentItem seg = (PhraseSegmentItem) item;
-
-                seg.appendContentsString(buffer);
+            } else if (item instanceof PhraseSegmentItem segment) {
+                segment.appendContentsString(buffer);
             } else {
                 buffer.append(item.toString());
             }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/NGramSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/NGramSearcher.java
@@ -122,6 +122,7 @@ public class NGramSearcher extends Searcher {
         String index = ((HasIndexItem)term).getIndexName();
         CompositeItem gramsItem = createGramRoot((HasIndexItem)term, query);
         gramsItem.setIndexName(index);
+        gramsItem.setWeight(term.getWeight());
         Substring origin = ((BlockItem)term).getOrigin();
         for (Iterator<GramSplitter.Gram> i = getGramSplitter().split(text, gramSize); i.hasNext(); ) {
             GramSplitter.Gram gram = i.next();

--- a/container-search/src/test/java/com/yahoo/search/querytransform/test/NGramSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/test/NGramSearcherTestCase.java
@@ -191,6 +191,12 @@ public class NGramSearcherTestCase {
         }
     }
 
+    @Test
+    void testWeightsArePreserved() {
+        assertEquals("WEAKAND(100) (AND gram2:ab!200 gram2:bc!200)!200", search("?query=gram2:abc!200&gram.match=all"));
+        assertEquals("WEAKAND(100) gram2:\"ab bc\"!200", search("?query=gram2:abc!200&gram.match=phrase"));
+    }
+
     String search(String query) {
         Query q = new Query(query);
         createExecution().search(q);


### PR DESCRIPTION
This is necessary because a phrase enforces that children added have the same weight as itself.
