### PR TITLE
abort messages in priority order

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -161,7 +161,7 @@ public:
         void dumpActiveHtml(std::ostream & os) const;
         void dumpQueueHtml(std::ostream & os) const;
         [[nodiscard]] std::mutex & exposeLock() { return *_lock; }
-        [[nodiscard]] PriorityQueue & exposeQueue() { return *_queue; }
+        void queue_emplace(MessageEntry entry) { _queue->emplace_back(std::move(entry)); }
         [[nodiscard]] BucketIdx & exposeBucketIdx() { return bmi::get<2>(*_queue); }
         void setMetrics(FileStorStripeMetrics * metrics) { _metrics = metrics; }
         [[nodiscard]] ActiveOperationsStats get_active_operations_stats(bool reset_min_max) const;


### PR DESCRIPTION
* Stripe::abort() was the only place iterating messages in sequence, but it shouldn't matter if we do it in priority order instead.
* Also, avoid exposing the internal PriorityQueue which was only used one place.
