### PR TITLE
Add flexible vector kernel dispatch function tables

### DIFF
--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -38,7 +38,8 @@ constexpr std::string_view type_string() noexcept {
 
 template <typename T, typename Fn>
 void register_accel_binary_arg_benchmark(std::string_view name, std::unique_ptr<IAccelerated> accel, Fn&& fn) {
-    std::string instance_name = std::format("{}/{}/{}/{}", name, type_string<T>(), accel->implementation_name(), accel->target_name());
+    const auto accel_target = accel->target_info();
+    std::string instance_name = std::format("{}/{}/{}/{}", name, type_string<T>(), accel_target.implementation_name(), accel_target.target_name());
     auto bench_fn = [fn = std::forward<Fn>(fn), accel = std::move(accel)](benchmark::State& state) {
         auto [a, b] = create_and_fill_lhs_rhs<T>(state.range());
         for (auto _ : state) {

--- a/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
@@ -10,8 +10,10 @@ endif()
 
 vespa_add_library(vespa_hwaccelerated
     SOURCES
+    fn_table.cpp
     iaccelerated.cpp
     highway.cpp
+    target_info.cpp
     ${ACCEL_FILES}
     DEPENDS
     INSTALL lib64

--- a/vespalib/src/vespa/vespalib/hwaccelerated/README.md
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/README.md
@@ -13,7 +13,7 @@ Where `$n` is the vector width _in bytes_ and should preferably be tested
 for all of `16, 32, 64, 128, 256`. SVE/SVE2 tops out at 2048 bits (256 bytes),
 so no need to test anything larger.
 
-Example output:
+Example output for 512-bit vector size:
 ```
 $ qemu-aarch64 -cpu max,sve-default-vector-length=64 ./vespalib_hwaccelerated_test_app
 [==========] Running 2 tests from 1 test suite.
@@ -31,4 +31,12 @@ Highway - NEON (128 bit vector width)
 [ RUN      ] HwAcceleratedTest.dot_product_impls_match_source_of_truth
 [       OK ] HwAcceleratedTest.dot_product_impls_match_source_of_truth (3651 ms)
 [----------] 2 tests from HwAcceleratedTest (6731 ms total)
+```
+
+Example command to test all vector sizes:
+
+```shell
+for vlen in 16 32 64 128 256 ;
+  do qemu-aarch64 -cpu max,sve-default-vector-length=$vlen ./vespalib_hwaccelerated_test_app ;
+done
 ```

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx2.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx2.cpp
@@ -2,48 +2,107 @@
 
 #include "avx2.h"
 #include "avxprivate.hpp"
+#include "fn_table.h"
 
 namespace vespalib::hwaccelerated {
 
+namespace {
+int64_t my_dot_product_i8(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return helper::multiplyAdd(a, b, sz);
+}
+double my_squared_euclidean_distance_i8(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return helper::squaredEuclideanDistance(a, b, sz);
+}
+double my_squared_euclidean_distance_f32(const float* a, const float* b, size_t sz) noexcept {
+    return avx::euclideanDistanceSelectAlignment<float, 32>(a, b, sz);
+}
+double my_squared_euclidean_distance_f64(const double* a, const double* b, size_t sz) noexcept {
+    return avx::euclideanDistanceSelectAlignment<double, 32>(a, b, sz);
+}
+size_t my_population_count(const uint64_t* buf, size_t sz) noexcept {
+    return helper::populationCount(buf, sz);
+}
+void my_convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) noexcept {
+    helper::convert_bfloat16_to_float(src, dest, sz);
+}
+void my_and_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    helper::andChunks<32u, 4u>(offset, src, dest);
+}
+void my_or_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    helper::orChunks<32u, 4u>(offset, src, dest);
+}
+TargetInfo my_target_info() noexcept {
+    return {"AutoVec", "AVX2", 32};
+}
+} // anon ns
+
 size_t
 Avx2Accelerator::populationCount(const uint64_t *a, size_t sz) const noexcept {
-    return helper::populationCount(a, sz);
+    return my_population_count(a, sz);
 }
 
 double
 Avx2Accelerator::squaredEuclideanDistance(const int8_t * a, const int8_t * b, size_t sz) const noexcept {
-    return helper::squaredEuclideanDistance(a, b, sz);
+    return my_squared_euclidean_distance_i8(a, b, sz);
 }
 
 double
 Avx2Accelerator::squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept {
-    return avx::euclideanDistanceSelectAlignment<float, 32>(a, b, sz);
+    return my_squared_euclidean_distance_f32(a, b, sz);
 }
 
 double
 Avx2Accelerator::squaredEuclideanDistance(const double * a, const double * b, size_t sz) const noexcept {
-    return avx::euclideanDistanceSelectAlignment<double, 32>(a, b, sz);
+    return my_squared_euclidean_distance_f64(a, b, sz);
 }
 
 void
 Avx2Accelerator::and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept {
-    helper::andChunks<32u, 4u>(offset, src, dest);
+    my_and_128(offset, src, dest);
 }
 
 void
 Avx2Accelerator::or128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept {
-    helper::orChunks<32u, 4u>(offset, src, dest);
+    my_or_128(offset, src, dest);
 }
 
 void
 Avx2Accelerator::convert_bfloat16_to_float(const uint16_t * src, float * dest, size_t sz) const noexcept {
-    helper::convert_bfloat16_to_float(src, dest, sz);
+    my_convert_bfloat16_to_float(src, dest, sz);
 }
 
 int64_t
-Avx2Accelerator::dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept
-{
-    return helper::multiplyAdd(a, b, sz);
+Avx2Accelerator::dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept {
+    return my_dot_product_i8(a, b, sz);
+}
+
+// TODO remove code duplication once we deprecate IAccelerated.
+namespace {
+
+[[nodiscard]] dispatch::FnTable build_fn_table() {
+    dispatch::FnTable ft(my_target_info());
+    ft.dot_product_i8 = my_dot_product_i8;
+    ft.squared_euclidean_distance_i8  = my_squared_euclidean_distance_i8;
+    ft.squared_euclidean_distance_f32 = my_squared_euclidean_distance_f32;
+    ft.squared_euclidean_distance_f64 = my_squared_euclidean_distance_f64;
+    ft.population_count = my_population_count;
+    ft.convert_bfloat16_to_float = my_convert_bfloat16_to_float;
+    ft.and_128 = my_and_128;
+    ft.or_128  = my_or_128;
+    return ft;
+}
+
+} // anon ns
+
+TargetInfo
+Avx2Accelerator::target_info() const noexcept {
+    return my_target_info();
+}
+
+const dispatch::FnTable&
+Avx2Accelerator::fn_table() const {
+    static const dispatch::FnTable tbl = build_fn_table();
+    return tbl;
 }
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx2.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx2.h
@@ -20,7 +20,8 @@ public:
     int64_t dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept override;
     void and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;
     void or128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;
-    const char* target_name() const noexcept override { return "AVX2"; }
+    TargetInfo target_info() const noexcept override;
+    const dispatch::FnTable& fn_table() const override;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3.cpp
@@ -2,63 +2,134 @@
 
 #include "avx3.h"
 #include "avxprivate.hpp"
+#include "fn_table.h"
 
 namespace vespalib::hwaccelerated {
 
+namespace {
+int64_t my_dot_product_i8(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return helper::multiplyAdd(a, b, sz);
+}
+float my_dot_product_f32(const float* a, const float* b, size_t sz) noexcept {
+    return avx::dotProductSelectAlignment<float, 64>(a, b, sz);
+}
+double my_dot_product_f64(const double* a, const double* b, size_t sz) noexcept {
+    return avx::dotProductSelectAlignment<double, 64>(a, b, sz);
+}
+double my_squared_euclidean_distance_i8(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return helper::squaredEuclideanDistance(a, b, sz);
+}
+double my_squared_euclidean_distance_f32(const float* a, const float* b, size_t sz) noexcept {
+    return avx::euclideanDistanceSelectAlignment<float, 64>(a, b, sz);
+}
+double my_squared_euclidean_distance_f64(const double* a, const double* b, size_t sz) noexcept {
+    return avx::euclideanDistanceSelectAlignment<double, 64>(a, b, sz);
+}
+size_t my_population_count(const uint64_t* buf, size_t sz) noexcept {
+    return helper::populationCount(buf, sz);
+}
+size_t my_binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) noexcept {
+    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+}
+void my_convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) noexcept {
+    helper::convert_bfloat16_to_float(src, dest, sz);
+}
+void my_and_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    helper::andChunks<64, 2>(offset, src, dest);
+}
+void my_or_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    helper::orChunks<64, 2>(offset, src, dest);
+}
+TargetInfo my_target_info() noexcept {
+    return {"AutoVec", "AVX3", 64};
+}
+} // anon ns
+
+int64_t
+Avx3Accelerator::dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept {
+    return my_dot_product_i8(a, b, sz);
+}
+
 float
 Avx3Accelerator::dotProduct(const float * af, const float * bf, size_t sz) const noexcept {
-    return avx::dotProductSelectAlignment<float, 64>(af, bf, sz);
+    return my_dot_product_f32(af, bf, sz);
 }
 
 double
 Avx3Accelerator::dotProduct(const double * af, const double * bf, size_t sz) const noexcept {
-    return avx::dotProductSelectAlignment<double, 64>(af, bf, sz);
+    return my_dot_product_f64(af, bf, sz);
 }
 
 size_t
 Avx3Accelerator::populationCount(const uint64_t *a, size_t sz) const noexcept {
-    return helper::populationCount(a, sz);
+    return my_population_count(a, sz);
 }
 
 double
 Avx3Accelerator::squaredEuclideanDistance(const int8_t * a, const int8_t * b, size_t sz) const noexcept {
-    return helper::squaredEuclideanDistance(a, b, sz);
+    return my_squared_euclidean_distance_i8(a, b, sz);
 }
 
 double
 Avx3Accelerator::squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept {
-    return avx::euclideanDistanceSelectAlignment<float, 64>(a, b, sz);
+    return my_squared_euclidean_distance_f32(a, b, sz);
 }
 
 double
 Avx3Accelerator::squaredEuclideanDistance(const double * a, const double * b, size_t sz) const noexcept {
-    return avx::euclideanDistanceSelectAlignment<double, 64>(a, b, sz);
+    return my_squared_euclidean_distance_f64(a, b, sz);
 }
 
 size_t
 Avx3Accelerator::binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept {
-    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+    return my_binary_hamming_distance(lhs, rhs, sz);
 }
 
 void
 Avx3Accelerator::and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept {
-    helper::andChunks<64, 2>(offset, src, dest);
+    my_and_128(offset, src, dest);
 }
 
 void
 Avx3Accelerator::or128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept {
-    helper::orChunks<64, 2>(offset, src, dest);
+    my_or_128(offset, src, dest);
 }
 
 void
 Avx3Accelerator::convert_bfloat16_to_float(const uint16_t * src, float * dest, size_t sz) const noexcept {
-    helper::convert_bfloat16_to_float(src, dest, sz);
+    my_convert_bfloat16_to_float(src, dest, sz);
 }
 
-int64_t
-Avx3Accelerator::dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept
-{
-    return helper::multiplyAdd(a, b, sz);
+// TODO remove code duplication once we deprecate IAccelerated.
+namespace {
+
+[[nodiscard]] dispatch::FnTable build_fn_table() {
+    dispatch::FnTable ft(my_target_info());
+    ft.dot_product_i8  = my_dot_product_i8;
+    ft.dot_product_f32 = my_dot_product_f32;
+    ft.dot_product_f64 = my_dot_product_f64;
+    ft.squared_euclidean_distance_i8  = my_squared_euclidean_distance_i8;
+    ft.squared_euclidean_distance_f32 = my_squared_euclidean_distance_f32;
+    ft.squared_euclidean_distance_f64 = my_squared_euclidean_distance_f64;
+    ft.binary_hamming_distance = my_binary_hamming_distance;
+    ft.population_count = my_population_count;
+    ft.convert_bfloat16_to_float = my_convert_bfloat16_to_float;
+    ft.and_128 = my_and_128;
+    ft.or_128  = my_or_128;
+    return ft;
+}
+
+} // anon ns
+
+TargetInfo
+Avx3Accelerator::target_info() const noexcept {
+    return my_target_info();
+}
+
+const dispatch::FnTable&
+Avx3Accelerator::fn_table() const {
+    static const dispatch::FnTable tbl = build_fn_table();
+    return tbl;
 }
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3.h
@@ -25,7 +25,8 @@ public:
     int64_t dotProduct(const int8_t * a, const int8_t * b, size_t sz) const noexcept override;
     void and128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;
     void or128(size_t offset, const std::vector<std::pair<const void *, bool>> &src, void *dest) const noexcept override;
-    const char* target_name() const noexcept override { return "AVX3"; }
+    TargetInfo target_info() const noexcept override;
+    const dispatch::FnTable& fn_table() const override;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.cpp
@@ -2,29 +2,21 @@
 
 #include "avx3_dl.h"
 #include "avxprivate.hpp"
+#include "fn_table.h"
 #include "x64_generic.h"
 
 namespace vespalib::hwaccelerated {
 
-float
-Avx3DlAccelerator::dotProduct(const float* af, const float* bf, size_t sz) const noexcept {
-    return avx::dotProductSelectAlignment<float, 64>(af, bf, sz);
-}
+namespace {
 
-double
-Avx3DlAccelerator::dotProduct(const double* af, const double* bf, size_t sz) const noexcept {
-    return avx::dotProductSelectAlignment<double, 64>(af, bf, sz);
-}
-
-size_t
-Avx3DlAccelerator::populationCount(const uint64_t* a, size_t sz) const noexcept {
+size_t my_population_count(const uint64_t* a, size_t sz) noexcept {
     if (sz <= 32) [[likely]] {
         // Don't fire up the AVX-512 steam engines for short vectors. Just looking at the
         // groundhog shadow of a 512 bits wide AVX instruction may be enough to send a Xeon
         // CPU from the baseline power license level 0 into a frequency throttled power
         // license level of 1. This is much less of a problem on >= Ice Lake microarchitectures,
         // but still measurable in practice.
-        return X64GenericAccelerator::populationCount(a, sz);
+        return X64GenericAccelerator().populationCount(a, sz);
     } else {
         // When targeting VPOPCNTDQ the compiler auto-vectorization somewhat ironically
         // gets horribly confused when the code is explicitly written to do popcounts
@@ -38,45 +30,127 @@ Avx3DlAccelerator::populationCount(const uint64_t* a, size_t sz) const noexcept 
     }
 }
 
+int64_t my_dot_product_i8(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return helper::multiplyAdd(a, b, sz);
+}
+float my_dot_product_f32(const float* a, const float* b, size_t sz) noexcept {
+    return avx::dotProductSelectAlignment<float, 64>(a, b, sz);
+}
+double my_dot_product_f64(const double* a, const double* b, size_t sz) noexcept {
+    return avx::dotProductSelectAlignment<double, 64>(a, b, sz);
+}
+double my_squared_euclidean_distance_i8(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return helper::squaredEuclideanDistance(a, b, sz);
+}
+double my_squared_euclidean_distance_f32(const float* a, const float* b, size_t sz) noexcept {
+    return avx::euclideanDistanceSelectAlignment<float, 64>(a, b, sz);
+}
+double my_squared_euclidean_distance_f64(const double* a, const double* b, size_t sz) noexcept {
+    return avx::euclideanDistanceSelectAlignment<double, 64>(a, b, sz);
+}
+size_t my_binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) noexcept {
+    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+}
+void my_convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) noexcept {
+    helper::convert_bfloat16_to_float(src, dest, sz);
+}
+void my_and_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    helper::andChunks<64, 2>(offset, src, dest);
+}
+void my_or_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    helper::orChunks<64, 2>(offset, src, dest);
+}
+TargetInfo my_target_info() noexcept {
+    return {"AutoVec", "AVX3_DL", 64};
+}
+
+} // anon ns
+
+int64_t
+Avx3DlAccelerator::dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept {
+    return my_dot_product_i8(a, b, sz);
+}
+
+float
+Avx3DlAccelerator::dotProduct(const float* af, const float* bf, size_t sz) const noexcept {
+    return my_dot_product_f32(af, bf, sz);
+}
+
+double
+Avx3DlAccelerator::dotProduct(const double* af, const double* bf, size_t sz) const noexcept {
+    return my_dot_product_f64(af, bf, sz);
+}
+
+size_t
+Avx3DlAccelerator::populationCount(const uint64_t* a, size_t sz) const noexcept {
+    return my_population_count(a, sz);
+}
+
 double
 Avx3DlAccelerator::squaredEuclideanDistance(const int8_t* a, const int8_t* b, size_t sz) const noexcept {
-    return helper::squaredEuclideanDistance(a, b, sz);
+    return my_squared_euclidean_distance_i8(a, b, sz);
 }
 
 double
 Avx3DlAccelerator::squaredEuclideanDistance(const float* a, const float* b, size_t sz) const noexcept {
-    return avx::euclideanDistanceSelectAlignment<float, 64>(a, b, sz);
+    return my_squared_euclidean_distance_f32(a, b, sz);
 }
 
 double
 Avx3DlAccelerator::squaredEuclideanDistance(const double* a, const double* b, size_t sz) const noexcept {
-    return avx::euclideanDistanceSelectAlignment<double, 64>(a, b, sz);
+    return my_squared_euclidean_distance_f64(a, b, sz);
 }
 
 size_t
 Avx3DlAccelerator::binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) const noexcept {
-    return helper::autovec_binary_hamming_distance(lhs, rhs, sz);
+    return my_binary_hamming_distance(lhs, rhs, sz);
 }
 
 void
 Avx3DlAccelerator::and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept {
-    helper::andChunks<64, 2>(offset, src, dest);
+    my_and_128(offset, src, dest);
 }
 
 void
 Avx3DlAccelerator::or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept {
-    helper::orChunks<64, 2>(offset, src, dest);
+    my_or_128(offset, src, dest);
 }
 
 void
 Avx3DlAccelerator::convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) const noexcept {
-    helper::convert_bfloat16_to_float(src, dest, sz);
+    my_convert_bfloat16_to_float(src, dest, sz);
 }
 
