### PR TITLE
Replace multi_index_container with std::set pair

### DIFF
--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -93,7 +93,7 @@ VisitorManager::onClose()
 {
     {
         std::lock_guard sync(_visitorLock);
-        for (auto& enqueued : _visitorQueue) {
+        for (const auto& enqueued : _visitorQueue) {
             auto reply = std::make_shared<api::CreateVisitorReply>(*enqueued._command);
             reply->setResult(api::ReturnCode(api::ReturnCode::ABORTED, "Shutting down storage node."));
             sendUp(reply);


### PR DESCRIPTION
replacing this boost::multi_index_container seems to be pretty straight-forward, keeping the code structure unchanged.
since this queue only holds api::CreateVisitorCommand it should only be performance critical for streaming search, I would guess.

@vekterli please review
@toregge FYI
