### PR TITLE
fix: specify version of javadoc plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -134,6 +134,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.vespa.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>${maven-plugin-tools.vespa.version}</version>
                     <configuration>


### PR DESCRIPTION
The version was not defined causing Maven to output a warning for each sub-module.