### PR TITLE
Support one content node in a group being down at a time

### DIFF
--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -160,7 +160,7 @@ public class NodeStateChangeCheckerTest {
                                            clusterStateWith0InMaintenance, UP_NODE_STATE, MAINTENANCE_NODE_STATE);
         assertFalse(result.allowed());
         assertFalse(result.isAlreadySet());
-        assertEquals("At most one node can have a wanted state when #groups = 1: Other storage node 0 has wanted state Maintenance",
+        assertEquals("At most one node can have a wanted state: Other storage node 0 has wanted state Maintenance",
                      result.reason());
     }
 
@@ -347,7 +347,7 @@ public class NodeStateChangeCheckerTest {
                 currentClusterStateVersion));
 
         settingToMaintenanceIsNotAllowed(1, cluster, clusterStateWith0InMaintenance,
-                                         "At most one node can have a wanted state when #groups = 1: Other distributor 0 has wanted state Down");
+                                         "At most one node can have a wanted state: Other distributor 0 has wanted state Down");
     }
 
     @ParameterizedTest

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -203,7 +203,8 @@ cluster_feed_block_noise_level double default=0.01
 
 # For apps that have several groups this controls how many groups are allowed to
 # be down simultaneously in this cluster. The default value of -1 means that
-# 1 group at a time is allowed to be down.
+# 1 group at a time is allowed to be down, 0 means one node at a time (for the whole
+# cluster, not per group).
 max_number_of_groups_allowed_to_be_down int default=-1
 
 ## Iff true, cluster state bundles sent from the cluster controller to distributors


### PR DESCRIPTION
Rough draft of how this can be done. No support for more than one node at a time or configuring this in services.xml. Probably want to use another config as well, so >1 node is easier to express.