### PR TITLE
Refactor add global options for selecting command in `vespa-significance` tool

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -10,7 +10,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 
-import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 
 /**
@@ -28,6 +29,38 @@ public class CommandLineOptions {
     public static final String ZST_COMPRESSION = "zst-compression";
 
     private final Options options = createOptions();
+
+    /** Options for selecting subcommand */
+    static Options createGlobalOptions() {
+        Options options = new Options();
+
+        options.addOption(Option.builder("h")
+                .longOpt("help")
+                .desc("Show available commands.")
+                .build());
+
+        return options;
+    }
+
+    /** Map command name to description */
+    static Map<String, String> registeredCommands() {
+        Map<String, String> commands = new LinkedHashMap<>();
+        commands.put("generate", "Generate a significance model from a JSONL feed file.");
+        return commands;
+    }
+
+    /** Pretty print the global help */
+    static void printGlobalHelp() {
+        HelpFormatter fmt = new HelpFormatter();
+        fmt.setWidth(100);
+        fmt.setLeftPadding(2);
+
+        StringBuilder header = new StringBuilder("Commands:\n");
+        registeredCommands().forEach((name, desc) -> header.append(String.format("  %-12s %s%n", name, desc)));
+        header.append("\nOptions:");
+
+        fmt.printHelp("vespa-significance <command>", header.toString(), createGlobalOptions(), "", true);
+    }
 
     @SuppressWarnings("AccessStaticViaInstance")
     private static Options createOptions() {

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
@@ -2,30 +2,55 @@
 
 package com.yahoo.vespasignificance;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.ParseException;
+
 import java.io.IOException;
-import java.util.List;
+import java.util.Arrays;
+
+import static com.yahoo.vespasignificance.CommandLineOptions.createGlobalOptions;
+import static com.yahoo.vespasignificance.CommandLineOptions.printGlobalHelp;
 
 /**
  * The vespa-significance tool generates significance models based on input feed files.
  *
  * @author MariusArhaug
  */
-
 public class Main {
 
     public static void main(String[] args) {
+        var parser = new DefaultParser();
+        CommandLine global;
         try {
-            if (args.length == 0) {
-                System.err.println("No arguments provided. Use --help to see available options.");
-                System.exit(1);
-            }
+            global = parser.parse(createGlobalOptions(), args, true);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
 
-            if (!args[0].equals("generate")) {
-                System.err.println("Invalid command. Use 'generate' to generate significance models.");
-                System.exit(1);
-            }
-            String[] commandLineArgs = List.of(args).subList(1, args.length).toArray(new String[0]);
+        String[] remaining = global.getArgs();
+        if (remaining.length == 0 || global.hasOption("help")) {
+            printGlobalHelp();
+            return;
+        }
 
+
+        String sub = remaining[0];
+        String[] subArgs = Arrays.copyOfRange(remaining, 1, remaining.length);
+        switch (sub) {
+            case "generate":
+                runGenerate(subArgs);
+                break;
+
+            default:
+                System.err.println("Error: Unknown command `" + sub + "`");
+                printGlobalHelp();
+                break;
+        }
+    }
+
+    static void runGenerate(String[] commandLineArgs) {
+        try {
             CommandLineOptions options = new CommandLineOptions();
             ClientParameters params = options.parseCommandLineArguments(commandLineArgs);
 


### PR DESCRIPTION
Before this change, providing no input to `vespa-significance` said use `--help`, but providing `--help` did not print any help message, only that `generate` was not provided.

This change makes `vespa-significance` extensible for additional commands and enhances the feedback provided by the tool. Motivated by functionality for generating significance model from indexes.

```shell
$ vespa-significance -h
usage: vespa-significance <command> [-h]
Commands:
  generate     Generate a significance model from a JSONL feed file.

Options:
  -h,--help   Show available commands.
```
