### PR TITLE
MERGEOK Added Vespa Slack community link to README [MERGEOK]

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ or run your own Vespa instance: [https://docs.vespa.ai/en/getting-started.html](
 - [Vespa APIs](https://docs.vespa.ai/en/api.html) is useful to understand how to interface with Vespa
 - Explore the [sample applications](https://github.com/vespa-engine/sample-apps/tree/master)
 - Follow the [Vespa Blog](https://blog.vespa.ai/) for feature updates / use cases
+- Join the [Vespa Slack community](https://slack.vespa.ai/) to ask questions and share feedback
 
 Full documentation is at [https://docs.vespa.ai](https://docs.vespa.ai).
 


### PR DESCRIPTION
Added a link to the Vespa Slack community under the "Usage" section.  This helps new users and contributors easily find the community for questions, support and discussions.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
