### PR TITLE
feat: allow disabling warmup queries

### DIFF
--- a/container-core/src/main/resources/configdefinitions/container.core.container-http.def
+++ b/container-core/src/main/resources/configdefinitions/container.core.container-http.def
@@ -6,3 +6,6 @@ hostResponseHeaderKey string default=""
 
 ## For debugging, number of requests to add trace and timing information too if debugging is enabled.
 numQueriesToTraceOnDebugAfterConstruction int default=1000
+
+## Whether to warmup the search handler or not
+warmup bool default=true

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -114,9 +114,14 @@ public class SearchHandler extends LoggingRequestHandler {
                          ComponentRegistry<Embedder> embedders,
                          ExecutionFactory executionFactory,
                          ZoneInfo zoneInfo) {
-        this(metric, threadpool.executor(), queryProfileRegistry, embedders, executionFactory,
+        this(metric,
+             threadpool.executor(),
+             queryProfileRegistry,
+             embedders,
+             executionFactory,
              config.numQueriesToTraceOnDebugAfterConstruction(),
-                config.hostResponseHeaderKey().isEmpty() ? Optional.empty() : Optional.of(config.hostResponseHeaderKey()),
+             config.hostResponseHeaderKey().isEmpty() ? Optional.empty() : Optional.of(config.hostResponseHeaderKey()),
+             config.warmup(),
              zoneInfo);
     }
 
@@ -127,6 +132,7 @@ public class SearchHandler extends LoggingRequestHandler {
                           ExecutionFactory executionFactory,
                           long numQueriesToTraceOnDebugAfterStartup,
                           Optional<String> hostResponseHeaderKey,
+                          boolean warmup,
                           ZoneInfo zoneInfo) {
         super(executor, metric, true);
 
@@ -142,7 +148,11 @@ public class SearchHandler extends LoggingRequestHandler {
         metric.set(SEARCH_CONNECTIONS, 0.0d, null);
         this.zoneInfo = zoneInfo;
 
-        warmup();
+        if (warmup) {
+            warmup();
+        } else {
+            log.log(Level.INFO, "SearchHandler not warmed up at startup as per configuration");
+        }
     }
 
     Metric metric() { return metric; }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The change addresses https://github.com/vespa-engine/vespa/issues/34950 by allowing users to disable warm up queries if they wanted to. I expect `warmupSearchHandler` to be exposed via `services.xml` so that we can disable that if we wanted to.

Now the issue is that there were no warmup tests at all and I couldn't figure out how to write them to check if this actually warms searchers up, so I could take a hint 