### PR TITLE
wire all HNSW parameters from protobuf

### DIFF
--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -1202,7 +1202,10 @@ TEST(QueryTest, wand_term_needs_ranking)
 TEST(QueryTest, nearest_neighbor_term_needs_ranking)
 {
     QueryBuilder<ProtonNodeTypes> builder;
-    builder.add_nearest_neighbor_term("qtensor", "f1", 1, Weight(1), 10, true, 100, 1.5);
+    search::query::NearestNeighborTerm::HnswParams hnsw_params;
+    hnsw_params.distance_threshold = 1.5;
+    hnsw_params.explore_additional_hits = 100;
+    builder.add_nearest_neighbor_term("qtensor", "f1", 1, Weight(1), 10, true, hnsw_params);
     EXPECT_TRUE(query_needs_ranking(StackDumpCreator::create(*builder.build())));
 }
 

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -1106,17 +1106,22 @@ TEST(QueryTest, requireThatConstBoolBlueprintsAreCreatedCorrectly)
 }
 
 class GlobalFilterBlueprint : public SimpleBlueprint {
+private:
+    bool _want_global_filter;
 public:
     std::shared_ptr<const GlobalFilter> filter;
     double estimated_hit_ratio;
     GlobalFilterBlueprint(const SimpleResult& result, bool want_global_filter)
         : search::queryeval::SimpleBlueprint(result),
+          _want_global_filter(want_global_filter),
           filter(),
           estimated_hit_ratio(-1.0)
     {
-        set_want_global_filter(want_global_filter);
     }
     ~GlobalFilterBlueprint() override;
+    bool want_global_filter(Blueprint::GlobalFilterLimits&) const override {
+        return _want_global_filter;
+    }
     void set_global_filter(const GlobalFilter& filter_, double estimated_hit_ratio_) override {
         filter = filter_.shared_from_this();
         estimated_hit_ratio = estimated_hit_ratio_;

--- a/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
@@ -353,7 +353,10 @@ public:
         request_ctx.set_query_tensor("query_tensor", tensor_spec);
     }
     Blueprint::UP create_blueprint() {
-        query::NearestNeighborTerm term("query_tensor", attr_name, 0, Weight(0), 7, true, 33, 100100.25);
+        query::NearestNeighborTerm::HnswParams hnsw_params;
+        hnsw_params.distance_threshold = 100100.25;
+        hnsw_params.explore_additional_hits = 33;
+        query::NearestNeighborTerm term("query_tensor", attr_name, 0, Weight(0), 7, true, hnsw_params);
         return BlueprintFactoryFixture::create_blueprint(term);
     }
 };

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1454,12 +1454,22 @@ public:
                                                              double global_filter_lower_limit = 0.05,
                                                              double target_hits_max_adjustment_factor = 20.0) {
         search::queryeval::FieldSpec field("foo", 0, 0);
+        NearestNeighborBlueprint::HnswParams hnsw_params{
+            .explore_additional_hits = 5,
+            .distance_threshold = 100100.25,
+            .global_filter_lower_limit = global_filter_lower_limit,
+            .global_filter_lower_limit_is_override = false,
+            .global_filter_upper_limit = 1.0,
+            .filter_first_upper_limit = 0.0,
+            .filter_first_exploration = 0.3,
+            .exploration_slack = 0.0,
+            .target_hits_max_adjustment_factor = target_hits_max_adjustment_factor
+        };
         auto bp = std::make_unique<NearestNeighborBlueprint>(
             field,
             std::make_unique<DistanceCalculator>(this->as_dense_tensor(),
                                                  create_query_tensor(vec_2d(17, 42))),
-            3, approximate, 5, 100100.25,
-            global_filter_lower_limit, 1.0, 0.0, 0.3, 0.0, target_hits_max_adjustment_factor, vespalib::Doom::never());
+            3, approximate, hnsw_params, vespalib::Doom::never());
         EXPECT_EQ(11u, bp->getState().estimate().estHits);
         EXPECT_EQ(100100.25 * 100100.25, bp->get_distance_threshold());
         return bp;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -43,6 +43,7 @@ using search::AttributeGuard;
 using search::AttributeVector;
 using search::attribute::DistanceMetric;
 using search::attribute::HnswIndexParams;
+using search::queryeval::Blueprint;
 using search::queryeval::GlobalFilter;
 using search::queryeval::NearestNeighborBlueprint;
 using search::tensor::DefaultNearestNeighborIndexFactory;