-int64_t
-Avx3DlAccelerator::dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept
-{
-    return helper::multiplyAdd(a, b, sz);
+// TODO remove code duplication once we deprecate IAccelerated.
+namespace {
+
+[[nodiscard]] dispatch::FnTable build_fn_table() {
+    dispatch::FnTable ft(my_target_info());
+    ft.dot_product_i8  = my_dot_product_i8;
+    ft.dot_product_f32 = my_dot_product_f32;
+    ft.dot_product_f64 = my_dot_product_f64;
+    ft.squared_euclidean_distance_i8  = my_squared_euclidean_distance_i8;
+    ft.squared_euclidean_distance_f32 = my_squared_euclidean_distance_f32;
+    ft.squared_euclidean_distance_f64 = my_squared_euclidean_distance_f64;
+    ft.binary_hamming_distance = my_binary_hamming_distance;
+    ft.population_count = my_population_count;
+    ft.convert_bfloat16_to_float = my_convert_bfloat16_to_float;
+    ft.and_128 = my_and_128;
+    ft.or_128  = my_or_128;
+    return ft;
+}
+
+} // anon ns
+
+TargetInfo
+Avx3DlAccelerator::target_info() const noexcept {
+    return my_target_info();
+}
+
+const dispatch::FnTable&
+Avx3DlAccelerator::fn_table() const {
+    static const dispatch::FnTable tbl = build_fn_table();
+    return tbl;
 }
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/avx3_dl.h
@@ -47,7 +47,8 @@ public:
     int64_t dotProduct(const int8_t* a, const int8_t* b, size_t sz) const noexcept override;
     void and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;
     void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;
-    const char* target_name() const noexcept override { return "AVX3_DL"; }
+    TargetInfo target_info() const noexcept override;
+    const dispatch::FnTable& fn_table() const override;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.cpp
@@ -1,0 +1,37 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "fn_table.h"
+#include <algorithm>
+#include <format>
+
+namespace vespalib::hwaccelerated::dispatch {
+
+FnTable::FnTable() = default;
+
+FnTable::FnTable(const TargetInfo& prefilled_target_info) {
+    std::ranges::fill(fn_target_infos, prefilled_target_info);
+}
+
+FnTable::~FnTable() = default;
+
+FnTable::FnTable(const FnTable&) = default;
+FnTable& FnTable::operator=(const FnTable&) = default;
+
+#define VESPA_HWACCEL_RETURN_FALSE_IF_FN_PTR_NULL(fn_type, fn_field, fn_id) \
+    if ((fn_field) == nullptr) return false;
+
+bool FnTable::is_complete() const noexcept {
+    VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_RETURN_FALSE_IF_FN_PTR_NULL);
+    return true;
+}
+
+#define VESPA_HWACCEL_STRINGIFY_FN_ENTRY(fn_type, fn_field, fn_id) \
+    fns += std::format("{} => {}\n", #fn_field, fn_target_info(fn_id).to_string());
+
+std::string FnTable::to_string() const {
+    std::string fns;
+    VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_STRINGIFY_FN_ENTRY);
+    return fns;
+}
+
+} // vespalib::hwaccelerated::dispatch

