### PR TITLE
Ensure we emit continuation tokens in error edge cases when streaming

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -1314,6 +1314,11 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
         return new VisitorContinuation(token.serializeToString(), token.percentFinished());
     }
 
+    private static ProgressToken cloneProgressToken(ProgressToken sourceToken) {
+        // FIXME this roundtrip feels pretty dirty, but no existing token API for deep-cloning...
+        return new ProgressToken(sourceToken.serialize());
+    }
+
     @SuppressWarnings("fallthrough")
     private void visit(HttpRequest request, VisitorParameters parameters, boolean streaming, boolean fullyApplied,
                        ResponseHandler handler, VisitCallback callback) {
@@ -1326,12 +1331,27 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
             VisitorControlHandler controller = new VisitorControlHandler() {
                 final ScheduledFuture<?> abort = streaming ? visitDispatcher.schedule(this::abort, visitTimeout(request), MILLISECONDS) : null;
                 final AtomicReference<VisitorSession> session = new AtomicReference<>();
+                ProgressToken initialProgress = parameters.getResumeToken(); // may be null
                 @Override public void setSession(VisitorControlSession session) { // Workaround for broken session API ಠ_ಠ
                     super.setSession(session);
-                    if (session instanceof VisitorSession visitorSession) this.session.set(visitorSession);
+                    if (session instanceof VisitorSession visitorSession) {
+                        // If no initial progress was provided (i.e. this is the first visit of potentially many)
+                        // we must remember the progress token implicitly created by the visitor session during
+                        // its bootstrap, as this token will represent the completely unfinished visit state.
+                        // This is because a session failure prior to receiving even a single bucket will not provide
+                        // us with an onProgress control handler callback, nor will the VisitorParameters have a
+                        // token. If we then don't remember the session's bootstrap token, we won't have a token
+                        // to communicate to the client, and the client may erroneously believe that visiting has
+                        // fully completed.
+                        if (initialProgress == null) {
+                            // The session has not yet been started when setSession() is invoked, so this is thread safe.
+                            initialProgress = cloneProgressToken(visitorSession.getProgress());
+                        }
+                        this.session.set(visitorSession);
+                    }
                 }
                 void writeCurrentProgressTokenToResponse() throws IOException {
-                    ProgressToken progress = getProgress() != null ? getProgress() : parameters.getResumeToken();
+                    ProgressToken progress = getProgress() != null ? getProgress() : initialProgress;
                     if (progress != null) {
                         if (progress.isFinished()) {
                             response.writeEpilogueContinuation(VisitorContinuation.FINISHED);
@@ -1436,11 +1456,9 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
             parameters.setControlHandler(controller);
             visits.put(controller, access.createVisitorSession(parameters));
             phaser.arriveAndDeregister();
-        }
-        catch (ParseException e) {
+        } catch (ParseException e) {
             badRequest(request, new IllegalArgumentException(e), handler);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             log.log(FINE, "Failed writing response", e);
         }
     }

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -1503,15 +1503,15 @@ public class DocumentV1ApiTest {
 
     private static ProgressToken makeIncompleteProgressToken() {
         var progress = new ProgressToken();
-        VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(1), new BucketId(2)), 8, progress)
-                .update(new BucketId(1), new BucketId(1));
+        VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(16, 1), new BucketId(16, 2)), 16, progress)
+                .update(new BucketId(16, 1), ProgressToken.NULL_BUCKET);
         assertFalse(progress.isFinished());
         return progress;
     }
 
     private static ProgressToken makePartiallyCompleteProgressToken() {
         var progress = new ProgressToken();
-        VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(16, 1), new BucketId(16, 2)), 8, progress)
+        VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(16, 1), new BucketId(16, 2)), 16, progress)
                 .update(new BucketId(16, 1), new BucketId(16, 1L << 33));
         assertFalse(progress.isFinished());
         return progress;
@@ -1520,7 +1520,7 @@ public class DocumentV1ApiTest {
     // Subsumes token from makePartiallyCompleteProgressToken
     private static ProgressToken makePartiallyCompleteProgressToken2() {
         var progress = new ProgressToken();
-        var iter = VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(16, 1), new BucketId(16, 2)), 8, progress);
+        var iter = VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(16, 1), new BucketId(16, 2)), 16, progress);
         iter.update(new BucketId(16, 1), ProgressToken.FINISHED_BUCKET);
         iter.update(new BucketId(16, 2), new BucketId(16, 2L << 33));
         assertFalse(progress.isFinished());
@@ -1529,9 +1529,9 @@ public class DocumentV1ApiTest {
 
     private static ProgressToken makeCompleteProgressToken() {
         var progress = new ProgressToken();
-        var iter = VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(1), new BucketId(2)), 8, progress);
-        iter.update(new BucketId(1), ProgressToken.FINISHED_BUCKET);
-        iter.update(new BucketId(2), ProgressToken.FINISHED_BUCKET);
+        var iter = VisitorIterator.createFromExplicitBucketSet(Set.of(new BucketId(16, 1), new BucketId(16, 2)), 16, progress);
+        iter.update(new BucketId(16, 1), ProgressToken.FINISHED_BUCKET);
+        iter.update(new BucketId(16, 2), ProgressToken.FINISHED_BUCKET);
         assertTrue(progress.isFinished());
         return progress;
     }


### PR DESCRIPTION
@bjorncs please review

The Document V1 API handler logic for handling visitor session errors did not consistently take into account the difference in
semantics between non-streaming and streaming responses. This could cause `continuation` tokens to _not_ be written to the response stream in certain error edge cases, because the code assumed it would be able to trigger an explicit client error via the HTTP response code. But in streaming mode we've already sent the response headers, so that communication channel is closed.

Ensure we emit the continuation token (unless complete) in error scenarios to avoid having it erroneously appear as if the visitor session has completed (signaled by not having a `continuation` object in the response).

Additionally, this fixes an error edge case that could happen during the very start of the very first visitor request of a (possibly multi-request) stream. If no initial progress token was provided by the client we must remember the progress token implicitly created by the visitor session during its bootstrap, as this token will represent the completely unfinished visit state.

This is because a session failure prior to receiving even a single bucket will not provide us with an `onProgress` control
handler callback, nor will the `VisitorParameters` have a valid token. If we then don't remember the session's bootstrap token, we won't have anything to communicate to the client, and it may erroneously believe that visiting has fully completed.