### PR TITLE
Fix use `vespamalloc` as default and temporary search for `libmimalloc.so.2`

### DIFF
--- a/client/go/internal/admin/prog/vespamalloc.go
+++ b/client/go/internal/admin/prog/vespamalloc.go
@@ -73,7 +73,8 @@ func (p *Spec) ConfigureVespaMalloc() {
 	mallocImpl := p.Getenv(envvars.VESPA_USE_MALLOC_IMPL)
 	if mallocImpl == "mimalloc" {
 		useFile = mimallocLib()
-	} else {
+	}
+	if useFile == "" {
 		switch {
 		case p.MatchesListEnv(envvars.VESPA_USE_VESPAMALLOC_DST):
 			useFile = vespaMallocLib("libvespamallocdst16.so")

--- a/client/go/internal/admin/prog/vespamalloc.go
+++ b/client/go/internal/admin/prog/vespamalloc.go
@@ -46,14 +46,20 @@ func fileExistsAlsoInLdLibraryPath(path string) (bool, string) {
 }
 
 func mimallocLib() string {
-	fileName := "libmimalloc.so"
-	ok, path := fileExistsAlsoInLdLibraryPath(fileName)
-	if !ok {
-		trace.Debug("missing library:", fileName)
-		return ""
+	// TODO(johsol) while resolving rpm packages for mimalloc, we check for both libmimalloc.so and libmimalloc.so.2
+	//              because currently the symlink libmimalloc.so is only available in devel image.
+	//              This is for testing.
+	fileNames := []string{"libmimalloc.so", "libmimalloc.so.2"}
+	for _, fileName := range fileNames {
+		ok, path := fileExistsAlsoInLdLibraryPath(fileName)
+		if ok {
+			trace.Debug("found library:", path)
+			return path
+		}
 	}
-	trace.Debug("found library:", path)
-	return path
+	trace.Debug("missing library:", strings.Join(fileNames, ","))
+	trace.Warning("Could not find library mimalloc.")
+	return ""
 }
 
 func (p *Spec) ConfigureVespaMalloc() {


### PR DESCRIPTION
- Use `vespamalloc` as the default if we cannot find `mimalloc`.
- Log a warning to the user if mimalloc cannot be found.
- Search for `libmimalloc.so.2` during testing. This will be removed once the symlink is set up in RPM.

@arnej27959 please review
@hmusum fyi