### PR TITLE
feat: add mirroring of Almalinux 9

### DIFF
--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -21,12 +21,14 @@ OSVERSION=$2
 ALLOWED_ARCHS=("x86_64" "aarch64")
 ALLOWED_VERSIONS=("8" "9")
 
-if [[ " ${ALLOWED_ARCHS[*]} " != " $RPMARCH " ]]; then
+# shellcheck disable=SC2076
+if [[ ! " ${ALLOWED_ARCHS[*]} " =~ " ${RPMARCH} " ]]; then
   echo "Architecture $RPMARCH not in allowed archs: ${ALLOWED_ARCHS[*]}"
   exit 1
 fi
 
-if [[ " ${ALLOWED_VERSIONS[*]} " != " $OSVERSION " ]]; then
+# shellcheck disable=SC2076
+if [[ ! " ${ALLOWED_VERSIONS[*]} " =~ " ${OSVERSION} " ]]; then
   echo "OS version $OSVERSION not in allowed versions: ${ALLOWED_VERSIONS[*]}"
   exit 1
 fi

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-        image: almalinux:8
+        image: almalinux:${{ matrix.os_version }}
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           CLOUDSMITH_API_TOKEN: ${{ secrets.CLOUDSMITH_API_TOKEN }}
@@ -44,6 +44,9 @@ jobs:
         arch:
           - x86_64
           - aarch64
+        os_version:
+          - '8'
+          - '9'
 
     steps:
       - name: Checkout code
@@ -53,6 +56,6 @@ jobs:
         run: |
           dnf install -y dnf-plugins-core jq
 
-      - name: Publish to ${{ matrix.arch }} mirror
+      - name: Publish to ${{ matrix.arch }} mirror (AlmaLinux ${{ matrix.os_version }})
         run: |
-          .github/scripts/publish-unpublished-rpms-to-archive.sh ${{ matrix.arch }}
+          .github/scripts/publish-unpublished-rpms-to-archive.sh ${{ matrix.arch }} ${{ matrix.os_version }}


### PR DESCRIPTION
## What

- Added support for multiple AlmaLinux OS versions (8 and 9) in the RPM publishing workflow.
- Improved robustness of workflow scripts by updating shell options, adding variable quotes, replacing for-loop with while-read, and simplifying error checks.

## Why

- Support AL9 in mirrors