### PR TITLE
Report content node initialization progress into slime

### DIFF
--- a/searchcore/src/tests/proton/server/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_executable(searchcore_proton_server_gtest_test_app TEST
     SOURCES
     gtest_runner.cpp
     ddbstate_test.cpp
+    document_db_initialization_status_test.cpp
     documentretriever_test.cpp
     feeddebugger_test.cpp
     feedstates_test.cpp

--- a/searchcore/src/tests/proton/server/document_db_initialization_status_test.cpp
+++ b/searchcore/src/tests/proton/server/document_db_initialization_status_test.cpp
@@ -1,0 +1,213 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchcommon/attribute/attribute_initialization_status.h>
+#include <vespa/searchcore/proton/server/ddbstate.h>
+#include <vespa/searchcore/proton/server/document_db_initialization_status.h>
+#include <vespa/searchcore/proton/server/i_replay_progress_producer.h>
+#include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+#include <memory>
+
+using proton::DDBState;
+using proton::DocumentDBInitializationStatus;
+
+class DummyReplayProgressProducer : public proton::IReplayProgressProducer {
+    float getReplayProgress() const override {
+        return 0.23f;
+    }
+};
+
+class DocumentDBInitializationStatusTest : public ::testing::Test {
+protected:
+    DummyReplayProgressProducer _producer;
+    DDBState _state;
+    DocumentDBInitializationStatus _status;
+
+    std::shared_ptr<AttributeInitializationStatus> _queued_attribute1;
+    std::shared_ptr<AttributeInitializationStatus> _queued_attribute2;
+    std::shared_ptr<AttributeInitializationStatus> _loading_attribute;
+    std::shared_ptr<AttributeInitializationStatus> _loaded_attribute;
+    std::shared_ptr<AttributeInitializationStatus> _reprocessing_attribute;
+    std::shared_ptr<AttributeInitializationStatus> _reprocessed_attribute;
+    std::shared_ptr<AttributeInitializationStatus> _reprocessed_loaded_attribute;
+
+    DocumentDBInitializationStatusTest()
+        : _status("test_database", _state, _producer) {
+        _queued_attribute1 = std::make_shared<AttributeInitializationStatus>("queued_attribute1");
+        _queued_attribute2 = std::make_shared<AttributeInitializationStatus>("queued_attribute2");
+
+        _loading_attribute = std::make_shared<AttributeInitializationStatus>("loading_attribute");
+        _loading_attribute->start_loading();
+
+        _loaded_attribute = std::make_shared<AttributeInitializationStatus>("loaded_attribute");
+        _loaded_attribute->start_loading();
+        _loaded_attribute->end_loading();
+
+        _reprocessing_attribute = std::make_shared<AttributeInitializationStatus>("reprocessing_attribute");
+        _reprocessing_attribute->start_loading();
+        _reprocessing_attribute->start_reprocessing();
+        _reprocessing_attribute->set_reprocessing_percentage(0.42f);
+
+        _reprocessed_attribute = std::make_shared<AttributeInitializationStatus>("reprocessed_attribute");
+        _reprocessed_attribute->start_loading();
+        _reprocessed_attribute->start_reprocessing();
+        _reprocessed_attribute->set_reprocessing_percentage(0.42f);
+        _reprocessed_attribute->end_reprocessing();
+
+        _reprocessed_loaded_attribute = std::make_shared<AttributeInitializationStatus>("reprocessed_loaded_attribute");
+        _reprocessed_loaded_attribute->start_loading();
+        _reprocessed_loaded_attribute->start_reprocessing();
+        _reprocessed_loaded_attribute->set_reprocessing_percentage(0.42f);
+        _reprocessed_loaded_attribute->end_reprocessing();
+        _reprocessed_loaded_attribute->end_loading();
+    }
+    ~DocumentDBInitializationStatusTest() override __attribute__((noinline)) = default; // Avoid warning about inline-unit-growth limit
+
+    void expect_children_and_state(size_t children, const std::string& state) const {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get().children(), children);
+        EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
+        EXPECT_EQ(slime.get()["state"].asString().make_string(), state);
+    }
+};
+
+TEST_F(DocumentDBInitializationStatusTest, test_reporting_initializing) {
+    _state.enterLoadState();
+
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+    _status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 4);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("load"));
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              DocumentDBInitializationStatus::timepoint_to_string(_state.get_load_time()));
+
+    vespalib::slime::Inspector& ready_subdb = slime.get()["ready_subdb"];
+    EXPECT_EQ(ready_subdb.children(), 3);
+
+    vespalib::slime::Inspector& _loaded_attributes = ready_subdb["loaded_attributes"];
+    EXPECT_TRUE(_loaded_attributes.valid());
+    EXPECT_EQ(_loaded_attributes.entries(), 0);
+
+    vespalib::slime::Inspector& _loading_attributes = ready_subdb["loading_attributes"];
+    EXPECT_TRUE(_loading_attributes.valid());
+    EXPECT_EQ(_loading_attributes.entries(), 0);
+
+    vespalib::slime::Inspector& _queued_attributes = ready_subdb["queued_attributes"];
+    EXPECT_TRUE(_queued_attributes.valid());
+    EXPECT_EQ(_queued_attributes.entries(), 0);
+}
+
+TEST_F(DocumentDBInitializationStatusTest, test_reporting_initializing_with_attributes) {
+    std::vector<std::shared_ptr<AttributeInitializationStatus> > attributes;
+    attributes.push_back(_queued_attribute1);
+    attributes.push_back(_queued_attribute2);
+    attributes.push_back(_loading_attribute);
+    attributes.push_back(_loaded_attribute);
+    attributes.push_back(_reprocessing_attribute);
+    attributes.push_back(_reprocessed_attribute);
+    attributes.push_back(_reprocessed_loaded_attribute);
+    _status.set_attribute_initialization_statuses(std::move(attributes));
+
+    _state.enterLoadState();
+
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+    _status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 4);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("load"));
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              DocumentDBInitializationStatus::timepoint_to_string(_state.get_load_time()));
+
+    vespalib::slime::Inspector& ready_subdb = slime.get()["ready_subdb"];
+    EXPECT_EQ(ready_subdb.children(), 3);
+
+    vespalib::slime::Inspector& _loaded_attributes = ready_subdb["loaded_attributes"];
+    EXPECT_TRUE(_loaded_attributes.valid());
+    EXPECT_EQ(_loaded_attributes.entries(), 2);
+    EXPECT_EQ(_loaded_attributes[0]["name"].asString().make_string(), "loaded_attribute");
+    EXPECT_EQ(_loaded_attributes[1]["name"].asString().make_string(), "reprocessed_loaded_attribute");
+
+    vespalib::slime::Inspector& _loading_attributes = ready_subdb["loading_attributes"];
+    EXPECT_TRUE(_loading_attributes.valid());
+    EXPECT_EQ(_loading_attributes.entries(), 3);
+    EXPECT_EQ(_loading_attributes[0]["name"].asString().make_string(), "loading_attribute");
+    EXPECT_EQ(_loading_attributes[1]["name"].asString().make_string(), "reprocessing_attribute");
+    EXPECT_EQ(_loading_attributes[2]["name"].asString().make_string(), "reprocessed_attribute");
+
+    vespalib::slime::Inspector& _queued_attributes = ready_subdb["queued_attributes"];
+    EXPECT_TRUE(_queued_attributes.valid());
+    EXPECT_EQ(_queued_attributes.entries(), 2);
+    EXPECT_EQ(_queued_attributes[0]["name"].asString().make_string(), "queued_attribute1");
+    EXPECT_EQ(_queued_attributes[1]["name"].asString().make_string(), "queued_attribute2");
+}
+
+TEST_F(DocumentDBInitializationStatusTest, test_reporting_online_with_attributes) {
+    std::vector<std::shared_ptr<AttributeInitializationStatus> > attributes;
+    attributes.push_back(_loaded_attribute);
+    attributes.push_back(_reprocessed_loaded_attribute);
+    _status.set_attribute_initialization_statuses(std::move(attributes));
+
+    _state.enterLoadState();
+    _state.enterReplayTransactionLogState();
+    _state.enterApplyLiveConfigState();
+    _state.enterReprocessState();
+    _state.enterOnlineState();
+
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+    _status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 7);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("online"));
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              DocumentDBInitializationStatus::timepoint_to_string(_state.get_load_time()));
+    EXPECT_EQ(slime.get()["loading_finished"].asString().make_string(),
+              DocumentDBInitializationStatus::timepoint_to_string(_state.get_load_time()));
+    EXPECT_EQ(slime.get()["replay_started"].asString().make_string(),
+              DocumentDBInitializationStatus::timepoint_to_string(_state.get_replay_time()));
+    EXPECT_EQ(slime.get()["replay_progress"].asString().make_string(), "0.230000");
+
+    vespalib::slime::Inspector& ready_subdb = slime.get()["ready_subdb"];
+    EXPECT_EQ(ready_subdb.children(), 3);
+
+    vespalib::slime::Inspector& _loaded_attributes = ready_subdb["loaded_attributes"];
+    EXPECT_TRUE(_loaded_attributes.valid());
+    EXPECT_EQ(_loaded_attributes.entries(), 2);
+    EXPECT_EQ(_loaded_attributes[0]["name"].asString().make_string(), "loaded_attribute");
+    EXPECT_EQ(_loaded_attributes[1]["name"].asString().make_string(), "reprocessed_loaded_attribute");
+
+    vespalib::slime::Inspector& _loading_attributes = ready_subdb["loading_attributes"];
+    EXPECT_TRUE(_loading_attributes.valid());
+    EXPECT_EQ(_loading_attributes.entries(), 0);
+
+    vespalib::slime::Inspector& _queued_attributes = ready_subdb["queued_attributes"];
+    EXPECT_TRUE(_queued_attributes.valid());
+    EXPECT_EQ(_queued_attributes.entries(), 0);
+}
+
+TEST_F(DocumentDBInitializationStatusTest, test_reporting_states_before_online) {
+    _state.enterLoadState();
+    expect_children_and_state(4, "load");
+
+    _state.enterReplayTransactionLogState();
+    expect_children_and_state(6, "replay_transaction_log");
+
+    _state.enterApplyLiveConfigState();
+    expect_children_and_state(6, "apply_live_config");
+
+    _state.enterReprocessState();
+    expect_children_and_state(6, "reprocess");
+
+    _state.enterOnlineState();
+    expect_children_and_state(7, "online");
+}

