### PR TITLE
Bump `vespa-build-dependencies` to 1.6.3

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -33,7 +33,7 @@
 %define _defattr_is_vespa_vespa 0
 %define _command_cmake cmake
 %global _vespa_abseil_cpp_version 20250127.1
-%global _vespa_build_depencencies_version 1.6.2
+%global _vespa_build_depencencies_version 1.6.3
 %global _vespa_gtest_version 1.16.0
 %global _vespa_protobuf_version 5.30.1
 %global _vespa_openblas_version 0.3.27


### PR DESCRIPTION
@arnej27959 please review. Holding off merge until commit refs are changed elsewhere.

This adds a build-time only dependency, so no changes to the runtime deps.

