### PR TITLE
Use TSV with headers in `vespa-significance merge`

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfKWayMerge.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfKWayMerge.java
@@ -2,7 +2,6 @@
 package ai.vespa.vespasignificance.merge;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
@@ -32,7 +31,7 @@ public class TermDfKWayMerge {
 
         Cursor(BufferedReader bufferedReader) {
             this.bufferedReader = bufferedReader;
-            this.lineNo = 1;
+            this.lineNo = 0;
         }
 
         /**
@@ -43,6 +42,7 @@ public class TermDfKWayMerge {
         boolean advance() throws IOException {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
+                lineNo++;
                 if (line.trim().isEmpty())
                     continue;
 
@@ -79,7 +79,7 @@ public class TermDfKWayMerge {
      */
     public static void merge(
             List<BufferedReader> inputs,
-            BufferedWriter output,
+            TermDfRowSink sink,
             long minKeep
     ) throws IOException {
         PriorityQueue<Cursor> queue = new PriorityQueue<>(inputs.size(), Comparator.comparing(c -> c.term));
@@ -104,14 +104,9 @@ public class TermDfKWayMerge {
             }
 
             if (sumDf >= minKeep) {
-                output.write(term);
-                output.write('\t');
-                output.write(Long.toString(sumDf));
-                output.write('\n');
+                sink.write(term, sumDf);
             }
         }
-
-        output.flush();
     }
 
 }

--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfRowSink.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/TermDfRowSink.java
@@ -1,0 +1,18 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.vespasignificance.merge;
+
+import java.io.IOException;
+
+/**
+ * Sink for merged term–document-frequency rows.
+ *
+ * @author johsol
+ */
+@FunctionalInterface
+public interface TermDfRowSink {
+
+    /**
+     * Accepts a single merged row.
+     */
+    void write(String term, long df) throws IOException;
+}

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/MergeCommandTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/MergeCommandTest.java
@@ -52,32 +52,60 @@ class MergeCommandTest {
                 .build();
     }
 
+    private static Path writeVstsv(Path p, long documentCount, String createdAtIsoUtc, List<String> dataLines) throws IOException {
+        Files.createDirectories(p.getParent());
+        try (BufferedWriter w = Files.newBufferedWriter(p, StandardCharsets.UTF_8)) {
+            w.write("#VESPA_SIGNIFICANCE_TSV\tv1\n");
+            w.write("document_count\t" + documentCount + "\n");
+            w.write("sorted\ttrue\n");
+            w.write("created_at\t" + createdAtIsoUtc + "\n");
+            w.write("--END-HEADER--\n");
+            for (String s : dataLines) { w.write(s); w.newLine(); }
+        }
+        return p;
+    }
+
+    private static Path writeVstsvZst(Path p, List<String> dataLines) throws IOException {
+        Files.createDirectories(p.getParent());
+        try (OutputStream raw = Files.newOutputStream(p);
+             var zwo = new io.airlift.compress.zstd.ZstdOutputStream(new BufferedOutputStream(raw));
+             var w = new BufferedWriter(new OutputStreamWriter(zwo, StandardCharsets.UTF_8))) {
+            w.write("#VESPA_SIGNIFICANCE_TSV\tv1\n");
+            w.write("document_count\t2\n");
+            w.write("sorted\ttrue\n");
+            w.write("created_at\t2025-10-14T07:56:27Z\n");
+            w.write("--END-HEADER--\n");
+            for (String s : dataLines) { w.write(s); w.newLine(); }
+        }
+        return p;
+    }
+
     @Test
