### PR TITLE
fix(config-provisioning): add back `isPublic()` used by older config …

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -63,6 +63,9 @@ public enum SystemName {
     /** Whether the system is similar to Public, e.g. PublicCd. */
     public boolean isPublicLike() { return this == Public || this == PublicCd; }
 
+    // TODO Vespa 9: remove. Use isPublicLike() instead.
+    @Deprecated(forRemoval = true, since = "2025-08-26") public boolean isPublic() { return isPublicLike(); }
+
     public boolean isMainLike() { return this == main || this == cd; }
 
     public boolean isKubernetes() { return this == kubernetes; }


### PR DESCRIPTION
…models

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
