### PR TITLE
Refactor evaluation of same element query node in streaming search to

### DIFF
--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -122,26 +122,10 @@ TEST(SameElementQueryNodeTest, test_same_element_evaluate)
     terms[2]->add(2, 6, 170, 17);
     HitList hits;
     sameElem->evaluateHits(hits);
-    EXPECT_EQ(4u, hits.size());
-    EXPECT_EQ(2u, hits[0].field_id());
-    EXPECT_EQ(0u, hits[0].element_id());
-    EXPECT_EQ(130, hits[0].element_weight());
-    EXPECT_EQ(0u, hits[0].position());
-
-    EXPECT_EQ(2u, hits[1].field_id());
-    EXPECT_EQ(2u, hits[1].element_id());
-    EXPECT_EQ(140, hits[1].element_weight());
-    EXPECT_EQ(0u, hits[1].position());
-
-    EXPECT_EQ(2u, hits[2].field_id());
-    EXPECT_EQ(4u, hits[2].element_id());
-    EXPECT_EQ(150, hits[2].element_weight());
-    EXPECT_EQ(0u, hits[2].position());
-
-    EXPECT_EQ(2u, hits[3].field_id());
-    EXPECT_EQ(5u, hits[3].element_id());
-    EXPECT_EQ(160, hits[3].element_weight());
-    EXPECT_EQ(0u, hits[3].position());
+    EXPECT_TRUE(hits.empty());
+    std::vector<uint32_t> element_ids;
+    sameElem->get_element_ids(element_ids);
+    EXPECT_EQ((std::vector<uint32_t>{ 0, 2, 4, 5}), element_ids);
     EXPECT_TRUE(sameElem->evaluate());
 
     SimpleTermData td;

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
@@ -3,6 +3,8 @@
 #include "same_element_query_node.h"
 #include <vespa/searchlib/fef/itermdata.h>
 #include <vespa/searchlib/fef/matchdata.h>