@@ -1564,21 +1565,24 @@ TEST(TensorAttributeTest, NN_blueprint_wants_global_filter_when_having_index)
 {
     NearestNeighborBlueprintFixture f;
     auto bp = f.make_blueprint();
-    EXPECT_TRUE(bp->getState().want_global_filter());
+    Blueprint::GlobalFilterLimits limits;
+    EXPECT_TRUE(bp->want_global_filter(limits));
 }
 
 TEST(TensorAttributeTest, NN_blueprint_do_NOT_want_global_filter_when_explicitly_using_brute_force)
 {
     NearestNeighborBlueprintFixture f;
     auto bp = f.make_blueprint(false);
-    EXPECT_FALSE(bp->getState().want_global_filter());
+    Blueprint::GlobalFilterLimits limits;
+    EXPECT_FALSE(bp->want_global_filter(limits));
 }
 
 TEST(TensorAttributeTest, NN_blueprint_do_NOT_want_global_filter_when_NOT_having_index_for_implicit_brute_force)
 {
     NearestNeighborBlueprintWithoutIndexFixture f;
     auto bp = f.make_blueprint();
-    EXPECT_FALSE(bp->getState().want_global_filter());
+    Blueprint::GlobalFilterLimits limits;
+    EXPECT_FALSE(bp->want_global_filter(limits));
 }
 
 auto test_values = ::testing::Values(1u, 2u);

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1458,7 +1458,6 @@ public:
             .explore_additional_hits = 5,
             .distance_threshold = 100100.25,
             .global_filter_lower_limit = global_filter_lower_limit,
-            .global_filter_lower_limit_is_override = false,
             .global_filter_upper_limit = 1.0,
             .filter_first_upper_limit = 0.0,
             .filter_first_exploration = 0.3,

