### PR TITLE
factory-command.sh: use safe positional param expansion under set -u

### DIFF
--- a/.buildkite/factory-command.sh
+++ b/.buildkite/factory-command.sh
@@ -27,13 +27,13 @@ TOKEN=$(curl -sL --key "$IDENTITY_PATH/key" --cert "$IDENTITY_PATH/cert" -X POST
 shift
 case $COMMAND in
   get-version)
-    VERSION=$1
+    VERSION="${1-}"
     if [[ -z $VERSION ]]; then echo "Usage: $0 $COMMAND <version>"; exit 1; fi
     $CURL -H "Authorization: Bearer $TOKEN" "$FACTORY_API/versions/$VERSION"
     ;;
   create-build)
-    FACTORY_PIPELINE_ID=$1
-    FACTORY_PLATFORM=$2
+    FACTORY_PIPELINE_ID="${1-}"
+    FACTORY_PLATFORM="${2-}"
     if [[ -z $FACTORY_PIPELINE_ID ]]; then echo "Usage: $0 $COMMAND <pipeline id> [factory platform]"; exit 1; fi
     if [[ -z $FACTORY_PLATFORM ]]; then FACTORY_PLATFORM="opensource_centos7"; fi
     $CURL -H "Authorization: Bearer $TOKEN" -d "{
@@ -47,8 +47,7 @@ case $COMMAND in
     "$FACTORY_API/builds"
     ;;
   create-release)
-    SYSTEM_NAME=$1
-    if [[ -z $SYSTEM_NAME ]]; then SYSTEM_NAME="opensource"; fi
+    SYSTEM_NAME="${1:-opensource}"
     $CURL -H "Authorization: Bearer $TOKEN" -d "{
         \"startSeconds\": $(date +%s),
         \"systemName\": \"$SYSTEM_NAME\"
@@ -56,9 +55,9 @@ case $COMMAND in
     "$FACTORY_API/releases"
     ;;
   update-build-status)
-    FACTORY_PIPELINE_ID=$1
-    STATUS=$2
-    DESCRIPTION=$3
+    FACTORY_PIPELINE_ID="${1-}"
+    STATUS="${2-}"
+    DESCRIPTION="${3-}"
     FACTORY_BUILD_NUMBER=$(( FACTORY_PIPELINE_ID << 32 | BUILDKITE_BUILD_NUMBER & 0xFFFFFF ))
     if [[ -z $FACTORY_PIPELINE_ID ]] || [[ -z $STATUS ]] || [[ -z $DESCRIPTION ]]; then
       echo "Usage: $0 $COMMAND <pipeline id> <status> <description>"
@@ -76,9 +75,8 @@ case $COMMAND in
     "$FACTORY_API/builds/$FACTORY_BUILD_NUMBER/status"
     ;;
   update-released-time)
-    VERSION=$1
-    SYSTEM_NAME=$2
-    if [[ -z $SYSTEM_NAME ]]; then SYSTEM_NAME="opensource"; fi
+    VERSION="${1-}"
+    SYSTEM_NAME="${2:-opensource}"
     if [[ -z $VERSION ]]; then echo "Usage: $0 $COMMAND <version> [<systemName>]"; exit 1; fi
     $CURL -H "Authorization: Bearer $TOKEN" -d "{
         \"releasedSeconds\": $(date +%s),
@@ -87,9 +85,9 @@ case $COMMAND in
     "$FACTORY_API/releases/$VERSION"
     ;;
   update-buildkite-job-run)
-    START_SECONDS=$1
-    FACTORY_PIPELINE_ID=$2
-    STATUS=$3
+    START_SECONDS="${1-}"
+    FACTORY_PIPELINE_ID="${2-}"
+    STATUS="${3-}"
     if [[ -z $START_SECONDS ]] || [[ -z $FACTORY_PIPELINE_ID ]] || [[ -z $STATUS ]]; then
       echo "Usage: $0 $COMMAND <start seconds> <pipeline id> <status>"
       exit 1
@@ -107,13 +105,13 @@ case $COMMAND in
     ;;
   update-github-job-run)
     # TODO: remove this when we have vespa-factory-cli in the build image (this must be implemented in the cli)
-    START_SECONDS=$1
-    GITHUB_API_URL=$2        # STRING, used to lookup ScrewdriverInstance
-    WORKFLOW_NAME=$3         # STRING, used to lookup ScrewdriverPipeline
-    JOB_NAME=$4              # STRING, used to lookup crewdriverJob
-    JOB_ID=$5                # LONG, github's numeric job id, used as the build id in factory
-    WEB_URL=$6               # STRING, the URL to the job in the github UI
-    STATUS=$7
+    START_SECONDS="${1-}"
+    GITHUB_API_URL="${2-}"        # STRING, used to lookup ScrewdriverInstance
+    WORKFLOW_NAME="${3-}"         # STRING, used to lookup ScrewdriverPipeline
+    JOB_NAME="${4-}"              # STRING, used to lookup crewdriverJob
+    JOB_ID="${5-}"                # LONG, github's numeric job id, used as the build id in factory
+    WEB_URL="${6-}"               # STRING, the URL to the job in the github UI
+    STATUS="${7-}"
     if [[ -z $START_SECONDS ]] || [[ -z $GITHUB_API_URL ]] ||  [[ -z $WORKFLOW_NAME ]] || \
        [[ -z $JOB_NAME ]] || [[ -z $JOB_ID ]] || [[ -z $WEB_URL ]] || [[ -z $STATUS ]]; then
       echo "Usage: $0 $COMMAND <start seconds> <github api url> <workflow name> <job name> <job id> <web url> <status>"


### PR DESCRIPTION
## What
• Replace direct `$1` etc with safe forms ("${N-}" and "${N:-default}")
  across all case branches 
• Default SYSTEM_NAME inline for create-release and update-released-time
  ("${1:-opensource}", "${2:-opensource}"), preserve FACTORY_PLATFORM
  defaulting.

## Why
Avoid "unbound variable" errors under nounset, 
e.g. `factory-command: line 50: $1: unbound variable`