### PR TITLE
Remove manual AVX2/AVX3 fallback for popcount without `VPOPCNTDQ`

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -186,30 +186,25 @@ double my_hwy_square_euclidean_distance_int8(const int8_t* HWY_RESTRICT a,
     return compute_chunked_sum<max_n_per_chunk, double>(sub_mul_add_i8_to_i32, a, b, sz);
 }
 
+// Performance note: AVX2 and AVX3 do not have dedicated vector popcount instructions,
+// so the Highway "emulation" ends up being slower in practice than the baseline one
+// using 4x pipelined POPCNT.
 HWY_INLINE
 size_t my_hwy_popcount(const uint64_t* a, const size_t sz) noexcept {
-    // TODO remove this special-casing once we've moved to function table dispatch
-#if HWY_TARGET != HWY_AVX2 && HWY_TARGET != HWY_AVX3
     const hn::ScalableTag<uint64_t> d;
     const auto kernel_fn = [](auto v, auto& accu) VESPA_NOEXCEPT_HWY_ATTR {
         accu = hn::Add(hn::PopulationCount(v), accu);
     };
     using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<8>, HasAccumulatorArity<1>>;
     return MyKernel::elementwise(d, d, a, sz, hn::Zero(d), kernel_fn, VecAdd(), LaneReduceSum());
-#else
-    // AVX2 and AVX3 do not have dedicated vector popcount instructions, so the Highway "emulation"
-    // ends up being slower in practice than the baseline one using 4x pipelined POPCNT.
-    return PlatformGenericAccelerator().populationCount(a, sz);
-#endif
 }
 
+// Performance note: will be slower on AVX2/AVX3; see `my_hwy_popcount`.
 HWY_INLINE
 size_t my_hwy_binary_hamming_distance(const void* HWY_RESTRICT untyped_lhs,
                                       const void* HWY_RESTRICT untyped_rhs,
                                       const size_t sz) noexcept
 {
-    // TODO remove this special-casing once we've moved to function table dispatch
-#if HWY_TARGET != HWY_AVX2 && HWY_TARGET != HWY_AVX3
     // Inputs may have arbitrary byte alignments, so we have to read with an 8-bit
     // type to ensure we don't violate any natural alignment requirements. The
     // `HwyReduceKernel` code uses unaligned vector loads, so this works fine and
@@ -231,10 +226,6 @@ size_t my_hwy_binary_hamming_distance(const void* HWY_RESTRICT untyped_lhs,
 
     using MyKernel = HwyReduceKernel<UsesNAccumulators<4>, UnrolledBy<4>, HasAccumulatorArity<1>>;
     return MyKernel::pairwise(d8, d64, lhs_u8, rhs_u8, sz, hn::Zero(d64), kernel_fn, VecAdd(), LaneReduceSum());
-#else
-    // See `my_hwy_popcount` for rationale on falling back to auto-vectorized code pre-AVX3-DL x64
-    return PlatformGenericAccelerator().binary_hamming_distance(untyped_lhs, untyped_rhs, sz);
-#endif
 }
 
 // Multiply i8*i8 with the result widened to i16. Widen the intermediate i16 results to i32 and accumulate.


### PR DESCRIPTION
@havardpe please review

Since avoiding the use of suboptimal functions is now handled at a higher level of abstraction, we no longer have to compile-time fallback to the baseline implementation to avoid regressions.
