### PR TITLE
Dump vectorization function table to `hwinfo` state V1 custom component JSON output

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.cpp
@@ -2,6 +2,7 @@
 
 #include "hw_info_explorer.h"
 #include <vespa/vespalib/data/slime/cursor.h>
+#include <vespa/vespalib/hwaccelerated/fn_table.h>
 
 namespace proton {
 
@@ -9,6 +10,22 @@ HwInfoExplorer::HwInfoExplorer(const vespalib::HwInfo& info)
     : _info(info)
 {
 }
+
+namespace {
+
+void dump_vectorization_fn_table(vespalib::slime::Cursor& out) {
+    using namespace vespalib::hwaccelerated::dispatch;
+    const auto& tbl = active_fn_table();
+    tbl.for_each_present_fn([&](FnTable::FnId fn_id) {
+        auto& info_cursor = out.setObject(FnTable::id_to_fn_name(fn_id));
+        const auto& target_info = tbl.fn_target_info(fn_id);
+        info_cursor.setString("impl",    target_info.implementation_name());
+        info_cursor.setString("target",  target_info.target_name());
+        info_cursor.setLong("bit_width", target_info.vector_width_bits());
+    });
+}
+
+} // anon ns
 
 void
 HwInfoExplorer::get_state(const vespalib::slime::Inserter& inserter, bool full) const
@@ -25,6 +42,11 @@ HwInfoExplorer::get_state(const vespalib::slime::Inserter& inserter, bool full) 
 
         auto& cpu = object.setObject("cpu");
         cpu.setLong("cores", _info.cpu().cores());
+
+        // Since we dynamically compose a vectorization function table at process startup,
+        // it's useful to be able to see what's actually being used to power these calls.
+        auto& vec_fn_table = object.setObject("vectorization_fn_table");
+        dump_vectorization_fn_table(vec_fn_table);
     }
 }
 

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
@@ -345,6 +345,19 @@ TEST(CompositeFnTableTest, suboptimal_functions_are_not_used_when_exclusion_is_r
     EXPECT_EQ(c.fn_target_info(FnTable::FnId::POPULATION_COUNT), b_info);
 }
 
+TEST(CompositeFnTableTest, for_each_present_fn_invokes_callback_for_non_nullptr_fns) {
+    FnTable tbl(b_info);
+    tbl.dot_product_i8 = my_dot_i8_b;
+    tbl.population_count = my_popcount;
+
+    std::string seen_fns;
+    tbl.for_each_present_fn([&](FnTable::FnId id) {
+        seen_fns += FnTable::id_to_fn_name(id);
+        seen_fns += " ";
+    });
+    EXPECT_EQ(seen_fns, "dot_product_i8 population_count ");
+}
+
 } // vespalib::hwaccelerated
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.cpp
@@ -34,4 +34,22 @@ std::string FnTable::to_string() const {
     return fns;
 }
 
+#define VESPA_HWACCEL_INVOKE_CALLBACK(fn_type, fn_field, fn_id) \
+    if ((fn_field) != nullptr) { callback(fn_id); }
+
+void FnTable::for_each_present_fn(const std::function<void(FnId)>& callback) const {
+    VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_INVOKE_CALLBACK);
+}
+
+#define VESPA_HWACCEL_SWITCH_CASE_PER_FN_ENTRY(fn_type, fn_field, fn_id) \
+    case fn_id: return #fn_field;
+
+std::string_view FnTable::id_to_fn_name(FnId id) noexcept {
+    switch (id) {
+    VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_SWITCH_CASE_PER_FN_ENTRY);
+    case FnId::MAX_ID_SENTINEL: abort();
+    }
+    abort();
+}
+
 } // vespalib::hwaccelerated::dispatch

--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
@@ -6,10 +6,12 @@
 #include <vespa/vespalib/util/bfloat16.h>
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <initializer_list>
 #include <span>
 #include <vector>
 #include <string>
+#include <string_view>
 
 namespace vespalib::hwaccelerated::dispatch {
 
@@ -131,10 +133,18 @@ struct FnTable {
         return fn_target_infos[static_cast<size_t>(fn_id)];
     }
 
+    // Invokes `callback` with the FnId of each non-nullptr function pointer in this
+    // function table.
+    void for_each_present_fn(const std::function<void(FnId)>& callback) const;
+
     [[nodiscard]] std::string to_string() const;
 
     // Returns true iff all function pointers are non-nullptr
     [[nodiscard]] bool is_complete() const noexcept;
+
+    // Returns a static string containing the name of the function field for a valid
+    // FnId. Example: FnId::DOT_PRODUCT_I8 -> "dot_product_i8"
+    [[nodiscard]] static std::string_view id_to_fn_name(FnId id) noexcept;
 };
 
 // Cheeky function table macro that can be used to avoid having to remember to update


### PR DESCRIPTION
@toregge please review
@havardpe FYI

Since we dynamically compose the vectorization function table at process startup, it's useful to be able to see what's actually being used to power the underlying calls. `hwinfo` seems to be the most appropriate existing place to put this since it's inherently HW-specific (let me know if there's a better place).

Example output (truncated):
```json
  "vectorization_fn_table": {
    "dot_product_i8": {
      "impl": "Highway",
      "target": "NEON_BF16",
      "bit_width": 128
    },
    "dot_product_i16": {
      "impl": "AutoVec",
      "target": "NEON_FP16_DOTPROD",
      "bit_width": 128
    },
```