### PR TITLE
feat: export Micrometer based JVM metrics from configserver clusters

### DIFF
--- a/metrics/src/main/java/ai/vespa/metrics/set/InfrastructureMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/InfrastructureMetricSet.java
@@ -28,7 +28,7 @@ import static ai.vespa.metrics.Suffix.sum;
 public class InfrastructureMetricSet {
 
     public static final MetricSet infrastructureMetricSet = new MetricSet("infrastructure",
-            getInfrastructureMetrics());
+            getInfrastructureMetrics(), Set.of(MicrometerMetrics.asMetricSet()));
 
     private static Set<Metric> getInfrastructureMetrics() {
         Set<Metric> metrics = new LinkedHashSet<>();


### PR DESCRIPTION
Add metrics to the infrastructure metric set.
See `metrics/src/main/java/ai/vespa/metrics/set/MicrometerMetrics.java` for list of metrics. The Micrometer component is already enabled as the configserver cluster is represented as an application container cluster in the config model 🙈.