### PR TITLE
use std::map/set for multi_index_container

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -736,13 +736,13 @@ FileStorHandlerImpl::remapMessage(api::StorageMessage& msg, const document::Buck
 void
 FileStorHandlerImpl::remapQueueNoLock(const RemapInfo& source, std::vector<RemapInfo*>& targets, Operation op)
 {
-    BucketIdx idx = stripe(source.bucket).exposeBucketIdx();
+    BucketIdxView idx = stripe(source.bucket).exposeBucketIdxView();
     auto range(idx.equal_range(source.bucket));
 
     std::vector<MessageEntry> entriesFound;
 
     // Find all the messages for the given bucket.
-    for (BucketIdx::iterator i = range.first; i != range.second; ++i) {
+    for (BucketIdxView::iterator i = range.first; i != range.second; ++i) {
         assert(i->_bucket == source.bucket);
         MessageEntry& entry = *i;
         entriesFound.push_back(std::move(entry));
@@ -853,8 +853,8 @@ FileStorHandlerImpl::Stripe::failOperations(const document::Bucket &bucket, cons
 {
     std::lock_guard guard(*_lock);
 
-    BucketIdx idx = exposeBucketIdx();
-    std::pair<BucketIdx::iterator, BucketIdx::iterator> range(idx.equal_range(bucket));
+    BucketIdxView idx = exposeBucketIdxView();
+    std::pair<BucketIdxView::iterator, BucketIdxView::iterator> range(idx.equal_range(bucket));
 
     for (auto iter = range.first; iter != range.second;) {
         // We want to post delete bucket to list before calling this
@@ -982,8 +982,8 @@ FileStorHandlerImpl::Stripe::next_message_impl(monitor_guard& guard, vespalib::s
     // second attempt. This is key to allowing the run loop to register
     // ticks at regular intervals while not busy-waiting.
     for (int attempt = 0; (attempt < 2) && !_owner.isPaused(); ++attempt) {
-        PriorityIdx idx = exposePriorityIdx();
-        PriorityIdx::iterator iter(idx.begin()), end(idx.end());
+        PriorityIdxView idx = exposePriorityIdxView();
+        PriorityIdxView::iterator iter(idx.begin()), end(idx.end());
         bool was_throttled = false;
 
         while ((iter != end) && operationIsInhibited(guard, iter->_bucket, *iter->_command)) {
@@ -1077,7 +1077,7 @@ FileStorHandlerImpl::Stripe::fill_feed_op_batch(monitor_guard& guard, LockedMess
 {
     assert(batch.size() == 1);
     assert(guard.owns_lock());
-    BucketIdx idx = exposeBucketIdx();
+    BucketIdxView idx = exposeBucketIdxView();
     auto bucket_msgs = idx.equal_range(batch.lock->getBucket());
     // Process in FIFO order (_not_ priority order) until we hit the end, a non-batchable operation
     // (implicit pipeline stall since bucket set might change) or can't get another throttle token.
@@ -1129,8 +1129,8 @@ FileStorHandlerImpl::Stripe::get_next_async_message(monitor_guard& guard)
     if (_owner.isPaused()) {
         return {};
     }
-    PriorityIdx idx = exposePriorityIdx();
-    PriorityIdx::iterator iter(idx.begin()), end(idx.end());
+    PriorityIdxView idx = exposePriorityIdxView();
+    PriorityIdxView::iterator iter(idx.begin()), end(idx.end());
 
     while ((iter != end) && operationIsInhibited(guard, iter->_bucket, *iter->_command)) {
         ++iter;
@@ -1149,7 +1149,7 @@ FileStorHandlerImpl::Stripe::get_next_async_message(monitor_guard& guard)
 }
 
 FileStorHandler::LockedMessage
-FileStorHandlerImpl::Stripe::getMessage(monitor_guard& guard, PriorityIdx& idx, PriorityIdx::iterator iter,
+FileStorHandlerImpl::Stripe::getMessage(monitor_guard& guard, PriorityIdxView& idx, PriorityIdxView::iterator iter,
                                         ThrottleToken throttle_token)
 {
     std::chrono::milliseconds waitTime(uint64_t(iter->_timer.stop(
@@ -1209,7 +1209,7 @@ FileStorHandlerImpl::Stripe::abort(std::vector<std::shared_ptr<api::StorageReply
                                    const AbortBucketOperationsCommand& cmd)
 {
     std::lock_guard lockGuard(*_lock);
-    PriorityIdx idx = exposePriorityIdx();
+    PriorityIdxView idx = exposePriorityIdxView();
     for (auto it = idx.begin(); it != idx.end();) {
         const MessageEntry &entry = *it;
         api::StorageMessage& msg(*entry._command);
@@ -1473,7 +1473,7 @@ FileStorHandlerImpl::Stripe::dumpQueueHtml(std::ostream & os) const
 {
     std::lock_guard guard(*_lock);
 
-    ConstPriorityIdx idx = exposePriorityIdx();
+    ConstPriorityIdxView idx = exposePriorityIdxView();
     for (const auto & entry : idx) {
         os << "<li>" << xml_content_escaped(entry._command->toString()) << " (priority: "
            << static_cast<int>(entry._command->getPriority()) << ")</li>\n";
@@ -1513,7 +1513,7 @@ void
 FileStorHandlerImpl::Stripe::dumpQueue(std::ostream & os) const
 {
     std::lock_guard guard(*_lock);
-    ConstPriorityIdx idx = exposePriorityIdx();
+    ConstPriorityIdxView idx = exposePriorityIdxView();
     for (const auto & entry : idx) {
         os << entry._bucket.getBucketId() << ": "
            << xml_content_escaped(entry._command->toString())

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -159,13 +159,6 @@ public:
                 return it;
             }
         };
-        struct ConstBucketIdx {
-            using iterator = ordered_iterator<ByBucketSet::const_iterator, const MapEntry>;
-            const PriorityQueue& _q;
-            iterator begin() const { return _q._sequence_ids_by_bucket.begin(); }
-            iterator end() const { return _q._sequence_ids_by_bucket.end(); }
-            ConstBucketIdx(PriorityQueue& q) : _q(q) {}
-        };
         struct BucketIdx {
             using iterator = ordered_iterator<ByBucketSet::const_iterator, MapEntry>;
             PriorityQueue& _q;
@@ -205,7 +198,6 @@ public:
     };
 
     using ConstPriorityIdx = PriorityQueue::ConstPriorityIdx;
-    using ConstBucketIdx = PriorityQueue::ConstBucketIdx;
     using PriorityIdx = PriorityQueue::PriorityIdx;
     using BucketIdx = PriorityQueue::BucketIdx;
     using Clock = std::chrono::steady_clock;
@@ -297,7 +289,6 @@ public:
         void queue_emplace(MessageEntry entry) { _queue->emplace_back(std::move(entry)); }
         [[nodiscard]] BucketIdx exposeBucketIdx() { return BucketIdx(*_queue); }
         [[nodiscard]] PriorityIdx exposePriorityIdx() { return PriorityIdx(*_queue); }
-     // [[nodiscard]] ConstBucketIdx exposeBucketIdx() const { return ConstBucketIdx(*_queue); }
         [[nodiscard]] ConstPriorityIdx exposePriorityIdx() const { return ConstPriorityIdx(*_queue); }
         void setMetrics(FileStorStripeMetrics * metrics) { _metrics = metrics; }
         [[nodiscard]] ActiveOperationsStats get_active_operations_stats(bool reset_min_max) const;

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -75,9 +75,9 @@ public:
                 return keyA < keyB;
             }
             template<typename T>
-            bool operator() (EntryPtr a, const T& b) const noexcept { return b.cvt(a) < b.cvt(); }
+            bool operator() (EntryPtr a, const T& b) const noexcept { return b.convert(a) < b.convert(); }
             template<typename T>
-            bool operator() (const T& a, EntryPtr b) const noexcept { return a.cvt() < a.cvt(b); }
+            bool operator() (const T& a, EntryPtr b) const noexcept { return a.convert() < a.convert(b); }
         };
         static bool compareByPriority(const MessageEntry& a, const MessageEntry&b) {
             return a._priority < b._priority;
@@ -173,8 +173,8 @@ public:
             }
             struct BucketCompare {
                 const document::Bucket& bucket;
-                const document::Bucket& cvt() const noexcept { return bucket; }
-                const document::Bucket& cvt(EntryPtr p) const noexcept { return p->second._bucket; }
+                const document::Bucket& convert() const noexcept { return bucket; }
+                const document::Bucket& convert(EntryPtr p) const noexcept { return p->second._bucket; }
             };
             std::pair<iterator, iterator> equal_range(const document::Bucket &bucket) {
                 BucketCompare cmp(bucket);

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -135,10 +135,10 @@ public:
             I _place;
         };
         struct ConstPriorityIdxView {
-            using iterator = ordered_iterator<ByPriSet::const_iterator, const MapEntry>;
+            using const_iterator = ordered_iterator<ByPriSet::const_iterator, const MapEntry>;
             const PriorityQueue& _q;
-            iterator begin() const noexcept { return _q._sequence_ids_by_priority.begin(); }
-            iterator end() const noexcept { return _q._sequence_ids_by_priority.end(); }
+            const_iterator begin() const noexcept { return _q._sequence_ids_by_priority.begin(); }
+            const_iterator end() const noexcept { return _q._sequence_ids_by_priority.end(); }
             ConstPriorityIdxView(PriorityQueue& q) : _q(q) {}
         };
         struct PriorityIdxView {

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -139,19 +139,19 @@ public:
         private:
             I _place;
         };
-        struct ConstPriorityIdx {
+        struct ConstPriorityIdxView {
             using iterator = ordered_iterator<ByPriSet::const_iterator, const MapEntry>;
             const PriorityQueue& _q;
             iterator begin() const { return _q._sequence_ids_by_priority.begin(); }
             iterator end() const { return _q._sequence_ids_by_priority.end(); }
-            ConstPriorityIdx(PriorityQueue& q) : _q(q) {}
+            ConstPriorityIdxView(PriorityQueue& q) : _q(q) {}
         };
-        struct PriorityIdx {
+        struct PriorityIdxView {
             using iterator = ordered_iterator<ByPriSet::iterator, MapEntry>;
             PriorityQueue& _q;
             iterator begin() const { return _q._sequence_ids_by_priority.begin(); }
             iterator end() const { return _q._sequence_ids_by_priority.end(); }
-            PriorityIdx(PriorityQueue& q) : _q(q) {}
+            PriorityIdxView(PriorityQueue& q) : _q(q) {}
             iterator erase(iterator it) {
                 EntryPtr p = it.deref();
                 ++it;
@@ -159,12 +159,12 @@ public:
                 return it;
             }
         };
-        struct BucketIdx {
+        struct BucketIdxView {
             using iterator = ordered_iterator<ByBucketSet::const_iterator, MapEntry>;
             PriorityQueue& _q;
             iterator begin() const { return _q._sequence_ids_by_bucket.begin(); }
             iterator end() const { return _q._sequence_ids_by_bucket.end(); }
-            BucketIdx(PriorityQueue& q) : _q(q) {}
+            BucketIdxView(PriorityQueue& q) : _q(q) {}
             iterator erase(iterator it) {
                 EntryPtr p = it.deref();
                 ++it;
@@ -197,9 +197,9 @@ public:
         ~PriorityQueue();
     };
 
-    using ConstPriorityIdx = PriorityQueue::ConstPriorityIdx;
-    using PriorityIdx = PriorityQueue::PriorityIdx;
-    using BucketIdx = PriorityQueue::BucketIdx;
+    using ConstPriorityIdxView = PriorityQueue::ConstPriorityIdxView;
+    using PriorityIdxView = PriorityQueue::PriorityIdxView;
+    using BucketIdxView = PriorityQueue::BucketIdxView;
     using Clock = std::chrono::steady_clock;
     using monitor_guard = std::unique_lock<std::mutex>;
     using atomic_size_t = vespalib::datastore::AtomicValueWrapper<size_t>;
@@ -287,9 +287,9 @@ public:
         void dumpQueueHtml(std::ostream & os) const;
         [[nodiscard]] std::mutex & exposeLock() { return *_lock; }
         void queue_emplace(MessageEntry entry) { _queue->emplace_back(std::move(entry)); }
-        [[nodiscard]] BucketIdx exposeBucketIdx() { return BucketIdx(*_queue); }
-        [[nodiscard]] PriorityIdx exposePriorityIdx() { return PriorityIdx(*_queue); }
-        [[nodiscard]] ConstPriorityIdx exposePriorityIdx() const { return ConstPriorityIdx(*_queue); }
+        [[nodiscard]] BucketIdxView exposeBucketIdxView() { return BucketIdxView(*_queue); }
+        [[nodiscard]] PriorityIdxView exposePriorityIdxView() { return PriorityIdxView(*_queue); }
+        [[nodiscard]] ConstPriorityIdxView exposePriorityIdxView() const { return ConstPriorityIdxView(*_queue); }
         void setMetrics(FileStorStripeMetrics * metrics) { _metrics = metrics; }
         [[nodiscard]] ActiveOperationsStats get_active_operations_stats(bool reset_min_max) const;
     private:
@@ -310,8 +310,8 @@ public:
 
         // Precondition: the bucket used by `iter`s operation is not locked in a way that conflicts
         // with its locking requirements.
-        [[nodiscard]] FileStorHandler::LockedMessage getMessage(monitor_guard & guard, PriorityIdx & idx,
-                                                                PriorityIdx::iterator iter,
+        [[nodiscard]] FileStorHandler::LockedMessage getMessage(monitor_guard & guard, PriorityIdxView & idx,
+                                                                PriorityIdxView::iterator iter,
                                                                 ThrottleToken throttle_token);
         using LockedBuckets = vespalib::hash_map<document::Bucket, MultiLockEntry, document::Bucket::hash>;
         const FileStorHandlerImpl      &_owner;

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -91,11 +91,6 @@ public:
         using ByPriSet = std::set<EntryPtr, ByPriCmp>;
         using ByBucketSet = std::set<EntryPtr, ByBucketCmp>;
 
-        uint64_t _next_sequence_id = 1;
-        EntryMap _main_map;
-        ByPriSet _sequence_ids_by_priority;
-        ByBucketSet _sequence_ids_by_bucket;
-
         size_t size() const { return _main_map.size(); }
         bool empty() const { return _main_map.empty(); }
         void emplace_back(MessageEntry entry) {
@@ -195,6 +190,12 @@ public:
             _sequence_ids_by_bucket()
         {}
         ~PriorityQueue();
+
+    private:
+        uint64_t _next_sequence_id = 1;
+        EntryMap _main_map;
+        ByPriSet _sequence_ids_by_priority;
+        ByBucketSet _sequence_ids_by_bucket;
     };
 
     using ConstPriorityIdxView = PriorityQueue::ConstPriorityIdxView;


### PR DESCRIPTION
This is the most complicated replacement so far.
Note that in-place writes to the entries were expected, so std::set as the main container was out.
On the other hand, there was no iteration in sequence-order (anymore), so I could use
unordered_map (for possible better performance).
Because of how the iterators were used, I found I should model the standard input iterator closely,
hiding the underlying iterator better.
As a bonus, this meant we got non-const iterators some places more, enabling std::move a couple
of places where comments indicated it would be preferrable.

@vekterli and @toregge please review

