### PR TITLE
Unify how runtime targets are handled between auto-vectorizer and Highway

### DIFF
--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -75,11 +75,10 @@ void register_benchmarks(std::string_view name, Fn fn) {
     for (auto& t : hwy_targets) {
         register_accel_binary_arg_benchmark<T>(name, std::move(t), fn);
     }
-    auto baseline_accel = IAccelerated::create_baseline_auto_vectorized_target();
-    register_accel_binary_arg_benchmark<T>(name, std::move(baseline_accel), fn);
-
-    auto best_autovec_accel = IAccelerated::create_best_auto_vectorized_target();
-    register_accel_binary_arg_benchmark<T>(name, std::move(best_autovec_accel), fn);
+    auto auto_vec_targets = IAccelerated::create_supported_auto_vectorized_targets();
+    for (auto& t : auto_vec_targets) {
+        register_accel_binary_arg_benchmark<T>(name, std::move(t), fn);
+    }
 }
 
 void register_all_benchmark_suites() {

--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
@@ -217,13 +217,6 @@ VESPA_HWACCEL_VISIT_FN_TABLE(VESPA_HWACCEL_DECLARE_DISPATCH_FN_PTR);
 // process is currently running on.
 [[nodiscard]] FnTable optimal_composite_fn_table() noexcept;
 
-// Returns a function table containing functions from one or more auto-vectorized
-// implementations for this architecture. This table is always complete and can therefore
-// be used as a fallback when building other composite tables. Note that this table may
-// itself may be a composite of functions from the "best" auto-vectorized table on top of
-// one or more "lesser" auto-vectorized tables. It's tables all the way down!
-[[nodiscard]] FnTable complete_baseline_fn_table() noexcept;
-
 // Returns a reference to the globally active function table. Its contents will usually be
 // equal to that of `optimal_composite_fn_table()` unless overridden at runtime.
 [[nodiscard]] const FnTable& active_fn_table() noexcept;

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -445,48 +445,6 @@ namespace {
         target_id_and_impl.emplace_back(hwy_target, hwy_ns::HwyTargetAccelerator::create_instance()); \
     }
 
-enum class ExcludeTargets {
-    // No targets should be excluded
-    None,
-    // Exclude targets that _we_ believe are not optimal for the purposes of running our
-    // vectorized kernels.
-    AssumedSuboptimal
-};
-
-bool target_is_assumed_suboptimal(uint64_t target_hwy_id) noexcept {
-    // SVE/SVE2 is not a strict superset of NEON, which means that certain very useful
-    // 128-bit NEON(_BF16) vector instructions are _not_ present as "sizeless" SVE vector
-    // operations.
-    //
-    // In particular:
-    //  - int8 squared Euclidean distance:
-    //    NEON has `ssub` signed subtraction of high/low vector lanes with implicit
-    //    widening. On SVE this needs separate unpack high/low instructions followed by
-    //    a non-widening subtraction, increasing instruction count and register pressure.
-    //  - BFloat16 dot product:
-    //    SVE does not have guaranteed BF16 support prior to armv8.6-a and its BF16 dot
-    //    product operation does not give the same result as NEON BF16 unless FEAT_EBF16
-    //    is present, due to differences in rounding behavior. Because of this, dynamic
-    //    target compilation for Highway does not by default use BF16 instructions for
-    //    _any_ SVE targets. It is also not clear how this could be enabled with today's
-    //    set of compilation targets, as they are not ARM architecture version-oriented.
-    //
-    // In practice this means that 128-bit SVE may be _slower_ for some important operations
-    // than 128-bit NEON_BF16. For both the above ops, the observed relative slowdown is
-    // on the order of ~1.5-2x. The only serious speed increase from SVE is for popcount.
-    //
-    // So for now, disable SVE targets entirely until it's had more time to cook. If SVE
-    // is present, NEON_BF16 is expected to always be present.
-    //
-    // This is based on testing on Google Axion (SVE2_128), Amazon Graviton 3 (SVE_256)
-    // and Amazon Graviton 4 (SVE2_128) nodes, and will be updated once newer/shinier
-    // hardware is available for testing.
-    //
-    // TODO consider still enabling if SVE2 vector length is > 128 bits. Needs benchmarking.
-    //  Only HW with >128 bits that's currently available is Graviton 3, which is only SVE.
-    return (target_hwy_id & HWY_ALL_SVE) != 0;
-}
-
 std::vector<std::pair<uint64_t, std::unique_ptr<IAccelerated>>> create_supported_targets_with_impls() {
     // On x64 we require AVX2 as a baseline, so don't bother wasting time with SSSE3/SSE4.
     // Ideally we would not even build these targets. No effect on Aarch64.
@@ -513,29 +471,24 @@ std::vector<std::pair<uint64_t, std::unique_ptr<IAccelerated>>> create_supported
 }
 
 // The "best" supported target will be the first element in the vector.
-std::vector<std::unique_ptr<IAccelerated>> create_supported_targets_impl(ExcludeTargets exclude_targets) {
+std::vector<std::unique_ptr<IAccelerated>> create_supported_targets_impl() {
     auto target_id_and_impl = create_supported_targets_with_impls();
 
     std::vector<std::unique_ptr<IAccelerated>> preferred_target_order;
     preferred_target_order.reserve(target_id_and_impl.size());
     for (auto& elem : target_id_and_impl) {
-        if ((exclude_targets == ExcludeTargets::AssumedSuboptimal) && target_is_assumed_suboptimal(elem.first)) {
-            continue; // Ignore this target
-        }
         preferred_target_order.emplace_back(std::move(elem.second));
     }
-    assert(!preferred_target_order.empty()); // Must be at least a fallback target
+    // If Vespa is compiled for a prehistoric CPU (e.g. < AVX2), it's possible we don't
+    // have any targets to return. In this case the caller must fall back to only using
+    // auto-vectorized targets (likely only the baseline target used for compilation).
     return preferred_target_order;
 }
 
 } // anon ns
 
 std::vector<std::unique_ptr<IAccelerated>> Highway::create_supported_targets() {
-    return create_supported_targets_impl(ExcludeTargets::None);
-}
-
-std::unique_ptr<IAccelerated> Highway::create_best_target() {
-    return std::move(create_supported_targets_impl(ExcludeTargets::AssumedSuboptimal).front());
+    return create_supported_targets_impl();
 }
 
 } // namespace vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.h
