### PR TITLE
Make logical predicate filters in grouping infix instead of functional

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/request/AndPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/AndPredicate.java
@@ -28,9 +28,9 @@ public class AndPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return "and(" + args.stream()
+        return args.stream()
                 .map(Object::toString)
-                .collect(Collectors.joining(", ")) + ")";
+                .collect(Collectors.joining(" and "));
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/AndPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/AndPredicate.java
@@ -28,9 +28,9 @@ public class AndPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return args.stream()
+        return "(" + args.stream()
                 .map(Object::toString)
-                .collect(Collectors.joining(" and "));
+                .collect(Collectors.joining(" and ")) + ")";
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
@@ -25,7 +25,7 @@ public class NotPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return "not %s".formatted(expression);
+        return "(not %s".formatted(expression) + ")";
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
@@ -25,7 +25,7 @@ public class NotPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return "not(%s)".formatted(expression);
+        return "not %s".formatted(expression);
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/OrPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/OrPredicate.java
@@ -28,9 +28,9 @@ public class OrPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return "or(" + args.stream()
+        return args.stream()
                 .map(Object::toString)
-                .collect(Collectors.joining(", ")) + ")";
+                .collect(Collectors.joining(" or "));
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/OrPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/OrPredicate.java
@@ -28,9 +28,9 @@ public class OrPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return args.stream()
+        return "(" + args.stream()
                 .map(Object::toString)
-                .collect(Collectors.joining(" or "));
+                .collect(Collectors.joining(" or ")) + ")";
     }
 
     @Override

--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -330,11 +330,7 @@ FilterExpression filterExp(GroupingOperation grp) :
     FilterExpression exp;
 }
 {
-    ( (exp = regexPredicate(grp)) |
-      (exp = rangePredicate(grp)) |
-      (exp = notPredicate(grp))   |
-      (exp = orPredicate(grp))    |
-      (exp = andPredicate(grp)))
+    ( (exp = orPredicate(grp)))
     { return exp; }
 }
 
@@ -952,6 +948,17 @@ XorBitFunction xorBitFunction(GroupingOperation grp) :
     { return new XorBitFunction(exp, num.intValue()); }
 }
 
+FilterExpression filterPrimary(GroupingOperation grp) :
+{
+    FilterExpression f;
+}
+{
+    (( lbrace() f = filterExp(grp) rbrace() ) |
+    ( f = regexPredicate(grp) )              |
+    ( f = rangePredicate(grp) ))
+    { return f; }
+}
+
 RegexPredicate regexPredicate(GroupingOperation grp) :
 {
     String pattern;
@@ -975,33 +982,41 @@ RangePredicate rangePredicate(GroupingOperation grp) :
     { return new RangePredicate(lower, upper, exp, lowerInclusive.getValue(), upperInclusive.getValue()); }
 }
 
-NotPredicate notPredicate(GroupingOperation grp) :
+FilterExpression orPredicate(GroupingOperation grp) :
 {
-    FilterExpression exp;
+    FilterExpression left, right;
+    java.util.List<FilterExpression> args = new java.util.ArrayList<FilterExpression>();
 }
 {
-    <NOT> lbrace() exp = filterExp(grp) rbrace()
-    { return new NotPredicate(exp); }
-}
-
-OrPredicate orPredicate(GroupingOperation grp) :
-{
-    FilterExpression exp;
-    List<FilterExpression> args = new ArrayList<FilterExpression>();
-}
-{
-    <OR> lbrace() ( exp = filterExp(grp) { args.add(exp); } ( comma() exp = filterExp(grp) { args.add(exp); } )+ ) rbrace()
-    { return new OrPredicate(args); }
+    ( left = andPredicate(grp) ( <OR> space() right = andPredicate(grp) { args.add(right); } )* )
+    {
+        if (args.isEmpty()) return left;
+        args.add(0, left);
+        return new OrPredicate(args);
+    }
 }
 
