### PR TITLE
Change getSerializedQueryTree to return reference instead of shared_ptr

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/search_session.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/search_session.h
@@ -69,8 +69,8 @@ public:
     std::string_view getStackDump() const noexcept {
         return _owned_objects.queryTree ? _owned_objects.queryTree->getStackRef() : std::string_view();
     }
-    const search::SerializedQueryTreeSP getSerializedQueryTree() const noexcept {
-        return _owned_objects.queryTree;
+    const search::SerializedQueryTree& getSerializedQueryTree() const noexcept {
+        return _owned_objects.queryTree ? *_owned_objects.queryTree : search::SerializedQueryTree::empty();
     }
 };
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -32,7 +32,9 @@ public:
     void initFromDocsumRequest(const search::engine::DocsumRequest &req);
 
     void setResultClassName(std::string_view name) { _resultClassName = name; }
-    void setSerializedQueryTree(SerializedQueryTreeSP tree) { _serializedQueryTree = std::move(tree); }
+    void setSerializedQueryTree(const search::SerializedQueryTree& tree) {
+        _serializedQueryTree = tree.shared_from_this();
+    }
     void locations_possible(bool value) { _locations_possible = value; }
     bool locations_possible() const { return _locations_possible; }
     const std::string &getLocation() const { return _location; }

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -251,7 +251,7 @@ SearchVisitor::SummaryGenerator::get_streaming_docsums_state(std::string_view su
         ds._args.setLocation(_location.value());
     }
     if (_serialized_query_tree) {
-        ds._args.setSerializedQueryTree(_serialized_query_tree);
+        ds._args.setSerializedQueryTree(*_serialized_query_tree);
     }
     ds._args.highlightTerms(_highlight_terms);
     _docsumWriter->initState(_attr_manager, ds, state->get_resolve_class_info());


### PR DESCRIPTION
Also update setSerializedQueryTree() methods to accept const references and call shared_from_this() internally.

@havardpe please review
