### PR TITLE
Extract RootItem base class

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1452,6 +1452,33 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.prelude.query.RootItem" : {
+    "superClass" : "com.yahoo.prelude.query.CompositeItem",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>()",
+      "public void <init>(com.yahoo.prelude.query.Item)",
+      "public void setIndexName(java.lang.String)",
+      "public com.yahoo.prelude.query.Item$ItemType getItemType()",
+      "public java.lang.String getName()",
+      "public int encode(java.nio.ByteBuffer)",
+      "protected void appendHeadingString(java.lang.StringBuilder)",
+      "public com.yahoo.prelude.query.Item getRoot()",
+      "public final void setRoot(com.yahoo.prelude.query.Item)",
+      "public boolean equals(java.lang.Object)",
+      "public com.yahoo.prelude.query.RootItem clone()",
+      "public void addItem(com.yahoo.prelude.query.Item)",
+      "public void addItem(int, com.yahoo.prelude.query.Item)",
+      "public boolean isEmpty()",
+      "public bridge synthetic com.yahoo.prelude.query.CompositeItem clone()",
+      "public bridge synthetic com.yahoo.prelude.query.Item clone()",
+      "public bridge synthetic java.lang.Object clone()"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.prelude.query.SameElementItem" : {
     "superClass" : "com.yahoo.prelude.query.NonReducibleCompositeItem",
     "interfaces" : [ ],
