### PR TITLE
Return `400 Bad Request` on HTTP `Accept` header parse failure

### DIFF
--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -1199,6 +1199,21 @@ public class DocumentV1ApiTest {
     }
 
     @Test
+    void malformed_accept_header_returns_400_bad_request() {
+        var driver = new RequestHandlerTestDriver(handler);
+        access.session.expect((__, ___) -> { throw new AssertionError("Not supposed to happen"); });
+        var request = driver.createRequest("http://localhost/document/v1?cluster=content&stream=true", HttpRequest.Method.GET);
+        request.headers().add("Accept", "Vazelina Bilopphøggers");
+        var response = driver.sendRequest(request, "");
+        assertSameJson("{" +
+                "  \"pathId\": \"/document/v1\"," +
+                "  \"message\": \"The request contained an unparseable HTTP Accept header. See: " +
+                                 "https://docs.vespa.ai/en/reference/document-v1-api-reference.html#accept\"" +
+                "}", response.readAll());
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
     public void batch_update_rewrites_tas_condition_with_timestamp_predicate_if_provided_by_backend() {
         var driver = new RequestHandlerTestDriver(handler); // try-with-resources hangs the test on assertion failure, which isn't optimal
         List<AckToken> tokens = List.of(new AckToken(null), new AckToken(null), new AckToken(null), new AckToken(null));


### PR DESCRIPTION
@bjorncs please review.

Will only ever kick in if the client has specified an `Accept` header and lexing/parsing fails entirely. I.e. this is _not_ the same as the server not finding a media type match without offering a fallback, as that would have been `406 Not Acceptable`.

It will also only kick in for streaming visiting, since that's currently the only code path in which we parse the `Accept` header.
