### PR TITLE
Revert back to gofmt

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -149,7 +149,7 @@ test: setenv
 	mkdir -p $(GO_TMPDIR) && GOTMPDIR=$(GO_TMPDIR) go test ./...
 
 checkfmt:
-	@sh -c "test -z $$(gofumpt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }
+	@sh -c "test -z $$(gofmt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }
 
 fmt:
 	gofmt -w .


### PR DESCRIPTION
'make' now returns exit code 0 if gofumpt is not installed or cannot be found.
Would be nice to detect this and fail with some hint on how to install gofumpt.