### PR TITLE
Encapsulate query stack dumps behind SerializedQueryTree

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -383,7 +383,7 @@ struct MyWorld {
     }
 
     static void setStackDump(Request &request, const std::string &stack_dump) {
-        request.setSerializedQueryTree(SerializedQueryTree::create(stack_dump));
+        request.setSerializedQueryTree(SerializedQueryTree::fromStackDumpRef(stack_dump));
     }
 
     static SearchRequest::SP createRequest(const std::string &stack_dump)

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -383,7 +383,7 @@ struct MyWorld {
     }
 
     static void setStackDump(Request &request, const std::string &stack_dump) {
-        request.stackDump.assign(stack_dump.data(), stack_dump.data() + stack_dump.size());
+        request.setSerializedQueryTree(SerializedQueryTree::create(stack_dump));
     }
 
     static SearchRequest::SP createRequest(const std::string &stack_dump)

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -383,7 +383,7 @@ struct MyWorld {
     }
 
     static void setStackDump(Request &request, const std::string &stack_dump) {
-        request.setSerializedQueryTree(SerializedQueryTree::fromStackDumpRef(stack_dump));
+        request.setSerializedQueryTree(SerializedQueryTree::fromStackDump(stack_dump));
     }
 
     static SearchRequest::SP createRequest(const std::string &stack_dump)

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -1156,7 +1156,7 @@ TEST(QueryTest, global_filter_is_calculated_and_handled)
 bool query_needs_ranking(const std::string& stack_dump)
 {
     Query query;
-    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stack_dump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stack_dump);
     query.buildTree(*serializedQueryTree, "", ViewResolver(), plain_index_env);
     return query.needs_ranking();
 

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -50,6 +50,7 @@ using search::query::QueryBuilder;
 using search::query::Range;
 using search::query::StackDumpCreator;
 using search::query::Weight;
+using search::SerializedQueryTree;
 using search::queryeval::AndBlueprint;
 using search::queryeval::AndNotBlueprint;
 using search::queryeval::Blueprint;
