### PR TITLE
fix two iterator-adapter bugs

### DIFF
--- a/searchlib/src/vespa/searchlib/query/from_proto.cpp
+++ b/searchlib/src/vespa/searchlib/query/from_proto.cpp
@@ -367,23 +367,23 @@ bool handle(const ItemGeoLocationTerm& item,
     _d.itemType = ParseItem::ItemType::ITEM_GEO_LOCATION_TERM;
     tmp = "";
     if (item.has_geo_circle()) {
-        int x = item.longitude() * M;
-        int y = item.latitude() * M;
-        int radius = item.radius() * M;
-        if (radius < 0)
-            radius = -1;
+        int x = std::round(item.longitude() * M);
+        int y = std::round(item.latitude() * M);
+        int radius = (item.radius() < 0) ? -1 : std::round(item.radius() * M);
+
         double radians = item.latitude() * M_PI / 180.0;
         double cosLat = cos(radians);
         int64_t aspect = cosLat * 4294967295L;
-        if (aspect < 0)
+        if (aspect < 0) {
             aspect = 0;
+        }
         tmp += std::format("(2,{},{},{},0,1,0,{})", x, y, radius, aspect);
     }
     if (item.has_bounding_box()) {
-        int w = item.w() * M;
-        int s = item.s() * M;
-        int e = item.e() * M;
-        int n = item.n() * M;
+        int w = std::round(item.w() * M);
+        int s = std::round(item.s() * M);
+        int e = std::round(item.e() * M);
+        int n = std::round(item.n() * M);
         tmp = std::format("[2,{},{},{},{}]", w, s, e, n);
     }
     if (tmp == "") return false;
@@ -551,8 +551,10 @@ ProtoTreeIterator::ProtoTreeIterator(const ProtobufQueryTree& proto_query_tree)
 }
 
 bool ProtoTreeIterator::next() {
+    _d.clear();
     if (_pos < _items.size()) {
-        return handle_variant_item(_items[_pos++]);
+        bool ok = handle_variant_item(_items[_pos++]);
+        return ok;
     }
     return false;
 }

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.cpp
@@ -34,4 +34,37 @@ std::unique_ptr<QueryStackIterator> QueryStackIterator::dummy() {
     return std::make_unique<Dummy>();
 }
 
+void QueryStackIterator::Data::clear() {
+    itemType = ParseItem::ItemType::ITEM_UNDEF;
+
+    noRankFlag = false;
+    noPositionDataFlag = false;
+    creaFilterFlag = false;
+    isSpecialTokenFlag = false;
+    allowApproximateFlag = false;
+    prefix_match_semantics_flag = false;
+
+    weight = query::Weight(0);
+
+    // XXX what about these?
+    // predicateQueryTerm = {};
+    // termVector = {};
+
+    index_view = {};
+    term_view = {};
+    integerTerm = 0;
+
+    distanceThreshold = 0;
+    scoreThreshold = 0;
+    thresholdBoostFactor = 0;
+
+    uniqueId = 0;
+    arity = 0;
+    nearDistance = 0;
+    targetHits = 0;
+    exploreAdditionalHits = 0;
+    fuzzy_max_edit_distance = 0;
+    fuzzy_prefix_lock_length = 0;
+}
+
 }

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
@@ -54,6 +54,7 @@ public:
         uint32_t fuzzy_max_edit_distance = 0;
         uint32_t fuzzy_prefix_lock_length = 0;
 
+        void clear();
     };
 protected:
     Data _d;


### PR DESCRIPTION
* use std::round() when converting floating-point position parameters to integers
* clear data at start of iterator next() (Juniper assumes arity==0 for non-intermediates)

@toregge please review
