### PR TITLE
Arnej/java 21 profiles

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -36,6 +36,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>${vespaClients.jdk.releaseVersion}</release>
+          <compilerArgs>-Werror</compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -335,10 +335,45 @@
         </profile>
         <profile>
             <id>ffm-preview</id>
-            <activation><jdk>[19,22)</jdk></activation>
+            <activation><jdk>[21,22)</jdk></activation>
             <properties>
                 <ffm.args>--enable-preview --enable-native-access=ALL-UNNAMED</ffm.args>
+                <org.apache.datasketches.memory.vespa.version>6.0.0</org.apache.datasketches.memory.vespa.version>
+                <org.apache.datasketches.vespa.version>8.0.0</org.apache.datasketches.vespa.version>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <release>21</release>
+                                <compilerArgs>
+                                <arg>--enable-preview</arg>
+                                <arg>-Xlint:all</arg>
+                                <arg>-Xlint:-this-escape</arg>
+                                <arg>-Xlint:-preview</arg>
+                                <arg>-Xlint:-serial</arg>
+                                <arg>-Xlint:-try</arg>
+                                <arg>-Xlint:-processing</arg>
+                                <arg>-Werror</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <release>21</release>
+                                <additionalJOptions>
+                                    <additionalJOption>--enable-preview</additionalJOption>
+                                </additionalJOptions>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>attach-sources</id>
@@ -454,24 +489,24 @@
                 </plugins>
             </build>
         </profile>
-	<profile>
-	    <id>java17VespaCompilerArgs</id>
-	    <activation>
-		<jdk>[1,21)</jdk>
-	    </activation>
-	    <properties>
-		<vespaCompilerArgs.xlint>-Xlint:all</vespaCompilerArgs.xlint>
-	    </properties>
-	</profile>
-	<profile>
-	    <id>java21VespaCompilerArgs</id>
-	    <activation>
-		<jdk>[21,25)</jdk>
-	    </activation>
-	    <properties>
-		<vespaCompilerArgs.xlint>-Xlint:all,-this-escape</vespaCompilerArgs.xlint>
-	    </properties>
-	</profile>
+        <profile>
+            <id>java17VespaCompilerArgs</id>
+            <activation>
+                <jdk>[1,21)</jdk>
+            </activation>
+            <properties>
+                <vespaCompilerArgs.xlint>-Xlint:all</vespaCompilerArgs.xlint>
+            </properties>
+        </profile>
+        <profile>
+            <id>java21VespaCompilerArgs</id>
+            <activation>
+                <jdk>[21,25)</jdk>
+            </activation>
+            <properties>
+                <vespaCompilerArgs.xlint>-Xlint:all,-this-escape</vespaCompilerArgs.xlint>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -86,7 +86,7 @@
                         <showWarnings>true</showWarnings>
                         <showDeprecation>false</showDeprecation>
                         <compilerArgs>
-                            <arg>${vespaCompilerArgs.xlint}</arg>
+                            <arg>-Xlint:all</arg>
                             <arg>-Xlint:-serial</arg>
                             <arg>-Xlint:-try</arg>
                             <arg>-Xlint:-processing</arg>
@@ -488,24 +488,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>java17VespaCompilerArgs</id>
-            <activation>
-                <jdk>[1,21)</jdk>
-            </activation>
-            <properties>
-                <vespaCompilerArgs.xlint>-Xlint:all</vespaCompilerArgs.xlint>
-            </properties>
-        </profile>
-        <profile>
-            <id>java21VespaCompilerArgs</id>
-            <activation>
-                <jdk>[21,25)</jdk>
-            </activation>
-            <properties>
-                <vespaCompilerArgs.xlint>-Xlint:all,-this-escape</vespaCompilerArgs.xlint>
-            </properties>
         </profile>
     </profiles>
 

--- a/vespa-feed-client-api/pom.xml
+++ b/vespa-feed-client-api/pom.xml
@@ -42,6 +42,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>${vespaClients.jdk.releaseVersion}</release>
+          <compilerArgs>-Werror</compilerArgs>
           <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>

--- a/vespa-feed-client-cli/pom.xml
+++ b/vespa-feed-client-cli/pom.xml
@@ -53,6 +53,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>${vespaClients.jdk.releaseVersion}</release>
+          <compilerArgs>-Werror</compilerArgs>
           <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>

--- a/vespa-feed-client/pom.xml
+++ b/vespa-feed-client/pom.xml
@@ -104,6 +104,7 @@
             <configuration>
               <release>${vespaClients.jdk.releaseVersion}</release>
               <showDeprecation>true</showDeprecation>
+              <compilerArgs>-Werror</compilerArgs>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
note: the various "client" packages needed an override of compilerArgs because they use their own `<release>` setting.

@bjorncs please review
@gjoranv @johansolbakken FYI
