### PR TITLE
Adjust cluster controller JVM max heap size

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -80,6 +80,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private Map<String, Integer> searchNodeInitializerThreads = new HashMap<>();
     private boolean useTriton = false;
     private double docprocHandlerThreadpool = 1.0;
+    private boolean adjustCCMaxHeap = false;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
     @Override public boolean multitenant() { return multitenant; }
@@ -137,6 +138,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     }
     @Override public boolean useTriton() { return useTriton; }
     @Override public double docprocHandlerThreadpool() { return docprocHandlerThreadpool; }
+    @Override public boolean adjustCCMaxHeap() { return adjustCCMaxHeap; }
 
     public TestProperties maxUnCommittedMemory(int maxUnCommittedMemory) {
         this.maxUnCommittedMemory = maxUnCommittedMemory;
@@ -353,6 +355,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setUseTriton(boolean value) {
         this.useTriton = value;
+        return this;
+    }
+
+    public TestProperties adjustCCMaxHeap(boolean value) {
+        this.adjustCCMaxHeap = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -369,6 +369,8 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
                 }
                 clusterControllers = admin.getClusterControllers();
             }
+            // Update node count so we can keep track of how many content nodes there are in total
+            clusterControllers.updateNodeCount(contentCluster.getNodeCount());
 
             addClusterControllerComponentsForThisCluster(clusterControllers, contentCluster);
             ReindexingContext reindexingContext = clusterControllers.reindexingContext();

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -2509,16 +2509,20 @@ public class ModelProvisioningTest {
         var hosted = false;
         assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 128);
         assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 128);
         adjustHeap = true;
         assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 128);
         assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 128);
 
         hosted = true;
         assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 192);
         assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 244);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 400);
         adjustHeap = false;
         assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 192);
         assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 192);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 192);
     }
 
     private void assertMaxHeapSizeForClusterController(String services, boolean adjustHeap,
@@ -2528,7 +2532,7 @@ public class ModelProvisioningTest {
         var properties = new TestProperties().adjustCCMaxHeap(adjustHeap);
         tester.setModelProperties(properties);
         tester.addHosts(new NodeResources(1, 3, 10, 1), 4);
-        tester.addHosts(new NodeResources(1, 128, 100, 0.3), 99);
+        tester.addHosts(new NodeResources(1, 128, 100, 0.3), 305);
         var deployStatebuilder = deployStateWithClusterEndpoints("foo.indexing", "bar.indexing");
         var model = tester.createModel(Zone.defaultZone(), services, true, false, false,
                                        NodeResources.unspecified(), 0, Optional.empty(),

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -330,7 +330,7 @@ public class ModelProvisioningTest {
         assertEquals(3, subGroups.get(0).getNodes().size());
         assertEquals(0, subGroups.get(0).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/0", subGroups.get(0).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-57", subGroups.get(0).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-057", subGroups.get(0).getNodes().get(0).getHostName());
         assertEquals(1, subGroups.get(0).getNodes().get(1).getDistributionKey());
         assertEquals("bar/storage/1", subGroups.get(0).getNodes().get(1).getConfigId());
         assertEquals(2, subGroups.get(0).getNodes().get(2).getDistributionKey());
@@ -339,13 +339,13 @@ public class ModelProvisioningTest {
         assertEquals(3, subGroups.get(1).getNodes().size());
         assertEquals(3, subGroups.get(1).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/3", subGroups.get(1).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-54", subGroups.get(1).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-054", subGroups.get(1).getNodes().get(0).getHostName());
         assertEquals(4, subGroups.get(1).getNodes().get(1).getDistributionKey());
         assertEquals("bar/storage/4", subGroups.get(1).getNodes().get(1).getConfigId());
         assertEquals(5, subGroups.get(1).getNodes().get(2).getDistributionKey());
         assertEquals("bar/storage/5", subGroups.get(1).getNodes().get(2).getConfigId());
         // ...
-        assertEquals("node-1-3-50-51", subGroups.get(2).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-051", subGroups.get(2).getNodes().get(0).getHostName());
         // ...
         assertEquals("8", subGroups.get(8).getIndex());
         assertEquals(3, subGroups.get(8).getNodes().size());
@@ -364,14 +364,14 @@ public class ModelProvisioningTest {
         assertEquals(1, subGroups.get(0).getNodes().size());
         assertEquals(0, subGroups.get(0).getNodes().get(0).getDistributionKey());
         assertEquals("baz/storage/0", subGroups.get(0).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-27", subGroups.get(0).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-027", subGroups.get(0).getNodes().get(0).getHostName());
         assertEquals("1", subGroups.get(1).getIndex());
         assertEquals(1, subGroups.get(1).getNodes().size());
         assertEquals(1, subGroups.get(1).getNodes().get(0).getDistributionKey());
         assertEquals("baz/storage/1", subGroups.get(1).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-26", subGroups.get(1).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-026", subGroups.get(1).getNodes().get(0).getHostName());
         // ...
-        assertEquals("node-1-3-50-25", subGroups.get(2).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-025", subGroups.get(2).getNodes().get(0).getHostName());
         // ...
         assertEquals("26", subGroups.get(26).getIndex());
         assertEquals(1, subGroups.get(26).getNodes().size());
@@ -591,7 +591,7 @@ public class ModelProvisioningTest {
         assertEquals(3, subGroups.get(0).getNodes().size());
         assertEquals(0, subGroups.get(0).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/0", subGroups.get(0).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-57", subGroups.get(0).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-057", subGroups.get(0).getNodes().get(0).getHostName());
         assertEquals(1, subGroups.get(0).getNodes().get(1).getDistributionKey());
         assertEquals("bar/storage/1", subGroups.get(0).getNodes().get(1).getConfigId());
         assertEquals(2, subGroups.get(0).getNodes().get(2).getDistributionKey());
@@ -600,13 +600,13 @@ public class ModelProvisioningTest {
         assertEquals(3, subGroups.get(1).getNodes().size());
         assertEquals(3, subGroups.get(1).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/3", subGroups.get(1).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-54", subGroups.get(1).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-054", subGroups.get(1).getNodes().get(0).getHostName());
         assertEquals(4, subGroups.get(1).getNodes().get(1).getDistributionKey());
         assertEquals("bar/storage/4", subGroups.get(1).getNodes().get(1).getConfigId());
         assertEquals(5, subGroups.get(1).getNodes().get(2).getDistributionKey());
         assertEquals("bar/storage/5", subGroups.get(1).getNodes().get(2).getConfigId());
         // ...
-        assertEquals("node-1-3-50-51", subGroups.get(2).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-051", subGroups.get(2).getNodes().get(0).getHostName());
         // ...
         assertEquals("8", subGroups.get(8).getIndex());
         assertEquals(3, subGroups.get(8).getNodes().size());
@@ -625,14 +625,14 @@ public class ModelProvisioningTest {
         assertEquals(1, subGroups.get(0).getNodes().size());
         assertEquals(0, subGroups.get(0).getNodes().get(0).getDistributionKey());
         assertEquals("baz/storage/0", subGroups.get(0).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-27", subGroups.get(0).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-027", subGroups.get(0).getNodes().get(0).getHostName());
         assertEquals("1", subGroups.get(1).getIndex());
         assertEquals(1, subGroups.get(1).getNodes().size());
         assertEquals(1, subGroups.get(1).getNodes().get(0).getDistributionKey());
         assertEquals("baz/storage/1", subGroups.get(1).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-26", subGroups.get(1).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-026", subGroups.get(1).getNodes().get(0).getHostName());
         // ...
-        assertEquals("node-1-3-50-25", subGroups.get(2).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-025", subGroups.get(2).getNodes().get(0).getHostName());
         // ...
         assertEquals("26", subGroups.get(26).getIndex());
         assertEquals(1, subGroups.get(26).getNodes().size());
@@ -667,9 +667,9 @@ public class ModelProvisioningTest {
         ClusterControllerContainerCluster clusterControllers = model.getAdmin().getClusterControllers();
         assertEquals(3, clusterControllers.getContainers().size());
         assertEquals("cluster-controllers", clusterControllers.getName());
-        assertEquals("node-1-3-50-03", clusterControllers.getContainers().get(0).getHostName());
-        assertEquals("node-1-3-50-02", clusterControllers.getContainers().get(1).getHostName());
-        assertEquals("node-1-3-50-01", clusterControllers.getContainers().get(2).getHostName());
+        assertEquals("node-1-3-50-003", clusterControllers.getContainers().get(0).getHostName());
+        assertEquals("node-1-3-50-002", clusterControllers.getContainers().get(1).getHostName());
+        assertEquals("node-1-3-50-001", clusterControllers.getContainers().get(2).getHostName());
 
         // Check content cluster
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -682,19 +682,19 @@ public class ModelProvisioningTest {
         assertEquals(1, subGroups.get(0).getNodes().size());
         assertEquals(0, subGroups.get(0).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/0", subGroups.get(0).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-11", subGroups.get(0).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-011", subGroups.get(0).getNodes().get(0).getHostName());
         // second group
         assertEquals("1", subGroups.get(1).getIndex());
         assertEquals(1, subGroups.get(1).getNodes().size());
         assertEquals(1, subGroups.get(1).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/1", subGroups.get(1).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-10", subGroups.get(1).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-010", subGroups.get(1).getNodes().get(0).getHostName());
         // ... last group
         assertEquals("7", subGroups.get(7).getIndex());
         assertEquals(1, subGroups.get(7).getNodes().size());
         assertEquals(7, subGroups.get(7).getNodes().get(0).getDistributionKey());
         assertEquals("bar/storage/7", subGroups.get(7).getNodes().get(0).getConfigId());
-        assertEquals("node-1-3-50-04", subGroups.get(7).getNodes().get(0).getHostName());
+        assertEquals("node-1-3-50-004", subGroups.get(7).getNodes().get(0).getHostName());
     }
 
     @Test
@@ -711,15 +711,15 @@ public class ModelProvisioningTest {
         int numberOfHosts = 11;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"), "node-1-3-50-09");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"), "node-1-3-50-009");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check slobroks clusters
         assertEquals(1+3, model.getAdmin().getSlobroks().size(), "Includes retired node");
-        assertEquals("node-1-3-50-11", model.getAdmin().getSlobroks().get(0).getHostName());
-        assertEquals("node-1-3-50-10", model.getAdmin().getSlobroks().get(1).getHostName());
-        assertEquals("node-1-3-50-08", model.getAdmin().getSlobroks().get(2).getHostName());
-        assertEquals("node-1-3-50-09", model.getAdmin().getSlobroks().get(3).getHostName(), "Included in addition because it is retired");
+        assertEquals("node-1-3-50-011", model.getAdmin().getSlobroks().get(0).getHostName());
+        assertEquals("node-1-3-50-010", model.getAdmin().getSlobroks().get(1).getHostName());
+        assertEquals("node-1-3-50-008", model.getAdmin().getSlobroks().get(2).getHostName());
+        assertEquals("node-1-3-50-009", model.getAdmin().getSlobroks().get(3).getHostName(), "Included in addition because it is retired");
     }
 
     @Test
@@ -736,16 +736,16 @@ public class ModelProvisioningTest {
         int numberOfHosts = 12;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"), "node-1-3-50-03", "node-1-3-50-04");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"), "node-1-3-50-003", "node-1-3-50-004");
         assertEquals(10+2, model.getRoot().hostSystem().getHosts().size());
 
         // Check slobroks clusters
         assertEquals(3+2, model.getAdmin().getSlobroks().size(), "Includes retired node");
-        assertEquals("node-1-3-50-12", model.getAdmin().getSlobroks().get(0).getHostName());
-        assertEquals("node-1-3-50-11", model.getAdmin().getSlobroks().get(1).getHostName());
-        assertEquals("node-1-3-50-10", model.getAdmin().getSlobroks().get(2).getHostName());
-        assertEquals("node-1-3-50-04", model.getAdmin().getSlobroks().get(3).getHostName(), "Included in addition because it is retired");
-        assertEquals("node-1-3-50-03", model.getAdmin().getSlobroks().get(4).getHostName(), "Included in addition because it is retired");
+        assertEquals("node-1-3-50-012", model.getAdmin().getSlobroks().get(0).getHostName());
+        assertEquals("node-1-3-50-011", model.getAdmin().getSlobroks().get(1).getHostName());
+        assertEquals("node-1-3-50-010", model.getAdmin().getSlobroks().get(2).getHostName());
+        assertEquals("node-1-3-50-004", model.getAdmin().getSlobroks().get(3).getHostName(), "Included in addition because it is retired");
+        assertEquals("node-1-3-50-003", model.getAdmin().getSlobroks().get(4).getHostName(), "Included in addition because it is retired");
     }
 
     @Test
@@ -765,19 +765,19 @@ public class ModelProvisioningTest {
         int numberOfHosts = 16;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo", "bar"), "node-1-3-50-15", "node-1-3-50-05", "node-1-3-50-04");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo", "bar"), "node-1-3-50-015", "node-1-3-50-005", "node-1-3-50-004");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check slobroks clusters
         // ... from cluster default
         assertEquals(7, model.getAdmin().getSlobroks().size(), "Includes retired node");
-        assertEquals("node-1-3-50-16", model.getAdmin().getSlobroks().get(0).getHostName());
-        assertEquals("node-1-3-50-14", model.getAdmin().getSlobroks().get(1).getHostName());
-        assertEquals("node-1-3-50-15", model.getAdmin().getSlobroks().get(2).getHostName(), "Included in addition because it is retired");
+        assertEquals("node-1-3-50-016", model.getAdmin().getSlobroks().get(0).getHostName());
+        assertEquals("node-1-3-50-014", model.getAdmin().getSlobroks().get(1).getHostName());
+        assertEquals("node-1-3-50-015", model.getAdmin().getSlobroks().get(2).getHostName(), "Included in addition because it is retired");
         // ... from cluster bar
-        assertEquals("node-1-3-50-03", model.getAdmin().getSlobroks().get(3).getHostName());
-        assertEquals("node-1-3-50-05", model.getAdmin().getSlobroks().get(5).getHostName(), "Included in addition because it is retired");
-        assertEquals("node-1-3-50-04", model.getAdmin().getSlobroks().get(6).getHostName(), "Included in addition because it is retired");
+        assertEquals("node-1-3-50-003", model.getAdmin().getSlobroks().get(3).getHostName());
+        assertEquals("node-1-3-50-005", model.getAdmin().getSlobroks().get(5).getHostName(), "Included in addition because it is retired");
+        assertEquals("node-1-3-50-004", model.getAdmin().getSlobroks().get(6).getHostName(), "Included in addition because it is retired");
     }
 
     @Test
@@ -1062,7 +1062,7 @@ public class ModelProvisioningTest {
         tester.addHosts(numberOfHosts);
         VespaModel model = tester.createModel(Zone.defaultZone(), services, false, false, true,
                                               NodeResources.unspecified(), 0, Optional.empty(),
-                                              deployStateWithClusterEndpoints("bar.indexing"), "node-1-3-50-03");
+                                              deployStateWithClusterEndpoints("bar.indexing"), "node-1-3-50-003");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -2326,7 +2326,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(4);
-        VespaModel model = tester.createModel(Zone.defaultZone(), servicesXml, true, deployStateWithClusterEndpoints("zk"), "node-1-3-50-04");
+        VespaModel model = tester.createModel(Zone.defaultZone(), servicesXml, true, deployStateWithClusterEndpoints("zk"), "node-1-3-50-004");
         ApplicationContainerCluster cluster = model.getContainerClusters().get("zk");
         assertEquals(1, cluster.getContainers().stream().filter(Container::isRetired).count());
         assertEquals(3, cluster.getContainers().stream().filter(c -> !c.isRetired()).count());
@@ -2355,7 +2355,7 @@ public class ModelProvisioningTest {
             assertTrue(config.build().server().stream().noneMatch(ZookeeperServerConfig.Server::joining), "Initial servers are not joining");
         }
         {
-            VespaModel nextModel = tester.createModel(Zone.defaultZone(), servicesXml.apply(3), true, false, false, NodeResources.unspecified(), 0, Optional.of(model), deployStateWithClusterEndpoints("zk"), "node-1-3-50-04", "node-1-3-50-03");
+            VespaModel nextModel = tester.createModel(Zone.defaultZone(), servicesXml.apply(3), true, false, false, NodeResources.unspecified(), 0, Optional.of(model), deployStateWithClusterEndpoints("zk"), "node-1-3-50-004", "node-1-3-50-003");
             ApplicationContainerCluster cluster = nextModel.getContainerClusters().get("zk");
             ZookeeperServerConfig.Builder config = new ZookeeperServerConfig.Builder();
             cluster.getContainers().forEach(c -> c.getConfig(config));
@@ -2508,21 +2508,23 @@ public class ModelProvisioningTest {
         var adjustHeap = false;
         var hosted = false;
         assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 128);
-        assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 128);
-        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(60, 2), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 2), adjustHeap, hosted, 128);
         adjustHeap = true;
+        assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(60, 2), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 2), adjustHeap, hosted, 128);
+
+        hosted = true;
+        assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 128);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(60, 2), adjustHeap, hosted, 165);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 2), adjustHeap, hosted, 353);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(600, 2), adjustHeap, hosted, 400);
+        adjustHeap = false;
         assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 128);
         assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 128);
         assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 128);
-
-        hosted = true;
-        assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 192);
-        assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 244);
-        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 400);
-        adjustHeap = false;
-        assertMaxHeapSizeForClusterController(multipleContentClusters(1, 2), adjustHeap, hosted, 192);
-        assertMaxHeapSizeForClusterController(multipleContentClusters(60, 3), adjustHeap, hosted, 192);
-        assertMaxHeapSizeForClusterController(multipleContentClusters(300, 3), adjustHeap, hosted, 192);
+        assertMaxHeapSizeForClusterController(multipleContentClusters(600, 3), adjustHeap, hosted, 128);
     }
 
     private void assertMaxHeapSizeForClusterController(String services, boolean adjustHeap,
@@ -2532,7 +2534,7 @@ public class ModelProvisioningTest {
         var properties = new TestProperties().adjustCCMaxHeap(adjustHeap);
         tester.setModelProperties(properties);
         tester.addHosts(new NodeResources(1, 3, 10, 1), 4);
-        tester.addHosts(new NodeResources(1, 128, 100, 0.3), 305);
+        tester.addHosts(new NodeResources(1, 128, 100, 0.3), 605);
         var deployStatebuilder = deployStateWithClusterEndpoints("foo.indexing", "bar.indexing");
         var model = tester.createModel(Zone.defaultZone(), services, true, false, false,
                                        NodeResources.unspecified(), 0, Optional.empty(),

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -86,7 +86,7 @@ public class VespaModelTester {
             // Let host names sort in the opposite order of the order the hosts are added
             // This allows us to test index vs. name order selection when subsets of hosts are selected from a cluster
             // (for e.g cluster controllers and slobrok nodes)
-            String hostname = String.format("%s-%02d",
+            String hostname = String.format("%s-%03d",
                                             "node" + "-" + Math.round(resources.vcpu()) +
                                                      "-" + Math.round(resources.memoryGiB()) +
                                                      "-" + Math.round(resources.diskGb()),
@@ -95,8 +95,8 @@ public class VespaModelTester {
         }
         this.hostsByResources.put(resources, hosts);
 
-        if (hosts.size() > 100)
-            throw new IllegalStateException("The host naming scheme is nameNN. To test more than 100 hosts, change to nameNNN");
+        if (hosts.size() > 999)
+            throw new IllegalStateException("The host naming scheme is nameNN. To test more than 999 hosts, change to nameNNN");
         return new Hosts(hosts);
     }
 


### PR DESCRIPTION
* Adjust max heap size based on total number of content nodes and a feature flag.
* Adjust in steps to avoid changing heap size with small changes to number of nodes.
* See also node resources allocated to cluster controllers that is adjusted in the same way in CapacityPolicies.
* There should be no changes to heap size for non-hosted setups and apps with fewer than 50 content nodes.