### PR TITLE
fix(publish): add backward compatibility for artifact upload

### DIFF
--- a/.buildkite/publish-artifacts.sh
+++ b/.buildkite/publish-artifacts.sh
@@ -26,5 +26,16 @@ for FILE in *.tar *.rpm; do
     cosign sign-blob -y --oidc-provider=buildkite-agent --output-signature "$FILE.sig" --output-certificate "$FILE.pem" "$FILE"
 done
 
-echo "Uploading artifacts to Buildkite..."
-buildkite-agent artifact upload "*.tar;*.tar.sig;*.tar.pem;*.rpm;*.rpm.sig;*.rpm.pem" "$BUILDKITE_ARTIFACT_DESTINATION/$VESPA_VERSION/artifacts/$ARCH"
+ARTIFACT_DESTINATION="${VESPA_ENGINE_ARTIFACTS_BUCKET}/${VESPA_ENGINE_ARTIFACTS_PREFIX}/${VESPA_VERSION}/artifacts/${ARCH}"
+echo "📦 Uploading artifacts to ${ARTIFACT_DESTINATION} ..."
+buildkite-agent artifact upload "*.tar;*.tar.sig;*.tar.pem;*.rpm;*.rpm.sig;*.rpm.pem" "$ARTIFACT_DESTINATION"
+
+# FIXME(marlon): Remove multiple upload in the transition period.
+#
+# For the specific case of vespa8/alma8, we also upload to the old path without the "alma8" segment
+# to maintain backward compatibility.
+if [[ "${VESPA_ENGINE_ARTIFACTS_PREFIX}" == "vespa8/alma8" ]]; then
+    ARTIFACT_DESTINATION="${VESPA_ENGINE_ARTIFACTS_BUCKET}/${VESPA_VERSION}/artifacts/${ARCH}"
+    echo "ℹ️ Backward compatibility upload to ${ARTIFACT_DESTINATION} ..."
+    buildkite-agent artifact upload "*.tar;*.tar.sig;*.tar.pem;*.rpm;*.rpm.sig;*.rpm.pem" "$ARTIFACT_DESTINATION"
+fi


### PR DESCRIPTION
Update artifact upload paths to include the new organized path using 
VESPA_ENGINE_ARTIFACTS_PREFIX. Maintain backward compatibility by 
uploading artifacts also to the old path for the specific case of 
vespa8/alma8 during the transition period. This ensures existing 
consumers of the artifacts can still access them without disruption.