### PR TITLE
Forward get_element_ids and and_element_ids_into member functions

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/multi_numeric_flag_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/multi_numeric_flag_search_context.cpp
@@ -29,7 +29,7 @@ MultiNumericFlagSearchContext<T, M>::createIterator(fef::TermFieldMatchData* mat
             const AttributeVector & attr = this->attribute();
             const BitVector * bv(get_bit_vector(this->_low));
             if (bv != nullptr) {
-                return BitVectorIterator::create(bv, attr.getCommittedDocIdLimit(), *matchData, strict);
+                return BitVectorIterator::create(bv, attr.getCommittedDocIdLimit(), *matchData, this, strict, false, false);
             } else {
                 return std::make_unique<queryeval::EmptySearch>();
             }


### PR DESCRIPTION
to search context for bitvector iterators created by flag attribute search context.

@havardpe : please review
