### PR TITLE
Rewrite `hwaccelerated` benchmarks to use Google Benchmark

### DIFF
--- a/vespalib/src/tests/hwaccelerated/CMakeLists.txt
+++ b/vespalib/src/tests/hwaccelerated/CMakeLists.txt
@@ -16,3 +16,4 @@ vespa_add_executable(vespalib_hwaccelerated_bench_app
     vespalib
     vespa_hwaccelerated
 )
+vespa_add_target_external_dependency(vespalib_hwaccelerated_bench_app benchmark)

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -3,174 +3,128 @@
 #include "data_utils.h"
 #include <vespa/vespalib/hwaccelerated/iaccelerated.h>
 #include <vespa/vespalib/hwaccelerated/highway.h>
-#include <vespa/vespalib/util/time.h>
-#include <cinttypes>
+#include <benchmark/benchmark.h>
+#include <format>
+#include <type_traits>
 
 using namespace vespalib;
 using namespace vespalib::hwaccelerated;
 
+template <typename> constexpr bool type_dependent_false_v = false;
+
 template <typename T>
-void do_not_optimize_away(T&& t) noexcept {
-    asm volatile("" : : "m"(t) : "memory"); // Clobber the value to avoid losing it to compiler optimizations
+constexpr std::string_view type_string() noexcept {
+    if constexpr (std::is_same_v<T, int8_t>) {
+        return "int8";
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return "uint8";
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return "int16";
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return "int32";
+    } else if constexpr (std::is_same_v<T, BFloat16>) {
+        return "BFloat16";
+    } else if constexpr (std::is_same_v<T, float>) {
+        return "float";
+    } else if constexpr (std::is_same_v<T, double>) {
+        return "double";
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return "uint64";
+    } else {
+        static_assert(type_dependent_false_v<T>, "type not known for stringification");
+        return "";
+    }
 }
 
 template <typename T, typename Fn>
-void benchmark_fn(Fn f, size_t sz, size_t n_iters) {
-    auto [a, b] = create_and_fill_lhs_rhs<T>(sz);
-    steady_time start = steady_clock::now();
-    double sumOfSums(0);
-    for (size_t j(0); j < n_iters; j++) {
-        double sum = f(a.data(), b.data(), sz);
-        sumOfSums += sum;
-    }
-    duration elapsed = steady_clock::now() - start;
-    printf("sum=%f of N=%zu and vector length=%zu took %.2f ms\n", sumOfSums, n_iters, sz,
-           std::chrono::duration<double, std::milli>(elapsed).count());
+void register_accel_binary_arg_benchmark(std::string_view name, std::unique_ptr<IAccelerated> accel, Fn&& fn) {
+    std::string instance_name = std::format("{}/{}/{}/{}", name, type_string<T>(), accel->implementation_name(), accel->target_name());
+    auto bench_fn = [fn = std::forward<Fn>(fn), accel = std::move(accel)](benchmark::State& state) {
+        auto [a, b] = create_and_fill_lhs_rhs<T>(state.range());
+        for (auto _ : state) {
+            // A tiny bit dirty, but beats duplicating a bunch of code.
+            constexpr bool is_void_fn = std::is_same_v<void, decltype(fn(*accel, a.data(), b.data(), state.range()))>;
+            if constexpr (is_void_fn) {
+                // Note that this is expected to mutate `a`, so different iterations do not
+                // necessarily use the same input data. Should not be not an issue in practice(tm).
+                fn(*accel, a.data(), b.data(), state.range());
+                // _Technically_ the compiler could stare into the void and realize the above
+                // code has no side effects since the output is not used for anything. Avoid this
+                // by having the void stare back (clobber output memory with an opaque access).
+                auto* clobber_data = a.data(); // Non-const ptr; pretend we may read/write
+                benchmark::DoNotOptimize(clobber_data);
+                benchmark::ClobberMemory(); // Compiler write barrier
+            } else {
+                auto result = fn(*accel, a.data(), b.data(), state.range());
+                benchmark::DoNotOptimize(result);
+            }
+        }
+        state.SetBytesProcessed(sizeof(T) * state.range() * state.iterations() * 2); // *2 due to lhs+rhs
+    };
+    auto* bench = benchmark::RegisterBenchmark(instance_name, std::move(bench_fn));
+    bench->RangeMultiplier(2)->Range(8, 8<<10); // TODO also with non-aligned sizes
 }
 
 template <typename T, typename Fn>
-void benchmark_void_fn(Fn f, size_t sz, size_t n_iters) {
-    auto [a, b] = create_and_fill_lhs_rhs<T>(sz);
-    steady_time start = steady_clock::now();
-    for (size_t i = 0; i < n_iters; ++i) {
-        // Note that this is expected to mutate `a`, so different iterations do not
-        // necessarily use the same input data. Should not be not an issue in practice(tm).
-        f(a.data(), b.data(), sz);
+void register_benchmarks(std::string_view name, Fn fn) {
+    auto hwy_targets = Highway::create_supported_targets();
+    for (auto& t : hwy_targets) {
+        register_accel_binary_arg_benchmark<T>(name, std::move(t), fn);
     }
-    if (n_iters > 0) {
-        // _Technically_ the compiler could stare into the void and realize the above
-        // code has no side effects since the output is not used for anything. So just
-        // to be on the safe side, clobber the final output byte.
-        do_not_optimize_away(a[a.size() - 1]);
-    }
-    duration elapsed = steady_clock::now() - start;
-    printf("N=%zu and vector length=%zu took %.2f ms\n", n_iters, sz,
-           std::chrono::duration<double, std::milli>(elapsed).count());
+    auto baseline_accel = IAccelerated::create_baseline_auto_vectorized_target();
+    register_accel_binary_arg_benchmark<T>(name, std::move(baseline_accel), fn);
+
+    auto best_autovec_accel = IAccelerated::create_best_auto_vectorized_target();
+    register_accel_binary_arg_benchmark<T>(name, std::move(best_autovec_accel), fn);
 }
 
-void benchmark_squared_euclidean_distance(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
-    auto euclidean_dist_fn = [&accelerator](const auto* lhs, const auto* rhs, size_t my_sz) {
+void register_all_benchmark_suites() {
+    auto euclidean_dist_fn = [](const IAccelerated& accelerator, const auto* lhs, const auto* rhs, size_t my_sz) {
         return accelerator.squaredEuclideanDistance(lhs, rhs, my_sz);
     };
-    printf("double : ");
-    benchmark_fn<double>(euclidean_dist_fn, sz, n_iters);
-    printf("float  : ");
-    benchmark_fn<float>(euclidean_dist_fn, sz, n_iters);
-    printf("BF16   : ");
-    benchmark_fn<BFloat16>(euclidean_dist_fn, sz, n_iters);
-    printf("int8_t : ");
-    benchmark_fn<int8_t>(euclidean_dist_fn, sz, n_iters);
-}
+    register_benchmarks<double>("Squared Euclidean Distance", euclidean_dist_fn);
+    register_benchmarks<float>("Squared Euclidean Distance", euclidean_dist_fn);
+    register_benchmarks<BFloat16>("Squared Euclidean Distance", euclidean_dist_fn);
+    register_benchmarks<int8_t>("Squared Euclidean Distance", euclidean_dist_fn);
 
-void benchmark_dot_product(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
-    auto dot_product_fn = [&accelerator](const auto* lhs, const auto* rhs, size_t my_sz) {
+    auto dot_product_fn = [](const IAccelerated& accelerator, const auto* lhs, const auto* rhs, size_t my_sz) {
         return accelerator.dotProduct(lhs, rhs, my_sz);
     };
-    printf("double : ");
-    benchmark_fn<double>(dot_product_fn, sz, n_iters);
-    printf("float  : ");
-    benchmark_fn<float>(dot_product_fn, sz, n_iters);
-    printf("BF16   : ");
-    benchmark_fn<BFloat16>(dot_product_fn, sz, n_iters);
-    printf("int8_t : ");
-    benchmark_fn<int8_t>(dot_product_fn, sz, n_iters);
-}
+    register_benchmarks<double>("Dot Product", dot_product_fn);
+    register_benchmarks<float>("Dot Product", dot_product_fn);
+    register_benchmarks<BFloat16>("Dot Product", dot_product_fn);
+    register_benchmarks<int8_t>("Dot Product", dot_product_fn);
 
-void benchmark_popcount(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
-    auto popcount_fn = [&accelerator](const auto* lhs, const auto* rhs, size_t my_sz) {
-        (void)rhs; // ... a little bit sneaky
+    auto popcount_fn = [](const IAccelerated& accelerator, const auto* lhs, const auto* rhs, size_t my_sz) {
+        (void)rhs; // ... a little bit sneaky; overestimates bytes processed/sec by 2x
         return accelerator.populationCount(lhs, my_sz);
     };
-    printf("uint64_t : ");
-    benchmark_fn<uint64_t>(popcount_fn, sz, n_iters);
-}
+    register_benchmarks<uint64_t>("Popcount", popcount_fn);
 
-template <typename Fn>
-void benchmark_byte_transform_fn(Fn fn, const IAccelerated& accelerator, size_t sz, size_t n_iters) {
-    auto wrapped_fn = [&accelerator, fn](auto* lhs, const auto* rhs, size_t my_sz) {
-        fn(accelerator, lhs, rhs, my_sz);
-    };
-    printf("uint8_t : ");
-    benchmark_void_fn<uint8_t>(wrapped_fn, sz, n_iters);
-}
-
-void benchmark_bitwise_and(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
     auto and_fn = [](const IAccelerated& accel, auto* lhs, const auto* rhs, size_t my_sz) {
-        return accel.andBit(lhs, rhs, my_sz);
+        accel.andBit(lhs, rhs, my_sz);
     };
-    benchmark_byte_transform_fn(and_fn, accelerator, sz, n_iters);
-}
+    register_benchmarks<uint8_t>("Bitwise AND", and_fn);
 
-void benchmark_bitwise_or(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
     auto or_fn = [](const IAccelerated& accel, auto* lhs, const auto* rhs, size_t my_sz) {
         return accel.orBit(lhs, rhs, my_sz);
     };
-    benchmark_byte_transform_fn(or_fn, accelerator, sz, n_iters);
-}
+    register_benchmarks<uint8_t>("Bitwise OR", or_fn);
 
-void benchmark_bitwise_and_not(const IAccelerated& accelerator, size_t sz, size_t n_iters) {
     auto and_not_fn = [](const IAccelerated& accel, auto* lhs, const auto* rhs, size_t my_sz) {
         return accel.andNotBit(lhs, rhs, my_sz);
     };
-    benchmark_byte_transform_fn(and_not_fn, accelerator, sz, n_iters);
-}
-
-void for_each_hwy_target(auto&& fn) {
-    const auto hwy_targets = Highway::create_supported_targets();
-    for (const auto& t : hwy_targets) {
-        fn(*t);
-    }
-}
-
-template <typename Fn>
-void run_benchmark(Fn fn, const char* name, size_t sz, size_t n_iters) {
-    auto baseline_accel      = IAccelerated::create_platform_baseline_accelerator();
-    const auto& native_accel = IAccelerated::getAccelerator();
-
-    printf("\n");
-    for_each_hwy_target([&](const IAccelerated& hwy_accel) {
-        printf("%s - Highway (%s)\n", name, hwy_accel.target_name());
-        fn(hwy_accel, sz, n_iters);
-    });
-    printf("%s - Legacy baseline (%s)\n", name, baseline_accel->target_name());
-    fn(*baseline_accel, sz, n_iters);
-    printf("%s - Legacy optimized for this CPU (%s)\n", name, native_accel.target_name());
-    fn(native_accel, sz, n_iters);
-}
-
-void perform_initial_warmup(size_t sz, size_t n_iters) {
-    const auto& native_accel = IAccelerated::getAccelerator();
-    // Run a single warmup run to crank up the CPU power budget enough that any downclocking
-    // should be immediately visible. Use the widest ("most optimal") available vectors (e.g.
-    // AVX-512 on x64) for this, since it's the most susceptible to throttling.
-    // So the term "warmup" in this case is fairly literal.
-    printf("Squared Euclidean Distance - Warmup round (%s)\n", native_accel.target_name());
-    benchmark_squared_euclidean_distance(native_accel, sz, n_iters);
-    printf("--------\n");
+    register_benchmarks<uint8_t>("Bitwise ANDNOT", and_not_fn);
 }
 
 int main(int argc, char *argv[]) {
-    int length = 1000;
-    int n_iters = 1000000;
-    if (argc > 1) {
-        length = atol(argv[1]);
-    }
-    if (argc > 2) {
-        n_iters = atol(argv[2]);
-    }
+    benchmark::MaybeReenterWithoutASLR(argc, argv);
 
-    printf("%s %d %d\n", argv[0], length, n_iters);
-    perform_initial_warmup(length, n_iters);
+    register_all_benchmark_suites();
 
-    run_benchmark(benchmark_squared_euclidean_distance, "Squared Euclidean Distance", length, n_iters);
-    run_benchmark(benchmark_dot_product, "Dot Product", length, n_iters);
-    run_benchmark(benchmark_popcount, "Popcount", length, n_iters);
-    // For bitwise ops, implicitly increase the length since they are the cheapest
-    // possible ops and also operate on byte vectors.
-    size_t bitwise_length = length * 10;
-    run_benchmark(benchmark_bitwise_and, "Bitwise AND", bitwise_length, n_iters);
-    run_benchmark(benchmark_bitwise_or, "Bitwise OR", bitwise_length, n_iters);
-    run_benchmark(benchmark_bitwise_and_not, "Bitwise AND NOT", bitwise_length, n_iters);
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
 
     return 0;
 }

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
@@ -51,7 +51,7 @@ void verify_dot_product(std::span<const IAccelerated*> accels, size_t test_lengt
 }
 
 const IAccelerated* baseline_accelerator() {
-    static auto baseline = IAccelerated::create_platform_baseline_accelerator();
+    static auto baseline = IAccelerated::create_baseline_auto_vectorized_target();
     return baseline.get();
 }
 

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -294,6 +294,9 @@ public:
     double squaredEuclideanDistance(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept override {
         return my_hwy_square_euclidean_distance_bf16(a, b, sz);
     }
+    const char* implementation_name() const noexcept override {
+        return "Highway";
+    }
     const char* target_name() const noexcept override {
         return my_hwy_target_name();
     }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
@@ -269,35 +269,9 @@ EnabledTargetLevel EnabledTargetLevel::create_from_env_var() {
     return EnabledTargetLevel(enabled_level);
 }
 
-IAccelerated::UP create_accelerator() {
+[[nodiscard]] EnabledTargetLevel enabled_target_level() {
     static auto target_level = EnabledTargetLevel::create_from_env_var();
-    if (target_level.is_enabled(target::HIGHWAY)) {
-        auto hwy_target = Highway::create_best_target();
-        LOG(debug, "Using Highway vectorization engine with target %s", hwy_target->target_name());
-        return hwy_target;
-    }
-#ifdef __x86_64__
-    if (target_level.is_enabled(target::AVX3_DL)) {
-        return std::make_unique<Avx3DlAccelerator>();
-    }
-    if (target_level.is_enabled(target::AVX3)) {
-        return std::make_unique<Avx3Accelerator>();
-    }
-    if (target_level.is_enabled(target::AVX2)) {
-        return std::make_unique<Avx2Accelerator>();
-    }
-#else // aarch64
-    if (target_level.is_enabled(target::SVE2)) {
-        return std::make_unique<Sve2Accelerator>();
-    }
-    if (target_level.is_enabled(target::SVE)) {
-        return std::make_unique<SveAccelerator>();
-    }
-    if (target_level.is_enabled(target::NEON_FP16_DOTPROD)) {
-        return std::make_unique<NeonFp16DotprodAccelerator>();
-    }
-#endif
-    return IAccelerated::create_platform_baseline_accelerator();
+    return target_level;
 }
 
 template<typename T>
@@ -503,14 +477,23 @@ private:
 
 RuntimeVerificator::RuntimeVerificator()
 {
-    verify(*IAccelerated::create_platform_baseline_accelerator());
-    verify(*create_accelerator());
+    verify(*IAccelerated::create_baseline_auto_vectorized_target());
+    verify(*IAccelerated::create_best_accelerator_impl_and_target());
+}
+
+// Simple wrapper to debug log created impl+target once during process startup.
+IAccelerated::UP create_and_log_best_accelerator() {
+    auto accel = IAccelerated::create_best_accelerator_impl_and_target();
+    LOG(debug, "Created accelerator of type %s for runtime target %s",
+        accel->implementation_name(), accel->target_name());
+    return accel;
 }
 
 } // anon ns
 
-IAccelerated::UP IAccelerated::create_platform_baseline_accelerator() {
-    // Important: must never recurse into create_accelerator(), as it defers to this function as a fallback.
+IAccelerated::UP IAccelerated::create_baseline_auto_vectorized_target() {
+    // Important: must never recurse into create_best_auto_vectorized_target(),
+    // as it defers to this function as a fallback.
 #ifdef __x86_64__
     return std::make_unique<X64GenericAccelerator>();
 #else
@@ -518,11 +501,46 @@ IAccelerated::UP IAccelerated::create_platform_baseline_accelerator() {
 #endif
 }
 
+IAccelerated::UP IAccelerated::create_best_auto_vectorized_target() {
+    const auto target_level = enabled_target_level();
+#ifdef __x86_64__
+    if (target_level.is_enabled(target::AVX3_DL)) {
+        return std::make_unique<Avx3DlAccelerator>();
+    }
+    if (target_level.is_enabled(target::AVX3)) {
+        return std::make_unique<Avx3Accelerator>();
+    }
+    if (target_level.is_enabled(target::AVX2)) {
+        return std::make_unique<Avx2Accelerator>();
+    }
+#else // aarch64
+    if (target_level.is_enabled(target::SVE2)) {
+        return std::make_unique<Sve2Accelerator>();
+    }
+    if (target_level.is_enabled(target::SVE)) {
+        return std::make_unique<SveAccelerator>();
+    }
+    if (target_level.is_enabled(target::NEON_FP16_DOTPROD)) {
+        return std::make_unique<NeonFp16DotprodAccelerator>();
+    }
+#endif
+    return create_baseline_auto_vectorized_target();
+}
+
+std::unique_ptr<IAccelerated> IAccelerated::create_best_accelerator_impl_and_target() {
+    const auto target_level = enabled_target_level();
+    if (target_level.is_enabled(target::HIGHWAY)) {
+        return Highway::create_best_target();
+    }
+    return create_best_auto_vectorized_target();
+}
+
+
 const IAccelerated &
 IAccelerated::getAccelerator()
 {
     static RuntimeVerificator verifyAccelerator_once;
-    static IAccelerated::UP accelerator = create_accelerator();
+    static auto accelerator = create_and_log_best_accelerator();
     return *accelerator;
 }
 

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -40,10 +40,13 @@ public:
     // OR 128 bytes from multiple, optionally inverted sources
     virtual void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept = 0;
 
-    // Returns a static string representing the name of the underlying accelerator implementation
+    [[nodiscard]] virtual const char* implementation_name() const noexcept { return "AutoVectorized"; }
+    // Returns a static string representing the name of the underlying accelerator target (e.g. "AVX3", "NEON" etc.)
     [[nodiscard]] virtual const char* target_name() const noexcept { return "Unknown"; }
 
-    static IAccelerated::UP create_platform_baseline_accelerator();
+    static std::unique_ptr<IAccelerated> create_baseline_auto_vectorized_target();
+    static std::unique_ptr<IAccelerated> create_best_auto_vectorized_target();
+    static std::unique_ptr<IAccelerated> create_best_accelerator_impl_and_target();
 
     static const IAccelerated& getAccelerator() __attribute__((noinline));
 };


### PR DESCRIPTION
@havardpe please review

This improves the resolution and accuracy of runtime sampling and makes it trivial to run each benchmarked function on a range of input vector lengths (this had to be done manually prior).

The benchmark suite is dynamically generated based on the set of targets that are available at compile+runtime. Standard Google Benchmark command line args/env vars can be used to select a subset of tests to run, or to export test results as JSON etc.

Also add a method to `IAccelerated` that reports the name of the underlying vectorization _implementation_, as the _target_ name alone may be ambiguous across distinct implementations built for the same target (e.g. "NEON", "AVX3" etc.).

