### PR TITLE
Increased Triton Onnx GRPC message size to 128 MIB from default 4 MIB

### DIFF
--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
@@ -43,7 +43,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 @Beta
 public class TritonOnnxClient implements AutoCloseable {
-    final int MAX_INBOUND_MESSAGE_SIZE_MIB = 32;
+    final int MAX_INBOUND_MESSAGE_SIZE_MIB = 128;
     private static final Logger log = Logger.getLogger(TritonOnnxClient.class.getName());
 
     private final GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingV2Stub grpcInferenceStub;

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
@@ -43,7 +43,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 @Beta
 public class TritonOnnxClient implements AutoCloseable {
-
+    final int MAX_INBOUND_MESSAGE_SIZE_MIB = 32;
     private static final Logger log = Logger.getLogger(TritonOnnxClient.class.getName());
 
     private final GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingV2Stub grpcInferenceStub;
@@ -59,6 +59,7 @@ public class TritonOnnxClient implements AutoCloseable {
     public TritonOnnxClient(TritonConfig config) {
         var ch = ManagedChannelBuilder.forTarget(config.target())
                 .usePlaintext()
+                .maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE_MIB * 1024 * 1024)
                 .build();
         this.grpcInferenceStub = GRPCInferenceServiceGrpc.newBlockingV2Stub(ch);
         this.grpcHealthStub = HealthGrpc.newBlockingV2Stub(ch);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