--- a/searchcore/src/tests/proton/server/document_db_initialization_status_test.cpp
+++ b/searchcore/src/tests/proton/server/document_db_initialization_status_test.cpp
@@ -89,7 +89,7 @@ TEST_F(DocumentDBInitializationStatusTest, test_reporting_initializing) {
     EXPECT_EQ(slime.get().children(), 4);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
     EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("load"));
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               DocumentDBInitializationStatus::timepoint_to_string(_state->get_load_time()));
 
     vespalib::slime::Inspector& ready_subdb = slime.get()["ready_subdb"];
@@ -129,7 +129,7 @@ TEST_F(DocumentDBInitializationStatusTest, test_reporting_initializing_with_attr
     EXPECT_EQ(slime.get().children(), 4);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
     EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("load"));
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               DocumentDBInitializationStatus::timepoint_to_string(_state->get_load_time()));
 
     vespalib::slime::Inspector& ready_subdb = slime.get()["ready_subdb"];
@@ -175,11 +175,11 @@ TEST_F(DocumentDBInitializationStatusTest, test_reporting_online_with_attributes
     EXPECT_EQ(slime.get().children(), 7);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("test_database"));
     EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("online"));
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               DocumentDBInitializationStatus::timepoint_to_string(_state->get_load_time()));
-    EXPECT_EQ(slime.get()["loading_finished"].asString().make_string(),
+    EXPECT_EQ(slime.get()["end_time"].asString().make_string(),
               DocumentDBInitializationStatus::timepoint_to_string(_state->get_online_time()));
-    EXPECT_EQ(slime.get()["replay_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["replay_start_time"].asString().make_string(),
               DocumentDBInitializationStatus::timepoint_to_string(_state->get_replay_time()));
     EXPECT_EQ(slime.get()["replay_progress"].asString().make_string(), "0.230000");
 

--- a/searchcore/src/tests/proton/server/initialization_status/initialization_status_test.cpp
+++ b/searchcore/src/tests/proton/server/initialization_status/initialization_status_test.cpp
@@ -97,7 +97,7 @@ TEST_F(ProtonInitializationStatusTest, test_reporting_initializing_no_dbs) {
     EXPECT_EQ(slime.get().children(), 7);
     EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("initializing"));
     EXPECT_TRUE(slime.get()["current_time"].valid());
-    EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
     EXPECT_EQ(slime.get()["load"].asLong(), 0);
     EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
@@ -119,9 +119,9 @@ TEST_F(ProtonInitializationStatusTest, test_reporting_ready_no_dbs) {
     EXPECT_EQ(slime.get().children(), 8);
     EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("ready"));
     EXPECT_TRUE(slime.get()["current_time"].valid());
-    EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
-    EXPECT_EQ(slime.get()["initialization_finished"].asString().make_string(),
+    EXPECT_EQ(slime.get()["end_time"].asString().make_string(),
               ProtonInitializationStatus::timepoint_to_string(_status.get_end_time()));
     EXPECT_EQ(slime.get()["load"].asLong(), 0);
     EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
@@ -148,7 +148,7 @@ TEST_F(ProtonInitializationStatusTest, test_reporting_with_dbs) {
         EXPECT_EQ(slime.get().children(), 7);
         EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("initializing"));
         EXPECT_TRUE(slime.get()["current_time"].valid());
-        EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+        EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
                   ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
         EXPECT_EQ(slime.get()["load"].asLong(), 2);
         EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
@@ -181,9 +181,9 @@ TEST_F(ProtonInitializationStatusTest, test_reporting_with_dbs) {
         EXPECT_EQ(slime.get().children(), 8);
         EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("ready"));
         EXPECT_TRUE(slime.get()["current_time"].valid());
-        EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+        EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
                   ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
-        EXPECT_EQ(slime.get()["initialization_finished"].asString().make_string(),
+        EXPECT_EQ(slime.get()["end_time"].asString().make_string(),
                   ProtonInitializationStatus::timepoint_to_string(_status.get_end_time()));
         EXPECT_EQ(slime.get()["load"].asLong(), 0);
         EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);

--- a/searchcore/src/tests/proton/server/initialization_status/initialization_status_test.cpp
+++ b/searchcore/src/tests/proton/server/initialization_status/initialization_status_test.cpp
@@ -1,40 +1,352 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchcore/proton/server/ddbstate.h>
+#include <vespa/searchcore/proton/server/document_db_initialization_status.h>
+#include <vespa/searchcore/proton/server/i_replay_progress_producer.h>
 #include <vespa/searchcore/proton/server/proton_initialization_status.h>
+#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
+using proton::DDBState;
+using proton::DocumentDBInitializationStatus;
+using proton::IReplayProgressProducer;
 using proton::ProtonInitializationStatus;
 
-TEST(AttributeInitializationStatusTest, test_state_to_string)
+class DummyReplayProgressProducer : public proton::IReplayProgressProducer {
+    float getReplayProgress() const override {
+        return 0.23f;
+    }
+};
+
+class ProtonInitializationStatusTest : public ::testing::Test {
+protected:
+    DummyReplayProgressProducer _producer;
+    DDBState _db_state1;
+    DDBState _db_state2;
+    DDBState _db_state3;
+
+    std::shared_ptr<DocumentDBInitializationStatus> _db_status1;
+    std::shared_ptr<DocumentDBInitializationStatus> _db_status2;
+    std::shared_ptr<DocumentDBInitializationStatus> _db_status3;
+
+    ProtonInitializationStatus _status;
+
+    ProtonInitializationStatusTest() {
+        _db_status1 = std::make_shared<DocumentDBInitializationStatus>("db1", _db_state1, _producer);
+        _db_status2 = std::make_shared<DocumentDBInitializationStatus>("db2", _db_state2, _producer);
+        _db_status3 = std::make_shared<DocumentDBInitializationStatus>("db3", _db_state3, _producer);
+
+    }
+    ~ProtonInitializationStatusTest() override __attribute__((noinline)) = default; // Avoid warning about inline-unit-growth limit
+
+    void expect_db_counts(size_t load, size_t replay, size_t online) const {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get()["load"].asLong(), load);
+        EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), replay);
+        EXPECT_EQ(slime.get()["online"].asLong(), online);
+    }
+};
+
+TEST_F(ProtonInitializationStatusTest, test_state_to_string)
 {
     EXPECT_EQ("initializing", ProtonInitializationStatus::state_to_string(ProtonInitializationStatus::INITIALIZING));
     EXPECT_EQ("ready", ProtonInitializationStatus::state_to_string(ProtonInitializationStatus::READY));
 }
 
