### PR TITLE
let the order be 1 if there is a single match

### DIFF
--- a/searchlib/src/tests/features/element_similarity_feature/element_similarity_feature_test.cpp
+++ b/searchlib/src/tests/features/element_similarity_feature/element_similarity_feature_test.cpp
@@ -285,16 +285,16 @@ TEST(ElementSimilarityFeatureTest, require_that_larger_perfect_match_gives_max_o
     EXPECT_EQ(1.0, f1.get_feature("a b c d e f g", indexFoo().element("a b c d e f g"), FIELD));
 }
 
-TEST(ElementSimilarityFeatureTest, require_that_extra_query_terms_reduces_order_but_not_proximity)
+TEST(ElementSimilarityFeatureTest, require_that_extra_query_terms_does_not_reduce_either_order_or_proximity)
 {
     RankFixture f1;
     EXPECT_EQ(1.0, f1.get_feature("x y", indexFoo().element("x"), PROXIMITY));
     EXPECT_EQ(1.0, f1.get_feature("x y y", indexFoo().element("x"), PROXIMITY));
     EXPECT_EQ(1.0, f1.get_feature("x y y y", indexFoo().element("x"), PROXIMITY));
 
-    EXPECT_EQ(0.0, f1.get_feature("x y", indexFoo().element("x"), ORDER));
-    EXPECT_EQ(0.0, f1.get_feature("x y y", indexFoo().element("x"), ORDER));
-    EXPECT_EQ(0.0, f1.get_feature("x y y y", indexFoo().element("x"), ORDER));
+    EXPECT_EQ(1.0, f1.get_feature("x y", indexFoo().element("x"), ORDER));
+    EXPECT_EQ(1.0, f1.get_feature("x y y", indexFoo().element("x"), ORDER));
+    EXPECT_EQ(1.0, f1.get_feature("x y y y", indexFoo().element("x"), ORDER));
 }
 
 TEST(ElementSimilarityFeatureTest, require_that_extra_field_terms_reduces_proximity_but_not_order)

--- a/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
@@ -180,12 +180,12 @@ struct State {
         sum_term_weight += weight;
     }
 
-    void calculate_scores(size_t num_query_terms, int total_term_weight) {
+    void calculate_scores(int total_term_weight) {
         element_length = std::max(element_length, matched_terms);
         double matches = matched_terms;
         if (matches < 2) {
             proximity = proximity_score(element_length);
-            order = (num_query_terms == 1) ? 1.0 : 0.0;
+            order = matches;
         } else {
             proximity = sum_proximity_score / (matches - 1);
             order = num_in_order / (double) (matches - 1);
@@ -300,7 +300,7 @@ public:
                     }
                 }
             }
-            state.calculate_scores(_terms.handles.size(), _terms.total_weight);
+            state.calculate_scores(_terms.total_weight);
             for (auto &output: _outputs) {
                 output.second->add(output.first(state.proximity, state.order,
                                                 state.query_coverage, state.field_coverage,


### PR DESCRIPTION
Note that this will change the order score for multi-term queries with a single match. Previously we required the query to be a single term to obtain an order score of 1 when there was no additional matches.

@hmusum please review