### PR TITLE
stop adjusting two HNSW-limits

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -1320,7 +1320,7 @@ TEST_F(MatchingTest, global_filter_params_are_scaled_with_active_hit_ratio)
 {
     CreateBlueprintParamsFixture f(0.2, 0.8, 5.0, FMA::DfaTable);
     auto params = f.extract(5, 10);
-    EXPECT_EQ(0.12, params.global_filter_lower_limit);
+    EXPECT_EQ(0.20, params.global_filter_lower_limit);
     EXPECT_EQ(0.48, params.global_filter_upper_limit);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -375,9 +375,9 @@ MatchToolsFactory::extract_create_blueprint_params(const RankSetup& rank_setup, 
     // This ensures that when searchable-copies=1, the ratio is 1.0.
     double active_hit_ratio = std::min(active_docids + 1, docid_limit) / static_cast<double>(docid_limit);
 
-    return {lower_limit * active_hit_ratio,
+    return {lower_limit,
             upper_limit * active_hit_ratio,
-            filter_first_upper_limit * active_hit_ratio,
+            filter_first_upper_limit,
             filter_first_exploration,
             exploration_slack,
             target_hits_max_adjustment_factor,


### PR DESCRIPTION
* global_filter_lower_limit and filter_first_upper_limit should not be tuned differently based on searchable-copies, because they should behave only based on what the impact (from the global filter) on the actual graph searching will be.
* global_filter_upper_limit is still adjusted; this one is different because the filter (from searchable-copies) is never correlated with the search, which is the main thing to worry about when activating upper_limit.  Also, the recommended values here are > 0.95 so to have any effect it needs to be adjusted when the max of the range is 0.50.

@boeker please review
@havardpe FYI
