### PR TITLE
Range filter in grouping

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -3856,6 +3856,25 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.grouping.request.RangePredicate" : {
+    "superClass" : "com.yahoo.search.grouping.request.FilterExpression",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.Number, java.lang.Number, com.yahoo.search.grouping.request.GroupingExpression)",
+      "public void <init>(java.lang.Number, java.lang.Number, boolean, boolean, com.yahoo.search.grouping.request.GroupingExpression)",
+      "public java.lang.Number getLower()",
+      "public java.lang.Number getUpper()",
+      "public boolean getLowerInclusive()",
+      "public boolean getUpperInclusive()",
+      "public com.yahoo.search.grouping.request.GroupingExpression getExpression()",
+      "public java.lang.String toString()",
+      "public com.yahoo.search.grouping.request.FilterExpression copy()"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.grouping.request.RawBucket" : {
     "superClass" : "com.yahoo.search.grouping.request.BucketValue",
     "interfaces" : [ ],

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -3864,7 +3864,7 @@
     ],
     "methods" : [
       "public void <init>(java.lang.Number, java.lang.Number, com.yahoo.search.grouping.request.GroupingExpression)",
-      "public void <init>(java.lang.Number, java.lang.Number, boolean, boolean, com.yahoo.search.grouping.request.GroupingExpression)",
+      "public void <init>(java.lang.Number, java.lang.Number, com.yahoo.search.grouping.request.GroupingExpression, boolean, boolean)",
       "public java.lang.Number getLower()",
       "public java.lang.Number getUpper()",
       "public boolean getLowerInclusive()",

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/RangePredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/RangePredicate.java
@@ -18,10 +18,10 @@ public class RangePredicate extends FilterExpression {
     private final GroupingExpression expression;
 
     public RangePredicate(Number lower, Number upper, GroupingExpression expression) {
-        this(lower, upper, true, false, expression);
+        this(lower, upper, expression, true, false);
     }
 
-    public RangePredicate(Number lower, Number upper, boolean lowerInclusive, boolean upperInclusive, GroupingExpression expression) {
+    public RangePredicate(Number lower, Number upper, GroupingExpression expression, boolean lowerInclusive, boolean upperInclusive) {
         this.lower = lower;
         this.upper = upper;
         this.lowerInclusive = lowerInclusive;
@@ -37,11 +37,11 @@ public class RangePredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return "range(%s, %s, %b, %b, %s)".formatted(lower, upper, lowerInclusive, upperInclusive, expression);
+        return "range(%s, %s, %s, %b, %b)".formatted(lower, upper, expression, lowerInclusive, upperInclusive);
     }
 
     @Override
     public FilterExpression copy() {
-        return new RangePredicate(lower, upper, lowerInclusive, upperInclusive, expression.copy());
+        return new RangePredicate(lower, upper, expression.copy(), lowerInclusive, upperInclusive);
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/RangePredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/RangePredicate.java
@@ -1,0 +1,47 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.grouping.request;
+
+import com.yahoo.api.annotations.Beta;
+
+/**
+ * Represents a filter expression that matches a value from the evaluated expression within a range.
+ *
+ * @author johsol
+ */
+@Beta
+public class RangePredicate extends FilterExpression {
+
+    private final Number lower;
+    private final Number upper;
+    private final boolean lowerInclusive;
+    private final boolean upperInclusive;
+    private final GroupingExpression expression;
+
+    public RangePredicate(Number lower, Number upper, GroupingExpression expression) {
+        this(lower, upper, true, false, expression);
+    }
+
+    public RangePredicate(Number lower, Number upper, boolean lowerInclusive, boolean upperInclusive, GroupingExpression expression) {
+        this.lower = lower;
+        this.upper = upper;
+        this.lowerInclusive = lowerInclusive;
+        this.upperInclusive = upperInclusive;
+        this.expression = expression;
+    }
+
+    public Number getLower() { return lower; }
+    public Number getUpper() { return upper; }
+    public boolean getLowerInclusive() { return lowerInclusive; }
+    public boolean getUpperInclusive() { return upperInclusive; }
+    public GroupingExpression getExpression() { return expression; }
+
+    @Override
+    public String toString() {
+        return "range(%s, %s, %b, %b, %s)".formatted(lower, upper, lowerInclusive, upperInclusive, expression);
+    }
+
+    @Override
+    public FilterExpression copy() {
+        return new RangePredicate(lower, upper, lowerInclusive, upperInclusive, expression.copy());
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
@@ -264,7 +264,7 @@ class ExpressionConverter {
         if (expression instanceof RegexPredicate rp) {
             return new RegexPredicateNode(rp.getPattern(), toExpressionNode(rp.getExpression()));
         } else if (expression instanceof RangePredicate rp) {
-            return new RangePredicateNode(rp.getLower(), rp.getUpper(), rp.getLowerInclusive(), rp.getUpperInclusive(), toExpressionNode(rp.getExpression()));
+            return new RangePredicateNode(rp.getLower(), rp.getUpper(), toExpressionNode(rp.getExpression()), rp.getLowerInclusive(), rp.getUpperInclusive());
         } else if (expression instanceof NotPredicate np) {
             return new NotPredicateNode(toFilterExpressionNode(np.getExpression()));
         } else if (expression instanceof OrPredicate op) {

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
@@ -68,6 +68,7 @@ import com.yahoo.search.grouping.request.NowFunction;
 import com.yahoo.search.grouping.request.OrFunction;
 import com.yahoo.search.grouping.request.OrPredicate;
 import com.yahoo.search.grouping.request.PredefinedFunction;
+import com.yahoo.search.grouping.request.RangePredicate;
 import com.yahoo.search.grouping.request.RawValue;
 import com.yahoo.search.grouping.request.RegexPredicate;
 import com.yahoo.search.grouping.request.RelevanceValue;
@@ -140,6 +141,7 @@ import com.yahoo.searchlib.expression.NumElemFunctionNode;
 import com.yahoo.searchlib.expression.OrFunctionNode;
 import com.yahoo.searchlib.expression.OrPredicateNode;
 import com.yahoo.searchlib.expression.RangeBucketPreDefFunctionNode;
+import com.yahoo.searchlib.expression.RangePredicateNode;
 import com.yahoo.searchlib.expression.RawBucketResultNode;
 import com.yahoo.searchlib.expression.RawBucketResultNodeVector;
 import com.yahoo.searchlib.expression.RawResultNode;
@@ -261,7 +263,9 @@ class ExpressionConverter {
     public FilterExpressionNode toFilterExpressionNode(FilterExpression expression) {
         if (expression instanceof RegexPredicate rp) {
             return new RegexPredicateNode(rp.getPattern(), toExpressionNode(rp.getExpression()));
-        }  else if (expression instanceof NotPredicate np) {
+        } else if (expression instanceof RangePredicate rp) {
+            return new RangePredicateNode(rp.getLower(), rp.getUpper(), rp.getLowerInclusive(), rp.getUpperInclusive(), toExpressionNode(rp.getExpression()));
+        } else if (expression instanceof NotPredicate np) {
             return new NotPredicateNode(toFilterExpressionNode(np.getExpression()));
         } else if (expression instanceof OrPredicate op) {
             var args = op.getArgs().stream().map(this::toFilterExpressionNode).toList();

--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -141,6 +141,7 @@ TOKEN :
     <POW: "pow"> |
     <PRECISION: "precision"> |
     <PREDEFINED: "predefined"> |
+    <RANGE: "range"> |
     <REGEX: "regex"> |
     <RELEVANCE: "relevance"> |
     <REVERSE: "reverse"> |
@@ -330,6 +331,7 @@ FilterExpression filterExp(GroupingOperation grp) :
 }
 {
     ( (exp = regexPredicate(grp)) |
+      (exp = rangePredicate(grp)) |
       (exp = notPredicate(grp))   |
       (exp = orPredicate(grp))    |
       (exp = andPredicate(grp)))
@@ -960,6 +962,19 @@ RegexPredicate regexPredicate(GroupingOperation grp) :
     { return new RegexPredicate(pattern, exp); }
 }
 
+RangePredicate rangePredicate(GroupingOperation grp) :
+{
+    Number lower;
+    Number upper;
+    BooleanValue lowerInclusive = new BooleanValue(true);
+    BooleanValue upperInclusive = new BooleanValue(false);
+    GroupingExpression exp;
+}
+{
+    <RANGE> lbrace() lower = number() comma() upper = number() comma() (lowerInclusive = booleanValue() comma() upperInclusive = booleanValue() comma() )? exp = exp(grp) rbrace()
+    { return new RangePredicate(lower, upper, lowerInclusive.getValue(), upperInclusive.getValue(), exp); }
+}
+
 NotPredicate notPredicate(GroupingOperation grp) :
 {
     FilterExpression exp;
@@ -1111,6 +1126,7 @@ String identifier() :
         <POW> |
         <PRECISION> |
         <PREDEFINED> |
+        <RANGE> |
         <REGEX> |
         <RELEVANCE> |
         <REVERSE> |

--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -966,13 +966,13 @@ RangePredicate rangePredicate(GroupingOperation grp) :
 {
     Number lower;
     Number upper;
+    GroupingExpression exp;
     BooleanValue lowerInclusive = new BooleanValue(true);
     BooleanValue upperInclusive = new BooleanValue(false);
-    GroupingExpression exp;
 }
 {
-    <RANGE> lbrace() lower = number() comma() upper = number() comma() (lowerInclusive = booleanValue() comma() upperInclusive = booleanValue() comma() )? exp = exp(grp) rbrace()
-    { return new RangePredicate(lower, upper, lowerInclusive.getValue(), upperInclusive.getValue(), exp); }
+    <RANGE> lbrace() lower = number() comma() upper = number() comma() exp = exp(grp) [ comma()  lowerInclusive = booleanValue() comma() upperInclusive = booleanValue() ] rbrace()
+    { return new RangePredicate(lower, upper, exp, lowerInclusive.getValue(), upperInclusive.getValue()); }
 }
 
 NotPredicate notPredicate(GroupingOperation grp) :

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
@@ -637,10 +637,10 @@ public class GroupingParserTestCase {
 
         assertAll("filter with range",
                 () -> assertParse("all(group(foo) filter(range(1990, 2012, foo)) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(range(1990, 2012, false, false, foo)) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(range(1990, 2012, true, false, foo)) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(range(1990, 2012, false, true, foo)) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(range(1990, 2012, true, true, foo)) each(output(count())))"));
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, foo, false, false)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, foo, true, false)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, foo, false, true)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, foo, true, true)) each(output(count())))"));
 
         assertAll("filter with alias",
                 () -> assertParse(

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
@@ -116,6 +116,7 @@ public class GroupingParserTestCase {
                 "pow",
                 "precision",
                 "predefined",
+                "range",
                 "regex",
                 "relevance",
                 "reverse",
@@ -633,6 +634,13 @@ public class GroupingParserTestCase {
                 () -> assertParse("all(group(foo) filter(regex(\"(stringinparentheses)?\", foo)) each(output(count())))"),
                 () -> assertParse("all(group(foo) filter(regex(\"[a-zA-Z_]+characterclass\", foo)) each(output(count())))"),
                 () -> assertParse("all(group(foo) filter(regex(\"中文\", foo)) each(output(count())))"));
+
+        assertAll("filter with range",
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, foo)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, false, false, foo)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, true, false, foo)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, false, true, foo)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(range(1990, 2012, true, true, foo)) each(output(count())))"));
 
         assertAll("filter with alias",
                 () -> assertParse(

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
@@ -839,9 +839,9 @@ public class RequestBuilderTestCase {
     @Test
     void require_that_range_filter_layout_is_correct() {
         assertLayout("all(group(a) filter(range(2020, 2021, a)) each(output(count())))",
-                "[[{ Attribute, filter = [Range [2020.000000, 2021.000000, true, false, Attribute]], result = [Count] }]]");
-        assertLayout("all(group(a) filter(range(0, 100, true, true, a)) each(output(count())))",
-                "[[{ Attribute, filter = [Range [0.000000, 100.000000, true, true, Attribute]], result = [Count] }]]");
+                "[[{ Attribute, filter = [Range [2020.000000, 2021.000000, Attribute, true, false]], result = [Count] }]]");
+        assertLayout("all(group(a) filter(range(0, 100, a, true, true)) each(output(count())))",
+                "[[{ Attribute, filter = [Range [0.000000, 100.000000, Attribute, true, true]], result = [Count] }]]");
     }
 
     @Test
@@ -1119,7 +1119,7 @@ public class RequestBuilderTestCase {
                 var lowerInclusive = rpn.getLowerInclusive() ? "true" : "false";
                 var upperInclusive = rpn.getUpperInclusive() ? "true" : "false";
                 var expression = rpn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
-                return "Range [%f, %f, %s, %s, %s]".formatted(lower, upper, lowerInclusive, upperInclusive, expression);
+                return "Range [%f, %f, %s, %s, %s]".formatted(lower, upper, expression, lowerInclusive, upperInclusive);
             } else if (filterExp instanceof NotPredicateNode npn) {
                 var simpleName = npn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
                 return "Not [%s]".formatted(simpleName);

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -196,6 +196,7 @@ TOKEN :
     <POW: "pow"> |
     <PRECISION: "precision"> |
     <PREDEFINED: "predefined"> |
+    <RANGE: "range"> |
     <REGEX: "regex"> |
     <RELEVANCE: "relevance"> |
     <REVERSE: "reverse"> |

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/RangePredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/RangePredicateNode.java
@@ -25,25 +25,25 @@ public class RangePredicateNode extends FilterExpressionNode {
 
     public RangePredicateNode() {}
 
-    public RangePredicateNode(Number lower, Number upper, boolean lowerInclusive, boolean upperInclusive, ExpressionNode expression) {
+    public RangePredicateNode(Number lower, Number upper,ExpressionNode expression, boolean lowerInclusive, boolean upperInclusive) {
         this.lower = lower;
         this.upper = upper;
         this.lowerInclusive = lowerInclusive;
         this.upperInclusive = upperInclusive;
         this.expression = expression;
     }
+
     public Number getLower() { return lower; }
     public Number getUpper() { return upper; }
     public boolean getLowerInclusive() { return lowerInclusive; }
     public boolean getUpperInclusive() { return upperInclusive; }
     public Optional<ExpressionNode> getExpression() { return Optional.ofNullable(expression); }
 
-
     @Override protected int onGetClassId() { return classId; }
 
     @Override
     public RangePredicateNode clone() {
-        return new RangePredicateNode(lower, upper, lowerInclusive, upperInclusive, expression != null ? expression.clone() : null);
+        return new RangePredicateNode(lower, upper, expression != null ? expression.clone() : null, lowerInclusive, upperInclusive);
     }
 
     @Override

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/RangePredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/RangePredicateNode.java
@@ -1,0 +1,93 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.expression;
+
+import com.yahoo.vespa.objects.Deserializer;
+import com.yahoo.vespa.objects.ObjectVisitor;
+import com.yahoo.vespa.objects.Serializer;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Protocol class for {@code RangePredicate}.
+ *
+ * @author johsol
+ */
+public class RangePredicateNode extends FilterExpressionNode {
+
+    public static final int classId = registerClass(0x4000 + 178, RangePredicateNode.class, RangePredicateNode::new);
+
+    private Number lower;
+    private Number upper;
+    private boolean lowerInclusive;
+    private boolean upperInclusive;
+    private ExpressionNode expression;
+
+    public RangePredicateNode() {}
+
+    public RangePredicateNode(Number lower, Number upper, boolean lowerInclusive, boolean upperInclusive, ExpressionNode expression) {
+        this.lower = lower;
+        this.upper = upper;
+        this.lowerInclusive = lowerInclusive;
+        this.upperInclusive = upperInclusive;
+        this.expression = expression;
+    }
+    public Number getLower() { return lower; }
+    public Number getUpper() { return upper; }
+    public boolean getLowerInclusive() { return lowerInclusive; }
+    public boolean getUpperInclusive() { return upperInclusive; }
+    public Optional<ExpressionNode> getExpression() { return Optional.ofNullable(expression); }
+
+
+    @Override protected int onGetClassId() { return classId; }
+
+    @Override
+    public RangePredicateNode clone() {
+        return new RangePredicateNode(lower, upper, lowerInclusive, upperInclusive, expression != null ? expression.clone() : null);
+    }
+
+    @Override
+    protected void onSerialize(Serializer buf) {
+        buf.putDouble(null, lower.doubleValue());
+        buf.putDouble(null, upper.doubleValue());
+        buf.putByte(null, (byte)(lowerInclusive ? 1 : 0) );
+        buf.putByte(null, (byte)(upperInclusive ? 1 : 0) );
+        serializeOptional(buf, expression);
+    }
+
+    @Override
+    protected void onDeserialize(Deserializer buf) {
+        lower = buf.getDouble(null);
+        upper = buf.getDouble(null);
+        lowerInclusive = buf.getByte(null) != 0;
+        upperInclusive = buf.getByte(null) != 0;
+        expression = (ExpressionNode)deserializeOptional(buf);
+    }
+
+    @Override
+    public void visitMembers(ObjectVisitor visitor) {
+        super.visitMembers(visitor);
+        visitor.visit("lower", lower);
+        visitor.visit("upper", upper);
+        visitor.visit("lowerInclusive", lowerInclusive);
+        visitor.visit("upperInclusive", upperInclusive);
+        visitor.visit("expression", expression);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RangePredicateNode that = (RangePredicateNode) o;
+        return Objects.equals(lower, that.lower) &&
+                Objects.equals(upper, that.upper) &&
+                Objects.equals(lowerInclusive, that.lowerInclusive) &&
+                Objects.equals(upperInclusive, that.upperInclusive) &&
+                Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lower, upper, lowerInclusive, upperInclusive, expression);
+    }
+}

--- a/searchlib/src/tests/expression/filter_predicate_node/filter_predicate_node_test.cpp
+++ b/searchlib/src/tests/expression/filter_predicate_node/filter_predicate_node_test.cpp
@@ -32,8 +32,8 @@ public:
     static std::unique_ptr<FilterPredicateNode> make_regex(const std::string& regex_value,
                                                            std::unique_ptr<ExpressionNode> result_node);
 
-    static std::unique_ptr<FilterPredicateNode> make_range(double lower, double upper, bool lower_inclusive, bool upper_inclusive,
-                                                           std::unique_ptr<ExpressionNode> result_node);
+    static std::unique_ptr<FilterPredicateNode> make_range(double lower, double upper, std::unique_ptr<ExpressionNode> result_node,
+                                                           bool lower_inclusive, bool upper_inclusive);
 
     static std::unique_ptr<FilterPredicateNode> make_not(std::unique_ptr<FilterPredicateNode> filter_node);
 
@@ -66,9 +66,9 @@ std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_regex(const 
     return std::make_unique<RegexPredicateNode>(regex_value, std::move(result_node));
 }
 
-std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_range(double lower, double upper, bool lower_inclusive, bool upper_inclusive,
-                                                                          std::unique_ptr<ExpressionNode> result_node) {
-    return std::make_unique<RangePredicateNode>(lower, upper, lower_inclusive, upper_inclusive, std::move(result_node));
+std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_range(double lower, double upper, std::unique_ptr<ExpressionNode> result_node,
+                                                                          bool lower_inclusive, bool upper_inclusive) {
+    return std::make_unique<RangePredicateNode>(lower, upper, std::move(result_node), lower_inclusive, upper_inclusive);
 }
 
 std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_not(std::unique_ptr<FilterPredicateNode> filter_node) {
@@ -104,31 +104,31 @@ TEST_F(FilterPredicateNodesTest, test_regex_match) {
 }
 
 TEST_F(FilterPredicateNodesTest, test_range_match_inside_range) {
-    EXPECT_TRUE(set_node(make_range(0,100,false,false, make_result(6.0))).evaluate());
-    EXPECT_TRUE(set_node(make_range(0,100,true,false, make_result(6.0))).evaluate());
-    EXPECT_TRUE(set_node(make_range(0,100,false,true, make_result(6.0))).evaluate());
-    EXPECT_TRUE(set_node(make_range(0,100,true,true, make_result(6.0))).evaluate());
+    EXPECT_TRUE(set_node(make_range(0, 100, make_result(6.0), false, false)).evaluate());
+    EXPECT_TRUE(set_node(make_range(0, 100, make_result(6.0), true,  false)).evaluate());
+    EXPECT_TRUE(set_node(make_range(0, 100, make_result(6.0), false, true)).evaluate());
+    EXPECT_TRUE(set_node(make_range(0, 100, make_result(6.0), true,  true)).evaluate());
 }
 
 TEST_F(FilterPredicateNodesTest, test_range_match_outside_range) {
-    EXPECT_FALSE(set_node(make_range(50,100,false,false, make_result(6.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,true,false, make_result(6.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,false,true, make_result(6.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,true,true, make_result(6.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,false,false, make_result(101.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,true,false, make_result(101.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,false,true, make_result(101.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(50,100,true,true, make_result(101.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(6.0),   false, false)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(6.0),   true,  false)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(6.0),   false, true)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(6.0),   true,  true)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(101.0), false, false)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(101.0), true,  false)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(101.0), false, true)).evaluate());
+    EXPECT_FALSE(set_node(make_range(50, 100, make_result(101.0), true,  true)).evaluate());
 }
 
 TEST_F(FilterPredicateNodesTest, test_range_match_lower_bound) {
-    EXPECT_TRUE(set_node(make_range(0,100,true,false, make_result(0.0))).evaluate());
-    EXPECT_FALSE(set_node(make_range(0,100,false,false, make_result(0.0))).evaluate());
+    EXPECT_TRUE(set_node(make_range(0, 100, make_result(0.0),  true, false)).evaluate());
+    EXPECT_FALSE(set_node(make_range(0, 100, make_result(0.0), false, false)).evaluate());
 }
 
 TEST_F(FilterPredicateNodesTest, test_range_match_upper_bound) {
-    EXPECT_FALSE(set_node(make_range(0,100,true,false, make_result(100.0))).evaluate());
-    EXPECT_TRUE(set_node(make_range(0,100,true,true, make_result(100.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(0, 100, make_result(100.0), true,  false)).evaluate());
+    EXPECT_TRUE(set_node(make_range(0, 100, make_result(100.0),  true,  true)).evaluate());
 }
 
 TEST_F(FilterPredicateNodesTest, test_not_predicate) {

--- a/searchlib/src/tests/expression/filter_predicate_node/filter_predicate_node_test.cpp
+++ b/searchlib/src/tests/expression/filter_predicate_node/filter_predicate_node_test.cpp
@@ -4,8 +4,10 @@
 #include <vespa/searchlib/expression/constantnode.h>
 #include <vespa/searchlib/expression/stringresultnode.h>
 #include <vespa/searchlib/expression/filter_predicate_node.h>
+#include <vespa/searchlib/expression/floatresultnode.h>
 #include <vespa/searchlib/expression/not_predicate_node.h>
 #include <vespa/searchlib/expression/or_predicate_node.h>
+#include <vespa/searchlib/expression/range_predicate_node.h>
 #include <vespa/searchlib/expression/regex_predicate_node.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
@@ -30,6 +32,9 @@ public:
     static std::unique_ptr<FilterPredicateNode> make_regex(const std::string& regex_value,
                                                            std::unique_ptr<ExpressionNode> result_node);
 
+    static std::unique_ptr<FilterPredicateNode> make_range(double lower, double upper, bool lower_inclusive, bool upper_inclusive,
+                                                           std::unique_ptr<ExpressionNode> result_node);
+
     static std::unique_ptr<FilterPredicateNode> make_not(std::unique_ptr<FilterPredicateNode> filter_node);
 
     template<typename... Nodes>
@@ -39,6 +44,8 @@ public:
     static std::unique_ptr<FilterPredicateNode> make_and(Nodes... nodes);
 
     static std::unique_ptr<ExpressionNode> make_result(const std::string& value);
+
+    static std::unique_ptr<ExpressionNode> make_result(double value);
 };
 
 FilterPredicateNodesTest::FilterPredicateNodesTest() = default;
@@ -57,6 +64,11 @@ FilterPredicateNodesTest& FilterPredicateNodesTest::set_node(std::unique_ptr<Fil
 std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_regex(const std::string& regex_value,
                                                                           std::unique_ptr<ExpressionNode> result_node) {
     return std::make_unique<RegexPredicateNode>(regex_value, std::move(result_node));
+}
+
+std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_range(double lower, double upper, bool lower_inclusive, bool upper_inclusive,
+                                                                          std::unique_ptr<ExpressionNode> result_node) {
+    return std::make_unique<RangePredicateNode>(lower, upper, lower_inclusive, upper_inclusive, std::move(result_node));
 }
 
 std::unique_ptr<FilterPredicateNode> FilterPredicateNodesTest::make_not(std::unique_ptr<FilterPredicateNode> filter_node) {
@@ -81,10 +93,42 @@ std::unique_ptr<ExpressionNode> FilterPredicateNodesTest::make_result(const std:
     return std::make_unique<ConstantNode>(std::make_unique<StringResultNode>(value));
 }
 
+std::unique_ptr<ExpressionNode> FilterPredicateNodesTest::make_result(double value) {
+    return std::make_unique<ConstantNode>(std::make_unique<FloatResultNode>(value));
+}
+
 TEST_F(FilterPredicateNodesTest, test_regex_match) {
     EXPECT_TRUE(set_node(make_regex("foo.*", make_result("foobar"))).evaluate());
     EXPECT_FALSE(set_node(make_regex("foo", make_result("foobar"))).evaluate());
     EXPECT_FALSE(set_node(make_regex("bar", make_result("foobar"))).evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_range_match_inside_range) {
+    EXPECT_TRUE(set_node(make_range(0,100,false,false, make_result(6.0))).evaluate());
+    EXPECT_TRUE(set_node(make_range(0,100,true,false, make_result(6.0))).evaluate());
+    EXPECT_TRUE(set_node(make_range(0,100,false,true, make_result(6.0))).evaluate());
+    EXPECT_TRUE(set_node(make_range(0,100,true,true, make_result(6.0))).evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_range_match_outside_range) {
+    EXPECT_FALSE(set_node(make_range(50,100,false,false, make_result(6.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,true,false, make_result(6.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,false,true, make_result(6.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,true,true, make_result(6.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,false,false, make_result(101.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,true,false, make_result(101.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,false,true, make_result(101.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(50,100,true,true, make_result(101.0))).evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_range_match_lower_bound) {
+    EXPECT_TRUE(set_node(make_range(0,100,true,false, make_result(0.0))).evaluate());
+    EXPECT_FALSE(set_node(make_range(0,100,false,false, make_result(0.0))).evaluate());
+}
+
+TEST_F(FilterPredicateNodesTest, test_range_match_upper_bound) {
+    EXPECT_FALSE(set_node(make_range(0,100,true,false, make_result(100.0))).evaluate());
+    EXPECT_TRUE(set_node(make_range(0,100,true,true, make_result(100.0))).evaluate());
 }
 
 TEST_F(FilterPredicateNodesTest, test_not_predicate) {

--- a/searchlib/src/vespa/searchlib/common/identifiable.h
+++ b/searchlib/src/vespa/searchlib/common/identifiable.h
@@ -184,3 +184,4 @@
 #define CID_search_expression_MultiArgPredicateNode         SEARCHLIB_CID(175)
 #define CID_search_expression_OrPredicateNode               SEARCHLIB_CID(176)
 #define CID_search_expression_AndPredicateNode              SEARCHLIB_CID(177)
+#define CID_search_expression_RangePredicateNode            SEARCHLIB_CID(178)

--- a/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
@@ -38,6 +38,7 @@ vespa_add_library(searchlib_expression OBJECT
     rawresultnode.cpp
     floatresultnode.cpp
     integerresultnode.cpp
+    range_predicate_node.cpp
     regex_predicate_node.cpp
     not_predicate_node.cpp
     multi_arg_predicate_node.cpp

--- a/searchlib/src/vespa/searchlib/expression/filter_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/filter_predicate_node.h
@@ -8,6 +8,9 @@
 
 namespace search::expression {
 
+/**
+ * Base class for filter nodes in grouping.
+ **/
 class FilterPredicateNode : public vespalib::Identifiable
 {
 public:
@@ -20,6 +23,9 @@ public:
     virtual bool allow(const document::Document &, HitRank) = 0;
 };
 
+/**
+ * A filter in grouping that is always true.
+ **/
 class TruePredicateNode : public FilterPredicateNode {
 public:
     // DECLARE_IDENTIFIABLE_NS2(search, expression, TruePredicateNode);

--- a/searchlib/src/vespa/searchlib/expression/range_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/range_predicate_node.cpp
@@ -1,0 +1,105 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "range_predicate_node.h"
+#include "resultnode.h"
+#include "resultvector.h"
+
+namespace search::expression {
+
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+IMPLEMENT_IDENTIFIABLE_NS2(search, expression, RangePredicateNode, FilterPredicateNode);
+
+bool RangePredicateNode::satisfies_bounds(double value) const {
+    bool satisfy_lower = false;
+    if (_lower_inclusive) {
+        satisfy_lower = value >= _lower;
+    } else {
+        satisfy_lower = value > _lower;
+    }
+
+    bool satisfy_upper = false;
+    if (_upper_inclusive) {
+        satisfy_upper = value <= _upper;
+    } else {
+        satisfy_upper = value < _upper;
+    }
+
+    return satisfy_lower && satisfy_upper;
+}
+
+bool RangePredicateNode::check(const ResultNode* result) const {
+    if (result->inherits(ResultNodeVector::classId)) {
+        const auto * rv = static_cast<const ResultNodeVector *>(result);
+        for (size_t i = 0; i < rv->size(); i++) {
+            if (satisfies_bounds(rv[i].getFloat())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return satisfies_bounds(result->getFloat());
+}
+
+bool RangePredicateNode::allow(const document::Document& doc, HitRank rank) {
+    if (_argument.getRoot()) {
+        _argument.execute(doc, rank);
+        return check(_argument.getResult());
+    }
+    return false;
+}
+
+bool RangePredicateNode::allow(DocId docId, HitRank rank) {
+    if (_argument.getRoot()) {
+        _argument.execute(docId, rank);
+        return check(_argument.getResult());
+    }
+    return false;
+}
+
+RangePredicateNode::RangePredicateNode() noexcept = default;
+
+RangePredicateNode::~RangePredicateNode() = default;
+
+RangePredicateNode::RangePredicateNode(const RangePredicateNode&) = default;
+
+RangePredicateNode& RangePredicateNode::operator=(const RangePredicateNode&) = default;
+
+RangePredicateNode::RangePredicateNode(double lower, double upper, bool lower_inclusive, bool upper_inclusive, ExpressionNode::UP input)
+  : _lower(lower),
+    _upper(upper),
+    _lower_inclusive(lower_inclusive),
+    _upper_inclusive(upper_inclusive),
+    _argument(std::move(input))
+{
+}
+
+
+Serializer& RangePredicateNode::onSerialize(Serializer& os) const {
+    return os << _lower << _upper << _lower_inclusive << _upper_inclusive << _argument;
+}
+
+Deserializer& RangePredicateNode::onDeserialize(Deserializer& is) {
+    is >> _lower;
+    is >> _upper;
+    is >> _lower_inclusive;
+    is >> _upper_inclusive;
+    is >> _argument;
+    return is;
+}
+
+void RangePredicateNode::visitMembers(vespalib::ObjectVisitor& visitor) const {
+    visit(visitor, "lower", _lower);
+    visit(visitor, "upper", _upper);
+    visit(visitor, "lower_inclusive", _lower_inclusive);
+    visit(visitor, "upper_inclusive", _upper_inclusive);
+    visit(visitor, "argument", _argument);
+}
+
+void RangePredicateNode::selectMembers(const vespalib::ObjectPredicate& predicate,
+                                       vespalib::ObjectOperation& operation) {
+    _argument.select(predicate, operation);
+}
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/range_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/range_predicate_node.cpp
@@ -66,7 +66,7 @@ RangePredicateNode::RangePredicateNode(const RangePredicateNode&) = default;
 
 RangePredicateNode& RangePredicateNode::operator=(const RangePredicateNode&) = default;
 
-RangePredicateNode::RangePredicateNode(double lower, double upper, bool lower_inclusive, bool upper_inclusive, ExpressionNode::UP input)
+RangePredicateNode::RangePredicateNode(double lower, double upper, ExpressionNode::UP input, bool lower_inclusive, bool upper_inclusive)
   : _lower(lower),
     _upper(upper),
     _lower_inclusive(lower_inclusive),

--- a/searchlib/src/vespa/searchlib/expression/range_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/range_predicate_node.h
@@ -9,10 +9,10 @@ namespace search::expression {
 /**
  **/
 class RangePredicateNode : public FilterPredicateNode {
-    double _lower;
-    double _upper;
-    bool _lower_inclusive;
-    bool _upper_inclusive;
+    double _lower{};
+    double _upper{};
+    bool _lower_inclusive{};
+    bool _upper_inclusive{};
     ExpressionTree _argument;
 
     [[nodiscard]] bool satisfies_bounds(double value) const;
@@ -24,10 +24,10 @@ public:
     RangePredicateNode(const RangePredicateNode&);
     RangePredicateNode& operator=(const RangePredicateNode&);
 
-    RangePredicateNode* clone() const override { return new RangePredicateNode(*this); }
+    [[nodiscard]] RangePredicateNode* clone() const override { return new RangePredicateNode(*this); }
 
     // for unit testing::
-    RangePredicateNode(double lower, double upper, bool lower_inclusive, bool upper_inclusive, ExpressionNode::UP input);
+    RangePredicateNode(double lower, double upper, ExpressionNode::UP input, bool lower_inclusive, bool upper_inclusive);
 
     DECLARE_IDENTIFIABLE_NS2(search, expression, RangePredicateNode);
     DECLARE_NBO_SERIALIZE;

--- a/searchlib/src/vespa/searchlib/expression/range_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/range_predicate_node.h
@@ -7,6 +7,10 @@
 namespace search::expression {
 
 /**
+ * Implements range filter in grouping expressions.
+ *
+ * Checks if a expression is between an lower and upper bound. Lower bound and upper bound can 
+ * be set inclusive or exclusive.
  **/
 class RangePredicateNode : public FilterPredicateNode {
     double _lower{};

--- a/searchlib/src/vespa/searchlib/expression/range_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/range_predicate_node.h
@@ -1,0 +1,41 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "expressiontree.h"
+#include "filter_predicate_node.h"
+
+namespace search::expression {
+
+/**
+ **/
+class RangePredicateNode : public FilterPredicateNode {
+    double _lower;
+    double _upper;
+    bool _lower_inclusive;
+    bool _upper_inclusive;
+    ExpressionTree _argument;
+
+    [[nodiscard]] bool satisfies_bounds(double value) const;
+    [[nodiscard]] bool check(const ResultNode* result) const;
+
+public:
+    RangePredicateNode() noexcept;
+    ~RangePredicateNode() override;
+    RangePredicateNode(const RangePredicateNode&);
+    RangePredicateNode& operator=(const RangePredicateNode&);
+
+    RangePredicateNode* clone() const override { return new RangePredicateNode(*this); }
+
+    // for unit testing::
+    RangePredicateNode(double lower, double upper, bool lower_inclusive, bool upper_inclusive, ExpressionNode::UP input);
+
+    DECLARE_IDENTIFIABLE_NS2(search, expression, RangePredicateNode);
+    DECLARE_NBO_SERIALIZE;
+    bool allow(DocId docId, HitRank rank) override;
+    bool allow(const document::Document&, HitRank) override;
+    void visitMembers(vespalib::ObjectVisitor& visitor) const override;
+    void selectMembers(const vespalib::ObjectPredicate& predicate,
+                       vespalib::ObjectOperation& operation) override;
+};
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/regex_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/regex_predicate_node.h
@@ -8,6 +8,9 @@
 namespace search::expression {
 
 /**
+ * Implements regex filter in grouping expressions.
+ *
+ * Checks if the expression matches the regex string provided.
  **/
 class RegexPredicateNode : public FilterPredicateNode {
 private:


### PR DESCRIPTION
@arnej27959 please review
@bjorncs fyi

The range operator in grouping:
```
filter(range(1990, 2010, field))
filter(range(1990, 2010, field, true, true))
```

This PR:
- Adds `RangePredicate` class in Java public API.
- Extends GroupingParser.jj with the required grammar. 
- Adds range predicate node class in Java and C++, and allocates 178 in identifiable.h for this node.


