### PR TITLE
Don't count RPC `TIMEOUT` code as a network error signal for statistics reporting

### DIFF
--- a/storage/src/tests/distributor/content_node_message_stats_test.cpp
+++ b/storage/src/tests/distributor/content_node_message_stats_test.cpp
@@ -52,13 +52,17 @@ TEST(ContentNodeMessageStatsTest, errors_are_categorized_based_on_result_code) {
     s.observe_incoming_response_result(id, static_cast<api::ReturnCode::Result>(mbus::ErrorCode::CONNECTION_ERROR));
     s.observe_incoming_response_result(id, static_cast<api::ReturnCode::Result>(mbus::ErrorCode::NETWORK_ERROR));
     s.observe_incoming_response_result(id, static_cast<api::ReturnCode::Result>(mbus::ErrorCode::NO_ADDRESS_FOR_SERVICE));
-    s.observe_incoming_response_result(id, api::ReturnCode::TIMEOUT);
     s.observe_incoming_response_result(id, api::ReturnCode::NOT_CONNECTED);
-    EXPECT_EQ(s.recv_network_error, 5);
+    EXPECT_EQ(s.recv_network_error, 4);
     s.observe_incoming_response_result(id, api::ReturnCode::STALE_TIMESTAMP);
     EXPECT_EQ(s.recv_clock_skew_error, 1);
     s.observe_incoming_response_result(id, api::ReturnCode::DISK_FAILURE);
     EXPECT_EQ(s.recv_other_error, 1);
+    // Timeouts may be due to both network problems and overloaded nodes, so
+    // count it under "other" since we can't really know this on the distributor.
+    s.observe_incoming_response_result(id, api::ReturnCode::TIMEOUT);
+    EXPECT_EQ(s.recv_network_error, 4); // unchanged
+    EXPECT_EQ(s.recv_other_error, 2);
 }
 
 TEST(ContentNodeMessageStatsTest, do_not_attribute_possible_transitive_errors_to_node) {

--- a/storage/src/vespa/storage/distributor/content_node_message_stats.cpp
+++ b/storage/src/vespa/storage/distributor/content_node_message_stats.cpp
@@ -50,11 +50,12 @@ constexpr bool is_rpc_related_error_code(api::ReturnCode::Result res) noexcept {
     const auto res_ignore_enum = static_cast<uint32_t>(res);
     switch (res_ignore_enum) {
     // See `StorageApiRpcService` for FRT RPC -> mbus/storage API error mapping.
-    // Whatever's assigned there for RPC-level errors should also be included here.
+    // Whatever's assigned there for RPC-level errors should also be included here
+    // (except timeouts, which may also happen due to deadline expiry for enqueued
+    // operations and would therefore be ambiguous).
     case mbus::ErrorCode::CONNECTION_ERROR:
     case mbus::ErrorCode::NETWORK_ERROR:
     case mbus::ErrorCode::NO_ADDRESS_FOR_SERVICE:
-    case api::ReturnCode::TIMEOUT:
     case api::ReturnCode::NOT_CONNECTED:
         return true;
     default:


### PR DESCRIPTION
@havardpe please review

If an operation reaches its deadline in the content node persistence queues, it will be automatically and immediately failed out with a `TIMEOUT` response code. This means that observing this code at a higher level does not necessarily mean that a network error condition exists; there could just as well be an overload condition.
