### PR TITLE
Add `PathSelector` for helping user resolve index path

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/PathSelector.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/PathSelector.java
@@ -1,0 +1,138 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+/**
+ * Pick exactly one path or describe why not.
+ *
+ * @author johsol
+ */
+final class PathSelector {
+
+    enum Outcome {
+
+        /**
+         * Either preferredName was in the items or it was null and rest of path unambiguous
+         */
+        CHOSEN,
+
+        /**
+         * The preferredName was not in the items
+         */
+        NOT_FOUND,
+
+        /**
+         * PreferredName was null and more than one path
+         */
+        AMBIGUOUS
+
+    }
+
+    /**
+     * Row describing a candidate for display/help.
+     */
+    record Row(String name, String path) {
+    }
+
+    /**
+     * Result of a selection attempt.
+     */
+    record Result<T>(
+            Outcome outcome,
+            @Nullable T value,
+            String message,
+            List<Row> options
+    ) {
+        static <T> Result<T> chosen(T value) {
+            return new Result<>(Outcome.CHOSEN, Objects.requireNonNull(value), "", List.of());
+        }
+
+        static <T> Result<T> notFound(String msg, List<Row> options) {
+            return new Result<>(Outcome.NOT_FOUND, null, msg, options);
+        }
+
+        static <T> Result<T> ambiguous(String msg, List<Row> options) {
+            return new Result<>(Outcome.AMBIGUOUS, null, msg, options);
+        }
+    }
+
+    /**
+     * Selects one path or returns options.
+     */
+    static <T> Result<T> selectOne(
+            List<T> items,
+            @Nullable String preferredName,
+            String kind,
+            Path container,
+            Function<T, String> displayName,
+            Function<T, String> displayPath,
+            BiPredicate<String, String> nameMatcher
+    ) {
+        if (items.isEmpty()) {
+            return Result.notFound("No " + kind + " directory found in: " + container, List.of());
+        }
+        if (items.size() == 1 && preferredName == null) {
+            return Result.chosen(items.get(0));
+        }
+
+        // List candidates and sort by name
+        final var candidates = new ArrayList<Map.Entry<T, Row>>(items.size());
+        for (T t : items) {
+            var name = displayName.apply(t);
+            var path = displayPath.apply(t);
+            candidates.add(Map.entry(t, new Row(name, path)));
+        }
+        candidates.sort(Comparator.comparing(e -> e.getValue().name().toLowerCase(Locale.ROOT)));
+
+        if (preferredName != null) {
+            for (var e : candidates) {
+                if (nameMatcher.test(e.getValue().name(), preferredName)) {
+                    return Result.chosen(e.getKey());
+                }
+            }
+            var msg = capitalize(kind) + " '" + preferredName + "' not found under: " + container
+                    + System.lineSeparator()
+                    + "Use `--" + kind + " <name>` to select one of the options below.";
+            return Result.notFound(msg, rows(candidates));
+        }
+
+        var msg = "Multiple " + kind + " directories found in: " + container
+                + System.lineSeparator()
+                + "Use `--" + kind + " <name>` to select one of the options below.";
+        return Result.ambiguous(msg, rows(candidates));
+    }
+
+    /**
+     * String::equals matcher.
+     */
+    static <T> Result<T> selectOne(
+            List<T> items,
+            @Nullable String preferredName,
+            String kind,
+            Path container,
+            Function<T, String> displayName,
+            Function<T, String> displayPath
+    ) {
+        return selectOne(items, preferredName, kind, container, displayName, displayPath, String::equals);
+    }
+
+    private static <T> List<Row> rows(List<Map.Entry<T, Row>> entries) {
+        return entries.stream().map(Map.Entry::getValue).toList();
+    }
+
+    private static String capitalize(String s) {
+        return s.isEmpty() ? s :
+                s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
+    }
+
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TablePrinter.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TablePrinter.java
@@ -1,0 +1,123 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Pretty print table.
+ *
+ * @author johsol
+ */
+final class TablePrinter {
+
+    static void printTable(String heading, List<String> headers, List<List<String>> rows) {
+        if (headers == null) headers = Collections.emptyList();
+        if (rows == null) rows = Collections.emptyList();
+
+        int cols = headers.size();
+        if (cols == 0) {
+            // Nothing to format — just print heading (if any) and return.
+            if (heading != null && !heading.isEmpty()) {
+                System.out.println(heading);
+            }
+            return;
+        }
+
+        // Normalize rows to avoid NPEs and differing lengths.
+        List<List<String>> normalized = new ArrayList<>(rows.size());
+        for (List<String> row : rows) {
+            List<String> r = new ArrayList<>(cols);
+            for (int c = 0; c < cols; c++) {
+                String v = (row != null && c < row.size()) ? row.get(c) : "";
+                r.add(v == null ? "" : v);
+            }
+            normalized.add(r);
+        }
+
+        // Compute column widths from headers and rows.
+        int[] widths = new int[cols];
+        for (int c = 0; c < cols; c++) {
+            widths[c] = len(safe(headers.get(c)));
+        }
+        for (List<String> r : normalized) {
+            for (int c = 0; c < cols; c++) {
+                widths[c] = Math.max(widths[c], len(safe(r.get(c))));
+            }
+        }
+
+        String sep = buildSeparator(widths);
+        int tableWidth = sep.length();
+
+        // Print heading (centered to table width, excluding trailing newline).
+        if (heading != null && !heading.isEmpty()) {
+            System.out.println(center(heading, tableWidth));
+        }
+
+        // Header
+        System.out.println(sep);
+        System.out.println(buildRow(headers, widths));
+        System.out.println(sep);
+
+        // Rows
+        for (List<String> r : normalized) {
+            System.out.println(buildRow(r, widths));
+        }
+        System.out.println(sep);
+    }
+
+    // ---- helpers ----
+
+    private static String buildSeparator(int[] widths) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('+');
+        for (int w : widths) {
+            sb.append(repeat('-', w + 2)).append('+');
+        }
+        return sb.toString();
+    }
+
+    private static String buildRow(List<String> cells, int[] widths) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('|');
+        for (int c = 0; c < widths.length; c++) {
+            String v = c < cells.size() ? safe(cells.get(c)) : "";
+            sb.append(' ').append(padRight(v, widths[c])).append(' ').append('|');
+        }
+        return sb.toString();
+    }
+
+    private static String padRight(String s, int width) {
+        int pad = width - len(s);
+        if (pad <= 0) return s;
+        return s + repeat(' ', pad);
+    }
+
+    private static String center(String s, int width) {
+        // Strip trailing spaces from width baseline (like separator newline)
+        int w = Math.max(0, width);
+        if (len(s) >= w) return s;
+        int totalPad = w - len(s);
+        int left = totalPad / 2;
+        int right = totalPad - left;
+        return repeat(' ', left) + s + repeat(' ', right);
+    }
+
+    private static String repeat(char ch, int count) {
+        if (count <= 0) return "";
+        char[] arr = new char[count];
+        Arrays.fill(arr, ch);
+        return new String(arr);
+    }
+
+    private static int len(String s) {
+        return s == null ? 0 : s.length();
+    }
+
+    private static String safe(String s) {
+        return s == null ? "" : s;
+    }
+
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/PathSelectorTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/PathSelectorTest.java
@@ -1,0 +1,119 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.export;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests outcome of {@link PathSelector}.
+ *
+ * @author johsol
+ */
+public class PathSelectorTest {
+    private static final String KIND = "cluster";
+    private static final Path CONTAINER = Path.of("/vespa/var/db/vespa/search");
+
+    private static String name(Path p) {
+        return p.getFileName().toString();
+    }
+
+    private static String path(Path p) {
+        return p.toString();
+    }
+
+    @Test
+    void emptyItemsReturnsNotFound() {
+        var res = PathSelector.selectOne(
+                List.<Path>of(),
+                null,
+                KIND,
+                CONTAINER,
+                PathSelectorTest::name,
+                PathSelectorTest::path
+        );
+
+        assertEquals(PathSelector.Outcome.NOT_FOUND, res.outcome());
+        assertNull(res.value());
+        assertTrue(res.options().isEmpty());
+    }
+
+    @Test
+    void singleItemAndNoPreferenceReturnsChosen() {
+        var only = Path.of("/root/cluster.alpha");
+        var res = PathSelector.selectOne(
+                List.of(only),
+                null,
+                KIND,
+                CONTAINER,
+                PathSelectorTest::name,
+                PathSelectorTest::path
+        );
+
+        assertEquals(PathSelector.Outcome.CHOSEN, res.outcome());
+        assertEquals(only, res.value());
+        assertEquals("", res.message());
+        assertTrue(res.options().isEmpty());
+    }
+
+    @Test
+    void multipleItemsNoPreferenceReturnsAmbiguous() {
+        var a = Path.of("/root/cluster.beta");
+        var b = Path.of("/root/cluster.Alpha");
+        var c = Path.of("/root/cluster.gamma");
+
+        var res = PathSelector.selectOne(
+                List.of(a, b, c),
+                null,
+                KIND,
+                CONTAINER,
+                PathSelectorTest::name,
+                PathSelectorTest::path
+        );
+
+        assertEquals(PathSelector.Outcome.AMBIGUOUS, res.outcome());
+        assertNull(res.value());
+        assertEquals(3, res.options().size());
+    }
+
+    @Test
+    void multipleItemsWithExactPreferenceMatchesChosen() {
+        var a = Path.of("/root/cluster.alpha");
+        var b = Path.of("/root/cluster.beta");
+        var res = PathSelector.selectOne(
+                List.of(a, b),
+                "cluster.beta",
+                KIND,
+                CONTAINER,
+                PathSelectorTest::name,
+                PathSelectorTest::path
+        );
+
+        assertEquals(PathSelector.Outcome.CHOSEN, res.outcome());
+        assertEquals(b, res.value());
+    }
+
+    @Test
+    void multipleItemsPreferenceNotFound() {
+        var a = Path.of("/root/cluster.alpha");
+        var b = Path.of("/root/cluster.beta");
+
+        var res = PathSelector.selectOne(
+                List.of(a, b),
+                "cluster.gamma",
+                KIND,
+                CONTAINER,
+                PathSelectorTest::name,
+                PathSelectorTest::path
+        );
+
+        assertEquals(PathSelector.Outcome.NOT_FOUND, res.outcome());
+        assertNull(res.value());
+        assertEquals(2, res.options().size());
+    }
+}


### PR DESCRIPTION
This PR:
- Adds `PathSelector` with tests.
- Adds `TablePrinter`

Table print example:
```text
+--------+-----------------------------+
| schema | path                        |
+--------+-----------------------------+
| test   | /home/johsol/vespa/var/...  |
| test2  | /home/johsol/vespa/var/...  |
+--------+-----------------------------+
```

To aid the user in selecting the correct index dir for `vespa-index-inspect`, `PathSelector` is added. How it works:

* If the user provides a preferred path **and it exists**, choose that.
* If the user provides a preferred path **and it does not exist**, report that it does not exist.
* If the user does **not** provide a preferred path and there is **only one** path to follow, choose that.
* If the user does **not** provide a preferred path and there is **no** path to follow, return *not found*.
* If the user does **not** provide a preferred path and there are **multiple** paths to follow, return *ambiguous*.
