### PR TITLE
Don't reset resource utilization metrics on leadership loss MERGEOK

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -163,12 +163,6 @@ public class MetricUpdater {
             }
             metricReporter.set(NODES_NOT_CONVERGED, 0, context);
         }
-        MetricReporter.Context context = createContext(Map.of());
-        metricReporter.set(MAX_DISK_UTILIZATION, 0.0, context);
-        metricReporter.set(MAX_MEMORY_UTILIZATION, 0.0, context);
-        metricReporter.set(NODES_ABOVE_LIMIT, 0, context);
-        metricReporter.set(DISK_LIMIT, 0.0, context);
-        metricReporter.set(MEMORY_LIMIT, 0.0, context);
     }
 
     public void updateClusterBucketsOutOfSyncRatio(double ratio) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
@@ -269,18 +269,6 @@ public class MetricReporterTest {
                 argThat(hasMetricContext(withNodeTypeDimension("distributor"))));
         verify(f.mockReporter).set(eq(metricName(NODES_NOT_CONVERGED)), eq(0),
                 argThat(hasMetricContext(withNodeTypeDimension("storage"))));
-
-        // Resource usage metrics are reset
-        verify(f.mockReporter).set(eq(metricName(MAX_DISK_UTILIZATION)), eq(0.0),
-                argThat(hasMetricContext(withClusterDimension())));
-        verify(f.mockReporter).set(eq(metricName(MAX_MEMORY_UTILIZATION)), eq(0.0),
-                argThat(hasMetricContext(withClusterDimension())));
-        verify(f.mockReporter).set(eq(metricName(NODES_ABOVE_LIMIT)), eq(0),
-                argThat(hasMetricContext(withClusterDimension())));
-        verify(f.mockReporter).set(eq(metricName(DISK_LIMIT)), eq(0.0),
-                argThat(hasMetricContext(withClusterDimension())));
-        verify(f.mockReporter).set(eq(metricName(MEMORY_LIMIT)), eq(0.0),
-                argThat(hasMetricContext(withClusterDimension())));
     }
 
 }


### PR DESCRIPTION
@hakonhall please review

Can cause spurious warnings when this is sampled in certain scenarios.
