### PR TITLE
Revert "Wire BFloat16 acceleration for distance functions and dot/l2 distance operations, take two"

### DIFF
--- a/eval/src/tests/instruction/l2_distance/l2_distance_test.cpp
+++ b/eval/src/tests/instruction/l2_distance/l2_distance_test.cpp
@@ -30,7 +30,7 @@ void verify(const TensorSpec &a, const TensorSpec &b, const std::string &expr, b
 void verify_cell_types(GenSpec a, GenSpec b, const std::string &expr, bool optimized = true) {
     for (CellType act : CellTypeUtils::list_types()) {
         for (CellType bct : CellTypeUtils::list_types()) {
-            if (optimized && (act == bct)) {
+            if (optimized && (act == bct) && (act != CellType::BFLOAT16)) {
                 verify(a.cpy().cells(act), b.cpy().cells(bct), expr, true);
             } else {
                 verify(a.cpy().cells(act), b.cpy().cells(bct), expr, false);

--- a/eval/src/vespa/eval/eval/inline_operation.cpp
+++ b/eval/src/vespa/eval/eval/inline_operation.cpp
@@ -28,8 +28,4 @@ double DotProduct<Int8Float, Int8Float>::apply(const Int8Float *lhs, const Int8F
     return static_cast<double>(accel.dotProduct(lhs_as_i8, rhs_as_i8, count));
 }
 
-double DotProduct<BFloat16, BFloat16>::apply(const BFloat16 *lhs, const BFloat16 *rhs, size_t count) {
-    return accel.dotProduct(lhs, rhs, count);
-}
-
 }

--- a/eval/src/vespa/eval/eval/inline_operation.h
+++ b/eval/src/vespa/eval/eval/inline_operation.h
@@ -4,7 +4,6 @@
 
 #include "int8float.h"
 #include "operation.h"
-#include <vespa/vespalib/util/bfloat16.h>
 #include <vespa/vespalib/util/typify.h>
 #include <cblas.h>
 #include <cmath>
@@ -179,11 +178,6 @@ struct DotProduct<double,double> {
 template <>
 struct DotProduct<Int8Float, Int8Float> {
     static double apply(const Int8Float *lhs, const Int8Float *rhs, size_t count);
-};
-
-template <>
-struct DotProduct<BFloat16, BFloat16> {
-    static double apply(const BFloat16 *lhs, const BFloat16 *rhs, size_t count);
 };
 
 //-----------------------------------------------------------------------------

--- a/eval/src/vespa/eval/instruction/l2_distance.cpp
+++ b/eval/src/vespa/eval/instruction/l2_distance.cpp
@@ -36,13 +36,17 @@ void my_squared_l2_distance_op(InterpretedFunction::State &state, uint64_t vecto
 struct SelectOp {
     template <typename CT>
     static InterpretedFunction::op_function invoke() {
-        return my_squared_l2_distance_op<CT>;
+        constexpr bool is_bfloat16 = std::is_same_v<CT, BFloat16>;
+        if constexpr (!is_bfloat16) {
+            return my_squared_l2_distance_op<CT>;
+        } else {
+            abort();
+        }
     }
 };
 
 bool compatible_cell_types(CellType lhs, CellType rhs) {
     return ((lhs == rhs) && ((lhs == CellType::INT8) ||
-                             (lhs == CellType::BFLOAT16) ||
                              (lhs == CellType::FLOAT) ||
                              (lhs == CellType::DOUBLE)));
 }

--- a/eval/src/vespa/eval/instruction/mixed_l2_distance.cpp
+++ b/eval/src/vespa/eval/instruction/mixed_l2_distance.cpp
@@ -27,6 +27,18 @@ double h_sq_l2<Int8Float>(const Int8Float *a, const Int8Float *b, size_t len) {
     return hw.squaredEuclideanDistance((const int8_t *)a, (const int8_t *)b, len);
 }
 
+template <>
+double h_sq_l2<BFloat16>(const BFloat16 *a, const BFloat16 *b, size_t len) {
+    float sum = 0.0;
+    for (size_t i = 0; i < len; ++i) {
+        float x = a[i];
+        float y = b[i];
+        float d = (x - y);
+        sum += d * d;
+    }
+    return sum;
+}
+
 struct MixedSqL2Param {
     const ValueType res_type;
     const size_t vec_len;

--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
@@ -75,16 +75,26 @@ void benchmark(size_t iterations, size_t elems, const DistanceFunctionFactory & 
 template<typename T>
 void benchmark(size_t iterations, size_t elems, const std::string & dist_functions) {
     if (dist_functions.find("euclid") != npos) {
-        benchmark<T>(iterations, elems, EuclideanDistanceFunctionFactory<T>());
+        if constexpr ( ! std::is_same<T, BFloat16>()) {
+            benchmark<T>(iterations, elems, EuclideanDistanceFunctionFactory<T>());
+        } else {
+            benchmark<BFloat16>(iterations, elems, EuclideanDistanceFunctionFactory<float>());
+        }
     }
     if (dist_functions.find("angular") != npos) {
-        benchmark<T>(iterations, elems, AngularDistanceFunctionFactory<T>());
+        if constexpr ( ! std::is_same<T, BFloat16>()) {
+            benchmark<T>(iterations, elems, AngularDistanceFunctionFactory<T>());
+        }
     }
     if (dist_functions.find("prenorm") != npos) {
-        benchmark<T>(iterations, elems, PrenormalizedAngularDistanceFunctionFactory<T>());
+        if constexpr ( ! std::is_same<T, BFloat16>()) {
+            benchmark<T>(iterations, elems, PrenormalizedAngularDistanceFunctionFactory<T>());
+        }
     }
     if (dist_functions.find("mips") != npos) {
-        benchmark<T>(iterations, elems, MipsDistanceFunctionFactory<T>());
+        if constexpr ( !std::is_same<T, BFloat16>()) {
+            benchmark<T>(iterations, elems, MipsDistanceFunctionFactory<T>());
+        }
     }
 }
 

--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
@@ -732,12 +732,26 @@ expect_reference_insertion_vector(FloatType exp_dist, DistanceMetric metric, Cel
     EXPECT_EQ(exp_dist, func->calc(t(rhs)));
 }
 
+template <typename FloatType>
+void
+expect_not_reference_insertion_vector(FloatType exp_dist, DistanceMetric metric, CellType cell_type)
+{
+    std::vector<FloatType> lhs{1.0, 0.0};
+    std::vector<FloatType> rhs{0.0, 1.0};
+    auto factory = make_distance_function_factory(metric, cell_type);
+    auto func = factory->for_insertion_vector(t(lhs));
+    // Updating the insertion vector should NOT be reflected in the calculation, as a copy has been created.
+    lhs[0] = 0.0;
+    lhs[1] = 1.0;
+    EXPECT_EQ(exp_dist, func->calc(t(rhs)));
+}
+
 TEST(DistanceFunctionsTest, angular_can_reference_insertion_vector)
 {
     expect_reference_insertion_vector<float>(1.0, DistanceMetric::Angular, CellType::FLOAT);
     expect_reference_insertion_vector<double>(1.0, DistanceMetric::Angular, CellType::DOUBLE);
     expect_reference_insertion_vector<Int8Float>(1.0, DistanceMetric::Angular, CellType::INT8);
-    expect_reference_insertion_vector<BFloat16>(1.0, DistanceMetric::Angular, CellType::BFLOAT16);
+    expect_not_reference_insertion_vector<BFloat16>(1.0, DistanceMetric::Angular, CellType::BFLOAT16);
 }
 
 TEST(DistanceFunctionsTest, prenormalized_angular_can_reference_insertion_vector)
@@ -745,7 +759,7 @@ TEST(DistanceFunctionsTest, prenormalized_angular_can_reference_insertion_vector
     expect_reference_insertion_vector<float>(1.0, DistanceMetric::PrenormalizedAngular, CellType::FLOAT);
     expect_reference_insertion_vector<double>(1.0, DistanceMetric::PrenormalizedAngular, CellType::DOUBLE);
     expect_reference_insertion_vector<Int8Float>(1.0, DistanceMetric::PrenormalizedAngular, CellType::INT8);
-    expect_reference_insertion_vector<BFloat16>(1.0, DistanceMetric::PrenormalizedAngular, CellType::BFLOAT16);
+    expect_not_reference_insertion_vector<BFloat16>(1.0, DistanceMetric::PrenormalizedAngular, CellType::BFLOAT16);
 }
 
 TEST(DistanceFunctionsTest, euclidean_can_reference_insertion_vector)
@@ -753,7 +767,7 @@ TEST(DistanceFunctionsTest, euclidean_can_reference_insertion_vector)
     expect_reference_insertion_vector<float>(2.0, DistanceMetric::Euclidean, CellType::FLOAT);
     expect_reference_insertion_vector<double>(2.0, DistanceMetric::Euclidean, CellType::DOUBLE);
     expect_reference_insertion_vector<Int8Float>(2.0, DistanceMetric::Euclidean, CellType::INT8);
-    expect_reference_insertion_vector<BFloat16>(2.0, DistanceMetric::Euclidean, CellType::BFLOAT16);
+    expect_not_reference_insertion_vector<BFloat16>(2.0, DistanceMetric::Euclidean, CellType::BFLOAT16);
 }
 
 TEST(DistanceFunctionsTest, dotproduct_can_reference_insertion_vector)
@@ -761,7 +775,7 @@ TEST(DistanceFunctionsTest, dotproduct_can_reference_insertion_vector)
     expect_reference_insertion_vector<float>(0.0, DistanceMetric::Dotproduct, CellType::FLOAT);
     expect_reference_insertion_vector<double>(0.0, DistanceMetric::Dotproduct, CellType::DOUBLE);
     expect_reference_insertion_vector<Int8Float>(0.0, DistanceMetric::Dotproduct, CellType::INT8);
-    expect_reference_insertion_vector<BFloat16>(0.0, DistanceMetric::Dotproduct, CellType::BFLOAT16);
+    expect_not_reference_insertion_vector<BFloat16>(0.0, DistanceMetric::Dotproduct, CellType::BFLOAT16);
 }
 
 TEST(DistanceFunctionsTest, hamming_can_reference_insertion_vector)
@@ -769,7 +783,7 @@ TEST(DistanceFunctionsTest, hamming_can_reference_insertion_vector)
     expect_reference_insertion_vector<float>(2.0, DistanceMetric::Hamming, CellType::FLOAT);
     expect_reference_insertion_vector<double>(2.0, DistanceMetric::Hamming, CellType::DOUBLE);
     expect_reference_insertion_vector<Int8Float>(2.0, DistanceMetric::Hamming, CellType::INT8);
-    expect_reference_insertion_vector<BFloat16>(2.0, DistanceMetric::Hamming, CellType::BFLOAT16);
+    expect_not_reference_insertion_vector<BFloat16>(2.0, DistanceMetric::Hamming, CellType::BFLOAT16);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
@@ -70,11 +70,9 @@ public:
 template class BoundAngularDistance<TemporaryVectorStore<float>>;
 template class BoundAngularDistance<TemporaryVectorStore<double>>;
 template class BoundAngularDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundAngularDistance<TemporaryVectorStore<vespalib::BFloat16>>;
 template class BoundAngularDistance<ReferenceVectorStore<float>>;
 template class BoundAngularDistance<ReferenceVectorStore<double>>;
 template class BoundAngularDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundAngularDistance<ReferenceVectorStore<vespalib::BFloat16>>;
 
 template <typename FloatType>
 BoundDistanceFunction::UP
@@ -98,6 +96,5 @@ AngularDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) 
 template class AngularDistanceFunctionFactory<float>;
 template class AngularDistanceFunctionFactory<double>;
 template class AngularDistanceFunctionFactory<Int8Float>;
-template class AngularDistanceFunctionFactory<vespalib::BFloat16>;
 
 }

--- a/searchlib/src/vespa/searchlib/tensor/bound_distance_function.h
+++ b/searchlib/src/vespa/searchlib/tensor/bound_distance_function.h
@@ -20,7 +20,6 @@ public:
     using UP = std::unique_ptr<BoundDistanceFunction>;
     using TypedCells = vespalib::eval::TypedCells;
     using Int8Float = vespalib::eval::Int8Float;
-    using BFloat16 = vespalib::BFloat16;
 
     BoundDistanceFunction() noexcept = default;
 
@@ -35,7 +34,6 @@ protected:
     static const double *cast(const double * p) { return p; }
     static const float *cast(const float * p) { return p; }
     static const int8_t *cast(const Int8Float * p) { return reinterpret_cast<const int8_t *>(p); }
-    static const BFloat16 *cast(const BFloat16* p) { return p; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
@@ -16,17 +16,15 @@ make_distance_function_factory(DistanceMetric variant, CellType cell_type)
     switch (variant) {
         case DistanceMetric::Angular:
             switch (cell_type) {
-                case CellType::DOUBLE:   return std::make_unique<AngularDistanceFunctionFactory<double>>(true);
-                case CellType::INT8:     return std::make_unique<AngularDistanceFunctionFactory<Int8Float>>(true);
-                case CellType::BFLOAT16: return std::make_unique<AngularDistanceFunctionFactory<vespalib::BFloat16>>(true);
-                case CellType::FLOAT:    return std::make_unique<AngularDistanceFunctionFactory<float>>(true);
-                default:                 return std::make_unique<AngularDistanceFunctionFactory<float>>();
+                case CellType::DOUBLE: return std::make_unique<AngularDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:   return std::make_unique<AngularDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:  return std::make_unique<AngularDistanceFunctionFactory<float>>(true);
+                default:               return std::make_unique<AngularDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::Euclidean:
             switch (cell_type) {
                 case CellType::DOUBLE:   return std::make_unique<EuclideanDistanceFunctionFactory<double>>(true);
                 case CellType::INT8:     return std::make_unique<EuclideanDistanceFunctionFactory<Int8Float>>(true);
-                case CellType::BFLOAT16: return std::make_unique<EuclideanDistanceFunctionFactory<vespalib::BFloat16>>(true);
                 case CellType::FLOAT:    return std::make_unique<EuclideanDistanceFunctionFactory<float>>(true);
                 default:                 return std::make_unique<EuclideanDistanceFunctionFactory<float>>();
             }
@@ -35,27 +33,24 @@ make_distance_function_factory(DistanceMetric variant, CellType cell_type)
             switch (cell_type) {
                 case CellType::DOUBLE:   return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<double>>(true);
                 case CellType::INT8:     return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<Int8Float>>(true);
-                case CellType::BFLOAT16: return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<vespalib::BFloat16>>(true);
                 case CellType::FLOAT:    return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<float>>(true);
                 default:                 return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::Dotproduct:
             switch (cell_type) {
-                case CellType::DOUBLE:   return std::make_unique<MipsDistanceFunctionFactory<double>>(true);
-                case CellType::INT8:     return std::make_unique<MipsDistanceFunctionFactory<Int8Float>>(true);
-                case CellType::BFLOAT16: return std::make_unique<MipsDistanceFunctionFactory<vespalib::BFloat16>>(true);
-                case CellType::FLOAT:    return std::make_unique<MipsDistanceFunctionFactory<float>>(true);
-                default:                 return std::make_unique<MipsDistanceFunctionFactory<float>>();
+                case CellType::DOUBLE: return std::make_unique<MipsDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:   return std::make_unique<MipsDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:  return std::make_unique<MipsDistanceFunctionFactory<float>>(true);
+                default:               return std::make_unique<MipsDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::GeoDegrees:
             return std::make_unique<GeoDistanceFunctionFactory>();
         case DistanceMetric::Hamming:
             switch (cell_type) {
-                case CellType::DOUBLE:   return std::make_unique<HammingDistanceFunctionFactory<double>>(true);
-                case CellType::INT8:     return std::make_unique<HammingDistanceFunctionFactory<Int8Float>>(true);
-                case CellType::BFLOAT16: return std::make_unique<HammingDistanceFunctionFactory<vespalib::BFloat16>>(true);
-                case CellType::FLOAT:    return std::make_unique<HammingDistanceFunctionFactory<float>>(true);
-                default:                 return std::make_unique<HammingDistanceFunctionFactory<float>>();
+                case CellType::DOUBLE: return std::make_unique<HammingDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:   return std::make_unique<HammingDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:  return std::make_unique<HammingDistanceFunctionFactory<float>>(true);
+                default:               return std::make_unique<HammingDistanceFunctionFactory<float>>();
             }
     }
     // Not reached:

--- a/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
@@ -46,11 +46,9 @@ public:
 };
 
 template class BoundEuclideanDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundEuclideanDistance<TemporaryVectorStore<vespalib::BFloat16>>;
 template class BoundEuclideanDistance<TemporaryVectorStore<float>>;
 template class BoundEuclideanDistance<TemporaryVectorStore<double>>;
 template class BoundEuclideanDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundEuclideanDistance<ReferenceVectorStore<vespalib::BFloat16>>;
 template class BoundEuclideanDistance<ReferenceVectorStore<float>>;
 template class BoundEuclideanDistance<ReferenceVectorStore<double>>;
 
@@ -74,7 +72,6 @@ EuclideanDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs
 }
 
 template class EuclideanDistanceFunctionFactory<Int8Float>;
-template class EuclideanDistanceFunctionFactory<vespalib::BFloat16>;
 template class EuclideanDistanceFunctionFactory<float>;
 template class EuclideanDistanceFunctionFactory<double>;
 

--- a/searchlib/src/vespa/searchlib/tensor/hamming_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hamming_distance.cpp
@@ -49,11 +49,9 @@ public:
 };
 
 template class BoundHammingDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundHammingDistance<TemporaryVectorStore<vespalib::BFloat16>>;
 template class BoundHammingDistance<TemporaryVectorStore<float>>;
 template class BoundHammingDistance<TemporaryVectorStore<double>>;
 template class BoundHammingDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundHammingDistance<ReferenceVectorStore<vespalib::BFloat16>>;
 template class BoundHammingDistance<ReferenceVectorStore<float>>;
 template class BoundHammingDistance<ReferenceVectorStore<double>>;
 
@@ -77,7 +75,6 @@ HammingDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) 
 }
 
 template class HammingDistanceFunctionFactory<Int8Float>;
-template class HammingDistanceFunctionFactory<vespalib::BFloat16>;
 template class HammingDistanceFunctionFactory<float>;
 template class HammingDistanceFunctionFactory<double>;
 

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
@@ -90,7 +90,6 @@ MipsDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) con
 };
 
 template class MipsDistanceFunctionFactory<Int8Float>;
-template class MipsDistanceFunctionFactory<vespalib::BFloat16>;
 template class MipsDistanceFunctionFactory<float>;
 template class MipsDistanceFunctionFactory<double>;
 

--- a/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.cpp
@@ -62,11 +62,9 @@ public:
 template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<float>>;
 template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<double>>;
 template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<vespalib::BFloat16>>;
 template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<float>>;
 template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<double>>;
 template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<vespalib::BFloat16>>;
 
 template <typename FloatType>
 BoundDistanceFunction::UP
@@ -90,6 +88,5 @@ PrenormalizedAngularDistanceFunctionFactory<FloatType>::for_insertion_vector(Typ
 template class PrenormalizedAngularDistanceFunctionFactory<float>;
 template class PrenormalizedAngularDistanceFunctionFactory<double>;
 template class PrenormalizedAngularDistanceFunctionFactory<Int8Float>;
-template class PrenormalizedAngularDistanceFunctionFactory<vespalib::BFloat16>;
 
 }

--- a/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
@@ -57,7 +57,6 @@ TemporaryVectorStore<FloatType>::internal_convert(TypedCells cells, size_t offse
 }
 
 template class TemporaryVectorStore<vespalib::eval::Int8Float>;
-template class TemporaryVectorStore<vespalib::BFloat16>;
 template class TemporaryVectorStore<float>;
 template class TemporaryVectorStore<double>;
 


### PR DESCRIPTION
@arnej27959 please review. Merging should be held off until we have at least one perf run with the wiring+Highway both present.

Reverts vespa-engine/vespa#34786

Needs another spin in the tumble dryer. Working on speeding up the legacy BF16 dot product and squared Euclidean distance kernels.