### PR TITLE
Update estimated hits in NearestNeighborBlueprint in case of fallback to exact search

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1567,7 +1567,7 @@ TEST(TensorAttributeTest, NN_blueprint_handles_strong_filter_triggering_exact_se
     bp->set_global_filter(*strong_filter, 0.6);
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(3u, bp->get_adjusted_target_hits());
-    EXPECT_EQ(11u, bp->getState().estimate().estHits);
+    EXPECT_EQ(1u, bp->getState().estimate().estHits);
     EXPECT_EQ(NNBA::EXACT_FALLBACK, bp->get_algorithm());
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -106,10 +106,10 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
         if (_global_filter->is_active()) { // pre-filtering case
             _global_filter_hits = _global_filter->count();
             _global_filter_hit_ratio = static_cast<double>(_global_filter_hits.value()) / est_hits;
+            est_hits = std::min(est_hits, _global_filter_hits.value());
             if (_global_filter_hit_ratio.value() < _hnsw_params.global_filter_lower_limit) {
                 _algorithm = Algorithm::EXACT_FALLBACK;
-            } else {
-                est_hits = std::min(est_hits, _global_filter_hits.value());
+                setEstimate(HitEstimate(est_hits, false));
             }
         } else { // post-filtering case
             // The goal is to expose 'targetHits' hits to first-phase ranking.


### PR DESCRIPTION
When we fall back to an exact search in NearestNeighborBlueprint due to a low hit ratio, we expect the exact search to be quite fast and should update the number of estimated hits to reflect this. This should then cause query planning to schedule the exact search earlier.

Before this PR, the exact search was always scheduled last regardless of the hit ratio, which proved to be rather subpar when falling back to an exact search with very low hit ratios when the rest of the query is very expensive.
