### PR TITLE
Implements retry logic with a model load when evaluating model

### DIFF
--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
@@ -91,6 +91,7 @@ public class TritonOnnxClient implements AutoCloseable {
     }
 
     public void unloadModel(String modelName) {
+        log.fine(() -> "Unloading model " + modelName);
         var request = GrpcService.RepositoryModelUnloadRequest.newBuilder()
                 .setModelName(modelName)
                 .build();

--- a/model-integration/src/test/triton/config.pbtxt
+++ b/model-integration/src/test/triton/config.pbtxt
@@ -1,10 +1,10 @@
 name: "dummy_transformer"
 platform: "onnxruntime_onnx"
+max_batch_size: 1
 instance_group {
   count: 1
   kind: KIND_CPU
 }
-max_batch_size: 1
 parameters {
   key: "enable_mem_area"
   value {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Added retry logic to model evaluate, which will load the model if the first evaluation fails.
This should help with redeployment as well as triton server restarts when sidecar config changes.
This is instead of reference counting, which doesn't cover server restart case.