### PR TITLE
Re-apply "feat(build): detect AlmaLinux version and tag images accordingly"

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -2,6 +2,7 @@
 export TOP := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 export ARCH ?= $(shell if [[ $$(arch) == x86_64 ]]; then echo amd64; else echo arm64; fi)
+export ALMALINUX_MAJOR ?= $(shell grep -oP 'release \K[0-9]+' /etc/almalinux-release || echo 8)
 
 export LOG_DIR ?= $(shell pwd)
 export SOURCE_DIR ?= $(shell pwd)
@@ -23,7 +24,7 @@ export NUM_MVN_THREADS := $(shell echo $$(( $(NUM_CPU_LIMIT)*2/3 )))
 
 export BUILDKITE ?= false
 export BUILDKITE_PULL_REQUEST ?= true
-ifeq ($(BUILDKITE_PULL_REQUEST),false)        
+ifeq ($(BUILDKITE_PULL_REQUEST),false)
 	export VESPA_MAVEN_TARGET ?= deploy
 else
 	export VESPA_MAVEN_TARGET ?= install

--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -1,27 +1,50 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
-set -euo pipefail
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 
 if ! docker ps &> /dev/null; then
     echo "No working docker command found."
     exit 1
 fi
 
-if [[ ! -d $WORKDIR/docker-image ]]; then
+# Detect AlmaLinux major version from current OS
+if [[ -f /etc/almalinux-release ]]; then
+  AL_MAJOR_VERSION=$(grep -oP 'release \K[0-9]+' /etc/almalinux-release | head -1)
+else
+  echo "Warning: Cannot detect AlmaLinux version, defaulting to 8"
+  AL_MAJOR_VERSION=8
+fi
+echo "Detected running AlmaLinux: $AL_MAJOR_VERSION"
+VESPA_BASE_IMAGE="el${AL_MAJOR_VERSION}"
+
+if [[ ! -d "${WORKDIR}/docker-image" ]]; then
     git clone --depth 1 https://github.com/vespa-engine/docker-image "$WORKDIR/docker-image"
 fi
 
-rm -rf docker-image/rpms
-cp -a "$WORKDIR/artifacts/$ARCH/rpms" docker-image/
+rm -rf "${WORKDIR}/docker-image/rpms"
+cp -a "${WORKDIR}/artifacts/$ARCH/rpms" "${WORKDIR}/docker-image/"
 
-cd "$WORKDIR/docker-image"
+cd "${WORKDIR}/docker-image"
 SOURCE_GITREF=$(git rev-parse HEAD)
+
+# Set default tag to be pointing to Almalinux 8 version.
+# TODO: Update when we switch default OS
+GHCR_PREVIEW_TAG="ghcr.io/vespa-engine/vespa-preview-$ARCH:${VESPA_VERSION}"
+if [[ "$AL_MAJOR_VERSION" != "8" ]]; then
+    GHCR_PREVIEW_TAG+="-al${AL_MAJOR_VERSION}"
+fi
+
 docker build --progress plain \
              --build-arg SOURCE_GITREF="$SOURCE_GITREF" \
              --build-arg VESPA_VERSION="$VESPA_VERSION" \
+             --build-arg VESPA_BASE_IMAGE="$VESPA_BASE_IMAGE" \
              --tag vespaengine/vespa \
-             --tag "ghcr.io/vespa-engine/vespa-preview-$ARCH:$VESPA_VERSION" \
+             --tag "${GHCR_PREVIEW_TAG}" \
              --file Dockerfile .
 
 declare -r GITREF="${GITREF_SYSTEM_TEST:-HEAD}"
@@ -40,9 +63,18 @@ rm -rf maven-repo
 cp -a "$HOME/.m2/repository" maven-repo
 rm -rf rpms
 mv "$WORKDIR/docker-image/rpms" rpms
-docker build --progress=plain \
-             --build-arg VESPA_BASE_IMAGE="ghcr.io/vespa-engine/vespa-preview-$ARCH:$VESPA_VERSION" \
-             --target systemtest \
-             --tag "docker.io/vespaengine/vespa-systemtest-preview-$ARCH:$VESPA_VERSION" \
-             --file Dockerfile .
 
+# Set default systemtest image to use AlmaLinux 8 version
+# TODO: Update when we switch default OS
+GHCR_SYSTEMTEST_TAG="ghcr.io/vespa-engine/vespa-systemtest-preview-$ARCH:$VESPA_VERSION"
+if [[ "$AL_MAJOR_VERSION" != "8" ]]; then
+    GHCR_SYSTEMTEST_TAG+="-al${AL_MAJOR_VERSION}"
+fi
+
+SYSTEM_TEST_BASE_IMAGE="almalinux:${AL_MAJOR_VERSION}"
+docker build --progress=plain \
+             --build-arg BASE_IMAGE="$SYSTEM_TEST_BASE_IMAGE" \
+             --build-arg VESPA_BASE_IMAGE="${GHCR_PREVIEW_TAG}" \
+             --target systemtest \
+             --tag "$GHCR_SYSTEMTEST_TAG" \
+             --file Dockerfile .

--- a/.buildkite/utils/get-container-tag.sh
+++ b/.buildkite/utils/get-container-tag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#
+# Generates a container tag name based on the provided arguments.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -n "${DEBUG:-}" ]]; then
+    set -o xtrace
+fi
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <registry> <image_name> <vespa_version>"
+    exit 1
+fi
+
+os-suffix() {
+  # Set default tag to be pointing to Almalinux 8 version.
+  # TODO: Update when we switch default OS
+  if [[ $ALMALINUX_MAJOR != "8" ]]; then
+      echo "-al${ALMALINUX_MAJOR}"
+  fi
+}
+
+main() {
+  local registry="$1" ; shift
+  local image_name="$1" ; shift
+  local vespa_version="$1" ; shift
+
+  echo "${registry}/${image_name}:${vespa_version}$(os-suffix)"
+}
+
+main "$@"


### PR DESCRIPTION
## What

- Reverts vespa-engine/vespa#34797 aka re-applies vespa-engine/vespa#34785
- unify container tagging with get-container-tag.sh
- Introduce ALMALINUX_MAJOR in Makefile to decrease code duplication in all build scripts
- Adds the `-al${ALMALINUX_MAJOR}"` suffix to buildkite metadata.

## Why

- Fix regresson from #34785
- Support Almalinux 9 build in parallel to AL8

> [!IMPORTANT]
> Check related PR in Buildkite repo. 