@@ -1155,7 +1156,7 @@ TEST(QueryTest, global_filter_is_calculated_and_handled)
 bool query_needs_ranking(const std::string& stack_dump)
 {
     Query query;
-    auto queryTree = search::SerializedQueryTree::create(stack_dump);
+    auto queryTree = SerializedQueryTree::create(stack_dump);
     query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     return query.needs_ranking();
 

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -661,9 +661,9 @@ TEST(QueryTest, requireThatQueryGluesEverythingTogether)
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm(string_term, field, 1, Weight(2));
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
-    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
+    query.buildTree(*serializedQueryTree, "", ViewResolver(), plain_index_env);
     vector<const ITermData *> term_data;
     query.extractTerms(term_data);
     EXPECT_EQ(1u, term_data.size());
@@ -691,9 +691,9 @@ checkQueryAddsLocation(const string &loc_in, const string &loc_out) {
 
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm(string_term, field, 1, Weight(2));
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
-    query.buildTree(*queryTree,
+    query.buildTree(*serializedQueryTree,
                     loc_field + ":" + loc_in,
                     ViewResolver(), index_environment);
     vector<const ITermData *> term_data;
@@ -722,10 +722,10 @@ void verifyThatRankBlueprintAndAndNotStaysOnTopAfterLocation(QueryBuilder<Proton
     builder.addStringTerm("foo", field, field_id, string_weight);
     builder.addStringTerm("bar", field, field_id, string_weight);
     builder.addStringTerm("baz", field, field_id, string_weight);
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
 
     Query query;
-    query.buildTree(*queryTree, loc_field + ":" + loc_string, ViewResolver(), attribute_index_env);
+    query.buildTree(*serializedQueryTree, loc_field + ":" + loc_string, ViewResolver(), attribute_index_env);
     FakeSearchContext context(42);
     context.addIdx(0).idx(0).getFake()
             .addResult(field, "foo", FakeResult().doc(1));
@@ -921,9 +921,9 @@ TEST(QueryTest, requireThatWhiteListBlueprintCanBeUsed)
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm("foo", field, field_id, string_weight);
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
-    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
+    query.buildTree(*serializedQueryTree, "", ViewResolver(), plain_index_env);
 
     FakeSearchContext context(42);
     context.addIdx(0).idx(0).getFake()
@@ -951,9 +951,9 @@ void verifyThatRankBlueprintAndAndNotStaysOnTopAfterWhiteListing(QueryBuilder<Pr
     builder.addStringTerm("foo", field, field_id, string_weight);
     builder.addStringTerm("bar", field, field_id, string_weight);
     builder.addStringTerm("baz", field, field_id, string_weight);
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
-    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
+    query.buildTree(*serializedQueryTree, "", ViewResolver(), plain_index_env);
     FakeSearchContext context(42);
     context.addIdx(0).idx(0).getFake()
             .addResult(field, "foo", FakeResult().doc(1));
@@ -1003,8 +1003,8 @@ make_same_element_stack_dump(const std::string &prefix, const std::string &term_
     builder.addSameElement(2, prefix, 0, Weight(1));
     builder.addStringTerm("xyz", term_prefix + "f1", 1, Weight(1));
     builder.addStringTerm("abc", term_prefix + "f2", 2, Weight(1));
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
-    auto stack_dump_iterator = queryTree->makeIterator();
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
+    auto stack_dump_iterator = serializedQueryTree->makeIterator();
     SameElementModifier sem;
     search::query::Node::UP query = search::query::QueryTreeCreator<ProtonNodeTypes>::create(*stack_dump_iterator);
     query->accept(sem);
@@ -1156,8 +1156,8 @@ TEST(QueryTest, global_filter_is_calculated_and_handled)
 bool query_needs_ranking(const std::string& stack_dump)
 {
     Query query;
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stack_dump);
-    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stack_dump);
+    query.buildTree(*serializedQueryTree, "", ViewResolver(), plain_index_env);
     return query.needs_ranking();
 
 }

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -660,7 +660,7 @@ TEST(QueryTest, requireThatQueryGluesEverythingTogether)
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm(string_term, field, 1, Weight(2));
-    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
     query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     vector<const ITermData *> term_data;
@@ -690,7 +690,7 @@ checkQueryAddsLocation(const string &loc_in, const string &loc_out) {
 
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm(string_term, field, 1, Weight(2));
-    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
     query.buildTree(*queryTree,
                     loc_field + ":" + loc_in,
@@ -721,7 +721,7 @@ void verifyThatRankBlueprintAndAndNotStaysOnTopAfterLocation(QueryBuilder<Proton
     builder.addStringTerm("foo", field, field_id, string_weight);
     builder.addStringTerm("bar", field, field_id, string_weight);
     builder.addStringTerm("baz", field, field_id, string_weight);
-    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
 
     Query query;
     query.buildTree(*queryTree, loc_field + ":" + loc_string, ViewResolver(), attribute_index_env);
@@ -920,7 +920,7 @@ TEST(QueryTest, requireThatWhiteListBlueprintCanBeUsed)
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm("foo", field, field_id, string_weight);
-    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
     query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
 
@@ -950,7 +950,7 @@ void verifyThatRankBlueprintAndAndNotStaysOnTopAfterWhiteListing(QueryBuilder<Pr
     builder.addStringTerm("foo", field, field_id, string_weight);
     builder.addStringTerm("bar", field, field_id, string_weight);
     builder.addStringTerm("baz", field, field_id, string_weight);
-    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     Query query;
     query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     FakeSearchContext context(42);
@@ -1002,7 +1002,7 @@ make_same_element_stack_dump(const std::string &prefix, const std::string &term_
     builder.addSameElement(2, prefix, 0, Weight(1));
     builder.addStringTerm("xyz", term_prefix + "f1", 1, Weight(1));
     builder.addStringTerm("abc", term_prefix + "f2", 2, Weight(1));
-    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*builder.build());
     auto stack_dump_iterator = queryTree->makeIterator();
     SameElementModifier sem;
     search::query::Node::UP query = search::query::QueryTreeCreator<ProtonNodeTypes>::create(*stack_dump_iterator);

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -1156,7 +1156,7 @@ TEST(QueryTest, global_filter_is_calculated_and_handled)
 bool query_needs_ranking(const std::string& stack_dump)
 {
     Query query;
-    auto queryTree = SerializedQueryTree::create(stack_dump);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stack_dump);
     query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     return query.needs_ranking();
 

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for query.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchcore/proton/matching/fakesearchcontext.h>
 #include <vespa/searchcore/proton/matching/matchdatareservevisitor.h>
 #include <vespa/searchcore/proton/matching/blueprintbuilder.h>
@@ -659,10 +660,9 @@ TEST(QueryTest, requireThatQueryGluesEverythingTogether)
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm(string_term, field, 1, Weight(2));
-    string stack_dump = StackDumpCreator::create(*builder.build());
-
+    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
     Query query;
-    query.buildTree(stack_dump, "", ViewResolver(), plain_index_env);
+    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     vector<const ITermData *> term_data;
     query.extractTerms(term_data);
     EXPECT_EQ(1u, term_data.size());
@@ -690,10 +690,9 @@ checkQueryAddsLocation(const string &loc_in, const string &loc_out) {
 
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm(string_term, field, 1, Weight(2));
-    string stack_dump = StackDumpCreator::create(*builder.build());
-
+    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
     Query query;
-    query.buildTree(stack_dump,
+    query.buildTree(*queryTree,
                     loc_field + ":" + loc_in,
                     ViewResolver(), index_environment);
     vector<const ITermData *> term_data;
@@ -722,10 +721,10 @@ void verifyThatRankBlueprintAndAndNotStaysOnTopAfterLocation(QueryBuilder<Proton
     builder.addStringTerm("foo", field, field_id, string_weight);
     builder.addStringTerm("bar", field, field_id, string_weight);
     builder.addStringTerm("baz", field, field_id, string_weight);
-    std::string stackDump = StackDumpCreator::create(*builder.build());
+    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
 
     Query query;
-    query.buildTree(stackDump, loc_field + ":" + loc_string, ViewResolver(), attribute_index_env);
+    query.buildTree(*queryTree, loc_field + ":" + loc_string, ViewResolver(), attribute_index_env);
     FakeSearchContext context(42);
     context.addIdx(0).idx(0).getFake()
             .addResult(field, "foo", FakeResult().doc(1));
@@ -921,10 +920,9 @@ TEST(QueryTest, requireThatWhiteListBlueprintCanBeUsed)
 {
     QueryBuilder<ProtonNodeTypes> builder;
     builder.addStringTerm("foo", field, field_id, string_weight);
-    std::string stackDump = StackDumpCreator::create(*builder.build());
-
+    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
     Query query;
-    query.buildTree(stackDump, "", ViewResolver(), plain_index_env);
+    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
 
     FakeSearchContext context(42);
     context.addIdx(0).idx(0).getFake()
@@ -952,9 +950,9 @@ void verifyThatRankBlueprintAndAndNotStaysOnTopAfterWhiteListing(QueryBuilder<Pr
     builder.addStringTerm("foo", field, field_id, string_weight);
     builder.addStringTerm("bar", field, field_id, string_weight);
     builder.addStringTerm("baz", field, field_id, string_weight);
-    std::string stackDump = StackDumpCreator::create(*builder.build());
+    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
     Query query;
-    query.buildTree(stackDump, "", ViewResolver(), plain_index_env);
+    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     FakeSearchContext context(42);
     context.addIdx(0).idx(0).getFake()
             .addResult(field, "foo", FakeResult().doc(1));
@@ -1004,10 +1002,10 @@ make_same_element_stack_dump(const std::string &prefix, const std::string &term_
     builder.addSameElement(2, prefix, 0, Weight(1));
     builder.addStringTerm("xyz", term_prefix + "f1", 1, Weight(1));
     builder.addStringTerm("abc", term_prefix + "f2", 2, Weight(1));
-    std::string stack = StackDumpCreator::create(*builder.build());
-    search::SimpleQueryStackDumpIterator stack_dump_iterator(stack);
+    auto queryTree = StackDumpCreator::createQueryTree(*builder.build());
+    auto stack_dump_iterator = queryTree->makeIterator();
     SameElementModifier sem;
-    search::query::Node::UP query = search::query::QueryTreeCreator<ProtonNodeTypes>::create(stack_dump_iterator);
+    search::query::Node::UP query = search::query::QueryTreeCreator<ProtonNodeTypes>::create(*stack_dump_iterator);
     query->accept(sem);
     return query;
 }
@@ -1157,7 +1155,8 @@ TEST(QueryTest, global_filter_is_calculated_and_handled)
 bool query_needs_ranking(const std::string& stack_dump)
 {
     Query query;
-    query.buildTree(stack_dump, "", ViewResolver(), plain_index_env);
+    auto queryTree = search::SerializedQueryTree::create(stack_dump);
+    query.buildTree(*queryTree, "", ViewResolver(), plain_index_env);
     return query.needs_ranking();
 
 }

--- a/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
@@ -52,8 +52,7 @@ DocsumContext::initState()
     _docsumState._args.initFromDocsumRequest(req);
     auto [session, expectSession] = Matcher::lookupSearchSession(_sessionMgr, req);
     if (session) {
-        std::string_view queryStack = session->getStackDump();
-        _docsumState._args.setStackDump(queryStack.size(), queryStack.data());
+        _docsumState._args.setSerializedQueryTree(session->getSerializedQueryTree());
     }
     _docsumState._docsumbuf.clear();
     _docsumState._docsumbuf.reserve(req.hits.size());

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -173,7 +173,7 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
                   ISearchContext             & searchContext,
                   IAttributeContext          & attributeContext,
                   search::engine::Trace      & root_trace,
-                  std::string_view             queryStack,
+                  const search::SerializedQueryTree & queryTree,
                   const std::string          & location,
                   const ViewResolver         & viewResolver,
                   const IDocumentMetaStore   & metaStore,
@@ -206,7 +206,7 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
     trace.addEvent(4, "Start query setup");
     _query.setWhiteListBlueprint(metaStore.createWhiteListBlueprint());
     trace.addEvent(5, "Deserialize and build query tree");
-    _valid = _query.buildTree(queryStack, location, viewResolver, indexEnv);
+    _valid = _query.buildTree(queryTree, location, viewResolver, indexEnv);
     if (_valid) {
         _query.extractTerms(_queryEnv.terms());
         _query.extractLocations(_queryEnv.locations());

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -22,6 +22,7 @@ using search::attribute::diversity::DiversityFilter;
 using search::queryeval::CreateBlueprintParams;
 using search::queryeval::ExecuteInfo;
 using search::queryeval::IDiversifier;
+using search::SerializedQueryTree;
 using vespalib::Issue;
 
 using namespace search::fef::indexproperties::matchphase;
@@ -173,7 +174,7 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
                   ISearchContext             & searchContext,
                   IAttributeContext          & attributeContext,
                   search::engine::Trace      & root_trace,
-                  const search::SerializedQueryTree & queryTree,
+                  const SerializedQueryTree & queryTree,
                   const std::string          & location,
                   const ViewResolver         & viewResolver,
                   const IDocumentMetaStore   & metaStore,

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -14,6 +14,7 @@
 #include <vespa/searchcommon/attribute/i_attribute_functor.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/common/idocumentmetastore.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/common/stringmap.h>
 #include <vespa/searchlib/queryeval/idiversifier.h>
 #include <vespa/vespalib/util/doom.h>
@@ -152,7 +153,7 @@ public:
                       ISearchContext &searchContext,
                       IAttributeContext &attributeContext,
                       search::engine::Trace & root_trace,
-                      std::string_view queryStack,
+                      const search::SerializedQueryTree & queryTree,
                       const std::string &location,
                       const ViewResolver &viewResolver,
                       const search::IDocumentMetaStore &metaStore,

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -162,8 +162,10 @@ Matcher::create_match_tools_factory(const search::engine::Request &request, ISea
                    _stats.softDoomFactor(), factor, hasFactorOverride, vespalib::count_ns(safeLeft));
     }
     vespalib::Doom doom(_now_ref, safeDoom, request.getTimeOfDoom(), hasFactorOverride);
+    auto* queryTree = request.getSerializedQueryTree();
+    assert(queryTree != nullptr);
     return std::make_unique<MatchToolsFactory>(_queryLimiter, doom, searchContext, attrContext,
-                                               request.trace(), request.getStackRef(), request.location,
+                                               request.trace(), *queryTree, request.location,
                                                _viewResolver, metaStore, _indexEnv, *_rankSetup,
                                                rankProperties, feature_overrides, thread_bundle,
                                                metaStoreReadGuard, maxHits, is_search);
@@ -276,8 +278,7 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
             // These should have been moved instead.
             owned_objects.feature_overrides = std::make_unique<Properties>(*feature_overrides);
             feature_overrides = owned_objects.feature_overrides.get();
-            std::string_view queryStack = request.getStackRef();
-            owned_objects.stackDump.assign(queryStack.begin(), queryStack.end());
+            owned_objects.queryTree = request.getSerializedQueryTree()->shared_from_this();
         }
 
         MatchToolsFactory::UP mtf = create_match_tools_factory(request, searchContext, attrContext, metaStore,

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -162,10 +162,9 @@ Matcher::create_match_tools_factory(const search::engine::Request &request, ISea
                    _stats.softDoomFactor(), factor, hasFactorOverride, vespalib::count_ns(safeLeft));
     }
     vespalib::Doom doom(_now_ref, safeDoom, request.getTimeOfDoom(), hasFactorOverride);
-    auto* queryTree = request.getSerializedQueryTree();
-    assert(queryTree != nullptr);
+    const auto& queryTree = request.getSerializedQueryTree();
     return std::make_unique<MatchToolsFactory>(_queryLimiter, doom, searchContext, attrContext,
-                                               request.trace(), *queryTree, request.location,
+                                               request.trace(), queryTree, request.location,
                                                _viewResolver, metaStore, _indexEnv, *_rankSetup,
                                                rankProperties, feature_overrides, thread_bundle,
                                                metaStoreReadGuard, maxHits, is_search);
@@ -278,7 +277,7 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
             // These should have been moved instead.
             owned_objects.feature_overrides = std::make_unique<Properties>(*feature_overrides);
             feature_overrides = owned_objects.feature_overrides.get();
-            owned_objects.queryTree = request.getSerializedQueryTree()->shared_from_this();
+            owned_objects.queryTree = request.getSerializedQueryTree().shared_from_this();
         }
 
         MatchToolsFactory::UP mtf = create_match_tools_factory(request, searchContext, attrContext, metaStore,

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -35,6 +35,7 @@ using search::query::Node;
 using search::query::QueryTreeCreator;
 using search::query::TemplateTermVisitor;
 using search::query::Weight;
+using search::SerializedQueryTree;
 using search::queryeval::AndBlueprint;
 using search::queryeval::AndNotBlueprint;
 using search::queryeval::Blueprint;
@@ -169,7 +170,7 @@ NeedsRankingVisitor::NeedsRankingVisitor()
 NeedsRankingVisitor::~NeedsRankingVisitor() = default;
 
 Node::UP
-create_query_tree(const search::SerializedQueryTree &queryTree)
+create_query_tree(const SerializedQueryTree &queryTree)
 {
     auto stack_dump_iterator = queryTree.makeIterator();
     return QueryTreeCreator<ProtonNodeTypes>::create(*stack_dump_iterator);
@@ -181,7 +182,7 @@ Query::Query() = default;
 Query::~Query() = default;
 
 bool
-Query::buildTree(const search::SerializedQueryTree &queryTree, const string &location,
+Query::buildTree(const SerializedQueryTree &queryTree, const string &location,
                  const ViewResolver &resolver, const IIndexEnvironment &indexEnv)
 {
     _query_tree = create_query_tree(queryTree);

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vespa/searchlib/common/geo_location_spec.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/fef/itermdata.h>
 #include <vespa/searchlib/fef/matchdatalayout.h>
 #include <vespa/searchlib/fef/iindexenvironment.h>
@@ -58,7 +59,7 @@ public:
      *
      * @return success(true)/failure(false)
      **/
-    bool buildTree(std::string_view stack,
+    bool buildTree(const search::SerializedQueryTree &queryTree,
                    const std::string &location,
                    const ViewResolver &resolver,
                    const search::fef::IIndexEnvironment &idxEnv);

--- a/searchcore/src/vespa/searchcore/proton/matching/search_session.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/search_session.cpp
@@ -29,7 +29,7 @@ SearchSession::OwnershipBundle::OwnershipBundle(MatchContext && match_context,
       context(std::move(match_context)),
       feature_overrides(),
       readGuard(),
-      stackDump()
+      queryTree()
 {}
 
 SearchSession::OwnershipBundle::OwnershipBundle() noexcept = default;

--- a/searchcore/src/vespa/searchcore/proton/matching/search_session.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/search_session.h
@@ -34,7 +34,7 @@ public:
         MatchContext context;
         std::unique_ptr<search::fef::Properties> feature_overrides;
         IDocumentMetaStoreContext::IReadGuard::SP readGuard;
-        search::QueryTreeSP queryTree;
+        search::SerializedQueryTreeSP queryTree;
     };
 private:
     using SessionId = std::string;
@@ -69,7 +69,7 @@ public:
     std::string_view getStackDump() const noexcept {
         return _owned_objects.queryTree ? _owned_objects.queryTree->getStackRef() : std::string_view();
     }
-    const search::QueryTreeSP getSerializedQueryTree() const noexcept {
+    const search::SerializedQueryTreeSP getSerializedQueryTree() const noexcept {
         return _owned_objects.queryTree;
     }
 };

--- a/searchcore/src/vespa/searchcore/proton/matching/search_session.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/search_session.h
@@ -5,6 +5,7 @@
 #include "match_context.h"
 #include <vespa/searchcore/proton/documentmetastore/i_document_meta_store_context.h>
 #include <vespa/searchcore/proton/summaryengine/isearchhandler.h>
+#include <vespa/searchlib/engine/request.h>
 #include <vespa/vespalib/util/time.h>
 #include <memory>
 #include <string>
@@ -33,7 +34,7 @@ public:
         MatchContext context;
         std::unique_ptr<search::fef::Properties> feature_overrides;
         IDocumentMetaStoreContext::IReadGuard::SP readGuard;
-        std::vector<char> stackDump;
+        search::QueryTreeSP queryTree;
     };
 private:
     using SessionId = std::string;
@@ -66,7 +67,10 @@ public:
 
     MatchToolsFactory &getMatchToolsFactory() { return *_match_tools_factory; }
     std::string_view getStackDump() const noexcept {
-        return {_owned_objects.stackDump.data(), _owned_objects.stackDump.size()};
+        return _owned_objects.queryTree ? _owned_objects.queryTree->getStackRef() : std::string_view();
+    }
+    const search::QueryTreeSP getSerializedQueryTree() const noexcept {
+        return _owned_objects.queryTree;
     }
 };
 

--- a/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
+++ b/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
@@ -208,7 +208,7 @@ TEST_F(SearchRequestTest, require_that_geo_location_is_converted) {
 TEST_F(SearchRequestTest, require_that_query_tree_blob_is_converted) {
     proto.set_query_tree_blob("query-tree-blob");
     convert();
-    EXPECT_EQ(std::string(&request.stackDump[0], request.stackDump.size()), "query-tree-blob");
+    EXPECT_EQ(std::string(request.getSerializedQueryTree()->getStackRef()), "query-tree-blob");
 }
 
 //-----------------------------------------------------------------------------
@@ -528,7 +528,7 @@ TEST_F(DocsumRequestTest, require_that_field_list_is_converted) {
 TEST_F(DocsumRequestTest, require_that_query_tree_blob_is_converted) {
     proto.set_query_tree_blob("query-tree-blob");
     convert();
-    EXPECT_EQ(std::string(&request.stackDump[0], request.stackDump.size()), "query-tree-blob");
+    EXPECT_EQ(std::string(request.getSerializedQueryTree()->getStackRef()), "query-tree-blob");
 }
 
 TEST_F(DocsumRequestTest, require_that_global_ids_are_converted) {

--- a/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
+++ b/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
@@ -208,7 +208,7 @@ TEST_F(SearchRequestTest, require_that_geo_location_is_converted) {
 TEST_F(SearchRequestTest, require_that_query_tree_blob_is_converted) {
     proto.set_query_tree_blob("query-tree-blob");
     convert();
-    EXPECT_EQ(std::string(request.getSerializedQueryTree()->getStackRef()), "query-tree-blob");
+    EXPECT_EQ(std::string(request.getSerializedQueryTree().getStackRef()), "query-tree-blob");
 }
 
 //-----------------------------------------------------------------------------
@@ -528,7 +528,7 @@ TEST_F(DocsumRequestTest, require_that_field_list_is_converted) {
 TEST_F(DocsumRequestTest, require_that_query_tree_blob_is_converted) {
     proto.set_query_tree_blob("query-tree-blob");
     convert();
-    EXPECT_EQ(std::string(request.getSerializedQueryTree()->getStackRef()), "query-tree-blob");
+    EXPECT_EQ(std::string(request.getSerializedQueryTree().getStackRef()), "query-tree-blob");
 }
 
 TEST_F(DocsumRequestTest, require_that_global_ids_are_converted) {

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -747,9 +747,9 @@ TEST(QueryBuilderTest, require_that_Query_Tree_Creator_Can_Replicate_Queries) {
 
 TEST(QueryBuilderTest, require_that_Query_Tree_Creator_Can_Create_Queries_From_Stack) {
     Node::UP node = createQueryTree<MyQueryNodeTypes>();
-    string stackDump = StackDumpCreator::create(*node);
+    auto stackDump = StackDumpCreator::create(*node);
 
-    SimpleQueryStackDumpIterator iterator(stackDump);
+    SimpleQueryStackDumpIterator iterator(std::string_view(stackDump.data(), stackDump.size()));
 
     Node::UP new_node = QueryTreeCreator<SimpleQueryNodeTypes>::create(iterator);
     checkQueryTreeTypes<SimpleQueryNodeTypes>(new_node.get());
@@ -768,8 +768,8 @@ TEST(QueryBuilderTest, require_that_All_Range_Syntaxes_Work) {
     builder.addRangeTerm(range2, "view", 0, Weight(0));
     Node::UP node = builder.build();
 
-    string stackDump = StackDumpCreator::create(*node);
-    SimpleQueryStackDumpIterator iterator(stackDump);
+    auto stackDump = StackDumpCreator::create(*node);
+    SimpleQueryStackDumpIterator iterator(std::string_view(stackDump.data(), stackDump.size()));
 
     Node::UP new_node = QueryTreeCreator<SimpleQueryNodeTypes>::create(iterator);
     And *and_node = dynamic_cast<And *>(new_node.get());
@@ -795,9 +795,9 @@ TEST(QueryBuilderTest, fuzzy_node_can_be_created) {
         builder.addFuzzyTerm("term", "view", 0, Weight(0), 3, 1, prefix_match);
         Node::UP node = builder.build();
 
-        string stackDump = StackDumpCreator::create(*node);
+        auto stackDump = StackDumpCreator::create(*node);
         {
-            SimpleQueryStackDumpIterator iterator(stackDump);
+            SimpleQueryStackDumpIterator iterator(std::string_view(stackDump.data(), stackDump.size()));
             Node::UP new_node = QueryTreeCreator<SimpleQueryNodeTypes>::create(iterator);
             auto *fuzzy_node = as_node<FuzzyTerm>(new_node.get());
             EXPECT_EQ(3u, fuzzy_node->max_edit_distance());
@@ -805,7 +805,7 @@ TEST(QueryBuilderTest, fuzzy_node_can_be_created) {
             EXPECT_EQ(prefix_match, fuzzy_node->prefix_match());
         }
         {
-            search::QueryTermSimple::UP queryTermSimple = search::QueryTermDecoder::decodeTerm(stackDump);
+            search::QueryTermSimple::UP queryTermSimple = search::QueryTermDecoder::decodeTerm(std::string_view(stackDump.data(), stackDump.size()));
             EXPECT_EQ(3u, queryTermSimple->fuzzy_max_edit_distance());
             EXPECT_EQ(1u, queryTermSimple->fuzzy_prefix_lock_length());
             EXPECT_EQ(prefix_match, queryTermSimple->fuzzy_prefix_match());
@@ -819,8 +819,8 @@ TEST(QueryBuilderTest, require_that_empty_intermediate_node_can_be_added) {
     Node::UP node = builder.build();
     ASSERT_TRUE(node.get());
 
-    string stackDump = StackDumpCreator::create(*node);
-    SimpleQueryStackDumpIterator iterator(stackDump);
+    auto stackDump = StackDumpCreator::create(*node);
+    SimpleQueryStackDumpIterator iterator(std::string_view(stackDump.data(), stackDump.size()));
 
     Node::UP new_node = QueryTreeCreator<SimpleQueryNodeTypes>::create(iterator);
     And *and_node = dynamic_cast<And *>(new_node.get());
@@ -994,8 +994,8 @@ test_in_node(const std::vector<TermType>& values)
     builder.add_in_term(make_subterms(values), MultiTerm::Type::STRING,
                         "view", 0, Weight(0));
     auto node = builder.build();
-    string stack_dump = StackDumpCreator::create(*node);
-    SimpleQueryStackDumpIterator iterator(stack_dump);
+    auto stack_dump = StackDumpCreator::create(*node);
+    SimpleQueryStackDumpIterator iterator({stack_dump.data(), stack_dump.size()});
     verify_in_node(*QueryTreeCreator<SimpleQueryNodeTypes>::create(iterator), values);
     verify_in_node(*QueryTreeCreator<SimpleQueryNodeTypes>::replicate(*node), values);
 }

--- a/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
@@ -91,9 +91,9 @@ EquivQueryNodeTest::make_simple_equiv_stack_dump()
 
 TEST_F(EquivQueryNodeTest, test_equiv_evaluate_and_unpack)
 {
-    auto queryTree = make_simple_equiv_stack_dump();
+    auto serializedQueryTree = make_simple_equiv_stack_dump();
     QueryNodeResultFactory empty;
-    Query q(empty, *queryTree);
+    Query q(empty, *serializedQueryTree);
     auto& eqn = dynamic_cast<EquivQueryNode&>(q.getRoot());
     auto& terms = eqn.get_terms();
     EXPECT_EQ(3, terms.size());
@@ -196,9 +196,9 @@ TEST_F(EquivQueryNodeTest, test_equiv_evaluate_and_unpack)
 
 TEST_F(EquivQueryNodeTest, test_equiv_flattening)
 {
-    auto queryTree = make_simple_equiv_stack_dump();
+    auto serializedQueryTree = make_simple_equiv_stack_dump();
     AllowRewrite allow_rewrite;
-    Query q(allow_rewrite, *queryTree);
+    Query q(allow_rewrite, *serializedQueryTree);
     auto& eqn = dynamic_cast<EquivQueryNode&>(q.getRoot());
     auto& terms = eqn.get_terms();
     // Query is flattened to equiv("2", "2.5", phrase("2","5"), "3")

--- a/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
@@ -85,7 +85,7 @@ EquivQueryNodeTest::make_simple_equiv_stack_dump()
         builder.addStringTerm("3", "", 0, Weight(0));
     }
     Node::UP node = builder.build();
-    return StackDumpCreator::createQueryTree(*node);
+    return StackDumpCreator::createSerializedQueryTree(*node);
 }
 
 TEST_F(EquivQueryNodeTest, test_equiv_evaluate_and_unpack)

--- a/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
@@ -23,6 +23,7 @@ using search::query::Node;
 using search::query::SimpleQueryNodeTypes;
 using search::query::StackDumpCreator;
 using search::query::Weight;
+using search::SerializedQueryTreeSP;
 using search::streaming::EquivQueryNode;
 using search::streaming::HitList;
 using search::streaming::PhraseQueryNode;
@@ -49,7 +50,7 @@ public:
                          uint32_t exp_position,
                          int32_t exp_element_weight,
                          uint32_t exp_element_length);
-    search::QueryTreeSP make_simple_equiv_stack_dump();
+    SerializedQueryTreeSP make_simple_equiv_stack_dump();
 };
 
 EquivQueryNodeTest::EquivQueryNodeTest()
@@ -74,7 +75,7 @@ EquivQueryNodeTest::assert_tfmd_pos(const std::string label,
     EXPECT_EQ(exp_element_length, tfmd_pos.getElementLen());
 }
 
-search::QueryTreeSP
+SerializedQueryTreeSP
 EquivQueryNodeTest::make_simple_equiv_stack_dump()
 {
     QueryBuilder<SimpleQueryNodeTypes> builder;

--- a/searchlib/src/tests/query/streaming/near_test.cpp
+++ b/searchlib/src/tests/query/streaming/near_test.cpp
@@ -167,9 +167,9 @@ NearTest::make_query(QueryTweak query_tweak, uint32_t distance, const std::vecto
         builder.addStringTerm(s.str(), "field", idx, Weight(0));
     }
     auto node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
     auto empty = std::make_unique<MyQueryNodeResultFactory>(_element_gap_setting.value_or(std::nullopt));
-    auto q = std::make_unique<Query>(*empty, *queryTree);
+    auto q = std::make_unique<Query>(*empty, *serializedQueryTree);
     if (GetParam().ordered()) {
         auto& top = dynamic_cast<ONearQueryNode&>(q->getRoot());
         EXPECT_EQ(top_arity, top.size());

--- a/searchlib/src/tests/query/streaming/near_test.cpp
+++ b/searchlib/src/tests/query/streaming/near_test.cpp
@@ -167,7 +167,7 @@ NearTest::make_query(QueryTweak query_tweak, uint32_t distance, const std::vecto
         builder.addStringTerm(s.str(), "field", idx, Weight(0));
     }
     auto node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
     auto empty = std::make_unique<MyQueryNodeResultFactory>(_element_gap_setting.value_or(std::nullopt));
     auto q = std::make_unique<Query>(*empty, *queryTree);
     if (GetParam().ordered()) {

--- a/searchlib/src/tests/query/streaming/near_test.cpp
+++ b/searchlib/src/tests/query/streaming/near_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/streaming/multi_term.h>
 #include <vespa/searchlib/query/streaming/near_query_node.h>
 #include <vespa/searchlib/query/streaming/onear_query_node.h>
@@ -166,9 +167,9 @@ NearTest::make_query(QueryTweak query_tweak, uint32_t distance, const std::vecto
         builder.addStringTerm(s.str(), "field", idx, Weight(0));
     }
     auto node = builder.build();
-    std::string stackDump = StackDumpCreator::create(*node);
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
     auto empty = std::make_unique<MyQueryNodeResultFactory>(_element_gap_setting.value_or(std::nullopt));
-    auto q = std::make_unique<Query>(*empty, stackDump);
+    auto q = std::make_unique<Query>(*empty, *queryTree);
     if (GetParam().ordered()) {
         auto& top = dynamic_cast<ONearQueryNode&>(q->getRoot());
         EXPECT_EQ(top_arity, top.size());

--- a/searchlib/src/tests/query/streaming/phrase_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/phrase_query_node_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/streaming/phrase_query_node.h>
 #include <vespa/searchlib/query/streaming/query.h>
 #include <vespa/searchlib/query/streaming/queryterm.h>
@@ -31,9 +32,9 @@ TEST(PhraseQueryNodeTest, test_phrase_evaluate)
         builder.addStringTerm("c", "", 0, Weight(0));
     }
     Node::UP node = builder.build();
-    std::string stackDump = StackDumpCreator::create(*node);
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
     QueryNodeResultFactory empty;
-    Query q(empty, stackDump);
+    Query q(empty, *queryTree);
     auto& p = dynamic_cast<PhraseQueryNode&>(q.getRoot());
     auto& terms = p.get_terms();
     for (auto& qt : terms) {

--- a/searchlib/src/tests/query/streaming/phrase_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/phrase_query_node_test.cpp
@@ -32,7 +32,7 @@ TEST(PhraseQueryNodeTest, test_phrase_evaluate)
         builder.addStringTerm("c", "", 0, Weight(0));
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory empty;
     Query q(empty, *queryTree);
     auto& p = dynamic_cast<PhraseQueryNode&>(q.getRoot());

--- a/searchlib/src/tests/query/streaming/phrase_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/phrase_query_node_test.cpp
@@ -32,9 +32,9 @@ TEST(PhraseQueryNodeTest, test_phrase_evaluate)
         builder.addStringTerm("c", "", 0, Weight(0));
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory empty;
-    Query q(empty, *queryTree);
+    Query q(empty, *serializedQueryTree);
     auto& p = dynamic_cast<PhraseQueryNode&>(q.getRoot());
     auto& terms = p.get_terms();
     for (auto& qt : terms) {

--- a/searchlib/src/tests/query/streaming/query_builder_test.cpp
+++ b/searchlib/src/tests/query/streaming/query_builder_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/streaming/query.h>
 #include <vespa/searchlib/query/streaming/queryterm.h>
 #include <vespa/searchlib/query/tree/querybuilder.h>
@@ -7,6 +8,7 @@
 #include <vespa/searchlib/query/tree/stackdumpcreator.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
+using search::SerializedQueryTree;
 using search::query::QueryBuilder;
 using search::query::SimpleQueryNodeTypes;
 using search::query::StackDumpCreator;
@@ -25,8 +27,9 @@ TEST(StreamingQueryBuilderTest, hidden_terms_are_not_ranked)
     builder.addStringTerm("c", "", 0, Weight(0));
     auto node =  builder.build();
     std::string stackDump = StackDumpCreator::create(*node);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
     QueryNodeResultFactory empty;
-    Query q(empty, stackDump);
+    Query q(empty, *serializedQueryTree);
     QueryTermList terms;
     q.getRoot().getLeaves(terms);
     EXPECT_EQ(3, terms.size());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -154,7 +154,7 @@ TEST_F(SameElementQueryNodeTest, a_unhandled_sameElement_stack)
     const char * stack = "\022\002\026xyz_abcdefghij_xyzxyzxQ\001\vxxxxxx_name\034xxxxxx_xxxx_xxxxxxx_xxxxxxxxE\002\005delta\b<0.00393";
     std::string_view stackDump(stack);
     EXPECT_EQ(85u, stackDump.size());
-    auto queryTree = SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -22,6 +22,7 @@ using search::query::Node;
 using search::query::SimpleQueryNodeTypes;
 using search::query::StackDumpCreator;
 using search::query::Weight;
+using search::SerializedQueryTree;
 using search::streaming::HitList;
 using search::streaming::Query;
 using search::streaming::QueryNode;
@@ -153,7 +154,7 @@ TEST_F(SameElementQueryNodeTest, a_unhandled_sameElement_stack)
     const char * stack = "\022\002\026xyz_abcdefghij_xyzxyzxQ\001\vxxxxxx_name\034xxxxxx_xxxx_xxxxxxx_xxxxxxxxE\002\005delta\b<0.00393";
     std::string_view stackDump(stack);
     EXPECT_EQ(85u, stackDump.size());
-    auto queryTree = search::SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::create(stackDump);
     AllowRewrite empty("");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -121,7 +121,7 @@ SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<s
         builder.addStringTerm(s.str(), "field", idx, Weight(0));
     }
     auto node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory empty;
     auto q = std::make_unique<Query>(empty, *queryTree);
     auto& top = dynamic_cast<SameElementQueryNode&>(q->getRoot());
@@ -185,7 +185,7 @@ TEST_F(SameElementQueryNodeTest, test_same_element_evaluate)
         builder.addStringTerm("c", "f3", 2, Weight(0));
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory empty;
     Query q(empty, *queryTree);
     auto * sameElem = dynamic_cast<SameElementQueryNode *>(&q.getRoot());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -154,7 +154,7 @@ TEST_F(SameElementQueryNodeTest, a_unhandled_sameElement_stack)
     const char * stack = "\022\002\026xyz_abcdefghij_xyzxyzxQ\001\vxxxxxx_name\034xxxxxx_xxxx_xxxxxxx_xxxxxxxxE\002\005delta\b<0.00393";
     std::string_view stackDump(stack);
     EXPECT_EQ(85u, stackDump.size());
-    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
     AllowRewrite empty("");
     const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/streaming/same_element_query_node.h>
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/fef/simpletermdata.h>
@@ -120,9 +121,9 @@ SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<s
         builder.addStringTerm(s.str(), "field", idx, Weight(0));
     }
     auto node = builder.build();
-    std::string stackDump = StackDumpCreator::create(*node);
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
     QueryNodeResultFactory empty;
-    auto q = std::make_unique<Query>(empty, stackDump);
+    auto q = std::make_unique<Query>(empty, *queryTree);
     auto& top = dynamic_cast<SameElementQueryNode&>(q->getRoot());
     EXPECT_EQ(top_arity, top.get_children().size());
     top.resizeFieldId(1);
@@ -152,8 +153,9 @@ TEST_F(SameElementQueryNodeTest, a_unhandled_sameElement_stack)
     const char * stack = "\022\002\026xyz_abcdefghij_xyzxyzxQ\001\vxxxxxx_name\034xxxxxx_xxxx_xxxxxxx_xxxxxxxxE\002\005delta\b<0.00393";
     std::string_view stackDump(stack);
     EXPECT_EQ(85u, stackDump.size());
+    auto queryTree = search::SerializedQueryTree::create(stackDump);
     AllowRewrite empty("");
-    const Query q(empty, stackDump);
+    const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     auto sameElement = dynamic_cast<const SameElementQueryNode *>(&root);
@@ -183,9 +185,9 @@ TEST_F(SameElementQueryNodeTest, test_same_element_evaluate)
         builder.addStringTerm("c", "f3", 2, Weight(0));
     }
     Node::UP node = builder.build();
-    std::string stackDump = StackDumpCreator::create(*node);
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
     QueryNodeResultFactory empty;
-    Query q(empty, stackDump);
+    Query q(empty, *queryTree);
     auto * sameElem = dynamic_cast<SameElementQueryNode *>(&q.getRoot());
     EXPECT_TRUE(sameElem != nullptr);
     EXPECT_EQ("field", sameElem->getIndex());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -122,9 +122,9 @@ SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<s
         builder.addStringTerm(s.str(), "field", idx, Weight(0));
     }
     auto node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory empty;
-    auto q = std::make_unique<Query>(empty, *queryTree);
+    auto q = std::make_unique<Query>(empty, *serializedQueryTree);
     auto& top = dynamic_cast<SameElementQueryNode&>(q->getRoot());
     EXPECT_EQ(top_arity, top.get_children().size());
     top.resizeFieldId(1);
@@ -154,9 +154,9 @@ TEST_F(SameElementQueryNodeTest, a_unhandled_sameElement_stack)
     const char * stack = "\022\002\026xyz_abcdefghij_xyzxyzxQ\001\vxxxxxx_name\034xxxxxx_xxxx_xxxxxxx_xxxxxxxxE\002\005delta\b<0.00393";
     std::string_view stackDump(stack);
     EXPECT_EQ(85u, stackDump.size());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("");
-    const Query q(empty, *queryTree);
+    const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     auto sameElement = dynamic_cast<const SameElementQueryNode *>(&root);
@@ -186,9 +186,9 @@ TEST_F(SameElementQueryNodeTest, test_same_element_evaluate)
         builder.addStringTerm("c", "f3", 2, Weight(0));
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory empty;
-    Query q(empty, *queryTree);
+    Query q(empty, *serializedQueryTree);
     auto * sameElem = dynamic_cast<SameElementQueryNode *>(&q.getRoot());
     EXPECT_TRUE(sameElem != nullptr);
     EXPECT_EQ("field", sameElem->getIndex());

--- a/searchlib/src/tests/query/streaming_query_large_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_large_test.cpp
@@ -45,7 +45,7 @@ TEST(StreamingQueryTest, testveryLongQueryResultingInBug6850778) {
         }
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory factory;
     Query q(factory, *queryTree);
     QueryTermList terms;

--- a/searchlib/src/tests/query/streaming_query_large_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_large_test.cpp
@@ -45,9 +45,9 @@ TEST(StreamingQueryTest, testveryLongQueryResultingInBug6850778) {
         }
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
     QueryNodeResultFactory factory;
-    Query q(factory, *queryTree);
+    Query q(factory, *serializedQueryTree);
     QueryTermList terms;
     QueryNodeRefList phrases;
     q.getLeaves(terms);

--- a/searchlib/src/tests/query/streaming_query_large_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_large_test.cpp
@@ -1,4 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/streaming/query.h>
 #include <vespa/searchlib/query/tree/querybuilder.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
@@ -44,10 +45,9 @@ TEST(StreamingQueryTest, testveryLongQueryResultingInBug6850778) {
         }
     }
     Node::UP node = builder.build();
-    std::string stackDump = StackDumpCreator::create(*node);
-
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
     QueryNodeResultFactory factory;
-    Query q(factory, stackDump);
+    Query q(factory, *queryTree);
     QueryTermList terms;
     QueryNodeRefList phrases;
     q.getLeaves(terms);

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -319,7 +319,7 @@ TEST(StreamingQueryTest, e_is_not_rewritten_even_if_allowed)
     const char term[6] = {TERM_UNIQ, 3, 1, 'c', 1, 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(6u, stackDump.size());
-    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
     AllowRewrite allowRewrite("c");
     const Query q(allowRewrite, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
@@ -336,7 +336,7 @@ TEST(StreamingQueryTest, onedot0e_is_not_rewritten_by_default)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
     AllowRewrite empty("nix");
     const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
@@ -353,7 +353,7 @@ TEST(StreamingQueryTest, onedot0e_is_rewritten_if_allowed_too)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
     AllowRewrite empty("c");
     const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
@@ -392,7 +392,7 @@ TEST(StreamingQueryTest, negative_integer_is_rewritten_if_allowed_for_string_fie
     const char term[7] = {TERM_UNIQ, 3, 1, 'c', 2, '-', '5'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(7u, stackDump.size());
-    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
     AllowRewrite empty("c");
     const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -27,6 +27,7 @@ using TermType = QueryTerm::Type;
 using search::fef::SimpleTermData;
 using search::fef::MatchData;
 using search::fef::test::IndexEnvironment;
+using search::SerializedQueryTree;
 
 void assertHit(const Hit & h, uint32_t exp_field_id, uint32_t exp_element_id, int32_t exp_element_weight, size_t exp_position) {
     EXPECT_EQ(h.field_id(), exp_field_id);
@@ -318,7 +319,7 @@ TEST(StreamingQueryTest, e_is_not_rewritten_even_if_allowed)
     const char term[6] = {TERM_UNIQ, 3, 1, 'c', 1, 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(6u, stackDump.size());
-    auto queryTree = search::SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::create(stackDump);
     AllowRewrite allowRewrite("c");
     const Query q(allowRewrite, *queryTree);
     EXPECT_TRUE(q.valid());
@@ -335,7 +336,7 @@ TEST(StreamingQueryTest, onedot0e_is_not_rewritten_by_default)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto queryTree = search::SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::create(stackDump);
     AllowRewrite empty("nix");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
@@ -352,7 +353,7 @@ TEST(StreamingQueryTest, onedot0e_is_rewritten_if_allowed_too)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto queryTree = search::SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::create(stackDump);
     AllowRewrite empty("c");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
@@ -391,7 +392,7 @@ TEST(StreamingQueryTest, negative_integer_is_rewritten_if_allowed_for_string_fie
     const char term[7] = {TERM_UNIQ, 3, 1, 'c', 2, '-', '5'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(7u, stackDump.size());
-    auto queryTree = search::SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::create(stackDump);
     AllowRewrite empty("c");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -432,7 +432,7 @@ TEST(StreamingQueryTest, test_get_query_parts)
         }
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
 
     QueryNodeResultFactory empty;
     Query q(empty, *queryTree);
@@ -740,7 +740,7 @@ TEST(StreamingQueryTest, test_nearest_neighbor_query_node)
     constexpr double distance = 0.5;
     builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, explore_additional_hits, distance_threshold);
     auto build_node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*build_node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
     QueryNodeResultFactory empty;
     Query q(empty, *queryTree);
     auto* qterm = dynamic_cast<QueryTerm *>(&q.getRoot());

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -319,7 +319,7 @@ TEST(StreamingQueryTest, e_is_not_rewritten_even_if_allowed)
     const char term[6] = {TERM_UNIQ, 3, 1, 'c', 1, 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(6u, stackDump.size());
-    auto queryTree = SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite allowRewrite("c");
     const Query q(allowRewrite, *queryTree);
     EXPECT_TRUE(q.valid());
@@ -336,7 +336,7 @@ TEST(StreamingQueryTest, onedot0e_is_not_rewritten_by_default)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto queryTree = SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("nix");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
@@ -353,7 +353,7 @@ TEST(StreamingQueryTest, onedot0e_is_rewritten_if_allowed_too)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto queryTree = SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("c");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
@@ -392,7 +392,7 @@ TEST(StreamingQueryTest, negative_integer_is_rewritten_if_allowed_for_string_fie
     const char term[7] = {TERM_UNIQ, 3, 1, 'c', 2, '-', '5'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(7u, stackDump.size());
-    auto queryTree = SerializedQueryTree::create(stackDump);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("c");
     const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -319,9 +319,9 @@ TEST(StreamingQueryTest, e_is_not_rewritten_even_if_allowed)
     const char term[6] = {TERM_UNIQ, 3, 1, 'c', 1, 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(6u, stackDump.size());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite allowRewrite("c");
-    const Query q(allowRewrite, *queryTree);
+    const Query q(allowRewrite, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     EXPECT_TRUE(dynamic_cast<const QueryTerm *>(&root) != nullptr);
@@ -336,9 +336,9 @@ TEST(StreamingQueryTest, onedot0e_is_not_rewritten_by_default)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("nix");
-    const Query q(empty, *queryTree);
+    const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     EXPECT_TRUE(dynamic_cast<const QueryTerm *>(&root) != nullptr);
@@ -353,9 +353,9 @@ TEST(StreamingQueryTest, onedot0e_is_rewritten_if_allowed_too)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("c");
-    const Query q(empty, *queryTree);
+    const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     EXPECT_TRUE(dynamic_cast<const EquivQueryNode *>(&root) != nullptr);
@@ -392,9 +392,9 @@ TEST(StreamingQueryTest, negative_integer_is_rewritten_if_allowed_for_string_fie
     const char term[7] = {TERM_UNIQ, 3, 1, 'c', 2, '-', '5'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(7u, stackDump.size());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
+    auto serializedQueryTree = SerializedQueryTree::fromStackDumpRef(stackDump);
     AllowRewrite empty("c");
-    const Query q(empty, *queryTree);
+    const Query q(empty, *serializedQueryTree);
     EXPECT_TRUE(q.valid());
     auto& root = q.getRoot();
     auto& equiv = dynamic_cast<const EquivQueryNode &>(root);
@@ -433,10 +433,10 @@ TEST(StreamingQueryTest, test_get_query_parts)
         }
     }
     Node::UP node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
 
     QueryNodeResultFactory empty;
-    Query q(empty, *queryTree);
+    Query q(empty, *serializedQueryTree);
     QueryTermList terms;
     q.getLeaves(terms);
     ASSERT_TRUE(terms.size() == 4);
@@ -741,9 +741,9 @@ TEST(StreamingQueryTest, test_nearest_neighbor_query_node)
     constexpr double distance = 0.5;
     builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, explore_additional_hits, distance_threshold);
     auto build_node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
     QueryNodeResultFactory empty;
-    Query q(empty, *queryTree);
+    Query q(empty, *serializedQueryTree);
     auto* qterm = dynamic_cast<QueryTerm *>(&q.getRoot());
     EXPECT_TRUE(qterm != nullptr);
     auto* node = dynamic_cast<NearestNeighborQueryNode *>(&q.getRoot());

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/fef/simpletermdata.h>
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/fef/test/indexenvironment.h>
@@ -317,8 +318,9 @@ TEST(StreamingQueryTest, e_is_not_rewritten_even_if_allowed)
     const char term[6] = {TERM_UNIQ, 3, 1, 'c', 1, 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(6u, stackDump.size());
+    auto queryTree = search::SerializedQueryTree::create(stackDump);
     AllowRewrite allowRewrite("c");
-    const Query q(allowRewrite, stackDump);
+    const Query q(allowRewrite, *queryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     EXPECT_TRUE(dynamic_cast<const QueryTerm *>(&root) != nullptr);
@@ -333,8 +335,9 @@ TEST(StreamingQueryTest, onedot0e_is_not_rewritten_by_default)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
+    auto queryTree = search::SerializedQueryTree::create(stackDump);
     AllowRewrite empty("nix");
-    const Query q(empty, stackDump);
+    const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     EXPECT_TRUE(dynamic_cast<const QueryTerm *>(&root) != nullptr);
@@ -349,8 +352,9 @@ TEST(StreamingQueryTest, onedot0e_is_rewritten_if_allowed_too)
     const char term[9] = {TERM_UNIQ, 3, 1, 'c', 4, '1', '.', '0', 'e'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(9u, stackDump.size());
+    auto queryTree = search::SerializedQueryTree::create(stackDump);
     AllowRewrite empty("c");
-    const Query q(empty, stackDump);
+    const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
     const QueryNode & root = q.getRoot();
     EXPECT_TRUE(dynamic_cast<const EquivQueryNode *>(&root) != nullptr);
@@ -387,8 +391,9 @@ TEST(StreamingQueryTest, negative_integer_is_rewritten_if_allowed_for_string_fie
     const char term[7] = {TERM_UNIQ, 3, 1, 'c', 2, '-', '5'};
     std::string_view stackDump(term, sizeof(term));
     EXPECT_EQ(7u, stackDump.size());
+    auto queryTree = search::SerializedQueryTree::create(stackDump);
     AllowRewrite empty("c");
-    const Query q(empty, stackDump);
+    const Query q(empty, *queryTree);
     EXPECT_TRUE(q.valid());
     auto& root = q.getRoot();
     auto& equiv = dynamic_cast<const EquivQueryNode &>(root);
@@ -427,10 +432,10 @@ TEST(StreamingQueryTest, test_get_query_parts)
         }
     }
     Node::UP node = builder.build();
-    std::string stackDump = StackDumpCreator::create(*node);
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
 
     QueryNodeResultFactory empty;
-    Query q(empty, stackDump);
+    Query q(empty, *queryTree);
     QueryTermList terms;
     q.getLeaves(terms);
     ASSERT_TRUE(terms.size() == 4);
@@ -735,9 +740,9 @@ TEST(StreamingQueryTest, test_nearest_neighbor_query_node)
     constexpr double distance = 0.5;
     builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, explore_additional_hits, distance_threshold);
     auto build_node = builder.build();
-    auto stack_dump = StackDumpCreator::create(*build_node);
+    auto queryTree = StackDumpCreator::createQueryTree(*build_node);
     QueryNodeResultFactory empty;
-    Query q(empty, stack_dump);
+    Query q(empty, *queryTree);
     auto* qterm = dynamic_cast<QueryTerm *>(&q.getRoot());
     EXPECT_TRUE(qterm != nullptr);
     auto* node = dynamic_cast<NearestNeighborQueryNode *>(&q.getRoot());

--- a/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
+++ b/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
@@ -173,7 +173,7 @@ TEST(WordAlternativesTest, require_that_tree_can_be_replicated) {
 
 TEST(WordAlternativesTest, require_that_tree_can_be_replicated_via_stack) {
     Node::UP node = createQueryTree<SimpleQueryNodeTypes>();
-    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
     auto iterator = queryTree->makeIterator();
     Node::UP new_node = QueryTreeCreator<MyQueryNodeTypes>::create(*iterator);
     EXPECT_TRUE(bool(new_node));

--- a/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
+++ b/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
@@ -173,8 +173,8 @@ TEST(WordAlternativesTest, require_that_tree_can_be_replicated) {
 
 TEST(WordAlternativesTest, require_that_tree_can_be_replicated_via_stack) {
     Node::UP node = createQueryTree<SimpleQueryNodeTypes>();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
-    auto iterator = queryTree->makeIterator();
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
+    auto iterator = serializedQueryTree->makeIterator();
     Node::UP new_node = QueryTreeCreator<MyQueryNodeTypes>::create(*iterator);
     EXPECT_TRUE(bool(new_node));
     Expectation expect;

--- a/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
+++ b/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // Unit tests for querybuilder.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/parsequery/parse.h>
 #include <vespa/searchlib/query/tree/customtypevisitor.h>
 #include <vespa/searchlib/query/tree/querybuilder.h>
@@ -172,9 +173,9 @@ TEST(WordAlternativesTest, require_that_tree_can_be_replicated) {
 
 TEST(WordAlternativesTest, require_that_tree_can_be_replicated_via_stack) {
     Node::UP node = createQueryTree<SimpleQueryNodeTypes>();
-    string stackDump = StackDumpCreator::create(*node);
-    SimpleQueryStackDumpIterator iterator(stackDump);
-    Node::UP new_node = QueryTreeCreator<MyQueryNodeTypes>::create(iterator);
+    auto queryTree = StackDumpCreator::createQueryTree(*node);
+    auto iterator = queryTree->makeIterator();
+    Node::UP new_node = QueryTreeCreator<MyQueryNodeTypes>::create(*iterator);
     EXPECT_TRUE(bool(new_node));
     Expectation expect;
     expect.use_my_node = true;

--- a/searchlib/src/vespa/searchlib/common/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/common/CMakeLists.txt
@@ -27,6 +27,7 @@ vespa_add_library(searchlib_common OBJECT
     partialbitvector.cpp
     resultset.cpp
     schedule_sequenced_task_callback.cpp
+    serialized_query_tree.cpp
     serialnumfileheadercontext.cpp
     sort.cpp
     sortdata.cpp

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
@@ -23,14 +23,14 @@ SerializedQueryTree::SerializedQueryTree(std::vector<char> stackDump, ctor_tag)
 
 SerializedQueryTree::~SerializedQueryTree() = default;
 
-SerializedQueryTreeSP SerializedQueryTree::create(std::vector<char> stackDump) {
+SerializedQueryTreeSP SerializedQueryTree::fromStackDump(std::vector<char> stackDump) {
     ctor_tag tag;
     return std::make_shared<SerializedQueryTree>(std::move(stackDump), tag);
 }
 
-SerializedQueryTreeSP SerializedQueryTree::create(std::string_view stackDumpRef) {
+SerializedQueryTreeSP SerializedQueryTree::fromStackDumpRef(std::string_view stackDumpRef) {
     std::vector<char> stackDump(stackDumpRef.data(), stackDumpRef.data() + stackDumpRef.size());
-    return create(std::move(stackDump));
+    return fromStackDump(std::move(stackDump));
 }
 
 std::unique_ptr<QueryStackIterator> SerializedQueryTree::makeIterator() const {

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
@@ -38,10 +38,9 @@ std::unique_ptr<QueryStackIterator> SerializedQueryTree::makeIterator() const {
     return std::make_unique<SdiWrap>(shared_from_this(), stackRef);
 }
 
-SerializedQueryTreeSP SerializedQueryTree::_empty = SerializedQueryTree::fromStackDump(std::vector<char>());
-
-SerializedQueryTreeSP SerializedQueryTree::empty() {
-    return _empty;
+const SerializedQueryTree& SerializedQueryTree::empty() {
+    static SerializedQueryTreeSP empty_instance = fromStackDump(std::vector<char>());
+    return *empty_instance;
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
@@ -28,7 +28,7 @@ SerializedQueryTreeSP SerializedQueryTree::fromStackDump(std::vector<char> stack
     return std::make_shared<SerializedQueryTree>(std::move(stackDump), tag);
 }
 
-SerializedQueryTreeSP SerializedQueryTree::fromStackDumpRef(std::string_view stackDumpRef) {
+SerializedQueryTreeSP SerializedQueryTree::fromStackDump(std::string_view stackDumpRef) {
     std::vector<char> stackDump(stackDumpRef.data(), stackDumpRef.data() + stackDumpRef.size());
     return fromStackDump(std::move(stackDump));
 }

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
@@ -38,4 +38,10 @@ std::unique_ptr<QueryStackIterator> SerializedQueryTree::makeIterator() const {
     return std::make_unique<SdiWrap>(shared_from_this(), stackRef);
 }
 
+SerializedQueryTreeSP SerializedQueryTree::_empty = SerializedQueryTree::fromStackDump(std::vector<char>());
+
+SerializedQueryTreeSP SerializedQueryTree::empty() {
+    return _empty;
+}
+
 } // namespace search

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.cpp
@@ -7,8 +7,8 @@ namespace search {
 
 namespace {
 struct SdiWrap : SimpleQueryStackDumpIterator {
-    QueryTreeSP ref;
-    SdiWrap(QueryTreeSP data, std::string_view stackRef)
+    SerializedQueryTreeSP ref;
+    SdiWrap(SerializedQueryTreeSP data, std::string_view stackRef)
       : SimpleQueryStackDumpIterator(stackRef),
         ref(std::move(data))
     {}
@@ -23,12 +23,12 @@ SerializedQueryTree::SerializedQueryTree(std::vector<char> stackDump, ctor_tag)
 
 SerializedQueryTree::~SerializedQueryTree() = default;
 
-QueryTreeSP SerializedQueryTree::create(std::vector<char> stackDump) {
+SerializedQueryTreeSP SerializedQueryTree::create(std::vector<char> stackDump) {
     ctor_tag tag;
     return std::make_shared<SerializedQueryTree>(std::move(stackDump), tag);
 }
 
-QueryTreeSP SerializedQueryTree::create(std::string_view stackDumpRef) {
+SerializedQueryTreeSP SerializedQueryTree::create(std::string_view stackDumpRef) {
     std::vector<char> stackDump(stackDumpRef.data(), stackDumpRef.data() + stackDumpRef.size());
     return create(std::move(stackDump));
 }

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace search {
+
+class QueryStackIterator;
+class SimpleQueryStackDumpIterator;
+class SerializedQueryTree;
+
+using QueryTreeSP = std::shared_ptr<const SerializedQueryTree>;
+
+class SerializedQueryTree : public std::enable_shared_from_this<SerializedQueryTree> {
+private:
+    struct ctor_tag {};
+public:
+    static QueryTreeSP create(std::vector<char> stackDump);
+    static QueryTreeSP create(std::string_view stackDumpRef);
+    std::unique_ptr<QueryStackIterator> makeIterator() const;
+    // use for testing only:
+    std::string_view getStackRef() const noexcept {
+        return std::string_view(_stackDump.data(), _stackDump.size());
+    }
+
+    SerializedQueryTree(std::vector<char> stackDump, ctor_tag tag);
+    ~SerializedQueryTree();
+private:
+    std::vector<char> _stackDump;
+};
+
+} // namespace search

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
@@ -28,8 +28,10 @@ public:
 
     SerializedQueryTree(std::vector<char> stackDump, ctor_tag tag);
     ~SerializedQueryTree();
+    static SerializedQueryTreeSP empty();
 private:
     std::vector<char> _stackDump;
+    static SerializedQueryTreeSP _empty;
 };
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
@@ -12,14 +12,14 @@ class QueryStackIterator;
 class SimpleQueryStackDumpIterator;
 class SerializedQueryTree;
 
-using QueryTreeSP = std::shared_ptr<const SerializedQueryTree>;
+using SerializedQueryTreeSP = std::shared_ptr<const SerializedQueryTree>;
 
 class SerializedQueryTree : public std::enable_shared_from_this<SerializedQueryTree> {
 private:
     struct ctor_tag {};
 public:
-    static QueryTreeSP create(std::vector<char> stackDump);
-    static QueryTreeSP create(std::string_view stackDumpRef);
+    static SerializedQueryTreeSP create(std::vector<char> stackDump);
+    static SerializedQueryTreeSP create(std::string_view stackDumpRef);
     std::unique_ptr<QueryStackIterator> makeIterator() const;
     // use for testing only:
     std::string_view getStackRef() const noexcept {

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
@@ -19,7 +19,7 @@ private:
     struct ctor_tag {};
 public:
     static SerializedQueryTreeSP fromStackDump(std::vector<char> stackDump);
-    static SerializedQueryTreeSP fromStackDumpRef(std::string_view stackDumpRef);
+    static SerializedQueryTreeSP fromStackDump(std::string_view stackDumpRef);
     std::unique_ptr<QueryStackIterator> makeIterator() const;
     // use for testing only:
     std::string_view getStackRef() const noexcept {

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
@@ -18,8 +18,8 @@ class SerializedQueryTree : public std::enable_shared_from_this<SerializedQueryT
 private:
     struct ctor_tag {};
 public:
-    static SerializedQueryTreeSP create(std::vector<char> stackDump);
-    static SerializedQueryTreeSP create(std::string_view stackDumpRef);
+    static SerializedQueryTreeSP fromStackDump(std::vector<char> stackDump);
+    static SerializedQueryTreeSP fromStackDumpRef(std::string_view stackDumpRef);
     std::unique_ptr<QueryStackIterator> makeIterator() const;
     // use for testing only:
     std::string_view getStackRef() const noexcept {

--- a/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
+++ b/searchlib/src/vespa/searchlib/common/serialized_query_tree.h
@@ -28,10 +28,9 @@ public:
 
     SerializedQueryTree(std::vector<char> stackDump, ctor_tag tag);
     ~SerializedQueryTree();
-    static SerializedQueryTreeSP empty();
+    static const SerializedQueryTree& empty();
 private:
     std::vector<char> _stackDump;
-    static SerializedQueryTreeSP _empty;
 };
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
@@ -125,7 +125,7 @@ ProtoConverter::search_request_from_proto(const ProtoSearchRequest &proto, Searc
     request.groupSpec.assign(proto.grouping_blob().begin(), proto.grouping_blob().end());
     request.location = proto.geo_location();
     std::string_view stackDumpRef(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
-    auto queryTree = SerializedQueryTree::create(stackDumpRef);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDumpRef);
     request.setSerializedQueryTree(queryTree);
 }
 
@@ -223,7 +223,7 @@ ProtoConverter::docsum_request_from_proto(const ProtoDocsumRequest &proto, Docsu
     }
     request.location = proto.geo_location();
     std::string_view stackDumpRef(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
-    auto queryTree = SerializedQueryTree::create(stackDumpRef);
+    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDumpRef);
     request.setSerializedQueryTree(queryTree);
     request.hits.resize(proto.global_ids_size());
     for (int i = 0; i < proto.global_ids_size(); ++i) {

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
@@ -125,7 +125,7 @@ ProtoConverter::search_request_from_proto(const ProtoSearchRequest &proto, Searc
     request.groupSpec.assign(proto.grouping_blob().begin(), proto.grouping_blob().end());
     request.location = proto.geo_location();
     std::string_view stackDumpRef(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDumpRef);
+    auto queryTree = SerializedQueryTree::fromStackDump(stackDumpRef);
     request.setSerializedQueryTree(queryTree);
 }
 
@@ -223,7 +223,7 @@ ProtoConverter::docsum_request_from_proto(const ProtoDocsumRequest &proto, Docsu
     }
     request.location = proto.geo_location();
     std::string_view stackDumpRef(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
-    auto queryTree = SerializedQueryTree::fromStackDumpRef(stackDumpRef);
+    auto queryTree = SerializedQueryTree::fromStackDump(stackDumpRef);
     request.setSerializedQueryTree(queryTree);
     request.hits.resize(proto.global_ids_size());
     for (int i = 0; i < proto.global_ids_size(); ++i) {

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
@@ -124,7 +124,9 @@ ProtoConverter::search_request_from_proto(const ProtoSearchRequest &proto, Searc
     }
     request.groupSpec.assign(proto.grouping_blob().begin(), proto.grouping_blob().end());
     request.location = proto.geo_location();
-    request.stackDump.assign(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
+    std::string_view stackDumpRef(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
+    auto queryTree = SerializedQueryTree::create(stackDumpRef);
+    request.setSerializedQueryTree(queryTree);
 }
 
 void
@@ -220,7 +222,9 @@ ProtoConverter::docsum_request_from_proto(const ProtoDocsumRequest &proto, Docsu
         add_multi_props(highlight_terms, proto.highlight_terms());
     }
     request.location = proto.geo_location();
-    request.stackDump.assign(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
+    std::string_view stackDumpRef(proto.query_tree_blob().begin(), proto.query_tree_blob().end());
+    auto queryTree = SerializedQueryTree::create(stackDumpRef);
+    request.setSerializedQueryTree(queryTree);
     request.hits.resize(proto.global_ids_size());
     for (int i = 0; i < proto.global_ids_size(); ++i) {
         const auto &gid = proto.global_ids(i);

--- a/searchlib/src/vespa/searchlib/engine/request.cpp
+++ b/searchlib/src/vespa/searchlib/engine/request.cpp
@@ -11,11 +11,11 @@ Request::Request(RelativeTime relativeTime)
 Request::Request(RelativeTime relativeTime, uint32_t reservePropMaps)
     : _relativeTime(std::move(relativeTime)),
       _timeOfDoom(vespalib::steady_time::max()),
+      _queryTree(),
       dumpFeatures(false),
       ranking(),
       location(),
       propertiesMap(reservePropMaps),
-      stackDump(),
       sessionId(),
       _trace(_relativeTime, 0)
 {

--- a/searchlib/src/vespa/searchlib/engine/request.h
+++ b/searchlib/src/vespa/searchlib/engine/request.h
@@ -35,7 +35,7 @@ public:
         _queryTree = std::move(queryTree);
     }
     const SerializedQueryTree& getSerializedQueryTree() const {
-        return _queryTree ? *_queryTree : *SerializedQueryTree::empty();
+        return _queryTree ? *_queryTree : SerializedQueryTree::empty();
     }
 private:
     RelativeTime          _relativeTime;

--- a/searchlib/src/vespa/searchlib/engine/request.h
+++ b/searchlib/src/vespa/searchlib/engine/request.h
@@ -31,14 +31,14 @@ public:
 
     Trace & trace() const { return _trace; }
 
-    void setSerializedQueryTree(QueryTreeSP queryTree) {
+    void setSerializedQueryTree(SerializedQueryTreeSP queryTree) {
         _queryTree = std::move(queryTree);
     }
     const SerializedQueryTree * getSerializedQueryTree() const { return _queryTree.get(); }
 private:
     RelativeTime          _relativeTime;
     vespalib::steady_time _timeOfDoom;
-    QueryTreeSP           _queryTree;
+    SerializedQueryTreeSP           _queryTree;
 public:
     /// Everything here should move up to private section and have accessors
     bool               dumpFeatures;

--- a/searchlib/src/vespa/searchlib/engine/request.h
+++ b/searchlib/src/vespa/searchlib/engine/request.h
@@ -34,7 +34,9 @@ public:
     void setSerializedQueryTree(SerializedQueryTreeSP queryTree) {
         _queryTree = std::move(queryTree);
     }
-    const SerializedQueryTree * getSerializedQueryTree() const { return _queryTree.get(); }
+    const SerializedQueryTree& getSerializedQueryTree() const {
+        return _queryTree ? *_queryTree : *SerializedQueryTree::empty();
+    }
 private:
     RelativeTime          _relativeTime;
     vespalib::steady_time _timeOfDoom;

--- a/searchlib/src/vespa/searchlib/engine/request.h
+++ b/searchlib/src/vespa/searchlib/engine/request.h
@@ -4,6 +4,7 @@
 
 #include "propertiesmap.h"
 #include "trace.h"
+#include <vespa/searchlib/common/serialized_query_tree.h>
 
 namespace search::engine {
 
@@ -23,26 +24,27 @@ public:
     vespalib::duration getTimeLeft() const;
     bool expired() const { return getTimeLeft() <= vespalib::duration::zero(); }
 
-    std::string_view getStackRef() const {
-        return std::string_view(stackDump.data(), stackDump.size());
-    }
-
     void setTraceLevel(uint32_t level, uint32_t minLevel) const {
         _trace.setLevel(level);
         _trace.start(minLevel);
     }
 
     Trace & trace() const { return _trace; }
+
+    void setSerializedQueryTree(QueryTreeSP queryTree) {
+        _queryTree = std::move(queryTree);
+    }
+    const SerializedQueryTree * getSerializedQueryTree() const { return _queryTree.get(); }
 private:
-    RelativeTime           _relativeTime;
-    vespalib::steady_time  _timeOfDoom;
+    RelativeTime          _relativeTime;
+    vespalib::steady_time _timeOfDoom;
+    QueryTreeSP           _queryTree;
 public:
     /// Everything here should move up to private section and have accessors
     bool               dumpFeatures;
-    std::string   ranking;
-    std::string   location;
+    std::string        ranking;
+    std::string        location;
     PropertiesMap      propertiesMap;
-    std::vector<char>  stackDump;
     std::vector<char>  sessionId;
 private:
     mutable Trace      _trace;

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.cpp
@@ -11,6 +11,14 @@ using search::query::StringTermVector;
 
 namespace search {
 
+namespace {
+struct Dummy : QueryStackIterator {
+    bool next() override { return false; }
+    ~Dummy();
+};
+Dummy::~Dummy() = default;
+}
+
 std::unique_ptr<query::PredicateQueryTerm> QueryStackIterator::getPredicateQueryTerm() {
     return std::move(_d.predicateQueryTerm);
 }
@@ -21,5 +29,9 @@ std::unique_ptr<query::TermVector> QueryStackIterator::get_terms() {
 std::string_view QueryStackIterator::DEFAULT_INDEX = "default";
 
 QueryStackIterator::~QueryStackIterator() = default;
+
+std::unique_ptr<QueryStackIterator> QueryStackIterator::dummy() {
+    return std::make_unique<Dummy>();
+}
 
 }

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
@@ -109,6 +109,8 @@ public:
 
     virtual std::string_view getStack() const noexcept { return ""; }
     virtual size_t getPosition() const noexcept { return 0; }
+
+    static std::unique_ptr<QueryStackIterator> dummy();
 };
 
 } // namespace

--- a/searchlib/src/vespa/searchlib/query/query_term_decoder.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_decoder.cpp
@@ -14,7 +14,7 @@ QueryTermDecoder::decodeTerm(QueryPacketT term)
 {
     QueryTermSimple::UP result;
     QueryNodeResultFactory factory;
-    auto queryTree = SerializedQueryTree::create(std::vector<char>(term.begin(), term.end()));
+    auto queryTree = SerializedQueryTree::fromStackDump(std::vector<char>(term.begin(), term.end()));
     Query query(factory, *queryTree);
     if (query.valid() && (dynamic_cast<const QueryTerm *>(&query.getRoot()))) {
         result.reset(static_cast<QueryTerm *>(Query::steal(std::move(query)).release()));

--- a/searchlib/src/vespa/searchlib/query/query_term_decoder.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_decoder.cpp
@@ -14,7 +14,7 @@ QueryTermDecoder::decodeTerm(QueryPacketT term)
 {
     QueryTermSimple::UP result;
     QueryNodeResultFactory factory;
-    auto queryTree = SerializedQueryTree::fromStackDump(std::vector<char>(term.begin(), term.end()));
+    auto queryTree = SerializedQueryTree::fromStackDump(term);
     Query query(factory, *queryTree);
     if (query.valid() && (dynamic_cast<const QueryTerm *>(&query.getRoot()))) {
         result.reset(static_cast<QueryTerm *>(Query::steal(std::move(query)).release()));

--- a/searchlib/src/vespa/searchlib/query/query_term_decoder.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_decoder.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "query_term_decoder.h"
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/streaming/query.h>
 #include <vespa/vespalib/util/exceptions.h>
 
@@ -13,7 +14,8 @@ QueryTermDecoder::decodeTerm(QueryPacketT term)
 {
     QueryTermSimple::UP result;
     QueryNodeResultFactory factory;
-    Query query(factory, term);
+    auto queryTree = SerializedQueryTree::create(std::vector<char>(term.begin(), term.end()));
+    Query query(factory, *queryTree);
     if (query.valid() && (dynamic_cast<const QueryTerm *>(&query.getRoot()))) {
         result.reset(static_cast<QueryTerm *>(Query::steal(std::move(query)).release()));
     } else {

--- a/searchlib/src/vespa/searchlib/query/streaming/query.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/query.h
@@ -4,6 +4,8 @@
 #include "queryterm.h"
 #include <vespa/searchlib/parsequery/parse.h>
 
+namespace search { class SerializedQueryTree; }
+
 namespace search::streaming {
 
 /**
@@ -127,14 +129,14 @@ class Query
 {
 public:
     Query();
-    Query(const QueryNodeResultFactory & factory, std::string_view queryRep);
+    Query(const QueryNodeResultFactory & factory, const SerializedQueryTree& queryTree);
     Query(const Query&) = delete;
     Query(Query&&) noexcept;
     ~Query();
     Query& operator=(const Query&) = delete;
     Query& operator=(Query&&) noexcept;
     /// Will build the query tree
-    bool build(const QueryNodeResultFactory & factory, std::string_view queryRep);
+    bool build(const QueryNodeResultFactory & factory, const SerializedQueryTree& queryTree);
     /// Will clear the results from the querytree.
     void reset();
     /// Will get all leafnodes.

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -17,6 +17,7 @@ using std::string;
 using std::vector;
 using search::ParseItem;
 using search::RawBuf;
+using search::SerializedQueryTree;
 using search::SerializedQueryTreeSP;
 using namespace search::query;
 
@@ -379,7 +380,7 @@ string StackDumpCreator::create(const Node &node) {
 SerializedQueryTreeSP StackDumpCreator::createSerializedQueryTree(const Node &node) {
     string stackDump = create(node);
     vector<char> buf(stackDump.begin(), stackDump.end());
-    return search::SerializedQueryTree::create(std::move(buf));
+    return SerializedQueryTree::create(std::move(buf));
 }
 
 using namespace search::query;

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -379,7 +379,7 @@ string StackDumpCreator::create(const Node &node) {
 
 SerializedQueryTreeSP StackDumpCreator::createSerializedQueryTree(const Node &node) {
     string stackDump = create(node);
-    return SerializedQueryTree::fromStackDumpRef(stackDump);
+    return SerializedQueryTree::fromStackDump(stackDump);
 }
 
 using namespace search::query;

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -379,8 +379,7 @@ string StackDumpCreator::create(const Node &node) {
 
 SerializedQueryTreeSP StackDumpCreator::createSerializedQueryTree(const Node &node) {
     string stackDump = create(node);
-    vector<char> buf(stackDump.begin(), stackDump.end());
-    return SerializedQueryTree::create(std::move(buf));
+    return SerializedQueryTree::fromStackDumpRef(stackDump);
 }
 
 using namespace search::query;

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -17,6 +17,7 @@ using std::string;
 using std::vector;
 using search::ParseItem;
 using search::RawBuf;
+using search::SerializedQueryTreeSP;
 using namespace search::query;
 
 namespace {
@@ -375,7 +376,7 @@ string StackDumpCreator::create(const Node &node) {
     return converter.getStackDump();
 }
 
-search::QueryTreeSP StackDumpCreator::createSerializedQueryTree(const Node &node) {
+SerializedQueryTreeSP StackDumpCreator::createSerializedQueryTree(const Node &node) {
     string stackDump = create(node);
     vector<char> buf(stackDump.begin(), stackDump.end());
     return search::SerializedQueryTree::create(std::move(buf));

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -4,12 +4,14 @@
 
 #include "intermediatenodes.h"
 #include "termnodes.h"
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/vespalib/objects/nbo.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchlib/parsequery/parse.h>
 #include <vespa/searchlib/util/rawbuf.h>
 #include <cassert>
+#include <vector>
 
 using std::string;
 using std::vector;
@@ -371,6 +373,12 @@ string StackDumpCreator::create(const Node &node) {
     QueryNodeConverter converter;
     const_cast<Node &>(node).accept(converter);
     return converter.getStackDump();
+}
+
+search::QueryTreeSP StackDumpCreator::createQueryTree(const Node &node) {
+    string stackDump = create(node);
+    vector<char> buf(stackDump.begin(), stackDump.end());
+    return search::SerializedQueryTree::create(std::move(buf));
 }
 
 using namespace search::query;

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -375,7 +375,7 @@ string StackDumpCreator::create(const Node &node) {
     return converter.getStackDump();
 }
 
-search::QueryTreeSP StackDumpCreator::createQueryTree(const Node &node) {
+search::QueryTreeSP StackDumpCreator::createSerializedQueryTree(const Node &node) {
     string stackDump = create(node);
     vector<char> buf(stackDump.begin(), stackDump.end());
     return search::SerializedQueryTree::create(std::move(buf));

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.h
@@ -2,7 +2,13 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+
+namespace search {
+    class SerializedQueryTree;
+    using QueryTreeSP = std::shared_ptr<const SerializedQueryTree>;
+}
 
 namespace search::query {
 
@@ -11,6 +17,8 @@ class Node;
 struct StackDumpCreator {
     // Creates a stack dump from a query tree.
     static std::string create(const Node &node);
+    // Creates a SerializedQueryTree from a query tree.
+    static search::QueryTreeSP createQueryTree(const Node &node);
 };
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.h
@@ -18,7 +18,7 @@ struct StackDumpCreator {
     // Creates a stack dump from a query tree.
     static std::string create(const Node &node);
     // Creates a SerializedQueryTree from a query tree.
-    static search::QueryTreeSP createQueryTree(const Node &node);
+    static search::QueryTreeSP createSerializedQueryTree(const Node &node);
 };
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.h
@@ -7,7 +7,7 @@
 
 namespace search {
     class SerializedQueryTree;
-    using QueryTreeSP = std::shared_ptr<const SerializedQueryTree>;
+    using SerializedQueryTreeSP = std::shared_ptr<const SerializedQueryTree>;
 }
 
 namespace search::query {
@@ -18,7 +18,7 @@ struct StackDumpCreator {
     // Creates a stack dump from a query tree.
     static std::string create(const Node &node);
     // Creates a SerializedQueryTree from a query tree.
-    static search::QueryTreeSP createSerializedQueryTree(const Node &node);
+    static SerializedQueryTreeSP createSerializedQueryTree(const Node &node);
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.cpp
@@ -98,14 +98,13 @@ GetDocsumsState::parse_locations()
                           _args.getLocation().c_str());
         }
     }
-    auto stackdump = _args.getStackDump();
-    if (! stackdump.empty()) {
-        search::SimpleQueryStackDumpIterator iterator(stackdump);
-        while (iterator.next()) {
-            if (iterator.getType() == search::ParseItem::ITEM_GEO_LOCATION_TERM) {
-                std::string view = iterator.index_as_string();
-                std::string term(iterator.getTerm());
-                GeoLocationParser parser;                
+    if (auto* tree = _args.getSerializedQueryTree()) {
+        auto iterator = tree->makeIterator();
+        while (iterator->next()) {
+            if (iterator->getType() == search::ParseItem::ITEM_GEO_LOCATION_TERM) {
+                std::string view = iterator->index_as_string();
+                std::string term(iterator->getTerm());
+                GeoLocationParser parser;
                 if (parser.parseNoField(term)) {
                     auto attr_name = PositionDataType::getZCurveFieldName(view);
                     GeoLocationSpec spec{attr_name, parser.getGeoLocation()};

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumstate.cpp
@@ -98,8 +98,9 @@ GetDocsumsState::parse_locations()
                           _args.getLocation().c_str());
         }
     }
-    if (auto* tree = _args.getSerializedQueryTree()) {
-        auto iterator = tree->makeIterator();
+    {
+        const auto& tree = _args.getSerializedQueryTree();
+        auto iterator = tree.makeIterator();
         while (iterator->next()) {
             if (iterator->getType() == search::ParseItem::ITEM_GEO_LOCATION_TERM) {
                 std::string view = iterator->index_as_string();

--- a/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
@@ -39,8 +39,8 @@ DynamicTeaserDFW::insert_juniper_field(uint32_t docid, std::string_view input, G
 {
     auto& query = state._dynteaser.get_query(_input_field_name);
     if (!query) {
-        const auto* tree = state._args.getSerializedQueryTree();
-        auto iterator = tree ? tree->makeIterator() : QueryStackIterator::dummy();
+        const auto& tree = state._args.getSerializedQueryTree();
+        auto iterator = tree.makeIterator();
         JuniperQueryAdapter iq(state.query_normalization(), _query_term_filter.get(),
                                std::move(iterator), state._args.highlightTerms());
         query = _juniper->CreateQueryHandle(iq, nullptr);

--- a/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
@@ -7,6 +7,8 @@
 #include "i_query_term_filter_factory.h"
 #include "juniper_query_adapter.h"
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
+#include <vespa/searchlib/query/query_stack_iterator.h>
 #include <vespa/vespalib/objects/hexdump.h>
 #include <vespa/juniper/config.h>
 #include <vespa/juniper/result.h>
@@ -37,8 +39,10 @@ DynamicTeaserDFW::insert_juniper_field(uint32_t docid, std::string_view input, G
 {
     auto& query = state._dynteaser.get_query(_input_field_name);
     if (!query) {
+        const auto* tree = state._args.getSerializedQueryTree();
+        auto iterator = tree ? tree->makeIterator() : QueryStackIterator::dummy();
         JuniperQueryAdapter iq(state.query_normalization(), _query_term_filter.get(),
-                               state._args.getStackDump(), state._args.highlightTerms());
+                               std::move(iterator), state._args.highlightTerms());
         query = _juniper->CreateQueryHandle(iq, nullptr);
     }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "getdocsumargs.h"
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/vespalib/stllike/hash_set_insert.hpp>
 
 namespace search::docsummary {
@@ -9,7 +10,7 @@ GetDocsumArgs::GetDocsumArgs()
     : _resultClassName(),
       _dumpFeatures(false),
       _locations_possible(true),
-      _stackDump(),
+      _serializedQueryTree(),
       _location(),
       _timeout(30s),
       _highlightTerms(),
@@ -23,18 +24,14 @@ GetDocsumArgs::initFromDocsumRequest(const engine::DocsumRequest &req)
 {
     _dumpFeatures       = req.dumpFeatures;
     _resultClassName    = req.resultClassName;
-    _stackDump          = req.stackDump;
+    if (const auto * queryTree = req.getSerializedQueryTree()) {
+        _serializedQueryTree = queryTree->shared_from_this();
+    }
     _location           = req.location;
     _locations_possible = true;
     _timeout            = req.getTimeLeft();
     _highlightTerms     = req.propertiesMap.highlightTerms();
     _fields             = FieldSet(req.getFields().begin(), req.getFields().end());
-}
-
-void
-GetDocsumArgs::setStackDump(uint32_t stackDumpLen, const char *stackDump)
-{
-    _stackDump.assign(stackDump, stackDump + stackDumpLen);
 }
 
 bool

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.cpp
@@ -24,9 +24,7 @@ GetDocsumArgs::initFromDocsumRequest(const engine::DocsumRequest &req)
 {
     _dumpFeatures       = req.dumpFeatures;
     _resultClassName    = req.resultClassName;
-    if (const auto * queryTree = req.getSerializedQueryTree()) {
-        _serializedQueryTree = queryTree->shared_from_this();
-    }
+    _serializedQueryTree = req.getSerializedQueryTree().shared_from_this();
     _location           = req.location;
     _locations_possible = true;
     _timeout            = req.getTimeLeft();

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -19,7 +19,7 @@ private:
     std::string                      _resultClassName;
     bool                             _dumpFeatures;
     bool                             _locations_possible;
-    QueryTreeSP                      _serializedQueryTree;
+    SerializedQueryTreeSP                      _serializedQueryTree;
     std::string                      _location;
     vespalib::duration               _timeout;
     fef::Properties                  _highlightTerms;
@@ -33,7 +33,7 @@ public:
     void initFromDocsumRequest(const search::engine::DocsumRequest &req);
 
     void setResultClassName(std::string_view name) { _resultClassName = name; }
-    void setSerializedQueryTree(QueryTreeSP tree) { _serializedQueryTree = std::move(tree); }
+    void setSerializedQueryTree(SerializedQueryTreeSP tree) { _serializedQueryTree = std::move(tree); }
     void locations_possible(bool value) { _locations_possible = value; }
     bool locations_possible() const { return _locations_possible; }
     const std::string &getLocation() const { return _location; }

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -18,7 +18,7 @@ private:
     std::string                      _resultClassName;
     bool                             _dumpFeatures;
     bool                             _locations_possible;
-    SerializedQueryTreeSP                      _serializedQueryTree;
+    SerializedQueryTreeSP            _serializedQueryTree;
     std::string                      _location;
     vespalib::duration               _timeout;
     fef::Properties                  _highlightTerms;
@@ -41,7 +41,9 @@ public:
     vespalib::duration getTimeout() const { return _timeout; }
 
     const std::string & getResultClassName()      const { return _resultClassName; }
-    const search::SerializedQueryTree* getSerializedQueryTree() const { return _serializedQueryTree.get(); }
+    const search::SerializedQueryTree& getSerializedQueryTree() const {
+        return _serializedQueryTree ? *_serializedQueryTree : *search::SerializedQueryTree::empty();
+    }
 
     void dumpFeatures(bool v) { _dumpFeatures = v; }
     bool dumpFeatures() const { return _dumpFeatures; }

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -15,7 +15,6 @@ class GetDocsumArgs
 {
 private:
     using FieldSet = vespalib::hash_set<std::string>;
-    using ConstQueryTree = const search::SerializedQueryTree;
     std::string                      _resultClassName;
     bool                             _dumpFeatures;
     bool                             _locations_possible;

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -42,7 +42,7 @@ public:
 
     const std::string & getResultClassName()      const { return _resultClassName; }
     const search::SerializedQueryTree& getSerializedQueryTree() const {
-        return _serializedQueryTree ? *_serializedQueryTree : *search::SerializedQueryTree::empty();
+        return _serializedQueryTree ? *_serializedQueryTree : search::SerializedQueryTree::empty();
     }
 
     void dumpFeatures(bool v) { _dumpFeatures = v; }

--- a/searchsummary/src/vespa/searchsummary/docsummary/juniper_dfw_query_item.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/juniper_dfw_query_item.h
@@ -4,7 +4,7 @@
 
 #include <vespa/juniper/query_item.h>
 
-namespace search { class SimpleQueryStackDumpIterator; }
+namespace search { class QueryStackIterator; }
 
 namespace search::docsummary {
 
@@ -17,12 +17,12 @@ struct JuniperDFWExplicitItemData;
  **/
 class JuniperDFWQueryItem : public juniper::QueryItem
 {
-    search::SimpleQueryStackDumpIterator *_si;
+    search::QueryStackIterator *_si;
     const JuniperDFWExplicitItemData *_data;
 public:
     JuniperDFWQueryItem() : _si(nullptr), _data(nullptr) {}
     ~JuniperDFWQueryItem() override = default;
-    explicit JuniperDFWQueryItem(search::SimpleQueryStackDumpIterator *si) : _si(si), _data(nullptr) {}
+    explicit JuniperDFWQueryItem(search::QueryStackIterator *si) : _si(si), _data(nullptr) {}
     explicit JuniperDFWQueryItem(const JuniperDFWExplicitItemData *data) : _si(nullptr), _data(data) {}
     JuniperDFWQueryItem(const QueryItem&) = delete;
     JuniperDFWQueryItem& operator= (const QueryItem&) = delete;

--- a/searchsummary/src/vespa/searchsummary/docsummary/juniper_query_adapter.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/juniper_query_adapter.h
@@ -3,10 +3,10 @@
 #pragma once
 
 #include <vespa/juniper/query.h>
-#include <string>
+#include <memory>
 
 namespace search {
-    class SimpleQueryStackDumpIterator;
+    class QueryStackIterator;
     class QueryNormalization;
 }
 namespace search::fef { class Properties; }
@@ -24,16 +24,16 @@ class JuniperQueryAdapter : public juniper::IQuery
 private:
     const QueryNormalization * _query_normalization;
     const IQueryTermFilter *_query_term_filter;
-    const std::string_view _buf;
+    std::unique_ptr<search::QueryStackIterator> _iterator;
     const search::fef::Properties & _highlightTerms;
 
 public:
     JuniperQueryAdapter(const JuniperQueryAdapter&) = delete;
     JuniperQueryAdapter operator= (const JuniperQueryAdapter&) = delete;
-    JuniperQueryAdapter(const QueryNormalization * normalization, const IQueryTermFilter *query_term_filter, std::string_view buf,
+    JuniperQueryAdapter(const QueryNormalization * normalization, const IQueryTermFilter *query_term_filter, std::unique_ptr<search::QueryStackIterator> iterator,
                         const search::fef::Properties & highlightTerms);
     ~JuniperQueryAdapter() override;
-    bool skipItem(search::SimpleQueryStackDumpIterator *iterator) const;
+    bool skipItem(search::QueryStackIterator& iterator) const;
     bool Traverse(juniper::IQueryVisitor *v) const override;
     bool UsefulIndex(const juniper::QueryItem* item) const override;
 };

--- a/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
+++ b/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
@@ -95,9 +95,9 @@ struct BoundTerm {
 BoundTerm::~BoundTerm() = default;
 
 Query make_query(std::unique_ptr<search::query::Node> root) {
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*root);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*root);
     QueryTermDataFactory factory(nullptr, nullptr);
-    Query query(factory, *queryTree);
+    Query query(factory, *serializedQueryTree);
     return query;
 }
 

--- a/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
+++ b/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
@@ -95,7 +95,7 @@ struct BoundTerm {
 BoundTerm::~BoundTerm() = default;
 
 Query make_query(std::unique_ptr<search::query::Node> root) {
-    auto queryTree = StackDumpCreator::createQueryTree(*root);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*root);
     QueryTermDataFactory factory(nullptr, nullptr);
     Query query(factory, *queryTree);
     return query;

--- a/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
+++ b/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
@@ -9,6 +9,7 @@
 #include <vespa/document/fieldvalue/structfieldvalue.h>
 #include <vespa/searchlib/common/matching_elements.h>
 #include <vespa/searchlib/common/matching_elements_fields.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/query/streaming/query.h>
 #include <vespa/searchlib/query/streaming/queryterm.h>
@@ -94,9 +95,9 @@ struct BoundTerm {
 BoundTerm::~BoundTerm() = default;
 
 Query make_query(std::unique_ptr<search::query::Node> root) {
-    std::string stack_dump = StackDumpCreator::create(*root);
+    auto queryTree = StackDumpCreator::createQueryTree(*root);
     QueryTermDataFactory factory(nullptr, nullptr);
-    Query query(factory, stack_dump);
+    Query query(factory, *queryTree);
     return query;
 }
 

--- a/streamingvisitors/src/tests/querywrapper/querywrapper_test.cpp
+++ b/streamingvisitors/src/tests/querywrapper/querywrapper_test.cpp
@@ -31,7 +31,7 @@ TEST(QueryWrapperTest, test_query_wrapper)
             builder.addStringTerm("e", "", 0, Weight(0));
         }
         Node::UP node = builder.build();
-        auto queryTree = StackDumpCreator::createQueryTree(*node);
+        auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
         Query q(empty, *queryTree);
         QueryWrapper wrap(q);
         QueryWrapper::TermList & tl = wrap.getTermList();

--- a/streamingvisitors/src/tests/querywrapper/querywrapper_test.cpp
+++ b/streamingvisitors/src/tests/querywrapper/querywrapper_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/query/tree/querybuilder.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
 #include <vespa/searchlib/query/tree/stackdumpcreator.h>
@@ -30,8 +31,8 @@ TEST(QueryWrapperTest, test_query_wrapper)
             builder.addStringTerm("e", "", 0, Weight(0));
         }
         Node::UP node = builder.build();
-        std::string stackDump = StackDumpCreator::create(*node);
-        Query q(empty, stackDump);
+        auto queryTree = StackDumpCreator::createQueryTree(*node);
+        Query q(empty, *queryTree);
         QueryWrapper wrap(q);
         QueryWrapper::TermList & tl = wrap.getTermList();
 

--- a/streamingvisitors/src/tests/querywrapper/querywrapper_test.cpp
+++ b/streamingvisitors/src/tests/querywrapper/querywrapper_test.cpp
@@ -31,8 +31,8 @@ TEST(QueryWrapperTest, test_query_wrapper)
             builder.addStringTerm("e", "", 0, Weight(0));
         }
         Node::UP node = builder.build();
-        auto queryTree = StackDumpCreator::createSerializedQueryTree(*node);
-        Query q(empty, *queryTree);
+        auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*node);
+        Query q(empty, *serializedQueryTree);
         QueryWrapper wrap(q);
         QueryWrapper::TermList & tl = wrap.getTermList();
 

--- a/streamingvisitors/src/tests/rank_processor/rank_processor_test.cpp
+++ b/streamingvisitors/src/tests/rank_processor/rank_processor_test.cpp
@@ -55,7 +55,7 @@ void
 RankProcessorTest::build_query(QueryBuilder<SimpleQueryNodeTypes> &builder)
 {
     auto build_node = builder.build();
-    auto queryTree = StackDumpCreator::createQueryTree(*build_node);
+    auto queryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
     _query = std::make_unique<Query>(_factory, *queryTree);
     _query_wrapper = std::make_unique<QueryWrapper>(*_query);
 }

--- a/streamingvisitors/src/tests/rank_processor/rank_processor_test.cpp
+++ b/streamingvisitors/src/tests/rank_processor/rank_processor_test.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/searchvisitor/rankprocessor.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/query/streaming/nearest_neighbor_query_node.h>
 #include <vespa/searchlib/query/streaming/query.h>
@@ -54,8 +55,8 @@ void
 RankProcessorTest::build_query(QueryBuilder<SimpleQueryNodeTypes> &builder)
 {
     auto build_node = builder.build();
-    auto stack_dump = StackDumpCreator::create(*build_node);
-    _query = std::make_unique<Query>(_factory, stack_dump);
+    auto queryTree = StackDumpCreator::createQueryTree(*build_node);
+    _query = std::make_unique<Query>(_factory, *queryTree);
     _query_wrapper = std::make_unique<QueryWrapper>(*_query);
 }
 

--- a/streamingvisitors/src/tests/rank_processor/rank_processor_test.cpp
+++ b/streamingvisitors/src/tests/rank_processor/rank_processor_test.cpp
@@ -55,8 +55,8 @@ void
 RankProcessorTest::build_query(QueryBuilder<SimpleQueryNodeTypes> &builder)
 {
     auto build_node = builder.build();
-    auto queryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
-    _query = std::make_unique<Query>(_factory, *queryTree);
+    auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
+    _query = std::make_unique<Query>(_factory, *serializedQueryTree);
     _query_wrapper = std::make_unique<QueryWrapper>(*_query);
 }
 

--- a/streamingvisitors/src/tests/searchvisitor/searchvisitor_test.cpp
+++ b/streamingvisitors/src/tests/searchvisitor/searchvisitor_test.cpp
@@ -104,8 +104,8 @@ public:
     }
     vdslib::Parameters build() {
         auto node = _builder.build();
-        std::string query_stack_dump = StackDumpCreator::create(*node);
-        _params.set("query", query_stack_dump);
+        auto query_stack_dump = StackDumpCreator::create(*node);
+        _params.set("query", std::string(query_stack_dump.data(), query_stack_dump.size()));
         return _params;
     }
 };

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -5,7 +5,6 @@
 #include "searchvisitor.h"
 #include "matching_elements_filler.h"
 #include <vespa/document/base/exceptions.h>
-#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/datatype/mapdatatype.h>
 #include <vespa/document/datatype/positiondatatype.h>
@@ -43,6 +42,7 @@ using document::DataType;
 using document::PositionDataType;
 using search::AttributeGuard;
 using search::AttributeVector;
+using search::SerializedQueryTree;
 using search::aggregation::HitsAggregationResult;
 using search::attribute::IAttributeVector;
 using search::attribute::make_sort_blob_writer;
@@ -524,7 +524,7 @@ SearchVisitor::init(const Parameters & params)
             _fieldSearchSpecMap.buildFromConfig(additionalFields);
 
             QueryTermDataFactory addOnFactory(this, &_element_gap_inspector);
-            auto serialized_query_tree = search::SerializedQueryTree::create(std::vector<char>(queryBlob.begin(), queryBlob.end()));
+            auto serialized_query_tree = SerializedQueryTree::create(std::vector<char>(queryBlob.begin(), queryBlob.end()));
             _query = Query(addOnFactory, *serialized_query_tree);
             _searchBuffer->reserve(0x10000);
 

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -5,6 +5,7 @@
 #include "searchvisitor.h"
 #include "matching_elements_filler.h"
 #include <vespa/document/base/exceptions.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/datatype/mapdatatype.h>
 #include <vespa/document/datatype/positiondatatype.h>
@@ -19,6 +20,7 @@
 #include <vespa/searchlib/attribute/make_sort_blob_writer.h>
 #include <vespa/searchlib/attribute/single_raw_ext_attribute.h>
 #include <vespa/searchlib/common/packets.h>
+#include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/features/setup.h>
 #include <vespa/searchlib/query/streaming/query_term_data.h>
 #include <vespa/searchlib/tensor/tensor_ext_attribute.h>
@@ -216,7 +218,7 @@ SearchVisitor::SummaryGenerator::SummaryGenerator(const search::IAttributeManage
       _buf(4_Ki),
       _dump_features(),
       _location(),
-      _stack_dump(),
+      _serialized_query_tree(),
       _highlight_terms(),
       _attr_manager(attr_manager),
       _query_normalization(query_normalization)
@@ -248,8 +250,8 @@ SearchVisitor::SummaryGenerator::get_streaming_docsums_state(std::string_view su
     if (_location.has_value()) {
         ds._args.setLocation(_location.value());
     }
-    if (_stack_dump.has_value()) {
-        ds._args.setStackDump(_stack_dump.value().size(), _stack_dump.value().data());
+    if (_serialized_query_tree) {
+        ds._args.setSerializedQueryTree(_serialized_query_tree);
     }
     ds._args.highlightTerms(_highlight_terms);
     _docsumWriter->initState(_attr_manager, ds, state->get_resolve_class_info());
@@ -522,12 +524,13 @@ SearchVisitor::init(const Parameters & params)
             _fieldSearchSpecMap.buildFromConfig(additionalFields);
 
             QueryTermDataFactory addOnFactory(this, &_element_gap_inspector);
-            _query = Query(addOnFactory, std::string_view(queryBlob.data(), queryBlob.size()));
+            auto serialized_query_tree = search::SerializedQueryTree::create(std::vector<char>(queryBlob.begin(), queryBlob.end()));
+            _query = Query(addOnFactory, *serialized_query_tree);
             _searchBuffer->reserve(0x10000);
 
             int stackCount = 0;
             if (params.get("querystackcount", stackCount)) {
-                _summaryGenerator.set_stack_dump(std::vector<char>(queryBlob.begin(), queryBlob.end()));
+                _summaryGenerator.set_serialized_query_tree(serialized_query_tree);
             } else {
                 Issue::report("Request without query stack count");
             }

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -524,7 +524,7 @@ SearchVisitor::init(const Parameters & params)
             _fieldSearchSpecMap.buildFromConfig(additionalFields);
 
             QueryTermDataFactory addOnFactory(this, &_element_gap_inspector);
-            auto serialized_query_tree = SerializedQueryTree::create(std::vector<char>(queryBlob.begin(), queryBlob.end()));
+            auto serialized_query_tree = SerializedQueryTree::fromStackDump(std::vector<char>(queryBlob.begin(), queryBlob.end()));
             _query = Query(addOnFactory, *serialized_query_tree);
             _searchBuffer->reserve(0x10000);
 

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.h
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.h
@@ -406,20 +406,20 @@ private:
         vespalib::ConstBufferRef fillSummary(search::AttributeVector::DocId lid, std::string_view summaryClass) override;
         void set_dump_features(bool dump_features) { _dump_features = dump_features; }
         void set_location(std::string location) { _location = std::move(location); }
-        void set_stack_dump(std::vector<char> stack_dump) { _stack_dump = std::move(stack_dump); }
+        void set_serialized_query_tree(search::QueryTreeSP tree) { _serialized_query_tree = std::move(tree); }
         void add_summary_field(std::string_view field) { _summaryFields.emplace_back(field); }
         search::fef::Properties & highlightTerms() { return _highlight_terms;}
     private:
         StreamingDocsumsState& get_streaming_docsums_state(std::string_view summary_class);
         vsm::GetDocsumsStateCallback            _callback;
         vespalib::hash_map<std::string, std::unique_ptr<StreamingDocsumsState>> _docsum_states;
-        std::vector<std::string>           _summaryFields;
+        std::vector<std::string>                _summaryFields;
         std::unique_ptr<vsm::DocsumFilter>      _docsumFilter;
         search::docsummary::IDocsumWriter     * _docsumWriter;
         vespalib::SmartBuffer                   _buf;
         std::optional<bool>                     _dump_features;
-        std::optional<std::string>         _location;
-        std::optional<std::vector<char>>        _stack_dump;
+        std::optional<std::string>              _location;
+        search::QueryTreeSP                     _serialized_query_tree;
         search::fef::Properties                 _highlight_terms;
         const search::IAttributeManager&        _attr_manager;
         const search::QueryNormalization &      _query_normalization;

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.h
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.h
@@ -406,7 +406,7 @@ private:
         vespalib::ConstBufferRef fillSummary(search::AttributeVector::DocId lid, std::string_view summaryClass) override;
         void set_dump_features(bool dump_features) { _dump_features = dump_features; }
         void set_location(std::string location) { _location = std::move(location); }
-        void set_serialized_query_tree(search::QueryTreeSP tree) { _serialized_query_tree = std::move(tree); }
+        void set_serialized_query_tree(search::SerializedQueryTreeSP tree) { _serialized_query_tree = std::move(tree); }
         void add_summary_field(std::string_view field) { _summaryFields.emplace_back(field); }
         search::fef::Properties & highlightTerms() { return _highlight_terms;}
     private:
@@ -419,7 +419,7 @@ private:
         vespalib::SmartBuffer                   _buf;
         std::optional<bool>                     _dump_features;
         std::optional<std::string>              _location;
-        search::QueryTreeSP                     _serialized_query_tree;
+        search::SerializedQueryTreeSP                     _serialized_query_tree;
         search::fef::Properties                 _highlight_terms;
         const search::IAttributeManager&        _attr_manager;
         const search::QueryNormalization &      _query_normalization;


### PR DESCRIPTION
Replace direct access to raw stack dump buffers with the makeIterator() factory method throughout the codebase. This improves type safety and lifetime management by:

- Replacing SimpleQueryStackDumpIterator construction with makeIterator() calls in streaming query and proton matching code
- Changing GetDocsumArgs to return SerializedQueryTree pointer instead of raw string_view from getStackDump()
- Refactoring JuniperQueryAdapter to store unique_ptr<QueryStackIterator> instead of string_view buffer
- Add StackDumpCreator::createQueryTree() helper to reduce boilerplate

The SerializedQueryTree abstraction now serves as the single point of access for query stack dumps, preventing direct manipulation of the underlying binary format and making future changes to the serialization format easier to manage.
