### PR TITLE
Revert "feat: produce Micrometer based JVM metrics for all container clusters"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -141,6 +141,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         addSimpleComponent("com.yahoo.container.jdisc.AthenzIdentityProviderProvider");
         addSimpleComponent("com.yahoo.container.core.documentapi.DocumentAccessProvider");
         addSimpleComponent("com.yahoo.container.jdisc.SecretsProvider");
+        addSimpleComponent("com.yahoo.container.jdisc.metric.MicrometerMetricReporter");
         addSimpleComponent(DOCUMENT_TYPE_MANAGER_CLASS);
 
         addMetricsHandlers();

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -202,7 +202,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         addSimpleComponent(com.yahoo.container.handler.ClustersStatus.class.getName());
         addSimpleComponent("com.yahoo.container.jdisc.DisabledConnectionLogProvider");
         addSimpleComponent(com.yahoo.jdisc.http.server.jetty.Janitor.class);
-        addSimpleComponent("com.yahoo.container.jdisc.metric.MicrometerMetricReporter");
     }
 
     protected abstract boolean messageBusEnabled();


### PR DESCRIPTION
Reverts vespa-engine/vespa#35088

There were concerns regarding the increased number of metrics exported. Let's revert to be on the safe side.