### PR TITLE
unroll BF16 loops to 16

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
@@ -101,7 +101,7 @@ VESPA_HWACCEL_TARGET_TYPE::dotProduct(const float * a, const float * b, size_t s
 float
 VESPA_HWACCEL_TARGET_TYPE::dotProduct(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept
 {
-    return multiplyAdd<float, BFloat16, 4>(a, b, sz);
+    return multiplyAdd<float, BFloat16, 16>(a, b, sz);
 }
 
 double
@@ -191,8 +191,8 @@ VESPA_HWACCEL_TARGET_TYPE::squaredEuclideanDistance(const double * a, const doub
 
 double
 VESPA_HWACCEL_TARGET_TYPE::squaredEuclideanDistance(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept {
-    // This is around 2x the perf of the naive loop in mixed_l2_distance.cpp
-    return squaredEuclideanDistanceT<float, BFloat16, 4>(a, b, sz);
+    // This is around 10x the perf of the naive loop in mixed_l2_distance.cpp
+    return squaredEuclideanDistanceT<float, BFloat16, 16>(a, b, sz);
 }
 
 void


### PR DESCRIPTION
microbenchmark shows this gives a large improvement both on x86_64 and aarch64.

@vekterli please review
