### PR TITLE
Skip fetching summary when only matchfeatures are needed

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -1,23 +1,18 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.fastsearch;
 
-import com.yahoo.prelude.fastsearch.DocumentDatabase;
-import com.yahoo.prelude.fastsearch.DocsumDefinitionSet;
 import com.yahoo.processing.IllegalInputException;
 
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.result.Hit;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -38,6 +33,8 @@ public class PartialSummaryHandler {
     public static final String DEFAULT_CLASS = "default";
     public static final String ALL_FIELDS_CLASS = "default"; // not really true, but best we can do for now
     public static final String PRESENTATION = "[presentation]";
+    public static final String MATCHFEATURES_MARKER = "[f:matchfeatures]";
+    public static final Set<String> ONLY_MATCHFEATURES_IN_SUMMARY_FIELDS = Set.of("matchfeatures");
 
     private static final Logger log = Logger.getLogger(PartialSummaryHandler.class.getName());
 
@@ -327,6 +324,10 @@ public class PartialSummaryHandler {
     private boolean needsMoreFill(Set<String> alreadyFilled) {
         // unfillable?
         if (alreadyFilled == null) return false;
+
+        boolean areMatchFeaturesAlreadyFilled = alreadyFilled.contains(MATCHFEATURES_MARKER);
+        boolean onlyMatchFeaturesNeeded = fieldsFromQuery.equals(ONLY_MATCHFEATURES_IN_SUMMARY_FIELDS);
+        if (areMatchFeaturesAlreadyFilled && onlyMatchFeaturesNeeded) return false;
 
         // do we already have the entire thing?
         if (alreadyFilled.contains(askForSummary)) return false;

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
@@ -140,6 +140,24 @@ public class PartialSummaryHandlerTestCase {
     }
 
     @Test
+    void testFillNotNeeded2() {
+        // When:
+        // 1) the summary class is not null;
+        // 2) only matchfeatures are selected;
+        // 3) want to fill the `[presentation]` summary class;
+        // Then resultAlreadyFilled
+        DocsumDefinitionSet set = createDocsumDefinitionSet();
+        var query = createQuery("default");
+        query.getPresentation().getSummaryFields().add("matchfeatures");
+        var hit1 = createHit(query, "[f:matchfeatures]");
+        var result = createResult(query, hit1);
+        var toTest = new PartialSummaryHandler(set);
+        String neededSummaryClass = "[presentation]"; // From the trace
+        toTest.wantToFill(result, neededSummaryClass);
+        assertTrue(toTest.resultAlreadyFilled());
+    }
+
+    @Test
     void testMultiFill() {
         DocsumDefinitionSet set = createDocsumDefinitionSet();
         var query = createQuery("first3");


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

It turns out that the logic introduced in #34029 is not enough to avoid sending a fill request.

For the query
```shell
vespa query 'select matchfeatures from sources * where true' \
  'ranking.profile=my_ranking_profile' \
  'trace.level=6' \
  'presentation.summary=default'
```

In the query trace, I see:
```json
{
    "message": "Sending 1 summary fetch requests with jrt/protobuf"
},
{
    "message": "Not resending query during document summary fetching"
}
```
Which means that the [check](https://github.com/vespa-engine/vespa/blob/6d5fb534b78493c53a8d1aee41c2776efe780e9e/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java#L85) `partialSummaryHandler.resultAlreadyFilled()` failed.

In the same trace there are plenty such messages:
```json
{
    "message": "Hits need fill([presentation]); hasFilled=[[f:matchfeatures]] in class com.yahoo.prelude.cluster.ClusterSearcher"
}
```
I read it as the evidence that somehow `default` summary class is turned into the `[presentation]` and there are no checks that properly short circuits the `.fill()`.