### PR TITLE
Rename JSONL `trace` output to `sessionTrace`

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
@@ -22,8 +22,8 @@ class JsonNames {
     static final SerializedString PUT              = new SerializedString("put");
     static final SerializedString REMOVE           = new SerializedString("remove");
     static final SerializedString SESSION_STATS    = new SerializedString("sessionStats");
+    static final SerializedString SESSION_TRACE    = new SerializedString("sessionTrace");
     static final SerializedString SEVERITY         = new SerializedString("severity");
     static final SerializedString TEXT             = new SerializedString("text");
     static final SerializedString TOKEN            = new SerializedString("token");
-    static final SerializedString TRACE            = new SerializedString("trace");
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamableJsonResponse.java
@@ -24,6 +24,12 @@ interface StreamableJsonResponse extends AutoCloseable {
     // underlying supplied resource may require locking for safe access.
     void reportUpdatedContinuation(Supplier<VisitorContinuation> continuationSupplier) throws IOException;
     void writeEpilogueContinuation(VisitorContinuation continuation) throws IOException;
+    /**
+     * Write a Trace that encapsulates a logical span of the <em>entire</em> request
+     * (e.g. Get/Put or visitor session). For visitor sessions traces are intentionally
+     * limited in total size due to the amount of messages involved, so for that case
+     * this is usually a very truncated representation of the full trace.
+     */
     void writeTrace(Trace trace) throws IOException;
 
     enum MessageSeverity {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponse.java
@@ -55,7 +55,10 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
 
     @Override
     public void commit(int status, boolean fullyApplied) throws IOException {
-        // TODO decide proper content type
+        // `application/jsonl` is the de facto (not de jure) media type for JSONL,
+        // so that's what we're going with. If this changes (JSONL gets some other
+        // IANA assignment) we can remap this based on what the client states it
+        // wants via the HTTP Accept header.
         responseWriter.commit(status, "application/jsonl; charset=UTF-8", fullyApplied);
     }
 
@@ -180,7 +183,7 @@ class StreamingJsonLinesResponse implements StreamableJsonResponse {
         }
         writeJsonLine((json) -> {
             json.writeStartObject();
-            json.writeFieldName(JsonNames.TRACE);
+            json.writeFieldName(JsonNames.SESSION_TRACE);
             json.writeStartObject();
             TraceJsonRenderer.writeTrace(json, trace.getRoot());
             json.writeEndObject();

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/StreamingJsonLinesResponseTest.java
@@ -252,7 +252,7 @@ public class StreamingJsonLinesResponseTest {
     }
 
     @Test
-    void trace_is_rendered_as_own_line() throws IOException {
+    void session_trace_is_rendered_as_own_line() throws IOException {
         var f = new Fixture();
         var trace = new Trace(9);
         trace.trace(7, "Poirot's deductions", false);
@@ -260,23 +260,21 @@ public class StreamingJsonLinesResponseTest {
                 .addChild("The butler did it")
                 .addChild("Weapon was a garden gnome"));
         f.jsonlResponse.writeTrace(trace);
-        // TODO the nested "trace" objects aren't beautiful; reconsider format for JSONL.
-        //  Since trace nodes may technically output "message" objects at any level, need a wrapper.
         String expected = """
-                {"trace":{"trace":[{"message":"Poirot's deductions"},{"fork":[{"message":"The butler did it"},{"message":"Weapon was a garden gnome"}]}]}}
+                {"sessionTrace":{"trace":[{"message":"Poirot's deductions"},{"fork":[{"message":"The butler did it"},{"message":"Weapon was a garden gnome"}]}]}}
                 """;
         verify(f.writer).write(expected, null);
     }
 
     @Test
-    void null_trace_is_not_rendered() throws Exception {
+    void null_session_trace_is_not_rendered() throws Exception {
         var f = new Fixture();
         f.jsonlResponse.writeTrace(null);
         verify(f.writer, never()).write(anyString(), any());
     }
 
     @Test
-    void empty_trace_is_not_rendered() throws Exception {
+    void empty_session_trace_is_not_rendered() throws Exception {
         var f = new Fixture();
         var trace = new Trace(9);
         // Not rendering traces without a root node is the behavior of the legacy


### PR DESCRIPTION
@bjorncs please review. I'm open to a better name, but as we know, naming stuff is NP-hard (Naming Problems-hard).

This name more accurately represents the semantics of the contents of the trace, and also frees up `trace` for later use if we want to add streaming per-message trace output.
