### PR TITLE
Avoid adding many edges on HNSW node deletion

### DIFF
--- a/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
@@ -671,12 +671,13 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_hierarchic_graph_with_heuristic
         EXPECT_EQ(0, root["unreachable_nodes"].asLong());
     }
 
-    // removing 1, its neighbors {2,3,4} will link together
+    // removing 1, its neighbors {2,3} will link together
+    // 4 will be isolated :(
     this->remove_document(1);
     this->expect_entry_point(6, 2);
-    this->expect_level_0(2, {3, 4, 5, 6});
-    this->expect_levels(3, {{2, 4, 7}, {6}});
-    this->expect_level_0(4, {2, 3});
+    this->expect_level_0(2, {3, 5, 6});
+    this->expect_levels(3, {{2, 7}, {6}});
+    this->expect_level_0(4, {});
     this->expect_level_0(5, {2, 6});
     this->expect_levels(6, {{2, 5, 7}, {3}, {}});
     this->expect_level_0(7, {3, 6});
@@ -694,12 +695,12 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_hierarchic_graph_with_heuristic
         EXPECT_EQ(6, root["valid_nodes"].asLong());
         EXPECT_EQ(0, root["level_histogram"][0].asLong());
         EXPECT_EQ(4, root["level_histogram"][1].asLong());
-        EXPECT_EQ(0, root["level_0_links_histogram"][0].asLong());
+        EXPECT_EQ(1, root["level_0_links_histogram"][0].asLong());
         EXPECT_EQ(0, root["level_0_links_histogram"][1].asLong());
         EXPECT_EQ(3, root["level_0_links_histogram"][2].asLong());
         EXPECT_EQ(2, root["level_0_links_histogram"][3].asLong());
-        EXPECT_EQ(1, root["level_0_links_histogram"][4].asLong());
-        EXPECT_EQ(0, root["unreachable_nodes"].asLong());
+        EXPECT_EQ(0, root["level_0_links_histogram"][4].asLong());
+        EXPECT_EQ(1, root["unreachable_nodes"].asLong());
     }
 }
 

--- a/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
@@ -671,13 +671,12 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_hierarchic_graph_with_heuristic
         EXPECT_EQ(0, root["unreachable_nodes"].asLong());
     }
 
-    // removing 1, its neighbors {2,3} will link together
-    // 4 will be isolated :(
+    // removing 1, its neighbors {2,3} and {3,4} will link together
     this->remove_document(1);
     this->expect_entry_point(6, 2);
     this->expect_level_0(2, {3, 5, 6});
-    this->expect_levels(3, {{2, 7}, {6}});
-    this->expect_level_0(4, {});
+    this->expect_levels(3, {{2, 4, 7}, {6}});
+    this->expect_level_0(4, {3});
     this->expect_level_0(5, {2, 6});
     this->expect_levels(6, {{2, 5, 7}, {3}, {}});
     this->expect_level_0(7, {3, 6});
@@ -695,12 +694,12 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_hierarchic_graph_with_heuristic
         EXPECT_EQ(6, root["valid_nodes"].asLong());
         EXPECT_EQ(0, root["level_histogram"][0].asLong());
         EXPECT_EQ(4, root["level_histogram"][1].asLong());
-        EXPECT_EQ(1, root["level_0_links_histogram"][0].asLong());
-        EXPECT_EQ(0, root["level_0_links_histogram"][1].asLong());
-        EXPECT_EQ(3, root["level_0_links_histogram"][2].asLong());
-        EXPECT_EQ(2, root["level_0_links_histogram"][3].asLong());
+        EXPECT_EQ(0, root["level_0_links_histogram"][0].asLong());
+        EXPECT_EQ(1, root["level_0_links_histogram"][1].asLong());
+        EXPECT_EQ(2, root["level_0_links_histogram"][2].asLong());
+        EXPECT_EQ(3, root["level_0_links_histogram"][3].asLong());
         EXPECT_EQ(0, root["level_0_links_histogram"][4].asLong());
-        EXPECT_EQ(1, root["unreachable_nodes"].asLong());
+        EXPECT_EQ(0, root["unreachable_nodes"].asLong());
     }
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -796,21 +796,21 @@ HnswIndex<type>::mutual_reconnect(const LinkArrayRef &cluster, uint32_t level)
     // Only add at most one edge per nodes
     vespalib::hash_set<uint32_t> already_added;
     for (const PairDist & pair : pairs) {
-        if (already_added.contains(pair.id_first) || already_added.contains(pair.id_second)) {
-            continue;
-        }
-
         LinkArrayRef old_links_1 = _graph.get_link_array(pair.id_first, level);
         if (old_links_1.size() >= max_links_for_level(level)) continue;
 
         LinkArrayRef old_links_2 = _graph.get_link_array(pair.id_second, level);
         if (old_links_2.size() >= max_links_for_level(level)) continue;
 
-        already_added.insert(pair.id_first);
-        already_added.insert(pair.id_second);
+        if ((old_links_1.empty() || old_links_2.empty())
+            || (!already_added.contains(pair.id_first) && !already_added.contains(pair.id_second))) {
 
-        add_link_to(pair.id_first, level, old_links_1, pair.id_second);
-        add_link_to(pair.id_second, level, old_links_2, pair.id_first);
+            already_added.insert(pair.id_first);
+            already_added.insert(pair.id_second);
+
+            add_link_to(pair.id_first, level, old_links_1, pair.id_second);
+            add_link_to(pair.id_second, level, old_links_2, pair.id_first);
+        }
     }
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -792,12 +792,22 @@ HnswIndex<type>::mutual_reconnect(const LinkArrayRef &cluster, uint32_t level)
         }
     }
     std::sort(pairs.begin(), pairs.end());
+
+    // Only add at most one edge per nodes
+    vespalib::hash_set<uint32_t> already_added;
     for (const PairDist & pair : pairs) {
+        if (already_added.contains(pair.id_first) || already_added.contains(pair.id_second)) {
+            continue;
+        }
+
         LinkArrayRef old_links_1 = _graph.get_link_array(pair.id_first, level);
         if (old_links_1.size() >= max_links_for_level(level)) continue;
 
         LinkArrayRef old_links_2 = _graph.get_link_array(pair.id_second, level);
         if (old_links_2.size() >= max_links_for_level(level)) continue;
+
+        already_added.insert(pair.id_first);
+        already_added.insert(pair.id_second);
 
         add_link_to(pair.id_first, level, old_links_1, pair.id_second);
         add_link_to(pair.id_second, level, old_links_2, pair.id_first);


### PR DESCRIPTION
Add at most one edge per node instead of filling up the edges up to `2M`.

@arnej27959 please review