### PR TITLE
Skip unpack for non-matching subtrees in streaming search.

### DIFF
--- a/searchlib/src/vespa/searchlib/query/streaming/query.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/query.cpp
@@ -64,8 +64,10 @@ QueryConnector::evaluateHits(HitList & hl)
 void
 QueryConnector::unpack_match_data(uint32_t docid, MatchData& match_data, const IIndexEnvironment& index_env)
 {
-    for (const auto & node : _children) {
-        node->unpack_match_data(docid, match_data, index_env);
+    if (evaluate()) {
+        for (const auto &node: _children) {
+            node->unpack_match_data(docid, match_data, index_env);
+        }
     }
 }
 

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
@@ -140,7 +140,7 @@ QueryTerm::set_element_length(uint32_t hitlist_idx, uint32_t element_length)
 void
 QueryTerm::unpack_match_data(uint32_t docid, MatchData& match_data, const IIndexEnvironment& index_env)
 {
-    if (isRanked()) {
+    if (evaluate() && isRanked()) {
         auto& qtd = static_cast<QueryTermData&>(getQueryItem());
         const ITermData& td = qtd.getTermData();
         unpack_match_data(docid, td, match_data, index_env);


### PR DESCRIPTION
This makes unpack for streaming search closer to unpack for indexed search.

@havardpe : please review
@arnej27959 : FYI
