### PR TITLE
Magnus/lsp small bugs

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -142,7 +142,10 @@ public class BuiltInFunctions {
         ), Set.of(
             "", // empty not actually allowed, but here for completion
             "firstPosition", 
-            "occurences"
+            "lastPosition",
+            "occurrences",
+            "weight",
+            "exactness"
         ))));
 
         put("matchCount", new GenericFunction("mathCount", new FunctionSignature(new FieldArgument(FieldType.STRING, FieldArgument.IndexAttributeType))));

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -310,7 +310,7 @@ public class SchemaParserTest {
             new BadFileTestCase("../../../config-model/src/test/examples/rankingexpressionfunction/rankingexpressionfunction.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/rankpropvars.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/stemmingresolver.sd", 1),
-            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 42),
+            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 41),
             new BadFileTestCase("../../../config-model/src/test/derived/renamedfeatures/foo.sd", 4),
 
             new BadFileTestCase("../../../config-model/src/test/derived/rankprofiles/rankprofiles.sd", 1), // only throws a warning during vespa deploy, but it is an unresolved reference case.

--- a/integration/schema-language-server/resources/CHANGENOTES.txt
+++ b/integration/schema-language-server/resources/CHANGENOTES.txt
@@ -1,2 +1,2 @@
-- Added support for 'elementwise' rank feature.
-- Improved ranking expression analysis and diagnostics.
+- Add some missing rank feature properties.
+- Fixed minor bugs.


### PR DESCRIPTION
Add some missing rank feature properties.
Ignore diagnostics on onnx-model outside rank-profile (which is deprecated).
