### PR TITLE
Update validClusterTypes to remove 'combined'

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/Validation.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/Validation.java
@@ -7,7 +7,7 @@ import java.util.Set;
 public class Validation {
     static final Set<String> validDiskSpeeds = Set.of("slow", "fast", "any");
     static final Set<String> validStorageTypes = Set.of("remote", "local", "any");
-    static final Set<String> validClusterTypes = Set.of("container", "content", "combined", "admin");
+    static final Set<String> validClusterTypes = Set.of("container", "content", "admin");
     static final Set<String> validArchitectures = Set.of("arm64", "x86_64", "any");
 
     static double requirePositive(String name, Double value) {


### PR DESCRIPTION
Removed 'combined' from validClusterTypes set.

Ref https://github.com/vespa-engine/vespa/pull/34939

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