-TEST(AttributeInitializationStatusTest, test_states)
+TEST_F(ProtonInitializationStatusTest, test_states)
 {
-    ProtonInitializationStatus status;
-    status.start_initialization();
-    EXPECT_EQ(ProtonInitializationStatus::State::INITIALIZING, status.get_state());
-    status.end_initialization();
-    EXPECT_EQ(ProtonInitializationStatus::State::READY, status.get_state());
+    _status.start_initialization();
+    EXPECT_EQ(ProtonInitializationStatus::State::INITIALIZING, _status.get_state());
+    _status.end_initialization();
+    EXPECT_EQ(ProtonInitializationStatus::State::READY, _status.get_state());
 }
 
-TEST(ProtonInitializationStatusTest, test_timestamps)
+TEST_F(ProtonInitializationStatusTest, test_timestamps)
 {
     ProtonInitializationStatus::time_point zero;
 
-    ProtonInitializationStatus status;
-    status.start_initialization();
-    ProtonInitializationStatus::time_point start_time = status.get_start_time();
+    _status.start_initialization();
+    ProtonInitializationStatus::time_point start_time = _status.get_start_time();
     EXPECT_GT(start_time, zero);
 
-    status.end_initialization();
-    ProtonInitializationStatus::time_point end_time = status.get_end_time();
+    _status.end_initialization();
+    ProtonInitializationStatus::time_point end_time = _status.get_end_time();
     EXPECT_GE(end_time, start_time);
 
-    EXPECT_EQ(start_time, status.get_start_time());
-    EXPECT_EQ(end_time, status.get_end_time());
+    EXPECT_EQ(start_time, _status.get_start_time());
+    EXPECT_EQ(end_time, _status.get_end_time());
+}
+
+TEST_F(ProtonInitializationStatusTest, test_reporting_initializing_no_dbs) {
+    _status.start_initialization();
+
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+    _status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 7);
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("initializing"));
+    EXPECT_TRUE(slime.get()["current_time"].valid());
+    EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+              ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
+    EXPECT_EQ(slime.get()["load"].asLong(), 0);
+    EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+    EXPECT_EQ(slime.get()["online"].asLong(), 0);
+
+    vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+    EXPECT_TRUE(dbs.valid());
+    EXPECT_EQ(dbs.entries(), 0);
+}
+
+TEST_F(ProtonInitializationStatusTest, test_reporting_ready_no_dbs) {
+    _status.start_initialization();
+    _status.end_initialization();
+
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+    _status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 8);
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("ready"));
+    EXPECT_TRUE(slime.get()["current_time"].valid());
+    EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+              ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
+    EXPECT_EQ(slime.get()["initialization_finished"].asString().make_string(),
+              ProtonInitializationStatus::timepoint_to_string(_status.get_end_time()));
+    EXPECT_EQ(slime.get()["load"].asLong(), 0);
+    EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+    EXPECT_EQ(slime.get()["online"].asLong(), 0);
+
+    vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+    EXPECT_TRUE(dbs.valid());
+    EXPECT_EQ(dbs.entries(), 0);
+};
+
+TEST_F(ProtonInitializationStatusTest, test_reporting_with_dbs) {
+    _status.start_initialization();
+
+    _status.addDocumentDBInitializationStatus(_db_status1);
+    _status.addDocumentDBInitializationStatus(_db_status2);
+    _db_state1.enterLoadState();
+    _db_state2.enterLoadState();
+
+    {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get().children(), 7);
+        EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("initializing"));
+        EXPECT_TRUE(slime.get()["current_time"].valid());
+        EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+                  ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
+        EXPECT_EQ(slime.get()["load"].asLong(), 2);
+        EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+        EXPECT_EQ(slime.get()["online"].asLong(), 0);
+
+        vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+        EXPECT_TRUE(dbs.valid());
+        EXPECT_EQ(dbs.entries(), 2);
+        EXPECT_EQ(dbs[0]["name"].asString().make_string(), std::string("db1"));
+        EXPECT_EQ(dbs[1]["name"].asString().make_string(), std::string("db2"));
+    }
+
+    _db_state1.enterReplayTransactionLogState();
+    _db_state1.enterApplyLiveConfigState();
+    _db_state1.enterReprocessState();
+    _db_state1.enterOnlineState();
+
+    _db_state2.enterReplayTransactionLogState();
+    _db_state2.enterApplyLiveConfigState();
+    _db_state2.enterReprocessState();
+    _db_state2.enterOnlineState();
+
+    _status.end_initialization();
+
+    {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get().children(), 8);
+        EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("ready"));
+        EXPECT_TRUE(slime.get()["current_time"].valid());
+        EXPECT_EQ(slime.get()["initialization_started"].asString().make_string(),
+                  ProtonInitializationStatus::timepoint_to_string(_status.get_start_time()));
+        EXPECT_EQ(slime.get()["initialization_finished"].asString().make_string(),
+                  ProtonInitializationStatus::timepoint_to_string(_status.get_end_time()));
+        EXPECT_EQ(slime.get()["load"].asLong(), 0);
+        EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+        EXPECT_EQ(slime.get()["online"].asLong(), 2);
+
+        vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+        EXPECT_TRUE(dbs.valid());
+        EXPECT_EQ(dbs.entries(), 2);
+        EXPECT_EQ(dbs[0]["name"].asString().make_string(), std::string("db1"));
+        EXPECT_EQ(dbs[1]["name"].asString().make_string(), std::string("db2"));
+    }
+}
+
+TEST_F(ProtonInitializationStatusTest, test_reporting_with_dbs_when_removing_and_adding_dbs) {
+    _status.start_initialization();
+
+    _status.addDocumentDBInitializationStatus(_db_status1);
+    _status.addDocumentDBInitializationStatus(_db_status2);
+
+    _db_state1.enterLoadState();
+    _db_state1.enterReplayTransactionLogState();
+    _db_state1.enterApplyLiveConfigState();
+    _db_state1.enterReprocessState();
+    _db_state1.enterOnlineState();
+
+    _db_state2.enterLoadState();
+    _db_state2.enterReplayTransactionLogState();
+    _db_state2.enterApplyLiveConfigState();
+    _db_state2.enterReprocessState();
+    _db_state2.enterOnlineState();
+
+    _status.end_initialization();
+
+    _status.removeDocumentDBInitializationStatus(_db_status1);
+    {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get().children(), 8);
+        EXPECT_EQ(slime.get()["load"].asLong(), 0);
+        EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+        EXPECT_EQ(slime.get()["online"].asLong(), 1);
+
+        vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+        EXPECT_TRUE(dbs.valid());
+        EXPECT_EQ(dbs.entries(), 1);
+        EXPECT_EQ(dbs[0]["name"].asString().make_string(), std::string("db2"));
+    }
+
+    _status.addDocumentDBInitializationStatus(_db_status3);
+    {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get().children(), 8);
+        EXPECT_EQ(slime.get()["load"].asLong(), 1);
+        EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+        EXPECT_EQ(slime.get()["online"].asLong(), 1);
+
+        vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+        EXPECT_TRUE(dbs.valid());
+        EXPECT_EQ(dbs.entries(), 2);
+        EXPECT_EQ(dbs[0]["name"].asString().make_string(), std::string("db2"));
+        EXPECT_EQ(dbs[1]["name"].asString().make_string(), std::string("db3"));
+    }
+
+    _db_state3.enterLoadState();
+    _db_state3.enterReplayTransactionLogState();
+    _db_state3.enterApplyLiveConfigState();
+    _db_state3.enterReprocessState();
+    _db_state3.enterOnlineState();
+
+    {
+        vespalib::Slime slime;
+        vespalib::slime::SlimeInserter inserter(slime);
+        _status.report_initialization_status(inserter);
+
+        EXPECT_EQ(slime.get().children(), 8);
+        EXPECT_EQ(slime.get()["load"].asLong(), 0);
+        EXPECT_EQ(slime.get()["replay_transaction_log"].asLong(), 0);
+        EXPECT_EQ(slime.get()["online"].asLong(), 2);
+
+        vespalib::slime::Inspector& dbs = slime.get()["dbs"];
+        EXPECT_TRUE(dbs.valid());
+        EXPECT_EQ(dbs.entries(), 2);
+        EXPECT_EQ(dbs[0]["name"].asString().make_string(), std::string("db2"));
+        EXPECT_EQ(dbs[1]["name"].asString().make_string(), std::string("db3"));
+    }
+}
+
+TEST_F(ProtonInitializationStatusTest, test_reporting_db_counts) {
+    _status.start_initialization();
+
+    _status.addDocumentDBInitializationStatus(_db_status1);
+    _status.addDocumentDBInitializationStatus(_db_status2);
+    _db_state1.enterLoadState();
+    _db_state2.enterLoadState();
+
+    expect_db_counts(2, 0, 0);
+
+    _db_state1.enterReplayTransactionLogState();
+    expect_db_counts(1, 1, 0);
+
+    _db_state1.enterApplyLiveConfigState();
+    expect_db_counts(2, 0, 0);
+
+    _db_state1.enterReprocessState();
+    expect_db_counts(2, 0, 0);
+
+    _db_state1.enterOnlineState();
+    expect_db_counts(1, 0, 1);
+
+    _db_state2.enterReplayTransactionLogState();
+    expect_db_counts(0, 1, 1);
+
+    _db_state2.enterApplyLiveConfigState();
+    expect_db_counts(1, 0, 1);
+
+    _db_state2.enterReprocessState();
+    expect_db_counts(1, 0, 1);
+
+    _db_state2.enterOnlineState();
+    expect_db_counts(0, 0, 2);
+
+    _status.end_initialization();
+    expect_db_counts(0, 0, 2);
+}
+
+TEST_F(ProtonInitializationStatusTest, test_reporting_db_counts_when_removing_and_adding_dbs) {
+    _status.start_initialization();
+
+    _status.addDocumentDBInitializationStatus(_db_status1);
+    _status.addDocumentDBInitializationStatus(_db_status2);
+
+    _db_state1.enterLoadState();
+    _db_state1.enterReplayTransactionLogState();
+    _db_state1.enterApplyLiveConfigState();
+    _db_state1.enterReprocessState();
+    _db_state1.enterOnlineState();
+
+    _db_state2.enterLoadState();
+    _db_state2.enterReplayTransactionLogState();
+    _db_state2.enterApplyLiveConfigState();
+    _db_state2.enterReprocessState();
+    _db_state2.enterOnlineState();
+
+    _status.end_initialization();
+    expect_db_counts(0, 0, 2);
+
+    _status.removeDocumentDBInitializationStatus(_db_status1);
+    expect_db_counts(0, 0, 1);
+
+    _status.addDocumentDBInitializationStatus(_db_status3);
+    expect_db_counts(1, 0, 1);
+
+    _db_state3.enterLoadState();
+    expect_db_counts(1, 0, 1);
+
+    _db_state3.enterReplayTransactionLogState();
+    _db_state3.enterApplyLiveConfigState();
+    _db_state3.enterReprocessState();
+    _db_state3.enterOnlineState();
+
+    expect_db_counts(0, 0, 2);
+
+    _status.removeDocumentDBInitializationStatus(_db_status2);
+    _status.removeDocumentDBInitializationStatus(_db_status3);
+    expect_db_counts(0, 0, 0);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -19,6 +19,7 @@ vespa_add_library(searchcore_server STATIC
     document_db_directory_holder.cpp
     document_db_explorer.cpp
     document_db_flush_config.cpp
+    document_db_initialization_status.cpp
     document_db_maintenance_config.cpp
     document_db_reconfig.cpp
     document_meta_store_read_guards.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.cpp
@@ -41,15 +41,15 @@ void DocumentDBInitializationStatus::report_initialization_status(const vespalib
     db_cursor.setString("state", state_string);
 
     if (state >= DDBState::State::LOAD) {
-        db_cursor.setString("loading_started", timepoint_to_string(_state->get_load_time()));
+        db_cursor.setString("start_time", timepoint_to_string(_state->get_load_time()));
     }
 
     if (state >= DDBState::State::REPLAY_TRANSACTION_LOG) {
-        db_cursor.setString("replay_started", timepoint_to_string(_state->get_replay_time()));
+        db_cursor.setString("replay_start_time", timepoint_to_string(_state->get_replay_time()));
     }
 
     if (state >= DDBState::State::ONLINE) {
-        db_cursor.setString("loading_finished", timepoint_to_string(_state->get_online_time()));
+        db_cursor.setString("end_time", timepoint_to_string(_state->get_online_time()));
     }
 
     if (state >= DDBState::State::REPLAY_TRANSACTION_LOG) {

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.cpp
@@ -1,0 +1,23 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "document_db_initialization_status.h"
+
+#include "ddbstate.h"
+#include "i_replay_progress_producer.h"
+#include <vespa/searchcommon/attribute/attribute_initialization_status.h>
+
+namespace proton {
+
+DocumentDBInitializationStatus::DocumentDBInitializationStatus(const std::string& name, const DDBState& state, const IReplayProgressProducer& replay_progress_producer)
+    : _name(name),
+      _state(state),
+      _replay_progress_producer(replay_progress_producer) {
+}
+
+void DocumentDBInitializationStatus::set_attribute_initialization_statuses(std::vector<std::shared_ptr<AttributeInitializationStatus>>&& attribute_initialization_statuses) {
+    std::lock_guard<std::mutex> guard(_mutex);
+
+    _attribute_initialization_statuses = std::move(attribute_initialization_statuses);
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.cpp
@@ -11,10 +11,9 @@
 
 namespace proton {
 
-DocumentDBInitializationStatus::DocumentDBInitializationStatus(const std::string& name, const DDBState& state, const IReplayProgressProducer& replay_progress_producer)
+DocumentDBInitializationStatus::DocumentDBInitializationStatus(const std::string& name, const std::shared_ptr<const DDBState>& state)
     : _name(name),
-      _state(state),
-      _replay_progress_producer(replay_progress_producer) {
+      _state(state) {
 }
 
 void DocumentDBInitializationStatus::set_attribute_initialization_statuses(std::vector<std::shared_ptr<AttributeInitializationStatus>>&& attribute_initialization_statuses) {
@@ -23,13 +22,18 @@ void DocumentDBInitializationStatus::set_attribute_initialization_statuses(std::
     _attribute_initialization_statuses = std::move(attribute_initialization_statuses);
 }
 
+void DocumentDBInitializationStatus::set_replay_progress_producer(const std::shared_ptr<const IReplayProgressProducer>& replay_progress_producer) {
+    std::lock_guard<std::mutex> guard(_mutex);
+    _replay_progress_producer = replay_progress_producer;
+}
+
 void DocumentDBInitializationStatus::report_initialization_status(const vespalib::slime::Inserter &inserter) const {
     std::lock_guard<std::mutex> guard(_mutex);
 
     vespalib::slime::Cursor &db_cursor = inserter.insertObject();
     db_cursor.setString("name", _name);
 
-    DDBState::State state = _state.getState();
+    DDBState::State state = _state->getState();
     std::string state_string = DDBState::getStateString(state);
     // Make stateString lowercase
     std::transform(state_string.begin(), state_string.end(), state_string.begin(),
@@ -37,19 +41,19 @@ void DocumentDBInitializationStatus::report_initialization_status(const vespalib
     db_cursor.setString("state", state_string);
 
     if (state >= DDBState::State::LOAD) {
-        db_cursor.setString("loading_started", timepoint_to_string(_state.get_load_time()));
+        db_cursor.setString("loading_started", timepoint_to_string(_state->get_load_time()));
     }
 
     if (state >= DDBState::State::REPLAY_TRANSACTION_LOG) {
-        db_cursor.setString("replay_started", timepoint_to_string(_state.get_replay_time()));
+        db_cursor.setString("replay_started", timepoint_to_string(_state->get_replay_time()));
     }
 
     if (state >= DDBState::State::ONLINE) {
-        db_cursor.setString("loading_finished", timepoint_to_string(_state.get_online_time()));
+        db_cursor.setString("loading_finished", timepoint_to_string(_state->get_online_time()));
     }
 
     if (state >= DDBState::State::REPLAY_TRANSACTION_LOG) {
-        db_cursor.setString("replay_progress", std::format("{:.6f}", _replay_progress_producer.getReplayProgress()));
+        db_cursor.setString("replay_progress", std::format("{:.6f}", _replay_progress_producer ? _replay_progress_producer->getProgress() : 0.0f));
     }
 
     vespalib::slime::Cursor &subdb_cursor = db_cursor.setObject("ready_subdb");

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.h
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace search::attribute { class AttributeInitializationStatus; }
+
+using search::attribute::AttributeInitializationStatus;
+
+namespace proton {
+
+class DDBState;
+class IReplayProgressProducer;
+
+/**
+ * Class that collects the objects that track the initialization status of a DocumentDB
+ * and can report this status into a slime.
+ *
+ * Thread-safe.
+ */
+class DocumentDBInitializationStatus {
+private:
+    const std::string              _name;
+    const DDBState&                _state;
+    const IReplayProgressProducer& _replay_progress_producer;
+
+    mutable std::mutex _mutex;  // protects vector below
+    std::vector<std::shared_ptr<AttributeInitializationStatus>> _attribute_initialization_statuses;
+
+public:
+    DocumentDBInitializationStatus(const std::string& name, const DDBState& state, const IReplayProgressProducer& replay_progress_producer);
+
+    void set_attribute_initialization_statuses(std::vector<std::shared_ptr<AttributeInitializationStatus>>&& attribute_initialization_statuses);
+
+    const DDBState& get_state() const { return _state; }
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.h
@@ -2,12 +2,15 @@
 
 #pragma once
 
+#include <vespa/vespalib/net/http/initialization_status_producer.h>
+
 #include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
 
 namespace search::attribute { class AttributeInitializationStatus; }
+namespace vespalib::slime { struct Inserter; }
 
 using search::attribute::AttributeInitializationStatus;
 
@@ -22,7 +25,7 @@ class IReplayProgressProducer;
  *
  * Thread-safe.
  */
-class DocumentDBInitializationStatus {
+class DocumentDBInitializationStatus : public vespalib::InitializationStatusProducer {
 private:
     const std::string              _name;
     const DDBState&                _state;
@@ -37,6 +40,8 @@ public:
     void set_attribute_initialization_statuses(std::vector<std::shared_ptr<AttributeInitializationStatus>>&& attribute_initialization_statuses);
 
     const DDBState& get_state() const { return _state; }
+
+    void report_initialization_status(const vespalib::slime::Inserter &inserter) const override;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_initialization_status.h
@@ -27,19 +27,22 @@ class IReplayProgressProducer;
  */
 class DocumentDBInitializationStatus : public vespalib::InitializationStatusProducer {
 private:
-    const std::string              _name;
-    const DDBState&                _state;
-    const IReplayProgressProducer& _replay_progress_producer;
+    const std::string                        _name;
+    std::shared_ptr<const DDBState>                _state;
+    std::shared_ptr<const IReplayProgressProducer> _replay_progress_producer;
 
     mutable std::mutex _mutex;  // protects vector below
     std::vector<std::shared_ptr<AttributeInitializationStatus>> _attribute_initialization_statuses;
 
 public:
-    DocumentDBInitializationStatus(const std::string& name, const DDBState& state, const IReplayProgressProducer& replay_progress_producer);
+    DocumentDBInitializationStatus(const std::string& name, const std::shared_ptr<const DDBState>& state);
+    ~DocumentDBInitializationStatus() override __attribute__((noinline)) = default; // Avoid warning about inlining
 
     void set_attribute_initialization_statuses(std::vector<std::shared_ptr<AttributeInitializationStatus>>&& attribute_initialization_statuses);
 
-    const DDBState& get_state() const { return _state; }
+    void set_replay_progress_producer(const std::shared_ptr<const IReplayProgressProducer> &replay_progress_producer);
+
+    const DDBState& get_state() const { return *_state; }
 
     void report_initialization_status(const vespalib::slime::Inserter &inserter) const override;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -34,10 +34,7 @@ namespace vespalib {
     struct ThreadBundle;
 }
 namespace search {
-    namespace attribute {
-        class AttributeInitializationStatus;
-        class Interlock;
-    }
+    namespace attribute { class Interlock; }
     namespace common { class FileHeaderContext; }
     namespace transactionlog {
         class TransLogClient;
@@ -60,6 +57,7 @@ namespace storage::spi { struct BucketExecutor; }
 
 namespace proton {
 class AttributeConfigInspector;
+class DocumentDBInitializationStatus;
 class DocumentDBReconfig;
 class ExecutorThreadingServiceStats;
 class IDocumentDBOwner;
@@ -148,9 +146,7 @@ private:
     DocumentDBJobTrackers                            _jobTrackers;
     std::shared_ptr<IBucketStateCalculator>          _calc;
     DocumentDBMetricsUpdater                         _metricsUpdater;
-
-    mutable std::mutex                               _initialization_mutex;  // protects vector below
-    std::vector<std::shared_ptr<search::attribute::AttributeInitializationStatus>> _attribute_initialization_statuses;
+    std::shared_ptr<DocumentDBInitializationStatus>  _initializationStatus;
 
     void registerReference();
     void setActiveConfig(DocumentDBConfigSP config);
@@ -434,6 +430,8 @@ public:
 
     void set_attribute_usage_listener(std::unique_ptr<IAttributeUsageListener> listener);
     const DDBState& get_state() const noexcept { return _state; }
+
+    std::shared_ptr<DocumentDBInitializationStatus> get_initialization_status() const;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -136,7 +136,7 @@ private:
     vespalib::MonitoredRefCount                      _refCount;
     IDocumentDBOwner                                &_owner;
     storage::spi::BucketExecutor                    &_bucketExecutor;
-    DDBState                                         _state;
+    std::shared_ptr<DDBState>                        _state;
     ResourceUsageForwarder                           _resource_usage_forwarder;
     AttributeUsageFilter                             _writeFilter;
     std::shared_ptr<ITransientResourceUsageProvider> _transient_usage_provider;
@@ -385,7 +385,7 @@ public:
      */
     vespalib::RetainGuard retain() { return {_refCount}; }
 
-    bool getDelayedConfig() const { return _state.getDelayedConfig(); }
+    bool getDelayedConfig() const { return _state->getDelayedConfig(); }
     void replayConfig(SerialNum serialNum) override;
     const DocTypeName & getDocTypeName() const noexcept { return _docTypeName; }
     std::unique_ptr<DocumentDBReconfig> prepare_reconfig(const DocumentDBConfig& new_config_snapshot, std::optional<SerialNum> serial_num);
@@ -429,7 +429,7 @@ public:
     ExecutorThreadingService & getWriteService() { return _writeService; }
 
     void set_attribute_usage_listener(std::unique_ptr<IAttributeUsageListener> listener);
-    const DDBState& get_state() const noexcept { return _state; }
+    const DDBState& get_state() const noexcept { return *_state; }
 
     std::shared_ptr<DocumentDBInitializationStatus> get_initialization_status() const;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.h
@@ -5,6 +5,7 @@
 #include "feed_handler_stats.h"
 #include "i_inc_serial_num.h"
 #include "i_operation_storer.h"
+#include "i_replay_progress_producer.h"
 #include "idocumentmovehandler.h"
 #include "igetserialnum.h"
 #include "iheartbeathandler.h"
@@ -51,7 +52,8 @@ class FeedHandler: private search::transactionlog::client::Callback,
                    public IHeartBeatHandler,
                    public IOperationStorer,
                    public IGetSerialNum,
-                   public IIncSerialNum
+                   public IIncSerialNum,
+                   public IReplayProgressProducer
 {
 private:
     using Packet = search::transactionlog::Packet;
@@ -226,7 +228,7 @@ public:
     uint64_t  inc_prepare_serial_num() { return ++_prepare_serial_num; }
 
     bool isDoingReplay() const;
-    float getReplayProgress() const {
+    float getReplayProgress() const override {
         return _tlsReplayProgress ? _tlsReplayProgress->getProgress() : 0;
     }
     bool getTransactionLogReplayDone() const;

--- a/searchcore/src/vespa/searchcore/proton/server/i_replay_progress_producer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_replay_progress_producer.h
@@ -1,0 +1,16 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace proton {
+
+/**
+ * An interface for getting the progress of an TLS replay.
+ **/
+class IReplayProgressProducer {
+public:
+    virtual ~IReplayProgressProducer() = default;
+    virtual float getReplayProgress() const = 0;
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/i_replay_progress_producer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_replay_progress_producer.h
@@ -10,7 +10,7 @@ namespace proton {
 class IReplayProgressProducer {
 public:
     virtual ~IReplayProgressProducer() = default;
-    virtual float getReplayProgress() const = 0;
+    virtual float getProgress() const = 0;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -3,6 +3,7 @@
 #include "proton.h"
 #include "disk_mem_usage_sampler.h"
 #include "document_db_explorer.h"
+#include "document_db_initialization_status.h"
 #include "documentdbconfig.h"
 #include "fileconfigmanager.h"
 #include "flushhandlerproxy.h"
@@ -730,6 +731,8 @@ Proton::addDocumentDB(const document::DocumentType &docType,
                                   initializeThreads,
                                   bootstrapConfig->getHwInfo(),
                                   _posting_list_cache);
+    _initialization_status.addDocumentDBInitializationStatus(ret->get_initialization_status());
+
     try {
         ret->start();
     } catch (vespalib::Exception &e) {
@@ -780,6 +783,7 @@ Proton::removeDocumentDB(const DocTypeName &docTypeName)
             return;
         }
         old = it->second;
+        _initialization_status.removeDocumentDBInitializationStatus(old->get_initialization_status());
         _documentDBMap.erase(it);
     }
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.cpp
@@ -2,6 +2,9 @@
 
 #include "proton_initialization_status.h"
 
+#include "ddbstate.h"
+#include "document_db_initialization_status.h"
+
 namespace proton {
 
 std::string ProtonInitializationStatus::state_to_string(State state) {
@@ -17,6 +20,15 @@ std::string ProtonInitializationStatus::state_to_string(State state) {
 
 ProtonInitializationStatus::ProtonInitializationStatus()
     : _state(State::INITIALIZING) {
+}
+
+void ProtonInitializationStatus::addDocumentDBInitializationStatus(const std::shared_ptr<DocumentDBInitializationStatus>& status) {
+    _ddb_initialization_statuses.push_back(status);
+}
+
+void ProtonInitializationStatus::removeDocumentDBInitializationStatus(const std::shared_ptr<DocumentDBInitializationStatus>& status) {
+    _ddb_initialization_statuses.erase(std::remove(_ddb_initialization_statuses.begin(), _ddb_initialization_statuses.end(), status),
+                                   _ddb_initialization_statuses.end());
 }
 
 ProtonInitializationStatus::State ProtonInitializationStatus::get_state() const {

--- a/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.cpp
@@ -66,10 +66,10 @@ void ProtonInitializationStatus::report_initialization_status(const vespalib::sl
     vespalib::slime::Cursor &cursor = inserter.insertObject();
     cursor.setString("state", ProtonInitializationStatus::state_to_string(_state));
     cursor.setString("current_time", timepoint_to_string(std::chrono::system_clock::now()));
-    cursor.setString("initialization_started", timepoint_to_string(_start_time));
+    cursor.setString("start_time", timepoint_to_string(_start_time));
 
     if (_state == ProtonInitializationStatus::READY) {
-        cursor.setString("initialization_finished", timepoint_to_string(_end_time));
+        cursor.setString("end_time", timepoint_to_string(_end_time));
     }
 
     // DB counts

--- a/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <mutex>
 
 namespace proton {
+
+class DocumentDBInitializationStatus;
 
 /**
  * Class that tracks the initialization state of Proton and keeps timestamps of when a state was entered.
@@ -29,8 +32,13 @@ private:
 
     State _state;
 
+    std::vector<std::shared_ptr<DocumentDBInitializationStatus>> _ddb_initialization_statuses;
+
 public:
     ProtonInitializationStatus();
+
+    void addDocumentDBInitializationStatus(const std::shared_ptr<DocumentDBInitializationStatus>& status);
+    void removeDocumentDBInitializationStatus(const std::shared_ptr<DocumentDBInitializationStatus>& status);
 
     State get_state() const;
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_initialization_status.h
@@ -2,9 +2,13 @@
 
 #pragma once
 
+#include <vespa/vespalib/net/http/initialization_status_producer.h>
+
 #include <chrono>
 #include <memory>
 #include <mutex>
+
+namespace vespalib::slime { struct Inserter; }
 
 namespace proton {
 
@@ -15,7 +19,7 @@ class DocumentDBInitializationStatus;
  *
  * Thread-safe.
  */
-class ProtonInitializationStatus {
+class ProtonInitializationStatus : public vespalib::InitializationStatusProducer {
 public:
     enum State {
         INITIALIZING,
@@ -47,6 +51,8 @@ public:
 
     time_point get_start_time() const;
     time_point get_end_time() const;
+
+    void report_initialization_status(const vespalib::slime::Inserter &inserter) const override;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/tls_replay_progress.h
+++ b/searchcore/src/vespa/searchcore/proton/server/tls_replay_progress.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "i_replay_progress_producer.h"
 #include <vespa/searchlib/common/serialnum.h>
 #include <atomic>
 #include <memory>
@@ -9,7 +10,7 @@
 
 namespace proton {
 
-class TlsReplayProgress
+class TlsReplayProgress : public IReplayProgressProducer
 {
 private:
     const std::string  _domainName;
@@ -33,7 +34,7 @@ public:
     search::SerialNum getFirst() const noexcept { return _first; }
     search::SerialNum getLast() const noexcept { return _last; }
     search::SerialNum getCurrent() const noexcept { return _current.load(std::memory_order_relaxed); }
-    float getProgress() const noexcept {
+    float getProgress() const noexcept override {
         if (_first == _last) {
             return 1.0;
         } else {

--- a/searchcore/src/vespa/searchcore/proton/server/transactionlogmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/transactionlogmanager.cpp
@@ -113,7 +113,7 @@ TransactionLogManager::prepareReplay(TransLogClient &client,
     }
 }
 
-std::unique_ptr<TlsReplayProgress>
+std::shared_ptr<TlsReplayProgress>
 TransactionLogManager::make_replay_progress(SerialNum first, SerialNum last)
 {
     return std::make_unique<TlsReplayProgress>(getDomainName(), first, last);

--- a/searchcore/src/vespa/searchcore/proton/server/transactionlogmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/server/transactionlogmanager.h
@@ -52,7 +52,7 @@ public:
     /*
      * Make a tls replay progress object for serial numbers (first..last]
      */
-    std::unique_ptr<TlsReplayProgress>
+    std::shared_ptr<TlsReplayProgress>
     make_replay_progress(SerialNum first, SerialNum last);
 
     /**

--- a/searchlib/src/tests/searchcommon/attribute/initialization_status/attribute_initialization_status_test.cpp
+++ b/searchlib/src/tests/searchcommon/attribute/initialization_status/attribute_initialization_status_test.cpp
@@ -126,7 +126,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_loading) {
     EXPECT_EQ(slime.get().children(), 3);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
     EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loading"));
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
 }
 
@@ -142,9 +142,9 @@ TEST(AttributeInitializationStatusTest, test_reporting_loaded) {
     EXPECT_EQ(slime.get().children(), 4);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
     EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loaded"));
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
-    EXPECT_EQ(slime.get()["loading_finished"].asString().make_string(),
+    EXPECT_EQ(slime.get()["end_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_end_time()));
 }
 
@@ -161,10 +161,10 @@ TEST(AttributeInitializationStatusTest, test_reporting_reprocessing) {
     EXPECT_EQ(slime.get().children(), 5);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
     EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("reprocessing"));
-    EXPECT_EQ(slime.get()["reprocessing_progress"].asString().make_string(), "0.420000");
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_progress"].asString().make_string(), "0.420000");
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
-    EXPECT_EQ(slime.get()["reprocessing_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_start_time()));
 }
 
@@ -182,12 +182,12 @@ TEST(AttributeInitializationStatusTest, test_reporting_reprocessing_loading) {
     EXPECT_EQ(slime.get().children(), 6);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
     EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loading"));
-    EXPECT_EQ(slime.get()["reprocessing_progress"].asString().make_string(), "1.000000");
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_progress"].asString().make_string(), "1.000000");
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
-    EXPECT_EQ(slime.get()["reprocessing_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_start_time()));
-    EXPECT_EQ(slime.get()["reprocessing_finished"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_end_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_end_time()));
 }
 
@@ -206,14 +206,14 @@ TEST(AttributeInitializationStatusTest, test_reporting_reprocessing_loaded) {
     EXPECT_EQ(slime.get().children(), 7);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
     EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loaded"));
-    EXPECT_EQ(slime.get()["reprocessing_progress"].asString().make_string(), "1.000000");
-    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_progress"].asString().make_string(), "1.000000");
+    EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
-    EXPECT_EQ(slime.get()["reprocessing_started"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_start_time()));
-    EXPECT_EQ(slime.get()["reprocessing_finished"].asString().make_string(),
+    EXPECT_EQ(slime.get()["reprocess_end_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_end_time()));
-    EXPECT_EQ(slime.get()["loading_finished"].asString().make_string(),
+    EXPECT_EQ(slime.get()["end_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_end_time()));
 }
 

--- a/searchlib/src/tests/searchcommon/attribute/initialization_status/attribute_initialization_status_test.cpp
+++ b/searchlib/src/tests/searchcommon/attribute/initialization_status/attribute_initialization_status_test.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/searchcommon/attribute/attribute_initialization_status.h>
+#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using search::attribute::AttributeInitializationStatus;
@@ -100,6 +101,120 @@ TEST(AttributeInitializationStatusTest, test_timestamps)
     EXPECT_EQ(reprocessing_start_time, status.get_reprocessing_start_time());
     EXPECT_EQ(reprocessing_end_time, status.get_reprocessing_end_time());
     EXPECT_EQ(end_time, status.get_end_time());
+}
+
+TEST(AttributeInitializationStatusTest, test_reporting_queued) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+
+    AttributeInitializationStatus status("testAttribute");
+    status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 2);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
+    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("queued"));
+}
+
+TEST(AttributeInitializationStatusTest, test_reporting_loading) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+
+    AttributeInitializationStatus status("testAttribute");
+    status.start_loading();
+    status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 3);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
+    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loading"));
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
+}
+
+TEST(AttributeInitializationStatusTest, test_reporting_loaded) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+
+    AttributeInitializationStatus status("testAttribute");
+    status.start_loading();
+    status.end_loading();
+    status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 4);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
+    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loaded"));
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
+    EXPECT_EQ(slime.get()["loading_finished"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_end_time()));
+}
+
+TEST(AttributeInitializationStatusTest, test_reporting_reprocessing) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+
+    AttributeInitializationStatus status("testAttribute");
+    status.start_loading();
+    status.start_reprocessing();
+    status.set_reprocessing_percentage(0.42f);
+    status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 5);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
+    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("reprocessing"));
+    EXPECT_EQ(slime.get()["reprocessing_progress"].asString().make_string(), "0.420000");
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
+    EXPECT_EQ(slime.get()["reprocessing_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_start_time()));
+}
+
+TEST(AttributeInitializationStatusTest, test_reporting_reprocessing_loading) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+
+    AttributeInitializationStatus status("testAttribute");
+    status.start_loading();
+    status.start_reprocessing();
+    status.set_reprocessing_percentage(0.42f);
+    status.end_reprocessing();
+    status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 6);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
+    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loading"));
+    EXPECT_EQ(slime.get()["reprocessing_progress"].asString().make_string(), "1.000000");
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
+    EXPECT_EQ(slime.get()["reprocessing_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_start_time()));
+    EXPECT_EQ(slime.get()["reprocessing_finished"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_end_time()));
+}
+
+TEST(AttributeInitializationStatusTest, test_reporting_reprocessing_loaded) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+
+    AttributeInitializationStatus status("testAttribute");
+    status.start_loading();
+    status.start_reprocessing();
+    status.set_reprocessing_percentage(0.42f);
+    status.end_reprocessing();
+    status.end_loading();
+    status.report_initialization_status(inserter);
+
+    EXPECT_EQ(slime.get().children(), 7);
+    EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
+    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loaded"));
+    EXPECT_EQ(slime.get()["reprocessing_progress"].asString().make_string(), "1.000000");
+    EXPECT_EQ(slime.get()["loading_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
+    EXPECT_EQ(slime.get()["reprocessing_started"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_start_time()));
+    EXPECT_EQ(slime.get()["reprocessing_finished"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_reprocessing_end_time()));
+    EXPECT_EQ(slime.get()["loading_finished"].asString().make_string(),
+              AttributeInitializationStatus::timepoint_to_string(status.get_end_time()));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.cpp
@@ -118,23 +118,23 @@ void AttributeInitializationStatus::report_initialization_status(const vespalib:
     cursor.setString("status", state_to_string(_state));
 
     if (_state >= State::LOADING && _was_reprocessed) {
-        cursor.setString("reprocessing_progress",  std::format("{:.6f}", _reprocessing_percentage));
+        cursor.setString("reprocess_progress",  std::format("{:.6f}", _reprocessing_percentage));
     }
 
     if (_state >= State::LOADING) {
-        cursor.setString("loading_started", timepoint_to_string(_start_time));
+        cursor.setString("start_time", timepoint_to_string(_start_time));
     }
 
     if (_state >= State::LOADING && _was_reprocessed) {
-        cursor.setString("reprocessing_started",timepoint_to_string(_reprocessing_start_time));
+        cursor.setString("reprocess_start_time",timepoint_to_string(_reprocessing_start_time));
     }
 
     if ((_state == State::LOADING || _state == State::LOADED) && _was_reprocessed) {
-        cursor.setString("reprocessing_finished", timepoint_to_string(_reprocessing_end_time));
+        cursor.setString("reprocess_end_time", timepoint_to_string(_reprocessing_end_time));
     }
 
     if (_state == State::LOADED) {
-        cursor.setString("loading_finished", timepoint_to_string(_end_time));
+        cursor.setString("end_time", timepoint_to_string(_end_time));
     }
 }
 

--- a/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.cpp
@@ -2,6 +2,10 @@
 
 #include "attribute_initialization_status.h"
 
+#include <vespa/vespalib/data/slime/cursor.h>
+#include <vespa/vespalib/data/slime/inserter.h>
+#include <vespa/vespalib/data/slime/slime.h>
+
 namespace search::attribute {
 
 std::string AttributeInitializationStatus::state_to_string(State state) {
@@ -103,6 +107,35 @@ float AttributeInitializationStatus::get_reprocessing_percentage() const {
     std::lock_guard<std::mutex> guard(_mutex);
 
     return _reprocessing_percentage;
+}
+
+void AttributeInitializationStatus::report_initialization_status(const vespalib::slime::Inserter &inserter) const {
+    std::lock_guard<std::mutex> guard(_mutex);
+
+    vespalib::slime::Cursor &cursor = inserter.insertObject();
+    cursor.setString("name", _name);
+
+    cursor.setString("status", state_to_string(_state));
+
+    if (_state >= State::LOADING && _was_reprocessed) {
+        cursor.setString("reprocessing_progress",  std::format("{:.6f}", _reprocessing_percentage));
+    }
+
+    if (_state >= State::LOADING) {
+        cursor.setString("loading_started", timepoint_to_string(_start_time));
+    }
+
+    if (_state >= State::LOADING && _was_reprocessed) {
+        cursor.setString("reprocessing_started",timepoint_to_string(_reprocessing_start_time));
+    }
+
+    if ((_state == State::LOADING || _state == State::LOADED) && _was_reprocessed) {
+        cursor.setString("reprocessing_finished", timepoint_to_string(_reprocessing_end_time));
+    }
+
+    if (_state == State::LOADED) {
+        cursor.setString("loading_finished", timepoint_to_string(_end_time));
+    }
 }
 
 }

--- a/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.h
+++ b/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.h
@@ -2,10 +2,12 @@
 
 #pragma once
 
-#include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/net/http/initialization_status_producer.h>
 
 #include <chrono>
 #include <mutex>
+
+namespace vespalib::slime { struct Inserter; }
 
 namespace search::attribute {
 
@@ -14,7 +16,7 @@ namespace search::attribute {
  *
  * Thread-safe.
  */
-class AttributeInitializationStatus {
+class AttributeInitializationStatus : public vespalib::InitializationStatusProducer {
 public:
     enum State {
         QUEUED,
@@ -41,6 +43,8 @@ public:
     time_point get_reprocessing_end_time() const;
     bool was_reprocessed() const;
     float get_reprocessing_percentage() const;
+
+    void report_initialization_status(const vespalib::slime::Inserter &inserter) const override;
 
 private:
     mutable std::mutex _mutex;

--- a/vespalib/src/vespa/vespalib/net/http/initialization_status_producer.h
+++ b/vespalib/src/vespa/vespalib/net/http/initialization_status_producer.h
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <chrono>
+#include <format>
+#include <string>
+
+namespace vespalib {
+
+namespace slime { struct Inserter; }
+
+/**
+ * Interface for reporting initialization status into a slime.
+ */
+struct InitializationStatusProducer {
+    virtual ~InitializationStatusProducer() = default;
+    virtual void report_initialization_status(const vespalib::slime::Inserter &inserter) const = 0;
+
+
+    using time_point = std::chrono::system_clock::time_point;
+
+    static std::string timepoint_to_string(time_point tp) {
+        time_t secs = std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count();
+        uint32_t usecs_part = std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count() % 1000000;
+        return std::format("{}.{:06}", secs, usecs_part);
+    }
+
+};
+
+} // namespace vespalib


### PR DESCRIPTION
This restructures the recently added classes, adds methods for reporting the progress into a slime, and adds unit tests for the reporting.