--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
@@ -1,0 +1,227 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "target_info.h"
+#include <vespa/vespalib/util/bfloat16.h>
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+#include <span>
+#include <vector>
+#include <string>
+
+namespace vespalib::hwaccelerated::dispatch {
+
+// Function pointer type declarations, since C function pointer syntax leaves a bit to be desired.
+using DotProductI8Fn  = int64_t (*)(const int8_t* a,  const int8_t* b,  size_t sz) noexcept;
+using DotProductI16Fn = int64_t (*)(const int16_t* a, const int16_t* b, size_t sz) noexcept;
+using DotProductI32Fn = int64_t (*)(const int32_t* a, const int32_t* b, size_t sz) noexcept;
+using DotProductI64Fn = int64_t (*)(const int64_t* a, const int64_t* b, size_t sz) noexcept;
+
+using DotProductBF16Fn = float (*)(const BFloat16* a, const BFloat16* b, size_t sz) noexcept;
+using DotProductF32Fn  = float (*)(const float* a, const float* b, size_t sz) noexcept;
+using DotProductF64Fn  = double (*)(const double* a, const double* b, size_t sz) noexcept;
+
+using SquaredEuclideanDistanceI8Fn   = double (*)(const int8_t* a, const int8_t* b, size_t sz) noexcept;
+using SquaredEuclideanDistanceBF16Fn = double (*)(const BFloat16* a, const BFloat16* b, size_t sz) noexcept;
+using SquaredEuclideanDistanceF32Fn  = double (*)(const float* a, const float* b, size_t sz) noexcept;
+using SquaredEuclideanDistanceF64Fn  = double (*)(const double* a, const double* b, size_t sz) noexcept;
+
+using BinaryHammingDistanceFn = size_t (*)(const void* lhs, const void* rhs, size_t sz) noexcept;
+
+using PopulationCountFn = size_t (*)(const uint64_t* buf, size_t sz) noexcept;
+
+using ConvertBFloat16ToFloatFn = void (*)(const uint16_t* src, float* dest, size_t sz) noexcept;
+
+using OrBitFn     = void (*)(void* a, const void* b, size_t bytes) noexcept;
+using AndBitFn    = void (*)(void* a, const void* b, size_t bytes) noexcept;
+using AndNotBitFn = void (*)(void* a, const void* b, size_t bytes) noexcept;
+using NotBitFn    = void (*)(void* a, size_t bytes) noexcept;
+
+using And128Fn = void (*)(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept;
+using Or128Fn  = void (*)(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept;
+
+// Function table containing (possibly nullptr) raw function pointers to vectorization
+// function implementations. These pointers must be entirely "freestanding" (i.e. not
+// require any explicit `this`-like state) and must be valid for the lifetime of the
+// process.
+struct FnTable {
+    FnTable();
+    explicit FnTable(const TargetInfo& prefilled_target_info);
+    ~FnTable();
+
+    FnTable(const FnTable&);
+    FnTable& operator=(const FnTable&);
+
+    // Important: new entries to the function table must also be added to VESPA_HWACCEL_VISIT_FN_TABLE
+
+    DotProductI8Fn  dot_product_i8  = nullptr;
+    DotProductI16Fn dot_product_i16 = nullptr;
+    DotProductI32Fn dot_product_i32 = nullptr;
+    DotProductI64Fn dot_product_i64 = nullptr;
+
+    DotProductBF16Fn dot_product_bf16 = nullptr;
+    DotProductF32Fn  dot_product_f32  = nullptr;
+    DotProductF64Fn  dot_product_f64  = nullptr;
+
+    SquaredEuclideanDistanceI8Fn   squared_euclidean_distance_i8   = nullptr;
+    SquaredEuclideanDistanceBF16Fn squared_euclidean_distance_bf16 = nullptr;
+    SquaredEuclideanDistanceF32Fn  squared_euclidean_distance_f32  = nullptr;
+    SquaredEuclideanDistanceF64Fn  squared_euclidean_distance_f64  = nullptr;
+
+    BinaryHammingDistanceFn binary_hamming_distance = nullptr;
+
+    PopulationCountFn population_count = nullptr;
+
+    ConvertBFloat16ToFloatFn convert_bfloat16_to_float = nullptr;
+
+    OrBitFn     or_bit      = nullptr;
+    AndBitFn    and_bit     = nullptr;
+    AndNotBitFn and_not_bit = nullptr;
+    NotBitFn    not_bit     = nullptr;
+
+    And128Fn and_128 = nullptr;
+    Or128Fn  or_128  = nullptr;
+
+    enum class FnId {
+        DOT_PRODUCT_I8 = 0,
+        DOT_PRODUCT_I16,
+        DOT_PRODUCT_I32,
+        DOT_PRODUCT_I64,
+        DOT_PRODUCT_BF16,
+        DOT_PRODUCT_F32,
+        DOT_PRODUCT_F64,
+        SQUARED_EUCLIDEAN_DISTANCE_I8,
+        SQUARED_EUCLIDEAN_DISTANCE_BF16,
+        SQUARED_EUCLIDEAN_DISTANCE_F32,
+        SQUARED_EUCLIDEAN_DISTANCE_F64,
+        BINARY_HAMMING_DISTANCE,
+        POPULATION_COUNT,
+        CONVERT_BFLOAT16_TO_FLOAT,
+        OR_BIT,
+        AND_BIT,
+        AND_NOT_BIT,
+        NOT_BIT,
+        AND_128,
+        OR_128,
+        MAX_ID_SENTINEL
+    };
+
+    static constexpr size_t NFunctions = static_cast<size_t>(FnId::MAX_ID_SENTINEL);
+
+    static_assert(NFunctions < 64);
+    uint64_t suboptimal_fn_mask = 0;
+    std::array<TargetInfo, NFunctions> fn_target_infos;
+
+    // Indicate that a particular function exists in this table, but its performance
+    // is expected to be suboptimal when compared to "worse" function tables. But the
+    // function is still available for testing and benchmarking.
+    constexpr void tag_fns_as_suboptimal(std::initializer_list<const FnId> fn_ids) noexcept {
+        for (FnId fn_id : fn_ids) {
+            suboptimal_fn_mask |= (1ULL << static_cast<uint64_t>(fn_id));
+        }
+    }
+
+    [[nodiscard]] constexpr bool fn_is_tagged_as_suboptimal(FnId fn_id) const noexcept {
+        return (suboptimal_fn_mask & (1ULL << static_cast<uint64_t>(fn_id))) != 0;
+    }
+
+    [[nodiscard]] constexpr const TargetInfo& fn_target_info(FnId fn_id) const noexcept {
+        return fn_target_infos[static_cast<size_t>(fn_id)];
+    }
+
+    [[nodiscard]] std::string to_string() const;
+
+    // Returns true iff all function pointers are non-nullptr
+    [[nodiscard]] bool is_complete() const noexcept;
+};
+
+// Cheeky function table macro that can be used to avoid having to remember to update
+// all places that need to poke at the fields of a function table. The `VISITOR` argument
+// is invoked with 3 args; the function ptr type, the function ptr name and its ID used
+// by the "is this function suboptimal for this target"-mask and the target info array.
+#define VESPA_HWACCEL_VISIT_FN_TABLE(VISITOR) \
+    VISITOR(DotProductI8Fn,                 dot_product_i8,                  FnTable::FnId::DOT_PRODUCT_I8)                  \
+    VISITOR(DotProductI16Fn,                dot_product_i16,                 FnTable::FnId::DOT_PRODUCT_I16)                 \
+    VISITOR(DotProductI32Fn,                dot_product_i32,                 FnTable::FnId::DOT_PRODUCT_I32)                 \
+    VISITOR(DotProductI64Fn,                dot_product_i64,                 FnTable::FnId::DOT_PRODUCT_I64)                 \
+    VISITOR(DotProductBF16Fn,               dot_product_bf16,                FnTable::FnId::DOT_PRODUCT_BF16)                \
+    VISITOR(DotProductF32Fn,                dot_product_f32,                 FnTable::FnId::DOT_PRODUCT_F32)                 \
+    VISITOR(DotProductF64Fn,                dot_product_f64,                 FnTable::FnId::DOT_PRODUCT_F64)                 \
+    VISITOR(SquaredEuclideanDistanceI8Fn,   squared_euclidean_distance_i8,   FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_I8)   \
+    VISITOR(SquaredEuclideanDistanceBF16Fn, squared_euclidean_distance_bf16, FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_BF16) \
+    VISITOR(SquaredEuclideanDistanceF32Fn,  squared_euclidean_distance_f32,  FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_F32)  \
+    VISITOR(SquaredEuclideanDistanceF64Fn,  squared_euclidean_distance_f64,  FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_F64)  \
+    VISITOR(BinaryHammingDistanceFn,        binary_hamming_distance,         FnTable::FnId::BINARY_HAMMING_DISTANCE)         \
+    VISITOR(PopulationCountFn,              population_count,                FnTable::FnId::POPULATION_COUNT)                \
+    VISITOR(ConvertBFloat16ToFloatFn,       convert_bfloat16_to_float,       FnTable::FnId::CONVERT_BFLOAT16_TO_FLOAT)       \
+    VISITOR(OrBitFn,                        or_bit,                          FnTable::FnId::OR_BIT)                          \
+    VISITOR(AndBitFn,                       and_bit,                         FnTable::FnId::AND_BIT)                         \
+    VISITOR(AndNotBitFn,                    and_not_bit,                     FnTable::FnId::AND_NOT_BIT)                     \
+    VISITOR(NotBitFn,                       not_bit,                         FnTable::FnId::NOT_BIT)                         \
+    VISITOR(And128Fn,                       and_128,                         FnTable::FnId::AND_128)                         \
+    VISITOR(Or128Fn,                        or_128,                          FnTable::FnId::OR_128)
+
+// Freestanding global dispatch function pointers declarations.
+// These are link-time initialized to the baseline target implementations (which
+// will be either from `neon.cpp` or `x64_generic.cpp` depending on architecture),
+// then at some unspecified point in time during global constructor invocation
+// they will be updated to point to the function that is considered optimal for
+// the current run-time platform environment. It is possible to change the function
+// table after this point (for testing!), but this must always be performed in a
+// single-threaded context to avoid data races (pointer loads are _not_ atomic).
+
+#define VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(name) _g_ ## name
+
+#define VESPA_HWACCEL_DECLARE_DISPATCH_FN_PTR(fn_type, fn_field, fn_id) \
+    extern fn_type VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(fn_field);
+
+VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_DECLARE_DISPATCH_FN_PTR);
+
+// The following functions are defined in iaccelerated.cpp:
+
+// Returns a new function table built from 1-N input function tables in `fn_tables`.
+// fn_tables is in "best to worst" order (i.e. best is at front, worst is at back),
+// meaning that if a function is present (non-null) in a "better" table, it will be
+// preferred over one in a "worse" table, _unless_ the function is tagged as suboptimal
+// by the table _and_ `ignore_suboptimal == true`. In the latter case, the function is
+// ignored in favor of the one from the technically worse table. This is to avoid
+// including functions with known suboptimal performance vs. another "worse" target.
+//
+// If the union of non-null input function pointers across all input tables is equal
+// to the full set of possible function pointers, the returned table will be complete.
+//
+// It is recommended that the last table of `fn_tables` be a complete table, to ensure
+// the returned table is also complete.
+//
+// Information about suboptimal functions is not preserved in the returned table.
+[[nodiscard]] FnTable build_composite_fn_table(std::span<const FnTable> fn_tables, bool ignore_suboptimal) noexcept;
+
+// Convenience function to build a composite table on top of a single other function table
+[[nodiscard]] FnTable build_composite_fn_table(const FnTable& fn_table,
+                                               const FnTable& base_table,
+                                               bool ignore_suboptimal) noexcept;
+
+// Returns the function table that is presumed to be optimal for the architecture the
+// process is currently running on.
+[[nodiscard]] FnTable optimal_composite_fn_table() noexcept;
+
+// Returns a function table containing functions from one or more auto-vectorized
+// implementations for this architecture. This table is always complete and can therefore
+// be used as a fallback when building other composite tables. Note that this table may
+// itself may be a composite of functions from the "best" auto-vectorized table on top of
+// one or more "lesser" auto-vectorized tables. It's tables all the way down!
+[[nodiscard]] FnTable complete_baseline_fn_table() noexcept;
+
+// Returns a reference to the globally active function table. Its contents will usually be
+// equal to that of `optimal_composite_fn_table()` unless overridden at runtime.
+[[nodiscard]] const FnTable& active_fn_table() noexcept;
+
+// This can be used wisely by single-threaded tests and benchmarks to replace the
+// entire vectorization world. The function table _must_ be _complete_, i.e. all
+// function pointers must be non-nullptr. This function does _not_ fall back to a
+// baseline target for unset function pointers.
+void thread_unsafe_update_function_dispatch_pointers(const FnTable& fns);
+
+} // vespalib::hwaccelerated::dispatch

--- a/vespalib/src/vespa/vespalib/hwaccelerated/functions.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/functions.h
@@ -1,0 +1,97 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "fn_table.h"
+
+namespace vespalib::hwaccelerated::vec_fn {
+
+// These are freestanding functions that will be dispatched to the vectorized implementation
+// expected to bring the best performance for the currently running CPU architecture.
+// Has the expected overhead of a single function pointer indirection, which is pretty much
+// as good as it gets for dynamic dispatch. Best of all, no need to carry an IAccelerated
+// instance around with you on your journeys.
+
+[[nodiscard]] inline int64_t dot_product(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_i8)(a, b, sz);
+}
+
+[[nodiscard]] inline int64_t dot_product(const int16_t* a, const int16_t* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_i16)(a, b, sz);
+}
+
+[[nodiscard]] inline int64_t dot_product(const int32_t* a, const int32_t* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_i32)(a, b, sz);
+}
+
+[[nodiscard]] inline int64_t dot_product(const int64_t* a, const int64_t* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_i64)(a, b, sz);
+}
+
+[[nodiscard]] inline float dot_product(const BFloat16* a, const BFloat16* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_bf16)(a, b, sz);
+}
+
+[[nodiscard]] inline float dot_product(const float* a, const float* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_f32)(a, b, sz);
+}
+
+[[nodiscard]] inline double dot_product(const double* a, const double* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(dot_product_f64)(a, b, sz);
+}
+
+[[nodiscard]] inline double squared_euclidean_distance(const int8_t* a, const int8_t* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(squared_euclidean_distance_i8)(a, b, sz);
+}
+
+[[nodiscard]] inline double squared_euclidean_distance(const BFloat16* a, const BFloat16* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(squared_euclidean_distance_bf16)(a, b, sz);
+}
+
+[[nodiscard]] inline double squared_euclidean_distance(const float* a, const float* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(squared_euclidean_distance_f32)(a, b, sz);
+}
+
+[[nodiscard]] inline double squared_euclidean_distance(const double* a, const double* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(squared_euclidean_distance_f64)(a, b, sz);
+}
+
+[[nodiscard]] inline size_t binary_hamming_distance(const void* a, const void* b, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(binary_hamming_distance)(a, b, sz);
+}
+
+[[nodiscard]] inline size_t population_count(const uint64_t* buf, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(population_count)(buf, sz);
+}
+
+inline void convert_bfloat16_to_float(const uint16_t* src, float* dest, size_t sz) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(convert_bfloat16_to_float)(src, dest, sz);
+}
+
+inline void or_bit(void* a, const void* b, size_t bytes) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(or_bit)(a, b, bytes);
+}
+
+inline void and_bit(void* a, const void* b, size_t bytes) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(and_bit)(a, b, bytes);
+}
+
+inline void and_not_bit(void* a, const void* b, size_t bytes) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(and_not_bit)(a, b, bytes);
+}
+
+inline void not_bit(void* a, size_t bytes) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(not_bit)(a, bytes);
+}
+
+// AND 128 bytes from multiple, optionally inverted sources
+inline void and_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(and_128)(offset, src, dest);
+}
+
+// OR128 bytes from multiple, optionally inverted sources
+inline void or_128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) noexcept {
+    dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(or_128)(offset, src, dest);
+}
+
+} // vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.h
@@ -36,9 +36,8 @@ public:
     double squaredEuclideanDistance(const BFloat16* a, const BFloat16* b, size_t sz) const noexcept override;
     void and128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;
     void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept override;
