### PR TITLE
Append document ID to visitor error messages on put/delete failure

### DIFF
--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -489,7 +489,7 @@ void ExternalOperationHandlerTest::do_test_second_command_rejected_due_to_oversi
     Operation::SP generated;
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(std::move(cmd1), generated));
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(std::move(cmd2)));
-    EXPECT_EQ("ReturnCode(REJECTED, Message size (1001 bytes) exceeds maximum configured limit (1000 bytes) for document id 'id:foo:testdoctype1::bar', "
+    EXPECT_EQ("ReturnCode(REJECTED, Message size (1001 bytes) exceeds maximum configured limit (1000 bytes), "
 	      "see https://docs.vespa.ai/en/reference/services-content.html#max-document-size for how to configure)",
               _sender.reply(0)->getResult().toString());
 }

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
-#include <string>
 
 namespace documentapi { class TestAndSetCondition; }
 namespace storage::lib { class ClusterState; }
@@ -121,7 +120,7 @@ private:
     void bounce_with_feed_blocked(api::StorageCommand& cmd);
     std::shared_ptr<Operation> try_generate_get_operation(const std::shared_ptr<api::GetCommand>&);
     [[nodiscard]] bool message_size_is_above_put_or_update_limit(uint32_t msg_size) const noexcept;
-    void reject_as_oversized_message(api::StorageCommand& cmd, const std::string& raw_document_id);
+    void reject_as_oversized_message(api::StorageCommand& cmd);
 
     bool checkSafeTimeReached(api::StorageCommand& cmd);
     api::ReturnCode makeSafeTimeRejectionResult(TimePoint unsafeTime);


### PR DESCRIPTION
When visitors in the distributor attempt to add or delete a document via the document API, the related document ID is not displayed. This PR appends the related document ID to the error message. And adds a test for the message format. Reverts the short-term fix.