### PR TITLE
Add synthetic [all] summary class

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumDefinition.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumDefinition.java
@@ -4,6 +4,8 @@ package com.yahoo.prelude.fastsearch;
 import com.yahoo.data.access.Inspector;
 import com.yahoo.search.schema.DocumentSummary;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,6 +44,19 @@ public class DocsumDefinition {
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
+    DocsumDefinition(String name, DocsumDefinition first, Collection<DocsumDefinition> sources) {
+        this.name = name;
+        this.dynamic = sources.stream().anyMatch(dd -> dd.isDynamic());
+        Map<String, DocsumField> map = ((first == null)
+                                        ? new LinkedHashMap<>()
+                                        : new LinkedHashMap<>(first.fields()));
+        for (var source : sources) {
+            for (var entry : source.fields().entrySet()) {
+                map.computeIfAbsent(entry.getKey(), k -> entry.getValue());
+            }
+        }
+        this.fields = Map.copyOf(map);
+    }
 
 
     public String name() { return name; }

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumDefinitionSet.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/DocsumDefinitionSet.java
@@ -34,10 +34,12 @@ public final class DocsumDefinitionSet {
     }
 
     public DocsumDefinitionSet(Collection<DocumentSummary> docsumDefinitions) {
-        this.definitionsByName = docsumDefinitions.stream()
-                                                  .map(DocsumDefinition::new)
-                                                  .collect(Collectors.toUnmodifiableMap(DocsumDefinition::name,
-                                                                                        summary -> summary));
+        var map = docsumDefinitions.stream()
+                .map(DocsumDefinition::new)
+                .collect(Collectors.toConcurrentMap(DocsumDefinition::name,
+                                                    summary -> summary));
+        map.computeIfAbsent("[all]", k -> new DocsumDefinition(k, map.get("default"), map.values()));
+        this.definitionsByName = Map.copyOf(map);
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  */
 public class PartialSummaryHandler {
     public static final String DEFAULT_CLASS = "default";
-    public static final String ALL_FIELDS_CLASS = "default"; // not really true, but best we can do for now
+    public static final String ALL_FIELDS_CLASS = "[all]"; // best we can do
     public static final String PRESENTATION = "[presentation]";
 
     private static final Logger log = Logger.getLogger(PartialSummaryHandler.class.getName());
@@ -238,9 +238,16 @@ public class PartialSummaryHandler {
 
     public static String enoughFields(String summaryClass, Result result) {
         var summaryFields = result.getQuery().getPresentation().getSummaryFields();
-        if (isDefaultRequest(summaryClass) && ! summaryFields.isEmpty()) {
-            // it's enough to have the string we would use as fillMarker
-            return syntheticName(summaryFields);
+        if (isDefaultRequest(summaryClass)) {
+            if (! summaryFields.isEmpty()) {
+                // it's enough to have the string we would use as fillMarker
+                return syntheticName(summaryFields);
+            }
+            String wantSum = result.getQuery().getPresentation().getSummary();
+            if (wantSum == null) {
+                return DEFAULT_CLASS;
+            }
+            return wantSum;
         } else {
             // this is 'always' enough:
             return ALL_FIELDS_CLASS;
@@ -266,7 +273,7 @@ public class PartialSummaryHandler {
     }
 
     private void computeEffectiveDocsumDef() {
-        if ((docsumDefinitions != null) && docsumDefinitions.hasDocsum(askForSummary)) {
+        if (docsumDefinitions != null) {
             effectiveDocsumDef = docsumDefinitions.getDocsum(askForSummary);
             if (askForFields != null) {
                 effectiveDocsumDef = new DocsumDefinition("<unnamed>", effectiveDocsumDef, askForFields);

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
@@ -367,9 +367,9 @@ public class PartialSummaryHandlerTestCase {
         var tracer = new TraceToString();
         query.getModel().getExecution().trace().accept(tracer);
         assertTrue(tracer.target.toString()
-                   .contains("requested summary=first3 does not contain all fields [SCORE, TOPIC] from query; trying fields=[SCORE, TITLE, TOPIC, WORDS] and summary=default"),
+                   .contains("requested summary=first3 does not contain all fields [SCORE, TOPIC] from query; trying fields=[SCORE, TITLE, TOPIC, WORDS] and summary=[all]"),
                    "Trace did not contain expected message, was: " + tracer.target);
-        assertEquals("default", toTest.askForSummary());
+        assertEquals("[all]", toTest.askForSummary());
         assertNotNull(toTest.askForFields());
         assertEquals(4, toTest.askForFields().size());
         assertFalse(toTest.resultAlreadyFilled());
@@ -395,13 +395,17 @@ public class PartialSummaryHandlerTestCase {
     @Test
     void enoughFields() {
         var query = createQuery("first3");
-        query.getPresentation().setSummaryFields("field1");
         var hit1 = createHit(query);
         var result = createResult(query, hit1);
+        assertEquals("first3", PartialSummaryHandler.enoughFields(null, result));
+        assertEquals("first3", PartialSummaryHandler.enoughFields(PartialSummaryHandler.DEFAULT_CLASS, result));
+        assertEquals("first3", PartialSummaryHandler.enoughFields(PartialSummaryHandler.PRESENTATION, result));
+        assertEquals("[all]", PartialSummaryHandler.enoughFields("first3", result));
+        query.getPresentation().setSummaryFields("field1");
         assertEquals("[f:field1]", PartialSummaryHandler.enoughFields(null, result));
         assertEquals("[f:field1]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.DEFAULT_CLASS, result));
         assertEquals("[f:field1]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.PRESENTATION, result));
-        assertEquals("default", PartialSummaryHandler.enoughFields("first3", result));
+        assertEquals("[all]", PartialSummaryHandler.enoughFields("first3", result));
     }
 
     @Test
@@ -413,7 +417,7 @@ public class PartialSummaryHandlerTestCase {
         assertEquals("[f:matchfeatures]", PartialSummaryHandler.enoughFields(null, result));
         assertEquals("[f:matchfeatures]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.DEFAULT_CLASS, result));
         assertEquals("[f:matchfeatures]", PartialSummaryHandler.enoughFields(PartialSummaryHandler.PRESENTATION, result));
-        assertEquals("default", PartialSummaryHandler.enoughFields("first3", result));
+        assertEquals("[all]", PartialSummaryHandler.enoughFields("first3", result));
     }
 
     static Query createQuery(String summaryClass) {


### PR DESCRIPTION
@bratseth please review
should be enough to satisfy request in https://github.com/vespa-engine/vespa/issues/35238

When a specific summary class is requested but doesn't contain all the fields needed from the query, the system needs to fetch additional fields. Previously, this fell back to the "default" summary class, which might not contain all necessary fields either.

This change introduces a synthetic "[all]" summary class that aggregates all fields from all available document summaries. The DocsumDefinitionSet now automatically creates this class during initialization by merging fields from all defined summaries (starting with "default" if available).

Changes:
- Add constructor in DocsumDefinition to merge fields from multiple sources
- Generate [all] summary in DocsumDefinitionSet initialization
- Update ALL_FIELDS_CLASS constant from "default" to "[all]"
- Improve enoughFields() logic to use requested summary or [all]
- Update tests to expect [all] instead of default

The backend already has similar logic for merging all config into an [all] summary class.
