### PR TITLE
Use accumulator type for intermediate subtraction result

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
@@ -49,12 +49,12 @@ squaredEuclideanDistanceT(const T * a, const T * b, size_t sz) noexcept
     size_t i(0);
     for (; i + UNROLL <= sz; i += UNROLL) {
         for (size_t j(0); j < UNROLL; j++) {
-            T d = a[i+j] - b[i+j];
+            AccuT d = a[i+j] - b[i+j];
             partial[j] += d * d;
         }
     }
     for (;i < sz; i++) {
-        T d = a[i] - b[i];
+        AccuT d = a[i] - b[i];
         partial[i%UNROLL] += d * d;
     }
     double sum(0);


### PR DESCRIPTION
@arnej27959 please review

Avoids potential precision issues with `BFloat16` element type. This function overload is not yet wired to anything except tests and benchmarks, so this has not been possible to observe as an issue in practice.
