### PR TITLE
Handle SameElement with one child in streaming search.

### DIFF
--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
@@ -24,6 +24,9 @@ SameElementQueryNode::evaluateHits(HitList & hl) const
 {
     hl.clear();
     const auto & children = get_terms();
+    if (children.size() == 1) {
+        return children.front()->evaluateHits(hl);
+    }
     for (auto& child : children) {
         if ( ! child->evaluate() ) {
             return hl;


### PR DESCRIPTION
@havardpe or @bratseth : please review

With this applied, the revert in #34605 is not needed.
