### PR TITLE
Give more memory to cluster controllers in Vespa cloud

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
@@ -44,7 +44,12 @@ public class ClusterControllerContainerCluster extends ContainerCluster<ClusterC
     public void getConfig(QrStartConfig.Builder builder) {
         super.getConfig(builder);
 
-        builder.jvm.heapsize(128);
+        if (isHostedVespa()) {
+            // In hosted Vespa we have more memory available, so we can use a larger heap
+            builder.jvm.heapsize(192);
+        } else {
+            builder.jvm.heapsize(128);
+        }
     }
 
     public ReindexingContext reindexingContext() { return reindexingContext; }


### PR DESCRIPTION
Nodes should have more than 1.3 GiB memory, so should be safe to use a sightly larger heap.