### PR TITLE
Reapply "Add `ContainerThreadpool` to docproc handler"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainsBuilder.java
@@ -6,6 +6,7 @@ import com.yahoo.config.model.producer.AnyConfigProducer;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainsBuilder;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.docproc.DocprocChain;
 import com.yahoo.vespa.model.container.docproc.DocprocChains;
 import com.yahoo.vespa.model.container.docproc.DocumentProcessor;
@@ -19,14 +20,17 @@ import java.util.Map;
  * @author gjoranv
  */
 public class DomDocprocChainsBuilder  extends DomChainsBuilder<DocumentProcessor, DocprocChain, DocprocChains> {
-    public DomDocprocChainsBuilder(Element outerChainsElem, boolean supportDocprocChainsDir) {
+    private final ContainerThreadpool docProcHandlerThreadpool;
+
+    public DomDocprocChainsBuilder(Element outerChainsElem, boolean supportDocprocChainsDir, ContainerThreadpool docProcHandlerThreadpool) {
         super(List.of(ComponentType.documentprocessor)
         );
+        this.docProcHandlerThreadpool = docProcHandlerThreadpool;
     }
 
     @Override
     protected DocprocChains newChainsInstance(TreeConfigProducer<AnyConfigProducer> parent) {
-        return new DocprocChains(parent, "docprocchains");
+        return new DocprocChains(parent, "docprocchains", docProcHandlerThreadpool);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/ContainerDocproc.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/ContainerDocproc.java
@@ -4,12 +4,16 @@ package com.yahoo.vespa.model.container.docproc;
 import com.yahoo.collections.Pair;
 import com.yahoo.config.docproc.DocprocConfig;
 import com.yahoo.config.docproc.SchemamappingConfig;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.container.jdisc.ContainerMbusConfig;
 import com.yahoo.container.jdisc.config.SessionConfig;
 import com.yahoo.docproc.jdisc.messagebus.MbusRequestContext;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.component.ContainerSubsystem;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
+import org.w3c.dom.Element;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +34,7 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
         this(cluster, chains, Options.empty());
     }
 
-    public ContainerDocproc(ContainerCluster<?> cluster, DocprocChains chains, Options options) {
+    private ContainerDocproc(ContainerCluster<?> cluster, DocprocChains chains, Options options) {
         this(cluster, chains, options, true);
     }
 
@@ -112,6 +116,7 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
 
     public static class Options {
 
+        public final Element threadpoolXml;
         public final Integer maxMessagesInQueue;
         public final Integer maxQueueTimeMs;
 
@@ -119,7 +124,8 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
         public final Double documentExpansionFactor;
         public final Integer containerCoreMemory;
 
-        public Options(Integer maxMessagesInQueue, Integer maxQueueTimeMs, Double maxConcurrentFactor, Double documentExpansionFactor, Integer containerCoreMemory) {
+        public Options(Integer maxMessagesInQueue, Integer maxQueueTimeMs, Double maxConcurrentFactor, Double documentExpansionFactor, Integer containerCoreMemory, Element threadpoolXml) {
+            this.threadpoolXml = threadpoolXml;
             this.maxMessagesInQueue = maxMessagesInQueue;
             this.maxQueueTimeMs = maxQueueTimeMs;
             this.maxConcurrentFactor = maxConcurrentFactor;
@@ -127,7 +133,27 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
             this.containerCoreMemory = containerCoreMemory;
         }
 
-        static Options empty() { return new Options(null, null, null, null, null); }
+        static Options empty() { return new Options(null, null, null, null, null, null); }
+
+    }
+
+    public static class Threadpool extends ContainerThreadpool {
+
+        private final double threads;
+
+        public Threadpool(DeployState ds, Element options) {
+            super(ds, "docproc-handler", options);
+            threads = ds.featureFlags().docprocHandlerThreadpool();
+        }
+
+        @Override
+        public void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder) {
+            builder.maxThreadExecutionTimeSeconds(190)
+                    .keepAliveTime(5.0)
+                    .relativeMaxThreads(threads)
+                    .relativeMinThreads(threads)
+                    .queueSize(Integer.MAX_VALUE);
+        }
 
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
@@ -9,6 +9,7 @@ import com.yahoo.docproc.jdisc.observability.DocprocsStatusExtension;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
@@ -25,11 +26,12 @@ public class DocprocChains extends Chains<DocprocChain> {
 
     private final ProcessingHandler<DocprocChains> docprocHandler;
 
-    public DocprocChains(TreeConfigProducer<? super Chains> parent, String subId) {
+    public DocprocChains(TreeConfigProducer<? super Chains> parent, String subId, ContainerThreadpool docprocHandlerThreadpool) {
         super(parent, subId);
         docprocHandler = new ProcessingHandler<>(
                 this,
-                BundleInstantiationSpecification.fromSearchAndDocproc("com.yahoo.docproc.jdisc.DocumentProcessingHandler"));
+                BundleInstantiationSpecification.fromSearchAndDocproc("com.yahoo.docproc.jdisc.DocumentProcessingHandler"),
+                docprocHandlerThreadpool);
         addComponent(docprocHandler);
         addComponent(new SimpleComponent(
                 new ComponentModel(DocprocsStatusExtension.class.getName(), null, PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE)));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -71,6 +71,7 @@ import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.ContainerModelEvaluation;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.DataplaneProxy;
 import com.yahoo.vespa.model.container.IdentityProvider;
 import com.yahoo.vespa.model.container.PlatformBundles;
@@ -1352,8 +1353,9 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         if (docprocElement == null)
             return null;
 
+        ContainerThreadpool docprocHandlerThreadpool = new ContainerDocproc.Threadpool(deployState, docprocElement);
         addIncludes(docprocElement);
-        DocprocChains chains = new DomDocprocChainsBuilder(null, false).build(deployState, cluster, docprocElement);
+        DocprocChains chains = new DomDocprocChainsBuilder(null, false, docprocHandlerThreadpool).build(deployState, cluster, docprocElement);
 
         ContainerDocproc.Options docprocOptions = DocprocOptionsBuilder.build(docprocElement, deployState.getDeployLogger());
         return new ContainerDocproc(cluster, chains, docprocOptions, !standaloneBuilder);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/DocprocOptionsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/DocprocOptionsBuilder.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.container.xml;
 
 import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.text.XML;
 import com.yahoo.vespa.model.container.docproc.ContainerDocproc;
 import org.w3c.dom.Element;
 import java.util.Set;
@@ -16,7 +17,8 @@ public class DocprocOptionsBuilder {
                 getTime(spec.getAttribute("maxqueuewait")),
                 getFactor(spec.getAttribute("maxconcurrentfactor")),
                 getFactor(spec.getAttribute("documentexpansionfactor")),
-                getInt(spec.getAttribute("containercorememory")));
+                getInt(spec.getAttribute("containercorememory")),
+                XML.getChild(spec, "threadpool"));
     }
 
     private static Integer getInt(String integer) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -239,7 +239,7 @@ public class Content extends ConfigModel {
                 if (targetCluster == null)
                     targetCluster = content.containers.iterator().next().getCluster();
 
-                addDocproc(targetCluster);
+                addDocproc(targetCluster, modelContext.getDeployState());
                 indexingCluster.setClusterName(targetCluster.getName());
                 addIndexingChainsTo(targetCluster, content, indexingCluster);
             }
@@ -318,7 +318,7 @@ public class Content extends ConfigModel {
             indexingCluster.addDefaultHandlersWithVip();
             indexingCluster.addAllPlatformBundles();
             indexingCluster.addAccessLog();
-            addDocproc(indexingCluster);
+            addDocproc(indexingCluster, modelContext.getDeployState());
 
             List<ApplicationContainer> nodes = new ArrayList<>();
             int index = 0;
@@ -350,9 +350,10 @@ public class Content extends ConfigModel {
             return null;
         }
 
-        private void addDocproc(ContainerCluster<?> cluster) {
+        private void addDocproc(ContainerCluster<?> cluster, DeployState deployState) {
             if (cluster.getDocproc() == null) {
-                DocprocChains chains = new DocprocChains(cluster, "docprocchains");
+                DocprocChains chains = new DocprocChains(cluster, "docprocchains",
+                        new ContainerDocproc.Threadpool(deployState, null));
                 ContainerDocproc containerDocproc = new ContainerDocproc(cluster, chains);
                 cluster.setDocproc(containerDocproc);
             }

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -211,7 +211,11 @@ DocprocInContainer = element document-processing {
     DocprocClusterAttributes? &
     DocumentProcessorV3* &
     ChainInDocprocInContainerCluster* &
-    GenericConfig*
+    GenericConfig*  &
+    element threadpool {
+        element threads { xsd:double { minExclusive = "0.0" } }? &
+        element queue { xsd:double { minInclusive = "0.0" } }?
+    }?
 }
 ChainInDocprocInContainerCluster = element chain {
     DocprocChainV3Contents

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/DocprocBuilderTest.java
@@ -65,6 +65,10 @@ public class DocprocBuilderTest extends DomBuilderTest {
                 "    <chain id='chein'>",
                 "      <documentprocessor id='docproc2'/>",
                 "    </chain>",
+                "    <threadpool>",
+                "      <threads>0.5</threads>",
+                "      <queue>1</queue>",
+                "    </threadpool>",
                 "  </document-processing>",
                 "</container>");
     }
@@ -136,6 +140,11 @@ public class DocprocBuilderTest extends DomBuilderTest {
         assertNotNull(intermediateClient);
         assertEquals("com.yahoo.container.jdisc.messagebus.MbusClientProvider", intermediateClient.classId());
         assertEquals("com.yahoo.container.jdisc.messagebus.MbusClientProvider", intermediateClient.bundle());
+
+        ComponentsConfig.Components threadpool = components.get("threadpool@docproc-handler");
+        assertNotNull(threadpool);
+        assertEquals("com.yahoo.container.handler.threadpool.ContainerThreadpoolImpl", threadpool.classId());
+        assertEquals("com.yahoo.container.handler.threadpool.ContainerThreadpoolImpl", threadpool.bundle());
     }
 
     @Test

--- a/config-model/src/test/schema-test-files/services.xml
+++ b/config-model/src/test/schema-test-files/services.xml
@@ -254,6 +254,10 @@
           </config>
         </documentprocessor>
       </chain>
+      <threadpool>
+        <threads>2.5</threads>
+        <queue>2.5</queue>
+      </threadpool>
     </document-processing>
 
   </container>

--- a/container-core/src/main/java/com/yahoo/container/handler/threadpool/ContainerThreadpoolImpl.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/threadpool/ContainerThreadpoolImpl.java
@@ -10,6 +10,7 @@ import com.yahoo.jdisc.Metric;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -75,7 +76,7 @@ public class ContainerThreadpoolImpl extends AbstractComponent implements AutoCl
         int minThreads = minThreads(config, cpus, hasRelThreads);
         int queueSize = queueSize(config, maxThreads, hasRelQueueSize);
 
-        log.config(String.format("Threadpool '%s': min=%d, max=%d, queue=%d", name, minThreads, maxThreads, queueSize));
+        log.config(String.format("Threadpool '%s': min=%d, max=%d, queue=%s", name, minThreads, maxThreads, queueSizeToString(queueSize)));
 
         ThreadPoolMetric threadPoolMetric = new ThreadPoolMetric(metric, name);
         WorkerCompletionTimingThreadPoolExecutor executor =
@@ -118,7 +119,12 @@ public class ContainerThreadpoolImpl extends AbstractComponent implements AutoCl
         }
     }
 
+    /** For the components requiring infinite queue, they must specify Integer.MAX_VALUE */
     private static BlockingQueue<Runnable> createQueue(int size) {
+        if (size == Integer.MAX_VALUE) {
+            return new LinkedBlockingQueue<>();
+        }
+
         return size == 0 ? new SynchronousQueue<>(false) : new ArrayBlockingQueue<>(size);
     }
 
@@ -154,6 +160,13 @@ public class ContainerThreadpoolImpl extends AbstractComponent implements AutoCl
                 c.relativeMinThreads(), c.relativeMaxThreads(), c.relativeQueueSize(),
                 cpus
         );
+    }
+
+    private String queueSizeToString(int queueSize) {
+        if (queueSize == Integer.MAX_VALUE) {
+            return "unlimited";
+        }
+        return Integer.toString(queueSize);
     }
 
 }

--- a/docproc/src/main/java/com/yahoo/docproc/impl/DocprocService.java
+++ b/docproc/src/main/java/com/yahoo/docproc/impl/DocprocService.java
@@ -4,6 +4,7 @@ package com.yahoo.docproc.impl;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.ComponentId;
 import com.yahoo.concurrent.DaemonThreadFactory;
+import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.docproc.CallStack;
 import com.yahoo.docproc.DocumentProcessor;
 import com.yahoo.docproc.Processing;
@@ -12,6 +13,7 @@ import com.yahoo.document.DocumentOperation;
 import com.yahoo.document.DocumentTypeManager;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -40,7 +42,7 @@ public class DocprocService extends AbstractComponent {
 
     /** The processings currently in progress at this service */
     private final LinkedBlockingQueue<Processing> queue;
-    private final ThreadPoolExecutor threadPool;
+    private final ContainerThreadPool threadPool;
     /** The current state of this service */
     private boolean inService = false;
     /** The current state of this service */
@@ -48,18 +50,10 @@ public class DocprocService extends AbstractComponent {
     public static SchemaMap schemaMap = new SchemaMap();
     private DocumentTypeManager documentTypeManager = null;
 
-    private DocprocService(ComponentId id, int numThreads) {
+    private DocprocService(ComponentId id, ContainerThreadPool threadPool) {
         super(id);
         queue = new LinkedBlockingQueue<>();
-        threadPool = new ThreadPoolExecutor(numThreads,
-                numThreads,
-                0, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<>(),
-                new DaemonThreadFactory("docproc-" + id.stringValue() + "-"));
-    }
-
-    public DocprocService(ComponentId id) {
-        this(id, Runtime.getRuntime().availableProcessors());
+        this.threadPool = threadPool;
     }
 
     /**
@@ -68,10 +62,10 @@ public class DocprocService extends AbstractComponent {
      * @param id the component id of the new service.
      * @param stack the call stack to use.
      * @param mgr the document type manager to use.
-     * @param numThreads to have in the thread pool
+     * @param threadPool thread pool to use.
      */
-    public DocprocService(ComponentId id, CallStack stack, DocumentTypeManager mgr, int numThreads) {
-        this(id, numThreads);
+    public DocprocService(ComponentId id, CallStack stack, DocumentTypeManager mgr, ContainerThreadPool threadPool) {
+        this(id, threadPool);
         setCallStack(stack);
         setDocumentTypeManager(mgr);
         setInService(true);
@@ -82,13 +76,13 @@ public class DocprocService extends AbstractComponent {
      * it will become the name "default".
      * Testing only
      */
-    public DocprocService(String name) {
-        this(new ComponentId(name, null), 1);
+    public DocprocService(String name, ContainerThreadPool threadpool) {
+        this(new ComponentId(name, null), threadpool);
     }
 
     @Override
     public void deconstruct() {
-        threadPool.shutdown();
+        threadPool.close();
     }
 
     public DocumentTypeManager getDocumentTypeManager() {
@@ -113,8 +107,8 @@ public class DocprocService extends AbstractComponent {
         return executor;
     }
 
-    public ThreadPoolExecutor getThreadPoolExecutor() {
-        return threadPool;
+    public Executor getThreadPoolExecutor() {
+        return threadPool.executor();
     }
 
     private void setExecutor(DocprocExecutor executor) {

--- a/docproc/src/main/java/com/yahoo/docproc/impl/DocprocService.java
+++ b/docproc/src/main/java/com/yahoo/docproc/impl/DocprocService.java
@@ -3,7 +3,6 @@ package com.yahoo.docproc.impl;
 
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.ComponentId;
-import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.docproc.CallStack;
 import com.yahoo.docproc.DocumentProcessor;
@@ -16,8 +15,6 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -78,11 +75,6 @@ public class DocprocService extends AbstractComponent {
      */
     public DocprocService(String name, ContainerThreadPool threadpool) {
         this(new ComponentId(name, null), threadpool);
-    }
-
-    @Override
-    public void deconstruct() {
-        threadPool.close();
     }
 
     public DocumentTypeManager getDocumentTypeManager() {

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
@@ -10,6 +10,7 @@ import com.yahoo.config.docproc.DocprocConfig;
 import com.yahoo.config.docproc.SchemamappingConfig;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.core.document.ContainerDocumentConfig;
+import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.docproc.AbstractConcreteDocumentFactory;
 import com.yahoo.docproc.CallStack;
 import com.yahoo.docproc.impl.DocprocService;
@@ -53,11 +54,11 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
     private DocumentProcessingHandler(ComponentRegistry<DocprocService> docprocServiceRegistry,
                                       ComponentRegistry<DocumentProcessor> documentProcessorComponentRegistry,
                                       ComponentRegistry<AbstractConcreteDocumentFactory> docFactoryRegistry,
-                                      int numThreads,
                                       DocumentTypeManager documentTypeManager,
                                       ChainsModel chainsModel, SchemaMap schemaMap,
                                       Metric metric,
-                                      ContainerDocumentConfig containerDocConfig) {
+                                      ContainerDocumentConfig containerDocConfig,
+                                      ContainerThreadPool threadPool) {
         this.docprocServiceRegistry = docprocServiceRegistry;
         this.docFactoryRegistry = docFactoryRegistry;
         this.containerDocConfig = containerDocConfig;
@@ -71,26 +72,22 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
 
             for (Chain<DocumentProcessor> chain : chainRegistry.allComponents()) {
                 log.config("Setting up call stack for chain " + chain.getId());
-                DocprocService service = new DocprocService(chain.getId(), convertToCallStack(chain, metric), documentTypeManager, computeNumThreads(numThreads));
+                DocprocService service = new DocprocService(chain.getId(), convertToCallStack(chain, metric), documentTypeManager, threadPool);
                 service.setInService(true);
                 docprocServiceRegistry.register(service.getId(), service);
             }
         }
     }
 
-    private static int computeNumThreads(int maxThreads) {
-        return (maxThreads > 0) ? maxThreads : Runtime.getRuntime().availableProcessors();
-    }
-
     DocumentProcessingHandler(ComponentRegistry<DocprocService> docprocServiceRegistry,
                               ComponentRegistry<DocumentProcessor> documentProcessorComponentRegistry,
                               ComponentRegistry<AbstractConcreteDocumentFactory> docFactoryRegistry,
-                              DocumentProcessingHandlerParameters params) {
+                              DocumentProcessingHandlerParameters params,
+                              ContainerThreadPool threadPool) {
         this(docprocServiceRegistry, documentProcessorComponentRegistry, docFactoryRegistry,
-             params.getMaxNumThreads(),
              params.getDocumentTypeManager(), params.getChainsModel(), params.getSchemaMap(),
              params.getMetric(),
-             params.getContainerDocConfig());
+             params.getContainerDocConfig(), threadPool);
     }
 
     @Inject
@@ -101,7 +98,8 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                                      DocumentTypeManager documentTypeManager,
                                      DocprocConfig docprocConfig,
                                      ContainerDocumentConfig containerDocConfig,
-                                     Metric metric) {
+                                     Metric metric,
+                                     ContainerThreadPool threadPool) {
         this(new ComponentRegistry<>(),
              documentProcessorComponentRegistry, docFactoryRegistry,
                 new DocumentProcessingHandlerParameters()
@@ -109,7 +107,8 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                      .setDocumentTypeManager(documentTypeManager)
                      .setChainsModel(buildFromConfig(chainsConfig)).setSchemaMap(configureMapping(mappingConfig))
                      .setMetric(metric)
-                     .setContainerDocumentConfig(containerDocConfig));
+                     .setContainerDocumentConfig(containerDocConfig),
+                threadPool);
         docprocServiceRegistry.freeze();
     }
 

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingTask.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingTask.java
@@ -16,6 +16,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.logging.Level;
@@ -34,10 +35,10 @@ public class DocumentProcessingTask implements Runnable {
     private final RequestContext requestContext;
 
     private final DocprocService service;
-    private final ThreadPoolExecutor executor;
+    private final Executor executor;
 
     public DocumentProcessingTask(RequestContext requestContext, DocumentProcessingHandler docprocHandler,
-                                  DocprocService service, ThreadPoolExecutor executor) {
+                                  DocprocService service, Executor executor) {
         this.requestContext = requestContext;
         this.docprocHandler = docprocHandler;
         this.service = service;

--- a/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
+++ b/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
@@ -4,6 +4,7 @@ namespace=config.docproc
 # Depreacated and a noop
 maxqueuetimems int default=-1
 
+# TODO remove in Vespa 9
 # The number of threads in the DocprocHandler worker thread pool
-# Default is number of cpu's, but any positive number larger than 0 will be used explicit.
+# numthreads no longer has an effect.
 numthreads int default=-1

--- a/docproc/src/test/java/com/yahoo/docproc/CallbackTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/CallbackTestCase.java
@@ -29,7 +29,7 @@ public class CallbackTestCase {
 
     @Before
     public void setUp() {
-        service = new DocprocService("callback");
+        service = new DocprocService("callback", new SimpleContainerThreadPool());
         service.setCallStack(new CallStack().addNext(new TestCallbackDp()));
         service.setInService(true);
 

--- a/docproc/src/test/java/com/yahoo/docproc/EmptyProcessingTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/EmptyProcessingTestCase.java
@@ -11,7 +11,7 @@ public class EmptyProcessingTestCase {
 
     @Test
     public void emptyProcessing() {
-        DocprocService service = new DocprocService("juba");
+        DocprocService service = new DocprocService("juba", new SimpleContainerThreadPool());
         DocumentProcessor processor = new IncrementingDocumentProcessor();
         CallStack stack = new CallStack("juba");
         stack.addLast(processor);

--- a/docproc/src/test/java/com/yahoo/docproc/FailingDocumentProcessingTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/FailingDocumentProcessingTestCase.java
@@ -26,7 +26,7 @@ public class FailingDocumentProcessingTestCase {
     @Test
     public void testFailingProcessing() {
         // Set up service programmatically
-        DocprocService service = new DocprocService("failing");
+        DocprocService service = new DocprocService("failing", new SimpleContainerThreadPool());
         DocumentProcessor first = new SettingValueProcessor("done 1");
         DocumentProcessor second = new FailingProcessor("done 2");
         DocumentProcessor third = new SettingValueProcessor("done 3");

--- a/docproc/src/test/java/com/yahoo/docproc/FailingDocumentProcessingWithoutExceptionTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/FailingDocumentProcessingWithoutExceptionTestCase.java
@@ -26,7 +26,7 @@ public class FailingDocumentProcessingWithoutExceptionTestCase {
     @Test
     public void testFailingProcessing() {
         // Set up service programmatically
-        DocprocService service = new DocprocService("failing-no-exception");
+        DocprocService service = new DocprocService("failing-no-exception", new SimpleContainerThreadPool());
         DocumentProcessor first = new SettingValueProcessor("done 1");
         DocumentProcessor second = new FailingProcessor("done 2");
         DocumentProcessor third = new SettingValueProcessor("done 3");

--- a/docproc/src/test/java/com/yahoo/docproc/FailingPermanentlyDocumentProcessingTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/FailingPermanentlyDocumentProcessingTestCase.java
@@ -29,7 +29,7 @@ public class FailingPermanentlyDocumentProcessingTestCase {
     @Test
     public void testFailingProcessing() {
         // Set up service programmatically
-        DocprocService service = new DocprocService("failing-permanently");
+        DocprocService service = new DocprocService("failing-permanently", new SimpleContainerThreadPool());
         DocumentProcessor first = new SettingValueProcessor("done 1");
         DocumentProcessor second = new FailingProcessor("done 2");
         DocumentProcessor third = new SettingValueProcessor("done 3");

--- a/docproc/src/test/java/com/yahoo/docproc/FailingWithErrorTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/FailingWithErrorTestCase.java
@@ -18,7 +18,7 @@ public class FailingWithErrorTestCase {
 
     @Test
     public void testErrors() {
-        DocprocService service = new DocprocService("failing");
+        DocprocService service = new DocprocService("failing", new SimpleContainerThreadPool());
         DocumentProcessor first = new ErrorThrowingProcessor();
         service.setCallStack(new CallStack().addLast(first));
         service.setInService(true);

--- a/docproc/src/test/java/com/yahoo/docproc/NotAcceptingNewProcessingsTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/NotAcceptingNewProcessingsTestCase.java
@@ -14,7 +14,7 @@ public class NotAcceptingNewProcessingsTestCase {
 
     @Test
     public void testNotAccepting() {
-        DocprocService service = new DocprocService("habla");
+        DocprocService service = new DocprocService("habla", new SimpleContainerThreadPool());
         service.setCallStack(new CallStack());
         service.setInService(true);
 

--- a/docproc/src/test/java/com/yahoo/docproc/ProcessingUpdateTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/ProcessingUpdateTestCase.java
@@ -51,7 +51,7 @@ public class ProcessingUpdateTestCase {
         update = new DocumentUpdate(articleType, new DocumentId("id:grape:article::2"));
         update.addFieldUpdate(upd);
 
-        DocprocService service = new DocprocService("update");
+        DocprocService service = new DocprocService("update", new SimpleContainerThreadPool());
         DocumentProcessor firstP = new TitleDocumentProcessor();
         service.setCallStack(new CallStack().addLast(firstP));
         service.setInService(true);

--- a/docproc/src/test/java/com/yahoo/docproc/SimpleContainerThreadPool.java
+++ b/docproc/src/test/java/com/yahoo/docproc/SimpleContainerThreadPool.java
@@ -1,0 +1,20 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.docproc;
+
+import com.yahoo.container.handler.threadpool.ContainerThreadPool;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Simple {@link ContainerThreadPool} for testing.
+ *
+ * @author johsol
+ */
+public class SimpleContainerThreadPool implements ContainerThreadPool {
+
+    private final Executor executor = Executors.newCachedThreadPool();
+
+    @Override public Executor executor() { return executor; }
+
+}

--- a/docproc/src/test/java/com/yahoo/docproc/SimpleDocumentProcessingTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/SimpleDocumentProcessingTestCase.java
@@ -23,7 +23,7 @@ public class SimpleDocumentProcessingTestCase extends DocumentProcessingAbstract
     @Test
     public void testSimpleProcessing() {
         // Set up service programmatically
-        DocprocService service = new DocprocService("simple");
+        DocprocService service = new DocprocService("simple", new SimpleContainerThreadPool());
         DocumentProcessor first = new TestDocumentProcessor1();
         DocumentProcessor second = new TestDocumentProcessor2();
         DocumentProcessor third = new TestDocumentProcessor3();

--- a/docproc/src/test/java/com/yahoo/docproc/SimpleDocumentProcessorTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/SimpleDocumentProcessorTestCase.java
@@ -29,7 +29,7 @@ public class SimpleDocumentProcessorTestCase {
     private static DocprocService setupDocprocService(SimpleDocumentProcessor processor, Metric metric) {
         CallStack stack = new CallStack("default", metric);
         stack.addLast(processor);
-        DocprocService service = new DocprocService("default");
+        DocprocService service = new DocprocService("default", new SimpleContainerThreadPool());
         service.setCallStack(stack);
         service.setInService(true);
         return service;

--- a/docproc/src/test/java/com/yahoo/docproc/TransientFailureTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/TransientFailureTestCase.java
@@ -29,7 +29,7 @@ public class TransientFailureTestCase {
 
     @Test
     public void testTransientFailures() {
-        DocprocService service = new DocprocService("transfail");
+        DocprocService service = new DocprocService("transfail", new SimpleContainerThreadPool());
         CallStack stack = new CallStack();
         stack.addNext(new OkDocProc()).addNext(new TransientFailDocProc());
         service.setCallStack(stack);


### PR DESCRIPTION
Reverts vespa-engine/vespa#35147

Do not close the shared thread pool in the `DocprocService` destructor, since `DocprocService` does not own its lifetime. The old thread pool had to be closed when the `DocprocService` created it. Closing the shared thread pool would disrupt other components that depend on it, potentially affecting them across config generations. This explains why certain tests, such as `addnewfield` and `schemachanges`, worked for the first generation but failed when the shared thread pool was closed.