### PR TITLE
Encapsulate visitor session document count in a `sessionStats` object 

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
@@ -21,6 +21,7 @@ class JsonNames {
     static final SerializedString PERCENT_FINISHED = new SerializedString("percentFinished");
     static final SerializedString PUT              = new SerializedString("put");
     static final SerializedString REMOVE           = new SerializedString("remove");
+    static final SerializedString SESSION_STATS    = new SerializedString("sessionStats");
     static final SerializedString SEVERITY         = new SerializedString("severity");
     static final SerializedString TEXT             = new SerializedString("text");
     static final SerializedString TOKEN            = new SerializedString("token");

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
@@ -175,6 +175,9 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
 
     @Override
     public void writeTrace(Trace trace) throws IOException {
+        if (trace == null || trace.getRoot().isEmpty()) {
+            return; // no-op
+        }
         writeJsonLine((json) -> {
             json.writeStartObject();
             json.writeFieldName(JsonNames.TRACE);

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
@@ -205,11 +205,13 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
 
     @Override
     public void writeDocumentCount(long count) throws IOException {
-        // TODO do we want this for streaming or do we want another kind of session summary?
         writeJsonLine((json) -> {
+            json.writeStartObject();
+            json.writeFieldName(JsonNames.SESSION_STATS);
             json.writeStartObject();
             json.writeFieldName(JsonNames.DOCUMENT_COUNT);
             json.writeNumber(count);
+            json.writeEndObject();
             json.writeEndObject();
         });
     }

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -1154,7 +1154,7 @@ public class DocumentV1ApiTest {
                 {"put":"id:space:music:n=1:two","fields":{"artist":"Asa-Chan & Jun-Ray","embedding":{"type":"tensor(x[3])","values":[4.0,5.0,6.0]}}}
                 {"put":"id:space:music:g=a:three","fields":{}}
                 {"remove":"id:space:music::t-square-truth"}
-                {"documentCount":4}
+                {"sessionStats":{"documentCount":4}}
                 """, response.readAll());
         assertEquals(200, response.getStatus());
         List<String> contentType = response.getResponse().headers().get("Content-Type");

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
@@ -269,6 +269,23 @@ public class StreamingJsonLinesResponseTest {
     }
 
     @Test
+    void null_trace_is_not_rendered() throws Exception {
+        var f = new Fixture();
+        f.jsonlResponse.writeTrace(null);
+        verify(f.writer, never()).write(anyString(), any());
+    }
+
+    @Test
+    void empty_trace_is_not_rendered() throws Exception {
+        var f = new Fixture();
+        var trace = new Trace(9);
+        // Not rendering traces without a root node is the behavior of the legacy
+        // JSON renderer, so we carry the torch of that particular tradition.
+        f.jsonlResponse.writeTrace(trace);
+        verify(f.writer, never()).write(anyString(), any());
+    }
+
+    @Test
     void message_is_rendered_as_own_line() throws IOException {
         var f = new Fixture();
         f.jsonlResponse.writeMessage("'ello, 'ello, this is London", StreamableJsonResponse.MessageSeverity.INFO);

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
@@ -307,11 +307,11 @@ public class StreamingJsonLinesResponseTest {
     }
 
     @Test
-    void document_count_is_rendered_as_own_line() throws IOException {
+    void document_count_is_rendered_as_part_of_session_stats_object() throws IOException {
         var f = new Fixture();
         f.jsonlResponse.writeDocumentCount(123456);
         String expected = """
-                {"documentCount":123456}
+                {"sessionStats":{"documentCount":123456}}
                 """;
         verify(f.writer).write(expected, null);
     }


### PR DESCRIPTION
@bjorncs please review

We might want to add more session statistics later, such as the number of bytes processed by the backend etc.

Also avoid rendering `null`/empty trace objects.