### PR TITLE
Add feature flag for tuning cluster controller JVM heap size

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1344,7 +1344,8 @@
       "public boolean useTriton()",
       "public boolean useNewPrepareForRestart()",
       "public int searchCoreMaxOutstandingMoveOps()",
-      "public double docprocHandlerThreadpool()"
+      "public double docprocHandlerThreadpool()",
+      "public boolean adjustCCMaxHeap()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -120,6 +120,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean useNewPrepareForRestart() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int searchCoreMaxOutstandingMoveOps() { return 100; }
         @ModelFeatureFlag(owners = {"johsol"}) default double docprocHandlerThreadpool() { return 1.0; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default boolean adjustCCMaxHeap() { return false; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -28,6 +28,7 @@ import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeResources.Architecture;
 import com.yahoo.config.provision.SharedHosts;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.flags.IntFlag;
@@ -211,7 +212,8 @@ public class ModelContextImpl implements ModelContext {
         private final boolean useTriton;
         private final int searchCoreMaxOutstandingMoveOps;
         private final boolean useNewPrepareForRestart;
-        private double docprocHandlerThreadpool;
+        private final double docprocHandlerThreadpool;
+        private final boolean adjustCCMaxHeap;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
             this.useNonPublicEndpointForTest = Flags.USE_NON_PUBLIC_ENDPOINT_FOR_TEST.bindTo(source).with(appId).with(version).value();
@@ -260,6 +262,7 @@ public class ModelContextImpl implements ModelContext {
             this.searchCoreMaxOutstandingMoveOps = Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS.bindTo(source).with(appId).with(version).value();
             this.useNewPrepareForRestart = Flags.USE_NEW_PREPARE_FOR_RESTART_METHOD.bindTo(source).with(appId).with(version).value();
             this.docprocHandlerThreadpool = Flags.DOCPROC_HANDLER_THREADPOOL.bindTo(source).with(appId).with(version).value();
+            this.adjustCCMaxHeap = Flags.ADJUST_JVM_HEAP_FOR_CC_BASED_ON_CONTENT_NODE_COUNT.bindTo(source).with(appId).with(version).value();
         }
 
         @Override public boolean useNonPublicEndpointForTest() { return useNonPublicEndpointForTest; }
@@ -309,6 +312,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean useNewPrepareForRestart() { return useNewPrepareForRestart; }
         @Override public int searchCoreMaxOutstandingMoveOps() { return searchCoreMaxOutstandingMoveOps; }
         @Override public double docprocHandlerThreadpool() { return docprocHandlerThreadpool; }
+        @Override public boolean adjustCCMaxHeap() { return adjustCCMaxHeap; }
     }
 
     public static class Properties implements ModelContext.Properties {
@@ -343,6 +347,7 @@ public class ModelContextImpl implements ModelContext {
         private final List<String> requestPrefixForLoggingContent;
         private final List<String> jdiscHttpComplianceViolations;
         private final StringFlag mallocImplFlag;
+        private final BooleanFlag adjustCCMaxHeap;
 
         public Properties(ApplicationId applicationId,
                           Version modelVersion,
@@ -394,6 +399,8 @@ public class ModelContextImpl implements ModelContext {
             this.mallocImplFlag = Flags.VESPA_USE_MALLOC_IMPL.bindTo(flagSource)
                     .with(applicationId)
                     .withVersion(Optional.of(modelVersion));
+            this.adjustCCMaxHeap = Flags.ADJUST_JVM_HEAP_FOR_CC_BASED_ON_CONTENT_NODE_COUNT.bindTo(flagSource)
+                                                                                           .with(applicationId);
         }
 
         @Override public ModelContext.FeatureFlags featureFlags() { return featureFlags; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -440,6 +440,14 @@ public class Flags {
             APPLICATION, INSTANCE_ID, HOSTNAME
     );
 
+    public static final UnboundBooleanFlag ADJUST_JVM_HEAP_FOR_CC_BASED_ON_CONTENT_NODE_COUNT = defineFeatureFlag(
+            "adjust-jvm-heap-for-cc-based-on-content-node-count", true,
+            List.of("hmusum"), "2025-11-04", "2026-02-04",
+            "Whether to increase max JVM heap size based on total number of content nodes in application",
+            "Takes effect at next restart after next deployment",
+            APPLICATION, INSTANCE_ID
+    );
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,


### PR DESCRIPTION
When enabled, uses total number of content nodes in application to decide max JVM heap size for cluster controllers