--- a/searchlib/src/tests/query/customtypevisitor_test.cpp
+++ b/searchlib/src/tests/query/customtypevisitor_test.cpp
@@ -123,8 +123,15 @@ struct MyRegExpTerm : InitTerm<RegExpTerm> {
 };
 
 struct MyNearestNeighborTerm : NearestNeighborTerm {
-    MyNearestNeighborTerm() : NearestNeighborTerm("qt", "fn", 0, Weight(42), 10, true, 666, 1234.5) {}
+    MyNearestNeighborTerm() : NearestNeighborTerm("qt", "fn", 0, Weight(42), 10, true, make_hnsw_params()) {}
     ~MyNearestNeighborTerm() override;
+private:
+    static HnswParams make_hnsw_params() {
+        HnswParams params;
+        params.distance_threshold = 1234.5;
+        params.explore_additional_hits = 666;
+        return params;
+    }
 };
 
 struct MyTrue : TrueQueryNode {

--- a/searchlib/src/tests/query/query_visitor_test.cpp
+++ b/searchlib/src/tests/query/query_visitor_test.cpp
@@ -86,7 +86,10 @@ TEST(QueryVisitorTest, requireThatAllNodesCanBeVisited) {
     checkVisit<SuffixTerm>(new SimpleSuffixTerm("t", "field", 0, Weight(0)));
     checkVisit<PredicateQuery>(new SimplePredicateQuery(PredicateQueryTerm::UP(), "field", 0, Weight(0)));
     checkVisit<RegExpTerm>(new SimpleRegExpTerm("t", "field", 0, Weight(0)));
-    checkVisit<NearestNeighborTerm>(new SimpleNearestNeighborTerm("query_tensor", "doc_tensor", 0, Weight(0), 123, true, 321, 100100.25));
+    NearestNeighborTerm::HnswParams hnsw_params;
+    hnsw_params.distance_threshold = 100100.25;
+    hnsw_params.explore_additional_hits = 321;
+    checkVisit<NearestNeighborTerm>(new SimpleNearestNeighborTerm("query_tensor", "doc_tensor", 0, Weight(0), 123, true, hnsw_params));
     checkVisit<TrueQueryNode>(new SimpleTrue());
     checkVisit<FalseQueryNode>(new SimpleFalse());
     checkVisit<FuzzyTerm>(new SimpleFuzzyTerm("t", "field", 0, Weight(0), 2, 0, false));

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -112,7 +112,10 @@ Node::UP createQueryTree() {
             builder.addStringTerm(str[5], view[5], id[5], weight[6]);
             builder.addStringTerm(str[6], view[6], id[6], weight[7]);
         }
-        builder.add_nearest_neighbor_term("query_tensor", "doc_tensor", id[3], weight[5], 7, true, 33, 100100.25);
+        NearestNeighborTerm::HnswParams hnsw_params;
+        hnsw_params.distance_threshold = 100100.25;
+        hnsw_params.explore_additional_hits = 33;
+        builder.add_nearest_neighbor_term("query_tensor", "doc_tensor", id[3], weight[5], 7, true, hnsw_params);
         builder.addAndNot(2);
         {
             builder.add_true_node();
@@ -521,9 +524,9 @@ struct MyRegExpTerm : RegExpTerm {
 struct MyNearestNeighborTerm : NearestNeighborTerm {
     MyNearestNeighborTerm(std::string_view query_tensor_name, const string & field_name,
                           int32_t i, Weight w, uint32_t target_num_hits,
-                          bool allow_approximate, uint32_t explore_additional_hits,
-                          double distance_threshold)
-      : NearestNeighborTerm(query_tensor_name, field_name, i, w, target_num_hits, allow_approximate, explore_additional_hits, distance_threshold)
+                          bool allow_approximate,
+                          HnswParams hnsw_params = HnswParams())
+      : NearestNeighborTerm(query_tensor_name, field_name, i, w, target_num_hits, allow_approximate, std::move(hnsw_params))
     {}
     ~MyNearestNeighborTerm() override;
 };

--- a/searchlib/src/tests/query/streaming/nearest_neighbor_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/nearest_neighbor_query_node_test.cpp
@@ -74,7 +74,10 @@ TEST_F(NearestNeighborQueryNodeTest, unpack_match_data_for_nearest_neighbor_quer
     constexpr uint32_t target_num_hits = 100;
     constexpr bool allow_approximate = false;
     constexpr uint32_t explore_additional_hits = 800;
-    builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, explore_additional_hits, distance_threshold);
+    search::query::NearestNeighborTerm::HnswParams hnsw_params;
+    hnsw_params.distance_threshold = distance_threshold;
+    hnsw_params.explore_additional_hits = explore_additional_hits;
+    builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, hnsw_params);
     build_query(builder);
     QueryTermList term_list;
     _query->getLeaves(term_list);

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -740,7 +740,10 @@ TEST(StreamingQueryTest, test_nearest_neighbor_query_node)
     constexpr bool allow_approximate = false;
     constexpr uint32_t explore_additional_hits = 800;
     constexpr double distance = 0.5;
-    builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, explore_additional_hits, distance_threshold);
+    NearestNeighborTerm::HnswParams hnsw_params;
+    hnsw_params.distance_threshold = distance_threshold;
+    hnsw_params.explore_additional_hits = explore_additional_hits;
+    builder.add_nearest_neighbor_term("qtensor", "field", id, Weight(weight), target_num_hits, allow_approximate, hnsw_params);
     auto build_node = builder.build();
     auto serializedQueryTree = StackDumpCreator::createSerializedQueryTree(*build_node);
     QueryNodeResultFactory empty;

--- a/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
@@ -123,9 +123,10 @@ TEST(IntermediateBlueprintsTest, test_AndNot_Blueprint) {
         AndNotBlueprint a;
         a.addChild(ap(MyLeafSpec(10).addField(1, 1).create()));
         EXPECT_EQ(0u, a.exposeFields().size());
-        EXPECT_EQ(false, a.getState().want_global_filter());
+        Blueprint::GlobalFilterLimits limits;
+        EXPECT_EQ(false, a.want_global_filter(limits));
         a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
-        EXPECT_EQ(true, a.getState().want_global_filter());
+        EXPECT_EQ(true, a.want_global_filter(limits));
         auto empty_global_filter = GlobalFilter::create();
         EXPECT_FALSE(empty_global_filter->is_active());
         a.set_global_filter(*empty_global_filter, 1.0);
@@ -225,9 +226,10 @@ TEST(IntermediateBlueprintsTest, test_And_Blueprint) {
         AndBlueprint a;
         a.addChild(ap(MyLeafSpec(10).addField(1, 1).create()));
         EXPECT_EQ(0u, a.exposeFields().size());
-        EXPECT_EQ(false, a.getState().want_global_filter());
+        Blueprint::GlobalFilterLimits limits;
+        EXPECT_EQ(false, a.want_global_filter(limits));
         a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
-        EXPECT_EQ(true, a.getState().want_global_filter());
+        EXPECT_EQ(true, a.want_global_filter(limits));
         auto empty_global_filter = GlobalFilter::create();
         a.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQ(false, got_global_filter(a.getChild(0)));
@@ -289,9 +291,10 @@ TEST(IntermediateBlueprintsTest, test_Or_Blueprint) {
         o.addChild(ap(MyLeafSpec(0, true).create()));
         EXPECT_EQ(0u, a->getState().numFields());
 
-        EXPECT_EQ(false, o.getState().want_global_filter());
+        Blueprint::GlobalFilterLimits limits;
+        EXPECT_EQ(false, o.want_global_filter(limits));
         o.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
-        EXPECT_EQ(true, o.getState().want_global_filter());
+        EXPECT_EQ(true, o.want_global_filter(limits));
         auto empty_global_filter = GlobalFilter::create();
         o.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQ(false, got_global_filter(o.getChild(0)));
@@ -416,9 +419,10 @@ TEST(IntermediateBlueprintsTest, test_Rank_Blueprint) {
         a.addChild(ap(MyLeafSpec(10).addField(1, 1).create()));
         EXPECT_EQ(0u, a.exposeFields().size());
 
-        EXPECT_EQ(false, a.getState().want_global_filter());
+        Blueprint::GlobalFilterLimits limits;
+        EXPECT_EQ(false, a.want_global_filter(limits));
         a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
-        EXPECT_EQ(true, a.getState().want_global_filter());
+        EXPECT_EQ(true, a.want_global_filter(limits));
         auto empty_global_filter = GlobalFilter::create();
         a.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQ(false, got_global_filter(a.getChild(0)));

--- a/searchlib/src/tests/queryeval/blueprint/mysearch.h
+++ b/searchlib/src/tests/queryeval/blueprint/mysearch.h
@@ -106,6 +106,7 @@ class MyLeaf : public SimpleLeafBlueprint
 {
     using TFMDA = search::fef::TermFieldMatchDataArray;
     bool _got_global_filter = false;
+    bool _want_global_filter = false;
     double _cost = 1.0;
 
 public:
@@ -136,12 +137,17 @@ public:
         set_cost_tier(value);
         return *this;
     }
+    MyLeaf &want_global_filter(bool value) {
+        _want_global_filter = value;
+        return *this;
+    }
+    bool want_global_filter(GlobalFilterLimits&) const override {
+        return _want_global_filter;
+    }
     void set_global_filter(const GlobalFilter &, double) override {
         _got_global_filter = true;
     }
     bool got_global_filter() const { return _got_global_filter; }
-    // make public
-    using LeafBlueprint::set_want_global_filter;
 
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
@@ -187,7 +193,7 @@ public:
         if (_cost_tier > 0) {
             leaf->cost_tier(_cost_tier);
         }
-        leaf->set_want_global_filter(_want_global_filter);
+        leaf->want_global_filter(_want_global_filter);
         return leaf;
     }
 };

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -769,18 +769,22 @@ public:
             auto calc = tensor::DistanceCalculator::make_with_validation(_attr, *query_tensor);
             const auto& params = getRequestContext().get_create_blueprint_params();
             const auto& hnsw_params = n.get_hnsw_params();
+            queryeval::NearestNeighborBlueprint::HnswParams blueprint_hnsw_params{
+                .explore_additional_hits = n.get_explore_additional_hits(),
+                .distance_threshold = n.get_distance_threshold(),
+                .global_filter_lower_limit = hnsw_params.approximate_threshold.value_or(params.global_filter_lower_limit),
+                .global_filter_lower_limit_is_override = hnsw_params.approximate_threshold.has_value(),
+                .global_filter_upper_limit = hnsw_params.post_filter_threshold.value_or(params.global_filter_upper_limit),
+                .filter_first_upper_limit = hnsw_params.filter_first_threshold.value_or(params.filter_first_upper_limit),
+                .filter_first_exploration = hnsw_params.filter_first_exploration.value_or(params.filter_first_exploration),
+                .exploration_slack = hnsw_params.exploration_slack.value_or(params.exploration_slack),
+                .target_hits_max_adjustment_factor = hnsw_params.target_hits_max_adjustment_factor.value_or(params.target_hits_max_adjustment_factor)
+            };
             setResult(std::make_unique<queryeval::NearestNeighborBlueprint>(_field,
                                                                             std::move(calc),
                                                                             n.get_target_num_hits(),
                                                                             n.get_allow_approximate(),
-                                                                            n.get_explore_additional_hits(),
-                                                                            n.get_distance_threshold(),
-                                                                            hnsw_params.approximate_threshold.value_or(params.global_filter_lower_limit),
-                                                                            hnsw_params.post_filter_threshold.value_or(params.global_filter_upper_limit),
-                                                                            hnsw_params.filter_first_threshold.value_or(params.filter_first_upper_limit),
-                                                                            hnsw_params.filter_first_exploration.value_or(params.filter_first_exploration),
-                                                                            hnsw_params.exploration_slack.value_or(params.exploration_slack),
-                                                                            hnsw_params.target_hits_max_adjustment_factor.value_or(params.target_hits_max_adjustment_factor),
+                                                                            blueprint_hnsw_params,
                                                                             getRequestContext().getDoom()));
         } catch (const vespalib::IllegalArgumentException& ex) {
             return fail_nearest_neighbor_term(n, ex.getMessage());

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -773,7 +773,6 @@ public:
                 .explore_additional_hits = n.get_explore_additional_hits(),
                 .distance_threshold = n.get_distance_threshold(),
                 .global_filter_lower_limit = hnsw_params.approximate_threshold.value_or(params.global_filter_lower_limit),
-                .global_filter_lower_limit_is_override = hnsw_params.approximate_threshold.has_value(),
                 .global_filter_upper_limit = hnsw_params.post_filter_threshold.value_or(params.global_filter_upper_limit),
                 .filter_first_upper_limit = hnsw_params.filter_first_threshold.value_or(params.filter_first_upper_limit),
                 .filter_first_exploration = hnsw_params.filter_first_exploration.value_or(params.filter_first_exploration),

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -43,6 +43,7 @@
 #include <vespa/vespalib/util/regexp.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <charconv>
+#include <limits>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.attribute.attribute_blueprint_factory");
@@ -767,18 +768,19 @@ public:
         try {
             auto calc = tensor::DistanceCalculator::make_with_validation(_attr, *query_tensor);
             const auto& params = getRequestContext().get_create_blueprint_params();
+            const auto& hnsw_params = n.get_hnsw_params();
             setResult(std::make_unique<queryeval::NearestNeighborBlueprint>(_field,
                                                                             std::move(calc),
                                                                             n.get_target_num_hits(),
                                                                             n.get_allow_approximate(),
                                                                             n.get_explore_additional_hits(),
                                                                             n.get_distance_threshold(),
-                                                                            params.global_filter_lower_limit,
-                                                                            params.global_filter_upper_limit,
-                                                                            params.filter_first_upper_limit,
-                                                                            params.filter_first_exploration,
-                                                                            params.exploration_slack,
-                                                                            params.target_hits_max_adjustment_factor,
+                                                                            hnsw_params.approximate_threshold.value_or(params.global_filter_lower_limit),
+                                                                            hnsw_params.post_filter_threshold.value_or(params.global_filter_upper_limit),
+                                                                            hnsw_params.filter_first_threshold.value_or(params.filter_first_upper_limit),
+                                                                            hnsw_params.filter_first_exploration.value_or(params.filter_first_exploration),
+                                                                            hnsw_params.exploration_slack.value_or(params.exploration_slack),
+                                                                            hnsw_params.target_hits_max_adjustment_factor.value_or(params.target_hits_max_adjustment_factor),
                                                                             getRequestContext().getDoom()));
         } catch (const vespalib::IllegalArgumentException& ex) {
             return fail_nearest_neighbor_term(n, ex.getMessage());

--- a/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
@@ -447,14 +447,30 @@ public:
     bool handle(const ItemNearestNeighbor& item) {
         auto d = fillTermProperties(item.properties());
 
-        std::string_view query_tensor_name = item.query_tensor_name();
-        uint32_t targetNumHits = item.target_num_hits();
-        bool allowApproximate = item.allow_approximate();
-        uint32_t exploreAdditionalHits = item.explore_additional_hits();
-        double distanceThreshold = item.distance_threshold();
-        auto &term = _builder.add_nearest_neighbor_term(query_tensor_name, d.index_view, d.uniqueId, d.weight,
-                                           targetNumHits, allowApproximate, exploreAdditionalHits,
-                                           distanceThreshold);
+        typename NodeTypes::NearestNeighborTerm::HnswParams hnsw_params;
+        hnsw_params.distance_threshold = item.distance_threshold();
+        hnsw_params.explore_additional_hits = item.explore_additional_hits();
+        if (item.has_approximate_threshold()) {
+            hnsw_params.approximate_threshold = item.approximate_threshold();
+        }
+        if (item.has_exploration_slack()) {
+            hnsw_params.exploration_slack = item.exploration_slack();
+        }
+        if (item.has_filter_first_exploration()) {
+            hnsw_params.filter_first_exploration = item.filter_first_exploration();
+        }
+        if (item.has_filter_first_threshold()) {
+            hnsw_params.filter_first_threshold = item.filter_first_threshold();
+        }
+        if (item.has_post_filter_threshold()) {
+            hnsw_params.post_filter_threshold = item.post_filter_threshold();
+        }
+        if (item.has_target_hits_max_adjustment_factor()) {
+            hnsw_params.target_hits_max_adjustment_factor = item.target_hits_max_adjustment_factor();
+        }
+
+        auto &term = _builder.add_nearest_neighbor_term(item.query_tensor_name(), d.index_view, d.uniqueId, d.weight,
+                                                        item.target_num_hits(), item.allow_approximate(), hnsw_params);
         // not meaningful?
         if (d.noRankFlag) term.setRanked(false);
         // not meaningful?

--- a/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
@@ -214,12 +214,12 @@ template <class NodeTypes>
 typename NodeTypes::NearestNeighborTerm *
 create_nearest_neighbor_term(std::string_view query_tensor_name, std::string field_name,
                              int32_t id, Weight weight, uint32_t target_num_hits,
-                             bool allow_approximate, uint32_t explore_additional_hits,
-                             double distance_threshold)
+                             bool allow_approximate,
+                             typename NodeTypes::NearestNeighborTerm::HnswParams hnsw_params)
 {
     return new typename NodeTypes::NearestNeighborTerm(query_tensor_name, field_name, id, weight,
-                                                       target_num_hits, allow_approximate, explore_additional_hits,
-                                                       distance_threshold);
+                                                       target_num_hits, allow_approximate,
+                                                       std::move(hnsw_params));
 }
 
 template <class NodeTypes>
@@ -400,11 +400,11 @@ public:
     }
     typename NodeTypes::NearestNeighborTerm &add_nearest_neighbor_term(string_view query_tensor_name, string field_name,
                                                                        int32_t id, Weight weight, uint32_t target_num_hits,
-                                                                       bool allow_approximate, uint32_t explore_additional_hits,
-                                                                       double distance_threshold)
+                                                                       bool allow_approximate,
+                                                                       typename NodeTypes::NearestNeighborTerm::HnswParams hnsw_params = typename NodeTypes::NearestNeighborTerm::HnswParams())
     {
         adjustWeight(weight);
-        return addTerm(create_nearest_neighbor_term<NodeTypes>(query_tensor_name, field_name, id, weight, target_num_hits, allow_approximate, explore_additional_hits, distance_threshold));
+        return addTerm(create_nearest_neighbor_term<NodeTypes>(query_tensor_name, field_name, id, weight, target_num_hits, allow_approximate, std::move(hnsw_params)));
     }
     typename NodeTypes::TrueQueryNode &add_true_node() {
         return addTerm(create_true<NodeTypes>());

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -172,8 +172,8 @@ private:
     void visit(NearestNeighborTerm &node) override {
         copyState(node, _builder.add_nearest_neighbor_term(node.get_query_tensor_name(), node.getView(),
                                                            node.getId(), node.getWeight(), node.get_target_num_hits(),
-                                                           node.get_allow_approximate(), node.get_explore_additional_hits(),
-                                                           node.get_distance_threshold()));
+                                                           node.get_allow_approximate(),
+                                                           node.get_hnsw_params()));
     }
 
     void visit(TrueQueryNode &) override {

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.h
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.h
@@ -142,11 +142,11 @@ struct SimpleRegExpTerm : RegExpTerm {
 struct SimpleNearestNeighborTerm : NearestNeighborTerm {
     SimpleNearestNeighborTerm(std::string_view query_tensor_name, std::string field_name,
                               int32_t id, Weight weight, uint32_t target_num_hits,
-                              bool allow_approximate, uint32_t explore_additional_hits,
-                              double distance_threshold)
+                              bool allow_approximate,
+                              HnswParams hnsw_params = HnswParams())
         : NearestNeighborTerm(query_tensor_name, std::move(field_name), id, weight,
-                              target_num_hits, allow_approximate, explore_additional_hits,
-                              distance_threshold)
+                              target_num_hits, allow_approximate,
+                              std::move(hnsw_params))
     {}
     ~SimpleNearestNeighborTerm() override;
 };

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -146,9 +146,12 @@ private:
             bool allow_approximate = queryStack.getAllowApproximate();
             uint32_t explore_additional_hits = queryStack.getExploreAdditionalHits();
             double distance_threshold = queryStack.getDistanceThreshold();
