### PR TITLE
Throw if select-elements-by references undefined summary feature

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/SummaryElementsSelectorValidator.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/SummaryElementsSelectorValidator.java
@@ -16,7 +16,6 @@ import com.yahoo.vespa.documentmodel.SummaryField;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 
 import java.util.Set;
-import java.util.logging.Level;
 
 import static com.yahoo.schema.document.ComplexAttributeFieldUtils.isSupportedComplexField;
 
@@ -74,9 +73,7 @@ public class SummaryElementsSelectorValidator extends Processor {
         if (!found) {
             var message = formatError(schema, summary, field, "select-elements-by summary feature '" + summaryFeatureName +
                     "' is not defined for source field '" + sourceField.getName() + "'.");
-            // Just log a warning for now, as this is not a critical error, consider always throwing an exception later
-            // throw new IllegalArgumentException(formatError(schema, summary, field, message));
-            deployLogger.logApplicationPackage(Level.WARNING, message);
+            throw new IllegalArgumentException(formatError(schema, summary, field, message));
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/processing/SummaryElementsSelectorValidator.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/SummaryElementsSelectorValidator.java
@@ -69,7 +69,7 @@ public class SummaryElementsSelectorValidator extends Processor {
                                        .stream()
                                        .map(RankProfile::getSummaryFeatures)
                                        .flatMap(Set::stream)
-                                       .anyMatch(s -> s.getName().equals(summaryFeatureName));
+                                       .anyMatch(s -> s.toString().equals(summaryFeatureName));
         if (!found) {
             var message = formatError(schema, summary, field, "select-elements-by summary feature '" + summaryFeatureName +
                     "' is not defined for source field '" + sourceField.getName() + "'.");

--- a/config-model/src/test/java/com/yahoo/schema/derived/SummaryTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/derived/SummaryTestCase.java
@@ -296,17 +296,24 @@ public class SummaryTestCase extends AbstractSchemaTestCase {
                 "        select-elements-by: elementwise(bm25(foo),x,double)",
                 "     }",
                 "    from-disk",
-                "}"));
+                "}",
+                "rank-profile xyzzy {",
+                "  summary-features {",
+                "    elementwise(bm25(foo),x,double)",
+                "  }",
+                "}")
+        );
+        var summary = new SummaryClass(schema, schema.getSummary("bar"), new BaseDeployLogger());
         assertElementSelect(schema, "baz", SummaryConfig.Classes.Fields.Elements.Select.Enum.BY_SUMMARY_FEATURE,
             "elementwise(bm25(foo),x,double)", "bar");
         assert(!schema.getSummary("default").getSummaryFields().containsKey("baz"));
     }
 
-    private void assertOverride(Schema schema, String expFieldName, String expCommand, String expSource) throws ParseException {
+    private void assertOverride(Schema schema, String expFieldName, String expCommand, String expSource) {
         assertOverride(schema, expFieldName, expCommand, expSource, "default");
     }
 
-    private void assertOverride(Schema schema, String expFieldName, String expCommand, String expSource, String summaryClass) throws ParseException {
+    private void assertOverride(Schema schema, String expFieldName, String expCommand, String expSource, String summaryClass) {
         var summary = new SummaryClass(schema, schema.getSummary(summaryClass), new BaseDeployLogger());
         var cfg = new SummaryConfig.Classes(summary.getSummaryClassConfig());
         var field = cfg.fields(0);
@@ -315,7 +322,7 @@ public class SummaryTestCase extends AbstractSchemaTestCase {
         assertEquals(expSource, field.source());
     }
 
-    private void assertElementSelect(Schema schema, String expFieldName, SummaryConfig.Classes.Fields.Elements.Select.Enum expSelect, String expSummaryFeature, String summaryClass) throws ParseException {
+    private void assertElementSelect(Schema schema, String expFieldName, SummaryConfig.Classes.Fields.Elements.Select.Enum expSelect, String expSummaryFeature, String summaryClass) {
         var summary = new SummaryClass(schema, schema.getSummary(summaryClass), new BaseDeployLogger());
         var cfg = new SummaryConfig.Classes(summary.getSummaryClassConfig());
         var field = cfg.fields(0);


### PR DESCRIPTION
Followup to https://github.com/vespa-engine/vespa/pull/34546

Note that this fails one unit test, it seems like `getSummaryFeatures()` in `RankProfile` will not give the full summary feature, e.g. when using `elementwise(bm25(foo),x,double)` as in the failing test.

@arnej27959 do you know of any other way of doing this that will work?