### PR TITLE
Add `--zst` flag to `vespa-significance export`

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/ExportClientParameters.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/ExportClientParameters.java
@@ -8,8 +8,13 @@ import java.util.Optional;
  *
  * @author johsol
  */
-public record ExportClientParameters(String indexDir, String outputFile, String fieldName,
-                                     Optional<String> schemaName, Optional<String> clusterName, Optional<String> nodeIndex) {
+public record ExportClientParameters(
+        String indexDir, String outputFile,
+        String fieldName,
+        Optional<String> schemaName,
+        Optional<String> clusterName,
+        Optional<String> nodeIndex,
+        boolean zstCompress) {
 
     public static Builder builder() {
         return new Builder();
@@ -23,6 +28,7 @@ public record ExportClientParameters(String indexDir, String outputFile, String 
         private String clusterName;
         private String schemaName;
         private String nodeIndex;
+        private boolean zstCompress = false;
 
         public Builder indexDir(String value) {
             this.indexDir = value;
@@ -54,8 +60,13 @@ public record ExportClientParameters(String indexDir, String outputFile, String 
             return this;
         }
 
+        public Builder zstCompress(boolean value) {
+            this.zstCompress = value;
+            return this;
+        }
+
         public ExportClientParameters build() {
-            return new ExportClientParameters(indexDir, outputFile, fieldName, Optional.ofNullable(schemaName), Optional.ofNullable(clusterName),  Optional.ofNullable(nodeIndex));
+            return new ExportClientParameters(indexDir, outputFile, fieldName, Optional.ofNullable(schemaName), Optional.ofNullable(clusterName), Optional.ofNullable(nodeIndex), zstCompress);
         }
     }
 

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TsvTermDfWriter.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/TsvTermDfWriter.java
@@ -3,8 +3,7 @@ package ai.vespa.vespasignificance.export;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.Writer;
 
 /**
  * Writes {@link VespaIndexInspectClient.TermDocumentFrequency} rows as TSV.
@@ -14,8 +13,10 @@ import java.nio.file.Path;
 public final class TsvTermDfWriter implements TermDfWriter {
     private final BufferedWriter out;
 
-    public TsvTermDfWriter(Path path) throws IOException {
-        this.out = Files.newBufferedWriter(path);
+    public TsvTermDfWriter(Writer writer) throws IOException {
+        this.out = (writer instanceof BufferedWriter)
+                ? (BufferedWriter) writer
+                : new BufferedWriter(writer, 1 << 16);
     }
 
     @Override

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -165,7 +165,7 @@ public class CommandLineOptions {
         options.addOption(Option.builder()
                 .longOpt(OUTPUT_OPTION)
                 .hasArg()
-                .argName("FILE.tsv")
+                .argName("FILE.tsv[.zst]")
                 .desc("Output TSV file.")
                 .build());
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -198,6 +198,11 @@ public class CommandLineOptions {
                 .desc("Node index directory.")
                 .build());
 
+        options.addOption(Option.builder("zst")
+                .longOpt(ZST_COMPRESSION)
+                .desc("Use Zstandard compression.")
+                .build());
+
         return options;
     }
 
@@ -221,6 +226,7 @@ public class CommandLineOptions {
                 .clusterName(cl.getOptionValue(CLUSTER_OPTION))
                 .schemaName(cl.getOptionValue(SCHEMA_NAME))
                 .nodeIndex(cl.getOptionValue(NODE_INDEX_OPTION))
+                .zstCompress(cl.hasOption(ZST_COMPRESSION))
                 .build();
     }
 


### PR DESCRIPTION
- User can provide `--zst` flag to write TSV as a Zstandard compressed file.
- If the user does not provide the `.zst` extension, we provide it for them.
- Update the TSV writer class to take a `Writer` instead, such that we can use it in a stream chain.
- Updates TSV writer tests to provide a writer instead of just a path.