### PR TITLE
Johsol/vespa significance merge

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/MergeClientParameters.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/MergeClientParameters.java
@@ -1,0 +1,59 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class contains the program parameters for merge subcommand.
+ *
+ * @author johsol
+ */
+public record MergeClientParameters(
+        String outputFile,
+        List<String> inputFiles,
+        long minKeep,
+        boolean zstCompress) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String outputFile;
+        private final List<String> inputFiles = new ArrayList<>();
+        private long minKeep = Long.MIN_VALUE;
+        private boolean zstCompress = false;
+
+        public Builder outputFile(String value) {
+            this.outputFile = value;
+            return this;
+        }
+
+        public Builder addInputFile(String file) {
+            this.inputFiles.add(file);
+            return this;
+        }
+
+        public Builder addInputFiles(List<String> files) {
+            files.forEach(this::addInputFile);
+            return this;
+        }
+
+        public Builder minKeep(long minKeep) {
+            this.minKeep = minKeep;
+            return this;
+        }
+
+        public Builder zstCompress(boolean value) {
+            this.zstCompress = value;
+            return this;
+        }
+
+        public MergeClientParameters build() {
+            return new MergeClientParameters(outputFile, inputFiles, minKeep, zstCompress);
+        }
+    }
+
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/MergeCommand.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/MergeCommand.java
@@ -1,0 +1,158 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import com.yahoo.vespasignificance.CommandLineOptions;
+import io.airlift.compress.zstd.ZstdInputStream;
+import io.airlift.compress.zstd.ZstdOutputStream;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * vespa-significance subcommand that merges multiple sorted TSV inputs into a single TSV output.
+ *
+ * @author johsol
+ */
+public class MergeCommand {
+
+    private final MergeClientParameters params;
+    private Path outputPath;
+    private final List<Path> inputPaths = new ArrayList<>();
+
+    public MergeCommand(MergeClientParameters params) {
+        this.params = params;
+    }
+
+    /**
+     * Main entry point for merge subcommand.
+     * <p>
+     * Returns 0 on success and 1 on failure.
+     */
+    public int run() {
+        try {
+            prepareOutputPath();
+            resolveAndValidateInputs();
+            ensureOutputNotInInputs();
+
+            var merger = new TermDfExternalMerger(new HalfSystemLimitBudget(), inputPaths, MergeCommand::openInputReader);
+            try (var writer = newOutputWriter(outputPath, params.zstCompress())) {
+                merger.mergeFiles(writer, params.minKeep());
+            }
+
+            System.out.println("Merged files to " + outputPath);
+        } catch (MergeFailure ignored) {
+            return 1;
+        } catch (IOException e) {
+            System.err.println("I/O error while merging: " + e.getMessage());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Ensures that output file is not null or blank and that we can create parent directories for
+     * output. If the output should be zst compressed we add .zst extension if not present.
+     */
+    private void prepareOutputPath() {
+        var out = params.outputFile();
+        if (out == null || out.isBlank()) {
+            System.err.println("Error: --output is required.");
+            CommandLineOptions.printMergeHelp();
+            throw new MergeFailure();
+        }
+
+        boolean wantsZst = params.zstCompress();
+        boolean hasZstSuffix = out.endsWith(".zst");
+        if (wantsZst && !hasZstSuffix) {
+            out = out + ".zst";
+        }
+        outputPath = Path.of(out);
+
+        Path parent = outputPath.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                System.err.println("Error: Unable to create parent directory for output: " + parent);
+                throw new MergeFailure();
+            }
+        }
+    }
+
+    /**
+     * Resolves input strings to {@link Path}s and validates existence.
+     */
+    private void resolveAndValidateInputs() {
+        if (params.inputFiles().isEmpty()) {
+            System.err.println("Error: No input files specified.");
+            CommandLineOptions.printMergeHelp();
+            throw new MergeFailure();
+        }
+
+        for (var input : params.inputFiles()) {
+            Path path = Path.of(input);
+            if (!Files.exists(path)) {
+                System.err.println("Error: Input file " + input + " does not exist.");
+                throw new MergeFailure();
+            }
+            inputPaths.add(path);
+        }
+    }
+
+    /**
+     * Check that we do not stream from output to one of the inputs.
+     */
+    private void ensureOutputNotInInputs() {
+        if (outputPath != null && inputPaths.stream()
+                .map(p -> p.toAbsolutePath().normalize())
+                .anyMatch(p -> p.equals(outputPath.toAbsolutePath().normalize()))) {
+            System.err.println("Error: Output file must be different from all input files: " + outputPath);
+            throw new MergeFailure();
+        }
+    }
+
+    /**
+     * Opens an input path as a buffered {@link BufferedReader}.
+     */
+    private static BufferedReader openInputReader(Path path) throws IOException {
+        String name = path.getFileName().toString().toLowerCase(java.util.Locale.ROOT);
+
+        if (name.endsWith(".zst")) {
+            InputStream in = Files.newInputStream(path, StandardOpenOption.READ);
+            BufferedInputStream bin = new BufferedInputStream(in);
+            ZstdInputStream zst = new ZstdInputStream(bin);
+            return new BufferedReader(new InputStreamReader(zst, StandardCharsets.UTF_8));
+        }
+
+        return Files.newBufferedReader(path, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Opens a buffered {@link BufferedWriter} for the output path.
+     */
+    private static BufferedWriter newOutputWriter(Path output, boolean zst) throws IOException {
+        var out = Files.newOutputStream(output, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        if (zst) {
+            return new BufferedWriter(new OutputStreamWriter(new ZstdOutputStream(new BufferedOutputStream(out)), StandardCharsets.UTF_8));
+        } else {
+            return new BufferedWriter(new OutputStreamWriter(new BufferedOutputStream(out), StandardCharsets.UTF_8));
+        }
+    }
+
+
+    static final class MergeFailure extends RuntimeException {
+    }
+}

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
@@ -3,6 +3,7 @@
 package com.yahoo.vespasignificance;
 
 import ai.vespa.vespasignificance.export.Export;
+import ai.vespa.vespasignificance.merge.MergeCommand;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.ParseException;
@@ -44,6 +45,10 @@ public class Main {
 
             case "export":
                 runExport(subArgs);
+                break;
+
+            case "merge":
+                runMerge(subArgs);
                 break;
 
             default:
@@ -97,6 +102,27 @@ public class Main {
         } catch (ParseException e) {
             System.err.printf("Error: %s.\n", e.getMessage());
             CommandLineOptions.printExportHelp();
+            System.exit(1);
+        }
+    }
+
+    static void runMerge(String[] commandLineArgs) {
+        try {
+            if (CommandLineOptions.Utils.hasHelpOption(commandLineArgs)) {
+                CommandLineOptions.printMergeHelp();
+                return;
+            }
+
+            var commandLineParser = new DefaultParser();
+            CommandLine commandLine = commandLineParser.parse(CommandLineOptions.createMergeOptions(), commandLineArgs, true);
+            System.setProperty("vespa.replace_invalid_unicode", "true");
+
+            var clientParams = CommandLineOptions.parseMergeCommandLineArguments(commandLine);
+            MergeCommand merge = new MergeCommand(clientParams);
+            System.exit(merge.run());
+        } catch (ParseException e) {
+            System.err.printf("Error: %s.\n", e.getMessage());
+            CommandLineOptions.printMergeHelp();
             System.exit(1);
         }
     }

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/MergeCommandTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/MergeCommandTest.java
@@ -1,0 +1,139 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import io.airlift.compress.zstd.ZstdInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end tests for MergeCommand.
+ *
+ * @author johsol
+ */
+class MergeCommandTest {
+
+    @TempDir Path tmp;
+
+    private static Path writeUtf8(Path p, List<String> lines) throws IOException {
+        Files.createDirectories(p.getParent());
+        try (BufferedWriter w = Files.newBufferedWriter(p, StandardCharsets.UTF_8)) {
+            for (String s : lines) { w.write(s); w.newLine(); }
+        }
+        return p;
+    }
+
+    private static List<String> readUtf8(Path p) throws IOException {
+        return Files.readAllLines(p, StandardCharsets.UTF_8);
+    }
+
+    private static List<String> readZstUtf8(Path p) throws IOException {
+        try (InputStream in = Files.newInputStream(p);
+             BufferedInputStream bin = new BufferedInputStream(in);
+             ZstdInputStream zst = new ZstdInputStream(bin);
+             BufferedReader r = new BufferedReader(new InputStreamReader(zst, StandardCharsets.UTF_8))) {
+            return r.lines().toList();
+        }
+    }
+
+    private static MergeClientParameters params(
+            String out, boolean zst, long minKeep, List<String> inputs) {
+        return MergeClientParameters.builder()
+                .addInputFiles(inputs)
+                .outputFile(out)
+                .zstCompress(zst)
+                .minKeep(minKeep)
+                .build();
+    }
+
+    @Test
+    void mergesTsvFiles() throws Exception {
+        Path in1 = writeUtf8(tmp.resolve("in1.tsv"), List.of("a\t1", "c\t1"));
+        Path in2 = writeUtf8(tmp.resolve("in2.tsv"), List.of("a\t2", "b\t3"));
+        Path out = tmp.resolve("out.tsv");
+
+        MergeCommand cmd = new MergeCommand(params(out.toString(), false, 1, List.of(in1.toString(), in2.toString())));
+        int rc = cmd.run();
+        assertEquals(0, rc);
+
+        assertEquals(List.of("a\t3", "b\t3", "c\t1"), readUtf8(out));
+    }
+
+    @Test
+    void mergesCombinationOfCompressedAndUncompressed() throws Exception {
+        Path inPlain = writeUtf8(tmp.resolve("in-plain.tsv"), List.of("x\t1", "z\t1"));
+        // prepare zst input
+        Path inZst = tmp.resolve("in.zst");
+        // compress: simplest is to write plain then recompress via MergeCommand’s reader path,
+        // but here we write plain and rely on filename for detection. To be strict, write legit zst:
+        try (OutputStream raw = Files.newOutputStream(inZst);
+             var zwo = new io.airlift.compress.zstd.ZstdOutputStream(new BufferedOutputStream(raw));
+             var w = new BufferedWriter(new OutputStreamWriter(zwo, StandardCharsets.UTF_8))) {
+            w.write("x\t2\n");
+            w.write("y\t5\n");
+        }
+
+        Path outNoSuffix = tmp.resolve("final"); // user omitted .zst
+        MergeCommand cmd = new MergeCommand(params(outNoSuffix.toString(), true, 1,
+                List.of(inPlain.toString(), inZst.toString())));
+        int rc = cmd.run();
+        assertEquals(0, rc);
+
+        Path out = Path.of(outNoSuffix + ".zst"); // suffix appended
+        assertTrue(Files.exists(out), "expected .zst to be appended");
+
+        assertEquals(List.of("x\t3", "y\t5", "z\t1"), readZstUtf8(out));
+    }
+
+    @Test
+    void appliesMinKeep() throws Exception {
+        Path f1 = writeUtf8(tmp.resolve("f1.tsv"), List.of("t\t2"));
+        Path f2 = writeUtf8(tmp.resolve("f2.tsv"), List.of("t\t2"));
+        Path f3 = writeUtf8(tmp.resolve("f3.tsv"), List.of("t\t2"));
+        Path out = tmp.resolve("out.tsv");
+
+        MergeCommand cmd = new MergeCommand(params(out.toString(), false, /*minKeep*/5,
+                List.of(f1.toString(), f2.toString(), f3.toString())));
+        int rc = cmd.run();
+        assertEquals(0, rc);
+
+        assertEquals(List.of("t\t6"), readUtf8(out));
+    }
+
+    @Test
+    void failsWhenOutputMissing() {
+        MergeCommand cmd = new MergeCommand(params("", false, 1, List.of("a")));
+        assertEquals(1, cmd.run());
+    }
+
+    @Test
+    void failsWhenNoInputsProvided() {
+        Path out = tmp.resolve("out.tsv");
+        MergeCommand cmd = new MergeCommand(params(out.toString(), false, 1, List.of()));
+        assertEquals(1, cmd.run());
+    }
+
+    @Test
+    void failsWhenAnyInputMissing() {
+        Path out = tmp.resolve("out.tsv");
+        Path existing = tmp.resolve("exists.tsv");
+        assertDoesNotThrow(() -> writeUtf8(existing, List.of("a\t1")));
+        MergeCommand cmd = new MergeCommand(params(out.toString(), false, 1,
+                List.of(existing.toString(), tmp.resolve("missing.tsv").toString())));
+        assertEquals(1, cmd.run());
+    }
+
+    @Test
+    void failsWhenOutputEqualsAnInput() throws Exception {
+        Path io = writeUtf8(tmp.resolve("same.tsv"), List.of("a\t1"));
+        MergeCommand cmd = new MergeCommand(params(io.toString(), false, 1, List.of(io.toString())));
+        assertEquals(1, cmd.run());
+    }
+}
+


### PR DESCRIPTION
- Adds `vespa-significance merge --output out.tsv input1.tsv input2.tsv.zst input3.tsv.zst`
- Can take both zst and tsv files as input.
- Checks that output is not in the input list.