### PR TITLE
Reset CC node state and resource usage metrics on leadership loss edge

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricDimensionNames.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricDimensionNames.java
@@ -1,0 +1,16 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+/**
+ * Predefined set of dimension names used by various cluster controller metrics.
+ *
+ * @author vekterli
+ */
+class MetricDimensionNames {
+    static final String CLUSTER = "cluster";
+    static final String CLUSTER_ID = "clusterid";
+    static final String CONTROLLER_INDEX = "controller-index";
+    static final String NODE_TYPE = "node-type";
+    static final String DID_WORK = "didWork";
+    static final String WORK_ID = "workId";
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricNames.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricNames.java
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+/**
+ * Set of names of the metrics emitted by the cluster controller.
+ *
+ * Note that these metric names will be implicitly prefixed with the
+ * string "cluster-controller." when updated via MetricUpdater.
+ *
+ * @author vekterli
+ */
+class MetricNames {
+    static final String AGREED_MASTER_VOTES = "agreed-master-votes";
+    static final String AVAILABLE_NODES_RATIO = "available-nodes.ratio";
+    static final String BUSY_TICK_TIME_MS = "busy-tick-time-ms";
+    static final String CLUSTER_BUCKETS_OUT_OF_SYNC_RATIO = "cluster-buckets-out-of-sync-ratio";
+    static final String CLUSTER_CONTROLLER = "cluster-controller";
+    static final String CLUSTER_STATE_CHANGE = "cluster-state-change";
+    static final String IDLE_TICK_TIME_MS = "idle-tick-time-ms";
+    static final String IS_MASTER = "is-master";
+    static final String NODES_NOT_CONVERGED = "nodes-not-converged";
+    static final String NODE_EVENT = "node-event";
+    static final String REMOTE_TASK_QUEUE_SIZE = "remote-task-queue.size";
+    static final String STORED_DOCUMENT_BYTES = "stored-document-bytes";
+    static final String STORED_DOCUMENT_COUNT = "stored-document-count";
+    static final String WORK_MS = "work-ms";
+
+    static class ResourceUsage {
+        static final String DISK_LIMIT = "resource_usage.disk_limit";
+        static final String MAX_DISK_UTILIZATION = "resource_usage.max_disk_utilization";
+        static final String MAX_MEMORY_UTILIZATION = "resource_usage.max_memory_utilization";
+        static final String MEMORY_LIMIT = "resource_usage.memory_limit";
+        static final String NODES_ABOVE_LIMIT = "resource_usage.nodes_above_limit";
+    }
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
@@ -229,4 +229,40 @@ public class MetricReporterTest {
         verify(f.mockReporter).set(eq("cluster-controller.stored-document-bytes"), eq(6789000L), any());
     }
 
+    @Test
+    void leadership_loss_edge_resets_cluster_metrics() {
+        Fixture f = new Fixture();
+        f.metricUpdater.updateMasterState(false);
+
+        // Node state counts are reset
+        verify(f.mockReporter).set(eq("cluster-controller.up.count"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("distributor"))));
+        verify(f.mockReporter).set(eq("cluster-controller.up.count"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("storage"))));
+        verify(f.mockReporter).set(eq("cluster-controller.down.count"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("distributor"))));
+        verify(f.mockReporter).set(eq("cluster-controller.down.count"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("storage"))));
+        verify(f.mockReporter).set(eq("cluster-controller.maintenance.count"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("storage"))));
+
+        // Non-convergence metrics are reset
+        verify(f.mockReporter).set(eq("cluster-controller.nodes-not-converged"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("distributor"))));
+        verify(f.mockReporter).set(eq("cluster-controller.nodes-not-converged"), eq(0),
+                argThat(hasMetricContext(withNodeTypeDimension("storage"))));
+
+        // Resource usage metrics are reset
+        verify(f.mockReporter).set(eq("cluster-controller.resource_usage.max_disk_utilization"), eq(0.0),
+                argThat(hasMetricContext(withClusterDimension())));
+        verify(f.mockReporter).set(eq("cluster-controller.resource_usage.max_memory_utilization"), eq(0.0),
+                argThat(hasMetricContext(withClusterDimension())));
+        verify(f.mockReporter).set(eq("cluster-controller.resource_usage.nodes_above_limit"), eq(0),
+                argThat(hasMetricContext(withClusterDimension())));
+        verify(f.mockReporter).set(eq("cluster-controller.resource_usage.disk_limit"), eq(0.0),
+                argThat(hasMetricContext(withClusterDimension())));
+        verify(f.mockReporter).set(eq("cluster-controller.resource_usage.memory_limit"), eq(0.0),
+                argThat(hasMetricContext(withClusterDimension())));
+    }
+
 }


### PR DESCRIPTION
@hakonhall please review

Metric gauge values are "sticky" once set, which potentially causes max-aggregation of metrics _across_ cluster controllers to return stale and unexpected values unless we explicitly zero out metrics when leadership is lost.

This PR zeroes out the following metrics:
 * Node state counts (storage+distributor)
 * Node non-convergence counts (storage+distributor)
 * Content node resource usage

