### PR TITLE
add useFieldEntry method

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.cpp
@@ -101,6 +101,15 @@ ProtonTermData::setDocumentFrequency(uint32_t estHits, uint32_t docIdLimit)
     }
 }
 
+void ProtonTermData::useFieldEntry(const FieldEntry &source) {
+    _fields.clear();
+    _fields.emplace_back(source.getName(), source.getFieldId(), source._field_spec.get_filter_threshold());
+    FieldEntry &target = _fields.back();
+    target._field_spec = source._field_spec;
+    target.attribute_field = source.attribute_field;
+    target.setDocFreq(source.get_matching_doc_count(), source.get_total_doc_count());
+}
+
 const ProtonTermData::FieldEntry *
 ProtonTermData::lookupField(uint32_t fieldId) const
 {

--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
@@ -67,6 +67,8 @@ public:
     void resolveFromChildren(const std::vector<search::query::Node *> &children);
     void allocateTerms(search::fef::MatchDataLayout &mdl);
     void setDocumentFrequency(uint32_t estHits, uint32_t numDocs);
+    // clear fields, and use just the provided entry:
+    void useFieldEntry(const FieldEntry &source);
 
     // ITermData interface
     [[nodiscard]] std::optional<std::string> query_tensor_name() const override { return std::nullopt; }


### PR DESCRIPTION
Will be used if splitting on fields, making a new term that uses just one of the original FieldEntry instances.

@toregge please review
@havardpe FYI
