### PR TITLE
Revert "Skip getting metrics from a service that is not alive"

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/HttpMetricFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/HttpMetricFetcher.java
@@ -63,7 +63,7 @@ public abstract class HttpMetricFetcher {
         logMessage("Unable to parse json '" + data + "' for service '" + service + "': ", e, timesFetched);
     }
 
-    protected void logMessage(String message, Exception e, int timesFetched) {
+    private void logMessage(String message, Exception e, int timesFetched) {
         if (service.isAlive() && timesFetched > 5) {
             log.log(Level.INFO, message, e);
         } else {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/MetricsParser.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/MetricsParser.java
@@ -49,11 +49,7 @@ public class MetricsParser {
 
     // Top level 'metrics' object, with e.g. 'time', 'status' and 'metrics'.
     private static void parse(JsonParser parser, Collector consumer) throws IOException {
-        JsonToken firstToken = parser.nextToken();
-        if (firstToken == null) {
-            return;
-        }
-        if (firstToken != JsonToken.START_OBJECT) {
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
             throw new IOException("Expected start of object, got " + parser.currentToken());
         }
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthMetricFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthMetricFetcher.java
@@ -29,7 +29,7 @@ public class RemoteHealthMetricFetcher extends HttpMetricFetcher {
     }
 
     /**
-     * Connect to remote service over http and fetch health
+     * Connect to remote service over http and fetch metrics
      */
     public HealthMetric getHealth(int fetchCount) {
         try (CloseableHttpResponse response = getResponse()) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
@@ -34,12 +34,10 @@ public class RemoteMetricsFetcher extends HttpMetricFetcher {
             } finally {
                 EntityUtils.consumeQuietly(entity);
             }
-        } catch (IOException e) {
-            logMessage("Got exception when getting metrics for service '" + service + "'", e, fetchCount);
-        }
+        } catch (IOException ignored) {}
     }
 
-    void createMetrics(String data, MetricsParser.Collector consumer) throws IOException {
+    void createMetrics(String data, MetricsParser.Collector consumer, int fetchCount) throws IOException {
         MetricsParser.parse(data, consumer);
     }
 }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java
@@ -10,9 +10,6 @@ import ai.vespa.metricsproxy.metric.model.ServiceId;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.INFO;
 
 
 /**
@@ -22,7 +19,6 @@ import static java.util.logging.Level.INFO;
  */
 public class VespaService implements Comparable<VespaService> {
 
-    private final static Logger log = Logger.getLogger(VespaService.class.getName());
     private static final Map<DimensionId, String> EMPTY_DIMENSIONS = Map.of();
     private static final String DEFAULT_MONITORING_PREFIX = "vespa";
     public static final String SEPARATOR = ".";
@@ -141,10 +137,6 @@ public class VespaService implements Comparable<VespaService> {
      * if a metric http port has been defined, otherwise from log file
      */
     public void consumeMetrics(MetricsParser.Collector consumer) {
-        if (!isAlive()) {
-            log.log(INFO, "Service not alive, skipping getting metrics");
-            return;
-        }
         remoteMetricsFetcher.getMetrics(consumer, metricsFetchCount.get());
         metricsFetchCount.getAndIncrement();
     }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/RpcMetricsTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/RpcMetricsTest.java
@@ -106,8 +106,6 @@ public class RpcMetricsTest {
             assertEquals("#Services should be 1 for config id " + SERVICE_1_CONFIG_ID, 1, services.size());
 
             VespaService container = services.get(0);
-            container.setPid(1);
-            container.setAlive(true);
             assertEquals(MONITORING_SYSTEM + VespaService.SEPARATOR + "container", container.getMonitoringName().id);
 
             Metrics metrics = container.getMetrics();
@@ -124,8 +122,6 @@ public class RpcMetricsTest {
                 assertEquals("#Services should be 1 for config id " + SERVICE_2_CONFIG_ID, 1, services.size());
 
                 VespaService storageService = services.get(0);
-                storageService.setPid(2);
-                storageService.setAlive(true);
                 verfiyMetricsFromServiceObject(storageService);
 
                 String metricsById = getMetricsById(storageService.getConfigId(), rpcClient);
@@ -198,10 +194,7 @@ public class RpcMetricsTest {
             List<VespaService> services = tester.vespaServices().getInstancesById(SERVICE_1_CONFIG_ID);
 
             assertEquals(1, services.size());
-            VespaService vespaService = services.get(0);
-            vespaService.setPid(123);
-            vespaService.setAlive(true);
-            Metrics metrics = vespaService.getMetrics();
+            Metrics metrics = services.get(0).getMetrics();
             assertEquals("Fetched number of metrics is not correct", 2, metrics.size());
             Metric m = getMetric("foo.count", metrics);
             assertNotNull("Did not find expected metric with name 'foo.count'", m);
@@ -210,7 +203,7 @@ public class RpcMetricsTest {
             assertNotNull("Did not find expected metric with name 'bar'", m2);
 
             try (RpcClient rpcClient = new RpcClient(tester.rpcPort())) {
-                String response = getAllMetricNamesForService(vespaService.getMonitoringName().id, vespaMetricsConsumerId, rpcClient);
+                String response = getAllMetricNamesForService(services.get(0).getMonitoringName().id, vespaMetricsConsumerId, rpcClient);
                 assertEquals("foo.count=ON;output-name=foo_count,bar.count=OFF,", response);
             }
         }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/ContainerServiceTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/ContainerServiceTest.java
@@ -39,8 +39,6 @@ public class ContainerServiceTest {
     public void testMultipleQueryDimensions() {
         int count = 0;
         VespaService service = VespaService.create("service1", "id", httpServer.port());
-        service.setPid(1);
-        service.setAlive(true);
         for (Metric m : service.getMetrics().list()) {
             if (m.getName().equals(toMetricId("queries.rate"))) {
                 count++;

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MetricsFetcherTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MetricsFetcherTest.java
@@ -31,7 +31,7 @@ public class MetricsFetcherTest {
     Metrics fetch(String data) throws IOException {
         RemoteMetricsFetcher fetcher = new RemoteMetricsFetcher(new DummyService(0, "dummy/id/0"), port);
         MetricsCollector collector = new MetricsCollector();
-        fetcher.createMetrics(data, collector);
+        fetcher.createMetrics(data, collector, 0);
         return collector.metrics;
     }
 
@@ -81,14 +81,12 @@ public class MetricsFetcherTest {
         String jsonData;
         Metrics metrics = null;
 
-        jsonData = "<";
+        jsonData = "";
         try {
             metrics = fetch(jsonData);
             fail("Should have an IOException instead");
         } catch (IOException e) {
-            assertEquals("Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                                 " at [Source: (String)\"<\"; line: 1, column: 1]",
-                         e.getMessage());
+            assertEquals("Expected start of object, got null", e.getMessage());
         }
         assertNull(metrics);
 

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/VespaServiceTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/VespaServiceTest.java
@@ -54,8 +54,6 @@ public class VespaServiceTest {
     // TODO: Make it possible to test this without running a HTTP server to create the response
     public void testMetricsFetching() {
         VespaService service = VespaService.create("service1", "id", httpServer.port());
-        service.setPid(1);
-        service.setAlive(true);
         assertEquals(28, getMetric("queries.count", service.getMetrics()).getValue().intValue());
 
         // Shutdown server and check that no metrics are returned (should use empty metrics


### PR DESCRIPTION
Reverts vespa-engine/vespa#35252

~A system test started failing, need to look into it~
Cannot skip those not alive as e.g. config server is not started by config sentinel and will never be seen as alive