### PR TITLE
Also enforce Highway lambda callee inlining

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -30,13 +30,14 @@ namespace {
 // Clang and GCC refuse to parse `noexcept HWY_ATTR` and `HWY_ATTR noexcept`,
 // respectively. GCC seems to be the one that is technically correct(tm), but
 // we still want Clang to compile, so hide the dirt under a macro carpet.
-// Also force lambda inlining to avoid GCC doing some wild codegen with vector
-// register spilling to stack temporaries if it decides to break the lambda
-// out as a separate logical function.
+// Force lambda caller inlining to avoid GCC doing some wild codegen with vector
+// register spilling to stack temporaries if it decides to break the lambda out
+// as a separate logical function. For good measure, also ensure that we inline
+// the lambda's _callees_. This mirrors the most prudent parts of HWY_API.
 #if defined(__clang__)
-#define VESPA_HWY_LAMBDA HWY_ATTR __attribute__((always_inline)) noexcept
+#define VESPA_HWY_LAMBDA HWY_ATTR __attribute__((always_inline, flatten)) noexcept
 #else
-#define VESPA_HWY_LAMBDA noexcept HWY_ATTR __attribute__((always_inline))
+#define VESPA_HWY_LAMBDA noexcept HWY_ATTR __attribute__((always_inline, flatten))
 #endif
 
 // Many of the Highway functions used within this file are fairly self-explanatory


### PR DESCRIPTION
@toregge please review

`__attribute__((flatten))` enforces inlining of the function's _callees_, basically acting as a complement to `always_inline` (which works from callee->caller).

[GCC docs](https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Common-Function-Attributes.html#index-flatten-function-attribute):

> `flatten`
> Generally, inlining into a function is limited. For a function marked with this attribute, every call inside this function is inlined including the calls such inlining introduces to the function (but not recursive calls to the function itself), if possible. Functions declared with attribute `noinline` and similar are not inlined. Whether the function itself is considered for inlining depends on its size and the current inlining parameters.


Supported on both GCC and Clang.
