### PR TITLE
some refactoring of numeric ranges in QueryTermSimple

### DIFF
--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -924,9 +924,9 @@ TEST(StreamingQueryTest, weighted_set_term)
 
 TEST(StreamingQueryTest, control_the_size_of_query_terms)
 {
-    EXPECT_EQ(48u + sizeof(std::string), sizeof(QueryTermSimple));
-    EXPECT_EQ(64u + sizeof(std::string), sizeof(QueryTermUCS4));
-    EXPECT_EQ(144u + 2*sizeof(std::string), sizeof(QueryTerm));
+    EXPECT_EQ(32u + sizeof(std::string), sizeof(QueryTermSimple));
+    EXPECT_EQ(48u + sizeof(std::string), sizeof(QueryTermUCS4));
+    EXPECT_EQ(128u + 2*sizeof(std::string), sizeof(QueryTerm));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/query/numeric_range_spec.h
+++ b/searchlib/src/vespa/searchlib/query/numeric_range_spec.h
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <limits>
+
+namespace search {
+
+/**
+ * Basic representation of a numeric range specificatino
+ */
+
+struct NumericRangeSpec {
+    bool             valid = false;
+    bool             valid_integers = false;
+    bool             lower_inclusive = true;
+    bool             upper_inclusive = true;
+    bool             diversityCutoffStrict = false;
+    // what we really want:
+    double           fp_lower_limit = -std::numeric_limits<double>::infinity();
+    double           fp_upper_limit = std::numeric_limits<double>::infinity();
+    int64_t          int64_lower_limit = std::numeric_limits<int64_t>::min();
+    int64_t          int64_upper_limit = std::numeric_limits<int64_t>::max();
+    int32_t          rangeLimit = 0;
+    uint32_t         maxPerGroup = 0;
+    uint32_t         diversityCutoffGroups = std::numeric_limits<uint32_t>::max();
+    std::string      diversityAttribute = "";
+
+    bool has_lower_limit() const noexcept { return fp_lower_limit > -std::numeric_limits<double>::infinity(); }
+    bool has_upper_limit() const noexcept { return fp_upper_limit < std::numeric_limits<double>::infinity(); }
+    bool has_range_limit() const noexcept { return rangeLimit != 0; }
+
+    bool with_diversity() const noexcept { return ! diversityAttribute.empty(); }
+    bool with_diversity_cutoff() const noexcept {
+        return diversityCutoffGroups != std::numeric_limits<uint32_t>::max();
+    }
+
+    constexpr auto operator <=>(const NumericRangeSpec &rhs) const noexcept = default;
+};
+
+} // namespace

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
@@ -9,27 +9,30 @@
 #include <limits>
 #include <charconv>
 
+using search::NumericRangeSpec;
+
 namespace {
 
 template <typename N>
 constexpr bool isValidInteger(int64_t value) noexcept
 {
     return (value >= std::numeric_limits<N>::min()) &&
-           (value <= std::numeric_limits<N>::max());
+            (value <= std::numeric_limits<N>::max());
 }
 
 constexpr bool isRepresentableByInt64(double d) noexcept {
     return (d > double(std::numeric_limits<int64_t>::min())) &&
-           (d < double(std::numeric_limits<int64_t>::max()));
+            (d < double(std::numeric_limits<int64_t>::max()));
 }
 
 bool isFullRange(std::string_view s) noexcept {
     const size_t sz(s.size());
     return (sz >= 3u) &&
-           (s[0] == '<' || s[0] == '[') &&
-           (s[sz-1] == '>' || s[sz-1] == ']');
+            (s[0] == '<' || s[0] == '[') &&
+            (s[sz-1] == '>' || s[sz-1] == ']');
 }
 
+/*
 struct IntDecoder {
     static int64_t fromstr(const char * q, const char * qend, const char ** end) noexcept {
         int64_t v(0);
@@ -78,8 +81,178 @@ struct FloatDecoder {
         return std::nextafter(n, max);
     }
 };
+*/
 
+bool isPartialRange(std::string_view s) noexcept {
+    return (s.size() > 1) &&
+            ((s[0] == '<') || (s[0] == '>'));
 }
+
+constexpr double NEG_INF = -std::numeric_limits<double>::infinity();
+constexpr double POS_INF = std::numeric_limits<double>::infinity();
+
+constexpr float NEG_INF_F = -std::numeric_limits<float>::infinity();
+constexpr float POS_INF_F = std::numeric_limits<float>::infinity();
+
+constexpr float NEG_MIN_F = -std::numeric_limits<float>::max();
+constexpr float POS_MAX_F = std::numeric_limits<float>::max();
+
+constexpr int64_t NEG_MIN_I64 = std::numeric_limits<int64_t>::min();
+constexpr int64_t POS_MAX_I64 = std::numeric_limits<int64_t>::max();
+
+bool parseNumberAsInt64(const char *startp, const char *endptr, int64_t &t2) {
+    if (*startp == '+')
+        ++startp;
+    auto result = std::from_chars(startp, endptr, t2);
+    if (result.ec == std::errc{} && result.ptr == endptr) {
+        return true;
+    }
+    return false;
+}
+
+bool parseNumberAsDouble(const char *startp, const char *endptr, double &target) {
+    if (startp == endptr) return false;
+    char *parsed_to;
+    double dv = vespalib::locale::c::strtod(startp, &parsed_to);
+    if (parsed_to != endptr) [[unlikely]] {
+        return false;
+    }
+    if (std::isnan(dv)) [[unlikely]] {
+        return false;
+    }
+    target = dv;
+    return true;
+}
+
+struct TwiceParser {
+    bool invalid = true;
+    bool valid_i = false;
+    double d = 0.0;
+    int64_t i = 0;
+    TwiceParser(std::string_view view) {
+        const char *s = view.data();
+        const char *e = view.data() + view.size();
+        if (parseNumberAsDouble(s, e, d)) {
+            invalid = false;
+            valid_i = parseNumberAsInt64(s, e, i);
+        }
+    }
+};
+
+std::unique_ptr<NumericRangeSpec> parsePartialRange(const std::string_view term) {
+    auto result = std::make_unique<NumericRangeSpec>();
+    TwiceParser parsed(term.substr(1));
+    if (parsed.invalid) {
+        return {};
+    }
+    if (term[0] == '<') {
+        result->upper_inclusive = false;
+        result->fp_upper_limit = parsed.d;
+        result->int64_upper_limit = parsed.i;
+        result->valid_integers = parsed.valid_i;
+        result->valid = true;
+        return result;
+    }
+    if (term[0] == '>') {
+        result->lower_inclusive = false;
+        result->fp_lower_limit = parsed.d;
+        result->int64_lower_limit = parsed.i;
+        result->valid_integers = parsed.valid_i;
+        result->valid = true;
+        return result;
+    }
+    return {};
+}
+
+std::unique_ptr<NumericRangeSpec> parseNoRange(const std::string &term) {
+    TwiceParser parsed(term);
+    if (parsed.invalid) return {};
+    auto result = std::make_unique<NumericRangeSpec>();
+    result->lower_inclusive = true;
+    result->upper_inclusive = true;
+    result->fp_lower_limit = parsed.d;
+    result->fp_upper_limit = parsed.d;
+    result->valid_integers = parsed.valid_i;
+    result->int64_lower_limit = parsed.i;
+    result->int64_upper_limit = parsed.i;
+    result->valid = true;
+    return result;
+}
+
+std::unique_ptr<NumericRangeSpec> parseFullRange(const std::string &_term) {
+    auto result = std::make_unique<NumericRangeSpec>();
+    std::string_view rest(_term.c_str() + 1, _term.size() - 2);
+    std::string_view parts[9];
+    size_t numParts(0);
+    while (! rest.empty() && ((numParts + 1) < NELEMS(parts))) {
+        size_t pos(rest.find(';'));
+        if (pos != std::string::npos) {
+            parts[numParts++] = rest.substr(0, pos);
+            rest = rest.substr(pos + 1);
+            if (rest.empty()) {
+                parts[numParts++] = rest;
+            }
+        } else {
+            parts[numParts++] = rest;
+            rest = std::string_view();
+        }
+    }
+    if (numParts < 2) return {};
+    if (NELEMS(parts) <= numParts) return {};
+
+    result->lower_inclusive = (_term[0] == '[');
+    result->upper_inclusive = (_term[_term.size() - 1] == ']');
+
+    bool valid_i = true;
+    if (parts[0].empty()) {
+        // note empty -> no limit
+        result->lower_inclusive = true; // <;3] is same as [;3]
+    } else {
+        TwiceParser parsed(parts[0]);
+        if (parsed.invalid) return {};
+        valid_i = parsed.valid_i;
+        result->fp_lower_limit = parsed.d;
+        result->int64_lower_limit = parsed.i;
+    }
+    if (parts[1].empty()) {
+        // note empty -> no limit
+        result->upper_inclusive = true; // [3;> is same as [3;]
+    } else {
+        TwiceParser parsed(parts[1]);
+        if (parsed.invalid) return {};
+        valid_i = valid_i && parsed.valid_i;
+        result->fp_upper_limit = parsed.d;
+        result->int64_upper_limit = parsed.i;
+    }
+    result->valid_integers = valid_i;
+    if (numParts > 2) {
+        result->rangeLimit = static_cast<int32_t>(strtol(parts[2].data(), nullptr, 0));
+        if (numParts > 3) {
+            if (numParts < 5) {
+                return {};
+            }
+            result->diversityAttribute = parts[3];
+            result->maxPerGroup = strtoul(parts[4].data(), nullptr, 0);
+            if ((result->maxPerGroup > 0) && (numParts > 5)) {
+                char *err = nullptr;
+                size_t cutoffGroups = strtoul(parts[5].data(), &err, 0);
+                if ((err == nullptr) || (size_t(err - parts[5].data()) == parts[5].size())) {
+                    result->diversityCutoffGroups = cutoffGroups;
+                }
+                if (numParts > 6) {
+                    result->diversityCutoffStrict = (parts[6] == "strict");
+                    if (numParts > 7) {
+                        return {};
+                    }
+                }
+            }
+        }
+    }
+    result->valid = true;
+    return result;
+}
+
+} // namespace
 
 namespace search {
 
@@ -94,17 +267,22 @@ template <typename N>
 QueryTermSimple::RangeResult<N>
 QueryTermSimple::getFloatRange() const noexcept
 {
-    N lowRaw, highRaw;
-    bool valid = getAsFloatTerm(lowRaw, highRaw);
     RangeResult<N> res;
-    res.valid = valid;
-    if (!valid) {
+    if (_numeric_range) {
+        res.valid = true;
+        res.low = _numeric_range->fp_lower_limit;
+        res.high = _numeric_range->fp_upper_limit;
+        if (! _numeric_range->lower_inclusive) {
+            res.low = std::nextafter(res.low, res.high);
+        }
+        if (! _numeric_range->upper_inclusive) {
+            res.high = std::nextafter(res.high, res.low);
+        }
+    } else {
+        res.valid = false;
         res.low = std::numeric_limits<N>::infinity();
         res.high = -std::numeric_limits<N>::infinity();
         res.adjusted = true;
-    } else {
-        res.low = lowRaw;
-        res.high = highRaw;
     }
     return res;
 }
@@ -114,9 +292,11 @@ QueryTermSimple::getRangeInternal(int64_t & low, int64_t & high) const noexcept
 {
     bool valid = getAsIntegerTerm(low, high);
     if ( ! valid ) {
-        double l(0), h(0);
-        valid = getAsFloatTerm(l, h);
-        if (valid) {
+        RangeResult<double> range = getFloatRange<double>();
+        if (range.valid) {
+            valid = true;
+            double l = range.low;
+            double h = range.high;
             if ((l == h) && isRepresentableByInt64(l)) {
                 low = high = static_cast<int64_t>(std::round(l));
             } else {
@@ -218,84 +398,74 @@ QueryTermSimple::getRange() const noexcept
 bool
 QueryTermSimple::getAsIntegerTerm(int64_t & lower, int64_t & upper) const noexcept
 {
-    lower = std::numeric_limits<int64_t>::min();
-    upper = std::numeric_limits<int64_t>::max();
-    return getAsNumericTerm(lower, upper, IntDecoder());
+    lower = NEG_MIN_I64;
+    upper = POS_MAX_I64;
+    if (_numeric_range && _numeric_range->valid_integers) {
+        lower = _numeric_range->int64_lower_limit;
+        upper = _numeric_range->int64_upper_limit;
+        if (! _numeric_range->lower_inclusive) {
+            ++lower;
+        }
+        if (! _numeric_range->upper_inclusive) {
+            --upper;
+        }
+        return true;
+    }
+    return false;
 }
 
 bool
 QueryTermSimple::getAsFloatTerm(double & lower, double & upper) const noexcept
 {
-    lower = -std::numeric_limits<double>::infinity();
-    upper = std::numeric_limits<double>::infinity();
-    return getAsNumericTerm(lower, upper, FloatDecoder<double>());
+    auto range = getFloatRange<double>();
+    lower = range.low;
+    upper = range.high;
+    return range.valid;
 }
 
 bool
 QueryTermSimple::getAsFloatTerm(float & lower, float & upper) const noexcept
 {
-    lower = -std::numeric_limits<float>::infinity();
-    upper = std::numeric_limits<float>::infinity();
-    return getAsNumericTerm(lower, upper, FloatDecoder<float>());
+    auto range = getFloatRange<float>();
+    lower = range.low;
+    upper = range.high;
+    return range.valid;
 }
 
 QueryTermSimple::~QueryTermSimple() = default;
 
 QueryTermSimple::QueryTermSimple(const string & term_, Type type)
-    : _rangeLimit(0),
-      _maxPerGroup(0),
-      _diversityCutoffGroups(std::numeric_limits<uint32_t>::max()),
-      _type(type),
-      _diversityCutoffStrict(false),
-      _valid(true),
-      _fuzzy_prefix_match(false),
-      _term(term_),
-      _diversityAttribute(),
-      _fuzzy_max_edit_distance(2),
-      _fuzzy_prefix_lock_length(0)
+  : _type(type),
+    _valid(true),
+    _fuzzy_prefix_match(false),
+    _term(term_),
+    _fuzzy_max_edit_distance(2),
+    _fuzzy_prefix_lock_length(0)
 {
     if (isFullRange(_term)) {
-        string_view rest(_term.c_str() + 1, _term.size() - 2);
-        string_view parts[9];
-        size_t numParts(0);
-        while (! rest.empty() && ((numParts + 1) < NELEMS(parts))) {
-            size_t pos(rest.find(';'));
-            if (pos != std::string::npos) {
-                parts[numParts++] = rest.substr(0, pos);
-                rest = rest.substr(pos + 1);
-                if (rest.empty()) {
-                    parts[numParts++] = rest;
-                }
-            } else {
-                parts[numParts++] = rest;
-                rest = string_view();
-            }
-        }
-        _valid = (numParts >= 2) && (numParts < NELEMS(parts));
-        if (_valid && numParts > 2) {
-            _rangeLimit = static_cast<int32_t>(strtol(parts[2].data(), nullptr, 0));
-            if (numParts > 3) {
-                _valid = (numParts >= 5);
-                if (_valid) {
-                    _diversityAttribute = parts[3];
-                    _maxPerGroup = strtoul(parts[4].data(), nullptr, 0);
-                    if ((_maxPerGroup > 0) && (numParts > 5)) {
-                        char *err = nullptr;
-                        size_t cutoffGroups = strtoul(parts[5].data(), &err, 0);
-                        if ((err == nullptr) || (size_t(err - parts[5].data()) == parts[5].size())) {
-                            _diversityCutoffGroups = cutoffGroups;
-                        }
-                        if (numParts > 6) {
-                            _diversityCutoffStrict = (parts[6] == "strict");
-                            _valid = (numParts == 7);
-                        }
-                    }
-                }
-            }
-        }
+        _numeric_range = parseFullRange(_term);
+        _valid = bool(_numeric_range);
+    } else if (isPartialRange(_term)) {
+        _numeric_range = parsePartialRange(_term);
+        _valid = bool(_numeric_range);
+    } else {
+        _numeric_range = parseNoRange(_term);
     }
-} 
+}
 
+NumericRangeSpec QueryTermSimple::emptyNumericRange;
+QueryTermSimple::QueryTermSimple(Type type, std::unique_ptr<NumericRangeSpec> range)
+  : _type(type),
+    _valid(range),
+    _fuzzy_prefix_match(false),
+    _term("<range>"),
+    _fuzzy_max_edit_distance(0),
+    _fuzzy_prefix_lock_length(0)
+{
+    _numeric_range = std::move(range);
+}
+
+/*
 template <typename T, typename D>
 bool
 QueryTermSimple::getAsNumericTerm(T & lower, T & upper, D d) const noexcept
@@ -350,6 +520,7 @@ QueryTermSimple::getAsNumericTerm(T & lower, T & upper, D d) const noexcept
     }
     return valid;
 }
+*/
 
 std::string
 QueryTermSimple::getClassName() const
@@ -357,7 +528,7 @@ QueryTermSimple::getClassName() const
     return vespalib::getClassName(*this);
 }
 
-}
+} // namespace
 
 void
 visit(vespalib::ObjectVisitor &self, const std::string &name, const search::QueryTermSimple *obj)

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.h
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.h
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "numeric_range_spec.h"
 #include "query_normalization.h"
 #include <vespa/vespalib/objects/objectvisitor.h>
 #include <vespa/vespalib/util/memory.h>
@@ -33,17 +34,20 @@ public:
     QueryTermSimple(QueryTermSimple &&) = delete;
     QueryTermSimple & operator = (QueryTermSimple &&) = delete;
     QueryTermSimple(const string & term_, Type type);
+    QueryTermSimple(Type type, std::unique_ptr<NumericRangeSpec> range);
     virtual ~QueryTermSimple();
+
+
     /**
      * Extracts the content of this query term as a range with low and high values.
      */
     template <typename N>
     RangeResult<N> getRange() const noexcept;
-    int                         getRangeLimit() const noexcept { return _rangeLimit; }
-    size_t                     getMaxPerGroup() const noexcept { return _maxPerGroup; }
-    size_t           getDiversityCutoffGroups() const noexcept { return _diversityCutoffGroups; }
-    bool             getDiversityCutoffStrict() const noexcept { return _diversityCutoffStrict; }
-    string_view         getDiversityAttribute() const noexcept { return _diversityAttribute; }
+    int                         getRangeLimit() const noexcept { return activeRange().rangeLimit; }
+    size_t                     getMaxPerGroup() const noexcept { return activeRange().maxPerGroup; }
+    size_t           getDiversityCutoffGroups() const noexcept { return activeRange().diversityCutoffGroups; }
+    bool             getDiversityCutoffStrict() const noexcept { return activeRange().diversityCutoffStrict; }
+    string_view         getDiversityAttribute() const noexcept { return activeRange().diversityAttribute; }
     [[nodiscard]] size_t fuzzy_max_edit_distance() const noexcept { return _fuzzy_max_edit_distance; }
     [[nodiscard]] size_t fuzzy_prefix_lock_length() const noexcept { return _fuzzy_prefix_lock_length; }
     [[nodiscard]] bool   fuzzy_prefix_match() const noexcept { return _fuzzy_prefix_match; }
@@ -65,26 +69,22 @@ public:
     string getClassName() const;
     bool isValid() const noexcept { return _valid; }
     const string & getTermString() const noexcept { return _term; }
+    const NumericRangeSpec& activeRange() const noexcept { return _numeric_range ? (*_numeric_range) : emptyNumericRange; }
 
 private:
+    static NumericRangeSpec emptyNumericRange;
+    std::unique_ptr<NumericRangeSpec> _numeric_range = {};
     bool getRangeInternal(int64_t & low, int64_t & high) const noexcept;
     template <typename N>
     RangeResult<N> getIntegerRange() const noexcept;
     template <typename N>
     RangeResult<N>    getFloatRange() const noexcept;
-    int32_t     _rangeLimit;
-    uint32_t    _maxPerGroup;
-    uint32_t    _diversityCutoffGroups;
     Type        _type;
-    bool        _diversityCutoffStrict;
     bool        _valid;
 protected:
     bool        _fuzzy_prefix_match; // set in QueryTerm
 private:
     string      _term;
-    string_view   _diversityAttribute;
-    template <typename T, typename D>
-    bool    getAsNumericTerm(T & lower, T & upper, D d) const noexcept;
 
 protected:
     uint32_t    _fuzzy_max_edit_distance;  // set in QueryTerm
@@ -97,4 +97,3 @@ void visit(vespalib::ObjectVisitor &self, const std::string &name,
            const search::QueryTermSimple &obj);
 void visit(vespalib::ObjectVisitor &self, const std::string &name,
            const search::QueryTermSimple *obj);
-

--- a/searchlib/src/vespa/searchlib/query/query_term_ucs4.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_ucs4.cpp
@@ -18,6 +18,13 @@ QueryTermUCS4::~QueryTermUCS4() {
     }
 }
 
+QueryTermUCS4::QueryTermUCS4(Type type, std::unique_ptr<NumericRangeSpec> range)
+  : QueryTermSimple(type, std::move(range)),
+    _termUCS4(nullptr),
+    _cachedTermLen(0)
+{
+}
+
 QueryTermUCS4::QueryTermUCS4(const string & termS, Type type) :
     QueryTermSimple(termS, type),
     _termUCS4(nullptr),

--- a/searchlib/src/vespa/searchlib/query/query_term_ucs4.h
+++ b/searchlib/src/vespa/searchlib/query/query_term_ucs4.h
@@ -17,6 +17,7 @@ public:
     QueryTermUCS4(QueryTermUCS4 &&) = delete;
     QueryTermUCS4 & operator = (QueryTermUCS4 &&) = delete;
     QueryTermUCS4(const string & term_, Type type);
+    QueryTermUCS4(Type type, std::unique_ptr<NumericRangeSpec> range);
     ~QueryTermUCS4() override;
     uint32_t getTermLen() const { return _cachedTermLen; }
     uint32_t term(const char * & t)     const { t = getTerm(); return _cachedTermLen; }
@@ -36,4 +37,3 @@ private:
 };
 
 }
-

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
@@ -66,6 +66,20 @@ QueryTerm::visitMembers(vespalib::ObjectVisitor & visitor) const
     visit(visitor, "uniqueid", _uniqueId);
 }
 
