### PR TITLE
Don't use sh to run bootstrap.sh.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -333,12 +333,12 @@ export FACTORY_VESPA_VERSION=%{version}
 export PATH="%{_prefix}-deps/bin:$PATH"
 
 %if 0%{?_use_mvn_wrapper}
-sh bootstrap.sh wrapper
+./bootstrap.sh wrapper
 %global _mvn_cmd $(pwd)/mvnw
 %else
 %global _mvn_cmd mvn
 %endif
-%{?_use_mvn_wrapper:env VESPA_MAVEN_COMMAND=%{_mvn_cmd} }sh bootstrap.sh java
+%{?_use_mvn_wrapper:env VESPA_MAVEN_COMMAND=%{_mvn_cmd} }./bootstrap.sh java
 %{_mvn_cmd} --batch-mode -nsu -T 1C install -DskipTests -Dmaven.javadoc.skip=true
 
 %{_command_cmake} -DCMAKE_INSTALL_PREFIX=%{_prefix} \


### PR DESCRIPTION
@esolitos : please review
@arnej27959 : FYI

When using sh, bootstrap.sh fails during rpmbuild due to the changes in PR #34793

```
+ export PATH=/opt/vespa-deps/bin:/usr/lib/jvm/java-17-openjdk/bin:/root/sdk/go1.24.2/bin/:/root/go/bin:/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ PATH=/opt/vespa-deps/bin:/usr/lib/jvm/java-17-openjdk/bin:/root/sdk/go1.24.2/bin/:/root/go/bin:/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ sh bootstrap.sh wrapper
error: Bad exit status from /var/tmp/rpm-tmp.miu8dC (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.miu8dC (%build)
[root@rpmbuild-a8-desk2 /]#
```