### PR TITLE
Revert "Get the failing statement in error messages"

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/StatementExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/StatementExpression.java
@@ -118,13 +118,8 @@ public final class StatementExpression extends ExpressionList<Expression> {
 
     @Override
     protected void doExecute(ExecutionContext context) {
-        try {
-            for (Expression expression : this) {
-                context.execute(expression);
-            }
-        }
-        catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Error executing '" + this + "'", e);
+        for (Expression expression : this) {
+            context.execute(expression);
         }
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#35116

It broke `FeedWithErrors::test_feedwitherrors__INDEXED` and `FeedWithErrors::test_feedwitherrors__STREAMING`
system tests.

@bratseth : please rewiew