+#include <algorithm>
+#include <span>
 
 namespace search::streaming {
 
@@ -15,72 +17,55 @@ SameElementQueryNode::~SameElementQueryNode() = default;
 
 bool
 SameElementQueryNode::evaluate() const {
-    HitList hl;
-    return ! evaluateHits(hl).empty();
+    std::vector<uint32_t> element_ids;
+    get_element_ids(element_ids);
+    return !element_ids.empty();
 }
 
 const HitList &
 SameElementQueryNode::evaluateHits(HitList & hl) const
 {
     hl.clear();
-    const auto & children = get_terms();
-    if (children.size() == 1) {
-        return children.front()->evaluateHits(hl);
-    }
-    for (auto& child : children) {
-        if ( ! child->evaluate() ) {
-            return hl;
-        }
-    }
-    HitList tmpHL;
-    unsigned int numFields = children.size();
-    unsigned int currMatchCount = 0;
-    std::vector<unsigned int> indexVector(numFields, 0);
-    auto curr = static_cast<const QueryTerm *> (children[currMatchCount].get());
-    bool exhausted( curr->evaluateHits(tmpHL).empty());
-    for (; !exhausted; ) {
-        auto next = static_cast<const QueryTerm *>(children[currMatchCount+1].get());
-        unsigned int & currIndex = indexVector[currMatchCount];
-        unsigned int & nextIndex = indexVector[currMatchCount+1];
-
-        const auto & currHit = curr->evaluateHits(tmpHL)[currIndex];
-        uint32_t currElemId = currHit.element_id();
-
-        const HitList & nextHL = next->evaluateHits(tmpHL);
-
-        size_t nextIndexMax = nextHL.size();
-        while ((nextIndex < nextIndexMax) && (nextHL[nextIndex].element_id() < currElemId)) {
-            nextIndex++;
-        }
-        if ((nextIndex < nextIndexMax) && (nextHL[nextIndex].element_id() == currElemId)) {
-            currMatchCount++;
-            if ((currMatchCount+1) == numFields) {
-                Hit h = nextHL[indexVector[currMatchCount]];
-                hl.emplace_back(h.field_id(), h.element_id(), h.element_weight(), 0);
-                currMatchCount = 0;
-                indexVector[0]++;
-            }
-        } else {
-            currMatchCount = 0;
-            indexVector[currMatchCount]++;
-        }
-        curr = static_cast<const QueryTerm *>(children[currMatchCount].get());
-        exhausted = (nextIndex >= nextIndexMax) || (indexVector[currMatchCount] >= curr->evaluateHits(tmpHL).size());
-    }
     return hl;
 }
 
 void
-SameElementQueryNode::get_element_ids(std::vector<uint32_t>&) const
+SameElementQueryNode::get_element_ids(std::vector<uint32_t>& element_ids) const
 {
+    const auto & children = get_terms();
+    if (children.empty()) {
+        return;
+    }
+    for (auto& child : children) {
+        if (!child->evaluate()) {
+            return;
+        }
+    }
+    children.front()->get_element_ids(element_ids);
+    std::span<const std::unique_ptr<QueryTerm>> others(children.begin() + 1, children.end());
+    if (others.empty()) {
+        return;
+    }
+    std::vector<uint32_t> temp_element_ids;
+    std::vector<uint32_t> result;
+    for (auto& child : others) {
+        temp_element_ids.clear();
+        result.clear();
+        child->get_element_ids(temp_element_ids);
+        std::set_intersection(element_ids.begin(), element_ids.end(),
+                              temp_element_ids.begin(), temp_element_ids.end(),
+                              std::back_inserter(result));
+        std::swap(element_ids, result);
+        if (element_ids.empty()) {
+            return;
+        }
+    }
 }
 
 void
 SameElementQueryNode::unpack_match_data(uint32_t docid, const fef::ITermData& td, fef::MatchData& match_data, const fef::IIndexEnvironment&)
 {
-    HitList list;
-    const HitList & hit_list = evaluateHits(list);
-    if (!hit_list.empty()) {
+    if (evaluate()) {
         auto num_fields = td.numFields();
         /*
          * Currently reports hit for all fields for query node instead of

--- a/streamingvisitors/src/vespa/searchvisitor/matching_elements_filler.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/matching_elements_filler.cpp
@@ -66,7 +66,7 @@ class Matcher
     void select_multiterm_children(const MatchingElementsFields& fields, const MultiTerm& multi_term);
     void select_query_term_node(const MatchingElementsFields& fields, const QueryTerm& term);
     void select_query_nodes(const MatchingElementsFields& fields, const QueryNode& query_node);
-    void add_matching_elements(const std::string& field_name, std::optional<FieldIdT> field_id, uint32_t doc_lid, const HitList& hit_list, MatchingElements& matching_elements);
+    void add_matching_elements(const std::string& field_name, FieldIdT field_id, uint32_t doc_lid, const HitList& hit_list, MatchingElements& matching_elements);
     void find_matching_elements(const SameElementQueryNode& same_element, uint32_t doc_lid, MatchingElements& matching_elements);
     void find_matching_elements(const SubFieldTerm& sub_field_term, uint32_t doc_lid, MatchingElements& matching_elements);
 public:
@@ -162,11 +162,11 @@ Matcher::select_query_nodes(const MatchingElementsFields& fields, const QueryNod
 }
 
 void
-Matcher::add_matching_elements(const std::string& field_name, std::optional<FieldIdT> field_id, uint32_t doc_lid, const HitList& hit_list, MatchingElements& matching_elements)
+Matcher::add_matching_elements(const std::string& field_name, FieldIdT field_id, uint32_t doc_lid, const HitList& hit_list, MatchingElements& matching_elements)
 {
     _elements.clear();
     for (auto& hit : hit_list) {
-        if (!field_id.has_value() || field_id.value() == hit.field_id()) {
+        if (field_id == hit.field_id()) {
             _elements.emplace_back(hit.element_id());
         }
     }
@@ -181,9 +181,10 @@ Matcher::add_matching_elements(const std::string& field_name, std::optional<Fiel
 void
 Matcher::find_matching_elements(const SameElementQueryNode& same_element, uint32_t doc_lid, MatchingElements& matching_elements)
 {
-    const HitList& hit_list = same_element.evaluateHits(_hit_list);
-    if (!hit_list.empty()) {
-        add_matching_elements(same_element.getIndex(), std::nullopt, doc_lid, hit_list, matching_elements);
+    _elements.clear();
+    same_element.get_element_ids(_elements);
+    if (!_elements.empty()) {
+        matching_elements.add_matching_elements(doc_lid, same_element.getIndex(), _elements);
     }
 }
 


### PR DESCRIPTION
use element ids from children instead of full hit lists.

@havardpe : please review
