### PR TITLE
Added missing deconstruct to close evaluator in RankProfilesEvaluator

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/ranking/RankProfilesEvaluator.java
+++ b/container-search/src/main/java/com/yahoo/search/ranking/RankProfilesEvaluator.java
@@ -67,4 +67,8 @@ public class RankProfilesEvaluator extends AbstractComponent {
         }
     }
 
+    @Override
+    public void deconstruct() {
+        evaluator.deconstruct();
+    }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Without deconstruct ONNX models used in ranking will not be unloaded, cleaned.
Potential cause for OOMs in ONNX runtime (both embedded and Triton).