### PR TITLE
Rename "status" to "state" in reported attribute initialization status

### DIFF
--- a/searchlib/src/tests/searchcommon/attribute/initialization_status/attribute_initialization_status_test.cpp
+++ b/searchlib/src/tests/searchcommon/attribute/initialization_status/attribute_initialization_status_test.cpp
@@ -112,7 +112,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_queued) {
 
     EXPECT_EQ(slime.get().children(), 2);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
-    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("queued"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("queued"));
 }
 
 TEST(AttributeInitializationStatusTest, test_reporting_loading) {
@@ -125,7 +125,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_loading) {
 
     EXPECT_EQ(slime.get().children(), 3);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
-    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loading"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("loading"));
     EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
 }
@@ -141,7 +141,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_loaded) {
 
     EXPECT_EQ(slime.get().children(), 4);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
-    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loaded"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("loaded"));
     EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
     EXPECT_EQ(slime.get()["end_time"].asString().make_string(),
@@ -160,7 +160,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_reprocessing) {
 
     EXPECT_EQ(slime.get().children(), 5);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
-    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("reprocessing"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("reprocessing"));
     EXPECT_EQ(slime.get()["reprocess_progress"].asString().make_string(), "0.420000");
     EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
@@ -181,7 +181,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_reprocessing_loading) {
 
     EXPECT_EQ(slime.get().children(), 6);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
-    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loading"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("loading"));
     EXPECT_EQ(slime.get()["reprocess_progress"].asString().make_string(), "1.000000");
     EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));
@@ -205,7 +205,7 @@ TEST(AttributeInitializationStatusTest, test_reporting_reprocessing_loaded) {
 
     EXPECT_EQ(slime.get().children(), 7);
     EXPECT_EQ(slime.get()["name"].asString().make_string(), std::string("testAttribute"));
-    EXPECT_EQ(slime.get()["status"].asString().make_string(), std::string("loaded"));
+    EXPECT_EQ(slime.get()["state"].asString().make_string(), std::string("loaded"));
     EXPECT_EQ(slime.get()["reprocess_progress"].asString().make_string(), "1.000000");
     EXPECT_EQ(slime.get()["start_time"].asString().make_string(),
               AttributeInitializationStatus::timepoint_to_string(status.get_start_time()));

--- a/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/attribute_initialization_status.cpp
@@ -115,7 +115,7 @@ void AttributeInitializationStatus::report_initialization_status(const vespalib:
     vespalib::slime::Cursor &cursor = inserter.insertObject();
     cursor.setString("name", _name);
 
-    cursor.setString("status", state_to_string(_state));
+    cursor.setString("state", state_to_string(_state));
 
     if (_state >= State::LOADING && _was_reprocessed) {
         cursor.setString("reprocess_progress",  std::format("{:.6f}", _reprocessing_percentage));


### PR DESCRIPTION
This brings the attribute state in line with the other reported states.