### PR TITLE
fix(container-search): use configured ONNX runtime in global phase

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/ranking/RankProfilesEvaluator.java
+++ b/container-search/src/main/java/com/yahoo/search/ranking/RankProfilesEvaluator.java
@@ -2,10 +2,9 @@
 
 package com.yahoo.search.ranking;
 
-import ai.vespa.models.evaluation.FunctionEvaluator;
+import ai.vespa.modelintegration.evaluator.OnnxRuntime;
 import ai.vespa.models.evaluation.Model;
 import ai.vespa.models.evaluation.ModelsEvaluator;
-import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.filedistribution.fileacquirer.FileAcquirer;
@@ -14,25 +13,17 @@ import com.yahoo.vespa.config.search.core.OnnxModelsConfig;
 import com.yahoo.vespa.config.search.core.RankingConstantsConfig;
 import com.yahoo.vespa.config.search.core.RankingExpressionsConfig;
 
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * proxy for model-evaluation components
  * @author arnej
  */
-@Beta
 public class RankProfilesEvaluator extends AbstractComponent {
 
     private final ModelsEvaluator evaluator;
-    private static final Logger logger = Logger.getLogger(RankProfilesEvaluator.class.getName());
 
     @Inject
     public RankProfilesEvaluator(
@@ -40,14 +31,16 @@ public class RankProfilesEvaluator extends AbstractComponent {
             RankingConstantsConfig constantsConfig,
             RankingExpressionsConfig expressionsConfig,
             OnnxModelsConfig onnxModelsConfig,
-            FileAcquirer fileAcquirer)
+            FileAcquirer fileAcquirer,
+            OnnxRuntime onnxRuntime)
     {
         this.evaluator = new ModelsEvaluator(
                 rankProfilesConfig,
                 constantsConfig,
                 expressionsConfig,
                 onnxModelsConfig,
-                fileAcquirer);
+                fileAcquirer,
+                onnxRuntime);
         extractGlobalPhaseData(rankProfilesConfig);
     }
 
@@ -59,11 +52,7 @@ public class RankProfilesEvaluator extends AbstractComponent {
         return m;
     }
 
-    public FunctionEvaluator evaluatorForFunction(String rankProfile, String functionName) {
-        return modelForRankProfile(rankProfile).evaluatorOf(functionName);
-    }
-
-    private Map<String, GlobalPhaseSetup> profilesWithGlobalPhase = new HashMap<>();
+    private final Map<String, GlobalPhaseSetup> profilesWithGlobalPhase = new HashMap<>();
 
     Optional<GlobalPhaseSetup> getGlobalPhaseSetup(String rankProfile) {
         return Optional.ofNullable(profilesWithGlobalPhase.get(rankProfile));

--- a/container-search/src/test/java/com/yahoo/search/ranking/GlobalPhaseSetupTest.java
+++ b/container-search/src/test/java/com/yahoo/search/ranking/GlobalPhaseSetupTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.ranking;
 
+import ai.vespa.modelintegration.evaluator.OnnxRuntime;
 import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.filedistribution.fileacquirer.MockFileAcquirer;
 import com.yahoo.tensor.Tensor;
@@ -142,6 +143,8 @@ public class GlobalPhaseSetupTest {
         RankingConstantsConfig constantsConfig = new RankingConstantsConfig.Builder().build();
         RankingExpressionsConfig expressionsConfig = new RankingExpressionsConfig.Builder().build();
         OnnxModelsConfig onnxModelsConfig = new OnnxModelsConfig.Builder().build();
-        return new RankProfilesEvaluator(config, constantsConfig, expressionsConfig, onnxModelsConfig, MockFileAcquirer.returnFile(null));
+        return new RankProfilesEvaluator(
+                config, constantsConfig, expressionsConfig, onnxModelsConfig, MockFileAcquirer.returnFile(null),
+                OnnxRuntime.testInstance());
     }
 }


### PR DESCRIPTION
The global phase ranker previously used a test instance of the ONNX runtime. Use instance from DI to get correct configuration and Triton suppport.