### PR TITLE
Johsol/vespa significance external merger

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/FileHandleBudget.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/FileHandleBudget.java
@@ -1,0 +1,11 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+/**
+ * Strategy for limiting how many file handles we can open.
+ *
+ * @author johsol
+ */
+public interface FileHandleBudget {
+    long maxReadersAllowed();
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/HalfSystemLimitBudget.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/HalfSystemLimitBudget.java
@@ -1,0 +1,22 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+/**
+ * Allows at max half of the maximum allowed number of open file descriptors by the operating system.
+ *
+ * @author johsol
+ */
+public class HalfSystemLimitBudget implements FileHandleBudget {
+
+    private final long maxOsFileHandles;
+
+    public HalfSystemLimitBudget() {
+        this.maxOsFileHandles = UlimitProbe.softLimit();
+    }
+
+    @Override
+    public long maxReadersAllowed() {
+        return maxOsFileHandles / 2;
+    }
+
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfExternalMerger.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfExternalMerger.java
@@ -1,0 +1,221 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+
+/**
+ * External k-way merge of multiple sorted files, respecting a file-handle budget.
+ * <p>
+ * If the number of inputs exceeds the available reader budget, inputs are merged in
+ * intermediate batches into temporary files that this class creates, manages, and cleans up.
+ * The final pass writes to the caller-provided {@link BufferedWriter}.
+ * <p>
+ * Ownership and I/O:
+ * <ul>
+ *   <li>Caller supplies input paths and a {@link BufferedReader} factory for caller-owned inputs.</li>
+ *   <li>Temporary files are created in a private directory and deleted when consumed.</li>
+ *   <li>This class closes all {@code BufferedReader}s it opens. The caller remains responsible for the
+ *       provided {@code BufferedWriter}.</li>
+ * </ul>
+ * <p>
+ * The {@code minKeep} filter is only applied to the final merge.
+ *
+ * @author johsol
+ */
+public class TermDfExternalMerger {
+
+    private static final long NO_MIN_KEEP = Long.MIN_VALUE;
+
+    private final FileHandleBudget fileHandleBudget;
+    private final List<Path> files;
+    private final BufferedReaderFactory readerFactory;
+
+    public TermDfExternalMerger(FileHandleBudget fileHandleBudget, List<Path> files, BufferedReaderFactory readerFactory) {
+        this.fileHandleBudget = Objects.requireNonNull(fileHandleBudget, "fileHandleBudget");
+        this.files = List.copyOf(files);
+        this.readerFactory = Objects.requireNonNull(readerFactory, "readerFactory");
+    }
+
+    /**
+     * Provide a function that can open a buffered reader from a path.
+     */
+    @FunctionalInterface
+    public interface BufferedReaderFactory {
+        BufferedReader open(Path path) throws IOException;
+    }
+
+    /**
+     * Classify if this class or the caller should open a file.
+     */
+    enum SourceType {
+
+        /** The caller should open the file */
+        External,
+
+        /** This class should open the file */
+        Tempfile
+
+    }
+
+    /**
+     * Holds a reference to a file in the queue .
+     */
+    record MergeSource(SourceType type, Path path) {
+    }
+
+    /**
+     * Represents a batch and holds a reference to the files that were consumed to have a reference
+     * to temporary files so we can delete them after they are consumed.
+     */
+    private record MergeBatch(List<BufferedReader> readers, List<MergeSource> consumed) {
+    }
+
+    /**
+     * Merges all configured input files and writes the merged result to {@code output}.
+     * <ul>
+     *   <li>If the file-handle budget is greater than the number of inputs, merging is performed in
+     *   a single pass.</li>
+     *   <li>Otherwise, inputs are merged in batches into temporary files. The final pass merges and writes to the
+     *   {@code output}.</li>
+     *   <li>Only the final pass applies {@code minKeep}; intermediate passes use {@link #NO_MIN_KEEP}.</li>
+     * </ul>
+     * <p>
+     * Ownership:
+     * <ul>
+     *   <li>All {@code BufferedReader}s opened by this class are closed within this method. Including those opened
+     *   with the {@link BufferedReaderFactory}.</li>
+     *   <li>The caller retains responsibility for closing {@code output}.</li>
+     * </ul>
+     */
+    public void mergeFiles(BufferedWriter output, long minKeep) throws IOException {
+        Objects.requireNonNull(output, "output");
+        if (files.isEmpty()) return;
+
+        int budget = computeReaderBudget();
+
+        // Fast path
+        if (budget >= files.size()) {
+            final List<BufferedReader> readers = new ArrayList<>(files.size());
+            try {
+                for (Path p : files) readers.add(readerFactory.open(p));
+                TermDfKWayMerge.merge(readers, output, minKeep);
+            } finally {
+                closeQuietly(readers);
+            }
+            return;
+        }
+
+        // Batched path
+        final Queue<MergeSource> filesToMerge = new ArrayDeque<>();
+        for (Path p : files) {
+            filesToMerge.offer(new MergeSource(SourceType.External, p));
+        }
+
+        final Path tempDir = Files.createTempDirectory("termdf-");
+        try {
+            while (filesToMerge.size() > budget) {
+                final MergeBatch batch = dequeueBatch(budget, filesToMerge);
+                final Path tempFile = Files.createTempFile(tempDir, "termdf-", ".tmp.tvl");
+
+                try (BufferedWriter tmpWriter = Files.newBufferedWriter(tempFile, StandardCharsets.UTF_8, StandardOpenOption.WRITE)) {
+                    TermDfKWayMerge.merge(batch.readers(), tmpWriter, NO_MIN_KEEP);
+                } finally {
+                    closeQuietly(batch.readers());
+                    for (MergeSource e : batch.consumed()) {
+                        if (e.type == SourceType.Tempfile) deleteQuietly(e.path);
+                    }
+                }
+
+                filesToMerge.offer(new MergeSource(SourceType.Tempfile, tempFile));
+            }
+
+            // Final pass. Write to output and filter out minKeep.
+            final MergeBatch finalBatch = dequeueBatch(budget, filesToMerge);
+            try {
+                TermDfKWayMerge.merge(finalBatch.readers(), output, minKeep);
+            } finally {
+                closeQuietly(finalBatch.readers());
+                for (MergeSource e : finalBatch.consumed()) {
+                    if (e.type == SourceType.Tempfile) deleteQuietly(e.path);
+                }
+            }
+        } finally {
+            deleteTreeQuietly(tempDir);
+        }
+    }
+
+    /**
+     * Validates the budget and converts to int.
+     */
+    private int computeReaderBudget() {
+        final long budget = fileHandleBudget.maxReadersAllowed();
+        if (budget < 3) throw new IllegalArgumentException("Cannot merge with less than 3 file handles.");
+        final long rawReaderBudget = budget - 1;
+        final int readerBudget;
+        if (rawReaderBudget >= files.size()) {
+            readerBudget = files.size();
+        } else {
+            readerBudget = (int) rawReaderBudget;
+        }
+        return readerBudget;
+    }
+
+    /**
+     * Makes a batch with reader budget amount of entries which are popped from the queue.
+     */
+    private MergeBatch dequeueBatch(int readerBudget, Queue<MergeSource> filesToMerge) throws IOException {
+        final List<BufferedReader> readers = new ArrayList<>(readerBudget);
+        final List<MergeSource> consumed = new ArrayList<>(readerBudget);
+
+        while (!filesToMerge.isEmpty() && readers.size() < readerBudget) {
+            MergeSource entry = filesToMerge.poll();
+            consumed.add(entry);
+            BufferedReader r = (entry.type == SourceType.Tempfile)
+                    ? Files.newBufferedReader(entry.path, StandardCharsets.UTF_8)
+                    : readerFactory.open(entry.path);
+            readers.add(r);
+        }
+        return new MergeBatch(readers, consumed);
+    }
+
+    private static void closeQuietly(List<BufferedReader> readers) {
+        for (BufferedReader r : readers) {
+            try {
+                if (r != null) r.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    private static void deleteQuietly(Path p) {
+        try {
+            Files.deleteIfExists(p);
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static void deleteTreeQuietly(Path dir) {
+        try (var s = Files.walk(dir)) {
+            s.sorted((a, b) -> b.getNameCount() - a.getNameCount()) // delete children first
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {
+                        }
+                    });
+        } catch (IOException ignored) {
+        }
+    }
+
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/UlimitProbe.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/UlimitProbe.java
@@ -1,0 +1,47 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Queries the OS for maximum fd allowed per process.
+ *
+ * @author johsol
+ */
+public class UlimitProbe {
+
+    /** Returns the soft limit for open files (`ulimit -n`), or -1 if unknown. */
+    public static long softLimit() {
+        return runShellAndParseLong("/bin/sh", "-lc", "ulimit -n");
+    }
+
+    /** Returns the hard limit for open files (`ulimit -Hn`), or -1 if unknown. */
+    public static long hardLimit() {
+        return runShellAndParseLong("/bin/sh", "-lc", "ulimit -Hn");
+    }
+
+    private static long runShellAndParseLong(String... cmd) {
+        Process p = null;
+        try {
+            p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                String out = r.readLine();
+                // Example outputs: "10240" or "unlimited"
+                if (out == null) return -1L;
+                out = out.trim();
+                if (out.equalsIgnoreCase("unlimited")) return Long.MAX_VALUE;
+                return Long.parseLong(out);
+            }
+        } catch (NumberFormatException | IOException e) {
+            return -1L;
+        } finally {
+            if (p != null) {
+                try { p.waitFor(2, TimeUnit.SECONDS); } catch (InterruptedException ignored) {}
+                p.destroyForcibly();
+            }
+        }
+    }
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfExternalMergerTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfExternalMergerTest.java
@@ -1,0 +1,220 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests methods in {@link TermDfExternalMerger}.
+ *
+ * @author johsol
+ */
+public class TermDfExternalMergerTest {
+
+    /**
+     * Tracks if the buffered reader was closed.
+     */
+    static class TrackingBufferedReader extends BufferedReader {
+        private volatile boolean closed = false;
+        TrackingBufferedReader(Path p) throws IOException {
+            super(Files.newBufferedReader(p, StandardCharsets.UTF_8));
+        }
+        @Override public void close() throws IOException {
+            super.close();
+            closed = true;
+        }
+        boolean isClosed() { return closed; }
+    }
+
+    /**
+     * Writes lines to temporary file, closes the handle and returns the path.
+     */
+    private static Path writeInput(String... lines) throws IOException {
+        Path f = Files.createTempFile("termdf-test-", ".tvl");
+        try (BufferedWriter w = Files.newBufferedWriter(f, StandardCharsets.UTF_8)) {
+            for (String line : lines) {
+                w.write(line);
+                w.write('\n');
+            }
+        }
+        return f;
+    }
+
+    /**
+     * Reads all lines from the writer.
+     */
+    private static List<String> readAllLines(WriterAndPath out) throws IOException {
+        try (BufferedReader r = Files.newBufferedReader(out.path(), StandardCharsets.UTF_8)) {
+            List<String> lines = new ArrayList<>();
+            String s;
+            while ((s = r.readLine()) != null) lines.add(s);
+            return lines;
+        }
+    }
+
+    private record WriterAndPath(BufferedWriter writer, Path path) {}
+
+    private static WriterAndPath newOutputFile() throws IOException {
+        Path out = Files.createTempFile("termdf-out-", ".tvl");
+        BufferedWriter w = Files.newBufferedWriter(out, StandardCharsets.UTF_8);
+        return new WriterAndPath(w, out);
+    }
+
+    private static TermDfExternalMerger.BufferedReaderFactory factoryWithTracking(List<TrackingBufferedReader> sink) {
+        return path -> {
+            TrackingBufferedReader t = new TrackingBufferedReader(path);
+            sink.add(t);
+            return t;
+        };
+    }
+
+    // ---------- Tests ----------
+
+    @Test
+    void budgetGreaterThanNumberOfFilesSuccess() throws Exception {
+        Path f1 = writeInput("a\t1", "c\t1");
+        Path f2 = writeInput("a\t2", "b\t1");
+        List<Path> files = List.of(f1, f2);
+
+        // Budget: maxReadersAllowed - 1 >= files.size() → single-pass
+        FileHandleBudget budget = () -> 1 + files.size(); // writer + all readers
+
+        var readers = new ArrayList<TrackingBufferedReader>();
+        var merger = new TermDfExternalMerger(budget, files, factoryWithTracking(readers));
+
+        WriterAndPath out = newOutputFile();
+        try (var writer = out.writer()) {
+            merger.mergeFiles(writer, /*minKeep*/ 1);
+        }
+
+        List<String> lines = readAllLines(out);
+        assertEquals(List.of("a\t3", "b\t1", "c\t1"), lines);
+
+        // All readers should be closed
+        assertEquals(files.size(), readers.size());
+        assertTrue(readers.stream().allMatch(TrackingBufferedReader::isClosed));
+    }
+
+    @Test
+    void budgetLessThanNumberOfFilesSuccess() throws Exception {
+        // 5 inputs, budget allows only 2 readers at a time → batching required
+        Path f1 = writeInput("a\t1", "b\t1");
+        Path f2 = writeInput("a\t1", "c\t1");
+        Path f3 = writeInput("b\t2");
+        Path f4 = writeInput("a\t3");
+        Path f5 = writeInput("d\t1");
+        List<Path> files = List.of(f1, f2, f3, f4, f5);
+
+        FileHandleBudget budget = () -> 3; // writer + 2 readers → batching
+
+        var readers = new ArrayList<TrackingBufferedReader>();
+        var merger = new TermDfExternalMerger(budget, files, factoryWithTracking(readers));
+
+        WriterAndPath out = newOutputFile();
+        try (var writer = out.writer()) {
+            merger.mergeFiles(writer, /*minKeep*/ 1);
+        }
+
+        List<String> lines = readAllLines(out);
+        // Totals: a=1+1+3=5, b=1+2=3, c=1, d=1
+        assertEquals(List.of("a\t5", "b\t3", "c\t1", "d\t1"), lines);
+
+        // All original readers eventually closed
+        assertEquals(files.size(), readers.size());
+        assertTrue(readers.stream().allMatch(TrackingBufferedReader::isClosed));
+    }
+
+    @Test
+    void appliesMinKeepSuccess() throws Exception {
+        // Set up so that per-batch counts are below minKeep but global total meets minKeep.
+        // With budget=3 -> 2 readers per batch. Arrange 'x' split across files.
+        Path f1 = writeInput("x\t2");  // batch 1 (alone) => 2
+        Path f2 = writeInput("x\t2");  // batch 1 => sum 4
+        Path f3 = writeInput("x\t2");  // later merged => final 6
+
+        List<Path> files = List.of(f1, f2, f3);
+        FileHandleBudget budget = () -> 3; // 2 readers per batch → (f1,f2) then merge with f3
+
+        var readers = new ArrayList<TrackingBufferedReader>();
+        var merger = new TermDfExternalMerger(budget, files, factoryWithTracking(readers));
+
+        WriterAndPath out = newOutputFile();
+        try (var writer = out.writer()) {
+            // Choose minKeep=5. If intermediate filtering were applied, 'x' would be dropped early.
+            merger.mergeFiles(writer, /*minKeep*/ 5);
+        }
+
+        List<String> lines = readAllLines(out);
+        assertEquals(List.of("x\t6"), lines); // kept only in final pass
+
+        assertTrue(readers.stream().allMatch(TrackingBufferedReader::isClosed));
+    }
+
+    @Test
+    void infinityBudgetSuccess() throws Exception {
+        Path f1 = writeInput("a\t1");
+        Path f2 = writeInput("b\t2");
+        List<Path> files = List.of(f1, f2);
+
+        FileHandleBudget budget = () -> Long.MAX_VALUE; // effectively infinite
+
+        var readers = new ArrayList<TrackingBufferedReader>();
+        var merger = new TermDfExternalMerger(budget, files, factoryWithTracking(readers));
+
+        WriterAndPath out = newOutputFile();
+        try (var writer = out.writer()) {
+            merger.mergeFiles(writer, 1);
+        }
+
+        List<String> lines = readAllLines(out);
+        assertEquals(List.of("a\t1", "b\t2"), lines);
+        assertTrue(readers.stream().allMatch(TrackingBufferedReader::isClosed));
+    }
+
+    @Test
+    void emptyInputsSuccess() throws Exception {
+        List<Path> files = List.of();
+        FileHandleBudget budget = () -> 10;
+
+        var readers = new ArrayList<TrackingBufferedReader>();
+        var merger = new TermDfExternalMerger(budget, files, factoryWithTracking(readers));
+
+        WriterAndPath out = newOutputFile();
+        try (var writer = out.writer()) {
+            merger.mergeFiles(writer, 1);
+        }
+
+        List<String> lines = readAllLines(out);
+        assertTrue(lines.isEmpty());
+        assertTrue(readers.isEmpty()); // no readers opened
+    }
+
+    @Test
+    void invalidBudgetThrows() {
+        List<Path> files = List.of(Path.of("")); // must be non-empty.
+        FileHandleBudget bad = () -> 2; // < 3
+
+        var merger = new TermDfExternalMerger(bad, files, p -> Files.newBufferedReader(p, StandardCharsets.UTF_8));
+
+        // Need a writer to invoke mergeFiles
+        assertThrows(IllegalArgumentException.class, () -> {
+            Path out = Files.createTempFile("termdf-out-", ".tvl");
+            try (BufferedWriter w = Files.newBufferedWriter(out, StandardCharsets.UTF_8)) {
+                merger.mergeFiles(w, 1);
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
### FileHandleBudget, HalfSystemLimitBudget, and UlimitProbe

- Strategy for limiting how many file handles to open.
- Takes the file system max and divides it by 2.

### TermDfExternalMerger

- The file handle budget defines how many buffered readers + buffered writers this class can have open at once.
- If there are fewer files than this budget, we can merge all in one pass.
- If not, we process the "budget" amount at a time and write output to temporary files.
- The temporary files are added back into the queue of files waiting to be processed.
- This process continues until we can process the last files and write to the output writer.

