### PR TITLE
Add explicitly vectorized kernels using Google Highway

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -419,3 +419,9 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Copyright (c) 2018, TensorFlow Authors. All rights reserved.
+
+----------------------------------------------------------------------
+Google Highway (https://github.com/google/highway)
+
+Google Highway is licensed under the Apache License 2.0. See LICENSE under the
+Vespa root for the full license text.

--- a/vespalib/src/tests/hwaccelerated/data_utils.h
+++ b/vespalib/src/tests/hwaccelerated/data_utils.h
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <random>
+#include <vector>
+
+namespace vespalib::hwaccelerated {
+
+template <typename T>
+constexpr auto choose_distribution() noexcept {
+    // All supported element types have a well-defined range of at least [-128, 127].
+    return std::uniform_int_distribution(-128, 127); // Closed interval
+}
+
+template <>
+constexpr auto choose_distribution<size_t>() noexcept {
+    // size_t is used for popcount, in which case we want to spray and pray across all bits.
+    return std::uniform_int_distribution<size_t>(0ULL, UINT64_MAX);
+}
+
+template <typename T, std::uniform_random_bit_generator Rng>
+std::vector<T> create_and_fill(Rng& rng, size_t sz) {
+    auto dist = choose_distribution<T>();
+    std::vector<T> v(sz);
+    for (size_t i(0); i < sz; i++) {
+        v[i] = dist(rng);
+    }
+    return v;
+}
+
+template <typename T>
+std::pair<std::vector<T>, std::vector<T>>
+create_and_fill_lhs_rhs(size_t sz) {
+    std::minstd_rand prng;
+    prng.seed(1234567);
+    std::vector<T> a = create_and_fill<T>(prng, sz);
+    std::vector<T> b = create_and_fill<T>(prng, sz);
+    return {std::move(a), std::move(b)};
+}
+
+}

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -1,102 +1,176 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "data_utils.h"
 #include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/highway.h>
 #include <vespa/vespalib/util/time.h>
 #include <cinttypes>
 
 using namespace vespalib;
+using namespace vespalib::hwaccelerated;
 
-template<typename T>
-std::vector<T> createAndFill(size_t sz) {
-    std::vector<T> v(sz);
-    for (size_t i(0); i < sz; i++) {
-        v[i] = rand()%128;
-    }
-    return v;
+template <typename T>
+void do_not_optimize_away(T&& t) noexcept {
+    asm volatile("" : : "m"(t) : "memory"); // Clobber the value to avoid losing it to compiler optimizations
 }
 
 template <typename T, typename Fn>
-void
-benchmark_fn(Fn f, size_t sz, size_t count) {
-    srand(1);
-    std::vector<T> a = createAndFill<T>(sz);
-    std::vector<T> b = createAndFill<T>(sz);
+void benchmark_fn(Fn f, size_t sz, size_t n_iters) {
+    auto [a, b] = create_and_fill_lhs_rhs<T>(sz);
     steady_time start = steady_clock::now();
     double sumOfSums(0);
-    for (size_t j(0); j < count; j++) {
-        double sum = f(&a[0], &b[0], sz);
+    for (size_t j(0); j < n_iters; j++) {
+        double sum = f(a.data(), b.data(), sz);
         sumOfSums += sum;
     }
     duration elapsed = steady_clock::now() - start;
-    printf("sum=%f of N=%zu and vector length=%zu took %.1f ms\n", sumOfSums, count, sz,
+    printf("sum=%f of N=%zu and vector length=%zu took %.2f ms\n", sumOfSums, n_iters, sz,
            std::chrono::duration<double, std::milli>(elapsed).count());
 }
 
-void
-benchmark_squared_euclidean_distance(const hwaccelerated::IAccelerated& accelerator, size_t sz, size_t count) {
+template <typename T, typename Fn>
+void benchmark_void_fn(Fn f, size_t sz, size_t n_iters) {
+    auto [a, b] = create_and_fill_lhs_rhs<T>(sz);
+    steady_time start = steady_clock::now();
+    for (size_t i = 0; i < n_iters; ++i) {
+        // Note that this is expected to mutate `a`, so different iterations do not
+        // necessarily use the same input data. Should not be not an issue in practice(tm).
+        f(a.data(), b.data(), sz);
+    }
+    if (n_iters > 0) {
+        // _Technically_ the compiler could stare into the void and realize the above
+        // code has no side effects since the output is not used for anything. So just
+        // to be on the safe side, clobber the final output byte.
+        do_not_optimize_away(a[a.size() - 1]);
+    }
+    duration elapsed = steady_clock::now() - start;
+    printf("N=%zu and vector length=%zu took %.2f ms\n", n_iters, sz,
+           std::chrono::duration<double, std::milli>(elapsed).count());
+}
+
+void benchmark_squared_euclidean_distance(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
     auto euclidean_dist_fn = [&accelerator](const auto* lhs, const auto* rhs, size_t my_sz) {
         return accelerator.squaredEuclideanDistance(lhs, rhs, my_sz);
     };
     printf("double : ");
-    benchmark_fn<double>(euclidean_dist_fn, sz, count);
+    benchmark_fn<double>(euclidean_dist_fn, sz, n_iters);
     printf("float  : ");
-    benchmark_fn<float>(euclidean_dist_fn, sz, count);
+    benchmark_fn<float>(euclidean_dist_fn, sz, n_iters);
+    printf("BF16   : ");
+    benchmark_fn<BFloat16>(euclidean_dist_fn, sz, n_iters);
     printf("int8_t : ");
-    benchmark_fn<int8_t>(euclidean_dist_fn, sz, count);
+    benchmark_fn<int8_t>(euclidean_dist_fn, sz, n_iters);
 }
 
-void
-benchmark_dot_product(const hwaccelerated::IAccelerated& accelerator, size_t sz, size_t count) {
+void benchmark_dot_product(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
     auto dot_product_fn = [&accelerator](const auto* lhs, const auto* rhs, size_t my_sz) {
         return accelerator.dotProduct(lhs, rhs, my_sz);
     };
     printf("double : ");
-    benchmark_fn<double>(dot_product_fn, sz, count);
+    benchmark_fn<double>(dot_product_fn, sz, n_iters);
     printf("float  : ");
-    benchmark_fn<float>(dot_product_fn, sz, count);
+    benchmark_fn<float>(dot_product_fn, sz, n_iters);
+    printf("BF16   : ");
+    benchmark_fn<BFloat16>(dot_product_fn, sz, n_iters);
     printf("int8_t : ");
-    benchmark_fn<int8_t>(dot_product_fn, sz, count);
+    benchmark_fn<int8_t>(dot_product_fn, sz, n_iters);
 }
 
-void
-benchmark_popcount(const hwaccelerated::IAccelerated& accelerator, size_t sz, size_t count) {
+void benchmark_popcount(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
     auto popcount_fn = [&accelerator](const auto* lhs, const auto* rhs, size_t my_sz) {
         (void)rhs; // ... a little bit sneaky
         return accelerator.populationCount(lhs, my_sz);
     };
     printf("uint64_t : ");
-    benchmark_fn<uint64_t>(popcount_fn, sz, count);
+    benchmark_fn<uint64_t>(popcount_fn, sz, n_iters);
+}
+
+template <typename Fn>
+void benchmark_byte_transform_fn(Fn fn, const IAccelerated& accelerator, size_t sz, size_t n_iters) {
+    auto wrapped_fn = [&accelerator, fn](auto* lhs, const auto* rhs, size_t my_sz) {
+        fn(accelerator, lhs, rhs, my_sz);
+    };
+    printf("uint8_t : ");
+    benchmark_void_fn<uint8_t>(wrapped_fn, sz, n_iters);
+}
+
+void benchmark_bitwise_and(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
+    auto and_fn = [](const IAccelerated& accel, auto* lhs, const auto* rhs, size_t my_sz) {
+        return accel.andBit(lhs, rhs, my_sz);
+    };
+    benchmark_byte_transform_fn(and_fn, accelerator, sz, n_iters);
+}
+
+void benchmark_bitwise_or(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
+    auto or_fn = [](const IAccelerated& accel, auto* lhs, const auto* rhs, size_t my_sz) {
+        return accel.orBit(lhs, rhs, my_sz);
+    };
+    benchmark_byte_transform_fn(or_fn, accelerator, sz, n_iters);
+}
+
+void benchmark_bitwise_and_not(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
+    auto and_not_fn = [](const IAccelerated& accel, auto* lhs, const auto* rhs, size_t my_sz) {
+        return accel.andNotBit(lhs, rhs, my_sz);
+    };
+    benchmark_byte_transform_fn(and_not_fn, accelerator, sz, n_iters);
+}
+
+void for_each_hwy_target(auto&& fn) {
+    const auto hwy_targets = Highway::create_supported_targets();
+    for (const auto& t : hwy_targets) {
+        fn(*t);
+    }
+}
+
+template <typename Fn>
+void run_benchmark(Fn fn, const char* name, size_t sz, size_t n_iters) {
+    auto baseline_accel      = IAccelerated::create_platform_baseline_accelerator();
+    const auto& native_accel = IAccelerated::getAccelerator();
+
+    printf("\n");
+    for_each_hwy_target([&](const IAccelerated& hwy_accel) {
+        printf("%s - Highway (%s)\n", name, hwy_accel.target_name());
+        fn(hwy_accel, sz, n_iters);
+    });
+    printf("%s - Legacy baseline (%s)\n", name, baseline_accel->target_name());
+    fn(*baseline_accel, sz, n_iters);
+    printf("%s - Legacy optimized for this CPU (%s)\n", name, native_accel.target_name());
+    fn(native_accel, sz, n_iters);
+}
+
+void perform_initial_warmup(size_t sz, size_t n_iters) {
+    const auto& native_accel = IAccelerated::getAccelerator();
+    // Run a single warmup run to crank up the CPU power budget enough that any downclocking
+    // should be immediately visible. Use the widest ("most optimal") available vectors (e.g.
+    // AVX-512 on x64) for this, since it's the most susceptible to throttling.
+    // So the term "warmup" in this case is fairly literal.
+    printf("Squared Euclidean Distance - Warmup round (%s)\n", native_accel.target_name());
+    benchmark_squared_euclidean_distance(native_accel, sz, n_iters);
+    printf("--------\n");
 }
 
 int main(int argc, char *argv[]) {
     int length = 1000;
-    int count = 1000000;
+    int n_iters = 1000000;
     if (argc > 1) {
         length = atol(argv[1]);
     }
     if (argc > 2) {
-        count = atol(argv[2]);
+        n_iters = atol(argv[2]);
     }
-    auto baseline_accel      = hwaccelerated::IAccelerated::create_platform_baseline_accelerator();
-    const auto& native_accel = hwaccelerated::IAccelerated::getAccelerator();
 
-    printf("%s %d %d\n", argv[0], length, count);
-    printf("Squared Euclidean Distance - Baseline (%s)\n", baseline_accel->target_name());
-    benchmark_squared_euclidean_distance(*baseline_accel, length, count);
-    printf("Squared Euclidean Distance - Optimized for this CPU (%s)\n", native_accel.target_name());
-    benchmark_squared_euclidean_distance(native_accel, length, count);
+    printf("%s %d %d\n", argv[0], length, n_iters);
+    perform_initial_warmup(length, n_iters);
 
-    printf("\n");
-    printf("Dot Product - Baseline (%s)\n", baseline_accel->target_name());
-    benchmark_dot_product(*baseline_accel, length, count);
-    printf("Dot Product - Optimized for this CPU (%s)\n", native_accel.target_name());
-    benchmark_dot_product(native_accel, length, count);
-
-    printf("\n");
-    printf("Popcount - Baseline (%s)\n", baseline_accel->target_name());
-    benchmark_popcount(*baseline_accel, length, count);
-    printf("Popcount - Optimized for this CPU (%s)\n", native_accel.target_name());
-    benchmark_popcount(native_accel, length, count);
+    run_benchmark(benchmark_squared_euclidean_distance, "Squared Euclidean Distance", length, n_iters);
+    run_benchmark(benchmark_dot_product, "Dot Product", length, n_iters);
+    run_benchmark(benchmark_popcount, "Popcount", length, n_iters);
+    // For bitwise ops, implicitly increase the length since they are the cheapest
+    // possible ops and also operate on byte vectors.
+    size_t bitwise_length = length * 10;
+    run_benchmark(benchmark_bitwise_and, "Bitwise AND", bitwise_length, n_iters);
+    run_benchmark(benchmark_bitwise_or, "Bitwise OR", bitwise_length, n_iters);
+    run_benchmark(benchmark_bitwise_and_not, "Bitwise AND NOT", bitwise_length, n_iters);
 
     return 0;
 }

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
@@ -1,48 +1,120 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "data_utils.h"
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/highway.h>
+#include <limits>
+#include <random>
+
 #include <vespa/log/log.h>
 LOG_SETUP("hwaccelerated_test");
 
-using namespace vespalib;
+namespace vespalib::hwaccelerated {
 
-template<typename T>
-std::vector<T> createAndFill(size_t sz) {
-    std::vector<T> v(sz);
-    for (size_t i(0); i < sz; i++) {
-        v[i] = rand()%500;
-    }
-    return v;
-}
+// TODO reconcile run-time startup verification in `iaccelerated.cpp` with what's in here!
+//  Ideally we want to run our tests on hardware that has enough bells and whistles in terms
+//  of supported targets that we don't have to re-run the same vectorization checks literally
+//  _every single time_ we launch a C++ binary that transitively loads `libvespalib.so`...!
 
-template<typename T, typename P>
-void verifyEuclideanDistance(const hwaccelerated::IAccelerated & accel, size_t testLength, double approxFactor) {
-    srand(1);
-    std::vector<T> a = createAndFill<T>(testLength);
-    std::vector<T> b = createAndFill<T>(testLength);
-    for (size_t j(0); j < 0x20; j++) {
-        P sum(0);
-        for (size_t i(j); i < testLength; i++) {
-            P d = P(a[i]) - P(b[i]);
+template <typename T>
+void verify_euclidean_distance(std::span<const IAccelerated*> accels, size_t test_length, double approx_factor) {
+    auto [a, b] = create_and_fill_lhs_rhs<T>(test_length);
+    for (size_t j = 0; j < 32; j++) {
+        double sum = 0; // Assume a double has sufficient precision for all test inputs/outputs
+        for (size_t i = j; i < test_length; i++) {
+            auto d = a[i] - b[i];
             sum += d * d;
         }
-        P hwComputedSum(accel.squaredEuclideanDistance(&a[j], &b[j], testLength - j));
-        EXPECT_NEAR(sum, hwComputedSum, sum*approxFactor);
+        for (const auto* accel : accels) {
+            LOG(spam, "verify_euclidean_distance(accel=%s, len=%zu, offset=%zu)", accel->target_name(), test_length, j);
+            auto computed = static_cast<double>(accel->squaredEuclideanDistance(&a[j], &b[j], test_length - j));
+            ASSERT_NEAR(sum, computed, sum*approx_factor) << accel->target_name();
+        }
     }
 }
 
-void
-verifyEuclideanDistance(const hwaccelerated::IAccelerated & accelerator, size_t testLength) {
-    verifyEuclideanDistance<int8_t, double>(accelerator, testLength, 0.0);
-    verifyEuclideanDistance<float, double>(accelerator, testLength, 0.0001); // Small deviation requiring EXPECT_APPROX
-    verifyEuclideanDistance<double, double>(accelerator, testLength, 0.0);
+template <typename T>
+void verify_dot_product(std::span<const IAccelerated*> accels, size_t test_length, double approx_factor) {
+    auto [a, b] = create_and_fill_lhs_rhs<T>(test_length);
+    for (size_t j = 0; j < 32; j++) {
+        double sum = 0; // Assume a double has sufficient precision for all test inputs/outputs
+        for (size_t i = j; i < test_length; i++) {
+            sum += a[i] * b[i];
+        }
+        for (const auto* accel : accels) {
+            LOG(spam, "verify_dot_product(accel=%s, len=%zu, offset=%zu)", accel->target_name(), test_length, j);
+            auto computed = static_cast<double>(accel->dotProduct(&a[j], &b[j], test_length - j));
+            ASSERT_NEAR(sum, computed, std::fabs(sum*approx_factor)) << accel->target_name();
+        }
+    }
 }
 
-TEST(HWAcceleratedTest, test_euclidean_distance) {
-    constexpr size_t TEST_LENGTH = 140000; // must be longer than 64k
-    GTEST_DO(verifyEuclideanDistance(*hwaccelerated::IAccelerated::create_platform_baseline_accelerator(), TEST_LENGTH));
-    GTEST_DO(verifyEuclideanDistance(hwaccelerated::IAccelerated::getAccelerator(), TEST_LENGTH));
+const IAccelerated* baseline_accelerator() {
+    static auto baseline = IAccelerated::create_platform_baseline_accelerator();
+    return baseline.get();
 }
+
+void fill_highway_accelerators(std::vector<const IAccelerated*>& accels) {
+    static auto hwy_targets = Highway::create_supported_targets();
+    for (const auto& t : hwy_targets) {
+        accels.emplace_back(t.get());
+    }
+}
+
+std::vector<const IAccelerated*> all_accelerators_to_test() {
+    std::vector<const IAccelerated*> accels;
+    accels.emplace_back(baseline_accelerator());
+    accels.emplace_back(&IAccelerated::getAccelerator());
+    fill_highway_accelerators(accels);
+    return accels;
+}
+
+void verify_euclidean_distance(std::span<const IAccelerated*> accelerators, size_t testLength) {
+    verify_euclidean_distance<int8_t>(accelerators, testLength, 0.0);
+    verify_euclidean_distance<float>(accelerators, testLength, 0.0001); // Small deviation requiring EXPECT_APPROX
+    verify_euclidean_distance<BFloat16>(accelerators, testLength, 0.001f); // Reduced BF16 precision requires more slack
+    verify_euclidean_distance<double>(accelerators, testLength, 0.0);
+}
+
+// Max number of elements that can be covered in one computed_chunked_sum() call
+// for our current chunked use cases (dot product + Euclidean distance).
+constexpr uint32_t max_chunk_i32_boundary = INT32_MAX / (INT8_MIN*INT8_MIN);
+
+constexpr std::span<const size_t> test_lengths() noexcept {
+    // verify_... checks all suffixes from offsets [0, 32), so test lengths must be at least this long.
+    // Lengths relative to max_chunk_i32_boundary are for testing chunk overflow handling.
+    static size_t lengths[] = {
+        32u, 64u, 256u, 1024u, max_chunk_i32_boundary - 1, max_chunk_i32_boundary,
+        max_chunk_i32_boundary + 1, max_chunk_i32_boundary + 256
+    };
+    return lengths;
+}
+
+TEST(HwAcceleratedTest, euclidean_distance_impls_match_source_of_truth) {
+    auto accelerators = all_accelerators_to_test();
+    for (size_t test_length : test_lengths()) {
+        GTEST_DO(verify_euclidean_distance(accelerators, test_length));
+    }
+}
+
+void verify_dot_product(std::span<const IAccelerated*> accelerators, size_t testLength) {
+    verify_dot_product<int8_t>(accelerators, testLength, 0.0);
+    verify_dot_product<int16_t>(accelerators, testLength, 0.0);
+    verify_dot_product<int32_t>(accelerators, testLength, 0.0);
+    verify_dot_product<int64_t>(accelerators, testLength, 0.0);
+    verify_dot_product<float>(accelerators, testLength, 0.0001);
+    verify_dot_product<BFloat16>(accelerators, testLength, 0.001f);
+    verify_dot_product<double>(accelerators, testLength, 0.0);
+}
+
+TEST(HwAcceleratedTest, dot_product_impls_match_source_of_truth) {
+    auto accelerators = all_accelerators_to_test();
+    for (size_t test_length : test_lengths()) {
+        GTEST_DO(verify_dot_product(accelerators, test_length));
+    }
+}
+
+} // vespalib::hwaccelerated
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 vespa_add_library(vespa_hwaccelerated
     SOURCES
     iaccelerated.cpp
+    highway.cpp
     ${ACCEL_FILES}
     DEPENDS
     INSTALL lib64
@@ -26,3 +27,4 @@ set_source_files_properties(sve2.cpp              PROPERTIES COMPILE_FLAGS "-O3 
 
 set(BLA_VENDOR OpenBLAS)
 vespa_add_target_package_dependency(vespa_hwaccelerated BLAS)
+vespa_add_target_external_dependency(vespa_hwaccelerated hwy)

--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.h
@@ -16,23 +16,25 @@ namespace vespalib::hwaccelerated {
 class VESPA_HWACCEL_TARGET_TYPE : public IAccelerated
 {
 public:
-    float dotProduct(const float * a, const float * b, size_t sz) const noexcept override;
-    double dotProduct(const double * a, const double * b, size_t sz) const noexcept override;
-    int64_t dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept override;
-    int64_t dotProduct(const int16_t * a, const int16_t * b, size_t sz) const noexcept override;
-    int64_t dotProduct(const int32_t * a, const int32_t * b, size_t sz) const noexcept override;
-    long long dotProduct(const int64_t * a, const int64_t * b, size_t sz) const noexcept override;
-    void orBit(void * a, const void * b, size_t bytes) const noexcept override;
-    void andBit(void * a, const void * b, size_t bytes) const noexcept override;
-    void andNotBit(void * a, const void * b, size_t bytes) const noexcept override;
-    void notBit(void * a, size_t bytes) const noexcept override;
-    size_t populationCount(const uint64_t *a, size_t sz) const noexcept override;
-    void convert_bfloat16_to_float(const uint16_t * src, float * dest, size_t sz) const noexcept override;
-    double squaredEuclideanDistance(const int8_t * a, const int8_t * b, size_t sz) const noexcept override;
-    double squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept override;
-    double squaredEuclideanDistance(const double * a, const double * b, size_t sz) const noexcept override;
-    void and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;
-    void or128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;
+    float dotProduct(const float* a, const float* b, size_t sz) const noexcept override;
+    float dotProduct(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept override;
+    double dotProduct(const double* a, const double* b, size_t sz) const noexcept override;
+    int64_t dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept override;
+    int64_t dotProduct(const int16_t* a, const int16_t* b, size_t sz) const noexcept override;
+    int64_t dotProduct(const int32_t* a, const int32_t* b, size_t sz) const noexcept override;
+    long long dotProduct(const int64_t* a, const int64_t* b, size_t sz) const noexcept override;
+    void orBit(void* a, const void* b, size_t bytes) const noexcept override;
+    void andBit(void* a, const void* b, size_t bytes) const noexcept override;
+    void andNotBit(void* a, const void* b, size_t bytes) const noexcept override;
+    void notBit(void* a, size_t bytes) const noexcept override;
+    size_t populationCount(const uint64_t* a, size_t sz) const noexcept override;
+    void convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) const noexcept override;
+    double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept override;
+    double squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept override;
+    double squaredEuclideanDistance(const double* a, const double* b, size_t sz) const noexcept override;
+    double squaredEuclideanDistance(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept override;
+    void and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;
+    void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;
 #ifdef VESPA_HWACCEL_TARGET_NAME
     const char* target_name() const noexcept override { return VESPA_HWACCEL_TARGET_NAME; }
 #endif

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -1,0 +1,325 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "highway.h"
+#include "platform_generic.h"
+#include <hwy/base.h>
+#include <algorithm>
+#include <cassert>
+
+// This file will be recursively included into itself with different target
+// compilation parameters. See the Highway docs.
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "vespa/vespalib/hwaccelerated/highway.cpp"
+#include <hwy/foreach_target.h>
+
+#include "hwy_kernel-inl.h"
+#include <hwy/contrib/dot/dot-inl.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace vespalib::hwaccelerated { // NOLINT: must nest namespaces
+namespace HWY_NAMESPACE {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+// Many of the Highway functions used within this file are fairly self-explanatory
+// of how they relate to elements in, and across, vectors (Sub, Mul, MulAdd etc.),
+// others not so much (ReorderWidenMulAccumulate, SumOfMulQuadAccumulate, ...).
+// Please refer to https://google.github.io/highway/en/master/quick_reference.html
+// for the exact semantics of such functions.
+
+template <typename T, typename R = T>
+requires (hwy::IsFloat<T>() || hwy::IsSame<T, hwy::bfloat16_t>())
+HWY_INLINE
+R my_hwy_dot_impl(const T* HWY_RESTRICT a,
+                  const T* HWY_RESTRICT b,
+                  const size_t sz) noexcept
+{
+    const hn::ScalableTag<T> d;
+    return hwy::ConvertScalarTo<R>(hn::Dot::Compute<0>(d, a, b, sz));
+}
+
+HWY_INLINE
+float my_hwy_dot_float(const float* HWY_RESTRICT a,
+                       const float* HWY_RESTRICT b,
+                       const size_t sz) noexcept
+{
+    return my_hwy_dot_impl(a, b, sz);
+}
+
+HWY_INLINE
+double my_hwy_dot_double(const double* HWY_RESTRICT a,
+                         const double* HWY_RESTRICT b,
+                         const size_t sz) noexcept
+{
+    return my_hwy_dot_impl(a, b, sz);
+}
+
+HWY_INLINE
+float my_hwy_dot_bf16(const BFloat16* HWY_RESTRICT a,
+                      const BFloat16* HWY_RESTRICT b,
+                      const size_t sz) noexcept
+{
+    // Highway already comes with dot product kernels supporting BF16, so use these.
+    static_assert(sizeof(BFloat16)  == sizeof(hwy::bfloat16_t));
+    static_assert(alignof(BFloat16) == alignof(hwy::bfloat16_t));
+
+    const auto* a_bf16 = reinterpret_cast<const hwy::bfloat16_t*>(a);
+    const auto* b_bf16 = reinterpret_cast<const hwy::bfloat16_t*>(b);
+    // Although our input parameters are BF16, the returned value must be a float to avoid losing precision.
+    return my_hwy_dot_impl<hwy::bfloat16_t, float>(a_bf16, b_bf16, sz);
+}
+
+template <typename T> requires (hwy::IsFloat<T>())
+HWY_INLINE
+double my_hwy_square_euclidean_distance(const T* HWY_RESTRICT a,
+                                        const T* HWY_RESTRICT b,
+                                        const size_t sz) noexcept
+{
+    const hn::ScalableTag<T> d;
+    // `HWY_ATTR` is needed to ensure lambdas have the expected codegen target.
+    // See https://google.github.io/highway/en/master/faq.html#boilerplate
+    const auto kernel_fn = [](auto lhs, auto rhs, auto& accu) noexcept HWY_ATTR {
+        const auto sub = hn::Sub(lhs, rhs);
+        accu = hn::MulAdd(sub, sub, accu); // note: using fused multiply-add
+    };
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<8>, HasAccumulatorArity<1>>;
+    return MyKernel::pairwise(d, d, a, b, sz, hn::Zero(d), kernel_fn, VecAdd(), LaneReduceSum());
+}
+
+HWY_INLINE
+double my_hwy_square_euclidean_distance_bf16(const BFloat16* HWY_RESTRICT a,
+                                             const BFloat16* HWY_RESTRICT b,
+                                             const size_t sz) noexcept
+{
+    static_assert(sizeof(BFloat16)  == sizeof(hwy::bfloat16_t));
+    static_assert(alignof(BFloat16) == alignof(hwy::bfloat16_t));
+    // We make the assumption that both vespalib::BFloat16 and hwy::bfloat16_t are POD-like
+    // wrappers around the same u16 bitwise representation, with zero padding bits, meaning
+    // we can treat them as-if identical.
+    const auto* a_bf16 = reinterpret_cast<const hwy::bfloat16_t*>(a);
+    const auto* b_bf16 = reinterpret_cast<const hwy::bfloat16_t*>(b);
+
+    const hn::ScalableTag<hwy::bfloat16_t> dbf16;
+    // Repartition to float vector with same vector size, but different number of lanes.
+    // E.g. for a 128-bit vector of 8x BF16 lanes this becomes a 4x float lanes vector.
+    const hn::Repartition<float, decltype(dbf16)> df;
+    // Since we're widening the element type, loading e.g. 8 lanes of BF16 in a single
+    // 128-bit vector requires us to process 2 vectors of 4 lanes of float32.
+    auto kernel_fn = [df](auto lhs, auto rhs, auto& acc0, auto& acc1) noexcept HWY_ATTR {
+        const auto sub_lo = hn::Sub(hn::PromoteLowerTo(df, lhs), hn::PromoteLowerTo(df, rhs));
+        acc0 = hn::MulAdd(sub_lo, sub_lo, acc0);
+        const auto sub_hi = hn::Sub(hn::PromoteUpperTo(df, lhs), hn::PromoteUpperTo(df, rhs));
+        acc1 = hn::MulAdd(sub_hi, sub_hi, acc1);
+    };
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<4>, UnrolledBy<2>, HasAccumulatorArity<2>>;
+    return MyKernel::pairwise(dbf16, df, a_bf16, b_bf16, sz, hn::Zero(df), kernel_fn, VecAdd(), LaneReduceSum());
+}
+
+// Widen i8 to i16 and subtract. Widen i16 intermediate result to i32 and multiply.
+// Important: `sz` should be low enough that the intermediate i32 sum does not overflow!
+HWY_INLINE
+int32_t sub_mul_add_i8_to_i32(const int8_t* HWY_RESTRICT a,
+                              const int8_t* HWY_RESTRICT b,
+                              const size_t sz)
+{
+    const hn::ScalableTag<int8_t>                  d8;
+    const hn::Repartition<int16_t, decltype(d8)>  d16;
+    const hn::Repartition<int32_t, decltype(d16)> d32;
+
+    auto kernel_fn = [d16, d32](auto lhs, auto rhs, auto& acc0, auto& acc1, auto& acc2, auto& acc3) noexcept HWY_ATTR {
+        const auto sub_l_i16 = hn::Sub(hn::PromoteLowerTo(d16, lhs), hn::PromoteLowerTo(d16, rhs));
+        const auto sub_u_i16 = hn::Sub(hn::PromoteUpperTo(d16, lhs), hn::PromoteUpperTo(d16, rhs));
+        acc0 = hn::ReorderWidenMulAccumulate(d32, sub_l_i16, sub_l_i16, acc0, acc1);
+        acc2 = hn::ReorderWidenMulAccumulate(d32, sub_u_i16, sub_u_i16, acc2, acc3);
+    };
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<4>, HasAccumulatorArity<4>>;
+    return MyKernel::pairwise(d8, d32, a, b, sz, hn::Zero(d32), kernel_fn, VecAdd(), LaneReduceSum());
+}
+
+HWY_INLINE
+double my_hwy_square_euclidean_distance_int8(const int8_t* HWY_RESTRICT a,
+                                             const int8_t* HWY_RESTRICT b,
+                                             const size_t sz) noexcept
+{
+    // If we cannot possibly overflow intermediate i32 accumulators we can directly
+    // compute the distance without requiring any chunking. Max chunk size is defined
+    // by the number of worst-case sums of -128**2 that can fit into an i32.
+    constexpr size_t max_n_per_chunk = INT32_MAX / (INT8_MIN*INT8_MIN);
+    return compute_chunked_sum<max_n_per_chunk, double>(sub_mul_add_i8_to_i32, a, b, sz);
+}
+
+HWY_INLINE
+size_t my_hwy_popcount(const uint64_t* a, const size_t sz) noexcept {
+    // TODO have a way to explicitly disable fallbacks for benchmarking purposes
+#if HWY_TARGET != HWY_AVX2 && HWY_TARGET != HWY_AVX3
+    const hn::ScalableTag<uint64_t> d;
+    const auto kernel_fn = [](auto v, auto& accu) noexcept HWY_ATTR {
+        accu = hn::Add(hn::PopulationCount(v), accu);
+    };
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<8>, HasAccumulatorArity<1>>;
+    return MyKernel::elementwise(d, d, a, sz, hn::Zero(d), kernel_fn, VecAdd(), LaneReduceSum());
+#else
+    // AVX2 and AVX3 do not have dedicated vector popcount instructions, so the Highway "emulation"
+    // ends up being slower in practice than the baseline one using 4x pipelined POPCNT.
+    return PlatformGenericAccelerator().populationCount(a, sz);
+#endif
+}
+
+
+// Multiply i8*i8 with the result widened to i16. Widen the intermediate i16 results to i32 and accumulate.
+// Depending on the implementation, the intermediate i16 widening step may be transparently done.
+HWY_INLINE
+int32_t mul_add_i8_to_i32(const int8_t* HWY_RESTRICT a,
+                          const int8_t* HWY_RESTRICT b,
+                          const size_t sz) noexcept
+{
+    const hn::ScalableTag<int8_t> d8;
+#if HWY_TARGET != HWY_NEON
+    const hn::Repartition<int32_t, decltype(d8)> d32;
+    const auto kernel_fn = [d32](auto lhs_i8, auto rhs_i8, auto& accu) noexcept HWY_ATTR {
+        accu = hn::SumOfMulQuadAccumulate(d32, lhs_i8, rhs_i8, accu);
+    };
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<8>, HasAccumulatorArity<1>>;
+    return MyKernel::pairwise(d8, d32, a, b, sz, hn::Zero(d32), kernel_fn, VecAdd(), LaneReduceSum());
+#else // HWY_NEON
+    // The `SumOfMulQuadAccumulate` op has suboptimal codegen for the baseline NEON target since
+    // it has to "emulate" the SDOT i8*i8 -> i16+i16 -> i32 instruction semantics without having
+    // access to any more explicit input/output accumulators, i.e. it can't readily use the
+    // `ReorderWidenMulAccumulate` operation since that takes in an extra output accumulator vector.
+    // We work around this by having a NEON-specific implementation that does not use this emulation,
+    // but instead runs 4x per-kernel accumulators in parallel and using high/low i8->i16 promotion
+    // before doing a fused mul+add of pairwise i16->i32 (this is similar to how we do i8 Euclidean
+    // distance computations).
+    // This brings the performance slightly beyond what the compiler auto-vectorizer is capable of
+    // conjuring up, since the auto-vectorizer does not seem to generate _fused_ mul+adds in this
+    // case (on GCC 14 at least).
+    const hn::Repartition<int16_t, decltype(d8)>  d16;
+    const hn::Repartition<int32_t, decltype(d16)> d32;
+
+    const auto kernel_fn = [d16, d32](auto lhs_i8, auto rhs_i8, auto& acc0, auto& acc1, auto& acc2, auto& acc3) noexcept HWY_ATTR {
+        const auto lhs_i16_lo = hn::PromoteLowerTo(d16, lhs_i8);
+        const auto lhs_i16_hi = hn::PromoteUpperTo(d16, lhs_i8);
+        const auto rhs_i16_lo = hn::PromoteLowerTo(d16, rhs_i8);
+        const auto rhs_i16_hi = hn::PromoteUpperTo(d16, rhs_i8);
+        acc0 = hn::ReorderWidenMulAccumulate(d32, lhs_i16_lo, rhs_i16_lo, acc0, acc1);
+        acc2 = hn::ReorderWidenMulAccumulate(d32, lhs_i16_hi, rhs_i16_hi, acc2, acc3);
+    };
+
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<2>, HasAccumulatorArity<4>>;
+    return MyKernel::pairwise(d8, d32, a, b, sz, hn::Zero(d32), kernel_fn, VecAdd(), LaneReduceSum());
+#endif // HWY_NEON
+}
+
+HWY_INLINE
+int64_t my_hwy_dot_int8(const int8_t* HWY_RESTRICT a,
+                        const int8_t* HWY_RESTRICT b,
+                        const size_t sz) noexcept
+{
+    // If we cannot possibly overflow intermediate i32 accumulators we can directly
+    // compute the dot product without requiring any chunking. Max chunk size is defined
+    // by the number of worst-case sums of i8 multiplications (-128**2) that can fit
+    // into a single i32 accumulator.
+    constexpr size_t max_n_per_chunk = INT32_MAX / (INT8_MIN*INT8_MIN);
+    return compute_chunked_sum<max_n_per_chunk, int64_t>(mul_add_i8_to_i32, a, b, sz);
+}
+
+HWY_INLINE
+const char* my_hwy_target_name() noexcept {
+    return hwy::TargetName(HWY_TARGET);
+}
+
+// Since we already do a virtual dispatch via the IAccelerated interface, avoid needing an
+// additional per-function dispatch step via Highway's function tables by creating a concrete
+// implementation class per target.
+class HwyTargetAccelerator final : public PlatformGenericAccelerator {
+public:
+    ~HwyTargetAccelerator() override = default;
+    float dotProduct(const float* a, const float* b, size_t sz) const noexcept override {
+        return my_hwy_dot_float(a, b, sz);
+    }
+    float dotProduct(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept override {
+        return my_hwy_dot_bf16(a, b, sz);
+    }
+    double dotProduct(const double* a, const double* b, size_t sz) const noexcept override {
+        return my_hwy_dot_double(a, b, sz);
+    }
+    int64_t dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept override {
+        return my_hwy_dot_int8(a, b, sz);
+    }
+    size_t populationCount(const uint64_t* a, size_t sz) const noexcept override {
+        return my_hwy_popcount(a, sz);
+    }
+    double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept override {
+        return my_hwy_square_euclidean_distance_int8(a, b, sz);
+    }
+    double squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept override {
+        return my_hwy_square_euclidean_distance(a, b, sz);
+    }
+    double squaredEuclideanDistance(const double* a, const double* b, size_t sz) const noexcept override {
+        return my_hwy_square_euclidean_distance(a, b, sz);
+    }
+    double squaredEuclideanDistance(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept override {
+        return my_hwy_square_euclidean_distance_bf16(a, b, sz);
+    }
+    const char* target_name() const noexcept override {
+        return my_hwy_target_name();
+    }
+
+    [[nodiscard]] static std::unique_ptr<IAccelerated> create_instance() {
+        return std::make_unique<HwyTargetAccelerator>();
+    }
+};
+
+}  // namespace HWY_NAMESPACE
+}  // namespace vespalib::hwaccelerated
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace vespalib::hwaccelerated {
+
+#define VESPA_HWY_ADD_SUPPORTED_IMPL_VISITOR(hwy_target, hwy_ns) \
+    if ((supported_targets & hwy_target) != 0) { \
+        target_id_and_impl.emplace_back(hwy_target, hwy_ns::HwyTargetAccelerator::create_instance()); \
+    }
+
+// The "best" supported target will be the first element in the vector.
+std::vector<std::unique_ptr<IAccelerated>> Highway::create_supported_targets() {
+    // On x64 we require AVX2 as a baseline, so don't bother wasting time with SSSE3/SSE4.
+    // Ideally we would not even build these targets. No effect on Aarch64.
+    hwy::DisableTargets(HWY_SSSE3 | HWY_SSE4);
+    const uint64_t supported_targets = hwy::SupportedTargets();
+
+    std::vector<std::pair<uint64_t, std::unique_ptr<IAccelerated>>> target_id_and_impl;
+    // Visits _compile-time_ supported targets in _alphabetical_ (i.e. not preferred) order.
+    // Intersect these with the _run-time_ supported targets and keep track of their target IDs.
+    // Since lower target IDs are considered more preferred, we then post-sort the list in
+    // preference order.
+    HWY_VISIT_TARGETS(VESPA_HWY_ADD_SUPPORTED_IMPL_VISITOR);
+    std::ranges::sort(target_id_and_impl, [](const auto& lhs, const auto& rhs) noexcept {
+        return lhs.first < rhs.first;
+    });
+    // We might get a duplicate output due to HWY_VISIT_TARGETS including the fallback static
+    // target, which is likely equal to another target. Remove dupes to avoid having to deal
+    // with this at a higher level.
+    auto to_erase = std::ranges::unique(target_id_and_impl, [](const auto& lhs, const auto& rhs) noexcept {
+        return lhs.first == rhs.first;
+    });
+    target_id_and_impl.erase(to_erase.begin(), to_erase.end());
+    assert(!target_id_and_impl.empty()); // Must be at least a fallback target
+
+    std::vector<std::unique_ptr<IAccelerated>> preferred_target_order;
+    preferred_target_order.reserve(target_id_and_impl.size());
+    for (auto& elem : target_id_and_impl) {
+        preferred_target_order.emplace_back(std::move(elem.second));
+    }
+    return preferred_target_order;
+}
+
+std::unique_ptr<IAccelerated> Highway::create_best_target() {
+    return std::move(create_supported_targets().front());
+}
+
+} // namespace vespalib::hwaccelerated
+
+#endif // HWY_ONCE

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.h
@@ -1,0 +1,23 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "iaccelerated.h"
+#include <memory>
+
+namespace vespalib::hwaccelerated {
+
+class Highway {
+public:
+    // Returns all accelerator targets that are supported by the current architecture and runtime.
+    // The targets are ordered in decreasing order of preference, i.e. element 0 is considered
+    // the most preferred target to use for the lifetime of this process.
+    // Always returns at least 1 element.
+    [[nodiscard]] static std::vector<std::unique_ptr<IAccelerated>> create_supported_targets();
+    // Returns the accelerator instance corresponding to the "best" Highway target that is
+    // supported by the current architecture and runtime. This is always equal to the first
+    // element returned by `create_supported_targets()`.
+    [[nodiscard]] static std::unique_ptr<IAccelerated> create_best_target();
+};
+
+}

--- a/vespalib/src/vespa/vespalib/hwaccelerated/hwy_kernel-inl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/hwy_kernel-inl.h
@@ -1,0 +1,785 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+// No include guard; this is intentional as this file will be included multiple times by
+// the same translation unit as part of compiling for multiple distinct Highway targets.
+
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace vespalib::hwaccelerated { // NOLINT: must nest namespaces
+namespace HWY_NAMESPACE {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+// Accumulator adding by arithmetic sum of two vectors
+struct VecAdd {
+    HWY_INLINE auto operator()(auto lhs, auto rhs) const noexcept {
+        return hn::Add(lhs, rhs);
+    }
+};
+
+// Accumulator reduction by summing across all vector lanes of `accu`.
+struct LaneReduceSum {
+    HWY_INLINE auto operator()(auto d0, auto accu) const noexcept {
+        return hn::ReduceSum(d0, accu);
+    }
+};
+
+// The counter for the current intra-loop trip counter in an unrolled loop body.
+// E.g. for a loop with an unroll factor of 4, the dispatcher function will
+// be instantiated with IterNum<N> with N in {0, 1, 2, 3}.
+template <size_t N>
+struct IterNum {
+    static constexpr size_t value = N;
+};
+
+// The number of accumulators that a kernel function should be invoked with, i.e.
+// its accumulator arity.
+template <size_t N>
+struct FnAccuArity {
+    static constexpr size_t value = N;
+};
+
+// We (partially) decouple accumulator parallelism, the unrolling factor and
+// how many accumulators a given kernel function uses. "Partially" is because
+// we inherently can't use a kernel function requiring _more_ accumulators than
+// there are accumulators present, and if we use an 1-ary kernel function with
+// an unroll factor of 2 and 4 parallel accumulators, the unrolled loop won't
+// be able to use all available accumulators (can only use 2).
+
+// The basic idea is that we want to evenly distribute accumulators across
+// kernel function invocations in order to "maximize" the distance between
+// definitions and usages of a given accumulator. This is to avoid stalling the
+// CPU pipeline by having to wait for in-flight instructions to settle the
+// next time the accumulator is loaded.
+//
+// We do this by constexpr-"striping" accumulator references based on which
+// iteration in the unrolled loop body we're currently at.
+//
+// For example, with 8x unrolling, 4x accumulators and an 1-ary kernel, the
+// loop body will be:
+//   fn(a0), fn(a1), fn(a2), fn(a3), fn(a0), fn(a1), fn(a2), fn(a3).
+// Similarly, with a 2-ary kernel:
+//   fn(a0, a1), fn(a2, a3), fn(a0, a1), fn(a2, a3), ...
+// Similarly, with a 4-ary kernel:
+//   fn(a0, a1, a2, a3), fn(a0, a1, a2, a3), ...
+// And so on.
+
+// 4-way accumulator dispatch
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<1>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3) noexcept
+{
+    constexpr size_t my_idx = Idx % 4;
+    if constexpr (my_idx == 0) {
+        kernel_fn(vec, accu0);
+    } else if (my_idx == 1) {
+        kernel_fn(vec, accu1);
+    } else if (my_idx == 2) {
+        kernel_fn(vec, accu2);
+    } else if (my_idx == 3) {
+        kernel_fn(vec, accu3);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<1>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3) noexcept
+{
+    constexpr size_t my_idx = Idx % 4;
+    if constexpr (my_idx == 0) {
+        kernel_fn(lhs, rhs, accu0);
+    } else if (my_idx == 1) {
+        kernel_fn(lhs, rhs, accu1);
+    } else if (my_idx == 2) {
+        kernel_fn(lhs, rhs, accu2);
+    } else if (my_idx == 3) {
+        kernel_fn(lhs, rhs, accu3);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<2>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3) noexcept
+{
+    constexpr size_t my_idx = Idx % 2;
+    if constexpr (my_idx == 0) {
+        kernel_fn(vec, accu0, accu1);
+    } else if (my_idx == 1) {
+        kernel_fn(vec, accu2, accu3);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<2>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3) noexcept
+{
+    constexpr size_t my_idx = Idx % 2;
+    if constexpr (my_idx == 0) {
+        kernel_fn(lhs, rhs, accu0, accu1);
+    } else if (my_idx == 1) {
+        kernel_fn(lhs, rhs, accu2, accu3);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<4>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3) noexcept
+{
+    kernel_fn(vec, accu0, accu1, accu2, accu3);
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<4>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3) noexcept
+{
+    kernel_fn(lhs, rhs, accu0, accu1, accu2, accu3);
+}
+
+// 8-way accumulator dispatch
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<1>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+              AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    constexpr size_t my_idx = Idx % 8;
+    if constexpr (my_idx == 0) {
+        kernel_fn(vec, accu0);
+    } else if (my_idx == 1) {
+        kernel_fn(vec, accu1);
+    } else if (my_idx == 2) {
+        kernel_fn(vec, accu2);
+    } else if (my_idx == 3) {
+        kernel_fn(vec, accu3);
+    } else if (my_idx == 4) {
+        kernel_fn(vec, accu4);
+    } else if (my_idx == 5) {
+        kernel_fn(vec, accu5);
+    } else if (my_idx == 6) {
+        kernel_fn(vec, accu6);
+    } else if (my_idx == 7) {
+        kernel_fn(vec, accu7);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<1>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+                       AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    constexpr size_t my_idx = Idx % 8;
+    if constexpr (my_idx == 0) {
+        kernel_fn(lhs, rhs, accu0);
+    } else if (my_idx == 1) {
+        kernel_fn(lhs, rhs, accu1);
+    } else if (my_idx == 2) {
+        kernel_fn(lhs, rhs, accu2);
+    } else if (my_idx == 3) {
+        kernel_fn(lhs, rhs, accu3);
+    } else if (my_idx == 4) {
+        kernel_fn(lhs, rhs, accu4);
+    } else if (my_idx == 5) {
+        kernel_fn(lhs, rhs, accu5);
+    } else if (my_idx == 6) {
+        kernel_fn(lhs, rhs, accu6);
+    } else if (my_idx == 7) {
+        kernel_fn(lhs, rhs, accu7);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<2>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+              AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    constexpr size_t my_idx = Idx % 4;
+    if constexpr (my_idx == 0) {
+        kernel_fn(vec, accu0, accu1);
+    } else if (my_idx == 1) {
+        kernel_fn(vec, accu2, accu3);
+    } else if (my_idx == 2) {
+        kernel_fn(vec, accu4, accu5);
+    } else if (my_idx == 3) {
+        kernel_fn(vec, accu6, accu7);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<2>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+                       AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    constexpr size_t my_idx = Idx % 4;
+    if constexpr (my_idx == 0) {
+        kernel_fn(lhs, rhs, accu0, accu1);
+    } else if (my_idx == 1) {
+        kernel_fn(lhs, rhs, accu2, accu3);
+    } else if (my_idx == 2) {
+        kernel_fn(lhs, rhs, accu4, accu5);
+    } else if (my_idx == 3) {
+        kernel_fn(lhs, rhs, accu6, accu7);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<4>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+              AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    constexpr size_t my_idx = Idx % 2;
+    if constexpr (my_idx == 0) {
+        kernel_fn(vec, accu0, accu1, accu2, accu3);
+    } else if (my_idx == 1) {
+        kernel_fn(vec, accu4, accu5, accu6, accu7);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<4>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+                       AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    constexpr size_t my_idx = Idx % 2;
+    if constexpr (my_idx == 0) {
+        kernel_fn(lhs, rhs, accu0, accu1, accu2, accu3);
+    } else if (my_idx == 1) {
+        kernel_fn(lhs, rhs, accu4, accu5, accu6, accu7);
+    }
+}
+
+template <size_t Idx, typename KernelFn, typename VecT, typename AccuV>
+HWY_INLINE
+void dispatch(FnAccuArity<8>, IterNum<Idx>, KernelFn&& kernel_fn, VecT vec,
+              AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+              AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    kernel_fn(vec, accu0, accu1, accu2, accu3, accu4, accu5, accu6, accu7);
+}
+
+template <size_t Idx, typename KernelFn, typename LhsT, typename RhsT, typename AccuV>
+HWY_INLINE
+void dispatch_pairwise(FnAccuArity<8>, IterNum<Idx>, KernelFn&& kernel_fn, LhsT lhs, RhsT rhs,
+                       AccuV& accu0, AccuV& accu1, AccuV& accu2, AccuV& accu3,
+                       AccuV& accu4, AccuV& accu5, AccuV& accu6, AccuV& accu7) noexcept
+{
+    kernel_fn(lhs, rhs, accu0, accu1, accu2, accu3, accu4, accu5, accu6, accu7);
+}
+
+// To avoid the need for any compiler pragma alchemy to achieve a desired loop unrolling
+// factor, we explicitly unroll loop bodies by specializing distinct implementations of
+// the loop bodies. We manually increment the loop induction variable between each kernel
+// function dispatch; the compiler happily optimizes this away.
+// Each unrolled dispatch within a loop body is provided with an IterNum<N> that corresponds
+// to the unroll trip counter. This can then be used by the dispatcher function to choose
+// which accumulator to use for this particular instantiation and kernel accumulator arity.
+
+template <size_t UnrollFactor>
+struct UnrolledLoopBody;
+
+template <>
+struct UnrolledLoopBody<1> {
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void elementwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a,
+                                              size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        (void)N;
+        const auto a0 = hn::LoadU(d, a + i);
+        dispatch(arity, IterNum<0>{}, kernel_fn, a0, std::forward<AccuVecs>(accu_vecs)...);
+    }
+
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void pairwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+                                           size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        (void)N;
+        const auto a0 = hn::LoadU(d, a + i);
+        const auto b0 = hn::LoadU(d, b + i);
+        dispatch_pairwise(arity, IterNum<0>{}, kernel_fn, a0, b0, std::forward<AccuVecs>(accu_vecs)...);
+    }
+};
+
+template <>
+struct UnrolledLoopBody<2> {
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void elementwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a,
+                                              size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        const auto a0 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<0>{}, kernel_fn, a0, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a1 = hn::LoadU(d, a + i);
+        dispatch(arity, IterNum<1>{}, kernel_fn, a1, std::forward<AccuVecs>(accu_vecs)...);
+    }
+
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void pairwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+                                           size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        const auto a0 = hn::LoadU(d, a + i);
+        const auto b0 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<0>{}, kernel_fn, a0, b0, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a1 = hn::LoadU(d, a + i);
+        const auto b1 = hn::LoadU(d, b + i);
+        dispatch_pairwise(arity, IterNum<1>{}, kernel_fn, a1, b1, std::forward<AccuVecs>(accu_vecs)...);
+    }
+};
+
+template <>
+struct UnrolledLoopBody<4> {
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void elementwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a,
+                                              size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        const auto a0 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<0>{}, kernel_fn, a0, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a1 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<1>{}, kernel_fn, a1, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a2 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<2>{}, kernel_fn, a2, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a3 = hn::LoadU(d, a + i);
+        dispatch(arity, IterNum<3>{}, kernel_fn, a3, std::forward<AccuVecs>(accu_vecs)...);
+    }
+
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void pairwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+                                           size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        const auto a0 = hn::LoadU(d, a + i);
+        const auto b0 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<0>{}, kernel_fn, a0, b0, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a1 = hn::LoadU(d, a + i);
+        const auto b1 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<1>{}, kernel_fn, a1, b1, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a2 = hn::LoadU(d, a + i);
+        const auto b2 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<2>{}, kernel_fn, a2, b2, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a3 = hn::LoadU(d, a + i);
+        const auto b3 = hn::LoadU(d, b + i);
+        dispatch_pairwise(arity, IterNum<3>{}, kernel_fn, a3, b3, std::forward<AccuVecs>(accu_vecs)...);
+    }
+};
+
+template <>
+struct UnrolledLoopBody<8> {
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void elementwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a,
+                                              size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        const auto a0 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<0>{}, kernel_fn, a0, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a1 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<1>{}, kernel_fn, a1, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a2 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<2>{}, kernel_fn, a2, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a3 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<3>{}, kernel_fn, a3, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a4 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<4>{}, kernel_fn, a4, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a5 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<5>{}, kernel_fn, a5, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a6 = hn::LoadU(d, a + i);
+        i += N;
+        dispatch(arity, IterNum<6>{}, kernel_fn, a6, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a7 = hn::LoadU(d, a + i);
+        dispatch(arity, IterNum<7>{}, kernel_fn, a7, std::forward<AccuVecs>(accu_vecs)...);
+    }
+
+    template <size_t Arity, typename D, typename T, typename KernelFn, typename... AccuVecs>
+    HWY_INLINE
+    static void pairwise_load_and_dispatch(const FnAccuArity<Arity> arity, D d, const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+                                           size_t i, const size_t N, KernelFn kernel_fn, AccuVecs&&... accu_vecs) noexcept
+    {
+        const auto a0 = hn::LoadU(d, a + i);
+        const auto b0 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<0>{}, kernel_fn, a0, b0, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a1 = hn::LoadU(d, a + i);
+        const auto b1 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<1>{}, kernel_fn, a1, b1, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a2 = hn::LoadU(d, a + i);
+        const auto b2 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<2>{}, kernel_fn, a2, b2, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a3 = hn::LoadU(d, a + i);
+        const auto b3 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<3>{}, kernel_fn, a3, b3, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a4 = hn::LoadU(d, a + i);
+        const auto b4 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<4>{}, kernel_fn, a4, b4, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a5 = hn::LoadU(d, a + i);
+        const auto b5 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<5>{}, kernel_fn, a5, b5, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a6 = hn::LoadU(d, a + i);
+        const auto b6 = hn::LoadU(d, b + i);
+        i += N;
+        dispatch_pairwise(arity, IterNum<6>{}, kernel_fn, a6, b6, std::forward<AccuVecs>(accu_vecs)...);
+        const auto a7 = hn::LoadU(d, a + i);
+        const auto b7 = hn::LoadU(d, b + i);
+        dispatch_pairwise(arity, IterNum<7>{}, kernel_fn, a7, b7, std::forward<AccuVecs>(accu_vecs)...);
+    }
+};
+
+// The kernel body wraps all needed boundary condition handling for vectorized loops.
+// For all input blocks that are a multiple of the vector size*unroll factor we run
+// the main vector steam engine loop block. This is where most of the work is expected
+// to be done, and is where accumulator and instruction parallelism will mean the most.
+// We then process any whole vectors that are remaining (for blocks that are a multiple
+// of the vector size), before any final remaining elements are processed.
+// Important: we handle elements _outside_ the boundary by making them implicitly zero!
+// This means the kernel function MUST treat zero-elements the same "as if" the elements
+// did not exist in the first place. For most distance functions this is implicitly the
+// case since the contribution of lhs 0 vs rhs 0 is also 0.
+
+template <size_t UnrollFactor>
+struct KernelBody {
+    template <
+        size_t Arity,
+        typename D,
+        typename T = hn::TFromD<D>,
+        typename KernelFn,
+        typename... Accumulators
+    >
+    HWY_INLINE
+    static void pairwise_body_impl(
+            const FnAccuArity<Arity> arity,
+            const D d,
+            const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+            const size_t n_elems,
+            const KernelFn kernel_fn,
+            Accumulators&&... accumulators) noexcept
+    {
+        HWY_LANES_CONSTEXPR const size_t N = hn::Lanes(d);
+        size_t i = 0;
+        for (; (i + UnrollFactor*N) <= n_elems; i += UnrollFactor*N) {
+            UnrolledLoopBody<UnrollFactor>::pairwise_load_and_dispatch(arity, d, a, b, i, N, kernel_fn,
+                                                                       std::forward<Accumulators>(accumulators)...);
+        }
+        // Boundary case: up to (and including) UnrollFactor-1 whole vectors at the end
+        for (; (i + N) <= n_elems; i += N) {
+            UnrolledLoopBody<1>::pairwise_load_and_dispatch(arity, d, a, b, i, N, kernel_fn,
+                                                            std::forward<Accumulators>(accumulators)...);
+        }
+        // Process up any final stragglers of < N elems
+        const size_t rem = n_elems - i;
+        if (rem != 0) {
+            // Lanes OOB will be _zero_
+            const auto a0 = hn::LoadN(d, a + i, rem);
+            const auto b0 = hn::LoadN(d, b + i, rem);
+            dispatch_pairwise(arity, IterNum<0>{}, kernel_fn, a0, b0,
+                              std::forward<Accumulators>(accumulators)...);
+        }
+    }
+
+    template <
+        size_t Arity,
+        typename D,
+        typename T = hn::TFromD<D>,
+        typename KernelFn,
+        typename... Accumulators
+    >
+    HWY_INLINE
+    static void elementwise_body_impl(
+            const FnAccuArity<Arity> arity,
+            const D d,
+            const T* HWY_RESTRICT a,
+            const size_t n_elems,
+            const KernelFn kernel_fn,
+            Accumulators&&... accumulators) noexcept
+    {
+        HWY_LANES_CONSTEXPR const size_t N = hn::Lanes(d);
+        size_t i = 0;
+        for (; (i + UnrollFactor*N) <= n_elems; i += UnrollFactor*N) {
+            UnrolledLoopBody<UnrollFactor>::elementwise_load_and_dispatch(arity, d, a, i, N, kernel_fn,
+                                                                          std::forward<Accumulators>(accumulators)...);
+        }
+        // Boundary case: up to (and including) UnrollFactor-1 whole vectors at the end
+        for (; (i + N) <= n_elems; i += N) {
+            UnrolledLoopBody<1>::elementwise_load_and_dispatch(arity, d, a, i, N, kernel_fn,
+                                                               std::forward<Accumulators>(accumulators)...);
+        }
+        // Process up any final stragglers of < N elems
+        const size_t rem = n_elems - i;
+        if (rem != 0) {
+            // Lanes OOB will be _zero_
+            const auto a0 = hn::LoadN(d, a + i, rem);
+            dispatch(arity, IterNum<0>{}, kernel_fn, a0,
+                     std::forward<Accumulators>(accumulators)...);
+        }
+    }
+};
+
+template <size_t N>
+struct UnrolledBy {
+    constexpr static size_t unrolled_by_v = N;
+};
+
+template <size_t N>
+struct UsesNAccumulators {
+    constexpr static size_t uses_n_accumulators_v = N;
+};
+
+template <size_t N>
+struct HasAccumulatorArity {
+    constexpr static size_t fn_has_accu_arity_v = N;
+};
+
+// TODO replace with concept constraints instead?
+//  For now, use distinct value names to cause compilation errors on wrong arg ordering
+template <
+    typename UsesNAccumulatorsT,
+    typename UnrolledByT,
+    typename FnHasAccuArityT
+>
+struct HwyReduceKernel;
+
+// Ideally we would be able to make our lives easier by representing N parallel accumulators
+// with having a vector array of size N. Unfortunately, vector types may be _sizeless_ on
+// some archs (SVE, RVV) so arrays (and even class members) are out of the question. Instead,
+// specialize a set of HwyReduceKernel implementations on the accumulator parallelism factor
+// and use N distinct, named accumulator variables. These can then be forwarded to more
+// generalized variadic templated functions.
+
+template <typename UnrolledByT, typename FnHasAccuArityT>
+struct HwyReduceKernel<UsesNAccumulators<4>, UnrolledByT, FnHasAccuArityT> {
+    static constexpr size_t AccumulatorCount = 4;
+    static constexpr size_t UnrollFactor = UnrolledByT::unrolled_by_v;
+    static constexpr size_t Arity = FnHasAccuArityT::fn_has_accu_arity_v;
+
+    template <typename AccuReducerFn, typename AccuV>
+    HWY_INLINE
+    static AccuV parallel_reduce_accumulators(AccuReducerFn accu_reducer_fn,
+                                              AccuV accu0, AccuV accu1, AccuV accu2, AccuV accu3) noexcept
+    {
+        // 4-way reduction tree:
+        //  0 + 1 => 0, 2 + 3 => 2
+        //  0 + 2 => result
+        accu0 = accu_reducer_fn(accu0, accu1);
+        accu2 = accu_reducer_fn(accu2, accu3);
+        return accu_reducer_fn(accu0, accu2);
+    }
+
+    template <
+        typename D,
+        typename DA,
+        typename T = hn::TFromD<D>,
+        typename R = hn::TFromD<DA>,
+        typename KernelFn,
+        typename AccuReducerFn,
+        typename LaneReducerFn
+    >
+    [[nodiscard]] static R elementwise(
+            const D d,
+            const DA da,
+            const T* HWY_RESTRICT a,
+            const size_t n_elems,
+            const hn::Vec<DA> init_accu,
+            const KernelFn kernel_fn,
+            const AccuReducerFn accu_reducer_fn,
+            const LaneReducerFn lane_reducer_fn) noexcept
+    {
+        using AccuV = hn::Vec<DA>;
+        AccuV accu0 = init_accu;
+        AccuV accu1 = init_accu;
+        AccuV accu2 = init_accu;
+        AccuV accu3 = init_accu;
+        KernelBody<UnrollFactor>::elementwise_body_impl(FnAccuArity<Arity>{}, d, a, n_elems, kernel_fn,
+                                                        accu0, accu1, accu2, accu3);
+        AccuV reduced = parallel_reduce_accumulators(accu_reducer_fn, accu0, accu1, accu2, accu3);
+        return lane_reducer_fn(da, reduced);
+    }
+
+    template <
+        typename D,
+        typename DA,
+        typename T = hn::TFromD<D>,
+        typename R = hn::TFromD<DA>,
+        typename KernelFn,
+        typename AccuReducerFn,
+        typename LaneReducerFn
+    >
+    [[nodiscard]] static R pairwise(
+            const D d,
+            const DA da,
+            const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+            const size_t n_elems,
+            const hn::Vec<DA> init_accu,
+            const KernelFn kernel_fn,
+            const AccuReducerFn accu_reducer_fn,
+            const LaneReducerFn lane_reducer_fn) noexcept
+    {
+        using AccuV = hn::Vec<DA>;
+        AccuV accu0 = init_accu;
+        AccuV accu1 = init_accu;
+        AccuV accu2 = init_accu;
+        AccuV accu3 = init_accu;
+        KernelBody<UnrollFactor>::pairwise_body_impl(FnAccuArity<Arity>{}, d, a, b, n_elems, kernel_fn,
+                                                     accu0, accu1, accu2, accu3);
+        AccuV reduced = parallel_reduce_accumulators(accu_reducer_fn, accu0, accu1, accu2, accu3);
+        return lane_reducer_fn(da, reduced);
+    }
+};
+
+template <typename UnrolledByT, typename FnHasAccuArityT>
+struct HwyReduceKernel<UsesNAccumulators<8>, UnrolledByT, FnHasAccuArityT> {
+    static constexpr size_t AccumulatorCount = 8;
+    static constexpr size_t UnrollFactor = UnrolledByT::unrolled_by_v;
+    static constexpr size_t Arity = FnHasAccuArityT::fn_has_accu_arity_v;
+
+    template <typename AccuReducerFn, typename AccuV>
+    HWY_INLINE
+    static AccuV parallel_reduce_accumulators(AccuReducerFn accu_reducer_fn,
+                                              AccuV accu0, AccuV accu1, AccuV accu2, AccuV accu3,
+                                              AccuV accu4, AccuV accu5, AccuV accu6, AccuV accu7) noexcept
+    {
+        // 8-way reduction tree:
+        //  first 0+1 => 0, 2+3 => 2, 4+5 => 4, 6+7 => 6
+        //  then  0+2 => 0, 4+6 => 4
+        //  then  0+4 => result
+        accu0 = accu_reducer_fn(accu0, accu1);
+        accu2 = accu_reducer_fn(accu2, accu3);
+        accu4 = accu_reducer_fn(accu4, accu5);
+        accu6 = accu_reducer_fn(accu6, accu7);
+
+        accu0 = accu_reducer_fn(accu0, accu2);
+        accu4 = accu_reducer_fn(accu4, accu6);
+
+        return accu_reducer_fn(accu0, accu4);
+    }
+
+    template <
+        typename D,
+        typename DA,
+        typename T = hn::TFromD<D>,
+        typename R = hn::TFromD<DA>,
+        typename KernelFn,
+        typename AccuReducerFn,
+        typename LaneReducerFn
+    >
+    [[nodiscard]] static R elementwise(
+            const D d,
+            const DA da,
+            const T* HWY_RESTRICT a,
+            const size_t n_elems,
+            const hn::Vec<DA> init_accu,
+            const KernelFn kernel_fn,
+            const AccuReducerFn accu_reducer_fn,
+            const LaneReducerFn lane_reducer_fn) noexcept
+    {
+        using AccuV = hn::Vec<DA>;
+        AccuV accu0 = init_accu;
+        AccuV accu1 = init_accu;
+        AccuV accu2 = init_accu;
+        AccuV accu3 = init_accu;
+        AccuV accu4 = init_accu;
+        AccuV accu5 = init_accu;
+        AccuV accu6 = init_accu;
+        AccuV accu7 = init_accu;
+        KernelBody<UnrollFactor>::elementwise_body_impl(FnAccuArity<Arity>{}, d, a, n_elems, kernel_fn,
+                                                        accu0, accu1, accu2, accu3, accu4, accu5, accu6, accu7);
+        AccuV reduced = parallel_reduce_accumulators(accu_reducer_fn, accu0, accu1, accu2,
+                                                     accu3, accu4, accu5, accu6, accu7);
+        return lane_reducer_fn(da, reduced);
+    }
+
+    template <
+        typename D,
+        typename DA,
+        typename T = hn::TFromD<D>,
+        typename R = hn::TFromD<DA>,
+        typename KernelFn,
+        typename AccuReducerFn,
+        typename LaneReducerFn
+    >
+    [[nodiscard]] static R pairwise(
+            const D d,
+            const DA da,
+            const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+            const size_t n_elems,
+            const hn::Vec<DA> init_accu,
+            const KernelFn kernel_fn,
+            const AccuReducerFn accu_reducer_fn,
+            const LaneReducerFn lane_reducer_fn) noexcept
+    {
+        using AccuV = hn::Vec<DA>;
+        AccuV accu0 = init_accu;
+        AccuV accu1 = init_accu;
+        AccuV accu2 = init_accu;
+        AccuV accu3 = init_accu;
+        AccuV accu4 = init_accu;
+        AccuV accu5 = init_accu;
+        AccuV accu6 = init_accu;
+        AccuV accu7 = init_accu;
+        KernelBody<UnrollFactor>::pairwise_body_impl(FnAccuArity<Arity>{}, d, a, b, n_elems, kernel_fn,
+                                                     accu0, accu1, accu2, accu3, accu4, accu5, accu6, accu7);
+        AccuV reduced = parallel_reduce_accumulators(accu_reducer_fn, accu0, accu1, accu2,
+                                                     accu3, accu4, accu5, accu6, accu7);
+        return lane_reducer_fn(da, reduced);
+    }
+};
+
+// Utility function for invoking a function that has an intermediate result type that
+// may overflow if the input size is beyond a certain threshold. If the size is > this
+// threshold, invoke the function on input chunks that do not exceed this threshold,
+// maintaining a running sum across the chunks. The sum type must be one that is _not_
+// expected to overflow regardless of the input size.
+template <size_t MaxChunkSize, typename SumT, typename F, typename T>
+[[nodiscard]] SumT
+compute_chunked_sum(F&& fn, const T* HWY_RESTRICT lhs, const T* HWY_RESTRICT rhs, const size_t sz) noexcept {
+    if (sz <= MaxChunkSize) [[likely]] {
+        return fn(lhs, rhs, sz);
+    }
+    // Process input in chunks that are small enough that the intermediate accumulators
+    // won't overflow, but large enough that we can spin up the vector steam engines fully.
+    SumT sum{};
+    size_t i = 0;
+    for (; i + MaxChunkSize <= sz; i += MaxChunkSize) {
+        sum += fn(lhs + i, rhs + i, MaxChunkSize);
+    }
+    if (sz > i) {
+        sum += fn(lhs + i, rhs + i, sz - i);
+    }
+    return sum;
+}
+
+
+}  // namespace HWY_NAMESPACE
+}  // namespace vespalib::hwaccelerated
+HWY_AFTER_NAMESPACE();

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/vespalib/util/bfloat16.h>
 #include <memory>
 #include <cstdint>
 #include <vector>
@@ -10,39 +11,41 @@ namespace vespalib::hwaccelerated {
 
 /**
  * This contains an interface to all primitives that has different cpu supported accelerations.
- * The actual implementation you get by calling the the static getAccelerator method.
+ * The actual implementation you get by calling the static getAccelerator method.
  */
 class IAccelerated
 {
 public:
     virtual ~IAccelerated() = default;
     using UP = std::unique_ptr<IAccelerated>;
-    virtual float dotProduct(const float * a, const float * b, size_t sz) const noexcept = 0;
-    virtual double dotProduct(const double * a, const double * b, size_t sz) const noexcept = 0;
-    virtual int64_t dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept = 0;
-    virtual int64_t dotProduct(const int16_t * a, const int16_t * b, size_t sz) const noexcept = 0;
-    virtual int64_t dotProduct(const int32_t * a, const int32_t * b, size_t sz) const noexcept = 0;
-    virtual long long dotProduct(const int64_t * a, const int64_t * b, size_t sz) const noexcept = 0;
-    virtual void orBit(void * a, const void * b, size_t bytes) const noexcept = 0;
-    virtual void andBit(void * a, const void * b, size_t bytes) const noexcept = 0;
-    virtual void andNotBit(void * a, const void * b, size_t bytes) const noexcept = 0;
-    virtual void notBit(void * a, size_t bytes) const noexcept = 0;
-    virtual size_t populationCount(const uint64_t *a, size_t sz) const noexcept = 0;
-    virtual void convert_bfloat16_to_float(const uint16_t * src, float * dest, size_t sz) const noexcept = 0;
-    virtual double squaredEuclideanDistance(const int8_t * a, const int8_t * b, size_t sz) const noexcept = 0;
-    virtual double squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept = 0;
-    virtual double squaredEuclideanDistance(const double * a, const double * b, size_t sz) const noexcept = 0;
+    virtual float dotProduct(const float* a, const float* b, size_t sz) const noexcept = 0;
+    virtual float dotProduct(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept = 0;
+    virtual double dotProduct(const double* a, const double* b, size_t sz) const noexcept = 0;
+    virtual int64_t dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept = 0;
+    virtual int64_t dotProduct(const int16_t* a, const int16_t* b, size_t sz) const noexcept = 0;
+    virtual int64_t dotProduct(const int32_t* a, const int32_t* b, size_t sz) const noexcept = 0;
+    virtual long long dotProduct(const int64_t* a, const int64_t* b, size_t sz) const noexcept = 0;
+    virtual void orBit(void* a, const void* b, size_t bytes) const noexcept = 0;
+    virtual void andBit(void* a, const void* b, size_t bytes) const noexcept = 0;
+    virtual void andNotBit(void* a, const void* b, size_t bytes) const noexcept = 0;
+    virtual void notBit(void* a, size_t bytes) const noexcept = 0;
+    virtual size_t populationCount(const uint64_t* a, size_t sz) const noexcept = 0;
+    virtual void convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) const noexcept = 0;
+    virtual double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept = 0;
+    virtual double squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept = 0;
+    virtual double squaredEuclideanDistance(const double* a, const double* b, size_t sz) const noexcept = 0;
+    virtual double squaredEuclideanDistance(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept = 0;
     // AND 128 bytes from multiple, optionally inverted sources
-    virtual void and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept = 0;
+    virtual void and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept = 0;
     // OR 128 bytes from multiple, optionally inverted sources
-    virtual void or128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept = 0;
+    virtual void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept = 0;
 
     // Returns a static string representing the name of the underlying accelerator implementation
     [[nodiscard]] virtual const char* target_name() const noexcept { return "Unknown"; }
 
     static IAccelerated::UP create_platform_baseline_accelerator();
 
-    static const IAccelerated & getAccelerator() __attribute__((noinline));
+    static const IAccelerated& getAccelerator() __attribute__((noinline));
 };
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/platform_generic.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/platform_generic.h
@@ -1,0 +1,17 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+// FIXME this feels a bit dirty, but will go away if we standardize on Highway anyway
+#ifdef __x86_64__
+#include "x64_generic.h"
+namespace vespalib::hwaccelerated {
+using PlatformGenericAccelerator = X64GenericAccelerator;
+}
+#else
+#include "neon.h"
+namespace vespalib::hwaccelerated {
+using PlatformGenericAccelerator = NeonAccelerator;
+}
+#endif
+


### PR DESCRIPTION
@havardpe please review 👹

Today's compilers are often able to auto-vectorize code in extremely impressive ways, enabling SIMD speedups "for free" in otherwise scalar code. Unfortunately, it's very hard to know how, when or why vectorization will kick in (or not) for any given combination of loop structure, compiler vendor or version, making this effort some times feel like source code divining (or "compiler prompting").

To move away from non-determinism, this commit adds a brand new suite of _explicitly_ vectorized kernels built using [Google Highway](https://github.com/google/highway) for the following `IAccelerated` overloads:

 * Dot product - i8, f32, f64, bf16 (new)
 * Squared Euclidean distance - i8, f32, f64, bf16 (new)
 * Population count - u64

The non-overloaded functions will use the platform's generic implementation, i.e. AVX2 on x64, NEON on arm64. This may in theory cause performance regressions for fallback operations if these are substantially faster on e.g. AVX3, but added performance tests for binary bitwise ops show effectively no difference at all for these.

Note that we now use our own (read: Highway's) kernels also for `float32`/`float64` dot product instead of deferring to OpenBLAS. Benchmarking indicates that this is more efficient in practice for vector sizes that are realistic for nearest neighbor et al. Larger scale performance testing will show if this holds true in practice (we can juse defer to OpenBLAS again if not).

New BFloat16 overloads for dot product and squared euclidean distance are added as part of this work. These will have to be wired into various callsites as a follow-up. I.e. BF16 will _not_ be automatically sped up from this commit alone.

A concrete `IAccelerated` implementation subclass is generated per supported Highway compilation target. The set of possible targets is set in stone at compile time for a given architecture (x64/arm64); at runtime the subset actually supported by the running CPU is enumerated and made available via the new `Highway` class, including the presumed "best" target (i.e. widest vectors, most bells and whistles).

All currently supported operations have similar semantics in that they are either elementwise or pairwise operations over homogonous vectors that reduce down to a single value. This commit introduces a high(-ish) level abstraction for writing efficient reduction kernels that allows for picking and choosing different values of:

 * The number of vector accumulators running in parallel
 * The kernel body loop unrolling factor
 * The accumulator arity of the kernel function (some kernels may need to use more than 1 accumulator due to vector widening et al.)

This includes automatic handling of boundary conditions where the input is not a multiple of either the vector length multiplied by the unroll factor or a multiple of the target vector length itself.

Kernels have been tuned to be monotonically faster than the legacy kernels in our benchmark suite based on results from the following platforms and their max supported Highway target:

 * Google Axion (arm64, SVE2_128)
 * Intel Sapphire Rapids (x64, AVX3_SPR)
 * Apple M3 Max (arm64, NEON_BF16)

Note: these vector kernels are **not** yet enabled by default.

Other changes:
 * Unit testing of squared euclidean distance
 * Extend testing of supported dot product kernels
 * Add Highway to NOTICES file
 * Make it possible to configure Highway as the runtime accelerator
 * Factor out test/benchmark vector data generation
 * Add benchmarking of bitwise AND/OR/AND NOT
