### PR TITLE
Set distance to empty tensor fields to infinity in DistanceCalculator

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/distance_calculator.h
+++ b/searchlib/src/vespa/searchlib/tensor/distance_calculator.h
@@ -72,7 +72,7 @@ public:
             return _dist_fun->calc_with_limit(cells, limit);
         } else {
             auto vectors = _attr_tensor.get_vectors(docid);
-            double result = std::numeric_limits<double>::max();
+            double result = std::numeric_limits<double>::infinity();
             for (uint32_t i = 0; i < vectors.subspaces(); ++i) {
                 double distance = _dist_fun->calc_with_limit(vectors.cells(i), limit);
                 result = std::min(result, distance);

--- a/searchlib/src/vespa/searchlib/tensor/distance_calculator.h
+++ b/searchlib/src/vespa/searchlib/tensor/distance_calculator.h
@@ -67,7 +67,7 @@ public:
         if (has_single_subspace) {
             auto cells = _attr_tensor.get_vector(docid, 0);
             if ( cells.non_existing_attribute_value() ) [[unlikely]] {
-                return std::numeric_limits<double>::max();
+                return std::numeric_limits<double>::infinity();
             }
             return _dist_fun->calc_with_limit(cells, limit);
         } else {


### PR DESCRIPTION
Currently, the distance to an empty tensor field is `std::numeric_limits<double>::max()` instead of `std::numeric_limits<double>::infinity()`.

This leads to unexpected behavior when using exact vector search via the `nearestNeighbor` operator. It can actually return documents that do not contain a vector for the tensor field, while both approximate search via HNSW and streaming search do not return such documents.

With this change to `std::numeric_limits<double>::infinity()`, all three search modes do not return such documents.

This fixes https://github.com/vespa-engine/vespa/issues/34514.