-    void mergesTsvFiles() throws Exception {
-        Path in1 = writeUtf8(tmp.resolve("in1.tsv"), List.of("a\t1", "c\t1"));
-        Path in2 = writeUtf8(tmp.resolve("in2.tsv"), List.of("a\t2", "b\t3"));
-        Path out = tmp.resolve("out.tsv");
+    void mergesVstsvFiles() throws Exception {
+        Path in1 = writeVstsv(tmp.resolve("in1.vstsv"), 1, "2025-10-14T07:56:26Z", List.of("a\t1", "c\t1"));
+        Path in2 = writeVstsv(tmp.resolve("in2.vstsv"), 2, "2025-10-14T07:56:27Z", List.of("a\t2", "b\t3"));
+        Path out = tmp.resolve("out.vstsv");
 
         MergeCommand cmd = new MergeCommand(params(out.toString(), false, 1, List.of(in1.toString(), in2.toString())));
         int rc = cmd.run();
         assertEquals(0, rc);
 
-        assertEquals(List.of("a\t3", "b\t3", "c\t1"), readUtf8(out));
+        var lines = readUtf8(out);
+        // Header assertions (created_at is dynamic; check shape)
+        assertEquals("#VESPA_SIGNIFICANCE_TSV\tv1", lines.get(0));
+        assertTrue(lines.get(1).startsWith("document_count\t")); // should be 1 + 2 = 3
+        assertEquals("sorted\ttrue", lines.get(2));
+        assertTrue(lines.get(3).startsWith("created_at\t"));
+        assertEquals("--END-HEADER--", lines.get(4));
+
+        // Data
+        assertEquals(List.of("a\t3", "b\t3", "c\t1"), lines.subList(5, lines.size()));
     }
 
     @Test
     void mergesCombinationOfCompressedAndUncompressed() throws Exception {
-        Path inPlain = writeUtf8(tmp.resolve("in-plain.tsv"), List.of("x\t1", "z\t1"));
-        // prepare zst input
-        Path inZst = tmp.resolve("in.zst");
-        // compress: simplest is to write plain then recompress via MergeCommand’s reader path,
-        // but here we write plain and rely on filename for detection. To be strict, write legit zst:
-        try (OutputStream raw = Files.newOutputStream(inZst);
-             var zwo = new io.airlift.compress.zstd.ZstdOutputStream(new BufferedOutputStream(raw));
-             var w = new BufferedWriter(new OutputStreamWriter(zwo, StandardCharsets.UTF_8))) {
-            w.write("x\t2\n");
-            w.write("y\t5\n");
-        }
+        Path inPlain = writeVstsv(tmp.resolve("in-plain.vstsv"), 1, "2025-10-14T07:56:26Z", List.of("x\t1", "z\t1"));
+        Path inZst = writeVstsvZst(tmp.resolve("in.vstsv.zst"), List.of("x\t2", "y\t5"));
 
         Path outNoSuffix = tmp.resolve("final"); // user omitted .zst
         MergeCommand cmd = new MergeCommand(params(outNoSuffix.toString(), true, 1,
@@ -85,25 +113,38 @@ class MergeCommandTest {
         int rc = cmd.run();
         assertEquals(0, rc);
 
-        Path out = Path.of(outNoSuffix + ".zst"); // suffix appended
+        Path out = Path.of(outNoSuffix + ".zst");
         assertTrue(Files.exists(out), "expected .zst to be appended");
 
-        assertEquals(List.of("x\t3", "y\t5", "z\t1"), readZstUtf8(out));
+        var lines = readZstUtf8(out);
+        assertEquals("#VESPA_SIGNIFICANCE_TSV\tv1", lines.get(0));
+        assertTrue(lines.get(1).startsWith("document_count\t")); // 1 + 2 = 3
+        assertEquals("sorted\ttrue", lines.get(2));
+        assertTrue(lines.get(3).startsWith("created_at\t"));
+        assertEquals("--END-HEADER--", lines.get(4));
+
+        assertEquals(List.of("x\t3", "y\t5", "z\t1"), lines.subList(5, lines.size()));
     }
 
     @Test
     void appliesMinKeep() throws Exception {
-        Path f1 = writeUtf8(tmp.resolve("f1.tsv"), List.of("t\t2"));
-        Path f2 = writeUtf8(tmp.resolve("f2.tsv"), List.of("t\t2"));
-        Path f3 = writeUtf8(tmp.resolve("f3.tsv"), List.of("t\t2"));
-        Path out = tmp.resolve("out.tsv");
+        Path f1 = writeVstsv(tmp.resolve("f1.vstsv"), 1, "2025-10-14T07:56:26Z", List.of("t\t2"));
+        Path f2 = writeVstsv(tmp.resolve("f2.vstsv"), 1, "2025-10-14T07:56:27Z", List.of("t\t2"));
+        Path f3 = writeVstsv(tmp.resolve("f3.vstsv"), 1, "2025-10-14T07:56:28Z", List.of("t\t2"));
+        Path out = tmp.resolve("out.vstsv");
 
         MergeCommand cmd = new MergeCommand(params(out.toString(), false, /*minKeep*/5,
                 List.of(f1.toString(), f2.toString(), f3.toString())));
         int rc = cmd.run();
         assertEquals(0, rc);
 
-        assertEquals(List.of("t\t6"), readUtf8(out));
+        var lines = readUtf8(out);
+        assertEquals("#VESPA_SIGNIFICANCE_TSV\tv1", lines.get(0));
+        assertTrue(lines.get(1).startsWith("document_count\t")); // 1+1+1=3
+        assertEquals("sorted\ttrue", lines.get(2));
+        assertTrue(lines.get(3).startsWith("created_at\t"));
+        assertEquals("--END-HEADER--", lines.get(4));
+        assertEquals(List.of("t\t6"), lines.subList(5, lines.size()));
     }
 
     @Test

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/merge/TermDfKWayMergeTest.java
@@ -33,7 +33,13 @@ public class TermDfKWayMergeTest {
                 .toList();
         StringWriter sw = new StringWriter();
         try (BufferedWriter bw = new BufferedWriter(sw)) {
-            TermDfKWayMerge.merge(readers, bw, minKeep);
+            TermDfRowSink sink = (term, df) -> {
+               bw.write(term);
+               bw.write('\t');
+               bw.write(Long.toString(df));
+               bw.write('\n');
+            };
+            TermDfKWayMerge.merge(readers, sink, minKeep);
         }
         return sw.toString();
     }


### PR DESCRIPTION
- Read input files in the new format.
- Write the output file in the new format.
- Temporary files still use normal TSV, do not need headers yet.
- Sum the document count of each input file before starting merging.
- Fixes line counting in TermDfKWayMerge.
