### PR TITLE
Rename searchcontext element iterator unit test to track change

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -98,7 +98,7 @@ vespa_define_module(
     src/tests/attribute/save_target
     src/tests/attribute/searchable
     src/tests/attribute/searchcontext
-    src/tests/attribute/searchcontextelementiterator
+    src/tests/attribute/search_iterator_element_ids
     src/tests/attribute/sort_blob_writers
     src/tests/attribute/sourceselector
     src/tests/attribute/stringattribute

--- a/searchlib/src/tests/attribute/search_iterator_element_ids/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/search_iterator_element_ids/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchlib_attribute_search_iterator_element_ids_test_app TEST
+    SOURCES
+    search_iterator_element_ids_test.cpp
+    DEPENDS
+    vespa_searchlib
+    GTest::gtest
+)
+vespa_add_test(NAME searchlib_attribute_search_iterator_element_ids_test_app COMMAND searchlib_attribute_search_iterator_element_ids_test_app)

--- a/searchlib/src/tests/attribute/searchcontextelementiterator/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/searchcontextelementiterator/CMakeLists.txt
@@ -1,9 +1,0 @@
-# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_executable(searchlib_attribute_searchcontextelementiterator_test_app TEST
-    SOURCES
-    searchcontextelementiterator_test.cpp
-    DEPENDS
-    vespa_searchlib
-    GTest::gtest
-)
-vespa_add_test(NAME searchlib_attribute_searchcontextelementiterator_test_app COMMAND searchlib_attribute_searchcontextelementiterator_test_app)


### PR DESCRIPTION
to using search iterator directly.

@havardpe : please review
