### PR TITLE
Add metrics related to vector search to Proton

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/searchcore/proton/matching/matching_stats.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
@@ -12,6 +13,9 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp)
     EXPECT_EQ(0u, stats.docsMatched());
     EXPECT_EQ(0u, stats.docsRanked());
     EXPECT_EQ(0u, stats.docsReRanked());
+    EXPECT_EQ(0u, stats.exact_nns_distances_computed());
+    EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
     EXPECT_EQ(0u, stats.queries());
     EXPECT_EQ(0u, stats.limited_queries());
     {
@@ -20,14 +24,25 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp)
         EXPECT_EQ(&rhs.docsMatched(1000), &rhs);
         EXPECT_EQ(&rhs.docsRanked(100), &rhs);
         EXPECT_EQ(&rhs.docsReRanked(10), &rhs);
+        EXPECT_EQ(&rhs.exact_nns_distances_computed(42), &rhs);
+        EXPECT_EQ(&rhs.approximate_nns_distances_computed(53), &rhs);
+        EXPECT_EQ(&rhs.approximate_nns_nodes_visited(7), &rhs);
         EXPECT_EQ(&rhs.queries(2), &rhs);
         EXPECT_EQ(&rhs.limited_queries(1), &rhs);
+        search::queryeval::QueryEvalStats qe_stats;
+        qe_stats.add_to_exact_nns_distances_computed(1);
+        qe_stats.add_to_approximate_nns_distances_computed(2);
+        qe_stats.add_to_approximate_nns_nodes_visited(3);
+        EXPECT_EQ(&stats.add_queryeval_stats(qe_stats), &stats);
         EXPECT_EQ(&stats.add(rhs), &stats);
     }
     EXPECT_EQ(10000u, stats.docidSpaceCovered());
     EXPECT_EQ(1000u, stats.docsMatched());
     EXPECT_EQ(100u, stats.docsRanked());
     EXPECT_EQ(10u, stats.docsReRanked());
+    EXPECT_EQ(43u, stats.exact_nns_distances_computed());
+    EXPECT_EQ(55u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(10u, stats.approximate_nns_nodes_visited());
     EXPECT_EQ(2u, stats.queries());
     EXPECT_EQ(1u, stats.limited_queries());
     EXPECT_EQ(&stats.add(MatchingStats().docidSpaceCovered(10000).docsMatched(1000).docsRanked(100)
@@ -165,6 +180,9 @@ TEST(MatchingStatsTest, requireThatPartitionsAreAddedCorrectly)
     EXPECT_EQ(3u, subPart.docsMatched());
     EXPECT_EQ(2u, subPart.docsRanked());
     EXPECT_EQ(1u, subPart.docsReRanked());
+    EXPECT_EQ(0u, all1.exact_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_nodes_visited());
     EXPECT_EQ(1.0, subPart.active_time_avg());
     EXPECT_EQ(0.5, subPart.wait_time_avg());
     EXPECT_EQ(1u, subPart.active_time_count());
@@ -179,6 +197,9 @@ TEST(MatchingStatsTest, requireThatPartitionsAreAddedCorrectly)
     EXPECT_EQ(3u, all1.docsMatched());
     EXPECT_EQ(2u, all1.docsRanked());
     EXPECT_EQ(1u, all1.docsReRanked());
+    EXPECT_EQ(0u, all1.exact_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_nodes_visited());
     EXPECT_EQ(1u, all1.getNumPartitions());
     EXPECT_EQ(1u, all1.softDoomed());
     EXPECT_EQ(1000ns, all1.doomOvertime());
@@ -207,6 +228,9 @@ TEST(MatchingStatsTest, requireThatPartitionsAreAddedCorrectly)
     EXPECT_EQ(6u, all1.docsMatched());
     EXPECT_EQ(4u, all1.docsRanked());
     EXPECT_EQ(2u, all1.docsReRanked());
+    EXPECT_EQ(0u, all1.exact_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_nodes_visited());
     EXPECT_EQ(2u, all1.getNumPartitions());
     EXPECT_EQ(3u, all1.getPartition(1).docsMatched());
     EXPECT_EQ(2u, all1.getPartition(1).docsRanked());
@@ -233,6 +257,9 @@ TEST(MatchingStatsTest, requireThatPartitionsAreAddedCorrectly)
     EXPECT_EQ(12u, all1.docsMatched());
     EXPECT_EQ(8u, all1.docsRanked());
     EXPECT_EQ(4u, all1.docsReRanked());
+    EXPECT_EQ(0u, all1.exact_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, all1.approximate_nns_nodes_visited());
     EXPECT_EQ(2u, all1.getNumPartitions());
     EXPECT_EQ(6u, all1.getPartition(0).docsMatched());
     EXPECT_EQ(4u, all1.getPartition(0).docsRanked());

--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -29,11 +29,11 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp)
         EXPECT_EQ(&rhs.approximate_nns_nodes_visited(7), &rhs);
         EXPECT_EQ(&rhs.queries(2), &rhs);
         EXPECT_EQ(&rhs.limited_queries(1), &rhs);
-        search::queryeval::QueryEvalStats qe_stats;
-        qe_stats.add_to_exact_nns_distances_computed(1);
-        qe_stats.add_to_approximate_nns_distances_computed(2);
-        qe_stats.add_to_approximate_nns_nodes_visited(3);
-        EXPECT_EQ(&stats.add_queryeval_stats(qe_stats), &stats);
+        auto qe_stats = search::queryeval::QueryEvalStats::create();
+        qe_stats->add_to_exact_nns_distances_computed(1);
+        qe_stats->add_to_approximate_nns_distances_computed(2);
+        qe_stats->add_to_approximate_nns_nodes_visited(3);
+        EXPECT_EQ(&stats.add_queryeval_stats(*qe_stats), &stats);
         EXPECT_EQ(&stats.add(rhs), &stats);
     }
     EXPECT_EQ(10000u, stats.docidSpaceCovered());

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -183,7 +183,7 @@ public:
     const Query & query() const { return _query; }
     const RequestContext & get_request_context() const { return _requestContext; }
     // Hand the QueryEvalStats object to the query, which further hands it to the blueprint tree
-    void install_stats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) { _query.install_stats(stats); }
+    void install_stats(search::queryeval::QueryEvalStats &stats) { _query.install_stats(stats); }
 
     const StringStringMap & get_feature_rename_map() const;
 

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -182,6 +182,8 @@ public:
 
     const Query & query() const { return _query; }
     const RequestContext & get_request_context() const { return _requestContext; }
+    // Hand the QueryEvalStats object to the query, which further hands it to the blueprint tree
+    void installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) { _query.installStats(stats); }
 
     const StringStringMap & get_feature_rename_map() const;
 

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -183,7 +183,7 @@ public:
     const Query & query() const { return _query; }
     const RequestContext & get_request_context() const { return _requestContext; }
     // Hand the QueryEvalStats object to the query, which further hands it to the blueprint tree
-    void installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) { _query.installStats(stats); }
+    void install_stats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) { _query.install_stats(stats); }
 
     const StringStringMap & get_feature_rename_map() const;
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -290,8 +290,8 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
         traceQuery(6, request.trace(), mtf->query());
 
         // Collect more detailed statistics about query evaluation
-        queryeval_stats = std::make_shared<search::queryeval::QueryEvalStats>();
-        mtf->install_stats(queryeval_stats);
+        queryeval_stats = search::queryeval::QueryEvalStats::create();
+        mtf->install_stats(*queryeval_stats);
 
         if (!mtf->valid()) {
             return reply;

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -291,7 +291,7 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
 
         // Collect more detailed statistics about query evaluation
         queryeval_stats = std::make_shared<search::queryeval::QueryEvalStats>();
-        mtf->installStats(queryeval_stats);
+        mtf->install_stats(queryeval_stats);
 
         if (!mtf->valid()) {
             return reply;

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -9,6 +9,7 @@
 #include "sessionmanager.h"
 #include <vespa/searchcore/grouping/groupingcontext.h>
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
+#include <vespa/searchcore/proton/matching/matching_stats.h>
 #include <vespa/searchlib/engine/docsumrequest.h>
 #include <vespa/searchlib/engine/searchrequest.h>
 #include <vespa/searchlib/engine/searchreply.h>
@@ -339,6 +340,7 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
             sessionMgr.insert(std::move(session));
         }
     }
+    my_stats.add_queryeval_stats(*queryeval_stats);
     queryeval_stats.reset(); // Manually reset pointer to include object tear-down in measured time
     double querySetupTime = vespalib::to_s(total_matching_time.elapsed()) - my_stats.queryLatencyAvg();
     my_stats.querySetupTime(querySetupTime);

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "matching_stats.h"
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <cmath>
 
 namespace proton::matching {
@@ -26,6 +27,9 @@ MatchingStats::MatchingStats(double prev_soft_doom_factor) noexcept
       _docsMatched(0),
       _docsRanked(0),
       _docsReRanked(0),
+      _exact_nns_distances_computed(0),
+      _approximate_nns_distances_computed(0),
+      _approximate_nns_nodes_visited(0),
       _softDoomed(0),
       _doomOvertime(),
       _softDoomFactor(prev_soft_doom_factor),
@@ -56,6 +60,13 @@ MatchingStats::merge_partition(const Partition &partition, size_t id)
     return *this;
 }
 
+void
+MatchingStats::add_queryeval_stats(const search::queryeval::QueryEvalStats &stats) noexcept {
+    _exact_nns_distances_computed += stats.exact_nns_distances_computed();
+    _approximate_nns_distances_computed += stats.approximate_nns_distances_computed();
+    _approximate_nns_nodes_visited +=  stats.approximate_nns_nodes_visited();
+}
+
 MatchingStats &
 MatchingStats::add(const MatchingStats &rhs) noexcept
 {
@@ -66,6 +77,9 @@ MatchingStats::add(const MatchingStats &rhs) noexcept
     _docsMatched += rhs._docsMatched;
     _docsRanked += rhs._docsRanked;
     _docsReRanked += rhs._docsReRanked;
+    _exact_nns_distances_computed += rhs._exact_nns_distances_computed;
+    _approximate_nns_distances_computed += rhs._approximate_nns_distances_computed;
+    _approximate_nns_nodes_visited += rhs._approximate_nns_nodes_visited;
     _softDoomed += rhs.softDoomed();
     _doomOvertime.add(rhs._doomOvertime);
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -60,11 +60,13 @@ MatchingStats::merge_partition(const Partition &partition, size_t id)
     return *this;
 }
 
-void
+MatchingStats &
 MatchingStats::add_queryeval_stats(const search::queryeval::QueryEvalStats &stats) noexcept {
     _exact_nns_distances_computed += stats.exact_nns_distances_computed();
     _approximate_nns_distances_computed += stats.approximate_nns_distances_computed();
     _approximate_nns_nodes_visited +=  stats.approximate_nns_nodes_visited();
+
+    return *this;
 }
 
 MatchingStats &

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -224,7 +224,7 @@ public:
 
     // used to merge in queryeval stats
     // these are collected in a distinct, thread-safe object
