### PR TITLE
Johsol/vespa significance k way merge

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfKWayMerge.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfKWayMerge.java
@@ -1,10 +1,12 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.vespasignificance.merge;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.rmi.UnexpectedException;
+import java.util.Comparator;
 import java.util.List;
+import java.util.PriorityQueue;
 
 /**
  * This class implements k-way merge for term-df files.
@@ -19,32 +21,35 @@ public class TermDfKWayMerge {
     /**
      * Holds each buffered reader and a cursor to the current line.
      */
-    static class Cursor {
-        final BufferedReader br;
+    final static class Cursor {
+        final BufferedReader bufferedReader;
 
         String term;
-        long df;
+        long documentFrequency;
 
-        Cursor(BufferedReader br) {
-            this.br = br;
+        Cursor(BufferedReader bufferedReader) {
+            this.bufferedReader = bufferedReader;
         }
 
         /**
          * Parses the next TermDf line from the buffered reader.
+         * <p>
+         * Returns true if a new term and df was parsed, else false if there
+         * is no more data to parse.
          */
         boolean advance() throws IOException {
             String line;
-            while ((line = br.readLine()) != null) {
+            while ((line = bufferedReader.readLine()) != null) {
                 if (line.trim().isEmpty())
                     continue;
 
                 int tab = line.indexOf('\t');
                 if (tab < 0) {
-                    throw new UnexpectedException("Invalid term line when expecting tab: " + line);
+                    throw new IllegalArgumentException("Invalid term line when expecting tab: " + line);
                 }
 
                 term = line.substring(0, tab);
-                df =  Long.parseLong(line.substring(tab + 1).trim());
+                documentFrequency = Long.parseLong(line.substring(tab + 1).trim());
                 return true;
             }
 
@@ -52,12 +57,54 @@ public class TermDfKWayMerge {
         }
     }
 
+    /**
+     * k-way merge between buffered readers expecting "term\tnumber" for each line.
+     * <p>
+     * Every reader is read linearly. And since we use a min-heap to keep track of which to compare the current with,
+     * and it has insertion of log(k), it will have a time complexity of O(n log(k)).
+     * <p>
+     * Assumes one term per line.
+     */
     public static void merge(
-            List<Path> paths,
-            Path output,
+            List<BufferedReader> inputs,
+            BufferedWriter output,
             long minKeep
-    ) {
+    ) throws IOException {
+        PriorityQueue<Cursor> queue = new PriorityQueue<>(inputs.size(), Comparator.comparing(c -> c.term));
+        for (var reader : inputs) {
+            Cursor cursor = new Cursor(reader);
+            if (cursor.advance()) {
+                queue.offer(cursor);
+            }
+        }
 
+        while (!queue.isEmpty()) {
+            Cursor cursor = queue.poll();
+            String term = cursor.term;
+            long sumDf = cursor.documentFrequency;
+
+            while (!queue.isEmpty() && queue.peek().term.equals(term)) {
+                Cursor matchedCursor = queue.poll();
+                sumDf += matchedCursor.documentFrequency;
+
+                if (matchedCursor.advance()) {
+                    queue.offer(matchedCursor);
+                }
+            }
+
+            if (cursor.advance()) {
+                queue.offer(cursor);
+            }
+
+            if (sumDf >= minKeep) {
+                output.write(term);
+                output.write('\t');
+                output.write(Long.toString(sumDf));
+                output.write('\n');
+            }
+        }
+
+        output.flush();
     }
 
 }

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfKWayMerge.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfKWayMerge.java
@@ -1,0 +1,63 @@
+package ai.vespa.vespasignificance.merge;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.rmi.UnexpectedException;
+import java.util.List;
+
+/**
+ * This class implements k-way merge for term-df files.
+ * <p>
+ * The implementation uses a min-heap on a set of cursors where each cursor
+ * holds a file handle to one of the files being merged.
+ *
+ * @author johsol
+ */
+public class TermDfKWayMerge {
+
+    /**
+     * Holds each buffered reader and a cursor to the current line.
+     */
+    static class Cursor {
+        final BufferedReader br;
+
+        String term;
+        long df;
+
+        Cursor(BufferedReader br) {
+            this.br = br;
+        }
+
+        /**
+         * Parses the next TermDf line from the buffered reader.
+         */
+        boolean advance() throws IOException {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.trim().isEmpty())
+                    continue;
+
+                int tab = line.indexOf('\t');
+                if (tab < 0) {
+                    throw new UnexpectedException("Invalid term line when expecting tab: " + line);
+                }
+
+                term = line.substring(0, tab);
+                df =  Long.parseLong(line.substring(tab + 1).trim());
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public static void merge(
+            List<Path> paths,
+            Path output,
+            long minKeep
+    ) {
+
+    }
+
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
@@ -4,8 +4,12 @@ package ai.vespa.vespasignificance.merge;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.StringReader;
-import java.rmi.UnexpectedException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,6 +25,17 @@ public class TermDfKWayMergeTest {
 
     private static TermDfKWayMerge.Cursor cursorFrom(String s) {
         return new TermDfKWayMerge.Cursor(new BufferedReader(new StringReader(s)));
+    }
+
+    private static String mergeStrings(long minKeep, String... inputs) throws IOException {
+        List<BufferedReader> readers = Arrays.stream(inputs)
+                .map(s -> new BufferedReader(new StringReader(s)))
+                .toList();
+        StringWriter sw = new StringWriter();
+        try (BufferedWriter bw = new BufferedWriter(sw)) {
+            TermDfKWayMerge.merge(readers, bw, minKeep);
+        }
+        return sw.toString();
     }
 
     @Test
@@ -49,14 +64,99 @@ public class TermDfKWayMergeTest {
     @Test
     void throwsOnLineWithoutTab() {
         var c = cursorFrom("notabline\n");
-        UnexpectedException ex = assertThrows(UnexpectedException.class, c::advance);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, c::advance);
         assertTrue(ex.getMessage().contains("Invalid term line"));
+    }
+
+    @Test
+    void throwsOnNonNumericDf() {
+        var c = cursorFrom("orange\tNaN\n");
+        assertThrows(NumberFormatException.class, c::advance);
     }
 
     @Test
     void returnsFalseOnCompletelyEmptyInput() throws Exception {
         var c = cursorFrom("\n \n\t \n");
         assertFalse(c.advance());
+    }
+
+    @Test
+    void mergesTwoSortedInputsAndKeepsGlobalOrder() throws Exception {
+        String in1 = "apple\t1\ncarrot\t2\n";
+        String in2 = "banana\t3\nzebra\t4\n";
+
+        String out = mergeStrings(0, in1, in2);
+
+        // Output must be globally sorted by term
+        assertEquals(
+                "apple\t1\n" +
+                        "banana\t3\n" +
+                        "carrot\t2\n" +
+                        "zebra\t4\n",
+                out
+        );
+    }
+
+    @Test
+    void sumsSameTermAcrossFiles() throws Exception {
+        String in1 = "apple\t1\nbanana\t5\n";
+        String in2 = "apple\t2\ncarrot\t7\n";
+        String in3 = "apple\t3\nbanana\t1\n";
+
+        String out = mergeStrings(0, in1, in2, in3);
+
+        assertEquals(
+                "apple\t6\n" +   // 1+2+3
+                        "banana\t6\n" +  // 5+1
+                        "carrot\t7\n",
+                out
+        );
+    }
+
+    @Test
+    void respectsMinKeepInclusive() throws Exception {
+        String in1 = "apple\t1\nbanana\t2\n";
+        String in2 = "apple\t1\nbanana\t1\n";
+
+        // apple sum=2, banana sum=3
+        String out = mergeStrings(2, in1, in2);
+
+        assertEquals(
+                "apple\t2\n" +   // kept (>= 2)
+                        "banana\t3\n",   // kept
+                out
+        );
+    }
+
+    @Test
+    void dropsBelowMinKeep() throws Exception {
+        String in1 = "a\t1\nb\t2\n";
+        String in2 = "a\t0\nb\t0\n";
+
+        String out = mergeStrings(3, in1, in2); // a=1, b=2 -> both dropped
+
+        assertEquals("", out);
+    }
+
+    @Test
+    void handlesEmptyReadersGracefully() throws Exception {
+        String empty = "\n \n";
+        String in = "alpha\t10\nbeta\t20\n";
+
+        String out = mergeStrings(0, empty, in, empty);
+
+        assertEquals(
+                "alpha\t10\n" +
+                        "beta\t20\n",
+                out
+        );
+    }
+
+    @Test
+    void stableWithSingleReader() throws Exception {
+        String in = "ant\t1\nbee\t2\ncat\t3\n";
+        String out = mergeStrings(0, in);
+        assertEquals(in, out);
     }
 
 }

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
@@ -1,3 +1,4 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.vespasignificance.merge;
 
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Tests methods in {@link TermDfKWayMerge}
+ *
+ * @author johsol
+ */
 public class TermDfKWayMergeTest {
+
     private static TermDfKWayMerge.Cursor cursorFrom(String s) {
         return new TermDfKWayMerge.Cursor(new BufferedReader(new StringReader(s)));
     }
@@ -21,11 +28,11 @@ public class TermDfKWayMergeTest {
         var c = cursorFrom("apple\t123\nbanana\t456\n");
         assertTrue(c.advance());
         assertEquals("apple", c.term);
-        assertEquals(123L, c.df);
+        assertEquals(123L, c.documentFrequency);
 
         assertTrue(c.advance());
         assertEquals("banana", c.term);
-        assertEquals(456L, c.df);
+        assertEquals(456L, c.documentFrequency);
 
         assertFalse(c.advance()); // EOF
     }
@@ -35,7 +42,7 @@ public class TermDfKWayMergeTest {
         var c = cursorFrom("\n   \npear\t  789   \n\n");
         assertTrue(c.advance());
         assertEquals("pear", c.term);
-        assertEquals(789L, c.df);
+        assertEquals(789L, c.documentFrequency);
         assertFalse(c.advance()); // nothing more after blanks
     }
 

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
@@ -1,0 +1,55 @@
+package ai.vespa.vespasignificance.merge;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.rmi.UnexpectedException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TermDfKWayMergeTest {
+    private static TermDfKWayMerge.Cursor cursorFrom(String s) {
+        return new TermDfKWayMerge.Cursor(new BufferedReader(new StringReader(s)));
+    }
+
+    @Test
+    void parsesTermAndDf() throws Exception {
+        var c = cursorFrom("apple\t123\nbanana\t456\n");
+        assertTrue(c.advance());
+        assertEquals("apple", c.term);
+        assertEquals(123L, c.df);
+
+        assertTrue(c.advance());
+        assertEquals("banana", c.term);
+        assertEquals(456L, c.df);
+
+        assertFalse(c.advance()); // EOF
+    }
+
+    @Test
+    void trimsWhitespaceAndSkipsBlankLines() throws Exception {
+        var c = cursorFrom("\n   \npear\t  789   \n\n");
+        assertTrue(c.advance());
+        assertEquals("pear", c.term);
+        assertEquals(789L, c.df);
+        assertFalse(c.advance()); // nothing more after blanks
+    }
+
+    @Test
+    void throwsOnLineWithoutTab() {
+        var c = cursorFrom("notabline\n");
+        UnexpectedException ex = assertThrows(UnexpectedException.class, c::advance);
+        assertTrue(ex.getMessage().contains("Invalid term line"));
+    }
+
+    @Test
+    void returnsFalseOnCompletelyEmptyInput() throws Exception {
+        var c = cursorFrom("\n \n\t \n");
+        assertFalse(c.advance());
+    }
+
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
@@ -65,13 +65,12 @@ public class TermDfKWayMergeTest {
     void throwsOnLineWithoutTab() {
         var c = cursorFrom("notabline\n");
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, c::advance);
-        assertTrue(ex.getMessage().contains("Invalid term line"));
     }
 
     @Test
     void throwsOnNonNumericDf() {
         var c = cursorFrom("orange\tNaN\n");
-        assertThrows(NumberFormatException.class, c::advance);
+        assertThrows(IllegalArgumentException.class, c::advance);
     }
 
     @Test


### PR DESCRIPTION
Previously added `vespa-significance export` (ref #34956), which locates a flushed index on a content node and writes its content as a sorted TSV list.

This PR works towards `vespa-significance merge`, which performs a k-way merge on several file input streams to these intermediate TSV files.

Adds `TermDfKWayMerge` class with tests.