### PR TITLE
Avoid `.fill()` by treating `[presentation]` summary class as the default request class

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -142,7 +142,7 @@ public class PartialSummaryHandler {
     }
 
     private static boolean isDefaultRequest(String summaryClass) {
-        return summaryClass == null || summaryClass.equals(DEFAULT_CLASS);
+        return summaryClass == null || summaryClass.equals(DEFAULT_CLASS) || summaryClass.equals(PRESENTATION);
     }
 
     private static boolean isPresentationRequest(String summaryClass) {

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
@@ -372,6 +372,30 @@ public class PartialSummaryHandlerTestCase {
         assertEquals(2, result.hits().getFilled().size());
     }
 
+    @Test
+    void enoughFields() {
+        var query = createQuery("first3");
+        query.getPresentation().setSummaryFields("field1");
+        var hit1 = createHit(query);
+        var result = createResult(query, hit1);
+        assertEquals("[f:field1]", PartialSummaryHandler.enoughFields(null, result));
+        assertEquals("[f:field1]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.DEFAULT_CLASS, result));
+        assertEquals("[f:field1]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.PRESENTATION, result));
+        assertEquals("default", PartialSummaryHandler.enoughFields("first3", result));
+    }
+
+    @Test
+    void enoughFieldsWhenOnlyMatchFeaturesAreInSummaryFeatures() {
+        var query = createQuery("first3");
+        query.getPresentation().setSummaryFields("matchfeatures");
+        var hit1 = createHit(query);
+        var result = createResult(query, hit1);
+        assertEquals("[f:matchfeatures]", PartialSummaryHandler.enoughFields(null, result));
+        assertEquals("[f:matchfeatures]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.DEFAULT_CLASS, result));
+        assertEquals("[f:matchfeatures]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.PRESENTATION, result));
+        assertEquals("default", PartialSummaryHandler.enoughFields("first3", result));
+    }
+
     static Query createQuery(String summaryClass) {
         if (summaryClass == null)
             return new Query("/search/?query=foo");


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

A different attempt to avoid `.fill()` when only `matchfeatures` are needed.  #34998

The idea is to claim that the`[presentation]` summary class is roughly the same as `default` when it comes to deciding that a synthetic summary generated from summary fields is enough.

I don't know if this is an intention behind the `PartialSummaryHandler.PRESENTATION`, but it helps to avoid `.fill()` when only `matchfeatures` are needed.