### PR TITLE
Refactor `minThreads`, `maxThreads` and `queueSize` in config-model and threadpool implementation

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -138,8 +138,8 @@ public class ContainerDocumentApi {
 
         @Override
         protected void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder) {
-            builder.maxThreads(-4)
-                    .minThreads(-4)
+            builder.relativeMaxThreads(4)
+                    .relativeMinThreads(4)
                     .queueSize(500);
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -122,7 +122,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
 
 
     public ApplicationContainerCluster(TreeConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState) {
-        super(parent, configSubId, clusterId, deployState, true, 10);
+        super(parent, configSubId, clusterId, deployState, true);
         this.tlsClientAuthority = deployState.tlsClientAuthority();
         previousHosts = Collections.unmodifiableSet(deployState.getPreviousModel().stream()
                                                                .map(Model::allocatedHosts)

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -171,10 +171,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private List<Client> clients = List.of();
 
     public ContainerCluster(TreeConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState, boolean zooKeeperLocalhostAffinity) {
-        this(parent, configSubId, clusterId, deployState, zooKeeperLocalhostAffinity, 4);
-    }
-
-    public ContainerCluster(TreeConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState, boolean zooKeeperLocalhostAffinity, int defaultPoolNumThreads) {
         super(parent, configSubId);
         this.name = clusterId;
         this.isHostedVespa = stateIsHosted(deployState);
@@ -186,7 +182,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         addCommonVespaBundles();
         addSimpleComponent(VoidRequestLog.class);
-        addComponent(new DefaultThreadpoolProvider(this, defaultPoolNumThreads));
+        addComponent(new DefaultThreadpoolProvider(this));
         defaultHandlerThreadpool = new Handler.DefaultHandlerThreadpool(deployState, null);
         addComponent(defaultHandlerThreadpool);
         addSimpleComponent(com.yahoo.concurrent.classlock.ClassLocking.class);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
@@ -15,16 +15,14 @@ import com.yahoo.vespa.model.container.component.SimpleComponent;
 class DefaultThreadpoolProvider extends SimpleComponent implements ThreadpoolConfig.Producer {
 
     private final ContainerCluster<?> cluster;
-    private final int defaultWorkerThreads;
 
-    DefaultThreadpoolProvider(ContainerCluster<?> cluster, int defaultWorkerThreads) {
+    DefaultThreadpoolProvider(ContainerCluster<?> cluster) {
         super(new ComponentModel(
                 BundleInstantiationSpecification.fromStrings(
                         "default-threadpool",
                         ThreadPoolProvider.class.getName(),
                         null)));
         this.cluster = cluster;
-        this.defaultWorkerThreads = defaultWorkerThreads;
     }
 
     @Override
@@ -35,7 +33,7 @@ class DefaultThreadpoolProvider extends SimpleComponent implements ThreadpoolCon
             builder.corePoolSize(-2).maxthreads(-100).queueSize(0);
         } else {
             // Container clusters such as logserver, metricsproxy and clustercontroller
-            builder.corePoolSize(defaultWorkerThreads).maxthreads(defaultWorkerThreads).queueSize(50);
+            builder.corePoolSize(4).maxthreads(4).queueSize(50);
         }
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -85,9 +85,9 @@ public class Handler extends Component<Component<?, ?>, ComponentModel> {
         public void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder) {
             builder.maxThreadExecutionTimeSeconds(190)
                     .keepAliveTime(5.0)
-                    .maxThreads(-2)
-                    .minThreads(-2)
-                    .queueSize(-40);
+                    .relativeMaxThreads(2)
+                    .relativeMinThreads(2)
+                    .relativeQueueSize(40);
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/SearchHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/SearchHandler.java
@@ -67,9 +67,9 @@ class SearchHandler extends ProcessingHandler<SearchChains> {
         public void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder) {
             builder.maxThreadExecutionTimeSeconds(190)
                     .keepAliveTime(5.0)
-                    .maxThreads(-threads)
-                    .minThreads(-threads)
-                    .queueSize(-40);
+                    .relativeMaxThreads(threads)
+                    .relativeMinThreads(threads)
+                    .relativeQueueSize(40);
         }
 
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
@@ -116,8 +116,8 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
 
         ContainerThreadpoolConfig config = root.getConfig(
                 ContainerThreadpoolConfig.class, "cluster1/component/com.yahoo.vespa.http.server.FeedHandler/threadpool@feedapi-handler");
-        assertEquals(-4, config.maxThreads());
-        assertEquals(-4, config.minThreads());
+        assertEquals(4, config.relativeMaxThreads());
+        assertEquals(4, config.relativeMinThreads());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
@@ -193,9 +193,9 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
 
         ContainerThreadpoolConfig config = root.getConfig(
                 ContainerThreadpoolConfig.class, "default/component/" + SearchHandler.HANDLER_CLASSNAME + "/threadpool@search-handler");
-        assertEquals(-10, config.maxThreads());
-        assertEquals(-10, config.minThreads());
-        assertEquals(-40, config.queueSize());
+        assertEquals(10, config.relativeMaxThreads());
+        assertEquals(10, config.relativeMinThreads());
+        assertEquals(40, config.relativeQueueSize());
     }
 
     @Test
@@ -234,9 +234,9 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
         createModel(root, clusterElem);
         ContainerThreadpoolConfig config = root.getConfig(
                 ContainerThreadpoolConfig.class, "default/component/" + SearchHandler.HANDLER_CLASSNAME + "/threadpool@search-handler");
-        assertEquals(-10, config.maxThreads());
-        assertEquals(-1, config.minThreads());
-        assertEquals(-50, config.queueSize());
+        assertEquals(10.2, config.relativeMaxThreads());
+        assertEquals(0.4, config.relativeMinThreads());
+        assertEquals(50, config.relativeQueueSize());
     }
 
     @Test

--- a/container-core/src/main/java/com/yahoo/container/handler/ThreadPoolProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ThreadPoolProvider.java
@@ -39,14 +39,33 @@ public class ThreadPoolProvider extends AbstractComponent implements Provider<Ex
      * as {@link ThreadpoolConfig} is currently public api.
      */
     private static ContainerThreadpoolConfig translateConfig(ThreadpoolConfig config) {
-        return new ContainerThreadpoolConfig(
-                new ContainerThreadpoolConfig.Builder()
-                        .maxThreads(config.maxthreads())
-                        .minThreads(config.corePoolSize())
+        var builder = new ContainerThreadpoolConfig.Builder()
                         .name(config.name())
-                        .queueSize(config.queueSize())
                         .keepAliveTime(config.keepAliveTime())
-                        .maxThreadExecutionTimeSeconds(config.maxThreadExecutionTimeSeconds()));
+                        .maxThreadExecutionTimeSeconds(config.maxThreadExecutionTimeSeconds());
+
+        int max = config.maxthreads();
+        if  (max > 0) {
+            builder.maxThreads(max);
+        } else {
+            builder.relativeMaxThreads(-max);
+        }
+
+        int min = config.corePoolSize();
+        if  (min > 0) {
+            builder.minThreads(min);
+        } else {
+            builder.relativeMinThreads(-min);
+        }
+
+        int queueSize = config.queueSize();
+        if  (queueSize > 0) {
+            builder.queueSize(queueSize);
+        } else {
+            builder.relativeQueueSize(-queueSize);
+        }
+
+        return new ContainerThreadpoolConfig(builder);
     }
 
     /**

--- a/container-core/src/main/resources/configdefinitions/container.handler.threadpool.container-threadpool.def
+++ b/container-core/src/main/resources/configdefinitions/container.handler.threadpool.container-threadpool.def
@@ -2,21 +2,17 @@
 
 namespace=container.handler.threadpool
 
-## Maximum number of thread in the thread pool
-## 0 is translated to vcpu*4
-## Negative value is interpreted as scale factor ( vcpu*abs(maxThreads) )
-maxThreads int default=0
+## Maximum number of thread in the thread pool (absolute)
+maxThreads int default=-1
 
-## Minimum number of thread in the thread pool
-## 0 is translated to vcpu*2
-## Negative value is interpreted as scale factor ( vcpu*abs(minThreads) )
-minThreads int default=0
+## Minimum number of thread in the thread pool (absolute)
+minThreads int default=-1
 
 ## Minimum number of threads relative to number of cores (vcpu)
-relativeMinThreads double default=0
+relativeMinThreads double default=-1.0
 
 ## Maximum number of threads relative to number of cores (vcpu)
-relativeMaxThreads double default=0
+relativeMaxThreads double default=-1.0
 
 ## The number of seconds that excess idle threads will wait for new tasks before terminating
 keepAliveTime double default=5.0
@@ -25,7 +21,7 @@ keepAliveTime double default=5.0
 queueSize int default=-1
 
 ## Max queue capacity relative to number of cores
-relativeQueueSize double default=-1
+relativeQueueSize double default=-1.0
 
 ## The max time the container tolerates having no threads available before it shuts down to
 ## get out of a bad state. This should be set a bit higher than the expected max execution

--- a/container-core/src/main/resources/configdefinitions/container.handler.threadpool.container-threadpool.def
+++ b/container-core/src/main/resources/configdefinitions/container.handler.threadpool.container-threadpool.def
@@ -12,12 +12,20 @@ maxThreads int default=0
 ## Negative value is interpreted as scale factor ( vcpu*abs(minThreads) )
 minThreads int default=0
 
+## Minimum number of threads relative to number of cores (vcpu)
+relativeMinThreads double default=0
+
+## Maximum number of threads relative to number of cores (vcpu)
+relativeMaxThreads double default=0
+
 ## The number of seconds that excess idle threads will wait for new tasks before terminating
 keepAliveTime double default=5.0
 
-## Max queue size
-## Negative value is interpreted as scale factor ( effectiveMaxThreads*abs(queueSize) )
-queueSize int default=0
+## Absolute queue capacity
+queueSize int default=-1
+
+## Max queue capacity relative to number of cores
+relativeQueueSize double default=-1
 
 ## The max time the container tolerates having no threads available before it shuts down to
 ## get out of a bad state. This should be set a bit higher than the expected max execution


### PR DESCRIPTION
### Context
Before this PR, configuring threadpools internally in the config model was hairy. When configuring a threadpool, the `minThreads`, `maxThreads`, and `queueSize` config parameters used their signedness to indicate whether they represented an absolute number (i.e., the number of threads) or a relative value scaled to the number of cores available. And, if you were to configure a threadpool in the config model, you would have to consult the threadpool implementation details (in `ContainerThreadpoolImpl`) to see how the parameters you provided might be interpreted. Additionally, the datatype was integer, which meant that relative scaling values could not be used to downscale, such as setting `minThreads` to 0.5. 

### This PR
- Introduces new parameters `relativeMinThreads`, `relativeMaxThreads`, and `relativeQueueSize` to simplify the configuration of threadpools. 
- Old parameters `minThreads`, `maxThreads`, and `queueSize` will be used to set absolute values.
- The threadpool implementation is simplified only to use either absolute values or `vcpu * relativeValue` such that we can move defaults to the config model.
- Negative numbers are now used to catch misconfiguration.
- ContainerThreadpool, which parses the `<threadpool>` XML-tag, is refactored to use the new parameters.
  - Deprecated `<min-threads>` and `<max-threads>` tags are now interpreted as absolute values and use old parameters.
  - The `<threads>` tag is now considered relative, meaning it will be multiplied by the number of cores.

The API is now more expressive, making it easier to understand when reading code later. And defaults, which were already defined in the config model, are now handled solely there, without the need to consult implementation details. And relative values are now doubles instead of ints, allowing downscaling when needed.

@bjorncs please review