### PR TITLE
Expose same element field. This information is used by OrBlueprint

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -14,8 +14,7 @@ namespace search::queryeval {
 SameElementBlueprint::SameElementBlueprint(const FieldSpec &field, fef::MatchDataLayout subtree_mdl, bool expensive)
     : IntermediateBlueprint(),
       _layout(std::move(subtree_mdl)),
-      _field_name(field.getName()),
-      _handle(field.getHandle()),
+      _field(field),
       _expensive(expensive)
 {
 }
@@ -55,7 +54,7 @@ SameElementBlueprint::calculate_cost_tier() const
 std::unique_ptr<SearchIterator>
 SameElementBlueprint::createSearchImpl(fef::MatchData& md) const
 {
-    auto* tfmd = md.resolveTermField(_handle);
+    auto* tfmd = md.resolveTermField(_field.getHandle());
     assert(tfmd != nullptr);
     return create_same_element_search(*tfmd);
 }
@@ -68,7 +67,9 @@ SameElementBlueprint::combine(const std::vector<HitEstimate>& data) const
 
 FieldSpecBaseList SameElementBlueprint::exposeFields() const
 {
-    return {};
+    FieldSpecBaseList fields;
+    fields.add(_field);
+    return fields;
 }
 
 void SameElementBlueprint::sort(Children& children, InFlow in_flow) const

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -15,8 +15,7 @@ class SameElementBlueprint : public IntermediateBlueprint
 {
 private:
     fef::MatchDataLayout  _layout;
-    std::string           _field_name;
-    fef::TermFieldHandle  _handle;
+    FieldSpec             _field;
     bool                  _expensive;
 
     AnyFlow my_flow(InFlow in_flow) const override;
@@ -43,7 +42,7 @@ public:
 
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
-    const std::string &field_name() const { return _field_name; }
+    const std::string &field_name() const { return _field.getName(); }
 };
 
 }


### PR DESCRIPTION
to determine if unpack is needed for children.

This fixes the regression introduced in PR #34817 (MatchesFeature::test_matches__INDEXED system tests).
With this PR applied, the revert of PR #34817 in PR #34819 is not needed.

@havardpe : please review
