### PR TITLE
Fix function table exclusion logic

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
@@ -185,8 +185,8 @@ VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_DECLARE_DISPATCH_FN_PTR);
 // fn_tables is in "best to worst" order (i.e. best is at front, worst is at back),
 // meaning that if a function is present (non-null) in a "better" table, it will be
 // preferred over one in a "worse" table, _unless_ the function is tagged as suboptimal
-// by the table _and_ `ignore_suboptimal == true`. In the latter case, the function is
-// ignored in favor of the one from the technically worse table. This is to avoid
+// by the table _and_ `exclude_suboptimal == true`. In the latter case, the function is
+// excluded in favor of the one from the technically worse table. This is to avoid
 // including functions with known suboptimal performance vs. another "worse" target.
 //
 // If the union of non-null input function pointers across all input tables is equal
@@ -196,12 +196,12 @@ VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_DECLARE_DISPATCH_FN_PTR);
 // the returned table is also complete.
 //
 // Information about suboptimal functions is not preserved in the returned table.
-[[nodiscard]] FnTable build_composite_fn_table(std::span<const FnTable> fn_tables, bool ignore_suboptimal) noexcept;
+[[nodiscard]] FnTable build_composite_fn_table(std::span<const FnTable> fn_tables, bool exclude_suboptimal) noexcept;
 
 // Convenience function to build a composite table on top of a single other function table
 [[nodiscard]] FnTable build_composite_fn_table(const FnTable& fn_table,
                                                const FnTable& base_table,
-                                               bool ignore_suboptimal) noexcept;
+                                               bool exclude_suboptimal) noexcept;
 
 // Returns the function table that is presumed to be optimal for the architecture the
 // process is currently running on.

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.cpp
@@ -572,16 +572,16 @@ IAccelerated::getAccelerator() {
 namespace dispatch {
 
 #define VESPA_HWACCEL_PATCH_FN_TABLE_VISITOR(fn_type, fn_field, fn_id) \
-    if ((src_tbl.fn_field) != nullptr && (ignore_suboptimal || !src_tbl.fn_is_tagged_as_suboptimal(fn_id))) { \
+    if ((src_tbl.fn_field) != nullptr && (!exclude_suboptimal || !src_tbl.fn_is_tagged_as_suboptimal(fn_id))) { \
         composite_tbl.fn_field = src_tbl.fn_field; \
         composite_tbl.fn_target_infos[static_cast<size_t>(fn_id)] = src_tbl.fn_target_infos[static_cast<size_t>(fn_id)]; \
     }
 
-FnTable build_composite_fn_table(std::span<const FnTable> fn_tables, bool ignore_suboptimal) noexcept {
+FnTable build_composite_fn_table(std::span<const FnTable> fn_tables, bool exclude_suboptimal) noexcept {
     assert(!fn_tables.empty());
     FnTable composite_tbl;
     // Start at the back (worst) and move towards the front (best), patching in present
-    // function pointers as we go (assuming not suboptimal & ignored). Painter's algorithm
+    // function pointers as we go (assuming not suboptimal & excluded). Painter's algorithm
     // for function pointers!
     for (const auto& src_tbl : std::ranges::reverse_view(fn_tables)) {
         VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_PATCH_FN_TABLE_VISITOR);
@@ -591,12 +591,12 @@ FnTable build_composite_fn_table(std::span<const FnTable> fn_tables, bool ignore
 
 FnTable build_composite_fn_table(const FnTable& fn_table,
                                  const FnTable& base_table,
-                                 bool ignore_suboptimal) noexcept
+                                 bool exclude_suboptimal) noexcept
 {
     std::vector<FnTable> fn_tables;
     fn_tables.emplace_back(fn_table);
     fn_tables.emplace_back(base_table);
-    return build_composite_fn_table(fn_tables, ignore_suboptimal);
+    return build_composite_fn_table(fn_tables, exclude_suboptimal);
 }
 
 FnTable optimal_composite_fn_table() noexcept {

--- a/vespalib/src/vespa/vespalib/hwaccelerated/target_info.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/target_info.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 namespace vespalib::hwaccelerated {
 
@@ -46,6 +47,12 @@ public:
     }
     [[nodiscard]] constexpr uint16_t vector_width_bits() const noexcept {
         return _vector_width_bytes * 8;
+    }
+
+    [[nodiscard]] constexpr bool operator==(const TargetInfo& rhs) const noexcept {
+        return (std::string_view{_implementation_name} == rhs._implementation_name &&
+                std::string_view{_target_name} == rhs._target_name &&
+                _vector_width_bytes == rhs._vector_width_bytes);
     }
 
     [[nodiscard]] std::string to_string() const;


### PR DESCRIPTION
@toregge please review. This is my cosmic karma from daring to think that a piece of code is so simple that surely it cannot be incorrect 😑
@havardpe please review

Parameter name was ambiguously named so that it could be interpreted in two separate ways ("ignore functions that are suboptimal" and "ignore _that_ functions are suboptimal") and both these interpretations found their way into the code. Only the former is correct, so fix logic and rename the variable. Also add explicit testing that of course should have been present initially.

This bug meant that we'd still use functions for better targets even though we had tagged them as suboptimal. This does not affect correctness, as all functions are tested, but a subset of operations may be slightly slower than they should be.

