### PR TITLE
add casts for "char" variants

### DIFF
--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -7,6 +7,7 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     gtest_runner.cpp
     bfloat16_test.cpp
     bits_test.cpp
+    casts_test.cpp
     cgroup_resource_limits_test.cpp
     crc_test.cpp
     crypto_test.cpp

--- a/vespalib/src/tests/util/casts_test.cpp
+++ b/vespalib/src/tests/util/casts_test.cpp
@@ -1,0 +1,43 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/casts.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using namespace vespalib;
+
+TEST(CastsTest, test_char_pointer_casts)
+{
+    char ca[5] = "foo1";
+    unsigned char ua[5] = "foo2";
+
+    char *cp = ca;
+    unsigned char *up = ua;
+    const char *ccp = "foo3";
+    const unsigned char *cup = up;
+
+    unsigned char *t1 = char_p_cast<unsigned char>(cp);
+    const unsigned char *t2 = char_p_cast<unsigned char>(ccp);
+
+    char *t3 = char_p_cast<char>(up);
+    const char *t4 = char_p_cast<char>(cup);
+
+    EXPECT_EQ((char *)t1, cp);
+    EXPECT_EQ((const char *)t2, ccp);
+    EXPECT_EQ(t3, (char *)up);
+    EXPECT_EQ(t4, (const char *)cup);
+
+    auto t5 = char_p_cast<char>(up);
+    auto t6 = char_p_cast<char>(cup);
+    EXPECT_TRUE((std::same_as<decltype(t5), char *>));
+    EXPECT_TRUE((std::same_as<decltype(t6), const char *>));
+}
+
+TEST(CastsTest, test_u8_literal)
+{
+    constexpr const char8_t *one = u8"Blåbær før München";
+    constexpr const char *two = u8"Blåbær før München"_C;
+    for (int i = 0; one[i] != 0; i++) {
+        EXPECT_EQ(uint8_t(one[i]), uint8_t(two[i]));
+    }
+    EXPECT_GT(strlen(two), 20);
+}

--- a/vespalib/src/vespa/vespalib/util/casts.h
+++ b/vespalib/src/vespa/vespalib/util/casts.h
@@ -1,0 +1,78 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace vespalib {
+
+/*
+ * Template wrapping casts between different variants of
+ * "char *" pointers.
+ *
+ * This is exactly the same as the usual reinterpret_cast,
+ * but restricted so the argument must be one of the
+ * expected types (char *, unsigned char *, char8_t *)
+ * with appropriate constness.
+ *
+ * Usage:
+ *  unsigned char *input;
+ *  char *x = char_p_cast<char>(input);
+ * Author: arnej
+ */
+template<typename T,
+         typename U,
+         typename R = std::conditional_t<std::is_const_v<U>, const T *, T *>>
+R char_p_cast(U* input) {
+    // currently we do not want to get char8_t, may change later:
+    static_assert(std::is_same<T, char>::value ||
+                  std::is_same<T, unsigned char>::value);
+    using DU = std::decay<U>::type;
+    static_assert(std::is_same<DU, char>::value ||
+                  std::is_same<DU, unsigned char>::value ||
+                  std::is_same<DU, char8_t>::value);
+    return reinterpret_cast<R>(input);
+}
+
+/*
+ * Helper templates for char8_t[] literals; * from:
+ * https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r3.html
+ */
+template<std::size_t N>
+struct char8_t_string_literal {
+  static constexpr inline std::size_t size = N;
+  template<std::size_t... I>
+  constexpr char8_t_string_literal(const char8_t (&r)[N],
+                                   std::index_sequence<I...>)
+    : s{r[I]...}
+  {}
+  constexpr char8_t_string_literal(const char8_t (&r)[N])
+    : char8_t_string_literal(r, std::make_index_sequence<N>())
+  {}
+  char8_t s[N];
+};
+
+template<char8_t_string_literal L, std::size_t... I>
+constexpr inline const char as_char_buffer[sizeof...(I)] =
+  { static_cast<char>(L.s[I])... };
+
+template<char8_t_string_literal L, std::size_t... I>
+constexpr auto& make_as_char_buffer(std::index_sequence<I...>) {
+  return as_char_buffer<L, I...>;
+}
+
+
+} // namespace
+
+
+/**
+ * String literal operator converting char8_t[] to char[]
+ *
+ * Usage example: const char *s = u8"Münich"_C;
+ */
+template<vespalib::char8_t_string_literal L>
+constexpr auto& operator""_C() {
+    return vespalib::make_as_char_buffer<L>(std::make_index_sequence<decltype(L)::size>());
+}


### PR DESCRIPTION
I've experimented with this for replacing some of the `reinterpret_cast` code converting between `unsigned char *`  and `char *`

Not sure if the name `char_p_cast` is the best; we could also consider `sign_cast` (possibly extending to other similar casts).

I have also included a string literal operator after some research, this can replace various instances of `char_from_u8` and can actually be used in constexpr contexts (doesn't need `reinterpret_cast`).

Please review/discuss.