### PR TITLE
Add async signal safe backtracing using `unwind.h` where available

### DIFF
--- a/vespalib/src/vespa/vespalib/util/backtrace.h
+++ b/vespalib/src/vespa/vespalib/util/backtrace.h
@@ -36,6 +36,21 @@ std::string getStackTrace(int ignoreTop, void* const* stack, int size);
  */
 int getStackTraceFrames(void** framesOut, int maxFrames);
 
+/**
+ * Returns true iff `signal_safe_collect_stack_frames()` is supported on
+ * this platform.
+ */
+[[nodiscard]] bool has_signal_safe_collect_stack_frames() noexcept;
+
+/**
+ * Collects up to and including `frames_max` stack frames into `frames_out` in
+ * an async signal safe way. The number of collected frames is returned.
+ *
+ * If `has_signal_safe_collect_stack_frames() == false`, the  function will
+ * return 0 and `frames_out` is not modified.
+ */
+[[nodiscard]] size_t signal_safe_collect_stack_frames(void** frames_out, size_t frames_max);
+
 
 }
 

--- a/vespalib/src/vespa/vespalib/util/signalhandler.cpp
+++ b/vespalib/src/vespa/vespalib/util/signalhandler.cpp
@@ -2,11 +2,6 @@
 
 #include "signalhandler.h"
 #include "backtrace.h"
-#ifdef __APPLE__
-#define BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED
-#endif
-#include <boost/stacktrace/safe_dump_to.hpp> // Header-only dependency
-#include <boost/stacktrace/frame.hpp>
 #include <array>
 #include <atomic>
 #include <cassert>
@@ -94,9 +89,7 @@ SignalHandler::dump_current_thread_stack_to_shared_state() noexcept
         return; // Someone else is already inside the house...!
     }
     auto& frames_buf = _shared_backtrace_data._stack_frames;
-    static_assert(std::is_same_v<const void*, boost::stacktrace::frame::native_frame_ptr_t>);
-    // Note: safe_dump_to() takes in buffer size in _bytes_, not in number of frames.
-    const auto n_frames = boost::stacktrace::safe_dump_to(frames_buf.data(), frames_buf.size() * sizeof(void*));
+    const size_t n_frames = signal_safe_collect_stack_frames(frames_buf.data(), frames_buf.size());
     _shared_backtrace_data._n_dumped_frames = static_cast<uint32_t>(n_frames);
     _shared_backtrace_data._signal_handler_done.store(true);
 }
@@ -211,8 +204,8 @@ SignalHandler::get_cross_thread_stack_trace(pthread_t thread_id)
         expected_done = true;
     }
     constexpr int frames_to_skip = 4; // handleSignal() -> gotSignal() -> dump_current_thread_...() -> backtrace()
-    return vespalib::getStackTrace(frames_to_skip, _shared_backtrace_data._stack_frames.data(),
-                                   static_cast<int>(_shared_backtrace_data._n_dumped_frames));
+    return getStackTrace(frames_to_skip, _shared_backtrace_data._stack_frames.data(),
+                         static_cast<int>(_shared_backtrace_data._n_dumped_frames));
 }
 
 void


### PR DESCRIPTION
@arnej27959 please review. Signal handler backtrace tests pass on both arm64 and x64. `boost::stacktrace::safe_dump_to` ends up using `_Backtrace_Unwind` when possible, so this should be no less signal safe than what we already have. This implementation is also inspired by the one found in Boost, but simplified.

By using `_Unwind_Backtrace` with a custom callback, we can get stack traces that can punch through a signal handler boundary. The low-level unwinding in Abseil does not seem to do this reliably (at least not on x64), so we can't simply use that.

If there is no `<unwind.h>` fall back to returning zero frames, since we don't have a known async signal safe implementation.

Use this new stack trace method for the cross-thread stack trace dumping functionality.

The changes in #34646 should no longer be needed after this.