-#ifdef VESPA_HWACCEL_TARGET_NAME
-    const char* target_name() const noexcept override { return VESPA_HWACCEL_TARGET_NAME; }
-#endif
+    TargetInfo target_info() const noexcept override;
+    const dispatch::FnTable& fn_table() const override;
 };
 
 } // vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "target_info.h"
 #include <vespa/vespalib/util/bfloat16.h>
 #include <memory>
 #include <cstdint>
@@ -9,12 +10,15 @@
 
 namespace vespalib::hwaccelerated {
 
+namespace dispatch { struct FnTable; }
+
+class TargetInfo;
+
 /**
  * This contains an interface to all primitives that has different cpu supported accelerations.
  * The actual implementation you get by calling the static getAccelerator method.
  */
-class IAccelerated
-{
+class IAccelerated {
 public:
     virtual ~IAccelerated() = default;
     using UP = std::unique_ptr<IAccelerated>;
@@ -41,11 +45,11 @@ public:
     // OR 128 bytes from multiple, optionally inverted sources
     virtual void or128(size_t offset, const std::vector<std::pair<const void*, bool>>& src, void* dest) const noexcept = 0;
 
-    [[nodiscard]] virtual const char* implementation_name() const noexcept { return "AutoVec"; }
-    // Returns a static string representing the name of the underlying accelerator target (e.g. "AVX3", "NEON" etc.)
-    [[nodiscard]] virtual const char* target_name() const noexcept { return "Unknown"; }
+    [[nodiscard]] virtual TargetInfo target_info() const noexcept = 0;
 
-    [[nodiscard]] virtual std::string friendly_name() const;
+    // The function table entries must be valid for the lifetime of the process,
+    // entirely independent of the lifetime of `this`.
+    [[nodiscard]] virtual const dispatch::FnTable& fn_table() const = 0;
 
     static std::unique_ptr<IAccelerated> create_baseline_auto_vectorized_target();
     static std::unique_ptr<IAccelerated> create_best_auto_vectorized_target();

--- a/vespalib/src/vespa/vespalib/hwaccelerated/neon.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/neon.cpp
@@ -1,4 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#define VESPA_HWACCEL_INCLUDE_DEFINITIONS 1
+#define VESPA_HWACCEL_INCLUDE_DEFINITIONS
+#define VESPA_HWACCEL_DEFINE_BASELINE_DISPATCH_FN_PTRS
 #include "neon.h"

--- a/vespalib/src/vespa/vespalib/hwaccelerated/target_info.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/target_info.cpp
@@ -1,0 +1,12 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "target_info.h"
+#include <format>
+
+namespace vespalib::hwaccelerated {
+
+std::string TargetInfo::to_string() const {
+    return std::format("{} - {} ({} bit vector width)", implementation_name(), target_name(), vector_width_bits());
+}
+
+} // vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/target_info.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/target_info.h
@@ -1,0 +1,54 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace vespalib::hwaccelerated {
+
+// Information that identifies a particular CPU vectorization target
+class TargetInfo {
+    // All strings must have static lifetime
+    const char* _implementation_name;
+    const char* _target_name;
+    uint16_t    _vector_width_bytes;
+public:
+    constexpr TargetInfo() noexcept
+        : _implementation_name("Unknown"),
+          _target_name("Unknown"),
+          _vector_width_bytes(16)
+    {}
+
+    constexpr TargetInfo(const char* implementation_name,
+                         const char* target_name,
+                         uint16_t vector_width_bytes) noexcept
+        : _implementation_name(implementation_name),
+          _target_name(target_name),
+          _vector_width_bytes(vector_width_bytes)
+    {
+    }
+    // Returns a static string representing what implementation was used to
+    // create the vectorization target. Currently;
+    //  - "AutoVec" - auto-vectorized kernel
+    //  - "Highway" - explicitly vectorized kernel via Google Highway
+    [[nodiscard]] constexpr const char* implementation_name() const noexcept {
+        return _implementation_name;
+    }
+    // Returns a static string representing the name of the underlying accelerator
+    // target (e.g. "AVX3", "NEON" etc.). Target names may be non-unique across
+    // different implementations.
+    [[nodiscard]] constexpr const char* target_name() const noexcept {
+        return _target_name;
+    }
+    [[nodiscard]] constexpr uint16_t vector_width_bytes() const noexcept {
+        return _vector_width_bytes;
+    }
+    [[nodiscard]] constexpr uint16_t vector_width_bits() const noexcept {
+        return _vector_width_bytes * 8;
+    }
+
+    [[nodiscard]] std::string to_string() const;
+};
+
+} // vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/x64_generic.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/x64_generic.cpp
@@ -1,4 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#define VESPA_HWACCEL_INCLUDE_DEFINITIONS 1
+#define VESPA_HWACCEL_INCLUDE_DEFINITIONS
+#define VESPA_HWACCEL_DEFINE_BASELINE_DISPATCH_FN_PTRS
 #include "x64_generic.h"


### PR DESCRIPTION
@havardpe please review

With the existing `IAccelerated` inheritance-based approach to vector kernel dispatch we have the inherent problem that all function dispatch is "all or nothing" for a given target (i.e subclass).

However, some targets are _slower_ for certain operations than targets that are considered _less preferred_. In particular this affects BF16 kernels on AArch64 SVE/SVE2 due to Highway not using certain instructions there due to rounding semantics.

The chosen hacky workarounds have been to either a) entirely disable some targets, or to b) conditionally not compile certain functions. a) has the immediate downside that it prevents the use of functions that are _faster_ on the target and b) has the downside that such functions remain unavailable for benchmarking and testing.

This commit introduces an entirely new mechanism for dispatching calls to vector kernels by adding explicit function tables to the mix. Each target exports a (potentially sparse) function table and at runtime we build a _composite_ table where we pick and choose individual functions from the targets available on the current platform. Each target may tag specific functions as _suboptimal_, which causes these to not be picked as part of the composite table compilation.

This means that when using Highway vectorization, we can fall back to the best auto-vectorized functions for the parts that are not yet covered by Highway kernels, rather than having to fall back to the generic implementation (as that's the base class).

Calling vectorized functions can now be done using freestanding functions (no need to carry around `IAccelerated` state) which dispatch via global function pointers. These function pointers are initialized by the linker to point to valid (but possibly suboptimal) baseline implementations, and are patched to point to the functions resolved by the "optimal" composite table at some point during the global constructor phase. Unit tests and benchmarks can also replace the global function dispatch table, as long as this is done in a single-threaded manner.

Eventually we probably want to compile the function table by using auto-tuning for current host instead of hard-coding what kernels we believe are (sub-)optimal.

The existing `IAccelerated` interface is left unchanged (aside from adding function table building and cleaning up target info reporting), and all other wiring remains as-is for now. Changing this will be done as a follow-up.

