### PR TITLE
Revert "Don't reduce SameElement with one child"

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1068,7 +1068,7 @@
     ],
     "methods" : [
       "public void <init>()",
-      "public final java.util.Optional extractSingleChild()"
+      "public java.util.Optional extractSingleChild()"
     ],
     "fields" : [ ]
   },
@@ -1487,6 +1487,7 @@
       "protected void encodeThis(java.nio.ByteBuffer)",
       "protected void appendHeadingString(java.lang.StringBuilder)",
       "protected void appendBodyString(java.lang.StringBuilder)",
+      "public java.util.Optional extractSingleChild()",
       "public com.yahoo.prelude.query.Item$ItemType getItemType()",
       "public java.lang.String getName()",
       "public java.lang.String getFieldName()",

--- a/container-search/src/main/java/com/yahoo/prelude/query/NonReducibleCompositeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/NonReducibleCompositeItem.java
@@ -7,15 +7,14 @@ import java.util.Optional;
  * A composite item which specifies semantics which are not maintained
  * if an instance with a single child is replaced by the single child.
  * Most composites, like AND and OR, are reducible as e.g (AND a) is semantically equal to (a).
- * This type functions as a marker type for query rewriters and returns empty when a single child is attempted extracted.
+ * This type functions as a marker type for query rewriters.
  *
  * @author bratseth
  */
 public abstract class NonReducibleCompositeItem extends CompositeItem {
 
-
     @Override
-    public final Optional<Item> extractSingleChild() {
+    public Optional<Item> extractSingleChild() {
         return Optional.empty();
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
@@ -41,6 +41,18 @@ public class SameElementItem extends NonReducibleCompositeItem {
     }
 
     @Override
+    public Optional<Item> extractSingleChild() {
+        if (getItemCount() == 1) {
+            if (getItem(0) instanceof SimpleIndexedItem child) {
+                if ( ! child.getIndexName().isEmpty())
+                    child.setIndexName(getFieldName() + "." + child.getIndexName());
+            }
+            return Optional.of(getItem(0));
+        }
+        return Optional.empty();
+    }
+    
+    @Override
     public ItemType getItemType() {
         return ItemType.SAME_ELEMENT;
     }

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/QueryRewrite.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/QueryRewrite.java
@@ -104,7 +104,8 @@ public class QueryRewrite {
         NotItem theOnlyNot = null;
         for (int i = 0; i < parent.getItemCount(); i++) {
             Item child = parent.getItem(i);
-            if (child instanceof NotItem thisNot) {
+            if (child instanceof NotItem) {
+                NotItem thisNot = (NotItem) child;
                 parent.setItem(i, thisNot.getPositiveItem());
                 if (theOnlyNot == null) {
                     theOnlyNot = thisNot;
@@ -220,9 +221,10 @@ public class QueryRewrite {
     }
     
     private static Item collapseSingleComposites(Item item) {
-        if (!(item instanceof CompositeItem parent)) {
+        if (!(item instanceof CompositeItem)) {
             return item;
         }
+        CompositeItem parent = (CompositeItem)item;
         int numChildren = parent.getItemCount();
         for (int i = 0; i < numChildren; ++i) {
             Item oldChild = parent.getItem(i);
@@ -235,7 +237,8 @@ public class QueryRewrite {
     }
 
     private static Item rewriteSddocname(Item item) {
-        if (item instanceof CompositeItem parent) {
+        if (item instanceof CompositeItem) {
+            CompositeItem parent = (CompositeItem)item;
             for (int i = 0, len = parent.getItemCount(); i < len; ++i) {
                 Item oldChild = parent.getItem(i);
                 Item newChild = rewriteSddocname(oldChild);
@@ -243,7 +246,8 @@ public class QueryRewrite {
                     parent.setItem(i, newChild);
                 }
             }
-        } else if (item instanceof SimpleIndexedItem oldItem) {
+        } else if (item instanceof SimpleIndexedItem) {
+            SimpleIndexedItem oldItem = (SimpleIndexedItem)item;
             if (Hit.SDDOCNAME_FIELD.equals(oldItem.getIndexName())) {
                 SubstringItem newItem = new SubstringItem(oldItem.getIndexedString());
                 newItem.setIndexName("[documentmetastore]");

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerTestCase.java
@@ -31,17 +31,11 @@ public class QueryCanonicalizerTestCase {
     }
 
     @Test
-    void testSingleLevelSingleItemNonReducibleWeakAndItem() {
+    void testSingleLevelSingleItemNonReducibleComposite() {
         CompositeItem root = new WeakAndItem();
+
         root.addItem(new WordItem("word"));
         assertCanonicalized("WEAKAND(100) word", null, root);
-    }
-
-    @Test
-    void testSingleLevelSingleItemNonReducibleSameElementItem() {
-        CompositeItem root = new SameElementItem("field");
-        root.addItem(new WordItem("word"));
-        assertCanonicalized("field:{word}", null, root);
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/SameElementItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/SameElementItemTestCase.java
@@ -67,4 +67,27 @@ public class SameElementItemTestCase {
         }
     }
 
+    private void verifyExtractSingle(TermItem term) {
+        String subFieldName = term.getIndexName();
+        SameElementItem s = new SameElementItem("structa");
+        s.addItem(term);
+        Optional<Item> single =s.extractSingleChild();
+        assertTrue(single.isPresent());
+        assertEquals(((TermItem)single.get()).getIndexName(), s.getFieldName() + "." + subFieldName);
+    }
+
+    @Test
+    void requireExtractSingleItemToExtractSingles() {
+        verifyExtractSingle(new WordItem("b", "f1"));
+        verifyExtractSingle(new IntItem("7", "f1"));
+    }
+
+    @Test
+    void requireExtractSingleItemToExtractSinglesOnly() {
+        SameElementItem s = new SameElementItem("structa");
+        s.addItem(new WordItem("b", "f1"));
+        s.addItem(new WordItem("c", "f2"));
+        assertTrue(s.extractSingleChild().isEmpty());
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -422,7 +422,7 @@ public class YqlParserTestCase {
         assertCanonicalParse("select foo from bar where baz contains sameElement(key contains \"a\", value.f2 = 10)",
                 "baz:{key:a value.f2:10}");
         assertCanonicalParse("select foo from bar where baz contains sameElement(key contains \"a\")",
-                "baz:{key:a}");
+                "baz.key:a");
     }
 
     @Test
@@ -1506,7 +1506,7 @@ public class YqlParserTestCase {
         Query q = new Query();
         q.getModel().getQueryTree().setRoot(qt.getRoot());
         QueryRewrite.collapseSingleComposites(q);
-        assertEquals(expectedQueryTree, q.getModel().getQueryTree().toString());
+        assertEquals(q.getModel().getQueryTree().toString(), expectedQueryTree);
     }
 
     private QueryTree assertParseFail(String yqlQuery, Throwable expectedException) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#34601

This broke 2 system tests on factory for streaming search due to streaming search backend not handling SameElement with one child. Fix for streaming search backend is in PR #34607, this revert is not needed when that fix is merged.

