### PR TITLE
Add `max` as alias for `boost` for `<threads>` when configuring threadpool that support `boost`

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
@@ -89,9 +89,15 @@ public abstract class ContainerThreadpool extends SimpleComponent implements Con
                 if (queueSizeElem != null) queue = Double.parseDouble(queueSizeElem.getTextContent());
                 isRelative = false;
             }
-            if (max != null && max <= 0) throw new IllegalArgumentException("Thread pool 'max' must be positive");
-            if (min != null && min < 0) throw new IllegalArgumentException("Thread pool 'min' must be positive");
-            if (queue != null && queue < 0) throw new IllegalArgumentException("Thread pool 'queue' must be positive");
+
+            if (min != null && min < 0)
+                throw new IllegalArgumentException("For <threadpool>: <threads> must be positive.");
+            if (max != null && max <= 0)
+                throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be positive.");
+            if (queue != null && queue < 0)
+                throw new IllegalArgumentException("For <threadpool>: <queue> must be positive.");
+            if (min != null && max != null && min > max)
+                throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be greater than <threads>.");
             options = new UserOptions(max, min, queue, isRelative);
         }
     }

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -146,7 +146,12 @@ Threadpool = element threadpool {
         element min-threads { xsd:nonNegativeInteger } &
         element queue-size { xsd:nonNegativeInteger }
     )|(
-        element threads { xsd:double { minExclusive = "0.0" } & attribute boost { xsd:double { minExclusive = "0.0" } }? }? &
+        element threads {
+            xsd:double { minExclusive = "0.0" } &
+            ( attribute max { xsd:double { minExclusive = "0.0" } }
+            | attribute boost { xsd:double { minExclusive = "0.0" } }
+            | empty )
+        }? &
         element queue { xsd:double { minInclusive = "0.0" } }?
     ))
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
@@ -225,7 +225,7 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
                 "<container id='default' version='1.0'>",
                 "  <search>",
                 "    <threadpool>",
-                "      <threads boost=\"10.2\">0.4</threads>",
+                "      <threads max=\"10.2\">0.4</threads>",
                 "      <queue>50</queue>",
                 "    </threadpool>",
                 "  </search>",


### PR DESCRIPTION
This PR:
- Adds `max` as an alias for `boost` in `<thread>` when configuring threadpools that support `boost`.
- The user cannot specify both `boost` and `max`.
- Enforce `min` $\leq$ `max` in conifg-model to validate this when building config model.

@hmusum please review
@bjorncs fyi
@arnej27959 fyi