### PR TITLE
Adds `IndexLocator` to `vespa-significance`

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/IndexLocator.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/IndexLocator.java
@@ -1,0 +1,107 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.export;
+
+import com.yahoo.vespa.defaults.Defaults;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Resolves the path of an index.
+ * <p>
+ * The path to the index might look like this:
+ * - $VESPA_HOME/var/db/vespa/search/CLUSTER/n0/documents/SCHEMA/0.ready/index/index.flush.1/
+ * <p>
+ * There is a possibility of two separate proton instances running on the same host, therefore,
+ * we need to take into consideration that the user must choose between several clusters.
+ * However, in the common case, trivially, if there is only one cluster, we can choose that one.
+ * <p>
+ * There might also be more than one document type for a cluster, and the same applies here. If
+ * there are multiple, tell the user to choose, else use trivial one.
+ * <p>
+ * This class does not consider fields, only locates index on a host.
+ *
+ * @author johsol
+ */
+public class IndexLocator {
+
+    private final String VESPA_HOME = Defaults.getDefaults().vespaHome();
+
+    /**
+     * Resolves the index dir or exits with a helpful message.
+     * <p>
+     * On none or more than 1 match, it will exit.
+     */
+    Path locateIndexDir(@Nullable String clusterName, @Nullable String schemaName) {
+        Path searchRoot = Paths.get(VESPA_HOME, "var", "db", "vespa", "search");
+
+        // Not common, but might be more than 1 cluster on one host.
+        List<Path> clusterDirs = listDirs(searchRoot, p -> p.getFileName().toString().startsWith("cluster"));
+        var clusterRes = PathSelector.selectOne(
+                clusterDirs,
+                clusterName,
+                "cluster",
+                searchRoot,
+                p -> {
+                    String name = p.getFileName().toString();
+                    return name.startsWith("cluster.") ? name.substring("cluster.".length()) : name;
+                },
+                Path::toString
+        );
+        Path clusterDir = chooseOrExit(clusterRes, "cluster");
+
+        Path documentsDir = clusterDir.resolve("n0").resolve("documents");
+        List<Path> schemaDirs = listDirs(documentsDir, Files::isDirectory);
+        var schemaRes = PathSelector.selectOne(
+                schemaDirs,
+                schemaName,
+                "schema",
+                documentsDir,
+                p -> p.getFileName().toString(),
+                Path::toString
+        );
+        Path schemaDir = chooseOrExit(schemaRes, "schema");
+
+        Path indexDir = schemaDir.resolve("0.ready").resolve("index").resolve("index.flush.1");
+        if (!Files.exists(indexDir)) {
+            System.out.println("Index directory does not exist: " + indexDir);
+            System.exit(1);
+        }
+
+        return indexDir;
+    }
+
+    /** Parse the {@link PathSelector.Result}. */
+    private static <T> T chooseOrExit(PathSelector.Result<T> res, String kind) {
+        if (res.outcome() == PathSelector.Outcome.CHOSEN) return res.value();
+
+        System.out.println("Error: " + res.message());
+        var rows = res.options();
+        if (!rows.isEmpty()) {
+            TablePrinter.printTable(
+                    null,
+                    List.of(kind, "path"),
+                    rows.stream().map(r -> List.of(r.name(), r.path())).toList()
+            );
+            System.out.println();
+            System.out.println("Use `--" + kind + " <name>` to select one of the above.");
+        }
+
+        System.exit(1);
+        throw new IllegalStateException("unreachable");
+    }
+
+    private static List<Path> listDirs(Path root, java.util.function.Predicate<Path> filter) {
+        try (Stream<Path> s = Files.list(root)) {
+            return s.filter(Files::isDirectory).filter(filter).sorted().toList();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to list: " + root, e);
+        }
+    }
+
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/SelectionException.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/SelectionException.java
@@ -1,0 +1,26 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.export;
+
+import java.util.List;
+
+/**
+ * Exception that contains outcome of selection and options.
+ *
+ * @author johsol
+ */
+final class SelectionException extends RuntimeException {
+    private final PathSelector.Outcome outcome;
+    private final String kind;
+    private final List<PathSelector.Row> options;
+
+    SelectionException(PathSelector.Outcome outcome, String kind, String message, List<PathSelector.Row> options) {
+        super(message);
+        this.outcome = outcome;
+        this.kind = kind;
+        this.options = options;
+    }
+
+    PathSelector.Outcome outcome() { return outcome; }
+    String kind() { return kind; }
+    List<PathSelector.Row> options() { return options; }
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/IndexLocatorTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/IndexLocatorTest.java
@@ -1,0 +1,153 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.export;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test path resolving logic in {@link IndexLocator}.
+ *
+ * @author johsol
+ */
+class IndexLocatorTest {
+
+    @TempDir
+    Path tmp;
+
+    private Path searchRoot() { return tmp.resolve("var/db/vespa/search"); }
+
+    private Path mkIndexTree(String cluster, String node, String schema, boolean withIndex) throws Exception {
+        Path base = searchRoot().resolve(cluster).resolve(node).resolve("documents").resolve(schema);
+        Path flush = base.resolve("0.ready/index/index.flush.1");
+        Files.createDirectories(withIndex ? flush : base.resolve("0.ready/index"));
+        return flush;
+    }
+
+    /**
+     * The user provides trough CLI cluster name, node index and schema name.
+     */
+    @Test
+    void resolvesWhenArgsProvided() throws Exception {
+        Path expected = mkIndexTree("cluster.alpha", "n0", "doc", true);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        Path actual = locator.locateIndexDir("alpha", "doc", "n0");
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * The user does not provide any flags, but the path is trivial so it resolves
+     * anyway.
+     */
+    @Test
+    void resolvesWhenUnambiguousAndNoArgsProvided() throws Exception {
+        Path expected = mkIndexTree("cluster.alpha", "n0", "doc", true);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        Path actual = locator.locateIndexDir(null, null, null);
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * If user wanted beta, but only alpha existed. Ensures that user preference has precedence.
+     */
+    @Test
+    void preferredClusterNotFoundThrowsSelectionException() throws Exception {
+        mkIndexTree("cluster.alpha", "n0", "doc", true);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        SelectionException e = assertThrows(
+                SelectionException.class,
+                () -> locator.locateIndexDir("beta", "doc", "n0")
+        );
+        assertEquals(PathSelector.Outcome.NOT_FOUND, e.outcome());
+        assertEquals("cluster", e.kind());
+    }
+
+    @Test
+    void ambiguousClustersThrowsSelectionException() throws Exception {
+        mkIndexTree("cluster.alpha", "n0", "doc", true);
+        mkIndexTree("cluster.beta",  "n0", "doc", true);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        SelectionException e = assertThrows(
+                SelectionException.class,
+                () -> locator.locateIndexDir(null, "doc", "n0")
+        );
+        assertEquals(PathSelector.Outcome.AMBIGUOUS, e.outcome());
+        assertEquals("cluster", e.kind());
+        assertFalse(e.options().isEmpty());
+    }
+
+    @Test
+    void ambiguousNodeThrowsSelectionException() throws Exception {
+        mkIndexTree("cluster.alpha", "n0", "doc", true);
+        mkIndexTree("cluster.alpha", "n1", "doc", true);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        SelectionException e = assertThrows(
+                SelectionException.class,
+                () -> locator.locateIndexDir("alpha", "doc", null)
+        );
+        assertEquals(PathSelector.Outcome.AMBIGUOUS, e.outcome());
+        assertEquals("node-index", e.kind());
+    }
+
+    @Test
+    void ambiguousSchemaThrowsSelectionException() throws Exception {
+        mkIndexTree("cluster.alpha", "n0", "docA", true);
+        mkIndexTree("cluster.alpha", "n0", "docB", true);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        SelectionException e = assertThrows(
+                SelectionException.class,
+                () -> locator.locateIndexDir("alpha", null, "n0")
+        );
+        assertEquals(PathSelector.Outcome.AMBIGUOUS, e.outcome());
+        assertEquals("schema", e.kind());
+    }
+
+    @Test
+    void missingDocumentsDirThrowsNoSuchFile() throws Exception {
+        // Create cluster/n0 but no "documents"
+        Path base = searchRoot().resolve("cluster.alpha").resolve("n0");
+        Files.createDirectories(base);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        NoSuchFileException e = assertThrows(
+                NoSuchFileException.class,
+                () -> locator.locateIndexDir("alpha", "doc", "n0")
+        );
+        assertTrue(e.getMessage().contains("Documents directory"));
+    }
+
+    @Test
+    void missingIndexDirThrowsNoSuchFile() throws Exception {
+        // Build to 0.ready/index but omit index.flush.1
+        mkIndexTree("cluster.alpha", "n0", "doc", false);
+        IndexLocator locator = new IndexLocator(tmp);
+
+        NoSuchFileException e = assertThrows(
+                NoSuchFileException.class,
+                () -> locator.locateIndexDir("alpha", "doc", "n0")
+        );
+        assertTrue(e.getMessage().contains("Index directory"));
+    }
+
+    @Test
+    void missingSearchRootThrowsNoSuchFile() {
+        IndexLocator locator = new IndexLocator(tmp);
+        assertThrows(NoSuchFileException.class, () -> locator.locateIndexDir(null, null, null));
+    }
+}


### PR DESCRIPTION
This PR:
- Adds `IndexLocator` class with tests.
- Adds `SelectionException` to provide details about ambiguous directories (e.g., two schema folders).

The `IndexLocator` resolves the path to a flushed index if the path is trivial or the user has provided the correct flags (future PR). Example: `$VESPA_HOME/var/db/vespa/search/CLUSTER/NODE_INDEX/documents/SCHEMA/0.ready/index/index.flush.1/`

If there are, for instance, two document types, then the SCHEMA must be defined by the user. If not, it is ambiguous, and the `IndexLocator` will throw a `SelectionException`. The CLI can then provide a helpful message with the information from the exception. This applies to both CLUSTER and NODE_INDEX.