### PR TITLE
Cleanup `vespa-significance generate`

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/generate/FormatStrategy.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/generate/FormatStrategy.java
@@ -1,0 +1,21 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.generate;
+
+import java.io.IOException;
+import java.util.SortedMap;
+
+/**
+ * Build document frequency map from input format.
+ *
+ * @author johsol
+ */
+public interface FormatStrategy {
+
+    /** Returns a map from term to document frequency */
+    Result build() throws IOException;
+
+    /** Language key for {@link com.yahoo.language.significance.SignificanceModel} */
+    String languageKey();
+
+    record Result(SortedMap<String, Long> termDf, long documentCount) {}
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/generate/JsonlDocumentFormatStrategy.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/generate/JsonlDocumentFormatStrategy.java
@@ -1,0 +1,102 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.generate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.language.Language;
+import com.yahoo.language.process.LinguisticsParameters;
+import com.yahoo.language.process.StemMode;
+import com.yahoo.language.process.Token;
+import com.yahoo.language.process.TokenScript;
+import com.yahoo.language.process.TokenType;
+import com.yahoo.language.process.Tokenizer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Builds a document-frequency (DF) map from a JSON Lines (JSONL) file containing Vespa feed documents.
+ *
+ * @author johsol
+ */
+public final class JsonlDocumentFormatStrategy implements FormatStrategy {
+
+    private final Path input;
+    private final String field;
+    private final Tokenizer tokenizer;
+    private final Language tokenizationLanguage;
+    private final List<Language> languageKeyParts;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public JsonlDocumentFormatStrategy(Path input,
+                                       Tokenizer tokenizer,
+                                       Language tokenizationLanguage,
+                                       List<Language> languageKeyParts,
+                                       String field) {
+        this.input = input;
+        this.field = field;
+        this.tokenizer = tokenizer;
+        this.tokenizationLanguage = tokenizationLanguage;
+        this.languageKeyParts = languageKeyParts;
+    }
+
+    @Override
+    public Result build() throws IOException {
+        SortedMap<String, Long> df = new TreeMap<>();
+        long docs = 0;
+
+        try (var br = Files.newBufferedReader(input)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.isBlank()) {
+                    docs++;
+                    continue;
+                }
+
+                JsonNode root = mapper.readTree(line);
+                JsonNode fields = root.get("fields");
+                if (fields != null) {
+                    JsonNode value = fields.get(field);
+                    if (value != null && !value.isNull()) {
+                        // Legacy parity: if it's a string, use it; otherwise tokenize the JSON rendering
+                        String text = value.isTextual() ? value.asText() : value.toString();
+                        tokenizeAndAccumulate(df, text);
+                    }
+                }
+
+                docs++;
+                if (docs % 50_000 == 0) {
+                    System.out.println("Documents processed: " + docs + ", unique terms: " + df.size());
+                }
+            }
+        }
+
+        return new Result(Collections.unmodifiableSortedMap(new TreeMap<>(df)), docs);
+    }
+
+    private void tokenizeAndAccumulate(SortedMap<String, Long> df, String text) {
+        var params = new LinguisticsParameters(tokenizationLanguage, StemMode.NONE, false, true);
+        var tokens = tokenizer.tokenize(text, params);
+
+        var unique = new java.util.HashSet<String>();
+        for (Token t : tokens) {
+            if (t.getType() == TokenType.ALPHABETIC && t.getScript() == TokenScript.LATIN) {
+                unique.add(t.getTokenString()); // legacy: no explicit lowercasing/normalization
+            }
+        }
+        for (String term : unique) {
+            df.merge(term, 1L, Long::sum);
+        }
+    }
+
+    @Override
+    public String languageKey() {
+        return String.join(",", languageKeyParts.stream().map(Language::languageCode).toList());
+    }
+}

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/ClientParameters.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/ClientParameters.java
@@ -14,6 +14,9 @@ public class ClientParameters {
     // Input file for the program
     public final String inputFile;
 
+    // Format of input file
+    public final String format;
+
     // Output file for the program
     public final String outputFile;
 
@@ -29,12 +32,14 @@ public class ClientParameters {
     public ClientParameters(
             boolean help,
             String inputFile,
+            String format,
             String outputFile,
             String field,
             String language,
             boolean zstCompression) {
         this.help = help;
         this.inputFile = inputFile;
+        this.format = format;
         this.outputFile = outputFile;
         this.field = field;
         this.language = language;
@@ -44,6 +49,7 @@ public class ClientParameters {
     public static class Builder {
         private boolean help;
         private String inputFile;
+        private String format;
         private String outputFile;
         private String field;
         private String language;
@@ -56,6 +62,11 @@ public class ClientParameters {
 
         public Builder setInputFile(String inputFile) {
             this.inputFile = inputFile;
+            return this;
+        }
+
+        public Builder setFormat(String format) {
+            this.format = format;
             return this;
         }
 
@@ -79,7 +90,7 @@ public class ClientParameters {
         }
 
         public ClientParameters build() {
-            return new ClientParameters(help, inputFile, outputFile, field, language, zstCompression);
+            return new ClientParameters(help, inputFile, format, outputFile, field, language, zstCompression);
         }
     }
 }

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -28,6 +28,7 @@ public class CommandLineOptions {
     public static final String FIELD_OPTION = "field";
     public static final String LANGUAGE_OPTION = "language";
     public static final String ZST_COMPRESSION = "zst-compression";
+    public static final String FORMAT_OPTION = "format";
 
     public static final String INDEX_DIR = "index-dir";
     public static final String CLUSTER_OPTION = "cluster";
@@ -91,9 +92,15 @@ public class CommandLineOptions {
                 .desc("Input JSON Lines file. One Vespa document per line.")
                 .build());
 
+        options.addOption(Option.builder()
+                .longOpt(FORMAT_OPTION)
+                .hasArg()
+                .argName("jsonl")
+                .desc("Format of input file. Default is jsonl.")
+                .build());
+
         options.addOption(Option.builder("o")
                 .longOpt(OUTPUT_OPTION)
-                .required()
                 .hasArg()
                 .argName("model.json[.zst]")
                 .desc("Output model file.")
@@ -101,7 +108,6 @@ public class CommandLineOptions {
 
         options.addOption(Option.builder("f")
                 .longOpt(FIELD_OPTION)
-                .required()
                 .hasArg()
                 .argName("fieldName")
                 .desc("Document field to analyze.")
@@ -109,7 +115,6 @@ public class CommandLineOptions {
 
         options.addOption(Option.builder("l")
                 .longOpt(LANGUAGE_OPTION)
-                .required()
                 .hasArg()
                 .argName("tag[,tag...]")
                 .desc("ISO language tag(s), comma-separated (e.g., 'en', 'no', or 'en,no').")
@@ -142,6 +147,7 @@ public class CommandLineOptions {
 
         builder.setHelp(cl.hasOption(HELP_OPTION));
         builder.setInputFile(cl.getOptionValue(INPUT_OPTION));
+        builder.setFormat(cl.hasOption(FORMAT_OPTION) ? cl.getOptionValue(FORMAT_OPTION) : "jsonl");
         builder.setOutputFile(cl.getOptionValue(OUTPUT_OPTION));
         builder.setField(cl.getOptionValue(FIELD_OPTION));
         builder.setLanguage(cl.getOptionValue(LANGUAGE_OPTION));

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
@@ -8,7 +8,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.ParseException;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 /**
@@ -71,13 +70,11 @@ public class Main {
             ClientParameters params = CommandLineOptions.parseGenerateCommandLineArguments(commandLine);
             System.setProperty("vespa.replace_invalid_unicode", "true");
             SignificanceModelGenerator significanceModelGenerator = createSignificanceModelGenerator(params);
-            significanceModelGenerator.generate();
+            System.exit(significanceModelGenerator.run());
         } catch (ParseException e) {
             System.err.printf("Error: %s.\n", e.getMessage());
             CommandLineOptions.printGenerateHelp();
             System.exit(1);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/SignificanceModelGenerator.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/SignificanceModelGenerator.java
@@ -1,204 +1,239 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
 package com.yahoo.vespasignificance;
 
-import com.fasterxml.jackson.core.JsonFactory;
+import ai.vespa.vespasignificance.generate.FormatStrategy;
+import ai.vespa.vespasignificance.generate.JsonlDocumentFormatStrategy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.yahoo.document.DataType;
-import com.yahoo.document.Document;
-import com.yahoo.document.DocumentPut;
-import com.yahoo.document.DocumentType;
-import com.yahoo.document.DocumentTypeManager;
-import com.yahoo.document.Field;
-import com.yahoo.document.datatypes.FieldValue;
-import com.yahoo.document.json.DocumentOperationType;
-import com.yahoo.document.json.JsonReader;
-import com.yahoo.document.json.ParsedDocumentOperation;
 import com.yahoo.language.Language;
 import com.yahoo.language.opennlp.OpenNlpLinguistics;
-import com.yahoo.language.process.LinguisticsParameters;
-import com.yahoo.language.process.StemMode;
-import com.yahoo.language.process.Token;
-import com.yahoo.language.process.TokenScript;
-import com.yahoo.language.process.TokenType;
-import com.yahoo.language.process.Tokenizer;
 import com.yahoo.language.significance.impl.DocumentFrequencyFile;
 import com.yahoo.language.significance.impl.SignificanceModelFile;
-import com.yahoo.text.Utf8;
 import io.airlift.compress.zstd.ZstdInputStream;
 import io.airlift.compress.zstd.ZstdOutputStream;
 
 import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.FileOutputStream;
 import java.io.FileInputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.List;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * @author MariusArhaug
+ * @author johsol
  */
 public class SignificanceModelGenerator {
 
     private final ClientParameters clientParameters;
-    private final Tokenizer tokenizer;
-    private final TreeMap<String, Long> documentFrequency = new TreeMap<>();
 
-    private final List<Language> languages;
+    private FormatStrategy formatStrategy;
+    private ObjectMapper objectMapper;
+    private InputFormat format;
+    private String outputFile;
+    private boolean useZstCompression;
 
-    private final Language languageTag;
-    private final ObjectMapper objectMapper;
-    private final static JsonFactory parserFactory = new JsonFactory();
-
-    final DocumentTypeManager types = new DocumentTypeManager();
-    final DocumentType docType;
-    private final boolean useZstCompression;
     private final static String VERSION = "1.0";
     private final static String ID = "1";
     private final static String SIGNIFICANCE_DESCRIPTION = "Significance model for input file";
     private final static String DOC_FREQ_DESCRIPTION = "Document frequency for language";
 
-    private final static String DUMMY_DOC_TYPE = "dummy";
-    private final static String DUMMY_DOC_ID = "id:dummy:" + DUMMY_DOC_TYPE + "::dummy";
 
     public SignificanceModelGenerator(ClientParameters clientParameters) {
         this.clientParameters = clientParameters;
-
-        if (clientParameters.zstCompression && !clientParameters.outputFile.endsWith(".zst")) {
-            throw new IllegalArgumentException("Output file must have .zst extension when using zst compression");
-        }
-
-        if (!clientParameters.zstCompression && clientParameters.outputFile.endsWith(".zst")) {
-            throw new IllegalArgumentException("Output file must not have .zst extension when not using zst compression");
-        }
-
-        this.languages = Arrays.stream(clientParameters.language.split(","))
-                .map(Language::fromLanguageTag)
-                .collect(Collectors.toList());
-
-        this.languageTag = this.languages.get(0);
-
-        OpenNlpLinguistics openNlpLinguistics = new OpenNlpLinguistics();
-        tokenizer = openNlpLinguistics.getTokenizer();
-        objectMapper = new ObjectMapper();
-
-        docType = new DocumentType(DUMMY_DOC_TYPE);
-        docType.addField(new Field(clientParameters.field, DataType.STRING));
-        useZstCompression = clientParameters.zstCompression;
-
-        types.registerDocumentType(docType);
     }
 
-
-    public void generate() throws IOException {
-
-        Path currentWorkingDir = Paths.get("").toAbsolutePath();
-
-        final InputStream rawDoc = Files.newInputStream(currentWorkingDir.resolve(clientParameters.inputFile));
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(rawDoc));
-
-        long i = 1;
-        while (reader.ready()) {
-            String line = reader.readLine();
-
-            // Avoid failing on empty lines
-            if (line.isBlank())
-                continue;
-
-            JsonReader jsonReader = new JsonReader(types, new ByteArrayInputStream(Utf8.toBytes(line)), parserFactory);
-
-            // Using DUMMY_DOC_ID since we are only interested in content.
-            ParsedDocumentOperation operation = jsonReader.readSingleDocumentStreaming(DocumentOperationType.PUT, DUMMY_DOC_ID);
-
-            DocumentPut put = (DocumentPut) operation.operation();
-            Document document = put.getDocument();
-            FieldValue fieldValue = document.getFieldValue(clientParameters.field);
-            this.handleTokenization(fieldValue.toString());
-            if (i % 50000 == 0) {
-                System.out.println("Documents processed: " + i + ", unique words: " + documentFrequency.size());
-            }
-            i++;
-        }
-
-        long pageCount = i - 1;
-        System.out.println("Total documents processed: " + pageCount + ", unique words: " + documentFrequency.size());
-
-        SignificanceModelFile modelFile;
-        File outputFile = Paths.get(clientParameters.outputFile).toFile();
-        String languagesKey = String.join(",", this.languages.stream().map(Language::languageCode).toList());
-        if (outputFile.exists()) {
-
-            InputStream in = outputFile.toString().endsWith(".zst") ?
-                    new ZstdInputStream(new FileInputStream(outputFile)) :
-                    new FileInputStream(outputFile);
-
-            modelFile = objectMapper.readValue(in, SignificanceModelFile.class);
-
-            modelFile.addLanguage(languagesKey, new DocumentFrequencyFile(DOC_FREQ_DESCRIPTION, pageCount, getFinalDocumentFrequency()));
-
-        } else {
-            HashMap<String, DocumentFrequencyFile> languages = new HashMap<>() {{
-                put(languagesKey, new DocumentFrequencyFile(DOC_FREQ_DESCRIPTION, pageCount, getFinalDocumentFrequency()));
-            }};
-
-            modelFile = new SignificanceModelFile(VERSION, ID, SIGNIFICANCE_DESCRIPTION + clientParameters.inputFile, languages);
-        }
+    /**
+     * Main entry point for generate subcommand. Returns 0 on success.
+     */
+    public int run() {
         try {
-            ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
-
-            OutputStream out = useZstCompression ?
-                    new ZstdOutputStream(new FileOutputStream(clientParameters.outputFile)) :
-                    new FileOutputStream(clientParameters.outputFile);
-
-            writer.writeValue(out, modelFile);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to write model to output file", e);
-        }
-    }
-
-    private void handleTokenization(String field) {
-        var parameters = new LinguisticsParameters(languageTag, StemMode.NONE, false, true);
-        var tokens = tokenizer.tokenize(field, parameters);
-
-        Set<String> uniqueWords = StreamSupport.stream(tokens.spliterator(), false)
-                .filter(t -> t.getType() == TokenType.ALPHABETIC)
-                .filter(t -> t.getScript() == TokenScript.LATIN)
-                .map(Token::getTokenString)
-                .collect(Collectors.toSet());
-
-        for (String word : uniqueWords) {
-            if (documentFrequency.containsKey(word)) {
-                documentFrequency.merge(word, 1L, Long::sum);
-            } else {
-                documentFrequency.put(word, 1L);
+            setFormat();
+            if (format == InputFormat.jsonl) {
+                validateJsonlFormatRequiredFields();
             }
+            resolveAndValidateOutputFile();
+
+            String language = Objects.requireNonNullElse(clientParameters.language, "un");
+            List<Language> languageKeyParts = Arrays.stream(language.split(","))
+                    .map(Language::fromLanguageTag)
+                    .collect(Collectors.toList());
+
+            Language tokenizationLanguage = languageKeyParts.get(0);
+
+            var openNlpLinguistics = new OpenNlpLinguistics();
+            var tokenizer = openNlpLinguistics.getTokenizer();
+            objectMapper = new ObjectMapper();
+            useZstCompression = clientParameters.zstCompression;
+
+            final Path input = Paths.get(clientParameters.inputFile);
+
+            switch (format) {
+                case jsonl -> formatStrategy = new JsonlDocumentFormatStrategy(
+                        input, tokenizer, tokenizationLanguage, languageKeyParts, clientParameters.field
+                );
+            }
+
+            generate();
+        } catch (GenerateFailure f) {
+           return 1;
+        } catch (IOException e) {
+            System.err.println("I/O error: " + e.getMessage());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private enum InputFormat {
+
+        /** Vespa documents in JSONL format. */
+        jsonl;
+
+        /** Creates a comma separated list of the targets as a String */
+        private static String allowed() {
+            var byName = Arrays.stream(values()).collect(Collectors.toMap(
+                    f -> f.name().toLowerCase(Locale.ROOT),
+                    f -> f
+            ));
+            return String.join(", ", byName.keySet());
+        }
+
+    }
+
+    /**
+     * Parse format from params. Default is jsonl.
+     */
+    private void setFormat() {
+        try {
+            String fmt = Objects.requireNonNullElse(clientParameters.format, InputFormat.jsonl.toString());
+            this.format = InputFormat.valueOf(fmt.toLowerCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            System.err.println("Error: invalid format specified: " + clientParameters.format);
+            CommandLineOptions.printGenerateHelp();
+            System.err.println("Use --format FORMAT to specify format.");
+            System.err.println("Allowed formats: " + InputFormat.allowed());
+            throw new GenerateFailure();
         }
     }
 
-    public Map<String, Long> getFinalDocumentFrequency() {
-        return documentFrequency.entrySet().stream()
-                .filter(k -> k.getValue() > 1)
+    /**
+     * Ensure required options for jsonl format.
+     */
+    private void validateJsonlFormatRequiredFields() {
+        List<String> fieldsMissing = new ArrayList<>();
+
+        if (clientParameters.language == null) {
+            fieldsMissing.add(CommandLineOptions.LANGUAGE_OPTION);
+        }
+
+        if (clientParameters.inputFile == null) {
+            fieldsMissing.add(CommandLineOptions.INPUT_OPTION);
+        }
+
+        if (clientParameters.outputFile == null) {
+            fieldsMissing.add(CommandLineOptions.OUTPUT_OPTION);
+        }
+
+        if (clientParameters.field == null) {
+            fieldsMissing.add(CommandLineOptions.FIELD_OPTION);
+        }
+
+        if (!fieldsMissing.isEmpty()) {
+            System.err.println("Missing required options: " + String.join(", ", fieldsMissing));
+            CommandLineOptions.printGenerateHelp();
+            throw new GenerateFailure();
+        }
+    }
+
+    /**
+     * If user did not provide output file, set it to model.json (or .zst). Legacy behavior: the user must
+     * provide output, but this is only kept for jsonl target (see
+     * {@link SignificanceModelGenerator#validateJsonlFormatRequiredFields()}).
+     */
+    private void resolveAndValidateOutputFile() {
+        String outputFile;
+        if (clientParameters.outputFile == null) {
+            // user did not provide output file.
+            outputFile = "model.json";
+            if (clientParameters.zstCompression) {
+                outputFile = outputFile + ".zst";
+            }
+        } else {
+            outputFile = clientParameters.outputFile;
+        }
+
+        // Legacy behavior for jsonl
+        if (clientParameters.zstCompression && !outputFile.endsWith(".zst")) {
+            System.err.println("Output file must have .zst extension when using zst compression");
+            CommandLineOptions.printGenerateHelp();
+            throw new GenerateFailure();
+        }
+
+        // Legacy behavior for jsonl
+        if (!clientParameters.zstCompression && outputFile.endsWith(".zst")) {
+            System.err.println("Output file must not have .zst extension when not using zst compression");
+            CommandLineOptions.printGenerateHelp();
+            throw new GenerateFailure();
+        }
+
+        this.outputFile = outputFile;
+    }
+
+    private void generate() throws IOException {
+        FormatStrategy.Result res = formatStrategy.build();
+        Map<String, Long> df = res.termDf();
+        long pageCount = res.documentCount();
+        String languagesKey = formatStrategy.languageKey();
+
+        // Legacy behavior: drop df == 1 terms
+        Map<String, Long> finalDf = df.entrySet().stream()
+                .filter(e -> e.getValue() > 1)
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         Map.Entry::getValue,
-                        (e1, e2) -> e1,
-                        TreeMap::new
+                        (a, b) -> a,
+                        TreeMap::new // keep output sorted
                 ));
+
+        System.out.println("Total documents processed: " + pageCount + ", unique words: " + finalDf.size());
+
+        SignificanceModelFile modelFile;
+        File outputFile = Paths.get(this.outputFile).toFile();
+
+        if (outputFile.exists()) {
+            try (InputStream in = outputFile.toString().endsWith(".zst")
+                    ? new ZstdInputStream(new FileInputStream(outputFile))
+                    : new FileInputStream(outputFile)) {
+                modelFile = objectMapper.readValue(in, SignificanceModelFile.class);
+            }
+            modelFile.addLanguage(languagesKey, new DocumentFrequencyFile(DOC_FREQ_DESCRIPTION, pageCount, finalDf));
+        } else {
+            var languagesMap = new HashMap<String, DocumentFrequencyFile>() {{
+                put(languagesKey, new DocumentFrequencyFile(DOC_FREQ_DESCRIPTION, pageCount, finalDf));
+            }};
+            modelFile = new SignificanceModelFile(VERSION, ID, SIGNIFICANCE_DESCRIPTION + " " + clientParameters.inputFile, languagesMap);
+        }
+
+        try (OutputStream out = useZstCompression
+                ? new ZstdOutputStream(new FileOutputStream(outputFile))
+                : new FileOutputStream(outputFile)) {
+            ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
+            writer.writeValue(out, modelFile);
+        }
+    }
+
+    static final class GenerateFailure extends RuntimeException {
     }
 }

--- a/vespaclient-java/src/test/java/com/yahoo/vespasignificance/SignificanceModelGeneratorTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespasignificance/SignificanceModelGeneratorTest.java
@@ -71,7 +71,7 @@ public class SignificanceModelGeneratorTest {
         String outputPath = "output.json";
         ClientParameters params = createParameters(inputPath, outputPath,  "text", "nb", "false").build();
         SignificanceModelGenerator generator = createSignificanceModelGenerator(params);
-        generator.generate();
+        generator.run();
 
         File outputFile = new File(tempDir.resolve(outputPath).toString());
         assertTrue(outputFile.exists());
@@ -90,14 +90,14 @@ public class SignificanceModelGeneratorTest {
         String inputPath = "no_1.jsonl";
         ClientParameters params1 = createParameters(inputPath, "output.json",  "text", "nb", "true").build();
 
-        // Throws exception when outputfile does not have .zst extension when using zst compression
-        assertThrows(IllegalArgumentException.class, () -> createSignificanceModelGenerator(params1));
+        // expected to fail when zstCompression is true but output path does not include .zst.
+        assertEquals(1, createSignificanceModelGenerator(params1).run());
 
         String outputPath = "output.json.zst";
         ClientParameters params = createParameters(inputPath, outputPath,  "text", "nb", "true").build();
 
         SignificanceModelGenerator generator = createSignificanceModelGenerator(params);
-        generator.generate();
+        generator.run();
 
         File outputFile = new File(tempDir.resolve(outputPath ).toString());
         assertTrue(outputFile.exists());
@@ -118,7 +118,7 @@ public class SignificanceModelGeneratorTest {
         String outputPath = "output.json";
         ClientParameters params1 = createParameters(inputPath, outputPath, "text", "nb",  "false").build();
         SignificanceModelGenerator generator = createSignificanceModelGenerator(params1);
-        generator.generate();
+        generator.run();
 
         File outputFile = new File(tempDir.resolve(outputPath).toString());
         assertTrue(outputFile.exists());
@@ -126,7 +126,7 @@ public class SignificanceModelGeneratorTest {
         String inputPath2 = "en.jsonl";
         ClientParameters params2 = createParameters(inputPath2,  outputPath, "text", "en",  "false").build();
         generator = createSignificanceModelGenerator(params2);
-        generator.generate();
+        generator.run();
 
         outputFile = new File(tempDir.resolve(outputPath).toString());
         assertTrue(outputFile.exists());
@@ -150,7 +150,7 @@ public class SignificanceModelGeneratorTest {
         String outputPath = "output.json";
         ClientParameters params1 = createParameters(inputPath, outputPath,  "text", "nb", "false").build();
         SignificanceModelGenerator generator = createSignificanceModelGenerator(params1);
-        generator.generate();
+        generator.run();
 
         File outputFile = new File(tempDir.resolve(outputPath).toString());
         assertTrue(outputFile.exists());
@@ -167,7 +167,7 @@ public class SignificanceModelGeneratorTest {
         String inputPath2 = "no_2.jsonl";
         ClientParameters params2 = createParameters(inputPath2, outputPath, "text", "nb", "false").build();
         SignificanceModelGenerator generator2 = createSignificanceModelGenerator(params2);
-        generator2.generate();
+        generator2.run();
 
         outputFile = new File(tempDir.resolve(outputPath).toString());
         assertTrue(outputFile.exists());
@@ -187,7 +187,7 @@ public class SignificanceModelGeneratorTest {
         String outputPath = "output.json";
         ClientParameters params = createParameters(inputPath, outputPath,  "text", "nb,un",  "false").build();
         SignificanceModelGenerator generator = createSignificanceModelGenerator(params);
-        generator.generate();
+        generator.run();
 
         File outputFile = new File(tempDir.resolve(outputPath).toString());
         assertTrue(outputFile.exists());


### PR DESCRIPTION
This PR:
- Adds FormatStrategy for SignificanceModelGenerator
- FormatStrategy is added to facilitate both the old behavior of reading Vespa Feed Documents and the new behavior of reading a TSV file with terms and document frequencies.
- An improved version of the JSONL reading is implemented as JsonlDocumentFormatStrategy.

Then, the `--format` flag was added, and the following changes was made:

- Adds `format` to ClientParameters.
- Adds `FORMAT_OPTION` in CommandLineOptions.
- Makes SignificanceModelGenerator use FormatStrategy.
- Refactor setup to `run()` in SignificanceModelGenerator to signal return code to Main.
- Cleanup param validation in SignificanceModelGenerator.
- Introduce InputFormat to accommodate tsv later.
- In Main, use run instead of generate.
- Update tests to use run instead of generate and depend on the return value instead of throwing.