### PR TITLE
Arnej/only execute once per docid

### DIFF
--- a/searchlib/src/tests/aggregator/attr_test.cpp
+++ b/searchlib/src/tests/aggregator/attr_test.cpp
@@ -248,6 +248,7 @@ TEST(AttrTest, testWithRelevance) {
         SCOPED_TRACE(vespalib::make_string("i=%d", i).c_str());
         EXPECT_TRUE(et.execute(0, HitRank(r)));
         EXPECT_EQ(et.getResult()->getFloat(), expect0[i]);
+        EXPECT_TRUE(et.execute(1, HitRank(r)));
     }
 
     EXPECT_TRUE(et.execute(0, HitRank(f1.doc0attr[2])));
@@ -256,21 +257,27 @@ TEST(AttrTest, testWithRelevance) {
     // docid 1
     EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[0] - 0.001)));
     EXPECT_EQ(et.getResult()->getFloat(), 0.0);
+    EXPECT_TRUE(et.execute(0, HitRank(0)));
 
     EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[0])));
     EXPECT_EQ(et.getResult()->getFloat(), 0.0);
+    EXPECT_TRUE(et.execute(0, HitRank(0)));
 
     EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[2])));
     EXPECT_EQ(et.getResult()->getFloat(), 2.0);
+    EXPECT_TRUE(et.execute(0, HitRank(0)));
                 
     EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[4])));
     EXPECT_EQ(et.getResult()->getFloat(), 4.0);
+    EXPECT_TRUE(et.execute(0, HitRank(0)));
 
     EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[10])));
     EXPECT_EQ(et.getResult()->getFloat(), 10.0);
+    EXPECT_TRUE(et.execute(0, HitRank(0)));
 
     EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[10] + 0.01)));
     EXPECT_EQ(et.getResult()->getFloat(), 10.0);
+    EXPECT_TRUE(et.execute(0, HitRank(0)));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/expression/attributenode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/attributenode.cpp
@@ -314,8 +314,10 @@ AttributeNode::EnumHandler::handle(const AttributeResult & r)
 
 void
 AttributeNode::setDocId(DocId docId) {
-    _scratchResult->setDocId(docId);
-    _needExecute = true;
+    if (_scratchResult->getDocId() != docId) {
+        _scratchResult->setDocId(docId);
+        _needExecute = true;
+    }
 }
 
 bool


### PR DESCRIPTION
@toregge please review
@havardpe FYI

We may want to look closer into why setDocid is called multiple times for same docid here,
but a simple experiment confirmed a performance problem reported on slack.

The unit test that needed changes doesn't run the expression in a realistic way; it did re-run with same docid but different relevance scores which isn't something that's supposed to be possible; for now I hacked it by calling with a different docid between to force needExecute=true.