@@ -12,15 +12,11 @@ public:
     // Returns all accelerator targets that are supported by the current architecture and runtime.
     // The targets are ordered in decreasing order of preference, i.e. element 0 is considered
     // the most preferred target to use for the lifetime of this process from the perspective of
-    // the Highway library. Note that this will also include targets that `create_best_target()`
-    // may exclude due to our own filtering decisions, so it's useful for tests and benchmarks.
-    // Always returns at least 1 element.
+    // the Highway library.
+    // May return zero elements iff Vespa has been custom compiled for an architecture level that
+    // is below our expected baseline (AVX2 on x64; AArch64 should always have NEON). Otherwise,
+    // always returns at least 1 element.
     [[nodiscard]] static std::vector<std::unique_ptr<IAccelerated>> create_supported_targets();
-    // Returns the accelerator instance corresponding to the "best" Highway target that is
-    // supported by the current architecture and runtime. This target may be chosen from a subset
-    // of what `create_supported_targets()` returns, as we may apply platform-specific target
-    // exclusions.
-    [[nodiscard]] static std::unique_ptr<IAccelerated> create_best_target();
 };
 
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/iaccelerated.h
@@ -51,11 +51,11 @@ public:
     // entirely independent of the lifetime of `this`.
     [[nodiscard]] virtual const dispatch::FnTable& fn_table() const = 0;
 
-    static std::unique_ptr<IAccelerated> create_baseline_auto_vectorized_target();
-    static std::unique_ptr<IAccelerated> create_best_auto_vectorized_target();
-    static std::unique_ptr<IAccelerated> create_best_accelerator_impl_and_target();
-
-    static const IAccelerated& getAccelerator() __attribute__((noinline));
+    // Returns all auto-vectorized accelerator targets that are supported by the current
+    // architecture and runtime. The targets are ordered in decreasing order of preference,
+    // i.e. element 0 is considered the most preferred target to use.
+    // Always returns at least 1 element.
+    static std::vector<std::unique_ptr<IAccelerated>> create_supported_auto_vectorized_targets();
 };
 
 }


### PR DESCRIPTION
@havardpe please review
@toregge FYI

Let _all_ supported auto-vectorized targets be enumerated and delegate the responsibility for choosing the combination of best functions to the composite function table logic instead of having partially overlapping target selection logic.

With this change, we now stack candidate function tables on top of each other, with Highway on top (in best to worst order) and auto-vectorized on the bottom (in best to worst order). The resulting composite table is then built bottom-up from these.

Also handle the scenario where Vespa has been custom-compiled for a prehistoric x64 CPU (pre-Haswell 🦖🦕) without AVX2. Since we currently don't enable x64 Highway targets worse than AVX2, it's possible for the Highway target enumeration to return the empty set. This would previously assert; it will now transparently fall back to the baseline auto-vectorized target.

Since `IAccelerated` isn't used for function dispatch anymore, start cleaning up unused APIs.

