### PR TITLE
Don't limit HostName to 63 characters

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/HostName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/HostName.java
@@ -7,17 +7,17 @@ import static ai.vespa.validation.Validation.require;
 import static ai.vespa.validation.Validation.requireLength;
 
 /**
- * Hostnames match {@link #domainNamePattern}, and are restricted to 64 characters in length.
+ * Fully qualified (FQDN) hostnames are DNS names ({@link #domainNamePattern}).
  *
- * @author jonmv
+ * <p>To allow long FQDN hostnames, the Linux kernel hostname should be set to the leaf label only
+ * (because it has a limitation of 64 characters), and system and DNS should be configured to resolve the FQDN hostname.</p>
+ *
+ * @author Jon Marius Venstad
  */
 public class HostName extends DomainName {
 
     private HostName(String value) {
-        super(requireLength(require( ! value.endsWith("."),
-                                     value, "hostname cannot end with '.'"),
-                            "hostname length", 1, 64),
-              "hostname");
+        super(require( ! value.endsWith("."), value, "hostname cannot end with '.'"), "hostname");
     }
 
     public static HostName of(String value) {

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/HostNameTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/HostNameTest.java
@@ -1,8 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
+import org.bouncycastle.oer.its.ieee1609dot2.basetypes.Hostname;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -27,8 +29,14 @@ public class HostNameTest {
         assertThrows(IllegalArgumentException.class, () -> HostName.of("foo.-.bar"));
         assertThrows(IllegalArgumentException.class, () -> HostName.of("foo/"));
         assertThrows(IllegalArgumentException.class, () -> HostName.of("foo%"));
-        assertThrows(IllegalArgumentException.class, () -> HostName.of(("." + "a".repeat(32)).repeat(2).substring(1, 66)));
+        HostName.of("a".repeat(63));
         assertThrows(IllegalArgumentException.class, () -> HostName.of("a".repeat(64)));
+
+        int r = 8;
+        String longHostname = ("." + "a".repeat(31)).repeat(r).substring(1, 32 * r);
+        assertEquals(255, longHostname.length());
+        HostName.of(longHostname);
+        assertThrows(IllegalArgumentException.class, () -> HostName.of(longHostname + "z"));
     }
 
 }


### PR DESCRIPTION
In Azure and now K8s long FQDN hostnames are supported by the hosts, which means HostName must allow up to 255 characters.

In Yahoo, AWS, and GCP we are limited to 64 character hostnames because the host's hostname is the FQDN.  But it should be possible to do the same as in Azure, at least in AWS and GCP. 

In any case, the limitation on HostName to 63 is too restrictive.