### PR TITLE
fix(CLI): only attempt to publish on Homebrew when required

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -16,7 +16,12 @@ on:
         description: 'The version to build and publish, it MUST be a tag in this repository without the "v" prefix.'
         required: true
         type: string
-
+      force-homebrew-publish:
+        description: 'This forces the attempt of publishing the update on the homebrew-core repo'
+        required: false
+        type: bool
+        default: false
+        
 defaults:
   run:
     # Specify to ensure "pipefail and errexit" are set.
@@ -172,44 +177,11 @@ jobs:
           release_url="$(cat /tmp/vespa-cli-release-url.txt)"
           echo "release-url=${release_url}" > "${GITHUB_OUTPUT}"
 
-      - name: Check Homebrew Status
-        id: check-homebrew
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Check if BrewTestBot has already updated or created a PR for this version
-          version="${VERSION}"
-
-          # Check for open PRs in homebrew-core that mention this version
-          prs=$(gh pr list --repo Homebrew/homebrew-core --search "vespa-cli ${version}" --json number,title --limit 1)
-
-          if [[ $(echo "${prs}" | jq 'length') -gt 0 ]]; then
-            echo "Found existing PR(s) for version ${version} in homebrew-core"
-            echo "needs-publish=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          # Check if the version already exists in the formula
-          formula_url="https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/v/vespa-cli.rb"
-          if curl -sf "${formula_url}" | grep -q "version \"${version}\""; then
-            echo "Version ${version} already exists in homebrew-core"
-            echo "needs-publish=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "Version ${version} not found in homebrew-core, publishing needed"
-          echo "needs-publish=true" >> "${GITHUB_OUTPUT}"
-
       - name: Publish to Homebrew
-        if: steps.github-release.outputs.release-url != '' && steps.check-homebrew.outputs.needs-publish == 'true'
+        if: steps.github-release.outputs.release-url != '' && input.force-homebrew-publish == 'true'
         env:
           GITHUB_RELEASE_URL: ${{ steps.github-release.outputs.release-url }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
           # Release to Homebrew directly, bypassing the diff check as we already perform this check in the "prepare" job.
           make -- --dist-homebrew
-
-      - name: Install via Homebrew
-        if: steps.github-release.outputs.release-url != '' && steps.check-homebrew.outputs.needs-publish == 'true'
-        run: |
-          make install-brew

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -178,7 +178,7 @@ jobs:
           echo "release-url=${release_url}" > "${GITHUB_OUTPUT}"
 
       - name: Publish to Homebrew
-        if: steps.github-release.outputs.release-url != '' && input.force-homebrew-publish == 'true'
+        if: steps.github-release.outputs.release-url != '' && inputs.force-homebrew-publish == 'true'
         env:
           GITHUB_RELEASE_URL: ${{ steps.github-release.outputs.release-url }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}


### PR DESCRIPTION
## What

- Remove the check for existing PRs in Homebrew Core
- Only publish to homebrew when manually-triggered run AND explicitly required to

## Why


Fix the error from Homebrew Core:
> Whoops, the vespa-cli formula has its version update pull requests automatically opened by BrewTestBot every ~3 hours!