@@ -5573,7 +5600,7 @@
     "fields" : [ ]
   },
   "com.yahoo.search.query.QueryTree" : {
-    "superClass" : "com.yahoo.prelude.query.CompositeItem",
+    "superClass" : "com.yahoo.prelude.query.RootItem",
     "interfaces" : [ ],
     "attributes" : [
       "public"
@@ -5581,22 +5608,13 @@
     "methods" : [
       "public void <init>()",
       "public void <init>(com.yahoo.prelude.query.Item)",
-      "public void setIndexName(java.lang.String)",
-      "public com.yahoo.prelude.query.Item$ItemType getItemType()",
-      "public java.lang.String getName()",
-      "public int encode(java.nio.ByteBuffer)",
-      "protected void appendHeadingString(java.lang.StringBuilder)",
-      "public com.yahoo.prelude.query.Item getRoot()",
-      "public final void setRoot(com.yahoo.prelude.query.Item)",
       "public boolean equals(java.lang.Object)",
       "public com.yahoo.search.query.QueryTree clone()",
-      "public void addItem(com.yahoo.prelude.query.Item)",
-      "public void addItem(int, com.yahoo.prelude.query.Item)",
-      "public boolean isEmpty()",
       "public com.yahoo.prelude.query.Item withRank(com.yahoo.prelude.query.Item)",
       "public com.yahoo.prelude.query.Item and(com.yahoo.prelude.query.Item)",
       "public static java.util.List getPositiveTerms(com.yahoo.prelude.query.Item)",
       "public int treeSize()",
+      "public bridge synthetic com.yahoo.prelude.query.RootItem clone()",
       "public bridge synthetic com.yahoo.prelude.query.CompositeItem clone()",
       "public bridge synthetic com.yahoo.prelude.query.Item clone()",
       "public bridge synthetic java.lang.Object clone()"

--- a/container-search/src/main/java/com/yahoo/prelude/query/CompositeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/CompositeItem.java
@@ -57,6 +57,7 @@ public abstract class CompositeItem extends Item {
     protected void adding(Item item) {
         Validator.ensureNotNull("A composite item child", item);
         Validator.ensure("Attempted to add a composite to itself", item != this);
+        Validator.ensure("Cannot add a RootItem as a child", !(item instanceof RootItem));
         if (item instanceof CompositeItem) {
             ensureNotInSubtree((CompositeItem) item);
         }

--- a/container-search/src/main/java/com/yahoo/prelude/query/RootItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/RootItem.java
@@ -1,0 +1,105 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.query;
+
+import java.nio.ByteBuffer;
+
+/**
+ * The root node of a query tree. This is always present above the actual semantic root to ease query manipulation,
+ * especially replacing the actual semantic root, but does not have any search semantics on its own.
+ *
+ * <p>To ease recursive manipulation of the query tree, this is a composite having one child, which is the actual root.
+ * <ul>
+ * <li>Setting the root item (at position 0, either directly or though the iterator of this, works as expected.
+ * Setting at any other position is disallowed.
+ * <li>Removing the root is allowed and causes this to be a null query.
+ * <li>Adding an item is only allowed if this is currently a null query (having no root)
+ * </ul>
+ *
+ * @author Arne Bergene Fossaa
+ */
+public class RootItem extends CompositeItem {
+
+    public RootItem() {
+        setRoot(new NullItem());
+    }
+
+    public RootItem(Item root) {
+        setRoot(root);
+    }
+
+    @Override
+    public void setIndexName(String index) {
+        if (getRoot() != null)
+            getRoot().setIndexName(index);
+    }
+
+    @Override
+    public ItemType getItemType() {
+        throw new RuntimeException("Packet type access attempted. A root item has no packet code. " +
+                                   "This is probably a misbehaving searcher.");
+    }
+
+    @Override
+    public String getName() { return "ROOT"; }
+
+    @Override
+    public int encode(ByteBuffer buffer) {
+        if (getRoot() == null) return 0;
+        return getRoot().encode(buffer);
+    }
+
+    // Let's not pollute toString() by adding "ROOT"
+    @Override
+    protected void appendHeadingString(StringBuilder sb) {
+    }
+
+    /** Returns the query root. This is null if this is a null query. */
+    public Item getRoot() {
+        if (getItemCount() == 0) return null;
+        return getItem(0);
+    }
+
+    public final void setRoot(Item root) {
+        if (root == this) throw new IllegalArgumentException("Cannot make a root point at itself");
+        if (root == null) throw new IllegalArgumentException("Root must not be null, use NullItem instead.");
+        if (root instanceof RootItem) throw new IllegalArgumentException("Do not use a new RootItem instance as a root.");
+        if (this.getItemCount() == 0) // initializing
+            super.addItem(root);
+        else
+            setItem(0, root); // replacing
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if( !(o instanceof RootItem)) return false;
+        return super.equals(o);
+    }
+
+    /** Returns a deep copy of this */
+    @Override
+    public RootItem clone() {
+        return (RootItem) super.clone();
+    }
+
+    @Override
+    public void addItem(Item item) {
+        if (getItemCount() == 0)
+            super.addItem(item);
+        else
+            throw new RuntimeException("Programming error: Cannot add multiple roots");
+    }
+
+    @Override
+    public void addItem(int index, Item item) {
+        if (getItemCount() == 0 && index == 0)
+            super.addItem(index, item);
+        else
+            throw new RuntimeException("Programming error: Cannot add multiple roots, have '" + getRoot() + "'");
+    }
+
+    /** Returns true if this represents the null query */
+    public boolean isEmpty() {
+        return getRoot() == null || getRoot() instanceof NullItem || getItemCount() == 0;
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
@@ -3,7 +3,6 @@ package com.yahoo.search.query;
 
 import com.yahoo.prelude.query.*;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -25,51 +24,14 @@ import java.util.ListIterator;
  *
  * @author Arne Bergene Fossaa
  */
-public class QueryTree extends CompositeItem {
+public class QueryTree extends RootItem {
 
     public QueryTree() {
-        setRoot(new NullItem());
+        super();
     }
 
     public QueryTree(Item root) {
-        setRoot(root);
-    }
-
-    public void setIndexName(String index) {
-        if (getRoot() != null)
-            getRoot().setIndexName(index);
-    }
-
-    public ItemType getItemType() {
-        throw new RuntimeException("Packet type access attempted. A query tree has no packet code. " + 
-                                   "This is probably a misbehaving searcher.");
-    }
-
-    public String getName() { return "ROOT"; }
-
-    public int encode(ByteBuffer buffer) {
-        if (getRoot() == null) return 0;
-        return getRoot().encode(buffer);
-    }
-
-    // Let's not pollute toString() by adding "ROOT"
-    protected void appendHeadingString(StringBuilder sb) {
-    }
-
-    /** Returns the query root. This is null if this is a null query. */
-    public Item getRoot() {
-        if (getItemCount() == 0) return null;
-        return getItem(0);
-    }
-
-    public final void setRoot(Item root) {
-        if (root == this) throw new IllegalArgumentException("Cannot make a root point at itself");
-        if (root == null) throw new IllegalArgumentException("Root must not be null, use NullItem instead.");
-        if (root instanceof QueryTree) throw new IllegalArgumentException("Do not use a new QueryTree instance as a root.");
-        if (this.getItemCount() == 0) // initializing
-            super.addItem(root);
-        else
-            setItem(0, root); // replacing
+        super(root);
     }
 
     @Override
@@ -88,27 +50,6 @@ public class QueryTree extends CompositeItem {
 
     private void fixClonedConnectivityReferences(QueryTree clone) {
         // TODO!
-    }
-
-    @Override
-    public void addItem(Item item) {
-        if (getItemCount() == 0)
-            super.addItem(item);
-        else
-            throw new RuntimeException("Programming error: Cannot add multiple roots");
-    }
-
-    @Override
-    public void addItem(int index, Item item) {
-        if (getItemCount() == 0 && index == 0)
-            super.addItem(index, item);
-        else
-            throw new RuntimeException("Programming error: Cannot add multiple roots, have '" + getRoot() + "'");
-    }
-
-    /** Returns true if this represents the null query */
-    public boolean isEmpty() {
-        return getRoot() == null || getRoot() instanceof NullItem || getItemCount() == 0;
     }
 
     // -------------- Facade

--- a/container-search/src/test/java/com/yahoo/prelude/query/FakeWSItem.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/FakeWSItem.java
@@ -1,0 +1,19 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.query;
+
+/** A fake weighted set item for testing purposes. */
+public class FakeWSItem extends CompositeIndexedItem {
+
+    public FakeWSItem() { setIndexName("index"); }
+    @Override public ItemType getItemType() { return ItemType.WEIGHTEDSET; }
+    @Override public String getName() { return "WEIGHTEDSET"; }
+    @Override public int getNumWords() { return 1; }
+    @Override public String getIndexedString() { return ""; }
+
+    public void add(String token, int weight) {
+        WordItem w = new WordItem(token, getIndexName());
+        w.setWeight(weight);
+        super.addItem(w);
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/prelude/query/MockItem.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/MockItem.java
@@ -1,0 +1,23 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.query;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A mock query item for testing purposes.
+ *
+ * @author Tony Vaagenes
+ */
+public class MockItem extends Item {
+
+    private final String name;
+
+    public MockItem(String name) { this.name = name; }
+    @Override public void setIndexName(String index) { }
+    @Override public ItemType getItemType() { return null; }
+    @Override public String getName() { return name; }
+    @Override public int encode(ByteBuffer buffer) { return 0; }
+    @Override public int getTermCount() { return 0; }
+    @Override protected void appendBodyString(StringBuilder buffer) { }
+
+}

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/WeightedSetItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/WeightedSetItemTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.prelude.query.test;
 
 import com.yahoo.prelude.query.CompositeIndexedItem;
+import com.yahoo.prelude.query.FakeWSItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.PureWeightedString;
 import com.yahoo.prelude.query.WeightedSetItem;
@@ -57,20 +58,6 @@ public class WeightedSetItemTestCase {
         assertEquals(Integer.valueOf(-10), ws.addToken("bad", -10));
         assertEquals(1, ws.getNumTokens());
         assertEquals(Integer.valueOf(-10), ws.getTokenWeight("bad"));
-    }
-
-    static class FakeWSItem extends CompositeIndexedItem {
-        public FakeWSItem() { setIndexName("index"); }
-        public ItemType getItemType() { return ItemType.WEIGHTEDSET; }
-        public String getName() { return "WEIGHTEDSET"; }
-        public int getNumWords() { return 1; }
-        public String getIndexedString() { return ""; }
-
-        public void add(String token, int weight) {
-            WordItem w = new WordItem(token, getIndexName());
-            w.setWeight(weight);
-            super.addItem(w);
-        }
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/query/textualrepresentation/test/TextualQueryRepresentationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/textualrepresentation/test/TextualQueryRepresentationTestCase.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.MockItem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.yahoo.prelude.query.textualrepresentation.Discloser;
@@ -27,42 +28,6 @@ public class TextualQueryRepresentationTestCase {
 
     private enum ExampleEnum {
         example;
-    }
-
-    private static class MockItem extends Item {
-        private final String name;
-
-        @Override
-        public void setIndexName(String index) {
-        }
-
-        @Override
-        public ItemType getItemType() {
-            return null;
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public int encode(ByteBuffer buffer) {
-            return 0;
-        }
-
-        @Override
-        public int getTermCount() {
-            return 0;
-        }
-
-        @Override
-        protected void appendBodyString(StringBuilder buffer) {
-        }
-
-        MockItem(String name) {
-            this.name = name;
-        }
     }
 
     private final Item basic = new MockItem("basic") {


### PR DESCRIPTION
Create new RootItem class containing root item functionality from QueryTree, making QueryTree extend RootItem.
Also extract MockItem and FakeWSItem from test cases to correct package.

the reason for this is that I want to add Protobuf Serialization as package-private methods; also I think it reads better that QueryTree is a RootItem rather than CompositeItem directly.

@bratseth please review
@bjorncs FYI
