### PR TITLE
Support specifying coverage policy in services.xml

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/CoveragePolicy.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/CoveragePolicy.java
@@ -1,0 +1,11 @@
+package com.yahoo.vespa.model.content;
+
+public record CoveragePolicy(Policy policy) {
+
+    enum Policy { GROUP, NODE }
+
+    static CoveragePolicy group() { return new CoveragePolicy(Policy.GROUP); }
+
+    static CoveragePolicy node() { return new CoveragePolicy(Policy.NODE); }
+
+}

--- a/config-model/src/main/resources/schema/content.rnc
+++ b/config-model/src/main/resources/schema/content.rnc
@@ -128,15 +128,19 @@ Content = element content {
     Documents? &
     ContentNodes? &
     TopGroup? &
-    Controllers?
+    Controllers? &
+    CoveragePolicy?
     # Contains experimental feature switches
     #Experimental?
 }
 
-Controllers =
-  element controllers {
+Controllers = element controllers {
     OptionalDedicatedNodes
-  }
+}
+
+CoveragePolicy = element coverage-policy {
+    xsd:string "group" | xsd:string "node"
+}
 
 ContentSearch = element search {
     element query-timeout { xsd:double { minInclusive = "0" } }? &

--- a/config-model/src/test/schema-test-files/services-hosted.xml
+++ b/config-model/src/test/schema-test-files/services-hosted.xml
@@ -34,6 +34,7 @@
     <nodes count="[10,20]" flavor="large" groups="[1,3]" group-size="[1,2]" vespamalloc-debug-stacktrace="proton">
       <resources vcpu="[3.0, 4]" memory="[32000.0Mb, 33Gb]" disk="[300 Gb, 1Tb]"/>
     </nodes>
+    <coverage-policy>group</coverage-policy>
   </content>
 
 </services>


### PR DESCRIPTION
Policy can be either 'group' (the default) or 'node'. For grouped setups this will be used to allow one group per cluster being down at a time, or one node at a time.