### PR TITLE
Use the correct number of maximum links when removing from HNSW index

### DIFF
--- a/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
@@ -671,14 +671,12 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_hierarchic_graph_with_heuristic
         EXPECT_EQ(0, root["unreachable_nodes"].asLong());
     }
 
-    // removing 1, its neighbors {2,3,4} will try to
-    // link together, but since 2 already has enough links
-    // only 3 and 4 will become neighbors:
+    // removing 1, its neighbors {2,3,4} will link together
     this->remove_document(1);
     this->expect_entry_point(6, 2);
-    this->expect_level_0(2, {5, 6});
-    this->expect_levels(3, {{4, 7}, {6}});
-    this->expect_level_0(4, {3});
+    this->expect_level_0(2, {3, 4, 5, 6});
+    this->expect_levels(3, {{2, 4, 7}, {6}});
+    this->expect_level_0(4, {2, 3});
     this->expect_level_0(5, {2, 6});
     this->expect_levels(6, {{2, 5, 7}, {3}, {}});
     this->expect_level_0(7, {3, 6});
@@ -697,10 +695,10 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_hierarchic_graph_with_heuristic
         EXPECT_EQ(0, root["level_histogram"][0].asLong());
         EXPECT_EQ(4, root["level_histogram"][1].asLong());
         EXPECT_EQ(0, root["level_0_links_histogram"][0].asLong());
-        EXPECT_EQ(1, root["level_0_links_histogram"][1].asLong());
-        EXPECT_EQ(4, root["level_0_links_histogram"][2].asLong());
-        EXPECT_EQ(1, root["level_0_links_histogram"][3].asLong());
-        EXPECT_EQ(0, root["level_0_links_histogram"][4].asLong());
+        EXPECT_EQ(0, root["level_0_links_histogram"][1].asLong());
+        EXPECT_EQ(3, root["level_0_links_histogram"][2].asLong());
+        EXPECT_EQ(2, root["level_0_links_histogram"][3].asLong());
+        EXPECT_EQ(1, root["level_0_links_histogram"][4].asLong());
         EXPECT_EQ(0, root["unreachable_nodes"].asLong());
     }
 }

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -794,10 +794,10 @@ HnswIndex<type>::mutual_reconnect(const LinkArrayRef &cluster, uint32_t level)
     std::sort(pairs.begin(), pairs.end());
     for (const PairDist & pair : pairs) {
         LinkArrayRef old_links_1 = _graph.get_link_array(pair.id_first, level);
-        if (old_links_1.size() >= _cfg.max_links_on_inserts()) continue;
+        if (old_links_1.size() >= max_links_for_level(level)) continue;
 
         LinkArrayRef old_links_2 = _graph.get_link_array(pair.id_second, level);
-        if (old_links_2.size() >= _cfg.max_links_on_inserts()) continue;
+        if (old_links_2.size() >= max_links_for_level(level)) continue;
 
         add_link_to(pair.id_first, level, old_links_1, pair.id_second);
         add_link_to(pair.id_second, level, old_links_2, pair.id_first);


### PR DESCRIPTION
On the lowest level, the HNSW graph has twice the number of links compared to the other levels. This commit also respects this when removing nodes to avoid a drop in recall when deleting a large number of documents.

@arnej27959 please review