### PR TITLE
Add option to disable perfdata feature when checking for java version

### DIFF
--- a/client/go/internal/admin/jvm/application_container.go
+++ b/client/go/internal/admin/jvm/application_container.go
@@ -220,7 +220,8 @@ func detectJavaMajorVersion() DetectJavaVersion {
 			java = candidate
 		}
 	}
-	cmd := exec.Command(java, "-version")
+	// The UsePerfData option is added to avoid issues with perf data path being locked
+	cmd := exec.Command(java, "-version", "-XX:-UsePerfData")
 	var out bytes.Buffer
 	var errorBuffer bytes.Buffer
 	cmd.Stdout = &out


### PR DESCRIPTION
We sometimes see that running "java -version" fails with "Cannot use file /tmp/hsperfdata_vespa/<pid> because it is locked by another process". Avoid the issue by suppplying a JVM option that disables the perfdata feature

