### PR TITLE
Explicitly exclude ARM64 SVE/SVE2 targets for now

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.h
@@ -11,12 +11,15 @@ class Highway {
 public:
     // Returns all accelerator targets that are supported by the current architecture and runtime.
     // The targets are ordered in decreasing order of preference, i.e. element 0 is considered
-    // the most preferred target to use for the lifetime of this process.
+    // the most preferred target to use for the lifetime of this process from the perspective of
+    // the Highway library. Note that this will also include targets that `create_best_target()`
+    // may exclude due to our own filtering decisions, so it's useful for tests and benchmarks.
     // Always returns at least 1 element.
     [[nodiscard]] static std::vector<std::unique_ptr<IAccelerated>> create_supported_targets();
     // Returns the accelerator instance corresponding to the "best" Highway target that is
-    // supported by the current architecture and runtime. This is always equal to the first
-    // element returned by `create_supported_targets()`.
+    // supported by the current architecture and runtime. This target may be chosen from a subset
+    // of what `create_supported_targets()` returns, as we may apply platform-specific target
+    // exclusions.
     [[nodiscard]] static std::unique_ptr<IAccelerated> create_best_target();
 };
 

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -40,7 +40,7 @@ public:
     // OR 128 bytes from multiple, optionally inverted sources
     virtual void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept = 0;
 
-    [[nodiscard]] virtual const char* implementation_name() const noexcept { return "AutoVectorized"; }
+    [[nodiscard]] virtual const char* implementation_name() const noexcept { return "AutoVec"; }
     // Returns a static string representing the name of the underlying accelerator target (e.g. "AVX3", "NEON" etc.)
     [[nodiscard]] virtual const char* target_name() const noexcept { return "Unknown"; }
 


### PR DESCRIPTION
@havardpe please review

SVE/SVE2 is not a strict superset of NEON, which means that certain very useful 128-bit NEON(_BF16) vector instructions are _not_ present as "sizeless" SVE vector operations, at least not for baseline SVE/SVE2.

In particular (caveat emptor: based on my understanding after staring at benchmark results, assembler code and ARM docs):

**int8 squared Euclidean distance**: NEON has a [`SSUBL`](https://developer.arm.com/documentation/dui0801/l/A64-SIMD-Vector-Instructions/SSUBL--SSUBL2--vector---A64-?lang=en) signed subtraction instruction of high/low vector lanes with implicit widening. On SVE this needs separate unpack high/low instructions followed by a non-widening subtraction, increasing instruction count and register pressure.

**BFloat16 dot product**: SVE does not have guaranteed BF16 support prior to ARMv8.6-A and its BF16 dot product instruction ([`BFDOT`](https://developer.arm.com/documentation/ddi0602/2025-06/SVE-Instructions/BFDOT--vectors---BFloat16-dot-product-to-single-precision-?lang=en)) does not give the same    result as NEON BF16 unless `FEAT_EBF16` is present, due to differences in rounding behavior. Because of this, dynamic target compilation for Highway does not by default use BF16 instructions for _any_ SVE targets. It is also not clear how this could be enabled with today's set of compilation targets, as they are not ARM architecture version-oriented.

In practice this means that SVE may be _slower_ for some important operations than 128-bit NEON_BF16. For both the above ops, the observed relative slowdown is on the order of ~1.5-2x. The only serious speed increase from SVE is for population count. This is observed on both 128-bit SVE/SVE2 and 256-bit SVE. Maybe larger vector sizes will fare differently, but I'm not aware of any such hardware available at the present time (the Fugaku 512-bit SVE supercomputer is out of my reach...! 👀)

So for now, exclude SVE targets entirely until they've had more time to cook. If SVE is present, NEON_BF16 is expected to always be present.

This is based on testing on Google Axion (SVE2_128), Amazon Graviton 3 (SVE_256) and Amazon Graviton 4 (SVE2_128) nodes, and will be updated/reconsidered once newer/shinier hardware is available for testing.

Future work:

Since SVE is still measurably faster for _some_ operations, what we likely want is to redesign how vector kernel dispatch is done. Today it's "monolithic" where all functions dispatch to code compiled for the same target. Instead, replace this with a function table where _each distinct_ vector op is dispatched to an implementation for the target we deem most optimal (e.g. BF16 dot product will dispatch to NEON_BF16, float dot product and popcount will dispatch to SVE2 etc.). Lovingly artisan crafted organic tables, made from the finest locally sourced instructions.