### PR TITLE
Export subcommand

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/Export.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/Export.java
@@ -1,0 +1,187 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.export;
+
+import com.yahoo.vespasignificance.CommandLineOptions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * This class uses vespa-index-inspect to read terms and their document frequency and sorts
+ * the rows lexicographically on term, then writes the result to disk.
+ *
+ * @author johsol
+ */
+public class Export {
+
+    private final ExportClientParameters params;
+    private final IndexLocator locator;
+    private final WriterFactory writerFactory;
+    private final DumpFn dumpFn;
+
+    private Path indexDir;
+    private String fieldName;
+
+    public Export(ExportClientParameters params) {
+        this(params,
+                new IndexLocator(),
+                TsvTermDfWriter::new,
+                (idx, field) -> new VespaIndexInspectClient().streamDumpWords(idx, field));
+    }
+
+    // for tests
+    Export(ExportClientParameters params,
+           IndexLocator locator,
+           WriterFactory writerFactory,
+           DumpFn dumpFn) {
+        this.params = Objects.requireNonNull(params);
+        this.locator = Objects.requireNonNull(locator);
+        this.writerFactory = Objects.requireNonNull(writerFactory);
+        this.dumpFn = Objects.requireNonNull(dumpFn);
+    }
+
+    @FunctionalInterface
+    interface WriterFactory {
+        TermDfWriter create(Path out) throws IOException;
+    }
+
+    @FunctionalInterface
+    interface DumpFn {
+        Stream<VespaIndexInspectClient.TermDocumentFrequency> open(Path indexDir, String field) throws IOException;
+    }
+
+    /**
+     * Main entry point for export subcommand.
+     * <p>
+     * Return 0 on success and 1 on failure.
+     */
+    public int run() {
+        try {
+            ensureOutputFile();
+            resolveIndexDir();
+            requireFieldDir(params.fieldName());
+
+            Path outFile = Path.of(params.outputFile());
+            var ordering = Comparator.comparing(VespaIndexInspectClient.TermDocumentFrequency::term);
+            try (var rows = dumpFn.open(indexDir, fieldName).sorted(ordering);
+                 TermDfWriter writer = writerFactory.create(outFile)) {
+                writer.writeAll(rows);
+            }
+
+            System.out.println("Exported " + Path.of(indexDir.toString(), fieldName) + " to " + outFile);
+            return 0;
+        } catch (ExportFailure ignored) {
+            return 1;
+        } catch (IOException e) {
+            System.err.println("Error during export: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    /**
+     * Ensures that output file is not null or blank and that we can create parent directories for
+     * output.
+     */
+    private void ensureOutputFile() {
+        if (params.outputFile() == null || params.outputFile().isBlank()) {
+            System.err.println("Error: --output is required.");
+            CommandLineOptions.printExportHelp();
+            throw new ExportFailure();
+        }
+
+        Path outFile = Path.of(params.outputFile());
+        Path parent = outFile.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                System.err.println("Error: Unable to create parent directory for output: " + parent);
+                throw new ExportFailure();
+            }
+        }
+    }
+
+    /**
+     * Resolves the index dir to read data from. If index directory is not provided, then we try to search
+     * for it using {@link IndexLocator}. If this procedure does not fail, the {@link Export#indexDir} field will
+     * be set to the index dir to search from.
+     */
+    private void resolveIndexDir() {
+        if (params.indexDir() == null) {
+            try {
+                indexDir = locator.locateIndexDir(params.clusterName().orElse(null),
+                        params.schemaName().orElse(null),
+                        params.nodeIndex().orElse(null));
+            } catch (SelectionException e) {
+                handleSelectionException(e);
+            } catch (NoSuchFileException nf) {
+                System.err.println(nf.getMessage());
+                throw new ExportFailure();
+            }
+        } else {
+            if (params.indexDir().isEmpty()) {
+                System.err.println("Error: No index directory specified.");
+                System.err.println("Use --index-dir to specify index directory or --locate-index to search for index directory.");
+                CommandLineOptions.printExportHelp();
+                throw new ExportFailure();
+            }
+
+            Path explicit = Path.of(params.indexDir());
+            if (!Files.isDirectory(explicit)) {
+                System.err.println("Error: Index directory `" + explicit + "` does not exist or is not a directory.");
+                throw new ExportFailure();
+            }
+            indexDir = explicit;
+        }
+    }
+
+    /**
+     * When the index directory is resolved, we can check that the field name is a subdirectory in the index
+     * directory. If the directory is found, then the {@link Export#fieldName} is set.
+     */
+    private void requireFieldDir(String fieldName) {
+        if (!Files.isDirectory(indexDir)) {
+            System.err.println("Error: Index directory `" + indexDir + "` does not exist or is not a directory.");
+            throw new ExportFailure();
+        }
+        List<Path> fieldDirs;
+        try (Stream<Path> s = Files.list(indexDir)) {
+            fieldDirs = s.filter(Files::isDirectory).toList();
+        } catch (IOException e) {
+            System.err.println("Failed to list index directory: " + indexDir + " (" + e.getMessage() + ")");
+            throw new ExportFailure();
+        }
+        var res = PathSelector.selectOne(fieldDirs, fieldName, "field", indexDir,
+                p -> p.getFileName().toString(), Path::toString);
+        if (res.outcome() == PathSelector.Outcome.CHOSEN) {
+            this.fieldName = Objects.requireNonNull(res.value()).getFileName().toString();
+            return;
+        }
+        handleSelectionException(new SelectionException(res.outcome(), "field", res.message(), res.options()));
+    }
+
+    private void handleSelectionException(SelectionException e) {
+        System.err.println("Error: " + e.getMessage());
+        var rows = e.options();
+        if (!rows.isEmpty()) {
+            TablePrinter.printTable(
+                    System.err,
+                    null,
+                    List.of(e.kind(), "path"),
+                    rows.stream().map(r -> List.of(r.name(), r.path())).toList()
+            );
+            System.err.println();
+            System.err.println("Use `--" + e.kind() + " <name>` to select one of the above.");
+        }
+        throw new ExportFailure();
+    }
+
+    static final class ExportFailure extends RuntimeException {
+    }
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/Export.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/Export.java
@@ -122,12 +122,13 @@ public class Export {
                 handleSelectionException(e);
             } catch (NoSuchFileException nf) {
                 System.err.println(nf.getMessage());
+                System.err.println("Note: you can use --index-dir to specify the index directory.");
                 throw new ExportFailure();
             }
         } else {
             if (params.indexDir().isEmpty()) {
                 System.err.println("Error: No index directory specified.");
-                System.err.println("Use --index-dir to specify index directory or --locate-index to search for index directory.");
+                System.err.println("Use --index-dir to specify index directory.");
                 CommandLineOptions.printExportHelp();
                 throw new ExportFailure();
             }

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/ExportClientParameters.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/ExportClientParameters.java
@@ -1,0 +1,62 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.export;
+
+import java.util.Optional;
+
+/**
+ * This class contains the program parameters for export subcommand.
+ *
+ * @author johsol
+ */
+public record ExportClientParameters(String indexDir, String outputFile, String fieldName,
+                                     Optional<String> schemaName, Optional<String> clusterName, Optional<String> nodeIndex) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String indexDir;
+        private String outputFile;
+        private String fieldName;
+        private String clusterName;
+        private String schemaName;
+        private String nodeIndex;
+
+        public Builder indexDir(String value) {
+            this.indexDir = value;
+            return this;
+        }
+
+        public Builder outputFile(String value) {
+            this.outputFile = value;
+            return this;
+        }
+
+        public Builder fieldName(String value) {
+            this.fieldName = value;
+            return this;
+        }
+
+        public Builder schemaName(String value) {
+            this.schemaName = value;
+            return this;
+        }
+
+        public Builder clusterName(String value) {
+            this.clusterName = value;
+            return this;
+        }
+
+        public Builder nodeIndex(String value) {
+            this.nodeIndex = value;
+            return this;
+        }
+
+        public ExportClientParameters build() {
+            return new ExportClientParameters(indexDir, outputFile, fieldName, Optional.ofNullable(schemaName), Optional.ofNullable(clusterName),  Optional.ofNullable(nodeIndex));
+        }
+    }
+
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/IndexLocator.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/IndexLocator.java
@@ -73,7 +73,7 @@ public class IndexLocator {
                 nodeIndex,
                 "node-index",
                 clusterDir,
-                p -> p.getFileName().toString(),
+                p -> p.getFileName().toString().substring(1),
                 Path::toString
         );
         Path nodeDir = chooseOrThrow(nodeRes, "node-index");

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespasignificance;
 
+import ai.vespa.vespasignificance.export.ExportClientParameters;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
@@ -22,10 +23,14 @@ public class CommandLineOptions {
 
     public static final String HELP_OPTION = "help";
     public static final String INPUT_OPTION = "in";
-    public static final String OUTPUT_OPTION = "out";
+    public static final String OUTPUT_OPTION = "output";
     public static final String FIELD_OPTION = "field";
     public static final String LANGUAGE_OPTION = "language";
     public static final String ZST_COMPRESSION = "zst-compression";
+
+    public static final String INDEX_DIR = "index-dir";
+    public static final String CLUSTER_OPTION = "cluster";
+    public static final String SCHEMA_NAME = "schema";
 
     /** Options for selecting subcommand */
     static Options createGlobalOptions() {
@@ -43,6 +48,7 @@ public class CommandLineOptions {
     static Map<String, String> registeredCommands() {
         Map<String, String> commands = new LinkedHashMap<>();
         commands.put("generate", "Generate a significance model from a JSONL feed file.");
+        commands.put("export", "Export subcommand.");
         return commands;
     }
 
@@ -137,6 +143,76 @@ public class CommandLineOptions {
         builder.setZstCompression(cl.hasOption(ZST_COMPRESSION) ? cl.getOptionValue(ZST_COMPRESSION) : "false");
 
         return builder.build();
+    }
+
+    /** Options for export command */
+    static Options createExportOptions() {
+        Options options = new Options();
+
+        options.addOption(Option.builder("h")
+                .longOpt(HELP_OPTION)
+                .desc("Show this help and exit.")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt(INDEX_DIR)
+                .hasArg()
+                .argName("path/to/index")
+                .desc("Path to index dir.")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt(OUTPUT_OPTION)
+                .hasArg()
+                .argName("term_df.tsv")
+                .desc("Output tab separated value file.")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt(FIELD_OPTION)
+                .required()
+                .hasArg()
+                .argName("fieldName")
+                .desc("Document field to analyze.")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt(CLUSTER_OPTION)
+                .hasArg()
+                .argName("clusterName")
+                .desc("Name of cluster")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt(SCHEMA_NAME)
+                .hasArg()
+                .argName("schemaName")
+                .desc("Name of schema")
+                .build());
+
+        return options;
+    }
+
+    /** Petty print help for export command */
+    public static void printExportHelp() {
+        HelpFormatter fmt = new HelpFormatter();
+        fmt.setWidth(100);
+        fmt.setLeftPadding(2);
+        fmt.setDescPadding(2);
+        fmt.setOptionComparator(Comparator.comparing(Option::getLongOpt));
+        String header = "Options:";
+        fmt.printHelp("vespa-significance export", header, createExportOptions(), "", true);
+    }
+
+    /** Parse generate command options to ClientParameters */
+    public static ExportClientParameters parseExportCommandLineArguments(CommandLine cl) {
+        return ExportClientParameters.builder()
+                .fieldName(cl.getOptionValue(FIELD_OPTION))
+                .outputFile(cl.hasOption(OUTPUT_OPTION) ? cl.getOptionValue(OUTPUT_OPTION) : "term_df.tsv")
+                .indexDir(cl.getOptionValue(INDEX_DIR))
+                .clusterName(cl.getOptionValue(CLUSTER_OPTION))
+                .schemaName(cl.getOptionValue(SCHEMA_NAME))
+                .build();
     }
 
     /**

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -49,7 +49,7 @@ public class CommandLineOptions {
     static Map<String, String> registeredCommands() {
         Map<String, String> commands = new LinkedHashMap<>();
         commands.put("generate", "Generate a significance model from a JSONL feed file.");
-        commands.put("export", "Export subcommand.");
+        commands.put("export", "Export terms and document frequency from a flushed index to TSV.");
         return commands;
     }
 
@@ -159,43 +159,43 @@ public class CommandLineOptions {
                 .longOpt(INDEX_DIR)
                 .hasArg()
                 .argName("path/to/index")
-                .desc("Path to index dir.")
+                .desc("Path to index directory.")
                 .build());
 
         options.addOption(Option.builder()
                 .longOpt(OUTPUT_OPTION)
                 .hasArg()
-                .argName("term_df.tsv")
-                .desc("Output tab separated value file.")
+                .argName("FILE.tsv")
+                .desc("Output TSV file.")
                 .build());
 
         options.addOption(Option.builder()
                 .longOpt(FIELD_OPTION)
                 .required()
                 .hasArg()
-                .argName("fieldName")
-                .desc("Document field to analyze.")
+                .argName("FIELD")
+                .desc("Field to export.")
                 .build());
 
         options.addOption(Option.builder()
                 .longOpt(CLUSTER_OPTION)
                 .hasArg()
-                .argName("clusterName")
-                .desc("Name of cluster")
+                .argName("NAME")
+                .desc("Cluster name.")
                 .build());
 
         options.addOption(Option.builder()
                 .longOpt(SCHEMA_NAME)
                 .hasArg()
-                .argName("schemaName")
-                .desc("Name of schema")
+                .argName("NAME")
+                .desc("Schema name (document type).")
                 .build());
 
         options.addOption(Option.builder()
                 .longOpt(NODE_INDEX_OPTION)
                 .hasArg()
-                .argName("n0")
-                .desc("Specify node dir if multiple exists.")
+                .argName("NUMBER")
+                .desc("Node index directory.")
                 .build());
 
         return options;

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -31,6 +31,7 @@ public class CommandLineOptions {
     public static final String INDEX_DIR = "index-dir";
     public static final String CLUSTER_OPTION = "cluster";
     public static final String SCHEMA_NAME = "schema";
+    public static final String NODE_INDEX_OPTION = "node-index";
 
     /** Options for selecting subcommand */
     static Options createGlobalOptions() {
@@ -190,6 +191,13 @@ public class CommandLineOptions {
                 .desc("Name of schema")
                 .build());
 
+        options.addOption(Option.builder()
+                .longOpt(NODE_INDEX_OPTION)
+                .hasArg()
+                .argName("n0")
+                .desc("Specify node dir if multiple exists.")
+                .build());
+
         return options;
     }
 
@@ -212,6 +220,7 @@ public class CommandLineOptions {
                 .indexDir(cl.getOptionValue(INDEX_DIR))
                 .clusterName(cl.getOptionValue(CLUSTER_OPTION))
                 .schemaName(cl.getOptionValue(SCHEMA_NAME))
+                .nodeIndex(cl.getOptionValue(NODE_INDEX_OPTION))
                 .build();
     }
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
@@ -2,6 +2,7 @@
 
 package com.yahoo.vespasignificance;
 
+import ai.vespa.vespasignificance.export.Export;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.ParseException;
@@ -41,6 +42,10 @@ public class Main {
                 runGenerate(subArgs);
                 break;
 
+            case "export":
+                runExport(subArgs);
+                break;
+
             default:
                 System.err.println("Error: Unknown command `" + sub + "`");
                 CommandLineOptions.printGlobalHelp();
@@ -73,5 +78,26 @@ public class Main {
 
     private static SignificanceModelGenerator createSignificanceModelGenerator(ClientParameters params) {
         return new SignificanceModelGenerator(params);
+    }
+
+    static void runExport(String[] commandLineArgs) {
+        try {
+            if (CommandLineOptions.Utils.hasHelpOption(commandLineArgs)) {
+                CommandLineOptions.printExportHelp();
+                return;
+            }
+
+            var commandLineParser = new DefaultParser();
+            CommandLine commandLine = commandLineParser.parse(CommandLineOptions.createExportOptions(), commandLineArgs);
+            System.setProperty("vespa.replace_invalid_unicode", "true");
+
+            var clientParams = CommandLineOptions.parseExportCommandLineArguments(commandLine);
+            Export export = new Export(clientParams);
+            System.exit(export.run());
+        } catch (ParseException e) {
+            System.err.printf("Error: %s.\n", e.getMessage());
+            CommandLineOptions.printExportHelp();
+            System.exit(1);
+        }
     }
 }

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
@@ -1,0 +1,96 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.export;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for Export command.
+ *
+ * @author johsol
+ */
+class ExportTest {
+
+    @TempDir
+    Path tmp;
+
+    private ExportClientParameters params(String outputFile, String indexDir, String field,
+                                          String cluster, String schema, String node) {
+        return ExportClientParameters.builder()
+                .outputFile(outputFile)
+                .indexDir(indexDir)
+                .fieldName(field)
+                .clusterName(cluster)
+                .schemaName(schema)
+                .nodeIndex(node)
+                .build();
+    }
+
+    /** Minimal fake writer that captures terms written. */
+    static class CapturingWriter implements TermDfWriter {
+        final List<String> terms = new ArrayList<>();
+
+        @Override
+        public void write(VespaIndexInspectClient.TermDocumentFrequency row) throws IOException {
+            terms.add(row.term());
+        }
+
+        @Override
+        public void flush() throws IOException {
+            TermDfWriter.super.flush();
+        }
+
+        @Override public void close() {}
+    }
+
+    @Test
+    void happyPathWritesSortedTerms() throws Exception {
+        var outPath = tmp.resolve("out.tsv").toString();
+
+        // Params: force IndexLocator path (null indexDir), and provide field name
+        var params = params(outPath, null, "myfield", "alpha", "doc", "n0");
+
+        // Create the index dir and the field dir on disk
+        Path indexDir = tmp.resolve("idx");
+        Files.createDirectories(indexDir.resolve("myfield"));
+
+        // Locator returns that path
+        IndexLocator locator = mock(IndexLocator.class);
+        when(locator.locateIndexDir("alpha", "doc", "n0")).thenReturn(indexDir);
+
+        // Dump function emits unsorted rows
+        Export.DumpFn dumpFn = (idx, field) -> Stream.of(
+                new VespaIndexInspectClient.TermDocumentFrequency("zulu", 2),
+                new VespaIndexInspectClient.TermDocumentFrequency("alpha", 5)
+        );
+
+        CapturingWriter writer = new CapturingWriter();
+        Export.WriterFactory wf = out -> writer;
+
+        var baosOut = new ByteArrayOutputStream();
+        var prevOut = System.out;
+        System.setOut(new PrintStream(baosOut));
+        try {
+            int code = new Export(params, locator, wf, dumpFn).run();
+            assertEquals(0, code);
+            assertEquals(List.of("alpha", "zulu"), writer.terms);
+        } finally {
+            System.setOut(prevOut);
+        }
+    }
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
@@ -63,7 +63,7 @@ class ExportTest {
         var outPath = tmp.resolve("out.tsv").toString();
 
         // Params: force IndexLocator path (null indexDir), and provide field name
-        var params = params(outPath, null, "myfield", "alpha", "doc", "n0");
+        var params = params(outPath, null, "myfield", "alpha", "doc", "0");
 
         // Create the index dir and the field dir on disk
         Path indexDir = tmp.resolve("idx");
@@ -71,7 +71,7 @@ class ExportTest {
 
         // Locator returns that path
         IndexLocator locator = mock(IndexLocator.class);
-        when(locator.locateIndexDir("alpha", "doc", "n0")).thenReturn(indexDir);
+        when(locator.locateIndexDir("alpha", "doc", "0")).thenReturn(indexDir);
 
         // Dump function emits unsorted rows
         Export.DumpFn dumpFn = (idx, field) -> Stream.of(

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/IndexLocatorTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/IndexLocatorTest.java
@@ -40,7 +40,7 @@ class IndexLocatorTest {
         Path expected = mkIndexTree("cluster.alpha", "n0", "doc", true);
         IndexLocator locator = new IndexLocator(tmp);
 
-        Path actual = locator.locateIndexDir("alpha", "doc", "n0");
+        Path actual = locator.locateIndexDir("alpha", "doc", "0");
 
         assertEquals(expected, actual);
     }
@@ -69,7 +69,7 @@ class IndexLocatorTest {
 
         SelectionException e = assertThrows(
                 SelectionException.class,
-                () -> locator.locateIndexDir("beta", "doc", "n0")
+                () -> locator.locateIndexDir("beta", "doc", "0")
         );
         assertEquals(PathSelector.Outcome.NOT_FOUND, e.outcome());
         assertEquals("cluster", e.kind());
@@ -83,7 +83,7 @@ class IndexLocatorTest {
 
         SelectionException e = assertThrows(
                 SelectionException.class,
-                () -> locator.locateIndexDir(null, "doc", "n0")
+                () -> locator.locateIndexDir(null, "doc", "0")
         );
         assertEquals(PathSelector.Outcome.AMBIGUOUS, e.outcome());
         assertEquals("cluster", e.kind());
@@ -112,7 +112,7 @@ class IndexLocatorTest {
 
         SelectionException e = assertThrows(
                 SelectionException.class,
-                () -> locator.locateIndexDir("alpha", null, "n0")
+                () -> locator.locateIndexDir("alpha", null, "0")
         );
         assertEquals(PathSelector.Outcome.AMBIGUOUS, e.outcome());
         assertEquals("schema", e.kind());
@@ -127,7 +127,7 @@ class IndexLocatorTest {
 
         NoSuchFileException e = assertThrows(
                 NoSuchFileException.class,
-                () -> locator.locateIndexDir("alpha", "doc", "n0")
+                () -> locator.locateIndexDir("alpha", "doc", "0")
         );
         assertTrue(e.getMessage().contains("Documents directory"));
     }
@@ -140,7 +140,7 @@ class IndexLocatorTest {
 
         NoSuchFileException e = assertThrows(
                 NoSuchFileException.class,
-                () -> locator.locateIndexDir("alpha", "doc", "n0")
+                () -> locator.locateIndexDir("alpha", "doc", "0")
         );
         assertTrue(e.getMessage().contains("Index directory"));
     }


### PR DESCRIPTION
- Ensures output can be written to.
- Resolves index dir.
- Resolves field path.
- Calls vespa-index-inspect.
- Writes output.