### PR TITLE
Revert "Stop using MAX_DISTRIBUTOR_DOCUMENT_OPERATION_SIZE_MIB"

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -115,7 +115,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"bjorncs"}) default int documentV1QueueSize() { return -1; /* use default from config def */ }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxContentNodeMaintenanceOpConcurrency() { return -1; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default int maxDocumentOperationRequestSizeMib() { return 2048; }
-        @ModelFeatureFlag(owners = {"vekterli"}, removeAfter = "8.599") default int maxDistributorDocumentOperationSizeMib() { return 128; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default int maxDistributorDocumentOperationSizeMib() { return 128; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default Object sidecarsForTest() { return null; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default boolean useTriton() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean useNewPrepareForRestart() { return false; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -76,6 +76,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private int contentLayerMetadataFeatureLevel = 0;
     private boolean logserverOtelCol = false;
     private int maxContentNodeMaintenanceOpConcurrency = -1;
+    private int maxDistributorDocumentOperationSizeMib = -1;
     private int searchCoreMaxOutstandingMoveOps = 100;
     private Map<ClusterSpec.Type, String> mallocImpl = new HashMap<>();
     private boolean useNewPrepareForRestart = false;
@@ -131,6 +132,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public int contentLayerMetadataFeatureLevel() { return contentLayerMetadataFeatureLevel; }
     @Override public boolean logserverOtelCol() { return logserverOtelCol; }
     @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
+    @Override public int maxDistributorDocumentOperationSizeMib() { return maxDistributorDocumentOperationSizeMib; }
     @Override public int searchCoreMaxOutstandingMoveOps() { return searchCoreMaxOutstandingMoveOps; }
     @Override public boolean useNewPrepareForRestart() { return useNewPrepareForRestart; }
     @Override public int searchNodeInitializerThreads() { return 0; }
@@ -336,6 +338,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setMaxContentNodeMaintenanceOpConcurrency(int maxConcurrency) {
         this.maxContentNodeMaintenanceOpConcurrency = maxConcurrency;
+        return this;
+    }
+
+    public TestProperties setMaxDistributorDocumentOperationSizeMib(int maxSizeMib) {
+        this.maxDistributorDocumentOperationSizeMib = maxSizeMib;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -103,7 +103,9 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
             var featureFlags = deployState.getProperties().featureFlags();
             int maxInhibitedGroups = featureFlags.maxActivationInhibitedOutOfSyncGroups();
             int contentLayerMetadataFeatureLevel = featureFlags.contentLayerMetadataFeatureLevel();
-            int maxDocumentOperationSizeMib = maxDocumentSizeInMib(clusterElement, deployState.getDeployLogger());
+            int maxDocumentOperationSizeMib = maxDocumentSizeInMib(featureFlags.maxDistributorDocumentOperationSizeMib(),
+                                                                   clusterElement,
+                                                                   deployState.getDeployLogger());
 
             return new DistributorCluster(parent,
                     new BucketSplitting.Builder().build(new ModelElement(producerSpec)), gc,
@@ -174,14 +176,14 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
         return parent.getName();
     }
 
-    private static int maxDocumentSizeInMib(ModelElement clusterElement, DeployLogger deployLogger) {
+    private static int maxDocumentSizeInMib(int featureFlagValue, ModelElement clusterElement, DeployLogger deployLogger) {
         var tuning = clusterElement.child("tuning");
-        if (tuning == null) return 0;
+        if (tuning == null) return featureFlagValue;
         var maxSize = tuning.child("max-document-size");
-        if (maxSize == null) return 0;
+        if (maxSize == null) return featureFlagValue;
 
         var configuredValue = maxSize.asString();
-        int maxDocumentSize = 0;
+        int maxDocumentSize = featureFlagValue;
         if (configuredValue != null && ! configuredValue.isEmpty()) {
             // The configured value has units, but the config expects it in MiB, extract the value and convert
             maxDocumentSize = (int) (BinaryUnit.valueOf(configuredValue) / 1024 / 1024);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1549,6 +1549,25 @@ public class ContentClusterTest extends ContentBaseTest {
         assertTrue(resolveDistributorOperationCancellationConfig(2));
     }
 
+    private int resolveMaxDistributorDocOperationSizeConfig(Integer flagValue) throws Exception {
+        return resolveDistributorConfig((props) -> {
+            if (flagValue != null) {
+                props.setMaxDistributorDocumentOperationSizeMib(flagValue);
+            }
+        }).max_document_operation_message_size_bytes();
+    }
+
+    @Test
+    void distributor_max_document_operation_size_config_is_controlled_by_properties() throws Exception {
+        int mi = 1024 * 1024;
+        assertEquals( 128 * mi, resolveMaxDistributorDocOperationSizeConfig(null)); // defaults to 134217728 (128 MiB)
+        assertEquals( 128 * mi, resolveMaxDistributorDocOperationSizeConfig(-2));
+        assertEquals( 128 * mi, resolveMaxDistributorDocOperationSizeConfig(0));
+        assertEquals( 100 * mi, resolveMaxDistributorDocOperationSizeConfig(100));
+        assertEquals(2047 * mi, resolveMaxDistributorDocOperationSizeConfig(2047));
+        assertEquals( 128 * mi, resolveMaxDistributorDocOperationSizeConfig(2048));
+    }
+
     @Test
     void node_distribution_key_outside_legal_range_is_disallowed() {
         // Only [0, UINT16_MAX - 1] is a valid range. UINT16_MAX is a special content layer-internal

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -209,6 +209,7 @@ public class ModelContextImpl implements ModelContext {
         private final int documentV1QueueSize;
         private final int maxContentNodeMaintenanceOpConcurrency;
         private final int maxDocumentOperationRequestSizeMib;
+        private final int maxDistributorDocumentOperationSizeMib;
         private final Sidecars sidecarsForTest;
         private final boolean useTriton;
         private final int searchCoreMaxOutstandingMoveOps;
@@ -257,6 +258,7 @@ public class ModelContextImpl implements ModelContext {
             this.documentV1QueueSize = Flags.DOCUMENT_V1_QUEUE_SIZE.bindTo(source).with(appId).with(version).value();
             this.maxContentNodeMaintenanceOpConcurrency = Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY.bindTo(source).with(appId).with(version).value();
             this.maxDocumentOperationRequestSizeMib = Flags.MAX_DOCUMENT_OPERATION_REQUEST_SIZE_MIB.bindTo(source).with(appId).with(version).value();
+            this.maxDistributorDocumentOperationSizeMib = Flags.MAX_DISTRIBUTOR_DOCUMENT_OPERATION_SIZE_MIB.bindTo(source).with(appId).with(version).value();
             this.sidecarsForTest = Flags.SIDECARS_FOR_TEST.bindTo(source).with(appId).with(version).value();
             this.useTriton = Flags.USE_TRITON.bindTo(source).with(appId).with(version).value();
             this.searchCoreMaxOutstandingMoveOps = Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS.bindTo(source).with(appId).with(version).value();
@@ -305,6 +307,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public int documentV1QueueSize() { return documentV1QueueSize; }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
         @Override public int maxDocumentOperationRequestSizeMib() { return maxDocumentOperationRequestSizeMib; }
+        @Override public int maxDistributorDocumentOperationSizeMib() { return maxDistributorDocumentOperationSizeMib; }
         @Override public Object sidecarsForTest() { return sidecarsForTest; }
         @Override public boolean useTriton() { return useTriton; }
         @Override public boolean useNewPrepareForRestart() { return useNewPrepareForRestart; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -329,6 +329,15 @@ public class Flags {
             INSTANCE_ID
     );
 
+    public static final UnboundIntFlag MAX_DISTRIBUTOR_DOCUMENT_OPERATION_SIZE_MIB = defineIntFlag(
+            "max-distributor-document-operation-size-mib", 128,
+            List.of("vekterli", "hmusum"), "2025-03-17", "2025-11-01",
+            "Sets the maximum size in MiB of a document operation (Put or Update) that a distributor " +
+            "will accept when it arrives over the Document API. Any value outside (1, 2048) implies " +
+            "effectively unbounded behavior. Setting this value too low will have the obvious consequences.",
+            "Takes effect immediately",
+            INSTANCE_ID);
+
     public static final UnboundBooleanFlag DEFER_OS_UPGRADE = defineFeatureFlag(
             "defer-os-upgrade", false,
             List.of("olaa"), "2025-04-09", "2025-11-01",


### PR DESCRIPTION
Reverts vespa-engine/vespa#35107

Need to revert this, a customer has still not configured this in services.xml