### PR TITLE
feat: add relevanceScore to the language server

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -245,6 +245,7 @@ public class BuiltInFunctions {
         put("firstPhase", new GenericFunction("firstPhase"));
         put("secondPhase", new GenericFunction("secondPhase"));
         put("firstPhaseRank", new GenericFunction("firstPhaseRank"));
+        put("relevanceScore", new GenericFunction("relevanceScore"));
 
         put("nativeFieldMatch", new GenericFunction("nativeFieldMatch", List.of(
             new FunctionSignature(),


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The `relevanceScore` is documented, but the language server doesn't know about it yet. 

https://docs.vespa.ai/en/reference/rank-features.html#relevancescore
https://github.com/vespa-engine/vespa/pull/34534