### PR TITLE
minor adjustment for negative terms in NEAR:

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/NearItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/NearItem.java
@@ -78,6 +78,9 @@ public class NearItem extends CompositeItem {
     protected void encodeThis(ByteBuffer buffer) {
         super.encodeThis(buffer);
         IntegerCompressor.putCompressedPositiveNumber(distance, buffer);
+        if (numNegativeItems != 0) {
+            throw new IllegalArgumentException("cannot serialize negative items in old protocol");
+        }
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -845,6 +845,9 @@ public class YqlParser implements Parser {
         int positiveCount = 0;
         for (OperatorNode<ExpressionOperator> word : ast.<List<OperatorNode<ExpressionOperator>>> getArgument(1)) {
             if (word.getOperator() == ExpressionOperator.NOT) {
+                if (positiveCount == 0) {
+                    throw new IllegalArgumentException("Must have some positive term before negative terms in " + nearItem.getName());
+                }
                 OperatorNode<ExpressionOperator> exp = word.getArgument(0);
                 assertHasOperator(exp, ExpressionOperator.class);
                 addNearItemChild(field, nearItem, exp);
@@ -867,7 +870,7 @@ public class YqlParser implements Parser {
             if (exclusionDistance != null) {
                 nearItem.setExclusionDistance(exclusionDistance);
             } else {
-                nearItem.setExclusionDistance(nearItem.getDistance() / 2);
+                nearItem.setExclusionDistance((nearItem.getDistance() + 1) / 2);
             }
         }
         return nearItem;

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -570,10 +570,10 @@ public class YqlParserTestCase {
 
     @Test
     void testNegativeTermsInNear() {
-        assertEquals("NEAR(7,2,3) default:a default:b default:c default:d",
+        assertEquals("NEAR(7,2,4) default:a default:b default:c default:d",
                      parse("SELECT * FROM sources * WHERE ({'distance':7} default contains near('a', 'b', !'c', ! 'd'))").getRoot().toString());
 
-        assertEquals("ONEAR(7,2,3) default:a default:b default:c default:d",
+        assertEquals("ONEAR(7,2,4) default:a default:b default:c default:d",
                      parse("SELECT * FROM sources * WHERE ({'distance':7} default contains onear('a', 'b', !'c', ! 'd'))").getRoot().toString());
     }
 


### PR DESCRIPTION
* require at least one positive term
* round up exclusionDistance
* throw on serialization which is not defined

@havardpe please review
