### PR TITLE
feat: produce Micrometer based JVM metrics for all container clusters

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -141,7 +141,6 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         addSimpleComponent("com.yahoo.container.jdisc.AthenzIdentityProviderProvider");
         addSimpleComponent("com.yahoo.container.core.documentapi.DocumentAccessProvider");
         addSimpleComponent("com.yahoo.container.jdisc.SecretsProvider");
-        addSimpleComponent("com.yahoo.container.jdisc.metric.MicrometerMetricReporter");
         addSimpleComponent(DOCUMENT_TYPE_MANAGER_CLASS);
 
         addMetricsHandlers();

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -202,6 +202,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         addSimpleComponent(com.yahoo.container.handler.ClustersStatus.class.getName());
         addSimpleComponent("com.yahoo.container.jdisc.DisabledConnectionLogProvider");
         addSimpleComponent(com.yahoo.jdisc.http.server.jetty.Janitor.class);
+        addSimpleComponent("com.yahoo.container.jdisc.metric.MicrometerMetricReporter");
     }
 
     protected abstract boolean messageBusEnabled();


### PR DESCRIPTION
Enable the component producing the additional metrics for all jdisc container clusters, including the configserver. See `metrics/src/main/java/ai/vespa/metrics/set/MicrometerMetrics.java` for list of metrics.

FYI @olaaun @hakonhall 