### PR TITLE
fix: remove unused imports causing build problems

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/GetSchemaFields.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/GetSchemaFields.java
@@ -9,12 +9,6 @@ import ai.vespa.schemals.index.Symbol.SymbolType;
 import ai.vespa.schemals.lsp.common.command.CommandUtils;
 import ai.vespa.schemals.tree.Node;
 
-import org.eclipse.lsp4j.jsonrpc.json.adapters.TupleTypeAdapters.TwoTypeAdapter;
-import org.eclipse.lsp4j.jsonrpc.util.ToStringBuilder;
-
-import com.google.gson.Gson;
-import com.yahoo.collections.Pair;
-
 public class GetSchemaFields implements SchemaCommand {
 
     private String schemaName;


### PR DESCRIPTION
These imports caused the intellij client build to fail probably due to lsp4j version mismatch.