### PR TITLE
Improve handling of empty or invalid content in metrics data

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/HttpMetricFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/HttpMetricFetcher.java
@@ -63,7 +63,7 @@ public abstract class HttpMetricFetcher {
         logMessage("Unable to parse json '" + data + "' for service '" + service + "': ", e, timesFetched);
     }
 
-    private void logMessage(String message, Exception e, int timesFetched) {
+    protected void logMessage(String message, Exception e, int timesFetched) {
         if (service.isAlive() && timesFetched > 5) {
             log.log(Level.INFO, message, e);
         } else {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/MetricsParser.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/MetricsParser.java
@@ -49,7 +49,11 @@ public class MetricsParser {
 
     // Top level 'metrics' object, with e.g. 'time', 'status' and 'metrics'.
     private static void parse(JsonParser parser, Collector consumer) throws IOException {
-        if (parser.nextToken() != JsonToken.START_OBJECT) {
+        JsonToken firstToken = parser.nextToken();
+        if (firstToken == null) {
+            return;
+        }
+        if (firstToken != JsonToken.START_OBJECT) {
             throw new IOException("Expected start of object, got " + parser.currentToken());
         }
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthMetricFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthMetricFetcher.java
@@ -29,7 +29,7 @@ public class RemoteHealthMetricFetcher extends HttpMetricFetcher {
     }
 
     /**
-     * Connect to remote service over http and fetch metrics
+     * Connect to remote service over http and fetch health status
      */
     public HealthMetric getHealth(int fetchCount) {
         try (CloseableHttpResponse response = getResponse()) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
@@ -34,7 +34,9 @@ public class RemoteMetricsFetcher extends HttpMetricFetcher {
             } finally {
                 EntityUtils.consumeQuietly(entity);
             }
-        } catch (IOException ignored) {}
+        } catch (IOException e) {
+            logMessage("Got exception when getting metrics for service '" + service + "'", e, fetchCount);
+        }
     }
 
     void createMetrics(String data, MetricsParser.Collector consumer, int fetchCount) throws IOException {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MetricsFetcherTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MetricsFetcherTest.java
@@ -81,12 +81,14 @@ public class MetricsFetcherTest {
         String jsonData;
         Metrics metrics = null;
 
-        jsonData = "";
+        jsonData = "<";
         try {
             metrics = fetch(jsonData);
             fail("Should have an IOException instead");
         } catch (IOException e) {
-            assertEquals("Expected start of object, got null", e.getMessage());
+            assertEquals("Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
+                                 " at [Source: (String)\"<\"; line: 1, column: 1]",
+                         e.getMessage());
         }
         assertNull(metrics);
 


### PR DESCRIPTION
Handle no content in response better
Log more/better when there are errors or exceptions

Followup to https://github.com/vespa-engine/vespa/pull/35252, now without skipping getting metrics from services that are not seen as alive