### PR TITLE
Remove unneeded clear of old guard bit when growing bitvector using

### DIFF
--- a/searchlib/src/vespa/searchlib/common/growablebitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/growablebitvector.cpp
@@ -27,9 +27,6 @@ GrowableBitVector::grow(BitWord::Index newSize, BitWord::Index newCapacity)
     assert(newCapacity >= newSize);
     if (newCapacity != self.capacity()) {
         auto tbv = std::make_unique<AllocatedBitVector>(newSize, newCapacity, &self, &self._alloc);
-        if (newSize > self.size()) {
-            tbv->clear_bit_and_maintain_count_no_range_check(self.size());  // Clear old guard bit.
-        }
         auto to_hold = std::make_unique<GenerationHeldAllocatedBitVector>(std::move(_stored));
         _self.store(tbv.get(), std::memory_order_release);
         _stored = std::move(tbv);


### PR DESCRIPTION
replacement.

@vekterli : please review
