### PR TITLE
Document how to test scalable AArch64 vectors using QEMU

### DIFF
--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
@@ -10,6 +10,8 @@
 #include <vespa/log/log.h>
 LOG_SETUP("hwaccelerated_test");
 
+using namespace ::testing;
+
 namespace vespalib::hwaccelerated {
 
 // TODO reconcile run-time startup verification in `iaccelerated.cpp` with what's in here!
@@ -91,7 +93,16 @@ constexpr std::span<const size_t> test_lengths() noexcept {
     return lengths;
 }
 
-TEST(HwAcceleratedTest, euclidean_distance_impls_match_source_of_truth) {
+struct HwAcceleratedTest : Test {
+    static void SetUpTestSuite() {
+        fprintf(stderr, "Testing accelerators:\n");
+        for (const auto* accel : all_accelerators_to_test()) {
+            fprintf(stderr, "%s\n", accel->friendly_name().c_str());
+        }
+    }
+};
+
+TEST_F(HwAcceleratedTest, euclidean_distance_impls_match_source_of_truth) {
     auto accelerators = all_accelerators_to_test();
     for (size_t test_length : test_lengths()) {
         GTEST_DO(verify_euclidean_distance(accelerators, test_length));
@@ -108,7 +119,7 @@ void verify_dot_product(std::span<const IAccelerated*> accelerators, size_t test
     verify_dot_product<double>(accelerators, testLength, 0.0);
 }
 
-TEST(HwAcceleratedTest, dot_product_impls_match_source_of_truth) {
+TEST_F(HwAcceleratedTest, dot_product_impls_match_source_of_truth) {
     auto accelerators = all_accelerators_to_test();
     for (size_t test_length : test_lengths()) {
         GTEST_DO(verify_dot_product(accelerators, test_length));

--- a/vespalib/src/vespa/vespalib/hwaccelerated/README.md
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/README.md
@@ -1,0 +1,34 @@
+# Testing scalable Highway AArch64 SVE/SVE2 vector kernels
+
+At the time of writing there is no hardware available for SVE2 with wider
+vector registers than 128 bits. This makes it tricky to ensure that vector
+kernels using `ScalableTag` will work in practice on future hardware.
+
+To get around this, QEMU user mode emulation can be used:
+
+```shell
+qemu-aarch64 -cpu max,sve-default-vector-length=$n ./vespalib_hwaccelerated_test_app
+```
+Where `$n` is the vector width _in bytes_ and should preferably be tested
+for all of `16, 32, 64, 128, 256`. SVE/SVE2 tops out at 2048 bits (256 bytes),
+so no need to test anything larger.
+
+Example output:
+```
+$ qemu-aarch64 -cpu max,sve-default-vector-length=64 ./vespalib_hwaccelerated_test_app
+[==========] Running 2 tests from 1 test suite.
+[----------] Global test environment set-up.
+[----------] 2 tests from HwAcceleratedTest
+Testing accelerators:
+AutoVec - NEON
+AutoVec - NEON_FP16_DOTPROD
+Highway - SVE2 (512 bit vector width)
+Highway - SVE (512 bit vector width)
+Highway - NEON_BF16 (128 bit vector width)
+Highway - NEON (128 bit vector width)
+[ RUN      ] HwAcceleratedTest.euclidean_distance_impls_match_source_of_truth
+[       OK ] HwAcceleratedTest.euclidean_distance_impls_match_source_of_truth (3079 ms)
+[ RUN      ] HwAcceleratedTest.dot_product_impls_match_source_of_truth
+[       OK ] HwAcceleratedTest.dot_product_impls_match_source_of_truth (3651 ms)
+[----------] 2 tests from HwAcceleratedTest (6731 ms total)
+```

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -5,6 +5,7 @@
 #include <hwy/base.h>
 #include <algorithm>
 #include <cassert>
+#include <format>
 
 // This file will be recursively included into itself with different target
 // compilation parameters. See the Highway docs.
@@ -262,6 +263,11 @@ const char* my_hwy_target_name() noexcept {
     return hwy::TargetName(HWY_TARGET);
 }
 
+[[nodiscard]] size_t vector_bit_count() noexcept {
+    const hn::ScalableTag<int8_t> d8; // Widest possible runtime vector
+    return hn::Lanes(d8) * 8;
+}
+
 // Since we already do a virtual dispatch via the IAccelerated interface, avoid needing an
 // additional per-function dispatch step via Highway's function tables by creating a concrete
 // implementation class per target.
@@ -300,6 +306,9 @@ public:
     }
     const char* target_name() const noexcept override {
         return my_hwy_target_name();
+    }
+    std::string friendly_name() const override {
+        return std::format("Highway - {} ({} bit vector width)", target_name(), vector_bit_count());
     }
 
     [[nodiscard]] static std::unique_ptr<IAccelerated> create_instance() {

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
@@ -26,6 +26,7 @@
 #include <vespa/vespalib/util/memory.h>
 #include <cstdio>
 #include <cstdlib>
+#include <format>
 #include <string>
 #include <vector>
 
@@ -533,6 +534,10 @@ std::unique_ptr<IAccelerated> IAccelerated::create_best_accelerator_impl_and_tar
         return Highway::create_best_target();
     }
     return create_best_auto_vectorized_target();
+}
+
+std::string IAccelerated::friendly_name() const {
+    return std::format("{} - {}", implementation_name(), target_name());
 }
 
 

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -44,6 +44,8 @@ public:
     // Returns a static string representing the name of the underlying accelerator target (e.g. "AVX3", "NEON" etc.)
     [[nodiscard]] virtual const char* target_name() const noexcept { return "Unknown"; }
 
+    [[nodiscard]] virtual std::string friendly_name() const;
+
     static std::unique_ptr<IAccelerated> create_baseline_auto_vectorized_target();
     static std::unique_ptr<IAccelerated> create_best_auto_vectorized_target();
     static std::unique_ptr<IAccelerated> create_best_accelerator_impl_and_target();


### PR DESCRIPTION
@havardpe please review.

Also adds a function to `IAccelerated` for generating a more user-friendly target information string that can have dynamic components. Let Highway kernels include their max vector width as part of this. Print all tested targets when running the primary unit test.
