### PR TITLE
glebashnik/fix-triton-model-name

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -3,6 +3,7 @@ package com.yahoo.config.provision;
 
 import com.yahoo.component.Version;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -20,7 +21,7 @@ public class ClusterMembership {
     private final String stringValue;
 
     private ClusterMembership(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
-                              ZoneEndpoint zoneEndpoint) {
+                              ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars) {
         String[] components = stringValue.split("/");
         if (components.length < 3)
             throw new RuntimeException("Could not parse '" + stringValue + "' to a cluster membership. " +
@@ -60,6 +61,7 @@ public class ClusterMembership {
                                   .dockerImageRepository(dockerImageRepo)
                                   .loadBalancerSettings(zoneEndpoint)
                                   .stateful(stateful)
+                                  .sidecars(sidecars)
                                   .build();
         this.index = nodeIndex;
         this.retired = retired;
@@ -137,7 +139,16 @@ public class ClusterMembership {
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                                          ZoneEndpoint zoneEndpoint) {
-        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint);
+        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, List.of());
+    }
+
+    public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo, List<SidecarSpec> sidecars) {
+        return from(stringValue, vespaVersion, dockerImageRepo, ZoneEndpoint.defaultEndpoint, sidecars);
+    }
+
+    public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
+                                         ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars) {
+        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars);
     }
 
     public static ClusterMembership from(ClusterSpec cluster, int index) {

--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluator.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluator.java
@@ -6,6 +6,7 @@ import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OnnxValue;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import ai.vespa.modelintegration.utils.ModelPathOrData;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 
@@ -32,11 +33,11 @@ class EmbeddedOnnxEvaluator implements OnnxEvaluator {
     private boolean isCudaLoaded;
 
     EmbeddedOnnxEvaluator(String modelPath, OnnxEvaluatorOptions options, EmbeddedOnnxRuntime runtime) {
-        session = createSession(EmbeddedOnnxRuntime.ModelPathOrData.of(modelPath), runtime, options, true);
+        session = createSession(ModelPathOrData.of(modelPath), runtime, options, true);
     }
 
     EmbeddedOnnxEvaluator(byte[] data, OnnxEvaluatorOptions options, EmbeddedOnnxRuntime runtime) {
-        session = createSession(EmbeddedOnnxRuntime.ModelPathOrData.of(data), runtime, options, true);
+        session = createSession(ModelPathOrData.of(data), runtime, options, true);
     }
 
     @Override
@@ -148,7 +149,7 @@ class EmbeddedOnnxEvaluator implements OnnxEvaluator {
     }
 
     private EmbeddedOnnxRuntime.ReferencedOrtSession createSession(
-            EmbeddedOnnxRuntime.ModelPathOrData model,
+            ModelPathOrData model,
             EmbeddedOnnxRuntime runtime,
             OnnxEvaluatorOptions options,
             boolean tryCuda) {

--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
@@ -1,6 +1,9 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.modelintegration.evaluator;
 
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -18,7 +21,12 @@ public record OnnxEvaluatorOptions(
         boolean gpuDeviceRequired,
         /* Optional runtime specific raw config */Optional<String> rawConfig) {
 
-
+    // Unlike hashCode, this hash doesn't change between runs
+    public long calculateHash() {
+        var bytes = toString().getBytes(StandardCharsets.UTF_8);
+        return XXHashFactory.fastestInstance().hash64().hash(bytes, 0, bytes.length, 0);
+    }
+    
     public OnnxEvaluatorOptions {
         Objects.requireNonNull(executionMode, "executionMode cannot be null");
         Objects.requireNonNull(rawConfig, "rawConfig cannot be null");

--- a/model-integration/src/main/java/ai/vespa/modelintegration/utils/ModelPathOrData.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/utils/ModelPathOrData.java
@@ -10,7 +10,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
- * Union object that contains model file path or data.
+ * Union object that contains either model file path or data.
  *
  * @author bjorncs
  */

--- a/model-integration/src/main/java/ai/vespa/modelintegration/utils/ModelPathOrData.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/utils/ModelPathOrData.java
@@ -1,0 +1,51 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.modelintegration.utils;
+
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+/**
+ * Union object that contains model file path or data.
+ *
+ * @author bjorncs
+ */
+public record ModelPathOrData(Optional<String> path, Optional<byte[]> data) {
+    public ModelPathOrData {
+        if (path.isEmpty() == data.isEmpty()) {
+            throw new IllegalArgumentException("Either path or data must be non-empty");
+        }
+    }
+
+    public static ModelPathOrData of(String path) {
+        return new ModelPathOrData(Optional.of(path), Optional.empty());
+    }
+
+    public static ModelPathOrData of(byte[] data) {
+        return new ModelPathOrData(Optional.empty(), Optional.of(data));
+    }
+
+    public long calculateHash() {
+        if (path.isPresent()) {
+            try (var hasher = XXHashFactory.fastestInstance().newStreamingHash64(0);
+                 var in = Files.newInputStream(Paths.get(path.get()))) {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    hasher.update(buffer, 0, bytesRead);
+                }
+
+                return hasher.getValue();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        } else {
+            return XXHashFactory.fastestInstance().hash64().hash(data.get(), 0, data.get().length, 0);
+        }
+    }
+}

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -100,7 +100,9 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         var fileName = Paths.get(modelPath).getFileName().toString();
         var baseName = fileName.substring(0, fileName.lastIndexOf('.')); // remove file extension
         var modelHash = ModelPathOrData.of(modelPath).calculateHash();
-        return baseName + "_" + modelHash; // add hash to avoid conflicts
+        var optionsHash = options.calculateHash();
+        var combinedHash = Long.toHexString(31 * modelHash + optionsHash);
+        return baseName + "_" + combinedHash; // add hash to avoid conflicts
     }
 
     // Generate a default model config based on evaluator options.

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -10,7 +10,6 @@ import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.vespa.defaults.Defaults;
 import inference.ModelConfigOuterClass;
-import org.apache.commons.io.FilenameUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -98,9 +97,10 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
     }
     
     static String createModelName(String modelPath, OnnxEvaluatorOptions options) {
-        var fileName = FilenameUtils.getBaseName(modelPath);
-        var modelHash = ModelPathOrData.of(modelPath).calculateHash(); // added hash to avoid conflicts
-        return fileName + "_" + modelHash;
+        var fileName = Paths.get(modelPath).getFileName().toString();
+        var baseName = fileName.substring(0, fileName.lastIndexOf('.')); // remove file extension
+        var modelHash = ModelPathOrData.of(modelPath).calculateHash();
+        return baseName + "_" + modelHash; // add hash to avoid conflicts
     }
 
     // Generate a default model config based on evaluator options.

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -5,10 +5,12 @@ import ai.vespa.llm.clients.TritonConfig;
 import ai.vespa.modelintegration.evaluator.OnnxEvaluator;
 import ai.vespa.modelintegration.evaluator.OnnxEvaluatorOptions;
 import ai.vespa.modelintegration.evaluator.OnnxRuntime;
+import ai.vespa.modelintegration.utils.ModelPathOrData;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.vespa.defaults.Defaults;
 import inference.ModelConfigOuterClass;
+import org.apache.commons.io.FilenameUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -42,11 +44,18 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
 
     @Override
     public OnnxEvaluator evaluatorOf(String modelPath, OnnxEvaluatorOptions options) {
-        if (!client.isHealthy())
+        if (!client.isHealthy()) {
             throw new IllegalStateException("Triton server is not healthy! (target=%s)".formatted(config.target()));
+        }
+
+        var modelName = createModelName(modelPath, options);
         var isExplicitControlMode = config.modelControlMode() == TritonConfig.ModelControlMode.EXPLICIT;
-        if (isExplicitControlMode) copyModelToRepository(modelPath, options);
-        return new TritonOnnxEvaluator(client, modelName(modelPath), isExplicitControlMode);
+        
+        if (isExplicitControlMode) {
+            copyModelToRepository(modelName, modelPath, options);
+        }
+        
+        return new TritonOnnxEvaluator(client, modelName, isExplicitControlMode);
     }
 
     @Override
@@ -55,10 +64,9 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
     }
 
     /** Copies the model file to the model repository and serializes the config */
-    private void copyModelToRepository(String externalModelPath, OnnxEvaluatorOptions options) {
+    private void copyModelToRepository(String modelName, String externalModelPath, OnnxEvaluatorOptions options) {
         var modelRepositoryPath = Defaults.getDefaults().underVespaHome(config.modelRepositoryPath());
-        var modelBasePath = Paths.get(modelRepositoryPath, modelName(externalModelPath));
-        
+        var modelBasePath = Paths.get(modelRepositoryPath, modelName);
         var modelVersionPath = modelBasePath.resolve("1");
         var modelFilePath = modelVersionPath.resolve("model.onnx");
         var modelConfigPath = modelBasePath.resolve("config.pbtxt");
@@ -71,7 +79,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
 
             Files.copy(Paths.get(externalModelPath), modelFilePath, StandardCopyOption.REPLACE_EXISTING);
             var modelConfig = options.rawConfig()
-                    .orElseGet(() -> generateConfigFromEvaluatorOptions(externalModelPath, options).toString());
+                    .orElseGet(() -> generateConfigFromEvaluatorOptions(modelName, options).toString());
             Files.writeString(modelConfigPath, modelConfig);
 
             // To ensure that the Triton can read the model files, explicitly grant world read
@@ -88,18 +96,17 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         modelPerms.add(PosixFilePermission.OTHERS_READ);
         Files.setPosixFilePermissions(path, modelPerms);
     }
-
-    // Hackish name to deduce model name from path.
-    // It should ideally include a suffix based on the model's hash/timestamp/file size to avoid conflicts
-    static String modelName(String modelPath) {
-        var name = modelPath.substring(modelPath.lastIndexOf('/') + 1);
-        return name.substring(0, name.lastIndexOf('.'));
+    
+    static String createModelName(String modelPath, OnnxEvaluatorOptions options) {
+        var fileName = FilenameUtils.getBaseName(modelPath);
+        var modelHash = ModelPathOrData.of(modelPath).calculateHash(); // added hash to avoid conflicts
+        return fileName + "_" + modelHash;
     }
 
     // Generate a default model config based on evaluator options.
     // These are not necqessarily optimal but should closely match the effective configuration for the embedded ONNX runtime.
     private static ModelConfigOuterClass.ModelConfig generateConfigFromEvaluatorOptions(
-            String modelPaths, OnnxEvaluatorOptions options) {
+            String modelName,OnnxEvaluatorOptions options) {
         // Similar to EmbeddedOnnxRuntime.overrideOptions(), relies on Triton to fall back to CPU if GPU is not available.
         var kind = options.gpuDeviceRequired()
                 ? ModelConfigOuterClass.ModelInstanceGroup.Kind.KIND_GPU
@@ -107,13 +114,13 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
                         ? ModelConfigOuterClass.ModelInstanceGroup.Kind.KIND_AUTO
                         : ModelConfigOuterClass.ModelInstanceGroup.Kind.KIND_CPU;
         return ModelConfigOuterClass.ModelConfig.newBuilder()
-                .setName(modelName(modelPaths))
+                .setName(modelName)
                 .addInstanceGroup(ModelConfigOuterClass.ModelInstanceGroup.newBuilder()
                         .setCount(1)
                         .setKind(kind)
                         .build())
                 .setPlatform("onnxruntime_onnx")
-                .setMaxBatchSize(1) // No batching for now.
+                .setMaxBatchSize(1)
                 .putParameters("enable_mem_area", ModelConfigOuterClass.ModelParameter.newBuilder()
                         .setStringValue("0")
                         .build())

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -42,7 +42,7 @@ class TritonOnnxRuntimeTest {
                         .build());
 
         var modelBaseName = "dummy_transformer";
-        var modelHash = "3100035948148863490";
+        var modelHash = "ed9202701f4a70a9";
         var testModelFilePath = String.format("src/test/models/onnx/transformer/%s.onnx", modelBaseName);
         var testModelConfigPath = "src/test/triton/config.pbtxt";
         var modelName = String.format("%s_%s", modelBaseName, modelHash);

--- a/model-integration/src/test/triton/config.pbtxt
+++ b/model-integration/src/test/triton/config.pbtxt
@@ -1,4 +1,4 @@
-name: "dummy_transformer"
+name: "dummy_transformer_3100035948148863490"
 platform: "onnxruntime_onnx"
 max_batch_size: 1
 instance_group {

--- a/model-integration/src/test/triton/config.pbtxt
+++ b/model-integration/src/test/triton/config.pbtxt
@@ -1,4 +1,4 @@
-name: "dummy_transformer_3100035948148863490"
+name: "dummy_transformer_ed9202701f4a70a9"
 platform: "onnxruntime_onnx"
 max_batch_size: 1
 instance_group {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adds hash to model name in triton.
Moved ModelPathOrData outside EmbeddedOnnxRuntime to use it in TritonOnnxRuntime as well.
