### PR TITLE
Forward get_elements_ids and and_element_ids member functions to search

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.cpp
@@ -17,6 +17,18 @@ AttributeIteratorBase::visitMembers(vespalib::ObjectVisitor &visitor) const
 }
 
 void
+AttributeIteratorBase::get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids)
+{
+    _baseSearchCtx.get_element_ids(docid, element_ids);
+}
+
+void
+AttributeIteratorBase::and_element_ids_into(uint32_t docid, std::vector<uint32_t>& element_ids)
+{
+    _baseSearchCtx.and_element_ids_into(docid, element_ids);
+}
+
+void
 AttributeIterator::visitMembers(vespalib::ObjectVisitor &visitor) const
 {
     AttributeIteratorBase::visitMembers(visitor);

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -40,6 +40,8 @@ public:
           _matchPosition(_matchData->populate_fixed())
     { }
     Trinary is_strict() const override { return Trinary::False; }
+    void get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) override;
+    void and_element_ids_into(uint32_t docid, std::vector<uint32_t>& element_ids) override;
 };
 
 
@@ -147,6 +149,7 @@ public:
     AttributeIteratorStrict(const SC &concreteSearchCtx, fef::TermFieldMatchData * matchData)
         : AttributeIteratorT<SC>(concreteSearchCtx, matchData)
     { }
+    ~AttributeIteratorStrict() override;
 };
 
 

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
@@ -441,6 +441,9 @@ FilterAttributeIteratorT<SC>::doSeek(uint32_t docId)
 }
 
 template <typename SC>
+AttributeIteratorStrict<SC>::~AttributeIteratorStrict() = default;
+
+template <typename SC>
 void
 AttributeIteratorStrict<SC>::doSeek(uint32_t docId)
 {


### PR DESCRIPTION
context for attribute vector iterators.

@vekterli : please reiew
