### PR TITLE
Replace `IAccelerated` use with dedicated vectorized functions

### DIFF
--- a/eval/src/vespa/eval/eval/inline_operation.cpp
+++ b/eval/src/vespa/eval/eval/inline_operation.cpp
@@ -1,21 +1,14 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "inline_operation.h"
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 
 namespace vespalib::eval::operation {
 
 // These are the ironically de-inlined operations of `inline_operation.h` that may benefit
 // from being in an explicit translation unit. In particular, this is for operations that
-// use our own vectorized kernels, trading off inlining with not having to call getAccelerator()
-// for each invocation of apply(), as well as hiding the iaccelerated header details.
-
-namespace {
-
-// Same pattern as in `mixed_l2_distance.cpp`
-static const auto &accel = hwaccelerated::IAccelerated::getAccelerator();
-
-}
+// use our own vectorized kernels, hiding the iaccelerated header details.
+// TODO consider moving to header file...!
 
 double DotProduct<Int8Float, Int8Float>::apply(const Int8Float *lhs, const Int8Float *rhs, size_t count) {
     // Do a few pre-flight checks before daring to touch the buffer as-if int8_t*...
@@ -25,11 +18,11 @@ double DotProduct<Int8Float, Int8Float>::apply(const Int8Float *lhs, const Int8F
 
     const auto *lhs_as_i8 = reinterpret_cast<const int8_t*>(lhs);
     const auto *rhs_as_i8 = reinterpret_cast<const int8_t*>(rhs);
-    return static_cast<double>(accel.dotProduct(lhs_as_i8, rhs_as_i8, count));
+    return static_cast<double>(hwaccelerated::dot_product(lhs_as_i8, rhs_as_i8, count));
 }
 
 double DotProduct<BFloat16, BFloat16>::apply(const BFloat16 *lhs, const BFloat16 *rhs, size_t count) {
-    return accel.dotProduct(lhs, rhs, count);
+    return hwaccelerated::dot_product(lhs, rhs, count);
 }
 
 }

--- a/eval/src/vespa/eval/instruction/generic_cell_cast.cpp
+++ b/eval/src/vespa/eval/instruction/generic_cell_cast.cpp
@@ -5,7 +5,7 @@
 #include <vespa/eval/eval/wrap_param.h>
 #include <vespa/vespalib/util/stash.h>
 #include <vespa/vespalib/util/typify.h>
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <cassert>
 
 using namespace vespalib::eval::tensor_function;
@@ -16,8 +16,6 @@ using State = InterpretedFunction::State;
 using Instruction = InterpretedFunction::Instruction;
 
 namespace {
-
-using hwaccelerated::IAccelerated;
 
 template <typename ICT, typename OCT>
 void my_generic_cell_cast_op(State &state, uint64_t param_in) {
@@ -40,9 +38,8 @@ void my_generic_cell_cast_op<BFloat16, float>(State &state, uint64_t param_in) {
     const Value &a = state.peek(0);
     auto input_cells = a.cells().typify<BFloat16>();
     auto output_cells = state.stash.create_uninitialized_array<float>(input_cells.size());
-    static const IAccelerated & accelerator = IAccelerated::getAccelerator();
-    accelerator.convert_bfloat16_to_float(reinterpret_cast<const uint16_t *>(input_cells.data()),
-                                         output_cells.data(), output_cells.size());
+    hwaccelerated::convert_bfloat16_to_float(reinterpret_cast<const uint16_t *>(input_cells.data()),
+                                             output_cells.data(), output_cells.size());
     Value &result_ref = state.stash.create<ValueView>(res_type, a.index(), TypedCells(output_cells));
     state.pop_push(result_ref);
 }

--- a/eval/src/vespa/eval/instruction/l2_distance.cpp
+++ b/eval/src/vespa/eval/instruction/l2_distance.cpp
@@ -3,7 +3,7 @@
 #include "l2_distance.h"
 #include <vespa/eval/eval/operation.h>
 #include <vespa/eval/eval/value.h>
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/util/require.h>
 
 #include <vespa/log/log.h>
@@ -15,11 +15,9 @@ using namespace tensor_function;
 
 namespace {
 
-static const auto &hw = hwaccelerated::IAccelerated::getAccelerator();
-
 template <typename T>
 double sq_l2(const Value &lhs, const Value &rhs, size_t len) {
-    return hw.squaredEuclideanDistance((const T *)lhs.cells().data, (const T *)rhs.cells().data, len);
+    return hwaccelerated::squared_euclidean_distance((const T *)lhs.cells().data, (const T *)rhs.cells().data, len);
 }
 
 template <>

--- a/eval/src/vespa/eval/instruction/mixed_l2_distance.cpp
+++ b/eval/src/vespa/eval/instruction/mixed_l2_distance.cpp
@@ -3,7 +3,7 @@
 #include "mixed_l2_distance.h"
 #include <vespa/eval/eval/operation.h>
 #include <vespa/eval/eval/value.h>
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/util/require.h>
 
 #include <vespa/log/log.h>
@@ -15,16 +15,14 @@ using namespace tensor_function;
 
 namespace {
 
-static const auto &hw = hwaccelerated::IAccelerated::getAccelerator();
-
 template <typename T>
 double h_sq_l2(const T *a, const T *b, size_t len) {
-    return hw.squaredEuclideanDistance(a, b, len);
+    return hwaccelerated::squared_euclidean_distance(a, b, len);
 }
 
 template <>
 double h_sq_l2<Int8Float>(const Int8Float *a, const Int8Float *b, size_t len) {
-    return hw.squaredEuclideanDistance((const int8_t *)a, (const int8_t *)b, len);
+    return hwaccelerated::squared_euclidean_distance((const int8_t *)a, (const int8_t *)b, len);
 }
 
 struct MixedSqL2Param {

--- a/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/fef/properties.h>
 #include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/value_codec.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/stash.h>
@@ -20,7 +21,6 @@ using namespace search::fef;
 using vespalib::eval::FastValueBuilderFactory;
 using vespalib::eval::TypedCells;
 using vespalib::Issue;
-using vespalib::hwaccelerated::IAccelerated;
 
 namespace search::features {
 namespace dotproduct::wset {
@@ -213,7 +213,6 @@ namespace dotproduct::array {
 template <typename BaseType>
 DotProductExecutorBase<BaseType>::DotProductExecutorBase(const V & queryVector)
     : FeatureExecutor(),
-      _multiplier(IAccelerated::getAccelerator()),
       _queryVector(queryVector)
 {
 }
@@ -225,7 +224,7 @@ template <typename BaseType>
 void DotProductExecutorBase<BaseType>::execute(uint32_t docId) {
     auto values = getAttributeValues(docId);
     size_t commonRange = std::min(values.size(), _queryVector.size());
-    outputs().set_number(0, _multiplier.dotProduct(
+    outputs().set_number(0, vespalib::hwaccelerated::dot_product(
             &_queryVector[0], values.data(), commonRange));
 }
 

--- a/searchlib/src/vespa/searchlib/features/dotproductfeature.h
+++ b/searchlib/src/vespa/searchlib/features/dotproductfeature.h
@@ -7,7 +7,6 @@
 #include <vespa/searchcommon/attribute/i_multi_value_read_view.h>
 #include <vespa/searchcommon/attribute/multivalue.h>
 #include <vespa/searchlib/fef/blueprint.h>
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 
 namespace search::fef { class Property; }
@@ -168,8 +167,7 @@ class DotProductExecutorBase : public fef::FeatureExecutor {
 public:
     using V  = std::vector<BaseType>;
 private:
-    const vespalib::hwaccelerated::IAccelerated   & _multiplier;
-    V                                             _queryVector;
+    V _queryVector;
     virtual std::span<const BaseType> getAttributeValues(uint32_t docid) = 0;
 public:
     DotProductExecutorBase(const V & queryVector);

--- a/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
@@ -4,28 +4,27 @@
 #include "andsearch.h"
 #include "andnotsearch.h"
 #include "sourceblendersearch.h"
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 
 namespace search::queryeval {
 
 using vespalib::Trinary;
-using vespalib::hwaccelerated::IAccelerated;
 using Meta = MultiBitVectorBase::Meta;
 
 namespace {
 
 struct And {
     using Word = BitWord::Word;
-    void operator () (const IAccelerated & accel, size_t offset, const std::vector<Meta> & src, void *dest) noexcept {
-        accel.and128(offset, src, dest);
+    void operator () (size_t offset, const std::vector<Meta> & src, void *dest) noexcept {
+        vespalib::hwaccelerated::and_128(offset, src, dest);
     }
     static constexpr bool isAnd() noexcept { return true; }
 };
 
 struct Or {
     using Word = BitWord::Word;
-    void operator () (const IAccelerated & accel, size_t offset, const std::vector<Meta> & src, void *dest) noexcept {
-        accel.or128(offset, src, dest);
+    void operator () (size_t offset, const std::vector<Meta> & src, void *dest) noexcept {
+        vespalib::hwaccelerated::or_128(offset, src, dest);
     }
     static constexpr bool isAnd() noexcept { return false; }
 };
@@ -52,7 +51,6 @@ template <typename Update>
 MultiBitVector<Update>::MultiBitVector(size_t reserved)
     : MultiBitVectorBase(reserved),
       _update(),
-      _accel(IAccelerated::getAccelerator()),
       _lastWords()
 {
     static_assert(sizeof(_lastWords) == 128, "Lastwords should have 128 byte size");
@@ -81,7 +79,7 @@ void
 MultiBitVector<Update>::fetchChunk(uint32_t index) noexcept
 {
     uint32_t baseIndex = index & ~(NumWordsInBatch - 1);
-    _update(_accel, baseIndex*sizeof(Word), _bvs, _lastWords);
+    _update(baseIndex*sizeof(Word), _bvs, _lastWords);
     _lastMaxDocIdLimitRequireFetch = (baseIndex + NumWordsInBatch) * BitWord::WordLen;
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.h
@@ -47,10 +47,7 @@ private:
     VESPA_DLL_LOCAL bool updateLastValueCold(uint32_t docId) noexcept __attribute__((noinline));
     VESPA_DLL_LOCAL void fetchChunk(uint32_t docId) noexcept __attribute__((noinline));
 
-    using IAccelerated = vespalib::hwaccelerated::IAccelerated;
-
     Update              _update;
-    const IAccelerated & _accel;
     alignas(64) Word    _lastWords[16];
     static constexpr size_t NumWordsInBatch = sizeof(_lastWords) / sizeof(Word);
 };

--- a/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
@@ -2,7 +2,7 @@
 
 #include "euclidean_distance.h"
 #include "temporary_vector_store.h"
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <cmath>
 
 using vespalib::typify_invoke;
@@ -15,22 +15,19 @@ using vespalib::eval::Int8Float;
 
 template <typename VectorStoreType>
 class BoundEuclideanDistance final : public BoundDistanceFunction {
-private:
     using FloatType = VectorStoreType::FloatType;
-    const vespalib::hwaccelerated::IAccelerated & _computer;
     mutable VectorStoreType _tmpSpace;
     const std::span<const FloatType> _lhs_vector;
 public:
     explicit BoundEuclideanDistance(TypedCells lhs)
-        : _computer(vespalib::hwaccelerated::IAccelerated::getAccelerator()),
-          _tmpSpace(lhs.size),
+        : _tmpSpace(lhs.size),
           _lhs_vector(_tmpSpace.storeLhs(lhs))
     {}
     double calc(TypedCells rhs) const noexcept override {
         std::span<const FloatType> rhs_vector = _tmpSpace.convertRhs(rhs);
         auto a = _lhs_vector.data();
         auto b = rhs_vector.data();
-        return _computer.squaredEuclideanDistance(cast(a), cast(b), _lhs_vector.size());
+        return vespalib::hwaccelerated::squared_euclidean_distance(cast(a), cast(b), _lhs_vector.size());
     }
     double convert_threshold(double threshold) const noexcept override {
         return threshold*threshold;

--- a/searchlib/src/vespa/searchlib/tensor/hamming_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hamming_distance.cpp
@@ -2,7 +2,7 @@
 
 #include "hamming_distance.h"
 #include "temporary_vector_store.h"
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 
 using vespalib::typify_invoke;
 using vespalib::eval::TypedCells;
@@ -15,20 +15,18 @@ using vespalib::eval::Int8Float;
 template <typename VectorStoreType>
 class BoundHammingDistance final : public BoundDistanceFunction {
     using FloatType = VectorStoreType::FloatType;
-    const vespalib::hwaccelerated::IAccelerated& _accelerator;
     mutable VectorStoreType _tmpSpace;
     const std::span<const FloatType> _lhs_vector;
 public:
     explicit BoundHammingDistance(TypedCells lhs)
-        : _accelerator(vespalib::hwaccelerated::IAccelerated::getAccelerator()),
-          _tmpSpace(lhs.size),
+        : _tmpSpace(lhs.size),
           _lhs_vector(_tmpSpace.storeLhs(lhs))
     {}
     double calc(TypedCells rhs) const noexcept override {
         size_t sz = _lhs_vector.size();
         std::span<const FloatType> rhs_vector = _tmpSpace.convertRhs(rhs);
         if constexpr (std::is_same<Int8Float, FloatType>::value) {
-            return (double)_accelerator.binary_hamming_distance(_lhs_vector.data(), rhs_vector.data(), sz);
+            return (double)vespalib::hwaccelerated::binary_hamming_distance(_lhs_vector.data(), rhs_vector.data(), sz);
         } else {
             size_t sum = 0;
             for (size_t i = 0; i < sz; ++i) {

--- a/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
@@ -1,11 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "temporary_vector_store.h"
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 
 using vespalib::eval::CellType;
 using vespalib::eval::TypedCells;
-using vespalib::hwaccelerated::IAccelerated;
 
 namespace search::tensor {
 
@@ -31,8 +30,7 @@ template<>
 std::span<const float>
 convert_cells<vespalib::BFloat16, float>(std::span<float> space, TypedCells cells) noexcept
 {
-    static const IAccelerated & accelerator = IAccelerated::getAccelerator();
-    accelerator.convert_bfloat16_to_float(reinterpret_cast<const uint16_t *>(cells.data), space.data(), space.size());
+    vespalib::hwaccelerated::convert_bfloat16_to_float(reinterpret_cast<const uint16_t *>(cells.data), space.data(), space.size());
     return space;
 }
 

--- a/vespalib/src/tests/dotproduct/dotproductbenchmark.cpp
+++ b/vespalib/src/tests/dotproduct/dotproductbenchmark.cpp
@@ -1,5 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/vespalib/hwaccelerated/iaccelerated.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <functional>
 #include <iostream>
@@ -8,7 +8,6 @@
 #include <vector>
 
 using namespace vespalib;
-using vespalib::hwaccelerated::IAccelerated;
 
 class Benchmark {
 public:
@@ -49,19 +48,17 @@ public:
     FullBenchmark(size_t numDocs, size_t numValue);
     ~FullBenchmark() override;
     void compute(size_t docId) const override {
-        _dp.dotProduct(&_query[0], &_values[docId * _query.size()], _query.size());
+        (void)hwaccelerated::dot_product(&_query[0], &_values[docId * _query.size()], _query.size());
     }
 private:
     std::vector<T> _values;
     std::vector<T> _query;
-    const IAccelerated & _dp;
 };
 
 template <typename T>
 FullBenchmark<T>::FullBenchmark(size_t numDocs, size_t numValues)
     : _values(numDocs*numValues),
-      _query(numValues),
-      _dp(IAccelerated::getAccelerator())
+      _query(numValues)
 {
     for (size_t i(0); i < numDocs; i++) {
         for (size_t j(0); j < numValues; j++) {

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
@@ -3,8 +3,8 @@
 #include "data_utils.h"
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/hwaccelerated/fn_table.h>
-#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/hwaccelerated/highway.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/hwaccelerated/iaccelerated.h>
 #include <limits>
 #include <random>
@@ -50,7 +50,7 @@ void verify_euclidean_distance(std::span<const IAccelerated*> accels, size_t tes
             ASSERT_NEAR(sum, computed, sum*approx_factor) << "(IAccelerated) " << accel->target_info().to_string();
 
             ScopedFnTableOverride fn_scope(accel->fn_table());
-            computed = vec_fn::squared_euclidean_distance(&a[j], &b[j], test_length - j);
+            computed = squared_euclidean_distance(&a[j], &b[j], test_length - j);
             ASSERT_NEAR(sum, computed, sum*approx_factor) << "(fn table) " << accel->target_info().to_string();
         }
     }
@@ -70,7 +70,7 @@ void verify_dot_product(std::span<const IAccelerated*> accels, size_t test_lengt
             ASSERT_NEAR(sum, computed, std::fabs(sum*approx_factor)) << "(IAccelerated) " << accel->target_info().to_string();
 
             ScopedFnTableOverride fn_scope(accel->fn_table());
-            computed = static_cast<double>(vec_fn::dot_product(&a[j], &b[j], test_length - j));
+            computed = static_cast<double>(dot_product(&a[j], &b[j], test_length - j));
             ASSERT_NEAR(sum, computed, std::fabs(sum*approx_factor)) << "(fn table) " << accel->target_info().to_string();
         }
     }
@@ -173,7 +173,7 @@ void verify_euclidean_distance_no_overflow(std::span<const IAccelerated*> accels
             ASSERT_EQ(sum, computed) << "(IAccelerated) overflow at length " << i << " for accel " << accel->target_info().to_string();
 
             ScopedFnTableOverride fn_scope(accel->fn_table());
-            computed = static_cast<int64_t>(vec_fn::squared_euclidean_distance(lhs.data(), rhs.data(), i));
+            computed = static_cast<int64_t>(squared_euclidean_distance(lhs.data(), rhs.data(), i));
             ASSERT_EQ(sum, computed) << "(fn table) overflow at length " << i << " for accel " << accel->target_info().to_string();
         }
     }
@@ -202,7 +202,7 @@ void verify_dot_product_no_overflow(std::span<const IAccelerated*> accels, size_
             ASSERT_EQ(sum, computed) << "(IAccelerated) overflow at length " << i << " for accel " << accel->target_info().to_string();
 
             ScopedFnTableOverride fn_scope(accel->fn_table());
-            computed = vec_fn::dot_product(lhs.data(), rhs.data(), i);
+            computed = dot_product(lhs.data(), rhs.data(), i);
             ASSERT_EQ(sum, computed) << "(fn table) overflow at length " << i << " for accel " << accel->target_info().to_string();
         }
     }
@@ -272,7 +272,7 @@ void check_with_flipping(std::span<const IAccelerated*> accels, void* mem_a, voi
         for (const auto* accel : accels) {
             ASSERT_EQ(accel->binary_hamming_distance(mem_a, mem_b, sz), dist) << "(IAccelerated) " << accel->target_info().to_string();
             ScopedFnTableOverride fn_scope(accel->fn_table());
-            ASSERT_EQ(vec_fn::binary_hamming_distance(mem_a, mem_b, sz), dist) << "(fn table) " << accel->target_info().to_string();
+            ASSERT_EQ(binary_hamming_distance(mem_a, mem_b, sz), dist) << "(fn table) " << accel->target_info().to_string();
         }
     };
     ASSERT_NO_FATAL_FAILURE(check_accelerators());

--- a/vespalib/src/vespa/vespalib/hwaccelerated/functions.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/functions.h
@@ -4,7 +4,7 @@
 
 #include "fn_table.h"
 
-namespace vespalib::hwaccelerated::vec_fn {
+namespace vespalib::hwaccelerated {
 
 // These are freestanding functions that will be dispatched to the vectorized implementation
 // expected to bring the best performance for the currently running CPU architecture.


### PR DESCRIPTION
@havardpe please review

This should transparently enable AArch64 SVE/SVE2 binary Hamming acceleration when this is supported by the CPU, as these are currently only enabled via the composite function tables and not via `IAccelerated`.

Holding off merge until we're done with the weekly release cycle, since I would like this to simmer for a couple of days.