### PR TITLE
Make default threadpool configurable in config model

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -20,6 +20,7 @@ import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.core.document.ContainerDocumentConfig;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
+import com.yahoo.container.handler.ThreadpoolConfig;
 import com.yahoo.container.jdisc.JdiscBindingsConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.container.jdisc.state.StateHandler;
@@ -146,6 +147,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private ContainerDocumentApi containerDocumentApi;
     private SecretStore secretStore;
     private final ContainerThreadpool defaultHandlerThreadpool;
+    private DefaultThreadpoolProvider defaultThreadpoolProvider;
 
     private boolean rpcServerEnabled = true;
     private boolean httpServerEnabled = true;
@@ -182,7 +184,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         addCommonVespaBundles();
         addSimpleComponent(VoidRequestLog.class);
-        addComponent(new DefaultThreadpoolProvider(this));
+        defaultThreadpoolProvider = new DefaultThreadpoolProvider(this);
+        addComponent(defaultThreadpoolProvider);
         defaultHandlerThreadpool = new Handler.DefaultHandlerThreadpool(deployState, null);
         addComponent(defaultHandlerThreadpool);
         addSimpleComponent(com.yahoo.concurrent.classlock.ClassLocking.class);
@@ -427,6 +430,12 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     public Optional<SecretStore> getSecretStore() {
         return Optional.ofNullable(secretStore);
+    }
+
+    public void setDefaultThreadpoolProvider(DefaultThreadpoolProvider defaultThreadpoolProvider) {
+        removeComponent(this.defaultThreadpoolProvider.getComponentId());
+        this.defaultThreadpoolProvider = defaultThreadpoolProvider;
+        addComponent(defaultThreadpoolProvider);
     }
 
     public Map<ComponentId, Component<?, ?>> getComponentsMap() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -20,7 +20,6 @@ import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.core.document.ContainerDocumentConfig;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
-import com.yahoo.container.handler.ThreadpoolConfig;
 import com.yahoo.container.jdisc.JdiscBindingsConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.container.jdisc.state.StateHandler;
@@ -147,7 +146,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private ContainerDocumentApi containerDocumentApi;
     private SecretStore secretStore;
     private final ContainerThreadpool defaultHandlerThreadpool;
-    private DefaultThreadpoolProvider defaultThreadpoolProvider;
 
     private boolean rpcServerEnabled = true;
     private boolean httpServerEnabled = true;
@@ -184,8 +182,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         addCommonVespaBundles();
         addSimpleComponent(VoidRequestLog.class);
-        defaultThreadpoolProvider = new DefaultThreadpoolProvider(this);
-        addComponent(defaultThreadpoolProvider);
         defaultHandlerThreadpool = new Handler.DefaultHandlerThreadpool(deployState, null);
         addComponent(defaultHandlerThreadpool);
         addSimpleComponent(com.yahoo.concurrent.classlock.ClassLocking.class);