+QueryTerm::QueryTerm(Type type, string index, std::unique_ptr<NumericRangeSpec> range)
+  : QueryTermUCS4(type, std::move(range)),
+    _hitList(),
+    _index(std::move(index)),
+    _result(),
+    _encoding(0x01),
+    _isRanked(false),
+    _filter(true),
+    _weight(100),
+    _uniqueId(0),
+    _fieldInfo()
+{
+}
+
 QueryTerm::QueryTerm(std::unique_ptr<QueryNodeResultBase> org, string_view termS, string indexS,
                      Type type, Normalizing normalizing)
     : QueryTermUCS4(QueryNormalization::optional_fold(termS, type, normalizing), type),

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
@@ -66,6 +66,7 @@ public:
         : QueryTerm(std::move(resultBase), term, std::move(index), type,
                     (type == Type::EXACTSTRINGTERM) ? Normalizing::LOWERCASE : Normalizing::LOWERCASE_AND_FOLD)
     {}
+    QueryTerm(Type type, string index, std::unique_ptr<NumericRangeSpec> range);
     QueryTerm(std::unique_ptr<QueryNodeResultBase> resultBase, string_view term, string index, Type type, Normalizing normalizing);
     QueryTerm(const QueryTerm &) = delete;
     QueryTerm & operator = (const QueryTerm &) = delete;
@@ -133,5 +134,3 @@ private:
 };
 
 }
-
-


### PR DESCRIPTION
This is the start of an attempt to fold lots of different code parsing, adjusting, and fooling around with numeric ranges into fewer consolidated pieces.  The actual behavior should be exactly the same for now.
Note that I've left a bunch of code unchanged but commented out - this is just to make the diff more readable.

@toregge please review
@havardpe FYI

should not be merged until Monday at the soonest.
