### PR TITLE
fix(build-container): use correct AlmaLinux version variable

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -52,7 +52,7 @@ rm -rf rpms
 mv "$WORKDIR/docker-image/rpms" rpms
 
 GHCR_SYSTEMTEST_TAG="$("${WORKDIR}/.buildkite/utils/get-container-tag.sh" "ghcr.io" "vespa-engine/vespa-systemtest-preview-$ARCH" "$VESPA_VERSION")"
-SYSTEM_TEST_BASE_IMAGE="almalinux:${AL_MAJOR_VERSION}"
+SYSTEM_TEST_BASE_IMAGE="almalinux:${ALMALINUX_MAJOR}"
 docker build --progress=plain \
              --build-arg BASE_IMAGE="$SYSTEM_TEST_BASE_IMAGE" \
              --build-arg VESPA_BASE_IMAGE="${GHCR_PREVIEW_TAG}" \


### PR DESCRIPTION
Update SYSTEM_TEST_BASE_IMAGE to use ALMALINUX_MAJOR instead of AL_MAJOR_VERSION to ensure the correct AlmaLinux major version is referenced during system test container builds. This prevents potential mismatches with base image tags.