### PR TITLE
add FakeIndex for visual test input building

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -203,6 +203,7 @@ vespa_define_module(
     src/tests/queryeval/dot_product
     src/tests/queryeval/equiv
     src/tests/queryeval/exact_nearest_neighbor
+    src/tests/queryeval/fake_index
     src/tests/queryeval/fake_searchable
     src/tests/queryeval/filter_search
     src/tests/queryeval/flow

--- a/searchlib/src/tests/queryeval/fake_index/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/fake_index/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchlib_fake_index_test_app TEST
+    SOURCES
+    fake_index_test.cpp
+    DEPENDS
+    vespa_searchlib
+    GTest::gtest
+)
+vespa_add_test(NAME searchlib_fake_index_test_app COMMAND searchlib_fake_index_test_app)

--- a/searchlib/src/tests/queryeval/fake_index/fake_index_test.cpp
+++ b/searchlib/src/tests/queryeval/fake_index/fake_index_test.cpp
@@ -1,0 +1,71 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/searchlib/queryeval/fake_index.h>
+
+using namespace search::queryeval;
+
+TEST(FakeIndexTest, require_that_basic_fake_index_works) {
+    FakeIndex index;
+    index.doc(69).elem(0, "..A..B..")
+                 .elem(1, ".C...D..");
+
+    auto a_result = index.lookup('A');
+    auto expected_a = FakeResult().doc(69).elem(0).len(8).pos(2);
+    EXPECT_EQ(a_result, expected_a);
+
+    auto b_result = index.lookup('B');
+    auto expected_b = FakeResult().doc(69).elem(0).len(8).pos(5);
+    EXPECT_EQ(b_result, expected_b);
+
+    auto c_result = index.lookup('C');
+    auto expected_c = FakeResult().doc(69).elem(1).len(8).pos(1);
+    EXPECT_EQ(c_result, expected_c);
+
+    auto d_result = index.lookup('D');
+    auto expected_d = FakeResult().doc(69).elem(1).len(8).pos(5);
+    EXPECT_EQ(d_result, expected_d);
+}
+
+TEST(FakeIndexTest, require_that_multiple_documents_work) {
+    FakeIndex index;
+    index.doc(10).elem(0, "A.B")
+         .doc(20).elem(0, "..A");
+
+    auto a_result = index.lookup('A');
+    auto expected_a = FakeResult().doc(10).elem(0).len(3).pos(0)
+                                  .doc(20).elem(0).len(3).pos(2);
+    EXPECT_EQ(a_result, expected_a);
+
+    auto b_result = index.lookup('B');
+    auto expected_b = FakeResult().doc(10).elem(0).len(3).pos(2);
+    EXPECT_EQ(b_result, expected_b);
+}
+
+TEST(FakeIndexTest, require_that_multiple_occurrences_in_same_element_work) {
+    FakeIndex index;
+    index.doc(69).elem(0, "A.A.A");
+
+    auto a_result = index.lookup('A');
+    auto expected_a = FakeResult().doc(69).elem(0).len(5).pos(0).pos(2).pos(4);
+    EXPECT_EQ(a_result, expected_a);
+}
+
+TEST(FakeIndexTest, require_that_empty_lookup_returns_empty_result) {
+    FakeIndex index;
+    index.doc(69).elem(0, "..A..B..");
+
+    auto z_result = index.lookup('Z');
+    EXPECT_EQ(z_result, FakeResult());
+}
+
+TEST(FakeIndexTest, require_that_dots_are_skipped) {
+    FakeIndex index;
+    index.doc(69).elem(0, "......");
+
+    // No terms should be registered
+    auto result = index.lookup('.');
+    EXPECT_EQ(result, FakeResult());
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
@@ -16,6 +16,7 @@ vespa_add_library(searchlib_queryeval OBJECT
     equivsearch.cpp
     exact_nearest_neighbor_iterator.cpp
     executeinfo.cpp
+    fake_index.cpp
     fake_requestcontext.cpp
     fake_result.cpp
     fake_search.cpp

--- a/searchlib/src/vespa/searchlib/queryeval/fake_index.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_index.cpp
@@ -1,0 +1,49 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "fake_index.h"
+
+namespace search::queryeval {
+
+FakeIndex::FakeIndex()
+    : _current_doc(0),
+      _terms()
+{
+}
+
+FakeIndex&
+FakeIndex::doc(uint32_t docid)
+{
+    _current_doc = docid;
+    return *this;
+}
+
+FakeIndex&
+FakeIndex::elem(uint32_t element_id, const std::string& layout)
+{
+    uint32_t len = layout.size();
+    for (size_t pos = 0; pos < layout.size(); ++pos) {
+        char ch = layout[pos];
+        if (ch != '.') {
+            auto& result = _terms[ch];
+            if (result.inspect().empty() || result.inspect().back().docId != _current_doc) {
+                result.doc(_current_doc);
+            }
+            if (result.inspect().back().elements.empty() ||
+                result.inspect().back().elements.back().id != element_id) {
+                result.elem(element_id).len(len);
+            }
+            result.pos((uint32_t)pos);
+        }
+    }
+    return *this;
+}
+
+const FakeResult&
+FakeIndex::lookup(char ch) const
+{
+    static FakeResult empty;
+    auto it = _terms.find(ch);
+    return (it != _terms.end()) ? it->second : empty;
+}
+
+}

--- a/searchlib/src/vespa/searchlib/queryeval/fake_index.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_index.cpp
@@ -10,6 +10,8 @@ FakeIndex::FakeIndex()
 {
 }
 
+FakeIndex::~FakeIndex() = default;
+
 FakeIndex&
 FakeIndex::doc(uint32_t docid)
 {

--- a/searchlib/src/vespa/searchlib/queryeval/fake_index.h
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_index.h
@@ -28,6 +28,7 @@ private:
 
 public:
     FakeIndex();
+    ~FakeIndex();
 
     /**
      * Start adding data for a new document.

--- a/searchlib/src/vespa/searchlib/queryeval/fake_index.h
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_index.h
@@ -1,0 +1,53 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "fake_result.h"
+#include <map>
+#include <string>
+
+namespace search::queryeval {
+
+/**
+ * Visual test data builder for creating FakeResult objects from string layouts.
+ *
+ * Allows defining test data visually where each character position represents
+ * a term occurrence. Use '.' for empty positions and letters (A-Z, a-z) for terms.
+ *
+ * Example usage:
+ *   FakeIndex index;
+ *   index.doc(69).elem(0, "..A..B..")
+ *                .elem(1, ".C...D..");
+ *   auto a = index.lookup('A');  // FakeResult with A's positions
+ *   auto b = index.lookup('B');
+ */
+class FakeIndex {
+private:
+    uint32_t _current_doc;
+    std::map<char, FakeResult> _terms;
+
+public:
+    FakeIndex();
+
+    /**
+     * Start adding data for a new document.
+     * @param docid The document ID
+     */
+    FakeIndex& doc(uint32_t docid);
+
+    /**
+     * Add an element with visual layout.
+     * @param element_id The element ID
+     * @param layout String where each character is either '.' (empty) or a term letter
+     */
+    FakeIndex& elem(uint32_t element_id, const std::string& layout);
+
+    /**
+     * Lookup the FakeResult for a given term character.
+     * @param ch The term character
+     * @return FakeResult containing all occurrences of this term
+     */
+    const FakeResult& lookup(char ch) const;
+};
+
+}


### PR DESCRIPTION
FakeIndex allows building test data visually using string layouts where each character position represents a term occurrence. Use '.' for empty positions and letters (A-Z, a-z) for terms.

Example usage:
  FakeIndex index;
  index.doc(69).elem(0, "..A..B..")
               .elem(1, ".C...D..");
  auto a = index.lookup('A');  // FakeResult with A's positions

This makes it much easier to understand and maintain test data by visualizing the layout of terms within elements.

@toregge please review