### PR TITLE
set document frequency for word alternatives also

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/DocumentFrequency.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/DocumentFrequency.java
@@ -13,4 +13,7 @@ import com.yahoo.api.annotations.Beta;
  */
 @Beta
 public record DocumentFrequency(long frequency, long count) {
+    public final String toString() {
+        return "{frequency: " + frequency + ", count: " + count + "}";
+    }
 }


### PR DESCRIPTION
SignificanceSearcher needs to set DocumentFrequency for Word Alternatives - use least-common alternative to tag the entire item.

@glebashnik please review
@havardpe FYI