@@ -433,8 +429,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     }
 
     public void setDefaultThreadpoolProvider(DefaultThreadpoolProvider defaultThreadpoolProvider) {
-        removeComponent(this.defaultThreadpoolProvider.getComponentId());
-        this.defaultThreadpoolProvider = defaultThreadpoolProvider;
         addComponent(defaultThreadpoolProvider);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container;
 
-import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.handler.threadpool.ContainerThreadPool;
@@ -9,9 +8,8 @@ import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.container.handler.threadpool.ContainerThreadpoolImpl;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
+import com.yahoo.vespa.model.container.xml.ContainerThreadpoolOptionsBuilder;
 import org.w3c.dom.Element;
-
-import java.util.logging.Level;
 
 /**
  * Component definition for a {@link java.util.concurrent.Executor} using {@link ContainerThreadPool}.
@@ -24,7 +22,7 @@ public abstract class ContainerThreadpool extends SimpleComponent implements Con
     private final String name;
     private final UserOptions options;
 
-    record UserOptions(Double max, Double min, Double queueSize, boolean isRelative){}
+    public record UserOptions(Double max, Double min, Double queueSize, boolean isRelative){}
 
     protected ContainerThreadpool(DeployState ds, String name, Element parent) {
         super(new ComponentModel(
@@ -33,74 +31,7 @@ public abstract class ContainerThreadpool extends SimpleComponent implements Con
                         ContainerThreadpoolImpl.class.getName(),
                         null)));
         this.name = name;
-        var threadpoolElem = XmlHelper.getOptionalChild(parent, "threadpool").orElse(null);
-        if (threadpoolElem == null) options = new UserOptions(null, null, null, false);
-        else {
-            // TODO Vespa 9 Remove min-threads, max-threads and queue-size
-
-            // TODO Vespa 9 Remove variable pool size (aka 'boost')
-            //      It's rarely used and the semantics are confusing.
-            //      The number of threads are scaled up after the queue is full, which is surprising,
-            //      as one would expect the pool size to scale before queuing up tasks.
-            //      This is a Java limitation in the thread pool class from the standard library.
-            Double max = null;
-            Double min = null;
-            Double queue = null;
-            boolean isRelative;
-            var threadsElem = XmlHelper.getOptionalChild(threadpoolElem, "threads").orElse(null);
-            if (threadsElem != null) {
-                // New syntax with values relative to number of CPU cores
-                min = Double.parseDouble(threadsElem.getTextContent());
-
-                // Until variable pool size is removed, prefer max to boost.
-                var maxAttribute = XmlHelper.getOptionalAttribute(threadsElem, "max").orElse(null);
-                var boostAttribute = XmlHelper.getOptionalAttribute(threadsElem, "boost").orElse(null);
-                if (maxAttribute != null && boostAttribute != null) {
-                    throw new IllegalArgumentException("For <threads>: both 'max' and 'boost' cannot be specified at the same time. Please use 'max' only.");
-                } else if (maxAttribute != null) {
-                    max = Double.parseDouble(maxAttribute);
-                } else if (boostAttribute != null) {
-                    ds.getDeployLogger()
-                            .logApplicationPackage(Level.WARNING, "For <threads>: the 'boost' attribute is deprecated, use 'max' instead.");
-                    max = Double.parseDouble(boostAttribute);
-                } else {
-                    max = min;
-                }
-
-                var queueElem = XmlHelper.getOptionalChild(threadpoolElem, "queue").orElse(null);
-                if (queueElem != null) queue = Double.parseDouble(queueElem.getTextContent());
-                isRelative = true;
-            } else {
-                // Old syntax with absolute values
-                var minElem = XmlHelper.getOptionalChild(threadpoolElem, "min-threads").orElse(null);
-                if (minElem != null) ds.getDeployLogger()
-                        .logApplicationPackage(Level.WARNING, "For <threadpool>: <min-threads> is deprecated, use <threads> instead");
-                var maxElem = XmlHelper.getOptionalChild(threadpoolElem, "max-threads").orElse(null);
-                if (maxElem != null) ds.getDeployLogger()
-                        .logApplicationPackage(Level.WARNING, "For <threadpool>: <max-threads> is deprecated, use <threads> with 'max' instead");
-                if (minElem != null) {
-                    min = Double.parseDouble(minElem.getTextContent());
-                }
-                if (maxElem != null) {
-                    max = Double.parseDouble(maxElem.getTextContent());
-                }
-                var queueSizeElem = XmlHelper.getOptionalChild(threadpoolElem, "queue-size").orElse(null);
-                if (queueSizeElem != null) ds.getDeployLogger()
-                        .logApplicationPackage(Level.WARNING, "For <threadpool>: <queue-size> is deprecated, use <queue> instead");
-                if (queueSizeElem != null) queue = Double.parseDouble(queueSizeElem.getTextContent());
-                isRelative = false;
-            }
-
-            if (min != null && min < 0)
-                throw new IllegalArgumentException("For <threadpool>: <threads> must be positive.");
-            if (max != null && max <= 0)
-                throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be positive.");
-            if (queue != null && queue < 0)
-                throw new IllegalArgumentException("For <threadpool>: <queue> must be positive.");
-            if (min != null && max != null && min > max)
-                throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be greater than <threads>.");
-            options = new UserOptions(max, min, queue, isRelative);
-        }
+        this.options = ContainerThreadpoolOptionsBuilder.build(ds, parent);
     }
 
     // Must be implemented by subclasses to set values that may be overridden by user options.

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
@@ -90,7 +90,7 @@ public class DefaultThreadpoolProvider extends SimpleComponent implements Thread
                     .logApplicationPackage(Level.WARNING,
                             "For <threadpool> in <container>: the value " +
                                     part + "=" + value + " will be truncated to " + truncated
-                                    + ". This will be removed in Vespa 9");
+                                    + ". This behavior will be removed in Vespa 9.");
         }
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
@@ -34,6 +34,7 @@ public class DefaultThreadpoolProvider extends SimpleComponent implements Thread
     @Override
     public void getConfig(ThreadpoolConfig.Builder builder) {
         if (userOptions != null) {
+            // Convert from config model to ThreadpoolConfig.
             boolean neg = userOptions.isRelative();
             int max = neg ? -userOptions.max().intValue() : userOptions.max().intValue();
             int min = neg ? -userOptions.min().intValue() : userOptions.min().intValue();

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -73,6 +73,7 @@ import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.ContainerModelEvaluation;
 import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.DataplaneProxy;
+import com.yahoo.vespa.model.container.DefaultThreadpoolProvider;
 import com.yahoo.vespa.model.container.IdentityProvider;
 import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.SecretStore;
@@ -219,6 +220,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         addSearch(deployState, spec, cluster, context);
         addDocproc(deployState, spec, cluster);
         addDocumentApi(deployState, spec, cluster, context);  // NOTE: Must be done after addSearch
+        addDefaultThreadpool(deployState, spec, cluster);
 
         cluster.addDefaultHandlersExceptStatus();
         addStatusHandlers(cluster, context.getDeployState().isHosted());
@@ -858,6 +860,13 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         validateAndAddConfiguredComponents(deployState, cluster, searchElement, "renderer", ContainerModelBuilder::validateRendererElement);
 
         addSignificance(deployState, searchElement, cluster);
+    }
+
+    private void addDefaultThreadpool(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {
+        Element threadpoolElement = XML.getChild(spec, "threadpool");
+        if (threadpoolElement == null) return;
+        var options = ContainerThreadpoolOptionsBuilder.build(deployState, spec);
+        cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(cluster, options));
     }
 
     private void addSignificance(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -866,7 +866,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         Element threadpoolElement = XML.getChild(spec, "threadpool");
         if (threadpoolElement == null) return;
         var options = ContainerThreadpoolOptionsBuilder.build(deployState, spec);
-        cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(cluster, options));
+        cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(deployState, cluster, options));
     }
 
     private void addSignificance(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -864,9 +864,12 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private void addDefaultThreadpool(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {
         Element threadpoolElement = XML.getChild(spec, "threadpool");
-        if (threadpoolElement == null) return;
-        var options = ContainerThreadpoolOptionsBuilder.build(deployState, spec);
-        cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(deployState, cluster, options));
+        if (threadpoolElement == null) {
+            cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(cluster));
+        } else {
+            var options = ContainerThreadpoolOptionsBuilder.build(deployState, spec);
+            cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(deployState, cluster, options));
+        }
     }
 
     private void addSignificance(DeployState deployState, Element spec, ApplicationContainerCluster cluster) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerThreadpoolOptionsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerThreadpoolOptionsBuilder.java
@@ -1,0 +1,83 @@
+package com.yahoo.vespa.model.container.xml;
+
+import com.yahoo.config.model.builder.xml.XmlHelper;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
+import org.w3c.dom.Element;
+
+import java.util.logging.Level;
+
+public class ContainerThreadpoolOptionsBuilder {
+    public static ContainerThreadpool.UserOptions build(DeployState ds, Element parent) {
+        var options = new ContainerThreadpool.UserOptions(null, null, null, false);
+        var threadpoolElem = XmlHelper.getOptionalChild(parent, "threadpool").orElse(null);
+        if (threadpoolElem == null)
+            return options;
+
+        // TODO Vespa 9 Remove min-threads, max-threads and queue-size
+
+        // TODO Vespa 9 Remove variable pool size (aka 'boost')
+        //      It's rarely used and the semantics are confusing.
+        //      The number of threads are scaled up after the queue is full, which is surprising,
+        //      as one would expect the pool size to scale before queuing up tasks.
+        //      This is a Java limitation in the thread pool class from the standard library.
+        Double max = null;
+        Double min = null;
+        Double queue = null;
+        boolean isRelative;
+        var threadsElem = XmlHelper.getOptionalChild(threadpoolElem, "threads").orElse(null);
+        if (threadsElem != null) {
+            // New syntax with values relative to number of CPU cores
+            min = Double.parseDouble(threadsElem.getTextContent());
+
+            // Until variable pool size is removed, prefer max to boost.
+            var maxAttribute = XmlHelper.getOptionalAttribute(threadsElem, "max").orElse(null);
+            var boostAttribute = XmlHelper.getOptionalAttribute(threadsElem, "boost").orElse(null);
+            if (maxAttribute != null && boostAttribute != null) {
+                throw new IllegalArgumentException("For <threads>: both 'max' and 'boost' cannot be specified at the same time. Please use 'max' only.");
+            } else if (maxAttribute != null) {
+                max = Double.parseDouble(maxAttribute);
+            } else if (boostAttribute != null) {
+                ds.getDeployLogger()
+                        .logApplicationPackage(Level.WARNING, "For <threads>: the 'boost' attribute is deprecated, use 'max' instead.");
+                max = Double.parseDouble(boostAttribute);
+            } else {
+                max = min;
+            }
+
+            var queueElem = XmlHelper.getOptionalChild(threadpoolElem, "queue").orElse(null);
+            if (queueElem != null) queue = Double.parseDouble(queueElem.getTextContent());
+            isRelative = true;
+        } else {
+            // Old syntax with absolute values
+            var minElem = XmlHelper.getOptionalChild(threadpoolElem, "min-threads").orElse(null);
+            if (minElem != null) ds.getDeployLogger()
+                    .logApplicationPackage(Level.WARNING, "For <threadpool>: <min-threads> is deprecated, use <threads> instead");
+            var maxElem = XmlHelper.getOptionalChild(threadpoolElem, "max-threads").orElse(null);
+            if (maxElem != null) ds.getDeployLogger()
+                    .logApplicationPackage(Level.WARNING, "For <threadpool>: <max-threads> is deprecated, use <threads> with 'max' instead");
+            if (minElem != null) {
+                min = Double.parseDouble(minElem.getTextContent());
+            }
+            if (maxElem != null) {
+                max = Double.parseDouble(maxElem.getTextContent());
+            }
+            var queueSizeElem = XmlHelper.getOptionalChild(threadpoolElem, "queue-size").orElse(null);
+            if (queueSizeElem != null) ds.getDeployLogger()
+                    .logApplicationPackage(Level.WARNING, "For <threadpool>: <queue-size> is deprecated, use <queue> instead");
+            if (queueSizeElem != null) queue = Double.parseDouble(queueSizeElem.getTextContent());
+            isRelative = false;
+        }
+
+        if (min != null && min < 0)
+            throw new IllegalArgumentException("For <threadpool>: <threads> must be positive.");
+        if (max != null && max <= 0)
+            throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be positive.");
+        if (queue != null && queue < 0)
+            throw new IllegalArgumentException("For <threadpool>: <queue> must be positive.");
+        if (min != null && max != null && min > max)
+            throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be greater than <threads>.");
+        options = new ContainerThreadpool.UserOptions(max, min, queue, isRelative);
+        return options;
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerThreadpoolOptionsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerThreadpoolOptionsBuilder.java
@@ -1,3 +1,4 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.xml;
 
 import com.yahoo.config.model.builder.xml.XmlHelper;
@@ -7,6 +8,11 @@ import org.w3c.dom.Element;
 
 import java.util.logging.Level;
 
+/**
+ * Parses <threadpool> elements for {@link ContainerThreadpool}.
+ *
+ * @author johsol
+ */
 public class ContainerThreadpoolOptionsBuilder {
     public static ContainerThreadpool.UserOptions build(DeployState ds, Element parent) {
         var options = new ContainerThreadpool.UserOptions(null, null, null, false);

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -26,7 +26,8 @@ ContainerServices =
     ZooKeeper? &
     GenericConfig* &
     Clients? &
-    Inference?
+    Inference? &
+    Threadpool?
 
 # TODO(ogronnesby): Change this configuration syntax
 ClientAuthorize = element client-authorize { empty }

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -429,11 +429,14 @@ public class ContainerClusterTest {
         ApplicationContainerCluster cluster = new ApplicationContainerCluster(root, "container0", "container1", root.getDeployState());
         cluster.setMemoryPercentage(memoryPercentage);
         cluster.setSearch(new ContainerSearch(root.getDeployState(), cluster, new SearchChains(cluster, "search-chain")));
+        cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(cluster));
         return cluster;
     }
 
     private static ClusterControllerContainerCluster createClusterControllerCluster(MockRoot root) {
-        return new ClusterControllerContainerCluster(root, "container0", "container1", root.getDeployState());
+        var cluster = new ClusterControllerContainerCluster(root, "container0", "container1", root.getDeployState());
+        cluster.setDefaultThreadpoolProvider(new DefaultThreadpoolProvider(cluster));
+        return cluster;
     }
 
     private static MockRoot createRoot(boolean isHosted) {

--- a/config-model/src/test/schema-test-files/services.xml
+++ b/config-model/src/test/schema-test-files/services.xml
@@ -259,6 +259,11 @@
       </threadpool>
     </document-processing>
 
+    <!-- Container default threadpool config -->
+    <threadpool>
+      <threads max="8">4</threads>
+      <queue>50</queue>
+    </threadpool>
   </container>
 
   <container id='qrsCluster_2' version='1.0'>


### PR DESCRIPTION
- Add `<threadpool>` syntax to services.xml schema.
- Move parsing of `<threadpool>` into `ContainerThreadpoolOptionsBuilder.java`.
- Reuse `ContainerThreadpool.UserOptions` to default threadpool.
- Must convert to `ThreadpoolConfig` to interop with config override. Thereby, rounding and telling the user that values will be truncated.
- Add configurable default container threadpool to `ContainerCluster` model and `ContainerModelBuilder`.