### PR TITLE
Add support for explicitly vectorized binary hamming distance calculations

### DIFF
--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -95,6 +95,11 @@ void register_all_benchmark_suites() {
     register_benchmarks<BFloat16>("Dot Product", dot_product_fn);
     register_benchmarks<int8_t>("Dot Product", dot_product_fn);
 
+    auto binary_hamming_fn = [](const IAccelerated& accelerator, const auto* lhs, const auto* rhs, size_t my_sz) {
+        return accelerator.binary_hamming_distance(lhs, rhs, my_sz);
+    };
+    register_benchmarks<uint8_t>("Binary Hamming Distance", binary_hamming_fn);
+
     auto popcount_fn = [](const IAccelerated& accelerator, const auto* lhs, const auto* rhs, size_t my_sz) {
         (void)rhs; // ... a little bit sneaky; overestimates bytes processed/sec by 2x
         return accelerator.populationCount(lhs, my_sz);

--- a/vespalib/src/tests/util/hamming/hamming_test.cpp
+++ b/vespalib/src/tests/util/hamming/hamming_test.cpp
@@ -7,6 +7,8 @@
 #include <cstring>
 #include <vector>
 
+// TODO remove these once usage has migrated to IAccelerated
+
 using namespace vespalib;
 
 constexpr size_t ALIGN = 8;
@@ -61,7 +63,7 @@ void check_with_sizes(void *mem_a, void *mem_b) {
     for (size_t sz : { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16, 32, 63, 64, 65 }) {
         check_with_flipping(mem_a, mem_b, sz);
     }
-}    
+}
 
 TEST(BinaryHammingTest, aligned_usage) {
     void *mem_a = my_alloc(0);

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3.cpp
@@ -35,6 +35,11 @@ Avx3Accelerator::squaredEuclideanDistance(const double * a, const double * b, si
     return avx::euclideanDistanceSelectAlignment<double, 64>(a, b, sz);
 }
 
+size_t
+Avx3Accelerator::binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept {
+    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+}
+
 void
 Avx3Accelerator::and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept {
     helper::andChunks<64, 2>(offset, src, dest);

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3.h
@@ -20,6 +20,7 @@ public:
     double squaredEuclideanDistance(const int8_t * a, const int8_t * b, size_t sz) const noexcept override;
     double squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept override;
     double squaredEuclideanDistance(const double * a, const double * b, size_t sz) const noexcept override;
+    size_t binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept override;
     void convert_bfloat16_to_float(const uint16_t * src, float * dest, size_t sz) const noexcept override;
     int64_t dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept override;
     void and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
@@ -53,6 +53,11 @@ Avx3DlAccelerator::squaredEuclideanDistance(const double* a, const double* b, si
     return avx::euclideanDistanceSelectAlignment<double, 64>(a, b, sz);
 }
 
+size_t
+Avx3DlAccelerator::binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept {
+    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+}
+
 void
 Avx3DlAccelerator::and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept {
     helper::andChunks<64, 2>(offset, src, dest);

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.h
@@ -42,6 +42,7 @@ public:
     double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept override;
     double squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept override;
     double squaredEuclideanDistance(const double* a, const double* b, size_t sz) const noexcept override;
+    size_t binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept override;
     void convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) const noexcept override;
     int64_t dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept override;
     void and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;

--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.h
@@ -28,6 +28,7 @@ public:
     void andNotBit(void* a, const void* b, size_t bytes) const noexcept override;
     void notBit(void* a, size_t bytes) const noexcept override;
     size_t populationCount(const uint64_t* a, size_t sz) const noexcept override;
+    size_t binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept override;
     void convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) const noexcept override;
     double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept override;
     double squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept override;

--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
@@ -174,6 +174,11 @@ VESPA_HWACCEL_TARGET_TYPE::populationCount(const uint64_t *a, size_t sz) const n
     return helper::populationCount(a, sz);
 }
 
+size_t
+VESPA_HWACCEL_TARGET_TYPE::binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept {
+    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+}
+
 double
 VESPA_HWACCEL_TARGET_TYPE::squaredEuclideanDistance(const int8_t * a, const int8_t * b, size_t sz) const noexcept {
     return helper::squaredEuclideanDistance(a, b, sz);

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -22,6 +22,7 @@ namespace vespalib::hwaccelerated { // NOLINT: must nest namespaces
 namespace HWY_NAMESPACE {
 
 namespace hn = hwy::HWY_NAMESPACE;
+namespace {
 
 // Must always be undef'd to ensure we expand the correct HWY_ATTR per target.
 #undef VESPA_NOEXCEPT_HWY_ATTR
@@ -200,6 +201,33 @@ size_t my_hwy_popcount(const uint64_t* a, const size_t sz) noexcept {
 #endif
 }
 
+HWY_INLINE
+size_t my_hwy_binary_hamming_distance(const void* HWY_RESTRICT untyped_lhs,
+                                      const void* HWY_RESTRICT untyped_rhs,
+                                      const size_t sz) noexcept
+{
+    // Inputs may have arbitrary byte alignments, so we have to read with an 8-bit
+    // type to ensure we don't violate any natural alignment requirements. The
+    // `HwyReduceKernel` code uses unaligned vector loads, so this works fine and
+    // with effectively the same performance regardless of input alignment.
+    // We then do the vector equivalent of reinterpret_cast (which is well-defined)
+    // to treat each set of 8x 8-bit lanes as 1x u64 lane before running 64-bit
+    // xor -> popcount -> accumulate operations.
+    const auto* lhs_u8 = static_cast<const uint8_t*>(untyped_lhs);
+    const auto* rhs_u8 = static_cast<const uint8_t*>(untyped_rhs);
+
+    const hn::ScalableTag<uint8_t> d8;
+    const hn::RepartitionToWideX3<decltype(d8)> d64;
+
+    const auto kernel_fn = [d64](auto lhs, auto rhs, auto& accu) VESPA_NOEXCEPT_HWY_ATTR {
+        auto lhs_u64 = hn::BitCast(d64, lhs);
+        auto rhs_u64 = hn::BitCast(d64, rhs);
+        accu = hn::Add(hn::PopulationCount(hn::Xor(lhs_u64, rhs_u64)), accu);
+    };
+
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<4>, UnrolledBy<4>, HasAccumulatorArity<1>>;
+    return MyKernel::pairwise(d8, d64, lhs_u8, rhs_u8, sz, hn::Zero(d64), kernel_fn, VecAdd(), LaneReduceSum());
+}
 
 // Multiply i8*i8 with the result widened to i16. Widen the intermediate i16 results to i32 and accumulate.
 // Depending on the implementation, the intermediate i16 widening step may be transparently done.
@@ -268,6 +296,8 @@ const char* my_hwy_target_name() noexcept {
     return hn::Lanes(d8) * 8;
 }
 
+} // anon ns
+
 // Since we already do a virtual dispatch via the IAccelerated interface, avoid needing an
 // additional per-function dispatch step via Highway's function tables by creating a concrete
 // implementation class per target.
@@ -288,6 +318,9 @@ public:
     }
     size_t populationCount(const uint64_t* a, size_t sz) const noexcept override {
         return my_hwy_popcount(a, sz);
+    }
+    size_t binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept override {
+        return my_hwy_binary_hamming_distance(lhs, rhs, sz);
     }
     double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept override {
         return my_hwy_square_euclidean_distance_int8(a, b, sz);

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -30,6 +30,7 @@ public:
     virtual void andNotBit(void* a, const void* b, size_t bytes) const noexcept = 0;
     virtual void notBit(void* a, size_t bytes) const noexcept = 0;
     virtual size_t populationCount(const uint64_t* a, size_t sz) const noexcept = 0;
+    virtual size_t binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept = 0;
     virtual void convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) const noexcept = 0;
     virtual double squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept = 0;
     virtual double squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept = 0;

--- a/vespalib/src/vespa/vespalib/hwaccelerated/private_helpers.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/private_helpers.hpp
@@ -32,7 +32,7 @@ constexpr uint8_t WORD_SZ = sizeof(uint64_t);
 constexpr uint8_t UNROLL_CNT = 4;
 }
 
-size_t
+inline size_t
 autovec_binary_hamming_distance(const void *lhs, const void *rhs, size_t sz) noexcept {
     auto addr_a = (uintptr_t) lhs;
     auto addr_b = (uintptr_t) rhs;

--- a/vespalib/src/vespa/vespalib/util/binary_hamming_distance.cpp
+++ b/vespalib/src/vespa/vespalib/util/binary_hamming_distance.cpp
@@ -1,43 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "binary_hamming_distance.h"
-#include <cstdint>
-#include <bit>
+#include <vespa/vespalib/hwaccelerated/private_helpers.hpp>
 
 namespace vespalib {
 
-namespace {
-    constexpr uint8_t WORD_SZ = sizeof (uint64_t);
-    constexpr uint8_t UNROLL_CNT = 4;
-    static_assert(sizeof(uint64_t) == 8);
-}
 size_t
 binary_hamming_distance(const void *lhs, const void *rhs, size_t sz) noexcept {
-    auto addr_a = (uintptr_t) lhs;
-    auto addr_b = (uintptr_t) rhs;
-    size_t sum = 0;
-    size_t i = 0;
-    bool aligned = ((addr_a & 0x7) == 0) && ((addr_b & 0x7) == 0);
-    if (__builtin_expect(aligned, true)) {
-        const auto *words_a = static_cast<const uint64_t *>(lhs);
-        const auto *words_b = static_cast<const uint64_t *>(rhs);
-        for (; (i+UNROLL_CNT) * WORD_SZ <= sz; i += UNROLL_CNT) {
-            for (uint8_t j=0; j < UNROLL_CNT; j++) {
-                sum += std::popcount(words_a[i+j] ^ words_b[i+j]);
-            }
-        }
-        for (; (i + 1) * WORD_SZ <= sz; ++i) {
-            sum += std::popcount(words_a[i] ^ words_b[i]);
-        }
-    }
-    if (__builtin_expect((i * WORD_SZ < sz), false)) {
-        const auto *bytes_a = static_cast<const uint8_t *>(lhs);
-        const auto *bytes_b = static_cast<const uint8_t *>(rhs);
-        for (i *= WORD_SZ; i < sz; ++i) {
-            uint64_t xor_bits = bytes_a[i] ^ bytes_b[i];
-            sum += std::popcount(xor_bits);
-        }
-    }
-    return sum;
-};
+    return hwaccelerated::helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+}
 
 }


### PR DESCRIPTION
@havardpe please review. The added unit tests have been casually appropriated and cleaned up from the existing `hamming_test.cpp`.

This PR adds binary Hamming distance to the `IAccelerated` API, allowing explicitly vectorized implementations. Callsites must be subsequently updated to use this API instead of the previous freestanding function (not done as part of this).

Since we work with vector registers we can avoid the complexities that the auto-vectorized code invokes to deal with unaligned input buffers (since it uses pointer type casting, requiring natural alignment). We load from possibly unaligned u8 pointers and then bit cast to u64 once the data is already nicely tucked into vector registers, where alignment is no longer a concern.

This means all input alignments should have basically the same expected performance, unlike the byte-wise scalar fallback in the auto-vectorized version, which is much slower than the aligned happy path.

Tested with all possible SVE vector lengths using QEMU.