### PR TITLE
Johsol/vespa significance tsv with header

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvReader.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvReader.java
@@ -1,0 +1,216 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.common;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Vespa significance tsv format. Streamable intermediate format for merging and generation of significance model
+ * from many nodes.
+ * <p>
+ * Format:
+ * <pre>
+ * #VESPA_SIGNIFICANCE_TSV\tv1
+ * document_count\tN
+ * sorted\t(true|false)
+ * created_at\tISO-8601 instant
+ * --END-HEADER--
+ * term\tdf\n ...
+ * </pre>
+ *
+ * @author johsol
+ */
+public final class VespaSignificanceTsvReader implements AutoCloseable {
+
+    public static final String MAGIC = "#VESPA_SIGNIFICANCE_TSV";
+    public static final String VERSION = "v1";
+    public static final String HEADER_END = "--END-HEADER--";
+
+    public static final String DOCUMENT_COUNT_HEADER = "document_count";
+    public static final String SORTED_HEADER = "sorted";
+    public static final String CREATED_AT_HEADER = "created_at";
+
+    /** Parsed header */
+    public record Header(long documentCount, boolean sorted, Instant createdAt, Map<String, String> raw) {
+    }
+
+    private final BufferedReader bufferedReader;
+    private final Header header;
+
+    private String currentTerm;
+    private long currentDf;
+    private boolean eof;
+
+    // for sorted validation
+    private final boolean enforceSorted;
+    private String lastTerm;
+
+    /** Open and validate header. */
+    public VespaSignificanceTsvReader(Path path) throws IOException {
+        this.bufferedReader = Files.newBufferedReader(path, StandardCharsets.UTF_8);
+        this.header = readAndValidateHeader(this.bufferedReader);
+        this.enforceSorted = this.header.sorted;
+    }
+
+    public Header header() {
+        return header;
+    }
+
+    /**
+     * Advance to next data line.
+     * <p>
+     * Returns true if parsed a row and false if EOF.
+     */
+    public boolean next() throws IOException {
+        if (eof) return false;
+
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+            if (line.isBlank()) continue;
+
+            int tab = line.indexOf('\t');
+            if (tab <= 0) {
+                throw new IllegalArgumentException("Bad data line (missing tab): " + truncate(line));
+            }
+            String term = line.substring(0, tab);
+            String dfStr = line.substring(tab + 1);
+
+            if (term.indexOf('\t') >= 0) {
+                throw new IllegalArgumentException("Term contains tab: " + truncate(term));
+            }
+            long df;
+            try {
+                df = Long.parseLong(dfStr);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Bad DF (not a number): " + truncate(dfStr));
+            }
+
+            if (enforceSorted && lastTerm != null && term.compareTo(lastTerm) <= 0) {
+                throw new IllegalArgumentException("Not strictly ascending: '" + term + "' <= '" + lastTerm + "'");
+            }
+            lastTerm = term;
+
+            this.currentTerm = term;
+            this.currentDf = df;
+            return true;
+        }
+
+        eof = true;
+        return false;
+    }
+
+    public String term() {
+        return currentTerm;
+    }
+
+    public long df() {
+        return currentDf;
+    }
+
+    @Override
+    public void close() throws IOException {
+        bufferedReader.close();
+    }
+
+    private static Header readAndValidateHeader(BufferedReader bufferedReader) throws IOException {
+        String line1 = bufferedReader.readLine();
+        if (line1 == null) throw new IllegalArgumentException("Empty file");
+        String expected = MAGIC + "\t" + VERSION;
+        if (!Objects.equals(line1, expected)) {
+            throw new IllegalArgumentException("Bad magic/version. Expected '" + expected + "', got: " + truncate(line1));
+        }
+
+        var kv = new LinkedHashMap<String, String>();
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+            if (Objects.equals(line, HEADER_END)) break;
+            if (line.isBlank()) continue;
+
+            int tab = line.indexOf('\t');
+            if (tab <= 0) {
+                throw new IllegalArgumentException("Malformed header line (expected key<TAB>value): " + truncate(line));
+            }
+            String key = line.substring(0, tab).trim();
+            String val = line.substring(tab + 1).trim();
+            if (key.isEmpty()) throw new IllegalArgumentException("Empty header key");
+            kv.put(key, val);
+        }
+        if (line == null) throw new IllegalArgumentException("Missing header terminator: " + HEADER_END);
+
+        List<String> missingKeys = new ArrayList<>();
+        String documentCountString = kv.get(DOCUMENT_COUNT_HEADER);
+        if (documentCountString == null) {
+            missingKeys.add(DOCUMENT_COUNT_HEADER);
+        }
+
+        String sortedStr = kv.get(SORTED_HEADER);
+        if (sortedStr == null) {
+            missingKeys.add(SORTED_HEADER);
+        }
+
+        String createdStr = kv.get(CREATED_AT_HEADER);
+        if (createdStr == null) {
+            missingKeys.add(CREATED_AT_HEADER);
+        }
+
+        if (!missingKeys.isEmpty()) {
+            throw new IllegalArgumentException("Header missing required keys: " + String.join(", ", missingKeys));
+        }
+
+        long docCount;
+        try {
+            docCount = Long.parseLong(documentCountString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("document_count must be integer");
+        }
+        if (docCount < 0) throw new IllegalArgumentException("document_count must be >= 0");
+
+        boolean sorted;
+        if ("true".equalsIgnoreCase(sortedStr)) sorted = true;
+        else if ("false".equalsIgnoreCase(sortedStr)) sorted = false;
+        else throw new IllegalArgumentException("sorted must be 'true' or 'false'");
+
+        Instant createdAt;
+        try {
+            createdAt = Instant.parse(createdStr);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("created_at must be ISO-8601 instant, e.g. 2025-10-13T11:59:00Z");
+        }
+
+        return new Header(docCount, sorted, createdAt, Collections.unmodifiableMap(kv));
+    }
+
+    private static String truncate(String s) {
+        if (s == null) return "null";
+        s = s.replace("\n", "\\n");
+        return (s.length() > 120) ? s.substring(0, 120) + "…" : s;
+    }
+
+    /** Container for materializing the whole file. */
+    public record Loaded(Header header, SortedMap<String, Long> df) {
+    }
+
+    /** Parse entire file into memory (merging duplicate terms). */
+    public static Loaded parseAll(Path path) throws IOException {
+        try (var reader = new VespaSignificanceTsvReader(path)) {
+            SortedMap<String, Long> df = new TreeMap<>();
+            while (reader.next()) {
+                df.merge(reader.term(), reader.df(), Long::sum);
+            }
+            return new Loaded(reader.header(), Collections.unmodifiableSortedMap(df));
+        }
+    }
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvReader.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvReader.java
@@ -3,6 +3,7 @@ package ai.vespa.vespasignificance.common;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -61,6 +62,14 @@ public final class VespaSignificanceTsvReader implements AutoCloseable {
     /** Open and validate header. */
     public VespaSignificanceTsvReader(Path path) throws IOException {
         this.bufferedReader = Files.newBufferedReader(path, StandardCharsets.UTF_8);
+        this.header = readAndValidateHeader(this.bufferedReader);
+        this.enforceSorted = this.header.sorted;
+    }
+
+    public VespaSignificanceTsvReader(Reader reader) throws IOException {
+        this.bufferedReader = (reader instanceof BufferedReader)
+                ? (BufferedReader) reader
+                : new BufferedReader(reader, 1 << 16);
         this.header = readAndValidateHeader(this.bufferedReader);
         this.enforceSorted = this.header.sorted;
     }

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvWriter.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvWriter.java
@@ -1,0 +1,83 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.common;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Writes vespa significance tsv files described in {@link VespaSignificanceTsvReader}.
+ *
+ * @author johsol
+ */
+public final class VespaSignificanceTsvWriter implements AutoCloseable {
+
+    private final BufferedWriter bw;
+    private final boolean sorted;
+    private String lastTerm;
+
+    public static final String MAGIC = VespaSignificanceTsvReader.MAGIC;
+    public static final String VERSION = VespaSignificanceTsvReader.VERSION;
+    public static final String HEADER_END = VespaSignificanceTsvReader.HEADER_END;
+
+    public VespaSignificanceTsvWriter(Path out,
+                                      long documentCount,
+                                      boolean sorted,
+                                      Instant createdAt) throws IOException {
+        this.bw = new BufferedWriter(
+                new OutputStreamWriter(Files.newOutputStream(out), StandardCharsets.UTF_8));
+        this.sorted = sorted;
+        writeHeader(documentCount, sorted, createdAt);
+    }
+
+    private void writeHeader(long documentCount, boolean sorted, Instant createdAt) throws IOException {
+        bw.write(MAGIC);
+        bw.write('\t');
+        bw.write(VERSION);
+        bw.write('\n');
+        bw.write(VespaSignificanceTsvReader.DOCUMENT_COUNT_HEADER);
+        bw.write("\t");
+        bw.write(Long.toString(documentCount));
+        bw.write('\n');
+        bw.write(VespaSignificanceTsvReader.SORTED_HEADER);
+        bw.write("\t");
+        bw.write(sorted ? "true" : "false");
+        bw.write('\n');
+        bw.write(VespaSignificanceTsvReader.CREATED_AT_HEADER);
+        bw.write("\t");
+        bw.write(Objects.requireNonNull(createdAt, "created_at").toString());
+        bw.write('\n');
+        bw.write(HEADER_END);
+        bw.write('\n');
+    }
+
+    /** Append one data row. If sorted==true, enforces strict ascending order. */
+    public void writeRow(String term, long df) throws IOException {
+        if (term == null || term.isEmpty()) throw new IllegalArgumentException("term is empty");
+        if (term.indexOf('\t') >= 0) throw new IllegalArgumentException("term contains tab");
+        if (df < 0) throw new IllegalArgumentException("negative df");
+        if (sorted && lastTerm != null && term.compareTo(lastTerm) <= 0) {
+            throw new IllegalArgumentException("Not strictly ascending: '" + term + "' <= '" + lastTerm + "'");
+        }
+        lastTerm = term;
+
+        bw.write(term);
+        bw.write('\t');
+        bw.write(Long.toString(df));
+        bw.write('\n');
+    }
+
+    public void flush() throws IOException {
+        bw.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        bw.close();
+    }
+}

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvWriter.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvWriter.java
@@ -4,6 +4,7 @@ package ai.vespa.vespasignificance.common;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +32,17 @@ public final class VespaSignificanceTsvWriter implements AutoCloseable {
                                       Instant createdAt) throws IOException {
         this.bw = new BufferedWriter(
                 new OutputStreamWriter(Files.newOutputStream(out), StandardCharsets.UTF_8));
+        this.sorted = sorted;
+        writeHeader(documentCount, sorted, createdAt);
+    }
+
+    public VespaSignificanceTsvWriter(Writer writer,
+                                      long documentCount,
+                                      boolean sorted,
+                                      Instant createdAt) throws IOException {
+        this.bw = (writer instanceof BufferedWriter)
+                ? (BufferedWriter) writer
+                : new BufferedWriter(writer, 1 << 16);
         this.sorted = sorted;
         writeHeader(documentCount, sorted, createdAt);
     }

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/common/VespaSignificanceTsvTest.java
@@ -1,0 +1,99 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license.
+package ai.vespa.vespasignificance.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Testing methods in {@link VespaSignificanceTsvReader} and {@link VespaSignificanceTsvWriter}.
+ *
+ * @author johsol
+ */
+public class VespaSignificanceTsvTest {
+    @TempDir
+    Path tmp;
+
+    @Test
+    void writeThenReadSuccess() throws Exception {
+        Path f = tmp.resolve("df.vespa_significance_tsv");
+
+        // Write header + rows (sorted = true)
+        try (var w = new VespaSignificanceTsvWriter(f, 12345, true, Instant.parse("2025-10-13T12:05:00Z"))) {
+            w.writeRow("beatles", 120);
+            w.writeRow("coldplay", 532);
+            w.writeRow("metallica", 488);
+            w.writeRow("radiohead", 301);
+            w.writeRow("red", 220);
+            w.flush();
+        }
+
+        // Read streamingly
+        try (var r = new VespaSignificanceTsvReader(f)) {
+            var h = r.header();
+            assertEquals(12345L, h.documentCount());
+            assertTrue(h.sorted());
+            assertEquals(Instant.parse("2025-10-13T12:05:00Z"), h.createdAt());
+
+            Map<String, Long> seen = new LinkedHashMap<>();
+            while (r.next()) {
+                seen.put(r.term(), r.df());
+            }
+
+            assertEquals(5, seen.size());
+            assertEquals(120L, seen.get("beatles"));
+            assertEquals(532L, seen.get("coldplay"));
+            assertEquals(488L, seen.get("metallica"));
+            assertEquals(301L, seen.get("radiohead"));
+            assertEquals(220L, seen.get("red"));
+        }
+
+        // ParseAll convenience
+        var loaded = VespaSignificanceTsvReader.parseAll(f);
+        assertEquals(12345L, loaded.header().documentCount());
+        assertTrue(loaded.header().sorted());
+        assertEquals(5, loaded.df().size());
+        assertEquals(532L, loaded.df().get("coldplay"));
+    }
+
+    @Test
+    void writerRejectsNonAscendingWhenSortedTrue() throws Exception {
+        Path f = tmp.resolve("bad-sorted.vespa_significance_tsv");
+
+        try (var w = new VespaSignificanceTsvWriter(f, 1, true, Instant.parse("2025-10-13T12:00:00Z"))) {
+            w.writeRow("b", 1);
+            assertThrows(IllegalArgumentException.class, () -> w.writeRow("a", 1)); // "a" <= "b"
+        }
+    }
+
+    @Test
+    void readerRejectsNonAscendingWhenSortedTrue() throws Exception {
+        Path f = tmp.resolve("bad-sorted-read.vespa_significance_tsv");
+
+        // Build a file by hand to bypass writer check:
+        java.nio.file.Files.writeString(f, """
+            #VESPA_SIGNIFICANCE_TSV\tv1
+            document_count\t1
+            sorted\ttrue
+            created_at\t2025-10-13T12:00:00Z
+            --END-HEADER--
+            b\t1
+            a\t1
+            """);
+
+        var ex = assertThrows(IllegalArgumentException.class, () -> {
+            try (var r = new VespaSignificanceTsvReader(f)) {
+                while (r.next()) {} // triggers order check
+            }
+        });
+        assertTrue(ex.getMessage().contains("Not strictly ascending"));
+    }
+}


### PR DESCRIPTION
Defines a new format for reading and writing intermediate results for `vespa-significance export` and `merge`.

Format:
```
#VESPA_SIGNIFICANCE_TSV \t v1 \n
document_count \t NUMBER \n
sorted \t (true|false) \n
created_at \t ISO-8601 UTC timestamp \n
--END-HEADER-- \n
TERM \t NUMBER \n
TERM \t NUMBER \n
TERM \t NUMBER \n
... until eof
```

This format lets us have a readable header and a streamable data section.