### PR TITLE
feat(vespa-curl): install curl wrapper to `bin`

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -460,6 +460,7 @@ fi
 %dir %{_prefix}
 %{_prefix}/bin
 %exclude %{_prefix}/bin/vespa
+%exclude %{_prefix}/bin/vespa-curl
 %exclude %{_prefix}/bin/vespa-destination
 %exclude %{_prefix}/bin/vespa-fbench
 %exclude %{_prefix}/bin/vespa-feed-client
@@ -562,6 +563,7 @@ fi
 %endif
 %dir %{_prefix}
 %dir %{_prefix}/bin
+%{_prefix}/bin/vespa-curl
 %{_prefix}/bin/vespa-jvm-dumper
 %{_prefix}/bin/vespa-logfmt
 %{_prefix}/bin/vespa-security-env

--- a/vespaclient-java/CMakeLists.txt
+++ b/vespaclient-java/CMakeLists.txt
@@ -13,4 +13,6 @@ vespa_install_script(src/main/sh/vespa-visit-target.sh vespa-visit-target bin)
 vespa_install_script(src/main/sh/vespa-feed-perf vespa-feed-perf bin)
 vespa_install_script(src/main/sh/vespa-status-filedistribution.sh vespa-status-filedistribution bin)
 vespa_install_script(src/main/sh/vespa-significance.sh vespa-significance bin)
+vespa_install_script(src/main/sh/vespa-curl-wrapper vespa-curl bin)
+# TODO Replace usage of vespa-curl-wrapper with vespa-curl
 vespa_install_script(src/main/sh/vespa-curl-wrapper vespa-curl-wrapper libexec/vespa)

--- a/vespaclient-java/src/main/sh/vespa-curl-wrapper
+++ b/vespaclient-java/src/main/sh/vespa-curl-wrapper
@@ -89,6 +89,10 @@ CURL_PARAMETERS=("$@")
 if [ -n "${VESPA_TLS_ENABLED}" ]
 then
   CURL_PARAMETERS=("${CURL_PARAMETERS[@]/http:/https:}")
+  # Ensure that scheme-less URLs (e.g. localhost:8080/status.html) default to HTTPS when TLS is enabled
+  CURL_PARAMETERS=("--proto-default" "https" "${CURL_PARAMETERS[@]}")
+else
+  CURL_PARAMETERS=("--proto-default" "http" "${CURL_PARAMETERS[@]}")
 fi
 
 if [ -n "${VESPA_TLS_HOSTNAME_VALIDATION_DISABLED}" ]


### PR DESCRIPTION
Install curl wrapper as `vespa-curl`. Override default scheme when URL is scheme-less.