### PR TITLE
Adjust trace verbosity for startcbinary

### DIFF
--- a/client/go/internal/admin/vespa-wrapper/startcbinary/cmd.go
+++ b/client/go/internal/admin/vespa-wrapper/startcbinary/cmd.go
@@ -20,6 +20,12 @@ func Run(args []string) int {
 		trace.Warning("missing program argument")
 		return 1
 	}
+	if doTrace := os.Getenv(envvars.TRACE_STARTUP); doTrace != "" {
+		trace.AdjustVerbosity(1)
+	}
+	if doDebug := os.Getenv(envvars.DEBUG_STARTUP); doDebug != "" {
+		trace.AdjustVerbosity(2)
+	}
 	spec := NewProgSpec(args)
 	err := vespa.LoadDefaultEnv()
 	if err != nil {


### PR DESCRIPTION
Enables trace and debug level output when running startcbinary by setting:

```
override TRACE_STARTUP yes
override DEBUG_STARTUP yes
```

@hmusum fyi