+            typename NodeTypes::NearestNeighborTerm::HnswParams hnsw_params;
+            hnsw_params.distance_threshold = distance_threshold;
+            hnsw_params.explore_additional_hits = explore_additional_hits;
             builder.add_nearest_neighbor_term(query_tensor_name, queryStack.index_as_string(), id, weight,
-                                              target_num_hits, allow_approximate, explore_additional_hits,
-                                              distance_threshold);
+                                              target_num_hits, allow_approximate,
+                                              hnsw_params);
         } else if (type == ParseItem::ITEM_TRUE) {
             builder.add_true_node();
         } else if (type == ParseItem::ITEM_FALSE) {

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -97,7 +97,6 @@ Blueprint::State::State() noexcept
       _tree_size(1),
       _estimateEmpty(true),
       _allow_termwise_eval(true),
-      _want_global_filter(false),
       _cost_tier(COST_TIER_NORMAL)
 {}
 
@@ -113,7 +112,6 @@ Blueprint::State::State(FieldSpecBaseList fields_in) noexcept
       _tree_size(1),
       _estimateEmpty(true),
       _allow_termwise_eval(true),
-      _want_global_filter(false),
       _cost_tier(COST_TIER_NORMAL)
 {
 }
@@ -527,10 +525,10 @@ IntermediateBlueprint::infer_allow_termwise_eval() const
 }
 
 bool
