### PR TITLE
Avoid locale-dependent error messages

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/XmlReadingTestCase.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -204,17 +203,13 @@ public class XmlReadingTestCase {
 
     @Test
     void testInvalid2() {
-        Locale defaultLocale = Locale.getDefault();
         try {
-            Locale.setDefault(Locale.ENGLISH);
             new QueryProfileXMLReader().read("src/test/java/com/yahoo/search/query/profile/config/test/invalidxml2");
             fail("Should have failed");
         }
         catch (IllegalArgumentException e) {
+            e.printStackTrace();
             assertEquals("Could not parse 'unparseable.xml', error at line 2, column 21: Element type \"query-profile\" must be followed by either attribute specifications, \">\" or \"/>\".", Exceptions.toMessageString(e));
-        }
-        finally {
-            Locale.setDefault(defaultLocale);
         }
     }
 

--- a/vespajlib/src/main/java/com/yahoo/text/XML.java
+++ b/vespajlib/src/main/java/com/yahoo/text/XML.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -150,7 +151,7 @@ public class XML {
             buffer.append(string.substring(0, i));
         }
 
-        // i is at the first codepoint which needs replacing
+        // 'i' is at the first codepoint which needs replacing
         // Don't guard against double-escaping, as:
         // don't try to be clever (LCJ).
         for (; i < string.length(); i = string.offsetByCodePoints(i, 1)) {
@@ -171,6 +172,7 @@ public class XML {
      */
     public static Document getDocument(File xmlFile) {
         try {
+            Locale.setDefault(Locale.US); // The SAX parser generates localized error messages
             return getDocumentBuilder().parse(xmlFile);
         }
         catch (IOException e) {
@@ -192,6 +194,7 @@ public class XML {
      */
     public static Document getDocument(Reader reader) {
         try {
+            Locale.setDefault(Locale.US); // The SAX parser generates localized error messages
             return getDocumentBuilder().parse(new InputSource(reader));
         }
         catch (IOException e) {


### PR DESCRIPTION
No need to restore the default as our runtime should not depend on it.
