### PR TITLE
feat: add new system for Kubernetes CD

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -313,7 +313,7 @@ public class DeployState implements ConfigDefinitionStore {
     public boolean isHostedTenantApplication(ApplicationType type) {
         boolean isTesterApplication = getProperties().applicationId().instance().isTester();
         return isHosted() && type == ApplicationType.DEFAULT && !isTesterApplication
-                && !zone().system().isKubernetes();
+                && !zone().system().isKubernetesLike();
     }
 
     public static class Builder {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
@@ -34,7 +34,7 @@ class ConsumersConfigGenerator {
                          combineConsumers(defaultConsumer, allConsumers.get(MetricsConsumer.vespa.id())));
         allConsumers.put(MetricsConsumer.autoscaling.id(), MetricsConsumer.autoscaling);
 
-        if (systemName.isPublicLike())
+        if (systemName.isPublicCloudLike())
             allConsumers.put(MetricsConsumer.vespaCloud.id(), MetricsConsumer.vespaCloud);
 
         return allConsumers.values().stream()

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/otel/OpenTelemetryConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/otel/OpenTelemetryConfigGenerator.java
@@ -47,7 +47,7 @@ public class OpenTelemetryConfigGenerator {
         boolean isCd = true;
         boolean isPublic = true;
         if (zone != null) {
-            isCd = zone.system().isCd();
+            isCd = zone.system().isCdLike();
             isPublic = zone.system().isPublicLike();
             this.useTls = true;
         } else {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/otel/OpenTelemetryConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/otel/OpenTelemetryConfigGenerator.java
@@ -48,7 +48,7 @@ public class OpenTelemetryConfigGenerator {
         boolean isPublic = true;
         if (zone != null) {
             isCd = zone.system().isCdLike();
-            isPublic = zone.system().isPublicLike();
+            isPublic = zone.system().isPublicCloudLike();
             this.useTls = true;
         } else {
             // for manual testing

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/AccessControlFilterExcludeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/AccessControlFilterExcludeValidator.java
@@ -21,7 +21,7 @@ public class AccessControlFilterExcludeValidator implements Validator {
 
     @Override
     public void validate(Context context) {
-        if (!context.deployState().isHosted() || context.deployState().zone().system().isPublicLike()) return;
+        if (!context.deployState().isHosted() || context.deployState().zone().system().isPublicCloudLike()) return;
         if (context.deployState().getProperties().allowDisableMtls()) return;
         context.model().getContainerClusters().forEach((id, cluster) -> {
             Http http = cluster.getHttp();

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidator.java
@@ -23,7 +23,7 @@ public class CloudDataPlaneFilterValidator implements Validator {
     @Override
     public void validate(Context context) {
         if (!context.deployState().isHosted()) return;
-        if (!context.deployState().zone().system().isPublicLike()) return;
+        if (!context.deployState().zone().system().isPublicCloudLike()) return;
 
         validateUniqueCertificates(context);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/TenantSecretValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/TenantSecretValidator.java
@@ -17,7 +17,7 @@ public class TenantSecretValidator implements Validator {
     @Override
     public void validate(Validation.Context context) {
         if ( ! context.deployState().isHosted()) return;
-        if ( ! context.deployState().zone().system().isPublicLike()) return;
+        if ( ! context.deployState().zone().system().isPublicCloudLike()) return;
 
         for (ApplicationContainerCluster cluster : context.model().getContainerClusters().values()) {
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UriBindingsValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UriBindingsValidator.java
@@ -72,7 +72,7 @@ class UriBindingsValidator implements Validator {
      * Logs to deploy logger in non-public systems, throw otherwise
      */
     private static void logOrThrow(String message, Context context) {
-        if (context.deployState().zone().system().isPublicLike()) {
+        if (context.deployState().zone().system().isPublicCloudLike()) {
             context.illegal(message);
         } else {
             context.deployState().getDeployLogger().log(Level.WARNING, message);

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UrlConfigValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UrlConfigValidator.java
@@ -34,7 +34,7 @@ public class UrlConfigValidator implements Validator {
         if (hasS3UrlInConfig(cluster)) {
             // TODO: Would be even better if we could add which config/field the url is set for in the error message
             String message = "Found s3:// urls in config for container cluster " + cluster.getName();
-            if ( ! context.deployState().zone().system().isPublicLike())
+            if ( ! context.deployState().zone().system().isPublicCloudLike())
                 context.illegal(message + ". This is only supported in public systems");
             else if ( ! isExclusive)
                 context.illegal(message + ". Nodes in the cluster need to be 'exclusive'," +

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
@@ -136,7 +136,7 @@ public abstract class DomAdminBuilderBase extends VespaDomBuilder.DomConfigProdu
     private String parseLogforwarderRole(String role, DeployState deployState) {
         if (role == null)
             return null;
-        if (deployState.zone().system().isPublicLike())
+        if (deployState.zone().system().isPublicCloudLike())
             throw new IllegalArgumentException("Logforwarder role not supported in public systems");
 
         // Currently only support athenz roles on format athenz://<domain>/role/<role>

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -426,7 +426,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     /** Returns whether the deployment in given deploy state should have endpoints */
     private static boolean configureEndpoints(DeployState deployState) {
         // TODO(bjorncs|onurkaracali|morioramdenbourg, 2025-08-27) handle endpoints for K8s
-        if (!deployState.isHosted() || deployState.zone().system().isKubernetes()) return false;
+        if (!deployState.isHosted() || deployState.zone().system().isKubernetesLike()) return false;
         if (deployState.getProperties().applicationId().instance().isTester()) return false;
         if (deployState.getProperties().applicationId().tenant().equals(HOSTED_VESPA)) return false;
         return true;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -206,7 +206,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
             addPlatformBundle(PlatformBundles.absoluteBundlePath("vespa-testrunner-components"));
             addPlatformBundle(PlatformBundles.absoluteBundlePath("vespa-osgi-testrunner"));
             addPlatformBundle(PlatformBundles.absoluteBundlePath("tenant-cd-api"));
-            if(deployState.zone().system().isPublicLike()) {
+            if(deployState.zone().system().isPublicCloudLike()) {
                 addPlatformBundle(PlatformBundles.absoluteBundlePath("cloud-tenant-cd"));
             }
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -245,7 +245,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         if ( ! deployState.isHosted()) return;
         // Always add platform bundle. Cannot be controlled by a feature flag as platform bundle cannot change.
         cluster.addPlatformBundle(PlatformBundles.absoluteBundlePath("jdisc-cloud-aws"));
-        if (deployState.zone().system().isPublicLike()) {
+        if (deployState.zone().system().isPublicCloudLike()) {
             BindingPattern bindingPattern = SystemBindingPattern.fromHttpPath("/validate-secret-store");
             Handler handler = new Handler(
                     new ComponentModel("com.yahoo.jdisc.cloud.aws.AwsParameterStoreValidationHandler", null, "jdisc-cloud-aws", null));
@@ -295,7 +295,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     private void addSecrets(ApplicationContainerCluster cluster, Element spec, DeployState deployState) {
-        if ( ! deployState.isHosted() || ! cluster.getZone().system().isPublicLike())
+        if ( ! deployState.isHosted() || ! cluster.getZone().system().isPublicCloudLike())
             return;
         Element secretsElement = XML.getChild(spec, "secrets");
         if (secretsElement != null) {
@@ -334,7 +334,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private void addCloudSecretStore(ApplicationContainerCluster cluster, Element secretStoreElement, DeployState deployState) {
         if ( ! deployState.isHosted()) return;
-        if ( ! cluster.getZone().system().isPublicLike())
+        if ( ! cluster.getZone().system().isPublicCloudLike())
             throw new IllegalArgumentException("Cloud secret store is not supported in non-public system, see the documentation");
         CloudSecretStore cloudSecretStore = new CloudSecretStore();
         Map<String, TenantSecretStore> secretStoresByName = deployState.getProperties().tenantSecretStores()
@@ -363,7 +363,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private void addAthenzServiceIdentityProvider(ApplicationContainerCluster cluster, ConfigModelContext context) {
         if ( ! context.getDeployState().isHosted()) return;
-        if ( ! context.getDeployState().zone().system().isPublicLike()) return; // Non-public is handled by deployment spec config.
+        if ( ! context.getDeployState().zone().system().isPublicCloudLike()) return; // Non-public is handled by deployment spec config.
         var appContext = context.getDeployState().zone().environment().isManuallyDeployed() ? "sandbox" : "production";
         addIdentityProvider(cluster,
                             context.getDeployState().getProperties().configServerSpecs(),
@@ -504,7 +504,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     private static void addCloudDataPlaneFilter(DeployState deployState, ApplicationContainerCluster cluster) {
-        if (!deployState.isHosted() || !deployState.zone().system().isPublicLike()) return;
+        if (!deployState.isHosted() || !deployState.zone().system().isPublicCloudLike()) return;
 
         var dataplanePort = getMtlsDataplanePort(deployState);
         // Setup secure filter chain
@@ -537,7 +537,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     protected void addClients(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {
-        if (!deployState.isHosted() || !deployState.zone().system().isPublicLike()) return;
+        if (!deployState.isHosted() || !deployState.zone().system().isPublicCloudLike()) return;
 
         List<Client> clients;
         Element clientsElement = XML.getChild(spec, "clients");
@@ -665,7 +665,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                     .flatMap(endpoint -> endpoint.names().stream())
                     .collect(Collectors.toSet());
             builder.knownServerNames(mtlsEndpointNames);
-            boolean isPublic = state.zone().system().isPublicLike();
+            boolean isPublic = state.zone().system().isPublicCloudLike();
             List<X509Certificate> clientCertificates = getClientCertificates(cluster);
             if (isPublic) {
                 if (clientCertificates.isEmpty())
@@ -1544,6 +1544,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private static boolean enableTokenSupport(DeployState state) {
         Set<ContainerEndpoint> tokenEndpoints = tokenEndpoints(state);
-        return state.isHosted() && state.zone().system().isPublicLike() && ! tokenEndpoints.isEmpty();
+        return state.isHosted() && state.zone().system().isPublicCloudLike() && ! tokenEndpoints.isEmpty();
     }
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CapacityPolicies.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CapacityPolicies.java
@@ -111,7 +111,7 @@ public class CapacityPolicies {
         }
 
         // Allow slow storage in zones which are not performance sensitive
-        if (zone.system().isCd() || zone.environment() == Environment.dev || zone.environment() == Environment.test)
+        if (zone.system().isCdLike() || zone.environment() == Environment.dev || zone.environment() == Environment.test)
             target = target.with(NodeResources.DiskSpeed.any).with(NodeResources.StorageType.any).withBandwidthGbps(0.1);
 
         return target;
@@ -128,7 +128,7 @@ public class CapacityPolicies {
     private NodeResources defaultResources(ClusterSpec clusterSpec) {
         var adminClusterArchitecture = tuning.adminClusterArchitecture();
         if (clusterSpec.type() == ClusterSpec.Type.admin) {
-            if (exclusivity.allocation(clusterSpec) && !zone.system().isKubernetes()) {
+            if (exclusivity.allocation(clusterSpec) && !zone.system().isKubernetesLike()) {
                 return smallestExclusiveResources().with(adminClusterArchitecture);
             }
 
@@ -223,7 +223,7 @@ public class CapacityPolicies {
 
     // The lowest amount of resources that can be exclusive allocated (i.e. a matching host flavor for this exists)
     private NodeResources smallestExclusiveResources() {
-        if (zone.system().isKubernetes()) return MIN_KUBERNETES_RESOURCES;
+        if (zone.system().isKubernetesLike()) return MIN_KUBERNETES_RESOURCES;
         return zone.cloud().name() == CloudName.AZURE || zone.cloud().name() == CloudName.GCP
                 ? new NodeResources(2, 8, 50, 0.3)
                 : new NodeResources(0.5, 8, 50, 0.3);
@@ -231,7 +231,7 @@ public class CapacityPolicies {
 
     // The lowest amount of resources that can be shared (i.e. a matching host flavor for this exists)
     private NodeResources smallestSharedResources() {
-        if (zone.system().isKubernetes()) throw new IllegalStateException("Not expecting shared nodes in Kubernetes");
+        if (zone.system().isKubernetesLike()) throw new IllegalStateException("Not expecting shared nodes in Kubernetes");
         return zone.cloud().name() == CloudName.GCP
                 ? new NodeResources(1, 4, 50, 0.3)
                 : new NodeResources(0.5, 2, 50, 0.3);

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudAccount.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudAccount.java
@@ -51,7 +51,7 @@ public class CloudAccount implements Comparable<CloudAccount> {
     /** Returns true if this is an exclave account. */
     public boolean isExclave(Zone zone) {
         return !isUnspecified() &&
-               zone.system().isPublicLike() &&
+               zone.system().isPublicCloudLike() &&
                !equals(zone.cloud().account());
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Exclusivity.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Exclusivity.java
@@ -27,7 +27,7 @@ public class Exclusivity {
      */
     public boolean allocation(ClusterSpec clusterSpec) {
         return clusterSpec.isExclusive() ||
-               ( clusterSpec.type().isContainer() && zone.system().isPublicLike() && !zone.environment().isTest() ) ||
+               ( clusterSpec.type().isContainer() && zone.system().isPublicCloudLike() && !zone.environment().isTest() ) ||
                ( !zone.cloud().allowHostSharing() && !sharedHost.supportsClusterType(clusterSpec.type()));
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -15,10 +16,10 @@ import java.util.stream.Stream;
  */
 public enum SystemName {
 
-    /** Continuous deployment system */
+    /** Yahoo Continuous deployment system */
     cd,
 
-    /** Production system */
+    /** Yahoo Production system */
     main,
 
     /** System accessible to the public */
@@ -34,23 +35,20 @@ public enum SystemName {
     kubernetes,
 
     /** Kubernetes CD */
-    kubernetesCd;
+    kubernetesCd,
+
+    /** Default system (for unit tests and non-hosted) */
+    Default;
 
     public static SystemName defaultSystem() {
-        return main; // TODO the default shouldn't be main but rather a 'default' system
+        return Default;
     }
 
     public static SystemName from(String value) {
-        return switch (value.toLowerCase()) {
-            case "dev" -> dev;
-            case "cd" -> cd;
-            case "main" -> main;
-            case "public" -> Public;
-            case "publiccd" -> PublicCd;
-            case "kubernetes" -> kubernetes;
-            case "kubernetescd" -> kubernetesCd;
-            default -> throw new IllegalArgumentException(String.format("'%s' is not a valid system", value));
-        };
+        return Arrays.stream(values())
+                .filter(systemName -> systemName.value().equals(value))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("'%s' is not a valid system".formatted(value)));
     }
 
     public String value() {
@@ -62,6 +60,7 @@ public enum SystemName {
             case PublicCd -> "publiccd";
             case kubernetes -> "kubernetes";
             case kubernetesCd -> "kubernetescd";
+            case Default -> "default";
         };
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -31,7 +31,10 @@ public enum SystemName {
     dev,
 
     /** Kubernetes */
-    kubernetes;
+    kubernetes,
+
+    /** Kubernetes CD */
+    kubernetesCd;
 
     public static SystemName defaultSystem() {
         return main; // TODO the default shouldn't be main but rather a 'default' system
@@ -45,6 +48,7 @@ public enum SystemName {
             case "public" -> Public;
             case "publiccd" -> PublicCd;
             case "kubernetes" -> kubernetes;
+            case "kubernetescd" -> kubernetesCd;
             default -> throw new IllegalArgumentException(String.format("'%s' is not a valid system", value));
         };
     }
@@ -57,6 +61,7 @@ public enum SystemName {
             case Public -> "public";
             case PublicCd -> "publiccd";
             case kubernetes -> "kubernetes";
+            case kubernetesCd -> "kubernetescd";
         };
     }
 
@@ -66,12 +71,21 @@ public enum SystemName {
     // TODO Remove and use isPublicLike() instead
     public boolean isPublic() { return isPublicLike(); }
 
-    public boolean isMainLike() { return this == main || this == cd; }
+    // TODO Remove and use isYahoo() instead
+    public boolean isMainLike() { return isYahoo(); }
 
-    public boolean isKubernetes() { return this == kubernetes; }
+    public boolean isYahoo() { return this == main || this == cd; }
+
+    // TODO Remove and use isKubernetesLike() instead
+    public boolean isKubernetes() { return isKubernetesLike(); }
+
+    public boolean isKubernetesLike() { return this == kubernetes || this == kubernetesCd; }
 
     /** Whether the system is used for continuous deployment. */
-    public boolean isCd() { return this == cd || this == PublicCd; }
+    // TODO Remove and use isCdLike() instead
+    public boolean isCd() { return isCdLike(); }
+
+    public boolean isCdLike() { return this == cd || this == PublicCd || this == kubernetesCd; }
 
     public static Set<SystemName> all() { return EnumSet.allOf(SystemName.class); }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -12,26 +12,27 @@ import java.util.stream.Stream;
  * Systems in hosted Vespa
  *
  * @author Martin Polden
+ * @author hakon
  * @author bjorncs
  */
 public enum SystemName {
 
-    /** Yahoo Continuous deployment system */
+    /** Yahoo Private Cloud CD */
     cd,
 
-    /** Yahoo Production system */
+    /** Yahoo Private Cloud Production */
     main,
 
-    /** System accessible to the public */
+    /** Vespa Cloud Production */
     Public,
 
-    /** Continuous deployment system for testing the Public system */
+    /** Vespa Cloud CD */
     PublicCd,
 
     /** Local development system */
     dev,
 
-    /** Kubernetes */
+    /** Kubernetes Production */
     kubernetes,
 
     /** Kubernetes CD */
@@ -65,15 +66,18 @@ public enum SystemName {
     }
 
     /** Whether the system is similar to Public, e.g. PublicCd. */
-    public boolean isPublicLike() { return this == Public || this == PublicCd; }
+    public boolean isPublicCloudLike() { return this == Public || this == PublicCd; }
 
-    // TODO Remove and use isPublicLike() instead
-    public boolean isPublic() { return isPublicLike(); }
+    // TODO Remove and use isPublicCloudLike() instead
+    public boolean isPublicLike() { return isPublicCloudLike(); }
 
-    // TODO Remove and use isYahoo() instead
-    public boolean isMainLike() { return isYahoo(); }
+    // TODO Remove and use isPublicCloudLike() instead
+    public boolean isPublic() { return isPublicCloudLike(); }
 
-    public boolean isYahoo() { return this == main || this == cd; }
+    // TODO Remove and use isYahooLike() instead
+    public boolean isMainLike() { return isYahooLike(); }
+
+    public boolean isYahooLike() { return this == main || this == cd; }
 
     // TODO Remove and use isKubernetesLike() instead
     public boolean isKubernetes() { return isKubernetesLike(); }
@@ -86,7 +90,7 @@ public enum SystemName {
 
     public boolean isCdLike() { return this == cd || this == PublicCd || this == kubernetesCd; }
 
-    public boolean isProduction() { return this == main || this == Public || this == kubernetes; }
+    public boolean isProdLike() { return this == main || this == Public || this == kubernetes; }
 
     public static Set<SystemName> all() { return EnumSet.allOf(SystemName.class); }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -87,6 +87,8 @@ public enum SystemName {
 
     public boolean isCdLike() { return this == cd || this == PublicCd || this == kubernetesCd; }
 
+    public boolean isProduction() { return this == main || this == Public || this == kubernetes; }
+
     public static Set<SystemName> all() { return EnumSet.allOf(SystemName.class); }
 
     public static Set<SystemName> allOf(Predicate<SystemName> predicate) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -90,7 +90,7 @@ public enum SystemName {
 
     public boolean isCdLike() { return this == cd || this == PublicCd || this == kubernetesCd; }
 
-    public boolean isProdLike() { return this == main || this == Public || this == kubernetes; }
+    public boolean isProductionLike() { return this == main || this == Public || this == kubernetes; }
 
     public static Set<SystemName> all() { return EnumSet.allOf(SystemName.class); }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -23,10 +23,10 @@ public enum SystemName {
     /** Yahoo Private Cloud Production */
     main,
 
-    /** Vespa Cloud Production */
+    /** Public Vespa Cloud Production */
     Public,
 
-    /** Vespa Cloud CD */
+    /** Public Vespa Cloud CD */
     PublicCd,
 
     /** Local development system */

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/SystemNameTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/SystemNameTest.java
@@ -21,6 +21,6 @@ public class SystemNameTest {
     @Test
     void allOf() {
         assertEquals(Set.of(SystemName.cd, SystemName.PublicCd, SystemName.kubernetesCd), SystemName.allOf(SystemName::isCdLike));
-        assertEquals(Set.of(SystemName.PublicCd, SystemName.Public), SystemName.allOf(SystemName::isPublicLike));
+        assertEquals(Set.of(SystemName.PublicCd, SystemName.Public), SystemName.allOf(SystemName::isPublicCloudLike));
     }
 }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/SystemNameTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/SystemNameTest.java
@@ -20,7 +20,7 @@ public class SystemNameTest {
 
     @Test
     void allOf() {
-        assertEquals(Set.of(SystemName.cd, SystemName.PublicCd), SystemName.allOf(SystemName::isCd));
+        assertEquals(Set.of(SystemName.cd, SystemName.PublicCd, SystemName.kubernetesCd), SystemName.allOf(SystemName::isCdLike));
         assertEquals(Set.of(SystemName.PublicCd, SystemName.Public), SystemName.allOf(SystemName::isPublicLike));
     }
 }

--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -43,7 +43,7 @@ applicationDirectory string default="conf/configserver-app"
 cloud string default="default"
 environment string default="prod"
 region string default="default"
-system string default="main"
+system string default="default"
 # TODO: Unused, remove in Vespa 9 at the latest
 zoneDnsSuffixes[] string
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployNodeAllocationTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployNodeAllocationTest.java
@@ -83,7 +83,7 @@ public class HostedDeployNodeAllocationTest {
                     .quota(new Quota(Optional.of(4), Optional.of(valueOf(0)))));
             fail("Expected to get a QuotaExceededException");
         } catch (QuotaExceededException e) {
-            assertEquals("main: The resources used cost $1.02 but your remaining quota is $0.00: Contact support to upgrade your plan.", e.getMessage());
+            assertEquals("default: The resources used cost $1.02 but your remaining quota is $0.00: Contact support to upgrade your plan.", e.getMessage());
         }
     }
 

--- a/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/VespaCliTestRunner.java
+++ b/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/VespaCliTestRunner.java
@@ -123,7 +123,7 @@ public class VespaCliTestRunner implements TestRunner {
         ProcessBuilder builder = new ProcessBuilder("vespa", "test", suitePath.get().toAbsolutePath().toString(),
                                                     "--application", config.application().toFullString(),
                                                     "--zone", config.zone().value(),
-                                                    "--target", config.system().isPublicLike() ? "cloud" : "hosted");
+                                                    "--target", config.system().isPublicCloudLike() ? "cloud" : "hosted");
         builder.redirectErrorStream(true);
         // The CI environment variables tells Vespa CLI to omit certain warnings that do not apply to CI environments
         builder.environment().put("CI", "true");
@@ -143,7 +143,7 @@ public class VespaCliTestRunner implements TestRunner {
     private Credentials getCredentials(TestConfig config) {
         final Path privateKeyFile;
         final Path certificateFile;
-        if (config.system().isPublicLike()) {
+        if (config.system().isPublicCloudLike()) {
             privateKeyFile = artifactsPath.resolve("key");
             certificateFile = artifactsPath.resolve("cert");
         } else {


### PR DESCRIPTION
Add new enum variant for `kubernetescd`.
Use same naming scheme for helper methods proping properties of a system.