### PR TITLE
Triton runtime overrides ONNX intra-op threads 

### DIFF
--- a/model-integration/src/main/java/ai/vespa/llm/clients/OnnxEncoderDecoder.java
+++ b/model-integration/src/main/java/ai/vespa/llm/clients/OnnxEncoderDecoder.java
@@ -66,7 +66,7 @@ public class OnnxEncoderDecoder extends AbstractComponent implements LanguageMod
 
         OnnxEvaluatorOptions encoderOptions = new OnnxEvaluatorOptions.Builder()
                 .setExecutionMode(config.encoderOnnxExecutionMode().toString())
-                .setThreads(config.encoderOnnxInterOpThreads(), config.encoderOnnxIntraOpThreads())
+                .setThreadsFromFactors(config.encoderOnnxInterOpThreads(), config.encoderOnnxIntraOpThreads())
                 .build();
 
         encoder = onnx.evaluatorOf(config.encoderModel().toString(), encoderOptions);
@@ -79,7 +79,7 @@ public class OnnxEncoderDecoder extends AbstractComponent implements LanguageMod
 
         OnnxEvaluatorOptions decoderOptions = new OnnxEvaluatorOptions.Builder()
                 .setExecutionMode(config.decoderOnnxExecutionMode().toString())
-                .setThreads(config.decoderOnnxInterOpThreads(), config.decoderOnnxIntraOpThreads())
+                .setThreadsFromFactors(config.decoderOnnxInterOpThreads(), config.decoderOnnxIntraOpThreads())
                 .build();
 
         decoder = onnx.evaluatorOf(config.decoderModel().toString(), decoderOptions);

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -80,7 +80,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
     @Inject
     public TritonOnnxRuntime(TritonConfig config) {
         log.info(() -> "Creating Triton ONNX runtime");
-        
+
         this.config = config;
         this.tritonClient = new TritonOnnxClient(config);
         this.isModelControlExplicit = config.modelControlMode() == TritonConfig.ModelControlMode.EXPLICIT;
@@ -184,6 +184,14 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
                         ? ModelConfigOuterClass.ModelInstanceGroup.Kind.KIND_AUTO
                         : ModelConfigOuterClass.ModelInstanceGroup.Kind.KIND_CPU;
 
+        // Each model instance in Triton executes requests sequentially, which is different from EmbeddedOnnxRuntime
+        // where one model instance (session) handles all requests.
+        // To maximize CPU utilization with Triton, available cores are ca. divided between model instances,
+        // Rounding up is used because it is better to overutilize CPU to underutilize.
+        // Intra-op threads parallize execution of each operator improving performance for any model.
+        var intraOpThreadCount =
+                Math.max(1, (int) Math.ceil(1d * options.availableProcessors() / options.numModelInstances()));
+
         var configBuilder = ModelConfigOuterClass.ModelConfig.newBuilder()
                 .setName(modelName)
                 .addInstanceGroup(ModelConfigOuterClass.ModelInstanceGroup.newBuilder()
@@ -205,7 +213,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
                 .putParameters(
                         "intra_op_thread_count",
                         ModelConfigOuterClass.ModelParameter.newBuilder()
-                                .setStringValue(Integer.toString(options.intraOpThreads()))
+                                .setStringValue(Integer.toString(intraOpThreadCount))
                                 .build())
                 .putParameters(
                         "inter_op_thread_count",

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -187,7 +187,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         // Each model instance in Triton executes requests sequentially, which is different from EmbeddedOnnxRuntime
         // where one model instance (session) handles all requests.
         // To maximize CPU utilization with Triton, available cores are ca. divided between model instances,
-        // Rounding up is used because it is better to overutilize CPU to underutilize.
+        // Rounding up is used because it is better to overutilize CPU than to underutilize.
         // Intra-op threads parallize execution of each operator improving performance for any model.
         var intraOpThreadCount =
                 Math.max(1, (int) Math.ceil(1d * options.availableProcessors() / options.numModelInstances()));

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -188,7 +188,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         // where one model instance (session) handles all requests.
         // To maximize CPU utilization with Triton, available cores are ca. divided between model instances,
         // Rounding up is used because it is better to overutilize CPU than to underutilize.
-        // Intra-op threads parallize execution of each operator improving performance for any model.
+        // Intra-op threads parallelize execution of each operator improving performance for any model.
         var intraOpThreadCount =
                 Math.max(1, (int) Math.ceil(1d * options.availableProcessors() / options.numModelInstances()));
 

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -51,7 +51,8 @@ class TritonOnnxRuntimeTest {
 
     @Test
     void load_model_with_threads() throws IOException {
-        var opts = optsBuilder.setThreads(8, 16).build();
+        // TritonOnnxRuntime ignores intraOpThreadsFactor
+        var opts = optsBuilder.setThreadsFromFactors(8, 16).build();
         assertLoadModel("src/test/triton/config_with_threads.pbtxt", opts);
     }
 

--- a/model-integration/src/test/triton/config_with_absolute_concurrency.pbtxt
+++ b/model-integration/src/test/triton/config_with_absolute_concurrency.pbtxt
@@ -26,6 +26,6 @@ parameters {
 parameters {
   key: "intra_op_thread_count"
   value {
-    string_value: "2"
+    string_value: "4"
   }
 }

--- a/model-integration/src/test/triton/config_with_batching.pbtxt
+++ b/model-integration/src/test/triton/config_with_batching.pbtxt
@@ -29,6 +29,6 @@ parameters {
 parameters {
   key: "intra_op_thread_count"
   value {
-    string_value: "2"
+    string_value: "8"
   }
 }

--- a/model-integration/src/test/triton/config_with_defaults.pbtxt
+++ b/model-integration/src/test/triton/config_with_defaults.pbtxt
@@ -26,6 +26,6 @@ parameters {
 parameters {
   key: "intra_op_thread_count"
   value {
-    string_value: "2"
+    string_value: "8"
   }
 }

--- a/model-integration/src/test/triton/config_with_model_config_override_error.pbtxt
+++ b/model-integration/src/test/triton/config_with_model_config_override_error.pbtxt
@@ -32,6 +32,6 @@ parameters {
 parameters {
   key: "intra_op_thread_count"
   value {
-    string_value: "6"
+    string_value: "8"
   }
 }

--- a/model-integration/src/test/triton/config_with_relative_concurrency.pbtxt
+++ b/model-integration/src/test/triton/config_with_relative_concurrency.pbtxt
@@ -26,6 +26,6 @@ parameters {
 parameters {
   key: "intra_op_thread_count"
   value {
-    string_value: "2"
+    string_value: "1"
   }
 }

--- a/model-integration/src/test/triton/config_with_threads.pbtxt
+++ b/model-integration/src/test/triton/config_with_threads.pbtxt
@@ -26,6 +26,6 @@ parameters {
 parameters {
   key: "intra_op_thread_count"
   value {
-    string_value: "16"
+    string_value: "8"
   }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This is due to differences how concurrent requests are handled by embedded ONNX runtime and Triton.
Each model instance in Triton executes requests sequentially, which is different from EmbeddedOnnxRuntime
where one model instance (session) handles all requests.
To maximize CPU utilization with Triton, available cores are ca. divided between model instances,
Rounding up is used because it is better to overutilize CPU to underutilize.
Intra-op threads parallize execution of each operator improving performance for any model.

Also renamed setThreads method to make it more explicit that it takes thread factors used to calculate number of threads rather than number of threads directly like setInterOpThreads and setIntraOpThreads. 