### PR TITLE
Add `TsvTermDfWriter` to `vespa-significance` to write tab separated values

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TermDfWriter.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TermDfWriter.java
@@ -1,0 +1,45 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.stream.Stream;
+
+/**
+ * An interface for writing {@link VespaIndexInspectClient.TermDocumentFrequency} rows.
+ *
+ * @author johsol
+ */
+public interface TermDfWriter extends AutoCloseable {
+
+    /**
+     * Write a single row. Implementations may buffer.
+     */
+    void write(VespaIndexInspectClient.TermDocumentFrequency row) throws IOException;
+
+    /**
+     * Write multiple rows. Closes the stream after consumption.
+     */
+    default long writeAll(Stream<VespaIndexInspectClient.TermDocumentFrequency> rows) throws IOException {
+        try (rows) {
+            long count = 0;
+            var it = rows.iterator();
+            while (it.hasNext()) {
+                write(it.next());   // can throw IOException and will propagate
+                count++;
+            }
+            return count;
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    /**
+     * Flush without closing.
+     */
+    default void flush() throws IOException {
+    }
+
+    @Override
+    void close() throws IOException;
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TsvTermDfWriter.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TsvTermDfWriter.java
@@ -1,0 +1,38 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Writes {@link VespaIndexInspectClient.TermDocumentFrequency} rows as TSV.
+ *
+ * @author johsol
+ */
+public final class TsvTermDfWriter implements TermDfWriter {
+    private final BufferedWriter out;
+
+    public TsvTermDfWriter(Path path) throws IOException {
+        this.out = Files.newBufferedWriter(path);
+    }
+
+    @Override
+    public void write(VespaIndexInspectClient.TermDocumentFrequency row) throws IOException {
+        out.write(row.term());
+        out.write('\t');
+        out.write(Long.toString(row.documentFrequency()));
+        out.newLine();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/TermDfWriterDefaultMethodTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/TermDfWriterDefaultMethodTest.java
@@ -1,0 +1,72 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Testing default methods on {@link TermDfWriter} interface.
+ *
+ * @author johsol
+ */
+class TermDfWriterDefaultMethodTest {
+
+    static final class ThrowingWriter implements TermDfWriter {
+        @Override
+        public void write(VespaIndexInspectClient.TermDocumentFrequency row) throws IOException {
+            throw new IOException("boom");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    static final class RecordingWriter implements TermDfWriter {
+        int n = 0;
+        boolean flushed = false;
+        boolean closed = false;
+
+        @Override
+        public void write(VespaIndexInspectClient.TermDocumentFrequency row) {
+            n++;
+        }
+
+        @Override
+        public void flush() {
+            flushed = true;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    @Test
+    void writeAllPropagatesIOExceptionFromWrite() {
+        var writer = new ThrowingWriter();
+        var rows = Stream.of(new VespaIndexInspectClient.TermDocumentFrequency("a", 1));
+        var ex = assertThrows(IOException.class, () -> writer.writeAll(rows));
+        assertEquals("boom", ex.getMessage());
+    }
+
+    @Test
+    void writeAllClosesInputStream() throws Exception {
+        var writer = new RecordingWriter();
+        AtomicBoolean closed = new AtomicBoolean(false);
+        var rows = Stream.of(new VespaIndexInspectClient.TermDocumentFrequency("a", 1)).onClose(() -> closed.set(true));
+
+        writer.writeAll(rows);
+        assertTrue(closed.get(), "writeAll should close the input stream");
+        assertEquals(1, writer.n);
+    }
+
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/TsvTermDfWriterTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/TsvTermDfWriterTest.java
@@ -1,0 +1,84 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Testing {@link TsvTermDfWriter}.
+ *
+ * @author johsol
+ */
+class TsvTermDfWriterTest {
+
+    @TempDir
+    Path tmp;
+
+    @Test
+    void writesUtf8TsvAndNewlines() throws Exception {
+        Path out = tmp.resolve("out.tsv");
+        try (var w = new TsvTermDfWriter(out)) {
+            w.write(new VespaIndexInspectClient.TermDocumentFrequency("hello", 1));
+            w.write(new VespaIndexInspectClient.TermDocumentFrequency("world", 2));
+            w.flush();
+        }
+        var text = Files.readString(out, StandardCharsets.UTF_8);
+        assertEquals("hello\t1\nworld\t2\n", text);
+    }
+
+    @Test
+    void writeAllConsumesStreamAndClosesIt() throws Exception {
+        Path out = tmp.resolve("out.tsv");
+        boolean[] closed = {false};
+        Stream<VespaIndexInspectClient.TermDocumentFrequency> rows =
+                Stream.of(
+                        new VespaIndexInspectClient.TermDocumentFrequency("a", 1),
+                        new VespaIndexInspectClient.TermDocumentFrequency("b", 2)
+                ).onClose(() -> closed[0] = true);
+
+        try (var w = new TsvTermDfWriter(out)) {
+            w.writeAll(rows); // should consume and close the stream
+        }
+        assertTrue(closed[0], "writeAll should close the input stream");
+
+        var lines = Files.readAllLines(out, StandardCharsets.UTF_8);
+        assertEquals(List.of("a\t1", "b\t2"), lines);
+    }
+
+    @Test
+    void cannotWriteAfterClose() throws Exception {
+        Path out = tmp.resolve("out.tsv");
+        var w = new TsvTermDfWriter(out);
+        w.close();
+        assertThrows(IOException.class,
+                () -> w.write(new VespaIndexInspectClient.TermDocumentFrequency("x", 1)));
+    }
+
+    @Test
+    void largeInputOrderIsCallerControlled() throws Exception {
+        Path out = tmp.resolve("out.tsv");
+        var rows = Stream.of(
+                new VespaIndexInspectClient.TermDocumentFrequency("c", 3),
+                new VespaIndexInspectClient.TermDocumentFrequency("a", 1),
+                new VespaIndexInspectClient.TermDocumentFrequency("b", 2)
+        ).sorted(Comparator.comparing(VespaIndexInspectClient.TermDocumentFrequency::term));
+
+        try (var w = new TsvTermDfWriter(out)) {
+            w.writeAll(rows);
+        }
+        var text = Files.readString(out, StandardCharsets.UTF_8);
+        assertEquals("a\t1\nb\t2\nc\t3\n", text);
+    }
+}


### PR DESCRIPTION
Can write `Stream<VespaIndexInspectClient.TermDocumentFrequency>` as TSV.