### PR TITLE
Update JSONL `message` object structure and semantics

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -964,7 +964,7 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
             if (response.isSuccess()) {
                 callback.onSuccess((response instanceof DocumentResponse) ? ((DocumentResponse) response).getDocument() : null, jsonResponse);
             } else {
-                jsonResponse.writeMessage(response.getTextMessage());
+                jsonResponse.writeMessage(response.getTextMessage(), StreamableJsonResponse.MessageSeverity.ERROR);
                 switch (response.outcome()) {
                     case NOT_FOUND -> jsonResponse.commit(Response.Status.NOT_FOUND);
                     case CONDITION_FAILED -> jsonResponse.commit(Response.Status.PRECONDITION_FAILED);
@@ -1348,7 +1348,8 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
                                 case ABORTED:
                                     if (error.get() == null && ! hasVisitedAnyBuckets() && parameters.getVisitInconsistentBuckets()) {
                                         response.writeMessage("No buckets visited within timeout of " +
-                                                              parameters.getSessionTimeoutMs() + "ms (request timeout -5s)");
+                                                              parameters.getSessionTimeoutMs() + "ms (request timeout -5s)",
+                                                              StreamableJsonResponse.MessageSeverity.INFO); // Timeout here is not an error
                                         status = Response.Status.GATEWAY_TIMEOUT;
                                         break;
                                     }
@@ -1367,7 +1368,8 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
                                         break;
                                     }
                                 default:
-                                    response.writeMessage(error.get() != null ? error.get() : message != null ? message : "Visiting failed");
+                                    response.writeMessage(error.get() != null ? error.get() : message != null ? message : "Visiting failed",
+                                                          StreamableJsonResponse.MessageSeverity.ERROR);
                             }
                             if ( ! streaming)
                                 response.commit(status, fullyApplied);

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
@@ -21,6 +21,8 @@ class JsonNames {
     static final SerializedString PERCENT_FINISHED = new SerializedString("percentFinished");
     static final SerializedString PUT              = new SerializedString("put");
     static final SerializedString REMOVE           = new SerializedString("remove");
+    static final SerializedString SEVERITY         = new SerializedString("severity");
+    static final SerializedString TEXT             = new SerializedString("text");
     static final SerializedString TOKEN            = new SerializedString("token");
     static final SerializedString TRACE            = new SerializedString("trace");
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonResponse.java
@@ -101,7 +101,7 @@ class JsonResponse implements StreamableJsonResponse {
      */
     static JsonResponse createWithPathAndMessage(HttpRequest request, String message, ResponseHandler handler, JsonFormat.EncodeOptions tensorOptions) throws IOException {
         JsonResponse response = createWithPath(request, handler, tensorOptions);
-        response.writeMessage(message);
+        response.writeMessage(message, MessageSeverity.ERROR); // Implied error severity
         return response;
     }
 
@@ -162,9 +162,10 @@ class JsonResponse implements StreamableJsonResponse {
     }
 
     @Override
-    public synchronized void writeMessage(String message) throws IOException {
+    public synchronized void writeMessage(String message, MessageSeverity severity) throws IOException {
         json.writeFieldName(JsonNames.MESSAGE);
         json.writeString(message);
+        // Severity is not included in the legacy format
     }
 
     @Override

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
@@ -25,7 +25,18 @@ interface StreamableJsonResponse extends AutoCloseable {
     void reportUpdatedContinuation(Supplier<VisitorContinuation> continuationSupplier) throws IOException;
     void writeEpilogueContinuation(VisitorContinuation continuation) throws IOException;
     void writeTrace(Trace trace) throws IOException;
-    void writeMessage(String message) throws IOException;
+
+    enum MessageSeverity {
+        INFO("info"),
+        WARNING("warning"),
+        ERROR("error");
+
+        private final String jsonValue;
+        MessageSeverity(String jsonValue) { this.jsonValue = jsonValue; }
+        public String jsonValue() { return jsonValue; }
+    }
+
+    void writeMessage(String message, MessageSeverity severity) throws IOException;
     void writeDocumentCount(long count) throws IOException;
     void close() throws IOException; // Narrowed exception specifier
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
@@ -186,11 +186,16 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
     }
 
     @Override
-    public void writeMessage(String message) throws IOException {
+    public void writeMessage(String message, MessageSeverity severity) throws IOException {
         writeJsonLine((json) -> {
             json.writeStartObject();
             json.writeFieldName(JsonNames.MESSAGE);
+            json.writeStartObject();
+            json.writeFieldName(JsonNames.TEXT);
             json.writeString(message);
+            json.writeFieldName(JsonNames.SEVERITY);
+            json.writeString(severity.jsonValue());
+            json.writeEndObject();
             json.writeEndObject();
         });
     }

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
@@ -271,9 +271,20 @@ public class StreamingJsonLinesResponseTest {
     @Test
     void message_is_rendered_as_own_line() throws IOException {
         var f = new Fixture();
-        f.jsonlResponse.writeMessage("'ello, 'ello, this is London");
+        f.jsonlResponse.writeMessage("'ello, 'ello, this is London", StreamableJsonResponse.MessageSeverity.INFO);
+        f.jsonlResponse.writeMessage("seagulls incoming", StreamableJsonResponse.MessageSeverity.WARNING);
+        f.jsonlResponse.writeMessage("seagulls have arrived, flee for your lives", StreamableJsonResponse.MessageSeverity.ERROR);
+
         String expected = """
-                {"message":"'ello, 'ello, this is London"}
+                {"message":{"text":"'ello, 'ello, this is London","severity":"info"}}
+                """;
+        verify(f.writer).write(expected, null);
+        expected = """
+                {"message":{"text":"seagulls incoming","severity":"warning"}}
+                """;
+        verify(f.writer).write(expected, null);
+        expected = """
+                {"message":{"text":"seagulls have arrived, flee for your lives","severity":"error"}}
                 """;
         verify(f.writer).write(expected, null);
     }


### PR DESCRIPTION
@bjorncs please review

`message` is now an outer envelope for an extensible inner object, as has been previously done for the other JSONL structures. Severity has been added to existing callsites. The legacy JSON response rendering ignores the severity value entirely.

Old format:
```json
  {"message":"seagulls incoming"}
```
New format:
```json
  {"message":{"text":"seagulls incoming","severity":"warning"}}
```
