### PR TITLE
Expose content node initialization progress via state/v1/initialization

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -62,6 +62,7 @@ vespa_add_library(searchcore_server STATIC
     idocumentdbowner.cpp
     ifeedview.cpp
     initialize_threads_calculator.cpp
+    initialization_handler.cpp
     ireplayconfig.cpp
     job_tracked_maintenance_job.cpp
     lid_space_compaction_handler.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/initialization_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/initialization_handler.cpp
@@ -1,0 +1,63 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "initialization_handler.h"
+
+#include <vespa/vespalib/net/tls/capability.h>
+#include <vespa/vespalib/util/jsonwriter.h>
+#include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/data/simple_buffer.h>
+#include <functional>
+
+using vespalib::InitializationStatusProducer;
+using vespalib::JsonGetHandler;
+using vespalib::net::tls::Capability;
+using vespalib::net::tls::CapabilitySet;
+
+namespace proton {
+
+namespace {
+
+JsonGetHandler::Response cap_checked(const vespalib::net::ConnectionAuthContext &auth_ctx,
+                                               CapabilitySet required_caps,
+                                               std::function<std::string()> fn)
+{
+    if (!auth_ctx.capabilities().contains_all(required_caps)) {
+        return JsonGetHandler::Response::make_failure(403, "Forbidden");
+    }
+    return JsonGetHandler::Response::make_ok_with_json(fn());
+}
+
+std::string respond_initialization(const InitializationStatusProducer &initialization_status_producer) {
+    vespalib::Slime slime;
+    vespalib::slime::SlimeInserter inserter(slime);
+    initialization_status_producer.report_initialization_status(inserter);
+
+    vespalib::SimpleBuffer buf;
+    vespalib::slime::JsonFormat::encode(slime, buf, false);
+    return buf.get().make_string();
+}
+
+} // namespace proton::unnamed
+
+InitializationHandler::InitializationHandler(InitializationStatusProducer &initialization_status_producer)
+    : _initialization_status_producer(initialization_status_producer)
+{
+}
+
+JsonGetHandler::Response
+InitializationHandler::get(const std::string &/*host*/,
+              const std::string &path,
+              const std::map<std::string,std::string> &/*params*/,
+              const vespalib::net::ConnectionAuthContext &auth_ctx) const
+{
+    if (path == "/state/v1/initialization") {
+        return cap_checked(auth_ctx, CapabilitySet::make_empty(), [&] {
+            return respond_initialization(_initialization_status_producer);
+        });
+    } else {
+        // TODO Return different error (?)
+        return Response::make_failure(403, "Forbidden");
+    }
+}
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/initialization_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/initialization_handler.h
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/net/http/initialization_status_producer.h>
+#include <vespa/vespalib/net/http/json_get_handler.h>
+#include <vespa/vespalib/net/connection_auth_context.h>
+#include <map>
+#include <string>
+
+namespace proton {
+
+/**
+ * Handler for serving /state/v1/initialization.
+ */
+class InitializationHandler : public vespalib::JsonGetHandler
+{
+private:
+    vespalib::InitializationStatusProducer &_initialization_status_producer;
+public:
+    InitializationHandler(vespalib::InitializationStatusProducer &initialization_status_producer);
+    Response get(const std::string &host,
+                 const std::string &path,
+                 const std::map<std::string,std::string> &params,
+                 const vespalib::net::ConnectionAuthContext &auth_ctx) const override;
+};
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -158,6 +158,7 @@ struct MetricsUpdateHook : metrics::UpdateHook
     }
 };
 
+const std::string INITIALIZATION_API_PATH = "/state/v1/initialization";
 const std::string CUSTOM_COMPONENT_API_PATH = "/state/v1/custom/component";
 
 VESPA_THREAD_STACK_TAG(proton_close_executor);
@@ -296,6 +297,9 @@ Proton::Proton(FNET_Transport & transport, const config::ConfigUri & configUri,
       _rpcHooks(),
       _healthAdapter(*this),
       _genericStateHandler(CUSTOM_COMPONENT_API_PATH, *this),
+      _initialization_handler(_initialization_status),
+      _initialization_bind_token(),
+      _initialization_root_token(),
       _customComponentBindToken(),
       _customComponentRootToken(),
       _stateServer(),
@@ -417,6 +421,13 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
     std::string fileConfigId;
     _compile_cache_executor_binding = vespalib::eval::CompileCache::bind(_shared_service->shared_raw());
 
+    _stateServer = std::make_unique<vespalib::StateServer>(protonConfig.httpport, _healthAdapter,
+                                                           _metricsEngine->metrics_producer(),
+                                                           *this,
+                                                           true);
+    _initialization_bind_token = _stateServer->repo().bind(INITIALIZATION_API_PATH, _initialization_handler);
+    _initialization_root_token = _stateServer->repo().add_root_resource(INITIALIZATION_API_PATH);
+
     InitializeThreadsCalculator calc(hwInfo.cpu(), protonConfig.basedir, protonConfig.initialize.threads);
     LOG(info, "Start initializing components: threads=%u, configured=%u",
         calc.num_threads(), protonConfig.initialize.threads);
@@ -434,8 +445,11 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
     calc.init_done();
 
     _metricsEngine->start(_configUri);
-    _stateServer = std::make_unique<vespalib::StateServer>(protonConfig.httpport, _healthAdapter,
-                                                           _metricsEngine->metrics_producer(), *this);
+
+    // Enable remaining /state/v1/ endpoints
+    _stateServer->set_limit_endpoints(false);
+
+    // Add /custom/component endpoint
     _customComponentBindToken = _stateServer->repo().bind(CUSTOM_COMPONENT_API_PATH, _genericStateHandler);
     _customComponentRootToken = _stateServer->repo().add_root_resource(CUSTOM_COMPONENT_API_PATH);
 
@@ -596,6 +610,8 @@ Proton::shutdown_config_fetching_and_state_exposing_components_once() noexcept
     _executor.sync();
     _customComponentRootToken.reset();
     _customComponentBindToken.reset();
+    _initialization_root_token.reset();
+    _initialization_bind_token.reset();
     _stateServer.reset();
     if (_metricsEngine) {
         _metricsEngine->removeMetricsHook(*_metricsHook);

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -8,6 +8,7 @@
 #include "health_adapter.h"
 #include "i_proton_configurer_owner.h"
 #include "idocumentdbowner.h"
+#include "initialization_handler.h"
 #include "memory_flush_config_updater.h"
 #include "proton_config_fetcher.h"
 #include "proton_configurer.h"
@@ -115,7 +116,10 @@ private:
     RPCHooks::UP                           _rpcHooks;
     HealthAdapter                          _healthAdapter;
     vespalib::GenericStateHandler          _genericStateHandler;
+    InitializationHandler                  _initialization_handler;
     ProtonInitializationStatus             _initialization_status;
+    vespalib::JsonHandlerRepo::Token::UP   _initialization_bind_token;
+    vespalib::JsonHandlerRepo::Token::UP   _initialization_root_token;
     vespalib::JsonHandlerRepo::Token::UP   _customComponentBindToken;
     vespalib::JsonHandlerRepo::Token::UP   _customComponentRootToken;
     std::unique_ptr<vespalib::StateServer> _stateServer;

--- a/vespalib/src/vespa/vespalib/net/http/state_api.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/state_api.cpp
@@ -77,14 +77,17 @@ void render_link(JSONStringer &json, const std::string &host, const std::string 
     json.endObject();
 }
 
-std::string respond_root(const JsonHandlerRepo &repo, const std::string &host) {
+std::string respond_root(const JsonHandlerRepo &repo, const std::string &host, bool limit_endpoints) {
     JSONStringer json;
     json.beginObject();
     json.appendKey("resources");
     json.beginArray();
-    for (auto path: {"/state/v1/health", "/state/v1/metrics", "/state/v1/config", "/state/v1/version"}) {
-        render_link(json, host, path);
+    if (!limit_endpoints) {
+        for (auto path: {"/state/v1/health", "/state/v1/metrics", "/state/v1/config"}) {
+            render_link(json, host, path);
+        }
     }
+    render_link(json, host, "/state/v1/version");
     for (const std::string &path: repo.get_root_resources()) {
         render_link(json, host, path);
     }
@@ -197,60 +200,66 @@ StateApi::get(const std::string &host,
 {
     if (path == "/state/v1/" || path == "/state/v1") {
         return cap_checked(auth_ctx, CapabilitySet::make_empty(), [&] { // TODO consider http_unclassified
-            return respond_root(_handler_repo, host);
-        });
-    } else if (path == "/state/v1/health") {
-        return cap_checked(auth_ctx, CapabilitySet::make_empty(), [&] { // TODO consider http_unclassified
-            return respond_health(_healthProducer);
-        });
-    } else if (path == "/state/v1/metrics") {
-        // Using a 'statereporter' consumer by default removes many uninteresting per-thread
-        // metrics but retains their aggregates (side note: per-thread metrics are NOT included
-        // in Prometheus metrics regardless of the specified consumer).
-        return cap_check_and_respond_metrics(auth_ctx, params, "statereporter", [&](auto& consumer, auto format) {
-            if (format == MetricsProducer::ExpositionFormat::Prometheus) {
-                auto metrics_text = _metricsProducer.getMetrics(consumer, MetricsProducer::ExpositionFormat::Prometheus);
-                return JsonGetHandler::Response::make_ok_with_content_type(std::move(metrics_text), prometheus_content_type());
-            } else {
-                auto json = respond_json_metrics(consumer, _healthProducer, _metricsProducer);
-                return JsonGetHandler::Response::make_ok_with_json(std::move(json));
-            }
-        });
-    } else if (path == "/state/v1/config") {
-        return cap_checked(auth_ctx, Capability::content_state_api(), [&] {
-            return respond_config(_componentConfigProducer);
+            return respond_root(_handler_repo, host, _limit_endpoints.load());
         });
     } else if (path == "/state/v1/version") {
         return cap_checked(auth_ctx, CapabilitySet::make_empty(), [&] {
             return respond_version();
         });
-    } else if (path == "/metrics/total") {
-        return cap_check_and_respond_metrics(auth_ctx, params, "", [&](auto& consumer, auto format) {
-            if (format == MetricsProducer::ExpositionFormat::Prometheus) {
-                auto metrics_text = _metricsProducer.getTotalMetrics(consumer, MetricsProducer::ExpositionFormat::Prometheus);
-                return JsonGetHandler::Response::make_ok_with_content_type(std::move(metrics_text), prometheus_content_type());
-            } else {
-                auto json = _metricsProducer.getTotalMetrics(consumer, vespalib::MetricsProducer::ExpositionFormat::JSON);
-                return JsonGetHandler::Response::make_ok_with_json(std::move(json));
-            }
-        });
-    } else {
-        // Assume this is for the nested state v1 stuff; may delegate capability check to handler later if desired.
-        if (!auth_ctx.capabilities().contains(Capability::content_state_api())) {
-            return Response::make_failure(403, "Forbidden");
+    } else if (!_limit_endpoints.load()) {
+        if (path == "/state/v1/health") {
+            return cap_checked(auth_ctx, CapabilitySet::make_empty(), [&] { // TODO consider http_unclassified
+                return respond_health(_healthProducer);
+            });
+        } else if (path == "/state/v1/metrics") {
+            // Using a 'statereporter' consumer by default removes many uninteresting per-thread
+            // metrics but retains their aggregates (side note: per-thread metrics are NOT included
+            // in Prometheus metrics regardless of the specified consumer).
+            return cap_check_and_respond_metrics(auth_ctx, params, "statereporter", [&](auto& consumer, auto format) {
+                if (format == MetricsProducer::ExpositionFormat::Prometheus) {
+                    auto metrics_text = _metricsProducer.getMetrics(consumer, MetricsProducer::ExpositionFormat::Prometheus);
+                    return JsonGetHandler::Response::make_ok_with_content_type(std::move(metrics_text), prometheus_content_type());
+                } else {
+                    auto json = respond_json_metrics(consumer, _healthProducer, _metricsProducer);
+                    return JsonGetHandler::Response::make_ok_with_json(std::move(json));
+                }
+            });
+        } else if (path == "/state/v1/config") {
+            return cap_checked(auth_ctx, Capability::content_state_api(), [&] {
+                return respond_config(_componentConfigProducer);
+            });
+        } else if (path == "/metrics/total") {
+            return cap_check_and_respond_metrics(auth_ctx, params, "", [&](auto& consumer, auto format) {
+                if (format == MetricsProducer::ExpositionFormat::Prometheus) {
+                    auto metrics_text = _metricsProducer.getTotalMetrics(consumer, MetricsProducer::ExpositionFormat::Prometheus);
+                    return JsonGetHandler::Response::make_ok_with_content_type(std::move(metrics_text), prometheus_content_type());
+                } else {
+                    auto json = _metricsProducer.getTotalMetrics(consumer, vespalib::MetricsProducer::ExpositionFormat::JSON);
+                    return JsonGetHandler::Response::make_ok_with_json(std::move(json));
+                }
+            });
         }
-        return _handler_repo.get(host, path, params, auth_ctx);
     }
+
+    // None of the endpoints matched or _limit_endpoints is set: check additional endpoints
+
+    // Assume this is for the nested state v1 stuff; may delegate capability check to handler later if desired.
+    if (!auth_ctx.capabilities().contains(Capability::content_state_api())) {
+        return Response::make_failure(403, "Forbidden");
+    }
+    return _handler_repo.get(host, path, params, auth_ctx);
 }
 
 //-----------------------------------------------------------------------------
 
 StateApi::StateApi(const HealthProducer &hp,
                    MetricsProducer &mp,
-                   ComponentConfigProducer &ccp)
+                   ComponentConfigProducer &ccp,
+                   bool limit_endpoints)
     : _healthProducer(hp),
       _metricsProducer(mp),
-      _componentConfigProducer(ccp)
+      _componentConfigProducer(ccp),
+      _limit_endpoints(limit_endpoints)
 {
 }
 

--- a/vespalib/src/vespa/vespalib/net/http/state_api.h
+++ b/vespalib/src/vespa/vespalib/net/http/state_api.h
@@ -6,8 +6,10 @@
 #include "health_producer.h"
 #include "metrics_producer.h"
 #include "component_config_producer.h"
-#include <memory>
 #include "json_handler_repo.h"
+
+#include <atomic>
+#include <memory>
 
 namespace vespalib {
 
@@ -24,17 +26,20 @@ private:
     MetricsProducer &_metricsProducer;
     ComponentConfigProducer &_componentConfigProducer;
     JsonHandlerRepo _handler_repo;
+    std::atomic<bool> _limit_endpoints;
 
 public:
     StateApi(const HealthProducer &hp,
              MetricsProducer &mp,
-             ComponentConfigProducer &ccp);
+             ComponentConfigProducer &ccp,
+             bool limit_endpoints = false);
     ~StateApi() override;
     Response get(const std::string &host,
                  const std::string &path,
                  const std::map<std::string,std::string> &params,
                  const net::ConnectionAuthContext &auth_ctx) const override;
     JsonHandlerRepo &repo() { return _handler_repo; }
+    void set_limit_endpoints(bool limit_endpoints) { _limit_endpoints.store(limit_endpoints); }
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/state_server.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/state_server.cpp
@@ -7,8 +7,9 @@ namespace vespalib {
 StateServer::StateServer(int port,
                          const HealthProducer &hp,
                          MetricsProducer &mp,
-                         ComponentConfigProducer &ccp)
-    : _api(hp, mp, ccp),
+                         ComponentConfigProducer &ccp,
+                         bool limit_endpoints)
+    : _api(hp, mp, ccp, limit_endpoints),
       _server(port),
       _tokens()
 {

--- a/vespalib/src/vespa/vespalib/net/http/state_server.h
+++ b/vespalib/src/vespa/vespalib/net/http/state_server.h
@@ -25,10 +25,11 @@ private:
 
 public:
     using UP = std::unique_ptr<StateServer>;
-    StateServer(int port, const HealthProducer &hp, MetricsProducer &mp, ComponentConfigProducer &ccp);
+    StateServer(int port, const HealthProducer &hp, MetricsProducer &mp, ComponentConfigProducer &ccp, bool limit_endpoints = false);
     ~StateServer();
     int getListenPort() { return _server.port(); }
     JsonHandlerRepo &repo() { return _api.repo(); }
+    void set_limit_endpoints(bool limit_endpoints) { _api.set_limit_endpoints(limit_endpoints); }
 };
 
 } // namespace vespalib


### PR DESCRIPTION
The `StateServer` is created at an earlier point during the initialization of Proton and serves a new endpoint called `initialization`, which serves the initialization progress.  The other endpoints are exposed only when the initialization is finished (with the exception of `version`).