### PR TITLE
Sort the inputs to `vespa-significance export`

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/Export.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/export/Export.java
@@ -14,6 +14,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -91,7 +92,7 @@ public class Export {
                  var maybeCompressed = params.zstCompress()
                          ? new ZstdOutputStream(new BufferedOutputStream(output))
                          : new BufferedOutputStream(output);
-                 var rows = dumpFn.open(indexDir, fieldName);
+                 var rows = dumpFn.open(indexDir, fieldName).sorted(Comparator.comparing(VespaIndexInspectClient.TermDocumentFrequency::term));
                  TermDfWriter writer = writerFactory.create(new OutputStreamWriter(maybeCompressed, StandardCharsets.UTF_8), documentCount, sorted, createdAt)) {
                 writer.writeAll(rows);
                 writer.flush();

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
@@ -75,8 +75,8 @@ class ExportTest {
 
         // Dump function emits unsorted rows
         Export.DumpFn dumpFn = (idx, field) -> Stream.of(
-                new VespaIndexInspectClient.TermDocumentFrequency("alpha", 5),
-                new VespaIndexInspectClient.TermDocumentFrequency("zulu", 2)
+                new VespaIndexInspectClient.TermDocumentFrequency("zulu", 2),
+                new VespaIndexInspectClient.TermDocumentFrequency("alpha", 5)
         );
 
         CapturingWriter writer = new CapturingWriter();


### PR DESCRIPTION
- Testing on documentation search in prod proved that the input is not sorted as expected.
- Updated test case to test that export sorts the inputs before writing to output.