### PR TITLE
Include docid in message size exceeds limit response

### DIFF
--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -489,7 +489,7 @@ void ExternalOperationHandlerTest::do_test_second_command_rejected_due_to_oversi
     Operation::SP generated;
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(std::move(cmd1), generated));
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(std::move(cmd2)));
-    EXPECT_EQ("ReturnCode(REJECTED, Message size (1001 bytes) exceeds maximum configured limit (1000 bytes), "
+    EXPECT_EQ("ReturnCode(REJECTED, Message size (1001 bytes) exceeds maximum configured limit (1000 bytes) for document id id:foo:testdoctype1::bar, "
 	      "see https://docs.vespa.ai/en/reference/services-content.html#max-document-size for how to configure)",
               _sender.reply(0)->getResult().toString());
 }

--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -489,7 +489,7 @@ void ExternalOperationHandlerTest::do_test_second_command_rejected_due_to_oversi
     Operation::SP generated;
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(std::move(cmd1), generated));
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(std::move(cmd2)));
-    EXPECT_EQ("ReturnCode(REJECTED, Message size (1001 bytes) exceeds maximum configured limit (1000 bytes) for document id id:foo:testdoctype1::bar, "
+    EXPECT_EQ("ReturnCode(REJECTED, Message size (1001 bytes) exceeds maximum configured limit (1000 bytes) for document id 'id:foo:testdoctype1::bar', "
 	      "see https://docs.vespa.ai/en/reference/services-content.html#max-document-size for how to configure)",
               _sender.reply(0)->getResult().toString());
 }

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -316,11 +316,11 @@ bool ExternalOperationHandler::message_size_is_above_put_or_update_limit(uint32_
     return (msg_size > _op_ctx.distributor_config().max_document_operation_message_size_bytes());
 }
 
-void ExternalOperationHandler::reject_as_oversized_message(api::StorageCommand& cmd, const std::string_view raw_document_id) {
+void ExternalOperationHandler::reject_as_oversized_message(api::StorageCommand& cmd, const std::string& raw_document_id) {
     const uint32_t limit = _op_ctx.distributor_config().max_document_operation_message_size_bytes();
     std::string msg = vespalib::make_string("Message size (%u bytes) exceeds maximum configured limit (%u bytes) for document id %s, "
                                             "see https://docs.vespa.ai/en/reference/services-content.html#max-document-size for how to configure",
-                                            cmd.getApproxByteSize(), limit, raw_document_id.data());
+                                            cmd.getApproxByteSize(), limit, raw_document_id.c_str()());
     // TODO increment a metric
     bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::REJECTED, std::move(msg)));
 }

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -316,18 +316,18 @@ bool ExternalOperationHandler::message_size_is_above_put_or_update_limit(uint32_
     return (msg_size > _op_ctx.distributor_config().max_document_operation_message_size_bytes());
 }
 
-void ExternalOperationHandler::reject_as_oversized_message(api::StorageCommand& cmd) {
+void ExternalOperationHandler::reject_as_oversized_message(api::StorageCommand& cmd, const std::string_view raw_document_id) {
     const uint32_t limit = _op_ctx.distributor_config().max_document_operation_message_size_bytes();
-    std::string msg = vespalib::make_string("Message size (%u bytes) exceeds maximum configured limit (%u bytes), "
+    std::string msg = vespalib::make_string("Message size (%u bytes) exceeds maximum configured limit (%u bytes) for document id %s, "
                                             "see https://docs.vespa.ai/en/reference/services-content.html#max-document-size for how to configure",
-                                            cmd.getApproxByteSize(), limit);
+                                            cmd.getApproxByteSize(), limit, raw_document_id.data());
     // TODO increment a metric
     bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::REJECTED, std::move(msg)));
 }
 
 bool ExternalOperationHandler::onPut(const std::shared_ptr<api::PutCommand>& cmd) {
     if (message_size_is_above_put_or_update_limit(cmd->getApproxByteSize())) [[unlikely]] {
-        reject_as_oversized_message(*cmd);
+        reject_as_oversized_message(*cmd, cmd->getDocumentId().toString());
         return true;
     }
     if (_op_ctx.cluster_state_bundle().block_feed_in_cluster()) [[unlikely]] {
@@ -382,7 +382,7 @@ bool ExternalOperationHandler::onPut(const std::shared_ptr<api::PutCommand>& cmd
 
 bool ExternalOperationHandler::onUpdate(const std::shared_ptr<api::UpdateCommand>& cmd) {
     if (message_size_is_above_put_or_update_limit(cmd->getApproxByteSize())) [[unlikely]] {
-        reject_as_oversized_message(*cmd);
+        reject_as_oversized_message(*cmd, cmd->getDocumentId().toString());
         return true;
     }
     if (_op_ctx.cluster_state_bundle().block_feed_in_cluster() &&

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -318,9 +318,9 @@ bool ExternalOperationHandler::message_size_is_above_put_or_update_limit(uint32_
 
 void ExternalOperationHandler::reject_as_oversized_message(api::StorageCommand& cmd, const std::string& raw_document_id) {
     const uint32_t limit = _op_ctx.distributor_config().max_document_operation_message_size_bytes();
-    std::string msg = vespalib::make_string("Message size (%u bytes) exceeds maximum configured limit (%u bytes) for document id %s, "
+    std::string msg = vespalib::make_string("Message size (%u bytes) exceeds maximum configured limit (%u bytes) for document id '%s', "
                                             "see https://docs.vespa.ai/en/reference/services-content.html#max-document-size for how to configure",
-                                            cmd.getApproxByteSize(), limit, raw_document_id.c_str()());
+                                            cmd.getApproxByteSize(), limit, raw_document_id.c_str());
     // TODO increment a metric
     bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::REJECTED, std::move(msg)));
 }

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
+#include <string_view>
 
 namespace documentapi { class TestAndSetCondition; }
 namespace storage::lib { class ClusterState; }
@@ -120,7 +121,7 @@ private:
     void bounce_with_feed_blocked(api::StorageCommand& cmd);
     std::shared_ptr<Operation> try_generate_get_operation(const std::shared_ptr<api::GetCommand>&);
     [[nodiscard]] bool message_size_is_above_put_or_update_limit(uint32_t msg_size) const noexcept;
-    void reject_as_oversized_message(api::StorageCommand& cmd);
+    void reject_as_oversized_message(api::StorageCommand& cmd, std::string_view raw_document_id);
 
     bool checkSafeTimeReached(api::StorageCommand& cmd);
     api::ReturnCode makeSafeTimeRejectionResult(TimePoint unsafeTime);

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -8,7 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
-#include <string_view>
+#include <string>
 
 namespace documentapi { class TestAndSetCondition; }
 namespace storage::lib { class ClusterState; }
@@ -121,7 +121,7 @@ private:
     void bounce_with_feed_blocked(api::StorageCommand& cmd);
     std::shared_ptr<Operation> try_generate_get_operation(const std::shared_ptr<api::GetCommand>&);
     [[nodiscard]] bool message_size_is_above_put_or_update_limit(uint32_t msg_size) const noexcept;
-    void reject_as_oversized_message(api::StorageCommand& cmd, std::string_view raw_document_id);
+    void reject_as_oversized_message(api::StorageCommand& cmd, const std::string& raw_document_id);
 
     bool checkSafeTimeReached(api::StorageCommand& cmd);
     api::ReturnCode makeSafeTimeRejectionResult(TimePoint unsafeTime);


### PR DESCRIPTION
Adds visibility for which document made the put or update command too large.

@vekterli please review
@hmusum fyi