-    void add_queryeval_stats(const search::queryeval::QueryEvalStats &stats) noexcept;
+    MatchingStats &add_queryeval_stats(const search::queryeval::QueryEvalStats &stats) noexcept;
 
     // used to aggregate accross searches (and configurations)
     MatchingStats &add(const MatchingStats &rhs) noexcept;

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -7,6 +7,10 @@
 #include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/datastore/atomic_value_wrapper.h>
 
+namespace search::queryeval {
+class QueryEvalStats;
+}
+
 namespace proton::matching {
 
 /**
@@ -123,6 +127,9 @@ private:
     size_t                 _docsMatched;
     size_t                 _docsRanked;
     size_t                 _docsReRanked;
+    size_t                 _exact_nns_distances_computed;
+    size_t                 _approximate_nns_distances_computed;
+    size_t                 _approximate_nns_nodes_visited;
     size_t                 _softDoomed;
     Avg                    _doomOvertime;
     using SoftDoomFactor = vespalib::datastore::AtomicValueWrapper<double>;
@@ -161,6 +168,15 @@ public:
 
     MatchingStats &docsReRanked(size_t value) { _docsReRanked = value; return *this; }
     size_t docsReRanked() const { return _docsReRanked; }
+
+    MatchingStats &exact_nns_distances_computed(size_t value) { _exact_nns_distances_computed = value; return *this; }
+    size_t exact_nns_distances_computed() const { return _exact_nns_distances_computed; }
+
+    MatchingStats &approximate_nns_distances_computed(size_t value) { _approximate_nns_distances_computed = value; return *this; }
+    size_t approximate_nns_distances_computed() const { return _approximate_nns_distances_computed; }
+
+    MatchingStats &approximate_nns_nodes_visited(size_t value) { _approximate_nns_nodes_visited = value; return *this; }
+    size_t approximate_nns_nodes_visited() const { return _approximate_nns_nodes_visited; }
 
     MatchingStats &softDoomed(size_t value) { _softDoomed = value; return *this; }
     size_t softDoomed() const { return _softDoomed; }
@@ -205,6 +221,10 @@ public:
     MatchingStats &merge_partition(const Partition &partition, size_t id);
     size_t getNumPartitions() const { return _partitions.size(); }
     const Partition &getPartition(size_t index) const { return _partitions[index]; }
+
+    // used to merge in queryeval stats
+    // these are collected in a distinct, thread-safe object
+    void add_queryeval_stats(const search::queryeval::QueryEvalStats &stats) noexcept;
 
     // used to aggregate accross searches (and configurations)
     MatchingStats &add(const MatchingStats &rhs) noexcept;

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -15,6 +15,7 @@
 #include <vespa/searchlib/parsequery/stackdumpiterator.h>
 #include <vespa/searchlib/query/tree/templatetermvisitor.h>
 #include <vespa/searchlib/queryeval/intermediate_blueprints.h>
+#include <vespa/searchlib/queryeval/nearest_neighbor_blueprint.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 #include <vespa/searchlib/query/proto_tree_converter.h>
@@ -363,6 +364,16 @@ SearchIterator::UP
 Query::createSearch(MatchData &md) const
 {
     return _blueprint->createSearch(md);
+}
+
+void
+Query::installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) {
+    _blueprint->each_node_post_order([stats](Blueprint& blueprint) {
+        auto nearest_neighbor = blueprint.asNearestNeighbor();
+        if (nearest_neighbor) {
+            nearest_neighbor->installStats(stats);
+        }
+    });
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -367,8 +367,8 @@ Query::createSearch(MatchData &md) const
 }
 
 void
-Query::install_stats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) {
-    _blueprint->each_node_post_order([stats](Blueprint& blueprint) {
+Query::install_stats(search::queryeval::QueryEvalStats &stats) {
+    _blueprint->each_node_post_order([&stats](Blueprint& blueprint) {
         auto nearest_neighbor = blueprint.asNearestNeighbor();
         if (nearest_neighbor) {
             nearest_neighbor->install_stats(stats);

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -367,11 +367,11 @@ Query::createSearch(MatchData &md) const
 }
 
 void
-Query::installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) {
+Query::install_stats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) {
     _blueprint->each_node_post_order([stats](Blueprint& blueprint) {
         auto nearest_neighbor = blueprint.asNearestNeighbor();
         if (nearest_neighbor) {
-            nearest_neighbor->installStats(stats);
+            nearest_neighbor->install_stats(stats);
         }
     });
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -146,7 +146,7 @@ public:
     Blueprint::HitEstimate estimate() const;
     const Blueprint * peekRoot() const { return _blueprint.get(); }
     // Hand the QueryEvalStats object to the underlying blueprint tree
-    void installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats);
+    void install_stats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats);
     bool needs_ranking() const noexcept { return _needs_ranking; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -146,7 +146,7 @@ public:
     Blueprint::HitEstimate estimate() const;
     const Blueprint * peekRoot() const { return _blueprint.get(); }
     // Hand the QueryEvalStats object to the underlying blueprint tree
-    void installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) { _blueprint->installStats(stats); }
+    void installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats);
     bool needs_ranking() const noexcept { return _needs_ranking; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -145,6 +145,8 @@ public:
      */
     Blueprint::HitEstimate estimate() const;
     const Blueprint * peekRoot() const { return _blueprint.get(); }
+    // Hand the QueryEvalStats object to the underlying blueprint tree
+    void installStats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats) { _blueprint->installStats(stats); }
     bool needs_ranking() const noexcept { return _needs_ranking; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -146,7 +146,7 @@ public:
     Blueprint::HitEstimate estimate() const;
     const Blueprint * peekRoot() const { return _blueprint.get(); }
     // Hand the QueryEvalStats object to the underlying blueprint tree
-    void install_stats(const std::shared_ptr<search::queryeval::QueryEvalStats> &stats);
+    void install_stats(search::queryeval::QueryEvalStats &stats);
     bool needs_ranking() const noexcept { return _needs_ranking; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
@@ -107,6 +107,9 @@ DocumentDBTaggedMetrics::MatchingMetrics::update(const MatchingStats &stats)
     docsMatched.inc(stats.docsMatched());
     docsRanked.inc(stats.docsRanked());
     docsReRanked.inc(stats.docsReRanked());
+    exact_nns_distances_computed.inc(stats.exact_nns_distances_computed());
+    approximate_nns_distances_computed.inc(stats.approximate_nns_distances_computed());
+    approximate_nns_nodes_visited.inc(stats.approximate_nns_nodes_visited());
     softDoomedQueries.inc(stats.softDoomed());
     queries.inc(stats.queries());
     querySetupTime.addValueBatch(stats.querySetupTimeAvg(), stats.querySetupTimeCount(),
@@ -120,6 +123,9 @@ DocumentDBTaggedMetrics::MatchingMetrics::MatchingMetrics(MetricSet *parent)
       docsMatched("docs_matched", {}, "Number of documents matched", this),
       docsRanked("docs_ranked", {}, "Number of documents ranked (first phase)", this),
       docsReRanked("docs_reranked", {}, "Number of documents re-ranked (second phase)", this),
+      exact_nns_distances_computed("exact_nns_distances_computed", {}, "Number of distance computations in exact nearest-neighbor search", this),
+      approximate_nns_distances_computed("approximate_nns_distances_computed", {}, "Number of distance computations in approximate nearest-neighbor search", this),
+      approximate_nns_nodes_visited("approximate_nns_nodes_visited", {}, "Number of nodes visited in approximate nearest-neighbor search", this),
       queries("queries", {}, "Number of queries executed", this),
       softDoomedQueries("soft_doomed_queries", {}, "Number of queries hitting the soft timeout", this),
       querySetupTime("query_setup_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
@@ -136,6 +142,9 @@ DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::RankProfileMetrics
       docsMatched("docs_matched", {}, "Number of documents matched", this),
       docsRanked("docs_ranked", {}, "Number of documents ranked (first phase)", this),
       docsReRanked("docs_reranked", {}, "Number of documents re-ranked (second phase)", this),
+      exact_nns_distances_computed("exact_nns_distances_computed", {}, "Number of distance computations in exact nearest-neighbor search", this),
+      approximate_nns_distances_computed("approximate_nns_distances_computed", {}, "Number of distance computations in approximate nearest-neighbor search", this),
+      approximate_nns_nodes_visited("approximate_nns_nodes_visited", {}, "Number of nodes visited in approximate nearest-neighbor search", this),
       queries("queries", {}, "Number of queries executed", this),
       limitedQueries("limited_queries", {}, "Number of queries limited in match phase", this),
       softDoomedQueries("soft_doomed_queries", {}, "Number of queries hitting the soft timeout", this),
@@ -185,6 +194,9 @@ DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::update(const metri
     docsMatched.inc(stats.docsMatched());
     docsRanked.inc(stats.docsRanked());
     docsReRanked.inc(stats.docsReRanked());
+    exact_nns_distances_computed.inc(stats.exact_nns_distances_computed());
+    approximate_nns_distances_computed.inc(stats.approximate_nns_distances_computed());
+    approximate_nns_nodes_visited.inc(stats.approximate_nns_nodes_visited());
     queries.inc(stats.queries());
     limitedQueries.inc(stats.limited_queries());
     softDoomedQueries.inc(stats.softDoomed());

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
@@ -108,6 +108,9 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
         metrics::LongCountMetric docsMatched;
         metrics::LongCountMetric docsRanked;
         metrics::LongCountMetric docsReRanked;
+        metrics::LongCountMetric exact_nns_distances_computed;
+        metrics::LongCountMetric approximate_nns_distances_computed;
+        metrics::LongCountMetric approximate_nns_nodes_visited;
         metrics::LongCountMetric queries;
         metrics::LongCountMetric softDoomedQueries;
         metrics::DoubleAverageMetric querySetupTime;
@@ -132,6 +135,9 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
             metrics::LongCountMetric     docsMatched;
             metrics::LongCountMetric     docsRanked;
             metrics::LongCountMetric     docsReRanked;
+            metrics::LongCountMetric     exact_nns_distances_computed;
+            metrics::LongCountMetric     approximate_nns_distances_computed;
+            metrics::LongCountMetric     approximate_nns_nodes_visited;
             metrics::LongCountMetric     queries;
             metrics::LongCountMetric     limitedQueries;
             metrics::LongCountMetric     softDoomedQueries;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1612,7 +1612,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // Without filter (with inactive filter)
     {
         auto bp = f.make_blueprint(true);
-        bp->installStats(stats);
+        bp->install_stats(stats);
         auto inactive_filter = GlobalFilter::create();
         bp->set_global_filter(*inactive_filter, 0.6);
     }
@@ -1622,7 +1622,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // With filter active
     {
         auto bp = f.make_blueprint(true);
-        bp->installStats(stats);
+        bp->install_stats(stats);
         auto filter = search::BitVector::create(1,11);
         filter->setBit(1);
         filter->setBit(3);
@@ -1639,7 +1639,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // Hitting fallback
     {
         auto bp = f.make_blueprint(true, 0.2);
-        bp->installStats(stats);
+        bp->install_stats(stats);
         auto filter = search::BitVector::create(1,11);
         filter->setBit(3);
         filter->invalidateCachedCount();
@@ -1652,7 +1652,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // Using exact search in the first place
     {
         auto bp = f.make_blueprint(false);
-        bp->installStats(stats);
+        bp->install_stats(stats);
         auto inactive_filter = GlobalFilter::create();
         bp->set_global_filter(*inactive_filter, 0.6);
     }

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -311,13 +311,15 @@ public:
         (void) header;
         return std::make_unique<MockIndexLoader>(_index_value, file);
     }
-    std::vector<Neighbor> find_top_k(uint32_t k,
+    std::vector<Neighbor> find_top_k(Stats &stats,
+                                     uint32_t k,
                                      const search::tensor::BoundDistanceFunction &df,
                                      uint32_t explore_k,
                                      double exploration_slack,
                                      const vespalib::Doom& doom,
                                      double distance_threshold) const override
     {
+        (void) stats;
         (void) k;
         (void) df;
         (void) explore_k;
@@ -326,13 +328,15 @@ public:
         (void) distance_threshold;
         return {};
     }
-    std::vector<Neighbor> find_top_k_with_filter(uint32_t k,
+    std::vector<Neighbor> find_top_k_with_filter(Stats &stats,
+                                                 uint32_t k,
                                                  const search::tensor::BoundDistanceFunction &df,
                                                  const GlobalFilter& filter, bool low_hit_ratio, double exploration, uint32_t explore_k,
                                                  double exploration_slack,
                                                  const vespalib::Doom& doom,
                                                  double distance_threshold) const override
     {
+        (void) stats;
         (void) k;
         (void) df;
         (void) explore_k;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/searchlib/attribute/attribute_read_guard.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/queryeval/nearest_neighbor_blueprint.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/searchlib/tensor/default_nearest_neighbor_index_factory.h>
 #include <vespa/searchlib/tensor/dense_tensor_attribute.h>
 #include <vespa/searchlib/tensor/direct_tensor_attribute.h>
@@ -319,7 +320,9 @@ public:
                                      const vespalib::Doom& doom,
                                      double distance_threshold) const override
     {
-        (void) stats;
+        stats.count_computed_distance();
+        stats.count_visited_node();
+        stats.count_visited_node();
         (void) k;
         (void) df;
         (void) explore_k;
@@ -336,6 +339,9 @@ public:
                                                  const vespalib::Doom& doom,
                                                  double distance_threshold) const override
     {
+        stats.count_computed_distance();
+        stats.count_visited_node();
+        stats.count_visited_node();
         (void) stats;
         (void) k;
         (void) df;
@@ -1597,6 +1603,61 @@ TEST(TensorAttributeTest, NN_blueprint_do_NOT_want_global_filter_when_NOT_having
     auto bp = f.make_blueprint();
     Blueprint::GlobalFilterLimits limits;
     EXPECT_FALSE(bp->want_global_filter(limits));
+}
+
+TEST(TensorAttributeTest, NN_blueprint_collects_stats)
+{
+    NearestNeighborBlueprintFixture f;
+    std::shared_ptr<search::queryeval::QueryEvalStats> stats = std::make_shared<search::queryeval::QueryEvalStats>();
+    // Without filter (with inactive filter)
+    {
+        auto bp = f.make_blueprint(true);
+        bp->installStats(stats);
+        auto inactive_filter = GlobalFilter::create();
+        bp->set_global_filter(*inactive_filter, 0.6);
+    }
+    EXPECT_EQ(1, stats->approximate_nns_distances_computed());
+    EXPECT_EQ(2, stats->approximate_nns_nodes_visited());
+
+    // With filter active
+    {
+        auto bp = f.make_blueprint(true);
+        bp->installStats(stats);
+        auto filter = search::BitVector::create(1,11);
+        filter->setBit(1);
+        filter->setBit(3);
+        filter->setBit(5);
+        filter->setBit(7);
+        filter->setBit(9);
+        filter->invalidateCachedCount();
+        auto weak_filter = GlobalFilter::create(std::move(filter));
+        bp->set_global_filter(*weak_filter, 0.6);
+    }
+    EXPECT_EQ(2, stats->approximate_nns_distances_computed());
+    EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
+
+    // Hitting fallback
+    {
+        auto bp = f.make_blueprint(true, 0.2);
+        bp->installStats(stats);
+        auto filter = search::BitVector::create(1,11);
+        filter->setBit(3);
+        filter->invalidateCachedCount();
+        auto strong_filter = GlobalFilter::create(std::move(filter));
+        bp->set_global_filter(*strong_filter, 0.6);
+    }
+    EXPECT_EQ(2, stats->approximate_nns_distances_computed());
+    EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
+
+    // Using exact search in the first place
+    {
+        auto bp = f.make_blueprint(false);
+        bp->installStats(stats);
+        auto inactive_filter = GlobalFilter::create();
+        bp->set_global_filter(*inactive_filter, 0.6);
+    }
+    EXPECT_EQ(2, stats->approximate_nns_distances_computed());
+    EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
 }
 
 auto test_values = ::testing::Values(1u, 2u);

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1608,11 +1608,11 @@ TEST(TensorAttributeTest, NN_blueprint_do_NOT_want_global_filter_when_NOT_having
 TEST(TensorAttributeTest, NN_blueprint_collects_stats)
 {
     NearestNeighborBlueprintFixture f;
-    std::shared_ptr<search::queryeval::QueryEvalStats> stats = std::make_shared<search::queryeval::QueryEvalStats>();
+    auto stats = search::queryeval::QueryEvalStats::create();
     // Without filter (with inactive filter)
     {
         auto bp = f.make_blueprint(true);
-        bp->install_stats(stats);
+        bp->install_stats(*stats);
         auto inactive_filter = GlobalFilter::create();
         bp->set_global_filter(*inactive_filter, 0.6);
     }
@@ -1622,7 +1622,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // With filter active
     {
         auto bp = f.make_blueprint(true);
-        bp->install_stats(stats);
+        bp->install_stats(*stats);
         auto filter = search::BitVector::create(1,11);
         filter->setBit(1);
         filter->setBit(3);
@@ -1639,7 +1639,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // Hitting fallback
     {
         auto bp = f.make_blueprint(true, 0.2);
-        bp->install_stats(stats);
+        bp->install_stats(*stats);
         auto filter = search::BitVector::create(1,11);
         filter->setBit(3);
         filter->invalidateCachedCount();
@@ -1652,7 +1652,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
     // Using exact search in the first place
     {
         auto bp = f.make_blueprint(false);
-        bp->install_stats(stats);
+        bp->install_stats(*stats);
         auto inactive_filter = GlobalFilter::create();
         bp->set_global_filter(*inactive_filter, 0.6);
     }

--- a/searchlib/src/tests/queryeval/exact_nearest_neighbor/exact_nearest_neighbor_test.cpp
+++ b/searchlib/src/tests/queryeval/exact_nearest_neighbor/exact_nearest_neighbor_test.cpp
@@ -121,7 +121,7 @@ struct Fixture {
 };
 
 template <bool strict>
-SimpleResult find_matches_impl(const std::shared_ptr<QueryEvalStats> &stats, Fixture &env, const Value &qtv, double threshold) {
+SimpleResult find_matches_impl(QueryEvalStats &stats, Fixture &env, const Value &qtv, double threshold) {
     auto md = MatchData::makeTestInstance(2, 2);
     auto &tfmd = *(md->resolveTermField(0));
     auto &attr = *(env._attr);
@@ -145,14 +145,14 @@ SimpleResult find_matches_impl(const std::shared_ptr<QueryEvalStats> &stats, Fix
 
 template <bool strict>
 SimpleResult find_matches(Fixture &env, const Value &qtv, double threshold = std::numeric_limits<double>::max()) {
-    auto stats = std::make_shared<QueryEvalStats>();
-    return find_matches_impl<strict>(stats, env, qtv, threshold);
+    auto stats = QueryEvalStats::create();
+    return find_matches_impl<strict>(*stats, env, qtv, threshold);
 }
 
 template <bool strict>
 std::shared_ptr<QueryEvalStats> get_search_stats(Fixture &env, const Value &qtv, double threshold = std::numeric_limits<double>::max()) {
-    std::shared_ptr<QueryEvalStats> stats = std::make_shared<QueryEvalStats>();
-    find_matches_impl<strict>(stats, env, qtv, threshold);
+    auto stats = QueryEvalStats::create();
+    find_matches_impl<strict>(*stats, env, qtv, threshold);
     return stats;
 }
 
@@ -324,8 +324,8 @@ std::vector<feature_t> get_rawscores(Fixture &env, const Value &qtv) {
     auto dff = search::tensor::make_distance_function_factory(DistanceMetric::Euclidean, qtv.cells().type);
     NearestNeighborDistanceHeap dh(2);
     auto dummy_filter = GlobalFilter::create();
-    auto stats= std::make_shared<QueryEvalStats>();
-    auto search = ExactNearestNeighborIterator::create(stats, strict, tfmd,
+    auto stats = QueryEvalStats::create();
+    auto search = ExactNearestNeighborIterator::create(*stats, strict, tfmd,
                                                        std::make_unique<DistanceCalculator>(attr, qtv),
                                                        dh, *dummy_filter, false);
     uint32_t limit = attr.getNumDocs();

--- a/searchlib/src/tests/queryeval/exact_nearest_neighbor/exact_nearest_neighbor_test.cpp
+++ b/searchlib/src/tests/queryeval/exact_nearest_neighbor/exact_nearest_neighbor_test.cpp
@@ -6,10 +6,12 @@
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/common/feature.h>
 #include <vespa/searchlib/fef/matchdata.h>
+#include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/global_filter.h>
 #include <vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.h>
 #include <vespa/searchlib/queryeval/matching_phase.h>
 #include <vespa/searchlib/queryeval/nns_index_iterator.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/searchlib/queryeval/simpleresult.h>
 #include <vespa/searchlib/tensor/dense_tensor_attribute.h>
 #include <vespa/searchlib/tensor/distance_calculator.h>
@@ -130,7 +132,8 @@ SimpleResult find_matches(Fixture &env, const Value &qtv, double threshold = std
     NearestNeighborDistanceHeap dh(2);
     dh.set_distance_threshold(threshold);
     const GlobalFilter &filter = *env._global_filter;
-    auto search = ExactNearestNeighborIterator::create(strict, tfmd,
+    auto stats = std::make_shared<QueryEvalStats>();
+    auto search = ExactNearestNeighborIterator::create(stats, strict, tfmd,
                                                        std::make_unique<DistanceCalculator>(attr, qtv),
                                                        dh, filter,
                                                        env._matching_phase != MatchingPhase::FIRST_PHASE);
@@ -276,7 +279,8 @@ std::vector<feature_t> get_rawscores(Fixture &env, const Value &qtv) {
     auto dff = search::tensor::make_distance_function_factory(DistanceMetric::Euclidean, qtv.cells().type);
     NearestNeighborDistanceHeap dh(2);
     auto dummy_filter = GlobalFilter::create();
-    auto search = ExactNearestNeighborIterator::create(strict, tfmd,
+    auto stats= std::make_shared<QueryEvalStats>();
+    auto search = ExactNearestNeighborIterator::create(stats, strict, tfmd,
                                                        std::make_unique<DistanceCalculator>(attr, qtv),
                                                        dh, *dummy_filter, false);
     uint32_t limit = attr.getNumDocs();

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/queryeval/i_element_gap_inspector.h>
 #include <vespa/searchlib/queryeval/nearsearch.h>
 #include <vespa/searchlib/queryeval/orsearch.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/searchlib/queryeval/simpleresult.h>
 #include <vespa/searchlib/queryeval/simplesearch.h>
 #include <vespa/searchlib/queryeval/ranksearch.h>
@@ -906,6 +907,29 @@ TEST(QueryEvalTest, test_andnotsearchstrict_iterators_adheres_to_init_range) {
         ir.verify( AndNotSearch::create({ir.createFullIterator(),
                                          ir.createIterator(inverted, false) }, true));
     }
+}
+
+TEST(QueryEvalTest, test_stats)
+{
+    QueryEvalStats stats;
+    EXPECT_EQ(0u, stats.exact_nns_distances_computed());
+    EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
+
+    stats.add_to_exact_nns_distances_computed(42u);
+    EXPECT_EQ(42u, stats.exact_nns_distances_computed());
+    stats.add_to_exact_nns_distances_computed(42u);
+    EXPECT_EQ(84u, stats.exact_nns_distances_computed());
+
+    stats.add_to_approximate_nns_distances_computed(1u);
+    EXPECT_EQ(1u, stats.approximate_nns_distances_computed());
+    stats.add_to_approximate_nns_distances_computed(1u);
+    EXPECT_EQ(2u, stats.approximate_nns_distances_computed());
+
+    stats.add_to_approximate_nns_nodes_visited(2u);
+    EXPECT_EQ(2u, stats.approximate_nns_nodes_visited());
+    stats.add_to_approximate_nns_nodes_visited(2u);
+    EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
 }
 
 

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -911,25 +911,25 @@ TEST(QueryEvalTest, test_andnotsearchstrict_iterators_adheres_to_init_range) {
 
 TEST(QueryEvalTest, test_stats)
 {
-    QueryEvalStats stats;
-    EXPECT_EQ(0u, stats.exact_nns_distances_computed());
-    EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
-    EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
+    auto stats = QueryEvalStats::create();
+    EXPECT_EQ(0u, stats->exact_nns_distances_computed());
+    EXPECT_EQ(0u, stats->approximate_nns_distances_computed());
+    EXPECT_EQ(0u, stats->approximate_nns_nodes_visited());
 
-    stats.add_to_exact_nns_distances_computed(42u);
-    EXPECT_EQ(42u, stats.exact_nns_distances_computed());
-    stats.add_to_exact_nns_distances_computed(42u);
-    EXPECT_EQ(84u, stats.exact_nns_distances_computed());
+    stats->add_to_exact_nns_distances_computed(42u);
+    EXPECT_EQ(42u, stats->exact_nns_distances_computed());
+    stats->add_to_exact_nns_distances_computed(42u);
+    EXPECT_EQ(84u, stats->exact_nns_distances_computed());
 
-    stats.add_to_approximate_nns_distances_computed(1u);
-    EXPECT_EQ(1u, stats.approximate_nns_distances_computed());
-    stats.add_to_approximate_nns_distances_computed(1u);
-    EXPECT_EQ(2u, stats.approximate_nns_distances_computed());
+    stats->add_to_approximate_nns_distances_computed(1u);
+    EXPECT_EQ(1u, stats->approximate_nns_distances_computed());
+    stats->add_to_approximate_nns_distances_computed(1u);
+    EXPECT_EQ(2u, stats->approximate_nns_distances_computed());
 
-    stats.add_to_approximate_nns_nodes_visited(2u);
-    EXPECT_EQ(2u, stats.approximate_nns_nodes_visited());
-    stats.add_to_approximate_nns_nodes_visited(2u);
-    EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
+    stats->add_to_approximate_nns_nodes_visited(2u);
+    EXPECT_EQ(2u, stats->approximate_nns_nodes_visited());
+    stats->add_to_approximate_nns_nodes_visited(2u);
+    EXPECT_EQ(4u, stats->approximate_nns_nodes_visited());
 }
 
 

--- a/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
@@ -284,7 +284,6 @@ public:
         }
         EXPECT_EQ(exp, act);
     }
-
     void expect_top_3(uint32_t docid, std::vector<uint32_t> exp_hits, bool filter_first = false, double exploration_slack = 0.0) {
         uint32_t k = 3;
         auto qv = vectors.get_vector(docid, 0);
@@ -309,6 +308,18 @@ public:
         if (!exp_hits.empty()) {
             check_with_distance_threshold(docid, exploration_slack);
         }
+    }
+    // Run a search and return the collected statistics for the search
+    NearestNeighborIndex::Stats stats_for_search(uint32_t k, uint32_t explore_k, std::vector<float> qv, const bool filter_first) {
+        double exploration_slack = 0.0;
+        std::span<float> qv_ref(qv);
+        vespalib::eval::TypedCells qv_cells(qv_ref);
+        NearestNeighborIndex::Stats stats;
+        auto df = index->distance_function_factory().for_query_vector(qv_cells);
+        auto got_by_docid = (global_filter->is_active()) ?
+                            index->find_top_k_with_filter(stats, k, *df, *global_filter, filter_first, 0.3, explore_k, exploration_slack, _doom->get_doom(), 10000.0) :
+                            index->find_top_k(stats, k, *df, explore_k, exploration_slack, _doom->get_doom(), 10000.0);
+        return stats;
     }
     void check_with_distance_threshold(uint32_t docid, double exploration_slack = 0.0) {
         auto qv = vectors.get_vector(docid, 0);
@@ -538,6 +549,63 @@ TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_in_level_0_graph_exploration_slack
         this->reset_doom(-1s);
         this->expect_top_3(2, {}, false, slack);
     }
+}
+
+TYPED_TEST(HnswIndexTest, stats_are_collected_during_search) {
+    this->init(false);
+    this->add_document(1);
+    this->add_document(2);
+    this->add_document(3);
+    this->add_document(4);
+    this->add_document(5);
+    this->add_document(6);
+    this->add_document(7);
+
+    // With traditional HNSW, the number of distance computations is the number of nodes visited
+    // With large enough k, this should be the whole graph
+    auto stats = this->stats_for_search(100, 0, {0, 0}, false);
+    uint32_t nodes = this->index->get_active_nodes();
+    EXPECT_EQ(nodes, stats.distances_computed());
+    EXPECT_EQ(nodes, stats.nodes_visited());
+
+    // With very small k, we will not explore the whole graph
+    stats = this->stats_for_search(1, 0, {0, 0}, false);
+    EXPECT_GT(nodes, stats.distances_computed());
+    EXPECT_LT(0, stats.distances_computed());
+    EXPECT_GT(nodes, stats.nodes_visited());
+    EXPECT_LT(0, stats.nodes_visited());
+    // The number of distance computations should still be the number of nodes visited
+    EXPECT_EQ(stats.distances_computed(), stats.nodes_visited());
+
+    // With filter-first and large k, we should still get the whole graph
+    stats = this->stats_for_search(100, 0, {0, 0}, true);
+    EXPECT_EQ(nodes, stats.distances_computed());
+    EXPECT_EQ(nodes, stats.nodes_visited());
+
+    // Small k and filter-first
+    stats = this->stats_for_search(1, 0, {0, 0}, true);
+    EXPECT_GT(nodes, stats.distances_computed());
+    EXPECT_LT(0, stats.distances_computed());
+    EXPECT_GT(nodes, stats.nodes_visited());
+    EXPECT_LT(0, stats.nodes_visited());
+
+    this->set_filter({2,3,4,6});
+
+    // With large k and traditional HNSW, we will explore the whole graph and compute all distances :(
+    stats = this->stats_for_search(100, 0, {0, 0}, false);
+    EXPECT_EQ(nodes, stats.distances_computed());
+    EXPECT_EQ(nodes, stats.nodes_visited());
+
+    // With large k filter-first, we will explore the whole graph
+    // but only compute distances to vertices passing the filter (plus entry point) :)
+    stats = this->stats_for_search(100, 0, {0, 0}, true);
+    EXPECT_EQ(5, stats.distances_computed());
+    EXPECT_EQ(nodes, stats.nodes_visited());
+
+    this->set_filter({2,3});
+    stats = this->stats_for_search(100, 0, {0, 0}, true);
+    EXPECT_EQ(3, stats.distances_computed());
+    EXPECT_EQ(nodes, stats.nodes_visited());
 }
 
 TYPED_TEST(HnswIndexTest, 2d_vectors_inserted_and_removed)

--- a/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/hnsw_index_test.cpp
@@ -272,10 +272,11 @@ public:
         double exploration_slack = 0.0;
         std::span<float> qv_ref(qv);
         vespalib::eval::TypedCells qv_cells(qv_ref);
+        NearestNeighborIndex::Stats stats;
         auto df = index->distance_function_factory().for_query_vector(qv_cells);
         auto got_by_docid = (global_filter->is_active()) ?
-                            index->find_top_k_with_filter(k, *df, *global_filter, false, 0.3, explore_k, exploration_slack, _doom->get_doom(), 10000.0) :
-                            index->find_top_k(k, *df, explore_k, exploration_slack, _doom->get_doom(), 10000.0);
+                            index->find_top_k_with_filter(stats, k, *df, *global_filter, false, 0.3, explore_k, exploration_slack, _doom->get_doom(), 10000.0) :
+                            index->find_top_k(stats, k, *df, explore_k, exploration_slack, _doom->get_doom(), 10000.0);
         std::vector<uint32_t> act;
         act.reserve(got_by_docid.size());
         for (auto& hit : got_by_docid) {
@@ -287,8 +288,9 @@ public:
     void expect_top_3(uint32_t docid, std::vector<uint32_t> exp_hits, bool filter_first = false, double exploration_slack = 0.0) {
         uint32_t k = 3;
         auto qv = vectors.get_vector(docid, 0);
+        NearestNeighborIndex::Stats stats;
         auto df = index->distance_function_factory().for_query_vector(qv);
-        auto rv = index->top_k_candidates(*df, k, exploration_slack, global_filter->ptr_if_active(), filter_first, 0.3, _doom->get_doom()).peek();
+        auto rv = index->top_k_candidates(stats, *df, k, exploration_slack, global_filter->ptr_if_active(), filter_first, 0.3, _doom->get_doom()).peek();
         std::sort(rv.begin(), rv.end(), LesserDistance());
         size_t idx = 0;
         for (const auto & hit : rv) {
@@ -299,7 +301,7 @@ public:
         if (exp_hits.size() == k) {
             std::vector<uint32_t> expected_by_docid = exp_hits;
             std::sort(expected_by_docid.begin(), expected_by_docid.end());
-            auto got_by_docid = index->find_top_k(k, *df, k, exploration_slack, _doom->get_doom(), 100100.25);
+            auto got_by_docid = index->find_top_k(stats, k, *df, k, exploration_slack, _doom->get_doom(), 100100.25);
             for (idx = 0; idx < k; ++idx) {
                 EXPECT_EQ(expected_by_docid[idx], got_by_docid[idx].docid);
             }
@@ -310,16 +312,17 @@ public:
     }
     void check_with_distance_threshold(uint32_t docid, double exploration_slack = 0.0) {
         auto qv = vectors.get_vector(docid, 0);
+        NearestNeighborIndex::Stats stats;
         auto df = index->distance_function_factory().for_query_vector(qv);
         uint32_t k = 3;
-        auto rv = index->top_k_candidates(*df, k, exploration_slack, global_filter->ptr_if_active(), false, 0.3, _doom->get_doom()).peek();
+        auto rv = index->top_k_candidates(stats, *df, k, exploration_slack, global_filter->ptr_if_active(), false, 0.3, _doom->get_doom()).peek();
         std::sort(rv.begin(), rv.end(), LesserDistance());
         EXPECT_EQ(rv.size(), 3);
         EXPECT_LE(rv[0].distance, rv[1].distance);
         double thr = (rv[0].distance + rv[1].distance) * 0.5;
         auto got_by_docid = (global_filter->is_active())
-            ? index->find_top_k_with_filter(k, *df, *global_filter, false, 0.3, k, exploration_slack, _doom->get_doom(), thr)
-            : index->find_top_k(k, *df, k, exploration_slack, _doom->get_doom(), thr);
+            ? index->find_top_k_with_filter(stats, k, *df, *global_filter, false, 0.3, k, exploration_slack, _doom->get_doom(), thr)
+            : index->find_top_k(stats, k, *df, k, exploration_slack, _doom->get_doom(), thr);
         EXPECT_EQ(got_by_docid.size(), 1);
         EXPECT_EQ(got_by_docid[0].docid, index->get_docid(rv[0].nodeid));
         for (const auto & hit : got_by_docid) {

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -702,6 +702,14 @@ IntermediateBlueprint::insertChild(size_t n, Blueprint::UP child)
     return *this;
 }
 
+
+void
+IntermediateBlueprint::installStats(const std::shared_ptr<QueryEvalStats> &stats) {
+    for (const auto &child : _children) {
+        child->installStats(stats);
+    }
+}
+
 void
 IntermediateBlueprint::visitMembers(vespalib::ObjectVisitor &visitor) const
 {

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -702,14 +702,6 @@ IntermediateBlueprint::insertChild(size_t n, Blueprint::UP child)
     return *this;
 }
 
-
-void
-IntermediateBlueprint::installStats(const std::shared_ptr<QueryEvalStats> &stats) {
-    for (const auto &child : _children) {
-        child->installStats(stats);
-    }
-}
-
 void
 IntermediateBlueprint::visitMembers(vespalib::ObjectVisitor &visitor) const
 {

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -43,6 +43,7 @@ class OrBlueprint;
 class EmptyBlueprint;
 class AlwaysTrueBlueprint;
 class QueryEvalStats;
+class NearestNeighborBlueprint;
 
 /**
  * A Blueprint is an intermediate representation of a search. More
@@ -444,9 +445,6 @@ public:
     static SearchIteratorUP create_first_child_filter(std::span<const UP> children, FilterConstraint constraint);
     static SearchIteratorUP create_default_filter(FilterConstraint constraint);
 
-    // For collecting statistics from within the blueprints
-    virtual void installStats(const std::shared_ptr<QueryEvalStats> &stats) = 0;
-
     // for debug dumping
     std::string asString() const;
     vespalib::slime::Cursor & asSlime(const vespalib::slime::Inserter & cursor) const;
@@ -462,6 +460,7 @@ public:
     bool isAnd() const noexcept { return const_cast<Blueprint *>(this)->asAnd() != nullptr; }
     virtual AndNotBlueprint * asAndNot() noexcept { return nullptr; }
     bool isAndNot() const noexcept { return const_cast<Blueprint *>(this)->asAndNot() != nullptr; }
+    virtual NearestNeighborBlueprint * asNearestNeighbor() noexcept { return nullptr; }
     virtual OrBlueprint * asOr() noexcept { return nullptr; }
     virtual SourceBlenderBlueprint * asSourceBlender() noexcept { return nullptr; }
     virtual WeakAndBlueprint * asWeakAnd() noexcept { return nullptr; }
@@ -559,10 +558,6 @@ public:
     virtual SearchIteratorUP
     createIntermediateSearch(MultiSearch::Children subSearches, fef::MatchData &md) const = 0;
 
-    // Hand a QueryEvalStats object through the blueprint tree.
-    // Blueprints can then write statistics to this object and pass it on to search iterators.
-    void installStats(const std::shared_ptr<QueryEvalStats> &stats) override;
-
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
     void freeze() final;
@@ -621,8 +616,6 @@ public:
     virtual bool getRange(search::NumericRangeSpec & range_spec) const;
     virtual SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, fef::MatchData &global_md) const;
     virtual SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const = 0;
-
-    void installStats(const std::shared_ptr<QueryEvalStats> &/*stats*/) override {}
 };
 
 // for leaf nodes representing a single term

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -42,6 +42,7 @@ class AndNotBlueprint;
 class OrBlueprint;
 class EmptyBlueprint;
 class AlwaysTrueBlueprint;
+class QueryEvalStats;
 
 /**
  * A Blueprint is an intermediate representation of a search. More
@@ -443,6 +444,9 @@ public:
     static SearchIteratorUP create_first_child_filter(std::span<const UP> children, FilterConstraint constraint);
     static SearchIteratorUP create_default_filter(FilterConstraint constraint);
 
+    // For collecting statistics from within the blueprints
+    virtual void installStats(const std::shared_ptr<QueryEvalStats> &stats) = 0;
+
     // for debug dumping
     std::string asString() const;
     vespalib::slime::Cursor & asSlime(const vespalib::slime::Inserter & cursor) const;
@@ -555,6 +559,10 @@ public:
     virtual SearchIteratorUP
     createIntermediateSearch(MultiSearch::Children subSearches, fef::MatchData &md) const = 0;
 
+    // Hand a QueryEvalStats object through the blueprint tree.
+    // Blueprints can then write statistics to this object and pass it on to search iterators.
+    void installStats(const std::shared_ptr<QueryEvalStats> &stats) override;
+
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
     void freeze() final;
@@ -613,6 +621,8 @@ public:
     virtual bool getRange(search::NumericRangeSpec & range_spec) const;
     virtual SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, fef::MatchData &global_md) const;
     virtual SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const = 0;
+
+    void installStats(const std::shared_ptr<QueryEvalStats> &/*stats*/) override {}
 };
 
 // for leaf nodes representing a single term

--- a/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.cpp
@@ -19,7 +19,7 @@ ExactNearestNeighborIterator::Params::Params(QueryEvalStats &stats_in,
                                              std::unique_ptr<search::tensor::DistanceCalculator> distance_calc_in,
                                              NearestNeighborDistanceHeap &distanceHeap_in,
                                              const GlobalFilter &filter_in)
-    : stats(stats_in.get_ptr()),
+    : stats(stats_in.shared_from_this()),
       tfmd(tfmd_in),
       distance_calc(std::move(distance_calc_in)),
       distanceHeap(distanceHeap_in),

--- a/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.cpp
@@ -14,12 +14,12 @@ using vespalib::eval::CellType;
 
 namespace search::queryeval {
 
-ExactNearestNeighborIterator::Params::Params(const std::shared_ptr<QueryEvalStats> &stats_in,
+ExactNearestNeighborIterator::Params::Params(QueryEvalStats &stats_in,
                                              fef::TermFieldMatchData &tfmd_in,
                                              std::unique_ptr<search::tensor::DistanceCalculator> distance_calc_in,
                                              NearestNeighborDistanceHeap &distanceHeap_in,
                                              const GlobalFilter &filter_in)
-    : stats(stats_in),
+    : stats(stats_in.get_ptr()),
       tfmd(tfmd_in),
       distance_calc(std::move(distance_calc_in)),
       distanceHeap(distanceHeap_in),
@@ -127,7 +127,7 @@ resolve_strict(bool strict, bool readonly_distance_heap, ExactNearestNeighborIte
 } // namespace <unnamed>
 
 std::unique_ptr<ExactNearestNeighborIterator>
-ExactNearestNeighborIterator::create(const std::shared_ptr<QueryEvalStats> &stats,
+ExactNearestNeighborIterator::create(QueryEvalStats &stats,
                                      bool strict, fef::TermFieldMatchData &tfmd,
                                      std::unique_ptr<search::tensor::DistanceCalculator> distance_calc,
                                      NearestNeighborDistanceHeap &distanceHeap, const GlobalFilter &filter,

--- a/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.h
@@ -14,6 +14,7 @@ namespace search::tensor { class DistanceCalculator; }
 
 namespace search::queryeval {
 
+class QueryEvalStats;
 class GlobalFilter;
 
 class ExactNearestNeighborIterator : public SearchIterator
@@ -23,12 +24,14 @@ public:
     using Value = vespalib::eval::Value;
 
     struct Params {
+        std::shared_ptr<QueryEvalStats> stats;
         fef::TermFieldMatchData &tfmd;
         std::unique_ptr<search::tensor::DistanceCalculator> distance_calc;
         NearestNeighborDistanceHeap &distanceHeap;
         const GlobalFilter &filter;
 
-        Params(fef::TermFieldMatchData &tfmd_in,
+        Params(const std::shared_ptr<QueryEvalStats> &stats,
+               fef::TermFieldMatchData &tfmd_in,
                std::unique_ptr<search::tensor::DistanceCalculator> distance_calc_in,
                NearestNeighborDistanceHeap &distanceHeap_in,
                const GlobalFilter &filter_in);
@@ -41,6 +44,7 @@ public:
     {}
 
     static std::unique_ptr<ExactNearestNeighborIterator> create(
+            const std::shared_ptr<QueryEvalStats> &stats,
             bool strict,
             fef::TermFieldMatchData &tfmd,
             std::unique_ptr<search::tensor::DistanceCalculator> distance_calc,

--- a/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/exact_nearest_neighbor_iterator.h
@@ -30,7 +30,7 @@ public:
         NearestNeighborDistanceHeap &distanceHeap;
         const GlobalFilter &filter;
 
-        Params(const std::shared_ptr<QueryEvalStats> &stats,
+        Params(QueryEvalStats &stats,
                fef::TermFieldMatchData &tfmd_in,
                std::unique_ptr<search::tensor::DistanceCalculator> distance_calc_in,
                NearestNeighborDistanceHeap &distanceHeap_in,
@@ -44,7 +44,7 @@ public:
     {}
 
     static std::unique_ptr<ExactNearestNeighborIterator> create(
-            const std::shared_ptr<QueryEvalStats> &stats,
+            QueryEvalStats &stats,
             bool strict,
             fef::TermFieldMatchData &tfmd,
             std::unique_ptr<search::tensor::DistanceCalculator> distance_calc,

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -74,7 +74,8 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
       _global_filter_hits(),
       _global_filter_hit_ratio(),
       _doom(doom),
-      _matching_phase(MatchingPhase::FIRST_PHASE)
+      _matching_phase(MatchingPhase::FIRST_PHASE),
+      _nni_stats()
 {
     _distance_heap.set_distance_threshold(_hnsw_params.distance_threshold);
     uint32_t est_hits = _attr_tensor.get_num_docs();
@@ -134,11 +135,11 @@ NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighborInd
     uint32_t k = _adjusted_target_hits;
     const auto &df = _distance_calc->function();
     if (_global_filter->is_active()) {
-        _found_hits = nns_index->find_top_k_with_filter(k, df, *_global_filter, _global_filter_hit_ratio.value() < _hnsw_params.filter_first_upper_limit, _hnsw_params.filter_first_exploration,
+        _found_hits = nns_index->find_top_k_with_filter(_nni_stats, k, df, *_global_filter, _global_filter_hit_ratio.value() < _hnsw_params.filter_first_upper_limit, _hnsw_params.filter_first_exploration,
                                                         k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _doom, _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K_WITH_FILTER;
     } else {
-        _found_hits = nns_index->find_top_k(k, df, k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _doom, _hnsw_params.distance_threshold);
+        _found_hits = nns_index->find_top_k(_nni_stats, k, df, k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _doom, _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K;
     }
 }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -176,7 +176,7 @@ NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
 }
 
 void NearestNeighborBlueprint::install_stats(QueryEvalStats &stats) {
-    _stats = stats.get_ptr();
+    _stats = stats.shared_from_this();
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -169,14 +169,14 @@ NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
     default:
         ;
     }
-    return ExactNearestNeighborIterator::create(_stats, strict(), tfmd,
+    return ExactNearestNeighborIterator::create(*_stats, strict(), tfmd,
                                                 std::make_unique<search::tensor::DistanceCalculator>(_attr_tensor, _query_tensor),
                                                 _distance_heap, *_global_filter,
                                                 _matching_phase != MatchingPhase::FIRST_PHASE);
 }
 
-void NearestNeighborBlueprint::install_stats(const std::shared_ptr<QueryEvalStats> &stats) {
-    _stats= stats;
+void NearestNeighborBlueprint::install_stats(QueryEvalStats &stats) {
+    _stats = stats.get_ptr();
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -175,7 +175,7 @@ NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
                                                 _matching_phase != MatchingPhase::FIRST_PHASE);
 }
 
-void NearestNeighborBlueprint::installStats(const std::shared_ptr<QueryEvalStats> &stats) {
+void NearestNeighborBlueprint::install_stats(const std::shared_ptr<QueryEvalStats> &stats) {
     _stats= stats;
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -55,6 +55,7 @@ private:
     const vespalib::Doom& _doom;
     MatchingPhase _matching_phase;
     search::tensor::NearestNeighborIndex::Stats _nni_stats;
+    std::shared_ptr<QueryEvalStats> _stats;
 
     static double convert_distance_threshold(double distance_threshold,
                                              const search::tensor::DistanceCalculator& distance_calc);
@@ -87,6 +88,7 @@ public:
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
+    void installStats(const std::shared_ptr<QueryEvalStats> &stats) override;
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -54,6 +54,7 @@ private:
     std::optional<double> _global_filter_hit_ratio;
     const vespalib::Doom& _doom;
     MatchingPhase _matching_phase;
+    search::tensor::NearestNeighborIndex::Stats _nni_stats;
 
     static double convert_distance_threshold(double distance_threshold,
                                              const search::tensor::DistanceCalculator& distance_calc);

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -88,10 +88,13 @@ public:
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
-    void installStats(const std::shared_ptr<QueryEvalStats> &stats) override;
+    // Write stats to the given QueryEvalStats object on destruction, and pass it on to
+    // created exact search iterators, which also write stats to it on destruction.
+    void installStats(const std::shared_ptr<QueryEvalStats> &stats);
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;
+    NearestNeighborBlueprint * asNearestNeighbor() noexcept final { return this; }
 };
 
 std::ostream&

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -90,7 +90,7 @@ public:
     }
     // Write stats to the given QueryEvalStats object on destruction, and pass it on to
     // created exact search iterators, which also write stats to it on destruction.
-    void installStats(const std::shared_ptr<QueryEvalStats> &stats);
+    void install_stats(const std::shared_ptr<QueryEvalStats> &stats);
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -90,7 +90,7 @@ public:
     }
     // Write stats to the given QueryEvalStats object on destruction, and pass it on to
     // created exact search iterators, which also write stats to it on destruction.
-    void install_stats(const std::shared_ptr<QueryEvalStats> &stats);
+    void install_stats(QueryEvalStats &stats);
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <atomic>
-#include <cstddef>
+#include <memory>
 
 namespace search::queryeval {
 
@@ -11,16 +11,22 @@ namespace search::queryeval {
  * Class for collecting statistics within blueprints and search iterators.
  * Thread-safe such that search iterators from different threads can write their collected statistics here.
  **/
-class QueryEvalStats {
+class QueryEvalStats : public std::enable_shared_from_this<QueryEvalStats> {
 private:
+    struct Private { explicit Private() = default; };
     std::atomic<size_t> _exact_nns_distances_computed;
     std::atomic<size_t> _approximate_nns_distances_computed;
     std::atomic<size_t> _approximate_nns_nodes_visited;
 public:
-    QueryEvalStats() noexcept
+    // Constructor is only usable by this class
+    QueryEvalStats(Private) noexcept
         : _exact_nns_distances_computed(0),
           _approximate_nns_distances_computed(0),
           _approximate_nns_nodes_visited(0) {}
+    // This factory function has to be used to create objects, meaning that all such objects will be in a shared_ptr
+    static std::shared_ptr<QueryEvalStats> create() { return std::make_shared<QueryEvalStats>(Private()); }
+    std::shared_ptr<QueryEvalStats> get_ptr() { return shared_from_this(); }
+
     size_t exact_nns_distances_computed() const noexcept { return _exact_nns_distances_computed.load(std::memory_order_relaxed); }
     void add_to_exact_nns_distances_computed(size_t value) noexcept { _exact_nns_distances_computed.fetch_add(value, std::memory_order_relaxed); }
 

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -25,7 +25,6 @@ public:
           _approximate_nns_nodes_visited(0) {}
     // This factory function has to be used to create objects, meaning that all such objects will be in a shared_ptr
     static std::shared_ptr<QueryEvalStats> create() { return std::make_shared<QueryEvalStats>(Private()); }
-    std::shared_ptr<QueryEvalStats> get_ptr() { return shared_from_this(); }
 
     size_t exact_nns_distances_computed() const noexcept { return _exact_nns_distances_computed.load(std::memory_order_relaxed); }
     void add_to_exact_nns_distances_computed(size_t value) noexcept { _exact_nns_distances_computed.fetch_add(value, std::memory_order_relaxed); }

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -13,9 +13,9 @@ namespace search::queryeval {
  **/
 class QueryEvalStats {
 private:
-    std::atomic<std::size_t> _exact_nns_distances_computed;
-    std::atomic<std::size_t> _approximate_nns_distances_computed;
-    std::atomic<std::size_t> _approximate_nns_nodes_visited;
+    std::atomic<size_t> _exact_nns_distances_computed;
+    std::atomic<size_t> _approximate_nns_distances_computed;
+    std::atomic<size_t> _approximate_nns_nodes_visited;
 public:
     QueryEvalStats() noexcept
         : _exact_nns_distances_computed(0),

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -21,14 +21,14 @@ public:
         : _exact_nns_distances_computed(0),
           _approximate_nns_distances_computed(0),
           _approximate_nns_nodes_visited(0) {}
-    size_t exact_nns_distances_computed() const noexcept { return _exact_nns_distances_computed; }
-    void add_to_exact_nns_distances_computed(size_t value) noexcept { _exact_nns_distances_computed += value; }
+    size_t exact_nns_distances_computed() const noexcept { return _exact_nns_distances_computed.load(std::memory_order_relaxed); }
+    void add_to_exact_nns_distances_computed(size_t value) noexcept { _exact_nns_distances_computed.fetch_add(value, std::memory_order_relaxed); }
 
-    size_t approximate_nns_distances_computed() const noexcept { return _approximate_nns_distances_computed; }
-    void add_to_approximate_nns_distances_computed(size_t value) noexcept { _approximate_nns_distances_computed += value; }
+    size_t approximate_nns_distances_computed() const noexcept { return _approximate_nns_distances_computed.load(std::memory_order_relaxed); }
+    void add_to_approximate_nns_distances_computed(size_t value) noexcept { _approximate_nns_distances_computed.fetch_add(value, std::memory_order_relaxed); }
 
-    size_t approximate_nns_nodes_visited() const noexcept { return _approximate_nns_nodes_visited; }
-    void add_to_approximate_nns_nodes_visited(size_t value) noexcept { _approximate_nns_nodes_visited += value; }
+    size_t approximate_nns_nodes_visited() const noexcept { return _approximate_nns_nodes_visited.load(std::memory_order_relaxed); }
+    void add_to_approximate_nns_nodes_visited(size_t value) noexcept { _approximate_nns_nodes_visited.fetch_add(value, std::memory_order_relaxed); }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+
+namespace search::queryeval {
+
+/**
+ * Class for collecting statistics within blueprints and search iterators.
+ * Thread-safe such that search iterators from different threads can write their collected statistics here.
+ **/
+class QueryEvalStats {
+private:
+    std::atomic<std::size_t> _exact_nns_distances_computed;
+    std::atomic<std::size_t> _approximate_nns_distances_computed;
+    std::atomic<std::size_t> _approximate_nns_nodes_visited;
+public:
+    QueryEvalStats() noexcept
+        : _exact_nns_distances_computed(0),
+          _approximate_nns_distances_computed(0),
+          _approximate_nns_nodes_visited(0) {}
+    size_t exact_nns_distances_computed() const noexcept { return _exact_nns_distances_computed; }
+    void add_to_exact_nns_distances_computed(size_t value) noexcept { _exact_nns_distances_computed += value; }
+
+    size_t approximate_nns_distances_computed() const noexcept { return _approximate_nns_distances_computed; }
+    void add_to_approximate_nns_distances_computed(size_t value) noexcept { _approximate_nns_distances_computed += value; }
+
+    size_t approximate_nns_nodes_visited() const noexcept { return _approximate_nns_nodes_visited; }
+    void add_to_approximate_nns_nodes_visited(size_t value) noexcept { _approximate_nns_nodes_visited += value; }
+};
+
+}

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -332,18 +332,20 @@ HnswIndex<type>::estimate_visited_nodes(uint32_t level, uint32_t nodeid_limit, u
 
 template <HnswIndexType type>
 HnswCandidate
-HnswIndex<type>::find_nearest_in_layer(const BoundDistanceFunction &df, const HnswCandidate& entry_point, uint32_t level) const
+HnswIndex<type>::find_nearest_in_layer(Stats &stats, const BoundDistanceFunction &df, const HnswCandidate& entry_point, uint32_t level) const
 {
     HnswCandidate nearest = entry_point;
     bool keep_searching = true;
     while (keep_searching) {
         keep_searching = false;
         for (uint32_t neighbor_nodeid : _graph.get_link_array(nearest.levels_ref, level)) {
+            stats.count_visited_node();
             auto& neighbor_node = _graph.acquire_node(neighbor_nodeid);
             auto neighbor_ref = neighbor_node.levels_ref().load_acquire();
             uint32_t neighbor_docid = acquire_docid(neighbor_node, neighbor_nodeid);
             uint32_t neighbor_subspace = neighbor_node.acquire_subspace();
             double dist = calc_distance(df, neighbor_docid, neighbor_subspace);
+            stats.count_computed_distance();
             if (_graph.still_valid(neighbor_nodeid, neighbor_ref)
                 && dist < nearest.distance)
             {
@@ -358,7 +360,7 @@ HnswIndex<type>::find_nearest_in_layer(const BoundDistanceFunction &df, const Hn
 template <HnswIndexType type>
 template <class VisitedTracker, class BestNeighbors>
 void
-HnswIndex<type>::search_layer_helper(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack,
+HnswIndex<type>::search_layer_helper(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack,
                                      BestNeighbors& best_neighbors, uint32_t level, const GlobalFilter *filter,
                                      uint32_t nodeid_limit, const vespalib::Doom* const doom,
                                      uint32_t estimated_visited_nodes) const
@@ -403,9 +405,11 @@ HnswIndex<type>::search_layer_helper(const BoundDistanceFunction &df, uint32_t n
             {
                 continue;
             }
+            stats.count_visited_node();
             uint32_t neighbor_docid = acquire_docid(neighbor_node, neighbor_nodeid);
             uint32_t neighbor_subspace = neighbor_node.acquire_subspace();
             double dist_to_input = calc_distance(df, neighbor_docid, neighbor_subspace);
+            stats.count_computed_distance();
             if (dist_to_input < (1.0 + exploration_slack) * limit_dist) {
                 candidates.emplace(neighbor_nodeid, neighbor_ref, dist_to_input);
 
@@ -428,7 +432,7 @@ HnswIndex<type>::search_layer_helper(const BoundDistanceFunction &df, uint32_t n
 template <HnswIndexType type>
 template <class VisitedTracker, class BestNeighbors>
 void
-HnswIndex<type>::search_layer_filter_first_helper(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack,
+HnswIndex<type>::search_layer_filter_first_helper(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack,
                                                   BestNeighbors& best_neighbors, double exploration, uint32_t level, const GlobalFilter *filter,
                                                   uint32_t nodeid_limit, const vespalib::Doom* const doom,
                                                   uint32_t estimated_visited_nodes) const
@@ -467,7 +471,7 @@ HnswIndex<type>::search_layer_filter_first_helper(const BoundDistanceFunction &d
 
         // Instead of taking immediate neighbors, we additionally explore 2-hop neighbors (and possibly 3-hop neighbors)
         neighborhood.clear();
-        exploreNeighborhood(cand, neighborhood, visited, exploration, level, filter_wrapper, nodeid_limit);
+        exploreNeighborhood(stats, cand, neighborhood, visited, exploration, level, filter_wrapper, nodeid_limit);
 
         for (uint32_t neighbor_nodeid : neighborhood) {
             auto& neighbor_node = _graph.acquire_node(neighbor_nodeid);
@@ -478,6 +482,7 @@ HnswIndex<type>::search_layer_filter_first_helper(const BoundDistanceFunction &d
             uint32_t neighbor_docid = acquire_docid(neighbor_node, neighbor_nodeid);
             uint32_t neighbor_subspace = neighbor_node.acquire_subspace();
             double dist_to_input = calc_distance(df, neighbor_docid, neighbor_subspace);
+            stats.count_computed_distance();
             if (dist_to_input < (1.0 + exploration_slack) * limit_dist) {
                 candidates.emplace(neighbor_nodeid, neighbor_ref, dist_to_input);
 
@@ -500,7 +505,7 @@ HnswIndex<type>::search_layer_filter_first_helper(const BoundDistanceFunction &d
 template <HnswIndexType type>
 template <class VisitedTracker>
 void
-HnswIndex<type>::exploreNeighborhood(HnswTraversalCandidate &cand, std::deque<uint32_t> &found, VisitedTracker &visited, double exploration,
+HnswIndex<type>::exploreNeighborhood(Stats &stats, HnswTraversalCandidate &cand, std::deque<uint32_t> &found, VisitedTracker &visited, double exploration,
                                      uint32_t level, const internal::GlobalFilterWrapper<type>& filter_wrapper, uint32_t nodeid_limit) const {
     assert(found.empty());
 
@@ -510,21 +515,21 @@ HnswIndex<type>::exploreNeighborhood(HnswTraversalCandidate &cand, std::deque<ui
     uint32_t max_neighbors_to_find = max_links_for_level(level);
 
     // Explore (1-hop) neighbors
-    exploreNeighborhoodByOneHop(todo, found, visited, level, filter_wrapper, nodeid_limit, max_neighbors_to_find);
+    exploreNeighborhoodByOneHop(stats, todo, found, visited, level, filter_wrapper, nodeid_limit, max_neighbors_to_find);
 
     // Explore 2-hop neighbors
-    exploreNeighborhoodByOneHop(todo, found, visited, level, filter_wrapper, nodeid_limit, max_neighbors_to_find);
+    exploreNeighborhoodByOneHop(stats, todo, found, visited, level, filter_wrapper, nodeid_limit, max_neighbors_to_find);
 
     // Explore 3-hop neighbors, but only if the 2-hop neighborhood is small, i.e., we are in a rather sparse part of the graph.
     if (static_cast<double>(todo.size()) < exploration * (max_neighbors_to_find * max_neighbors_to_find)) {
-        exploreNeighborhoodByOneHop(todo, found, visited, level, filter_wrapper, nodeid_limit, max_neighbors_to_find);
+        exploreNeighborhoodByOneHop(stats, todo, found, visited, level, filter_wrapper, nodeid_limit, max_neighbors_to_find);
     }
 }
 
 template <HnswIndexType type>
 template <class VisitedTracker>
 void
-HnswIndex<type>::exploreNeighborhoodByOneHop(std::deque<uint32_t> &todo, std::deque<uint32_t> &found, VisitedTracker &visited, uint32_t level,
+HnswIndex<type>::exploreNeighborhoodByOneHop(Stats &stats, std::deque<uint32_t> &todo, std::deque<uint32_t> &found, VisitedTracker &visited, uint32_t level,
                                              const internal::GlobalFilterWrapper<type>& filter_wrapper, uint32_t nodeid_limit,
                                              uint32_t max_neighbors_to_find) const {
     // We do not explore the candidates that we newly add to the deque
@@ -548,6 +553,7 @@ HnswIndex<type>::exploreNeighborhoodByOneHop(std::deque<uint32_t> &todo, std::de
             if (!neighbor_ref.valid() || !visited.try_mark(neighbor_nodeid)) {
                 continue;
             }
+            stats.count_visited_node();
 
             uint32_t neighbor_docid = acquire_docid(neighbor_node, neighbor_nodeid);
             if (filter_wrapper.check(neighbor_docid)) {
@@ -566,30 +572,30 @@ HnswIndex<type>::exploreNeighborhoodByOneHop(std::deque<uint32_t> &todo, std::de
 template <HnswIndexType type>
 template <class BestNeighbors>
 void
-HnswIndex<type>::search_layer(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
+HnswIndex<type>::search_layer(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
                               uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter) const
 {
     uint32_t nodeid_limit = _graph.nodes_size.load(std::memory_order_acquire);
     uint32_t estimated_visited_nodes = estimate_visited_nodes(level, nodeid_limit, neighbors_to_find, filter);
     if (estimated_visited_nodes >= nodeid_limit / 128) {
-        search_layer_helper<BitVectorVisitedTracker>(df, neighbors_to_find, exploration_slack, best_neighbors, level, filter, nodeid_limit, doom, estimated_visited_nodes);
+        search_layer_helper<BitVectorVisitedTracker>(stats, df, neighbors_to_find, exploration_slack, best_neighbors, level, filter, nodeid_limit, doom, estimated_visited_nodes);
     } else {
-        search_layer_helper<HashSetVisitedTracker>(df, neighbors_to_find, exploration_slack, best_neighbors, level, filter, nodeid_limit, doom, estimated_visited_nodes);
+        search_layer_helper<HashSetVisitedTracker>(stats, df, neighbors_to_find, exploration_slack, best_neighbors, level, filter, nodeid_limit, doom, estimated_visited_nodes);
     }
 }
 
 template <HnswIndexType type>
 template <class BestNeighbors>
 void
-HnswIndex<type>::search_layer_filter_first(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors, double exploration,
+HnswIndex<type>::search_layer_filter_first(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors, double exploration,
                                            uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter) const
 {
     uint32_t nodeid_limit = _graph.nodes_size.load(std::memory_order_acquire);
     uint32_t estimated_visited_nodes = estimate_visited_nodes(level, nodeid_limit, neighbors_to_find, filter);
     if (estimated_visited_nodes >= nodeid_limit / 128) {
-        search_layer_filter_first_helper<BitVectorVisitedTracker>(df, neighbors_to_find, exploration_slack, best_neighbors, exploration, level, filter, nodeid_limit, doom, estimated_visited_nodes);
+        search_layer_filter_first_helper<BitVectorVisitedTracker>(stats, df, neighbors_to_find, exploration_slack, best_neighbors, exploration, level, filter, nodeid_limit, doom, estimated_visited_nodes);
     } else {
-        search_layer_filter_first_helper<HashSetVisitedTracker>(df, neighbors_to_find, exploration_slack, best_neighbors, exploration, level, filter, nodeid_limit, doom, estimated_visited_nodes);
+        search_layer_filter_first_helper<HashSetVisitedTracker>(stats, df, neighbors_to_find, exploration_slack, best_neighbors, exploration, level, filter, nodeid_limit, doom, estimated_visited_nodes);
     }
 }
 
@@ -649,6 +655,7 @@ template <HnswIndexType type>
 void
 HnswIndex<type>::internal_prepare_add_node(PreparedAddDoc& op, TypedCells input_vector, const typename GraphType::EntryNode& entry) const
 {
+    Stats stats; // Not used for now. Wire this in to all places where distances are computed if to be used.
     int node_max_level = std::min(_level_generator->max_level(), max_max_level);
     std::vector<PreparedAddNode::Links> connections(node_max_level + 1);
     if (entry.nodeid == 0) {
@@ -663,7 +670,7 @@ HnswIndex<type>::internal_prepare_add_node(PreparedAddDoc& op, TypedCells input_
     // TODO: check if entry nodeid/levels_ref is still valid here
     HnswCandidate entry_point(entry.nodeid, entry_docid, entry.levels_ref, entry_dist);
     while (search_level > node_max_level) {
-        entry_point = find_nearest_in_layer(*df, entry_point, search_level);
+        entry_point = find_nearest_in_layer(stats, *df, entry_point, search_level);
         --search_level;
     }
 
@@ -672,7 +679,7 @@ HnswIndex<type>::internal_prepare_add_node(PreparedAddDoc& op, TypedCells input_
     search_level = std::min(node_max_level, search_level);
     // Find neighbors of the added document in each level it should exist in.
     while (search_level >= 0) {
-        search_layer(*df, _cfg.neighbors_to_explore_at_construction(), 0.0, best_neighbors, search_level, nullptr);
+        search_layer(stats, *df, _cfg.neighbors_to_explore_at_construction(), 0.0, best_neighbors, search_level, nullptr);
         auto neighbors = select_neighbors(best_neighbors.peek(), _cfg.max_links_on_inserts());
         auto& links = connections[search_level];
         links.reserve(neighbors.used.size());
@@ -1011,10 +1018,10 @@ struct NeighborsByDocId {
 
 template <HnswIndexType type>
 std::vector<NearestNeighborIndex::Neighbor>
-HnswIndex<type>::top_k_by_docid(uint32_t k, const BoundDistanceFunction &df, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
+HnswIndex<type>::top_k_by_docid(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
                                 uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const
 {
-    SearchBestNeighbors candidates = top_k_candidates(df, std::max(k, explore_k), exploration_slack, filter, low_hit_ratio, exploration, doom);
+    SearchBestNeighbors candidates = top_k_candidates(stats, df, std::max(k, explore_k), exploration_slack, filter, low_hit_ratio, exploration, doom);
     auto result = candidates.get_neighbors(k, distance_threshold);
     std::sort(result.begin(), result.end(), NeighborsByDocId());
     return result;
@@ -1022,23 +1029,23 @@ HnswIndex<type>::top_k_by_docid(uint32_t k, const BoundDistanceFunction &df, con
 
 template <HnswIndexType type>
 std::vector<NearestNeighborIndex::Neighbor>
-HnswIndex<type>::find_top_k(uint32_t k, const BoundDistanceFunction &df, uint32_t explore_k, double exploration_slack,
+HnswIndex<type>::find_top_k(Stats &stats, uint32_t k, const BoundDistanceFunction &df, uint32_t explore_k, double exploration_slack,
                             const vespalib::Doom& doom, double distance_threshold) const
 {
-    return top_k_by_docid(k, df, nullptr, false, 0.0, explore_k, exploration_slack, doom, distance_threshold);
+    return top_k_by_docid(stats, k, df, nullptr, false, 0.0, explore_k, exploration_slack, doom, distance_threshold);
 }
 
 template <HnswIndexType type>
 std::vector<NearestNeighborIndex::Neighbor>
-HnswIndex<type>::find_top_k_with_filter(uint32_t k, const BoundDistanceFunction &df, const GlobalFilter &filter, bool low_hit_ratio, double exploration,
+HnswIndex<type>::find_top_k_with_filter(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter &filter, bool low_hit_ratio, double exploration,
                                         uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const
 {
-    return top_k_by_docid(k, df, &filter, low_hit_ratio, exploration, explore_k, exploration_slack, doom, distance_threshold);
+    return top_k_by_docid(stats, k, df, &filter, low_hit_ratio, exploration, explore_k, exploration_slack, doom, distance_threshold);
 }
 
 template <HnswIndexType type>
 typename HnswIndex<type>::SearchBestNeighbors
-HnswIndex<type>::top_k_candidates(const BoundDistanceFunction &df, uint32_t k, double exploration_slack, const GlobalFilter *filter, bool low_hit_ratio, double exploration, const vespalib::Doom& doom) const
+HnswIndex<type>::top_k_candidates(Stats &stats, const BoundDistanceFunction &df, uint32_t k, double exploration_slack, const GlobalFilter *filter, bool low_hit_ratio, double exploration, const vespalib::Doom& doom) const
 {
     SearchBestNeighbors best_neighbors;
     auto entry = _graph.get_entry_node();
@@ -1046,20 +1053,22 @@ HnswIndex<type>::top_k_candidates(const BoundDistanceFunction &df, uint32_t k, d
         // graph has no entry point
         return best_neighbors;
     }
+    stats.count_visited_node(); // Count entry point as visited node
     int search_level = entry.level;
     double entry_dist = calc_distance(df, entry.nodeid);
+    stats.count_computed_distance();
     uint32_t entry_docid = get_docid(entry.nodeid);
     // TODO: check if entry docid/levels_ref is still valid here
     HnswCandidate entry_point(entry.nodeid, entry_docid, entry.levels_ref, entry_dist);
     while (search_level > 0) {
-        entry_point = find_nearest_in_layer(df, entry_point, search_level);
+        entry_point = find_nearest_in_layer(stats, df, entry_point, search_level);
         --search_level;
     }
     best_neighbors.push(entry_point);
     if (filter && filter->is_active() && low_hit_ratio) {
-        search_layer_filter_first(df, k, exploration_slack, best_neighbors, exploration, 0, &doom, filter);
+        search_layer_filter_first(stats, df, k, exploration_slack, best_neighbors, exploration, 0, &doom, filter);
     } else {
-        search_layer(df, k, exploration_slack, best_neighbors, 0, &doom, filter);
+        search_layer(stats, df, k, exploration_slack, best_neighbors, 0, &doom, filter);
     }
     return best_neighbors;
 }

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
@@ -208,29 +208,29 @@ protected:
     /**
      * Performs a greedy search in the given layer to find the candidate that is nearest the input vector.
      */
-    HnswCandidate find_nearest_in_layer(const BoundDistanceFunction &df, const HnswCandidate& entry_point, uint32_t level) const __attribute__((noinline));
+    HnswCandidate find_nearest_in_layer(Stats &stats, const BoundDistanceFunction &df, const HnswCandidate& entry_point, uint32_t level) const __attribute__((noinline));
     template <class VisitedTracker, class BestNeighbors>
-    void search_layer_helper(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
+    void search_layer_helper(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
                              uint32_t level, const GlobalFilter *filter, uint32_t nodeid_limit,
                              const vespalib::Doom* const doom, uint32_t estimated_visited_nodes) const __attribute__((noinline));
     template <class VisitedTracker, class BestNeighbors>
-    void search_layer_filter_first_helper(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
+    void search_layer_filter_first_helper(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
                                           double exploration, uint32_t level, const GlobalFilter *filter, uint32_t nodeid_limit,
                                           const vespalib::Doom* const doom, uint32_t estimated_visited_nodes) const __attribute__((noinline));
     template <class VisitedTracker>
-    void exploreNeighborhood(HnswTraversalCandidate &cand, std::deque<uint32_t> &found, VisitedTracker &visited, double exploration, uint32_t level,
+    void exploreNeighborhood(Stats &stats, HnswTraversalCandidate &cand, std::deque<uint32_t> &found, VisitedTracker &visited, double exploration, uint32_t level,
                              const internal::GlobalFilterWrapper<type>& filter_wrapper, uint32_t nodeid_limit) const;
     template <class VisitedTracker>
-    void exploreNeighborhoodByOneHop(std::deque<uint32_t> &todo, std::deque<uint32_t> &found, VisitedTracker &visited, uint32_t level,
+    void exploreNeighborhoodByOneHop(Stats &stats, std::deque<uint32_t> &todo, std::deque<uint32_t> &found, VisitedTracker &visited, uint32_t level,
                                      const internal::GlobalFilterWrapper<type>& filter_wrapper, uint32_t nodeid_limit,
                                      uint32_t max_neighbors_to_find) const;
     template <class BestNeighbors>
-    void search_layer(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
+    void search_layer(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
                       uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter = nullptr) const;
     template <class BestNeighbors>
-    void search_layer_filter_first(const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors, double exploration,
+    void search_layer_filter_first(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors, double exploration,
                                    uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter = nullptr) const;
-    std::vector<Neighbor> top_k_by_docid(uint32_t k, const BoundDistanceFunction &df, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
+    std::vector<Neighbor> top_k_by_docid(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
                                          uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const;
 
     internal::PreparedAddDoc internal_prepare_add(uint32_t docid, VectorBundle input_vectors,
@@ -270,15 +270,15 @@ public:
     std::unique_ptr<NearestNeighborIndexSaver> make_saver(vespalib::GenericHeader& header) const override;
     std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file, const vespalib::GenericHeader& header) override;
 
-    std::vector<Neighbor> find_top_k(uint32_t k, const BoundDistanceFunction &df, uint32_t explore_k, double exploration_slack,
+    std::vector<Neighbor> find_top_k(Stats &stats, uint32_t k, const BoundDistanceFunction &df, uint32_t explore_k, double exploration_slack,
                                      const vespalib::Doom& doom, double distance_threshold) const override;
 
-    std::vector<Neighbor> find_top_k_with_filter(uint32_t k, const BoundDistanceFunction &df, const GlobalFilter &filter, bool low_hit_ratio, double exploration,
+    std::vector<Neighbor> find_top_k_with_filter(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter &filter, bool low_hit_ratio, double exploration,
                                                  uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const override;
 
     DistanceFunctionFactory &distance_function_factory() const override { return *_distance_ff; }
 
-    SearchBestNeighbors top_k_candidates(const BoundDistanceFunction &df, uint32_t k, double exploration_slack, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
+    SearchBestNeighbors top_k_candidates(Stats &stats, const BoundDistanceFunction &df, uint32_t k, double exploration_slack, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
                                          const vespalib::Doom& doom) const;
 
     uint32_t get_entry_nodeid() const { return _graph.get_entry_node().nodeid; }

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
@@ -40,6 +40,24 @@ class NearestNeighborIndexSaver;
  */
 class NearestNeighborIndex {
 public:
+    /**
+     * Class for collecting statistics during search.
+     * An instance of this class is handed to find_top_k() or find_top_k_with_filter(),
+     * where the statistics are then written to this object.
+     */
+    class Stats {
+    private:
+        size_t _distances_computed;
+        size_t _nodes_visited;
+
+    public:
+        Stats() : _distances_computed(0), _nodes_visited(0) {}
+        size_t distances_computed() const { return _distances_computed; }
+        void count_computed_distance() { ++_distances_computed; }
+        size_t nodes_visited() const { return _nodes_visited; }
+        void count_visited_node() { ++_nodes_visited; }
+    };
+
     using GlobalFilter = search::queryeval::GlobalFilter;
     using CompactionSpec = vespalib::datastore::CompactionSpec;
     using CompactionStrategy = vespalib::datastore::CompactionStrategy;
@@ -102,7 +120,8 @@ public:
      */
     virtual std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file, const vespalib::GenericHeader& header) = 0;
 
-    virtual std::vector<Neighbor> find_top_k(uint32_t k,
+    virtual std::vector<Neighbor> find_top_k(Stats &stats,
+                                             uint32_t k,
                                              const BoundDistanceFunction &df,
                                              uint32_t explore_k,
                                              double exploration_slack,
@@ -110,7 +129,8 @@ public:
                                              double distance_threshold) const = 0;
 
     // only return neighbors where the corresponding filter bit is set
-    virtual std::vector<Neighbor> find_top_k_with_filter(uint32_t k,
+    virtual std::vector<Neighbor> find_top_k_with_filter(Stats &stats,
+                                                         uint32_t k,
                                                          const BoundDistanceFunction &df,
                                                          const GlobalFilter &filter,
                                                          bool low_hit_ratio,


### PR DESCRIPTION
This adds new metrics `matching.exact_nns_distances_computed`, `matching.approximate_nns_distances_computed`, and `matching.approximate_nns_nodes_visited` and their rank-profile equivalents to Proton, which are collected during vector search. There is an accompanying system test.

Any suggestions on the names? I think `enn_distances_computed`, `ann_distances_computed`, and `ann_nodes_visited` would probably be better. 🤔 

@havardpe please review