### PR TITLE
Make `vespalib::BFloat16` conversions easier to optimize for the compiler

### DIFF
--- a/vespalib/src/vespa/vespalib/util/bfloat16.h
+++ b/vespalib/src/vespa/vespalib/util/bfloat16.h
@@ -22,40 +22,17 @@ namespace vespalib {
 class BFloat16 {
 private:
     uint16_t _bits;
-    struct TwoU16 {
-        uint16_t u1;
-        uint16_t u2;
-    };
 
-    template<std::endian native_endian = std::endian::native>
     static constexpr uint16_t float_to_bits(float value) noexcept {
-        TwoU16 both{0,0};
-        static_assert(sizeof(TwoU16) == sizeof(float));
-        both = std::bit_cast<TwoU16>(value);
-        if constexpr (native_endian == std::endian::big) {
-            return both.u1;
-        } else {
-            static_assert(native_endian == std::endian::little,
-                          "Unknown endian, cannot handle");
-            return both.u2;
-        }
+        const uint32_t as_u32 = std::bit_cast<uint32_t>(value);
+        return as_u32 >> 16;
     }
 
-    template<std::endian native_endian = std::endian::native>
     static constexpr float bits_to_float(uint16_t bits) noexcept {
-        TwoU16 both{0,0};
-        if constexpr (native_endian == std::endian::big) {
-            both.u1 = bits;
-        } else {
-            static_assert(native_endian == std::endian::little,
-                          "Unknown endian, cannot handle");
-            both.u2 = bits;
-        }
-        float result = 0.0;
-        static_assert(sizeof(TwoU16) == sizeof(float));
-        result = std::bit_cast<float>(both);
-        return result;
+        const uint32_t as_u32 = static_cast<uint32_t>(bits) << 16;
+        return std::bit_cast<float>(as_u32);
     }
+
 public:
     constexpr BFloat16(float value) noexcept : _bits(float_to_bits(value)) {}
     BFloat16() noexcept = default;


### PR DESCRIPTION
@arnej27959 please review compiler horse-whispering.

By using plain bit-casts and shifts we can seduce the compiler into generating much more efficient auto-vectorized code. Not using struct "aliasing" makes the auto-vectorized dot product and squared Euclidean distance kernels ~3x faster in local benchmarks. This also means we don't have to care about endianness.

Note that the Highway kernels are still measured to be up to several times faster on top of this, since they can directly emit e.g. dedicated BF16 dot product instructions on ARM.
