### PR TITLE
Throw exception if using deploy attribute with 'include' preprocessin…

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/application/IncludeProcessor.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/IncludeProcessor.java
@@ -50,6 +50,8 @@ class IncludeProcessor implements PreProcessor {
             boolean required = ! elem.hasAttribute("required") || Boolean.parseBoolean(elem.getAttribute("required"));
             FileWrapper file = currentFolder.child(filename);
 
+            ckeckForDeployAttributeInsideInclude(elem, filename);
+
             Document subFile = IncludeProcessor.parseIncludeFile(file, parent.getTagName(), required);
             includeFile(file.parent().orElseThrow(() -> new NoSuchElementException(file + " has no parent")),
                         subFile.getDocumentElement());
@@ -60,6 +62,19 @@ class IncludeProcessor implements PreProcessor {
             parent.removeChild(elem);
             //System.out.println("document after removing child: " + documentAsString(doc));
             list = currentElement.getElementsByTagNameNS(XmlPreProcessor.preprocessNamespaceUri, "include");
+        }
+    }
+
+    private static void ckeckForDeployAttributeInsideInclude(Element elem, String filename) {
+        var attributes = elem.getAttributes();
+        for (int i=0; i < attributes.getLength(); i++) {
+            var item = attributes.item(i);
+            String nodeName = item.getNodeName();
+            if (nodeName.startsWith("deploy:")) {
+                throw new IllegalArgumentException("Using '"  + nodeName +
+                                                   "' within a 'preprocess:include' is not supported: 'preprocess:include file=" +
+                                                   filename + ", please use " + nodeName + " in the included file instead");
+            }
         }
     }
 

--- a/config-application-package/src/test/java/com/yahoo/config/application/XmlPreprocessorTest.java
+++ b/config-application-package/src/test/java/com/yahoo/config/application/XmlPreprocessorTest.java
@@ -12,6 +12,9 @@ import org.w3c.dom.Document;
 import java.io.File;
 import java.io.StringReader;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * @author hmusum
  */
@@ -310,6 +313,26 @@ public class XmlPreprocessorTest {
                                                Cloud.defaultCloud().name(),
                                                Tags.empty()).run());
         TestBase.assertDocument(expectedProd, docDev);
+    }
+
+    @Test
+    public void testIncludeWithDeployEnvironment() throws Exception {
+        var appDir = new File("src/test/resources/multienv-with-include");
+        var services = new File(appDir, "services.xml");
+
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+                new XmlPreProcessor(appDir,
+                                    services,
+                                    InstanceName.defaultName(),
+                                    Environment.prod,
+                                    RegionName.defaultName(),
+                                    Cloud.defaultCloud()
+                                         .name(),
+                                    Tags.empty()).run());
+        assertEquals("Using 'deploy:environment' within a 'preprocess:include' is not supported: " +
+                     "'preprocess:include file=container-dev.xml, please use " +
+                     "deploy:environment in the included file instead",
+                     exception.getMessage());
     }
 
 }

--- a/config-application-package/src/test/resources/multienv-with-include/container-dev.xml
+++ b/config-application-package/src/test/resources/multienv-with-include/container-dev.xml
@@ -1,0 +1,3 @@
+<container id="dev" version="1.0">
+    <nodes count="2" />
+</container>

--- a/config-application-package/src/test/resources/multienv-with-include/container-prod.xml
+++ b/config-application-package/src/test/resources/multienv-with-include/container-prod.xml
@@ -1,0 +1,3 @@
+<container id="prod" version="1.0">
+    <nodes count="2" />
+</container>

--- a/config-application-package/src/test/resources/multienv-with-include/services.xml
+++ b/config-application-package/src/test/resources/multienv-with-include/services.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<services version="1.0" xmlns:deploy="vespa" xmlns:preprocess="properties">
+    <preprocess:include deploy:environment="dev" file="container-dev.xml" />
+    <preprocess:include deploy:environment="prod" file="container-prod.xml" />
+</services>


### PR DESCRIPTION
…g statement

We don't handle `include` with `deploy:` attributes, throw an exception and suggest workaround