-AndPredicate andPredicate(GroupingOperation grp) :
+FilterExpression andPredicate(GroupingOperation grp) :
 {
-    FilterExpression exp;
-    List<FilterExpression> args = new ArrayList<FilterExpression>();
+    FilterExpression left, right;
+    java.util.List<FilterExpression> args = new java.util.ArrayList<FilterExpression>();
 }
 {
-    <AND> lbrace() ( exp = filterExp(grp) { args.add(exp); } ( comma() exp = filterExp(grp) { args.add(exp); } )+ ) rbrace()
-    { return new AndPredicate(args); }
+    ( left = notPredicate(grp) ( <AND> space() right = notPredicate(grp) { args.add(right); } )* )
+    {
+        if (args.isEmpty()) return left;
+        args.add(0, left);
+        return new AndPredicate(args);
+    }
+}
+
+FilterExpression notPredicate(GroupingOperation grp) :
+{
+    FilterExpression inner;
+}
+{
+    ( <NOT> space() inner = notPredicate(grp) ) { return new NotPredicate(inner); }
+  | ( inner = filterPrimary(grp) )               { return inner; }
 }
 
 void bucket(GroupingOperation grp, BucketResolver resolver) :

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserTestCase.java
@@ -648,10 +648,10 @@ public class GroupingParserTestCase {
                         "all(group(foo) filter(regex(\".*mysubstring.*\", foo)) each(output(count())))"));
 
         assertAll("filter with predicates",
-                () -> assertParse("all(group(foo) filter(not(regex(\"mybar\", foo))) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(or(regex(\"mybar\", foo), regex(\"mybaz\", foo), regex(\"myfoo\", boz))) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(and(regex(\"mybar\", foo), regex(\"mybaz\", foo), regex(\"myfoo\", boz))) each(output(count())))"),
-                () -> assertParse("all(group(foo) filter(and(or(regex(\"mybar\", foo), not(regex(\"mybaz\", foo))), regex(\"myfoo\", boz))) each(output(count())))"));
+                () -> assertParse("all(group(foo) filter(not regex(\"mybar\", foo)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(regex(\"mybar\", foo) or regex(\"mybaz\", foo) or regex(\"myfoo\", boz)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter(regex(\"mybar\", foo) and regex(\"mybaz\", foo) and regex(\"myfoo\", boz)) each(output(count())))"),
+                () -> assertParse("all(group(foo) filter((regex(\"mybar\", foo) or not regex(\"mybaz\", foo)) and regex(\"myfoo\", boz)) each(output(count())))"));
     }
 
     // --------------------------------------------------------------------------------

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
@@ -846,14 +846,57 @@ public class RequestBuilderTestCase {
 
     @Test
     void require_that_filter_predicate_layout_is_correct() {
-        assertLayout("all(group(a) filter(not(regex(\".*suffix$\", a))) each(output(count())))",
+        // Not[Regex]
+        assertLayout("all(group(a) filter(not regex(\".*suffix$\", a)) each(output(count())))",
                 "[[{ Attribute, filter = [Not [Regex [Attribute]]], result = [Count] }]]");
-        assertLayout("all(group(a) filter(or(regex(\".*suffix$\", a),regex(\".*suffix$\", b))) each(output(count())))",
+
+        // Or[Regex, Regex]
+        assertLayout("all(group(a) filter(regex(\".*suffix$\", a) or regex(\".*suffix$\", b)) each(output(count())))",
                 "[[{ Attribute, filter = [Or [Regex [Attribute], Regex [Attribute]]], result = [Count] }]]");
-        assertLayout("all(group(a) filter(and(regex(\".*suffix$\", a),regex(\".*suffix$\", b))) each(output(count())))",
+
+        // And[Regex, Regex]
+        assertLayout("all(group(a) filter(regex(\".*suffix$\", a) and regex(\".*suffix$\", b)) each(output(count())))",
                 "[[{ Attribute, filter = [And [Regex [Attribute], Regex [Attribute]]], result = [Count] }]]");
-        assertLayout("all(group(a) filter(and(or(regex(\".*suffix$\", a),regex(\".*suffix$\", b)), not(regex(\".*suffix$\", c)))) each(output(count())))",
+
+        // NOT binds to atom before AND
+        assertLayout("all(group(a) filter(not regex(\".*suffix$\", a) and regex(\".*suffix$\", b)) each(output(count())))",
+                "[[{ Attribute, filter = [And [Not [Regex [Attribute]], Regex [Attribute]]], result = [Count] }]]");
+
+        // Parentheses force (A OR B) to bind before AND
+        assertLayout("all(group(a) filter((regex(\".*suffix$\", a) or regex(\".*suffix$\", b)) and not regex(\".*suffix$\", c)) each(output(count())))",
                 "[[{ Attribute, filter = [And [Or [Regex [Attribute], Regex [Attribute]], Not [Regex [Attribute]]]], result = [Count] }]]");
+
+        // Parentheses force (NOT A OR B) to bind before AND
+        assertLayout("all(group(a) filter(not (regex(\".*suffix$\", a) or regex(\".*suffix$\", b)) and regex(\".*suffix$\", c)) each(output(count())))",
+                "[[{ Attribute, filter = [And [Not [Or [Regex [Attribute], Regex [Attribute]]], Regex [Attribute]]], result = [Count] }]]");
+
+        // Precedence check: NOT > AND > OR
+        assertLayout("all(group(a) filter(not regex(\".*suffix$\", a) or regex(\".*suffix$\", b) and regex(\".*suffix$\", c)) each(output(count())))",
+                "[[{ Attribute, filter = [Or [Not [Regex [Attribute]], And [Regex [Attribute], Regex [Attribute]]]], result = [Count] }]]");
+
+        // Parentheses override
+        assertLayout("all(group(a) filter((not regex(\".*suffix$\", a) or regex(\".*suffix$\", b)) and regex(\".*suffix$\", c)) each(output(count())))",
+                "[[{ Attribute, filter = [And [Or [Not [Regex [Attribute]], Regex [Attribute]], Regex [Attribute]]], result = [Count] }]]");
+
+        // Chain OR flattening
+        assertLayout("all(group(a) filter(regex(\".*suffix$\", a) or regex(\".*suffix$\", b) or regex(\".*suffix$\", c)) each(output(count())))",
+                "[[{ Attribute, filter = [Or [Regex [Attribute], Regex [Attribute], Regex [Attribute]]], result = [Count] }]]");
+
+        // Chain AND flattening
+        assertLayout("all(group(a) filter(regex(\".*suffix$\", a) and regex(\".*suffix$\", b) and regex(\".*suffix$\", c)) each(output(count())))",
+                "[[{ Attribute, filter = [And [Regex [Attribute], Regex [Attribute], Regex [Attribute]]], result = [Count] }]]");
+
+        // Mix AND/OR without parentheses
+        assertLayout("all(group(a) filter(regex(\".*suffix$\", a) or regex(\".*suffix$\", b) and regex(\".*suffix$\", c) or regex(\".*suffix$\", d)) each(output(count())))",
+                "[[{ Attribute, filter = [Or [Regex [Attribute], And [Regex [Attribute], Regex [Attribute]], Regex [Attribute]]], result = [Count] }]]");
+
+        // AND around OR groups
+        assertLayout("all(group(a) filter(regex(\".*suffix$\", a) and (regex(\".*suffix$\", b) or regex(\".*suffix$\", c)) and regex(\".*suffix$\", d)) each(output(count())))",
+                "[[{ Attribute, filter = [And [Regex [Attribute], Or [Regex [Attribute], Regex [Attribute]], Regex [Attribute]]], result = [Count] }]]");
+
+        // Double NOT
+        assertLayout("all(group(a) filter(not not regex(\".*suffix$\", a)) each(output(count())))",
+                "[[{ Attribute, filter = [Not [Not [Regex [Attribute]]]], result = [Count] }]]");
     }
 
     private static void assertTotalGroupsAndSummaries(long expected, String query) {


### PR DESCRIPTION
Convert grouping filter predicates from functional to **infix** operators for readability. Introduces `filterPrimary` (parses unary expressions and atoms) and restructures the parser as `filterExp → orPredicate → andPredicate → notPredicate → filterPrimary`, yielding conventional precedence and associativity. `not` has the highest precedence (unary), `and` binds tighter than `or`, and both `and`/`or` are left-associative. Parentheses are supported via `filterPrimary` for explicit grouping. No semantic changes beyond syntax and explicit precedence.

```txt
# Before (functional)
and(or(a, b), not(c))

# Now (infix)
a or b and not c          # parsed as: a or (b and (not c))
(a or b) and not c        # explicit grouping
```

Also expands tests for precedence, associativity, unary `not`, and parentheses.
