### PR TITLE
Added sidecars to cluster membership constructors

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -3,6 +3,7 @@ package com.yahoo.config.provision;
 
 import com.yahoo.component.Version;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -20,7 +21,7 @@ public class ClusterMembership {
     private final String stringValue;
 
     private ClusterMembership(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
-                              ZoneEndpoint zoneEndpoint) {
+                              ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars) {
         String[] components = stringValue.split("/");
         if (components.length < 3)
             throw new RuntimeException("Could not parse '" + stringValue + "' to a cluster membership. " +
@@ -60,6 +61,7 @@ public class ClusterMembership {
                                   .dockerImageRepository(dockerImageRepo)
                                   .loadBalancerSettings(zoneEndpoint)
                                   .stateful(stateful)
+                                  .sidecars(sidecars)
                                   .build();
         this.index = nodeIndex;
         this.retired = retired;
@@ -137,7 +139,16 @@ public class ClusterMembership {
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                                          ZoneEndpoint zoneEndpoint) {
-        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint);
+        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, List.of());
+    }
+
+    public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo, List<SidecarSpec> sidecars) {
+        return from(stringValue, vespaVersion, dockerImageRepo, ZoneEndpoint.defaultEndpoint, sidecars);
+    }
+
+    public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
+                                         ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars) {
+        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars);
     }
 
     public static ClusterMembership from(ClusterSpec cluster, int index) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This change is necessary for deserialization of cluster membership stored in zookeeper. 