### PR TITLE
Configure new and removed packages for newer JDKs

### DIFF
--- a/jdisc_core/src/test/java/com/yahoo/jdisc/core/ExportPackagesIT.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/core/ExportPackagesIT.java
@@ -54,6 +54,22 @@ public class ExportPackagesIT {
 
     private static final List<String> newPackagesInJava21 = List.of("java.lang.foreign");
     private static final List<String> removedPackagesInJava21 = List.of("com.sun.jarsigner");
+    private static final List<String> newPackagesInJava22 = List.of(
+            "java.lang.classfile",
+            "java.lang.classfile.attribute",
+            "java.lang.classfile.constantpool",
+            "java.lang.classfile.instruction",
+            "java.lang.classfile.components"
+    );
+    private static final List<String> removedPackagesInJava22 = List.of();
+    private static final List<String> newPackagesInJava23 = List.of();
+    private static final List<String> removedPackagesInJava23 = List.of();
+    private static final List<String> newPackagesInJava24 = List.of(
+            "jdk.management"
+    );
+    private static final List<String> removedPackagesInJava24 = List.of(
+            "java.lang.classfile.components"
+    );
 
     private static final Pattern PACKAGE_PATTERN = Pattern.compile("([^;,]+);\\s*version=\"([^\"]*)\"(?:,\\s*([^;,]+);\\s*uses:=\"([^\"]*)\")?");
 
@@ -128,6 +144,17 @@ public class ExportPackagesIT {
         if (Runtime.version().feature() >= 21) {
             expectedPackages = expectedPackages.removePackages(removedPackagesInJava21)
                     .addPackages(newPackagesInJava21);
+        }
+        if (Runtime.version().feature() >= 22) {
+            expectedPackages = expectedPackages.removePackages(removedPackagesInJava22)
+                    .addPackages(newPackagesInJava22);
+        }
+        if (Runtime.version().feature() >= 23) {
+            expectedPackages = expectedPackages.removePackages(removedPackagesInJava23)
+                    .addPackages(newPackagesInJava23);
+        }
+        if (Runtime.version().feature() >= 24) {
+            expectedPackages = expectedPackages.removePackages(removedPackagesInJava24).addPackages(newPackagesInJava24);
         }
         var actualPackages = parsePackages(actualValue).removeJavaVersion();
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Compiling with a newer JDK is not working properly. 
This PR fixes one little issue to get compilation working with JDK 21+.

Tested with:
```
sdk use java 22.0.2-oracle                                                                                                           
sdk use java 23.0.1-open                                                                                                             
sdk use java 24.0.1-open 
```