### PR TITLE
Use HTTP `Accept` header from client to select JSONL response format

### DIFF
--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -853,6 +853,9 @@
       "public com.yahoo.container.jdisc.RequestHandlerTestDriver$MockResponseHandler sendRequest(java.lang.String, com.yahoo.jdisc.http.HttpRequest$Method, java.lang.String, java.lang.String)",
       "public com.yahoo.container.jdisc.RequestHandlerTestDriver$MockResponseHandler sendRequest(java.lang.String, com.yahoo.jdisc.http.HttpRequest$Method, java.nio.ByteBuffer)",
       "public com.yahoo.container.jdisc.RequestHandlerTestDriver$MockResponseHandler sendRequest(java.lang.String, com.yahoo.jdisc.http.HttpRequest$Method, java.nio.ByteBuffer, java.lang.String)",
+      "public com.yahoo.container.jdisc.RequestHandlerTestDriver$MockResponseHandler sendRequest(com.yahoo.jdisc.Request, java.nio.ByteBuffer)",
+      "public com.yahoo.jdisc.Request createRequest(java.lang.String, com.yahoo.jdisc.http.HttpRequest$Method)",
+      "public com.yahoo.container.jdisc.RequestHandlerTestDriver$MockResponseHandler sendRequest(com.yahoo.jdisc.Request, java.lang.String)",
       "public java.lang.String censorDigits(java.lang.String)"
     ],
     "fields" : [ ]

--- a/container-core/src/main/java/com/yahoo/container/jdisc/RequestHandlerTestDriver.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/RequestHandlerTestDriver.java
@@ -96,6 +96,24 @@ public class RequestHandlerTestDriver implements AutoCloseable {
         return responseHandler;
     }
 
+    public MockResponseHandler sendRequest(Request request, ByteBuffer body) {
+        var responseHandler = new MockResponseHandler();
+        ContentChannel requestContent = request.connect(responseHandler);
+        requestContent.write(body, null);
+        requestContent.close(null);
+        request.release();
+        this.responseHandler = responseHandler;
+        return responseHandler;
+    }
+
+    public Request createRequest(String uri, HttpRequest.Method method) {
+        return HttpRequest.newServerRequest(driver, URI.create(uri), method);
+    }
+
+    public MockResponseHandler sendRequest(Request request, String body) {
+        return sendRequest(request, ByteBuffer.wrap(body.getBytes(StandardCharsets.UTF_8)));
+    }
+
     /** Replaces all occurrences of 0-9 digits by d's */
     public String censorDigits(String s) {
         return s.replaceAll("[0-9]","d");


### PR DESCRIPTION
@bjorncs please review

We only return JSONL if the client explicitly indicates it accepts the `application/jsonl` media type, and only if the `application/json` type is not specified with a greater preference.

For backwards compatibility reasons we assume a client will always accept `application/json` if nothing is specified.

