### PR TITLE
use std::set combination for multi_index_container

### DIFF
--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.cpp
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.cpp
@@ -163,7 +163,7 @@ PendingMessageTracker::reply(const api::StorageReply& r)
     uint64_t msgId = r.getMsgId();
 
     std::unique_lock guard(_lock);
-    auto& msgs = _messages.byMessageIdSet;
+    const auto& msgs = _messages.byMessageId();
     auto iter = msgs.find(msgId);
     if (iter != msgs.end()) {
         bucket = iter->bucket;

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -263,25 +263,25 @@ private:
 
         // Index wrapping the set using NodeBucketTypeIdComparator
         struct IndexByNodeAndBucket {
-            using iterator = wrap_set_iterator<ByNodeAndBucketSet::const_iterator>;
+            using const_iterator = wrap_set_iterator<ByNodeAndBucketSet::const_iterator>;
             Messages& _m;
-            auto begin() const noexcept { return iterator(_m.byNodeAndBucketSet.begin()); }
-            auto end()   const noexcept { return iterator(_m.byNodeAndBucketSet.end()); }
+            auto begin() const noexcept { return const_iterator(_m.byNodeAndBucketSet.begin()); }
+            auto end()   const noexcept { return const_iterator(_m.byNodeAndBucketSet.end()); }
 
             IndexByNodeAndBucket(Messages& m) : _m(m) {}
             template<typename Key>
-            std::pair<iterator, iterator> equal_range(Key key) const noexcept {
+            std::pair<const_iterator, const_iterator> equal_range(Key key) const noexcept {
                 auto inner_range = _m.byNodeAndBucketSet.equal_range(key);
-                return std::make_pair(iterator(inner_range.first),
-                                      iterator(inner_range.second));
+                return std::make_pair(const_iterator(inner_range.first),
+                                      const_iterator(inner_range.second));
             }
-            iterator erase(iterator it) {
+            const_iterator erase(const_iterator it) {
                 const MessageEntry& entry = *it;
                 ++it;
                 _m.remove(entry);
                 return it;
             }
-            void erase(iterator it, iterator to) {
+            void erase(const_iterator it, const_iterator to) {
                 while (it != to) {
                     it = erase(it);
                 }
@@ -290,14 +290,14 @@ private:
 
         // Index wrapping the set using BucketTypeNodeIdComparator
         struct IndexByBucketAndType {
-            using iterator = wrap_set_iterator<ByBucketAndTypeSet::const_iterator>;
+            using const_iterator = wrap_set_iterator<ByBucketAndTypeSet::const_iterator>;
             Messages& _m;
-            auto begin() const noexcept { return iterator(_m.byBucketAndTypeSet.begin()); }
-            auto end()   const noexcept { return iterator(_m.byBucketAndTypeSet.end()); }
-            std::pair<iterator, iterator> equal_range(BucketKey key) const noexcept {
+            auto begin() const noexcept { return const_iterator(_m.byBucketAndTypeSet.begin()); }
+            auto end()   const noexcept { return const_iterator(_m.byBucketAndTypeSet.end()); }
+            std::pair<const_iterator, const_iterator> equal_range(BucketKey key) const noexcept {
                 auto inner_range = _m.byBucketAndTypeSet.equal_range(key);
-                return std::make_pair(iterator(inner_range.first),
-                                      iterator(inner_range.second));
+                return std::make_pair(const_iterator(inner_range.first),
+                                      const_iterator(inner_range.second));
             }
             IndexByBucketAndType(Messages& m) : _m(m) {}
         };

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -162,22 +162,22 @@ private:
         [[nodiscard]] std::string toHtml() const;
 
         // make it easy to implement comparison operators:
-        operator NodeBucketTypeIdKey() const {
+        operator NodeBucketTypeIdKey() const noexcept {
             return NodeBucketTypeIdKey(nodeIdx, bucket, msgType, msgId);
         }
-        operator NodeBucketTypeKey() const {
+        operator NodeBucketTypeKey() const noexcept {
             return NodeBucketTypeKey(nodeIdx, bucket, msgType);
         }
-        operator NodeBucketKey() const {
+        operator NodeBucketKey() const noexcept {
             return NodeBucketKey(nodeIdx, bucket);
         }
-        operator NodeKey() const {
+        operator NodeKey() const noexcept {
             return NodeKey(nodeIdx);
         }
-        operator BucketTypeNodeIdKey() const {
+        operator BucketTypeNodeIdKey() const noexcept {
             return BucketTypeNodeIdKey(bucket, msgType, nodeIdx, msgId);
         }
-        operator BucketKey() const {
+        operator BucketKey() const noexcept {
             return BucketKey(bucket);
         }
     };
@@ -185,13 +185,13 @@ private:
     // comparator using just the 64-bit unique msgId:
     struct MessageIdKey {
         using is_transparent = std::true_type;
-        bool operator() (const MessageEntry &a, const MessageEntry &b) const {
+        bool operator() (const MessageEntry &a, const MessageEntry &b) const noexcept {
             return a.msgId < b.msgId;
         }
-        bool operator() (const MessageEntry &a, uint64_t b) const {
+        bool operator() (const MessageEntry &a, uint64_t b) const noexcept {
             return a.msgId < b;
         }
-        bool operator() (uint64_t a, const MessageEntry &b) const {
+        bool operator() (uint64_t a, const MessageEntry &b) const noexcept {
             return a < b.msgId;
         }
     };
@@ -203,14 +203,14 @@ private:
      */
     struct NodeBucketTypeIdComparator {
         using is_transparent = std::true_type;
-        bool operator() (const MessageEntry *a, const MessageEntry *b) const {
+        bool operator() (const MessageEntry *a, const MessageEntry *b) const noexcept {
             NodeBucketTypeIdKey ka(*a);
             NodeBucketTypeIdKey kb(*b);
             return ka < kb;
         }
         // allow compare both ways with partial Key tuples:
-        template<typename T> bool operator() (const MessageEntry * a, const T& b) const { return T(*a) < b; }
-        template<typename T> bool operator() (const T& a, const MessageEntry * b) const { return a < T(*b); }
+        template<typename T> bool operator() (const MessageEntry * a, const T& b) const noexcept { return T(*a) < b; }
+        template<typename T> bool operator() (const T& a, const MessageEntry * b) const noexcept { return a < T(*b); }
     };
 
     // We also have an index keyed no bucket id+type+node
@@ -218,20 +218,20 @@ private:
     // so maybe it could be simplified
     struct BucketTypeNodeIdComparator {
         using is_transparent = std::true_type;
-        bool operator() (const MessageEntry *a, const MessageEntry *b) const {
+        bool operator() (const MessageEntry *a, const MessageEntry *b) const noexcept {
             BucketTypeNodeIdKey ka(*a);
             BucketTypeNodeIdKey kb(*b);
             return ka < kb;
         }
         // allow compare both ways with partial Key tuples:
-        template<typename T> bool operator() (const MessageEntry * a, const T& b) const { return T(*a) < b; }
-        template<typename T> bool operator() (const T& a, const MessageEntry * b) const { return a < T(*b); }
+        template<typename T> bool operator() (const MessageEntry * a, const T& b) const noexcept { return T(*a) < b; }
+        template<typename T> bool operator() (const T& a, const MessageEntry * b) const noexcept { return a < T(*b); }
     };
 
     // wraps an iterator for std::set<MessageEntry *>, hiding the extra indirection
     template<typename I> struct wrap_set_iterator : public I {
-        auto * operator-> () const { return I::operator*(); }
-        auto & operator* () const { return *I::operator*(); }
+        auto * operator-> () const noexcept { return I::operator*(); }
+        auto & operator* () const noexcept { return *I::operator*(); }
     };
 
     // multi-index container:
@@ -265,12 +265,12 @@ private:
         struct IndexByNodeAndBucket {
             using iterator = wrap_set_iterator<ByNodeAndBucketSet::const_iterator>;
             Messages& _m;
-            auto begin() const { return iterator(_m.byNodeAndBucketSet.begin()); }
-            auto end()   const { return iterator(_m.byNodeAndBucketSet.end()); }
+            auto begin() const noexcept { return iterator(_m.byNodeAndBucketSet.begin()); }
+            auto end()   const noexcept { return iterator(_m.byNodeAndBucketSet.end()); }
 
             IndexByNodeAndBucket(Messages& m) : _m(m) {}
             template<typename Key>
-            std::pair<iterator, iterator> equal_range(Key key) const {
+            std::pair<iterator, iterator> equal_range(Key key) const noexcept {
                 auto inner_range = _m.byNodeAndBucketSet.equal_range(key);
                 return std::make_pair(iterator(inner_range.first),
                                       iterator(inner_range.second));
@@ -292,9 +292,9 @@ private:
         struct IndexByBucketAndType {
             using iterator = wrap_set_iterator<ByBucketAndTypeSet::const_iterator>;
             Messages& _m;
-            auto begin() const { return iterator(_m.byBucketAndTypeSet.begin()); }
-            auto end()   const { return iterator(_m.byBucketAndTypeSet.end()); }
-            std::pair<iterator, iterator> equal_range(BucketKey key) const {
+            auto begin() const noexcept { return iterator(_m.byBucketAndTypeSet.begin()); }
+            auto end()   const noexcept { return iterator(_m.byBucketAndTypeSet.end()); }
+            std::pair<iterator, iterator> equal_range(BucketKey key) const noexcept {
                 auto inner_range = _m.byBucketAndTypeSet.equal_range(key);
                 return std::make_pair(iterator(inner_range.first),
                                       iterator(inner_range.second));
@@ -319,7 +319,7 @@ private:
         ByBucketAndTypeSet   byBucketAndTypeSet;
     public:
         // index wrappers:
-        const MainSet& byMessageId() const { return byMessageIdSet; }
+        const MainSet& byMessageId() const noexcept { return byMessageIdSet; }
         IndexByNodeAndBucket byNodeAndBucketIdx;
         IndexByBucketAndType byBucketAndTypeIdx;
     };

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -9,13 +9,7 @@
 #include <vespa/storageframework/generic/status/htmlstatusreporter.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/vespalib/stllike/hash_set.h>
-#include <boost/multi_index/composite_key.hpp>
-#include <boost/multi_index/identity.hpp>
-#include <boost/multi_index/mem_fun.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
-#include <boost/multi_index_container.hpp>
+#include <cassert>
 #include <chrono>
 #include <functional>
 #include <mutex>
@@ -136,6 +130,25 @@ public:
     void enumerate_matching_pending_bucket_ops(const std::function<bool(const document::Bucket&)>& bucket_predicate,
                                                const std::function<void(uint64_t)>& msg_id_callback) const;
 private:
+    // these are all the full and partial keys for the first extra index:
+    using NodeBucketTypeIdKey =
+            std::tuple<uint16_t, const document::Bucket &, uint32_t, uint64_t>;
+    using NodeBucketTypeKey =
+            std::tuple<uint16_t, const document::Bucket &, uint32_t>;
+    using NodeBucketKey =
+            std::tuple<uint16_t, const document::Bucket &>;
+    using NodeKey =
+            std::tuple<uint16_t>;
+    // these are all the full and partial keys for the second extra index:
+    using BucketTypeNodeIdKey =
+            std::tuple<const document::Bucket &, uint32_t, uint16_t, uint64_t>;
+    using BucketTypeNodeKey =
+            std::tuple<const document::Bucket &, uint32_t, uint16_t>;
+    using BucketTypeKey =
+            std::tuple<const document::Bucket &, uint32_t>;
+    using BucketKey =
+            std::tuple<const document::Bucket &>;
+
     struct MessageEntry {
         TimePoint        timeStamp;
         uint32_t         msgType;
@@ -147,48 +160,167 @@ private:
         MessageEntry(TimePoint timeStamp, uint32_t msgType, uint32_t priority,
                      uint64_t msgId, document::Bucket bucket, uint16_t nodeIdx) noexcept;
         [[nodiscard]] std::string toHtml() const;
+
+        // make it easy to implement comparison operators:
+        operator NodeBucketTypeIdKey() const {
+            return NodeBucketTypeIdKey(nodeIdx, bucket, msgType, msgId);
+        }
+        operator NodeBucketTypeKey() const {
+            return NodeBucketTypeKey(nodeIdx, bucket, msgType);
+        }
+        operator NodeBucketKey() const {
+            return NodeBucketKey(nodeIdx, bucket);
+        }
+        operator NodeKey() const {
+            return NodeKey(nodeIdx);
+        }
+        operator BucketTypeNodeIdKey() const {
+            return BucketTypeNodeIdKey(bucket, msgType, nodeIdx, msgId);
+        }
+        operator BucketKey() const {
+            return BucketKey(bucket);
+        }
     };
 
-    struct MessageIdKey : boost::multi_index::member<MessageEntry, uint64_t, &MessageEntry::msgId> {};
+    // comparator using just the 64-bit unique msgId:
+    struct MessageIdKey {
+        using is_transparent = std::true_type;
+        bool operator() (const MessageEntry &a, const MessageEntry &b) const {
+            return a.msgId < b.msgId;
+        }
+        bool operator() (const MessageEntry &a, uint64_t b) const {
+            return a.msgId < b;
+        }
+        bool operator() (uint64_t a, const MessageEntry &b) const {
+            return a < b.msgId;
+        }
+    };
 
     /**
      * Each entry has a separate composite keyed index on node+bucket id+type.
      * This makes it efficient to find all messages for a node, for a bucket
      * on that node and specific message types to an exact bucket on the node.
      */
-    struct CompositeNodeBucketKey
-        : boost::multi_index::composite_key<
-              MessageEntry,
-              boost::multi_index::member<MessageEntry, uint16_t, &MessageEntry::nodeIdx>,
-              boost::multi_index::member<MessageEntry, document::Bucket, &MessageEntry::bucket>,
-              boost::multi_index::member<MessageEntry, uint32_t, &MessageEntry::msgType>
-          >
-    {
+    struct NodeBucketTypeIdComparator {
+        using is_transparent = std::true_type;
+        bool operator() (const MessageEntry *a, const MessageEntry *b) const {
+            NodeBucketTypeIdKey ka(*a);
+            NodeBucketTypeIdKey kb(*b);
+            return ka < kb;
+        }
+        // allow compare both ways with partial Key tuples:
+        template<typename T> bool operator() (const MessageEntry * a, const T& b) const { return T(*a) < b; }
+        template<typename T> bool operator() (const T& a, const MessageEntry * b) const { return a < T(*b); }
     };
 
-    struct CompositeBucketMsgNodeKey
-        : boost::multi_index::composite_key<
-              MessageEntry,
-              boost::multi_index::member<MessageEntry, document::Bucket, &MessageEntry::bucket>,
-              boost::multi_index::member<MessageEntry, uint32_t, &MessageEntry::msgType>,
-              boost::multi_index::member<MessageEntry, uint16_t, &MessageEntry::nodeIdx>
-          >
-    {
+    // We also have an index keyed no bucket id+type+node
+    // currently only used to gather all messages for a specific bucket,
+    // so maybe it could be simplified
+    struct BucketTypeNodeIdComparator {
+        using is_transparent = std::true_type;
+        bool operator() (const MessageEntry *a, const MessageEntry *b) const {
+            BucketTypeNodeIdKey ka(*a);
+            BucketTypeNodeIdKey kb(*b);
+            return ka < kb;
+        }
+        // allow compare both ways with partial Key tuples:
+        template<typename T> bool operator() (const MessageEntry * a, const T& b) const { return T(*a) < b; }
+        template<typename T> bool operator() (const T& a, const MessageEntry * b) const { return a < T(*b); }
     };
 
-    using Messages = boost::multi_index::multi_index_container <
-        MessageEntry,
-        boost::multi_index::indexed_by<
-            boost::multi_index::ordered_unique<MessageIdKey>,
-            boost::multi_index::ordered_non_unique<CompositeNodeBucketKey>,
-            boost::multi_index::ordered_non_unique<CompositeBucketMsgNodeKey>
-        >
-    >;
+    // wraps an iterator for std::set<MessageEntry *>, hiding the extra indirection
+    template<typename I> struct wrap_set_iterator : public I {
+        auto * operator-> () const { return I::operator*(); }
+        auto & operator* () const { return *I::operator*(); }
+    };
 
-    // Must match Messages::nth_index<N>
-    static constexpr uint32_t IndexByMessageId     = 0;
-    static constexpr uint32_t IndexByNodeAndBucket = 1;
-    static constexpr uint32_t IndexByBucketAndType = 2;
+    // multi-index container:
+    struct Messages {
+        using MainSet = std::set<MessageEntry, MessageIdKey>;
+        using ByNodeAndBucketSet = std::set<const MessageEntry *, NodeBucketTypeIdComparator>;
+        using ByBucketAndTypeSet = std::set<const MessageEntry *, BucketTypeNodeIdComparator>;
+
+        // generic emplace, keeping indexes in sync
+        template<typename ...Args>
+        void emplace(Args&&... args)
+        {
+            auto [iter, added] = byMessageIdSet.emplace(std::forward<Args>(args)...);
+            assert(added);
+            const MessageEntry &entry = *iter;
+            byNodeAndBucketSet.insert(&entry);
+            byBucketAndTypeSet.insert(&entry);
+        }
+
+        // remove by key, keeping indexes in sync
+        void remove(const MessageEntry &key) {
+            auto iter = byMessageIdSet.find(key);
+            assert (iter != byMessageIdSet.end());
+            const MessageEntry &entry = *iter;
+            byNodeAndBucketSet.erase(&entry);
+            byBucketAndTypeSet.erase(&entry);
+            byMessageIdSet.erase(iter);
+        }
+
+        // Index wrapping the set using NodeBucketTypeIdComparator
+        struct IndexByNodeAndBucket {
+            using iterator = wrap_set_iterator<ByNodeAndBucketSet::const_iterator>;
+            Messages& _m;
+            auto begin() const { return iterator(_m.byNodeAndBucketSet.begin()); }
+            auto end()   const { return iterator(_m.byNodeAndBucketSet.end()); }
+
+            IndexByNodeAndBucket(Messages& m) : _m(m) {}
+            template<typename Key>
+            std::pair<iterator, iterator> equal_range(Key key) const {
+                auto inner_range = _m.byNodeAndBucketSet.equal_range(key);
+                return std::make_pair(iterator(inner_range.first),
+                                      iterator(inner_range.second));
+            }
+            iterator erase(iterator it) {
+                const MessageEntry& entry = *it;
+                ++it;
+                _m.remove(entry);
+                return it;
+            }
+            void erase(iterator it, iterator to) {
+                while (it != to) {
+                    it = erase(it);
+                }
+            }
+        };
+
+        // Index wrapping the set using BucketTypeNodeIdComparator
+        struct IndexByBucketAndType {
+            using iterator = wrap_set_iterator<ByBucketAndTypeSet::const_iterator>;
+            Messages& _m;
+            auto begin() const { return iterator(_m.byBucketAndTypeSet.begin()); }
+            auto end()   const { return iterator(_m.byBucketAndTypeSet.end()); }
+            std::pair<iterator, iterator> equal_range(BucketKey key) const {
+                auto inner_range = _m.byBucketAndTypeSet.equal_range(key);
+                return std::make_pair(iterator(inner_range.first),
+                                      iterator(inner_range.second));
+            }
+            IndexByBucketAndType(Messages& m) : _m(m) {}
+        };
+
+        // the actual contents:
+        MainSet byMessageIdSet;
+        // sets of pointers:
+        ByNodeAndBucketSet   byNodeAndBucketSet;
+        ByBucketAndTypeSet   byBucketAndTypeSet;
+        // index wrappers:
+        IndexByNodeAndBucket byNodeAndBucketIdx;
+        IndexByBucketAndType byBucketAndTypeIdx;
+
+        Messages()
+          : byMessageIdSet(),
+            byNodeAndBucketSet(),
+            byBucketAndTypeSet(),
+            byNodeAndBucketIdx(*this),
+            byBucketAndTypeIdx(*this)
+        {}
+
+        ~Messages();
+    };
 
     using DeferredBucketTaskMap = std::unordered_multimap<
             document::Bucket,

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -301,16 +301,6 @@ private:
             }
             IndexByBucketAndType(Messages& m) : _m(m) {}
         };
-
-        // the actual contents:
-        MainSet byMessageIdSet;
-        // sets of pointers:
-        ByNodeAndBucketSet   byNodeAndBucketSet;
-        ByBucketAndTypeSet   byBucketAndTypeSet;
-        // index wrappers:
-        IndexByNodeAndBucket byNodeAndBucketIdx;
-        IndexByBucketAndType byBucketAndTypeIdx;
-
         Messages()
           : byMessageIdSet(),
             byNodeAndBucketSet(),
@@ -320,6 +310,18 @@ private:
         {}
 
         ~Messages();
+
+    private:
+        // the actual contents:
+        MainSet byMessageIdSet;
+        // sets of pointers:
+        ByNodeAndBucketSet   byNodeAndBucketSet;
+        ByBucketAndTypeSet   byBucketAndTypeSet;
+    public:
+        // index wrappers:
+        const MainSet& byMessageId() const { return byMessageIdSet; }
+        IndexByNodeAndBucket byNodeAndBucketIdx;
+        IndexByBucketAndType byBucketAndTypeIdx;
     };
 
     using DeferredBucketTaskMap = std::unordered_multimap<


### PR DESCRIPTION
This sounds like it might be a critical bit of code, but luckily the structure of the code maps easily, and the containers used should be fairly similar to what the boost variant used internally.  Planning to merge this Thursday to get some performance numbers on factory, if it looks good to you.

@vekterli please review
@toregge feel free to take a look also
