### PR TITLE
Fix locale-dependent failure in XmlReadingTestCase

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -203,12 +204,17 @@ public class XmlReadingTestCase {
 
     @Test
     void testInvalid2() {
+        Locale defaultLocale = Locale.getDefault();
         try {
+            Locale.setDefault(Locale.ENGLISH);
             new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/invalidxml2");
             fail("Should have failed");
         }
         catch (IllegalArgumentException e) {
             assertEquals("Could not parse 'unparseable.xml', error at line 2, column 21: Element type \"query-profile\" must be followed by either attribute specifications, \">\" or \"/>\".", Exceptions.toMessageString(e));
+        }
+        finally {
+            Locale.setDefault(defaultLocale);
         }
     }
 


### PR DESCRIPTION
**Describe the bug**
When `XmlReadingTestCase.testInvalid2` is executed under a non‑English locale, the XML parser’s exception message becomes localized.
As a result, the JUnit assertion that compares the expected English message fails.
This makes the test result depend on the JVM’s default locale.

Failure example(Japanese locale):
```
[ERROR] Failures:
[ERROR]   XmlReadingTestCase.testInvalid2:211 expected: <Could not parse 'unparseable.xml', error at line 2, column 21: Element type "query-profile" must be followed by either attribute specifications, ">" or "/>".> but was: <Could not parse 'unparseable.xml', error at line 2, column 21: 要素タイプ"query-profile"の後には、属性指定">"または"/>"が必要です。>
[INFO]
[ERROR] Tests run: 2510, Failures: 1, Errors: 0, Skipped: 16
```


**To Reproduce**
1. Set your JVM default locale to non-English locale, for example Japanese:
```
export JAVA_TOOL_OPTIONS="-Duser.language=ja -Duser.country=JP"
```
2. Run the specific test:
```
(container-search)
mvn clean test -Dtest=XmlReadingTestCase
```


**Expected behavior**
The test should produce consistent results regardless of the system locale by always asserting against the same (English) parser error message.
This ensures reproducible behavior both locally and in CI environments.

**Environment:**
- OS: macOS
- JVM locale: `ja_JP` (default)