-IntermediateBlueprint::infer_want_global_filter() const
+IntermediateBlueprint::want_global_filter(GlobalFilterLimits& limits) const
 {
     for (const Blueprint::UP &child : _children) {
-        if (child->getState().want_global_filter()) {
+        if (child->want_global_filter(limits)) {
             return true;
         }
     }
@@ -602,7 +600,6 @@ IntermediateBlueprint::calculateState() const
     state.estimate(calculateEstimate());
     state.cost_tier(calculate_cost_tier());
     state.allow_termwise_eval(infer_allow_termwise_eval());
-    state.want_global_filter(infer_want_global_filter());
     state.tree_size(calculate_tree_size());
     return state;
 }
@@ -654,8 +651,9 @@ IntermediateBlueprint::sort(InFlow in_flow)
 void
 IntermediateBlueprint::set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio)
 {
+    GlobalFilterLimits limits;  // Not used here, just checking if filter is wanted
     for (auto & child : _children) {
-        if (child->getState().want_global_filter()) {
+        if (child->want_global_filter(limits)) {
             child->set_global_filter(global_filter, estimated_hit_ratio);
         }
     }
@@ -856,13 +854,6 @@ LeafBlueprint::set_cost_tier(uint32_t value)
 {
     assert(value < 0x100);
     _state.cost_tier(value);
-    notifyChange();
-}
-
-void
-LeafBlueprint::set_want_global_filter(bool value)
-{
-    _state.want_global_filter(value);
     notifyChange();
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -10,6 +10,7 @@
 #include "matching_phase.h"
 #include "multisearch.h"
 #include <vespa/searchlib/common/bitvector.h>
+#include <optional>
 #include <span>
 
 namespace vespalib { class ObjectVisitor; }
@@ -132,6 +133,15 @@ public:
         }
     };
 
+    struct GlobalFilterLimits {
+        std::optional<double> lower_limit;
+        std::optional<double> upper_limit;
+
+        constexpr GlobalFilterLimits() noexcept = default;
+        constexpr GlobalFilterLimits(std::optional<double> lower, std::optional<double> upper) noexcept
+            : lower_limit(lower), upper_limit(upper) {}
+    };
+
     class State
     {
     private:
@@ -140,7 +150,6 @@ public:
         uint32_t          _tree_size : 20;
         bool              _estimateEmpty : 1;
         bool              _allow_termwise_eval : 1;
-        bool              _want_global_filter : 1;
         uint8_t           _cost_tier;
 
     public:
@@ -189,8 +198,6 @@ public:
         uint32_t tree_size() const noexcept { return _tree_size; }
         void allow_termwise_eval(bool value) noexcept { _allow_termwise_eval = value; }
         bool allow_termwise_eval() const noexcept { return _allow_termwise_eval; }
-        void want_global_filter(bool value) noexcept { _want_global_filter = value; }
-        bool want_global_filter() const noexcept { return _want_global_filter; }
         void cost_tier(uint8_t value) noexcept { _cost_tier = value; }
         uint8_t cost_tier() const noexcept { return _cost_tier; }
     };
@@ -347,10 +354,20 @@ public:
     virtual bool always_needs_unpack() const { return false; }
 
     /**
+     * Indicates whether this blueprint wants a global filter.
+     *
+     * @param limits Output parameter where blueprint can provide override limits.
+     * @return true if global filter is wanted, false otherwise.
+     */
+    virtual bool want_global_filter(GlobalFilterLimits&) const {
+        return false;
+    }
+
+    /**
      * Sets the global filter on the query blueprint tree.
      *
      * This function is implemented by leaf blueprints that want the global filter,
-     * signaled by LeafBlueprint::set_want_global_filter().
+     * signaled by returning true from want_global_filter().
      *
      * @param global_filter The global filter that is calculated once per query if wanted.
      * @param estimated_hit_ratio The estimated hit ratio of the query (in the range [0.0, 1.0]).
@@ -479,7 +496,6 @@ private:
     virtual uint8_t calculate_cost_tier() const;
     uint32_t calculate_tree_size() const;
     bool infer_allow_termwise_eval() const;
-    bool infer_want_global_filter() const;
 
     size_t count_termwise_nodes(const UnpackInfo &unpack) const;
     virtual AnyFlow my_flow(InFlow in_flow) const = 0;
@@ -534,6 +550,8 @@ public:
 
     UnpackInfo calculateUnpackInfo(const fef::MatchData & md) const;
     IntermediateBlueprint * asIntermediate() noexcept final { return this; }
+
+    bool want_global_filter(GlobalFilterLimits& limits) const override;
 };
 
 
@@ -552,7 +570,6 @@ protected:
         _state.allow_termwise_eval(value);
         notifyChange();
     }
-    void set_want_global_filter(bool value);
     void set_tree_size(uint32_t value);
 
     explicit LeafBlueprint(bool allow_termwise_eval) noexcept

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -61,7 +61,6 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
       _hnsw_params{.explore_additional_hits = hnsw_params.explore_additional_hits,
                    .distance_threshold = convert_distance_threshold(hnsw_params.distance_threshold, *_distance_calc),
                    .global_filter_lower_limit = hnsw_params.global_filter_lower_limit,
-                   .global_filter_lower_limit_is_override = hnsw_params.global_filter_lower_limit_is_override,
                    .global_filter_upper_limit = hnsw_params.global_filter_upper_limit,
                    .filter_first_upper_limit = hnsw_params.filter_first_upper_limit,
                    .filter_first_exploration = hnsw_params.filter_first_exploration,
@@ -89,12 +88,8 @@ NearestNeighborBlueprint::want_global_filter(GlobalFilterLimits& limits) const
 {
     auto nns_index = _attr_tensor.nearest_neighbor_index();
     if (nns_index && _approximate) {
-        if (_hnsw_params.global_filter_lower_limit_is_override) {
-            limits.lower_limit = _hnsw_params.global_filter_lower_limit;
-        }
-        if (_hnsw_params.global_filter_upper_limit.has_value()) {
-            limits.upper_limit = _hnsw_params.global_filter_upper_limit.value();
-        }
+        limits.lower_limit = _hnsw_params.global_filter_lower_limit;
+        limits.upper_limit = _hnsw_params.global_filter_upper_limit;
         return true;
     }
     return false;
@@ -194,9 +189,7 @@ NearestNeighborBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) const
     visitor.visitBool("set", _global_filter_set);
     visitor.visitBool("calculated", _global_filter->is_active());
     visitor.visitFloat("lower_limit", _hnsw_params.global_filter_lower_limit);
-    if (_hnsw_params.global_filter_upper_limit.has_value()) {
-        visitor.visitFloat("upper_limit", _hnsw_params.global_filter_upper_limit.value());
-    }
+    visitor.visitFloat("upper_limit", _hnsw_params.global_filter_upper_limit);
     if (_global_filter_hits.has_value()) {
         visitor.visitInt("hits", _global_filter_hits.value());
     }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -31,8 +31,7 @@ public:
         uint32_t explore_additional_hits;
         double distance_threshold;
         double global_filter_lower_limit;
-        bool global_filter_lower_limit_is_override;
-        std::optional<double> global_filter_upper_limit;
+        double global_filter_upper_limit;
         double filter_first_upper_limit;
         double filter_first_exploration;
         double exploration_slack;
@@ -82,7 +81,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
         return default_flow_stats(docid_limit, getState().estimate().estHits, 0);
     }
-    
+
     std::unique_ptr<SearchIterator> createLeafSearch(const search::fef::TermFieldMatchDataArray& tfmda) const override;
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -77,6 +77,7 @@ public:
     const vespalib::eval::Value& get_query_tensor() const { return _query_tensor; }
     uint32_t get_target_hits() const { return _target_hits; }
     uint32_t get_adjusted_target_hits() const { return _adjusted_target_hits; }
+    bool want_global_filter(GlobalFilterLimits& limits) const override;
     void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
     Algorithm get_algorithm() const { return _algorithm; }
     double get_distance_threshold() const { return _hnsw_params.distance_threshold; }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -31,7 +31,8 @@ public:
         uint32_t explore_additional_hits;
         double distance_threshold;
         double global_filter_lower_limit;
-        double global_filter_upper_limit;
+        bool global_filter_lower_limit_is_override;
+        std::optional<double> global_filter_upper_limit;
         double filter_first_upper_limit;
         double filter_first_exploration;
         double exploration_slack;
@@ -61,14 +62,8 @@ private:
 public:
     NearestNeighborBlueprint(const queryeval::FieldSpec& field,
                              std::unique_ptr<search::tensor::DistanceCalculator> distance_calc,
-                             uint32_t target_hits, bool approximate, uint32_t explore_additional_hits,
-                             double distance_threshold,
-                             double global_filter_lower_limit,
-                             double global_filter_upper_limit,
-                             double filter_first_upper_limit,
-                             double filter_first_exploration,
-                             double exploration_slack,
-                             double target_hits_max_adjustment_factor,
+                             uint32_t target_hits, bool approximate,
+                             const HnswParams& hnsw_params,
                              const vespalib::Doom& doom);
     NearestNeighborBlueprint(const NearestNeighborBlueprint&) = delete;
     NearestNeighborBlueprint& operator=(const NearestNeighborBlueprint&) = delete;


### PR DESCRIPTION
 - Add HnswParams struct in NearestNeighborTerm, with all the new (optional) parameters
 - Fill the parameters in proto_tree_converter
 - Use HnswParams to override CreateBlueprintParams in attribute blueprint factory
 - Add corresponding HnswParams in NearestNeighborBlueprint, with final, actual parameter values (const)
 - Use designated initializers for clear, maintainable initialization
 - Add static convert_distance_threshold() helper to enable const initialization

@boeker please review
@toregge @havardpe FYI
