### PR TITLE
Track estimated distributor memory usage from put/update operations

### DIFF
--- a/storage/src/tests/distributor/CMakeLists.txt
+++ b/storage/src/tests/distributor/CMakeLists.txt
@@ -25,6 +25,7 @@ vespa_add_executable(storage_distributor_gtest_runner_app TEST
     joinbuckettest.cpp
     maintenancemocks.cpp
     maintenanceschedulertest.cpp
+    memory_usage_tracker_test.cpp
     mergelimitertest.cpp
     mergeoperationtest.cpp
     multi_thread_stripe_access_guard_test.cpp

--- a/storage/src/tests/distributor/blockingoperationstartertest.cpp
+++ b/storage/src/tests/distributor/blockingoperationstartertest.cpp
@@ -22,7 +22,7 @@ const MockOperation& as_mock_operation(const Operation& operation) {
 
 }
 
-struct FakeDistributorStripeOperationContext : public DistributorStripeOperationContext {
+struct FakeDistributorStripeOperationContext : DistributorStripeOperationContext {
 
     PendingMessageTracker& _message_tracker;
 
@@ -101,6 +101,9 @@ struct FakeDistributorStripeOperationContext : public DistributorStripeOperation
         abort();
     }
     const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept override {
+        abort();
+    }
+    MemoryUsageToken make_memory_usage_token(uint32_t) noexcept override {
         abort();
     }
 };

--- a/storage/src/tests/distributor/distributor_stripe_test_util.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.cpp
@@ -45,7 +45,8 @@ DistributorStripeTestUtil::createLinks()
     _metrics = std::make_shared<DistributorMetricSet>();
     _ideal_state_metrics = std::make_shared<IdealStateMetricSet>();
     _stripe = std::make_unique<DistributorStripe>(_node->getComponentRegister(), *_metrics, *_ideal_state_metrics,
-                                                  _node->node_identity(), _messageSender, *this, _done_initializing);
+                                                  _node->node_identity(), _messageSender, *this,
+                                                  _memory_usage_tracker, _done_initializing);
 }
 
 void

--- a/storage/src/tests/distributor/distributor_stripe_test_util.h
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.h
@@ -8,6 +8,7 @@
 #include <tests/common/storage_config_set.h>
 #include <vespa/storage/common/hostreporter/hostinfo.h>
 #include <vespa/storage/config/config-stor-distributormanager.h>
+#include <vespa/storage/distributor/memory_usage_token.h>
 #include <vespa/storage/distributor/stripe_host_info_notifier.h>
 #include <vespa/storage/storageutil/utils.h>
 
@@ -243,6 +244,7 @@ protected:
     std::unique_ptr<TestDistributorApp> _node;
     std::shared_ptr<DistributorMetricSet> _metrics;
     std::shared_ptr<IdealStateMetricSet>  _ideal_state_metrics;
+    MemoryUsageTracker _memory_usage_tracker;
     std::unique_ptr<DistributorStripe> _stripe;
     DistributorMessageSenderStub _sender;
     DistributorMessageSenderStub _senderDown;

--- a/storage/src/tests/distributor/memory_usage_tracker_test.cpp
+++ b/storage/src/tests/distributor/memory_usage_tracker_test.cpp
@@ -1,0 +1,76 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/storage/distributor/memory_usage_token.h>
+#include <gtest/gtest.h>
+
+namespace storage::distributor {
+
+TEST(MemoryTrackerTest, memory_usage_is_intially_zero) {
+    MemoryUsageTracker t;
+    EXPECT_EQ(t.bytes_total(), 0);
+    EXPECT_EQ(t.max_observed_bytes(), 0);
+    auto snap = t.relaxed_snapshot();
+    EXPECT_EQ(snap.bytes_total, 0);
+    EXPECT_EQ(snap.max_observed_bytes, 0);
+}
+
+TEST(MemoryTrackerTest, memory_token_has_scope_semantics) {
+    MemoryUsageTracker t;
+    {
+        MemoryUsageToken t1(t, 1000);
+        EXPECT_EQ(t.bytes_total(), 1000);
+        EXPECT_EQ(t.max_observed_bytes(), 1000);
+        auto snap = t.relaxed_snapshot();
+        EXPECT_EQ(snap.bytes_total, 1000);
+        EXPECT_EQ(snap.max_observed_bytes, 1000);
+        {
+            MemoryUsageToken t2(t, 2000);
+            EXPECT_EQ(t.bytes_total(), 3000);
+            EXPECT_EQ(t.max_observed_bytes(), 3000);
+            snap = t.relaxed_snapshot();
+            EXPECT_EQ(snap.bytes_total, 3000);
+            EXPECT_EQ(snap.max_observed_bytes, 3000);
+        }
+        EXPECT_EQ(t.bytes_total(), 1000);
+        EXPECT_EQ(t.max_observed_bytes(), 3000);
+        snap = t.relaxed_snapshot();
+        EXPECT_EQ(snap.bytes_total, 1000);
+        EXPECT_EQ(snap.max_observed_bytes, 3000);
+    }
+    EXPECT_EQ(t.bytes_total(), 0);
+    EXPECT_EQ(t.max_observed_bytes(), 3000);
+    auto snap = t.relaxed_snapshot();
+    EXPECT_EQ(snap.bytes_total, 0);
+    EXPECT_EQ(snap.max_observed_bytes, 3000);
+}
+
+TEST(MemoryTrackerTest, can_change_size_of_token) {
+    MemoryUsageTracker t;
+    MemoryUsageToken t1(t, 1000);
+    t1.update(1500);
+    EXPECT_EQ(t.bytes_total(), 1500);
+    EXPECT_EQ(t.max_observed_bytes(), 1500);
+    t1.update(200);
+    EXPECT_EQ(t.bytes_total(), 200);
+    EXPECT_EQ(t.max_observed_bytes(), 1500);
+}
+
+TEST(MemoryTrackerTest, can_reset_max_observed_bytes) {
+    MemoryUsageTracker t;
+    {
+        MemoryUsageToken t1(t, 1000);
+        EXPECT_EQ(t.max_observed_bytes(), 1000);
+        t.reset_max_observed_bytes();
+        EXPECT_EQ(t.max_observed_bytes(), 0);
+        // Special case: we should observe max of 1000 even though we've reset the max
+        // to zero since we're currently holding an active token.
+        auto snap = t.relaxed_snapshot();
+        EXPECT_EQ(snap.bytes_total, 1000);
+        EXPECT_EQ(snap.max_observed_bytes, 1000);
+    }
+    auto snap = t.relaxed_snapshot();
+    EXPECT_EQ(snap.bytes_total, 0);
+    EXPECT_EQ(snap.max_observed_bytes, 0);
+}
+
+} // storage::distributor

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -37,6 +37,7 @@ DistributorStripe::DistributorStripe(DistributorComponentRegister& compReg,
                                      const NodeIdentity& node_identity,
                                      ChainedMessageSender& messageSender,
                                      StripeHostInfoNotifier& stripe_host_info_notifier,
+                                     MemoryUsageTracker& shared_memory_usage_tracker,
                                      const bool& done_initializing_ref,
                                      uint32_t stripe_index)
     : DistributorStripeInterface(),
@@ -54,6 +55,7 @@ DistributorStripe::DistributorStripe(DistributorComponentRegister& compReg,
       _idealStateManager(_component, _component, ideal_state_metrics),
       _messageSender(messageSender),
       _stripe_host_info_notifier(stripe_host_info_notifier),
+      _shared_memory_usage_tracker(shared_memory_usage_tracker),
       _externalOperationHandler(_component, _component, getMetrics(), getMessageSender(),
                                 *_operation_sequencer, *this, _component,
                                 _idealStateManager, _operationOwner),
@@ -1038,6 +1040,11 @@ const NodeSupportedFeaturesRepo&
 DistributorStripe::node_supported_features_repo() const noexcept
 {
     return *_node_supported_features_repo;
+}
+
+MemoryUsageToken
+DistributorStripe::make_memory_usage_token(uint32_t bytes_used) noexcept {
+    return MemoryUsageToken(_shared_memory_usage_tracker, bytes_used);
 }
 
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -70,6 +70,7 @@ public:
                       const NodeIdentity& node_identity,
                       ChainedMessageSender& messageSender,
                       StripeHostInfoNotifier& stripe_host_info_notifier,
+                      MemoryUsageTracker& shared_memory_usage_tracker,
                       const bool& done_initializing_ref,
                       uint32_t stripe_index = 0);
 
@@ -312,6 +313,7 @@ private:
     void report_bucket_db_status(document::BucketSpace bucket_space, std::ostream& out) const override;
     void report_single_bucket_requests(vespalib::xml::XmlOutputStream& xos) const override;
     void report_delayed_single_bucket_requests(vespalib::xml::XmlOutputStream& xos) const override;
+    MemoryUsageToken make_memory_usage_token(uint32_t bytes_used) noexcept override;
 
     lib::ClusterStateBundle _clusterStateBundle;
     std::unique_ptr<DistributorBucketSpaceRepo> _bucketSpaceRepo;
@@ -319,7 +321,7 @@ private:
     // during cluster state transitions. Bucket set does not overlap that of _bucketSpaceRepo
     // and the DBs are empty during non-transition phases.
     std::unique_ptr<DistributorBucketSpaceRepo> _readOnlyBucketSpaceRepo;
-    storage::distributor::DistributorStripeComponent _component;
+    DistributorStripeComponent _component;
     std::shared_ptr<const DistributorConfiguration> _total_config;
     DistributorMetricSet& _metrics;
 
@@ -332,6 +334,7 @@ private:
     IdealStateManager _idealStateManager;
     ChainedMessageSender& _messageSender;
     StripeHostInfoNotifier& _stripe_host_info_notifier;
+    MemoryUsageTracker& _shared_memory_usage_tracker;
     ExternalOperationHandler _externalOperationHandler;
 
     std::shared_ptr<lib::Distribution> _distribution;

--- a/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
@@ -257,4 +257,9 @@ DistributorStripeComponent::remove_node_from_bucket_database(const document::Buc
     remove_nodes_from_bucket_database(bucket, toVector<uint16_t>(node_index));
 }
 
+MemoryUsageToken
+DistributorStripeComponent::make_memory_usage_token(uint32_t bytes_used) noexcept {
+    return _distributor.make_memory_usage_token(bytes_used);
+}
+
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe_component.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_component.h
@@ -153,6 +153,8 @@ public:
     // Implements DocumentSelectionParser
     std::unique_ptr<document::select::Node> parse_selection(const std::string& selection) const override;
 
+    MemoryUsageToken make_memory_usage_token(uint32_t bytes_used) noexcept override;
+
 private:
     DistributorStripeInterface& _distributor;
     DistributorBucketSpaceRepo& _bucketSpaceRepo;

--- a/storage/src/vespa/storage/distributor/distributor_stripe_interface.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_interface.h
@@ -4,6 +4,7 @@
 #include "bucketgctimecalculator.h"
 #include "distributormessagesender.h"
 #include "bucketownership.h"
+#include "memory_usage_token.h"
 #include "operation_routing_snapshot.h"
 #include <vespa/storage/bucketdb/bucketdatabase.h>
 #include <vespa/document/bucket/bucket.h>
@@ -23,10 +24,9 @@ class Operation;
 /**
  * TODO STRIPE add class comment.
  */
-class DistributorStripeInterface : public DistributorStripeMessageSender
-{
+class DistributorStripeInterface : public DistributorStripeMessageSender {
 public:
-    virtual DistributorMetricSet& getMetrics() = 0;
+    [[nodiscard]] virtual DistributorMetricSet& getMetrics() = 0;
     virtual void enableClusterStateBundle(const lib::ClusterStateBundle& state) = 0;
     [[nodiscard]] virtual const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const = 0;
     virtual void notifyDistributionChangeEnabled() = 0;
@@ -37,7 +37,7 @@ public:
      */
     virtual void recheckBucketInfo(uint16_t nodeIdx, const document::Bucket &bucket) = 0;
 
-    virtual bool handleReply(const std::shared_ptr<api::StorageReply>& reply) = 0;
+    [[nodiscard]] virtual bool handleReply(const std::shared_ptr<api::StorageReply>& reply) = 0;
 
     /**
      * Checks whether a bucket needs to be split, and sends a split
@@ -51,9 +51,9 @@ public:
     /**
      * @return Returns the current cluster state bundle.
      */
-    virtual const lib::ClusterStateBundle& getClusterStateBundle() const = 0;
+    [[nodiscard]] virtual const lib::ClusterStateBundle& getClusterStateBundle() const = 0;
 
-    virtual OperationRoutingSnapshot read_snapshot_for_bucket(const document::Bucket&) const = 0;
+    [[nodiscard]] virtual OperationRoutingSnapshot read_snapshot_for_bucket(const document::Bucket&) const = 0;
 
     /**
      * Returns true if the node is currently initializing.
@@ -62,10 +62,11 @@ public:
 
     [[nodiscard]] virtual std::shared_ptr<Operation> maintenance_op_from_message_id(uint64_t msg_id) const noexcept = 0;
     virtual void handleCompletedMerge(const std::shared_ptr<api::MergeBucketReply>&) = 0;
-    virtual const DistributorConfiguration& getConfig() const = 0;
-    virtual ChainedMessageSender& getMessageSender() = 0;
-    virtual const BucketGcTimeCalculator::BucketIdHasher& getBucketIdHasher() const = 0;
-    virtual const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept = 0;
+    [[nodiscard]] virtual const DistributorConfiguration& getConfig() const = 0;
+    [[nodiscard]] virtual ChainedMessageSender& getMessageSender() = 0;
+    [[nodiscard]] virtual const BucketGcTimeCalculator::BucketIdHasher& getBucketIdHasher() const = 0;
+    [[nodiscard]] virtual const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept = 0;
+    [[nodiscard]] virtual MemoryUsageToken make_memory_usage_token(uint32_t bytes_used) noexcept = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe_operation_context.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_operation_context.h
@@ -4,6 +4,7 @@
 
 #include "bucketgctimecalculator.h"
 #include "bucketownership.h"
+#include "memory_usage_token.h"
 #include "operation_routing_snapshot.h"
 #include <vespa/document/bucket/bucketspace.h>
 #include <vespa/storageapi/defs.h>
@@ -36,17 +37,9 @@ public:
     virtual void update_bucket_database(const document::Bucket& bucket,
                                         const BucketCopy& changed_node,
                                         uint32_t update_flags) = 0;
-    void update_bucket_database(const document::Bucket& bucket,
-                                const BucketCopy& changed_node) {
-        update_bucket_database(bucket, changed_node, 0);
-    }
     virtual void update_bucket_database(const document::Bucket& bucket,
                                         const std::vector<BucketCopy>& changed_nodes,
                                         uint32_t update_flags) = 0;
-    void update_bucket_database(const document::Bucket& bucket,
-                                const std::vector<BucketCopy>& changed_nodes) {
-        update_bucket_database(bucket, changed_nodes, 0);
-    }
     virtual void remove_node_from_bucket_database(const document::Bucket& bucket, uint16_t node_index) = 0;
     virtual void remove_nodes_from_bucket_database(const document::Bucket& bucket,
                                                    const std::vector<uint16_t>& nodes) = 0;
@@ -68,6 +61,7 @@ public:
     [[nodiscard]] virtual bool storage_node_is_up(document::BucketSpace bucket_space, uint32_t node_index) const = 0;
     [[nodiscard]] virtual const BucketGcTimeCalculator::BucketIdHasher& bucket_id_hasher() const = 0;
     [[nodiscard]] virtual const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept = 0;
+    [[nodiscard]] virtual MemoryUsageToken make_memory_usage_token(uint32_t bytes_used) noexcept = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/distributor_total_metrics.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_total_metrics.cpp
@@ -7,7 +7,10 @@ namespace storage::distributor {
 DistributorTotalMetrics::DistributorTotalMetrics(uint32_t num_distributor_stripes)
     : DistributorMetricSet(),
       _stripes_metrics(),
-      _bucket_db_updater_metrics()
+      _bucket_db_updater_metrics(),
+      _mutatating_op_memory_usage("mutating_op_memory_usage", {},
+             "Estimated amount of memory used by active mutating operations "
+             "across all distributor stripes, in bytes", this)
 {
     _stripes_metrics.reserve(num_distributor_stripes);
     for (uint32_t i = 0; i < num_distributor_stripes; ++i) {

--- a/storage/src/vespa/storage/distributor/distributor_total_metrics.h
+++ b/storage/src/vespa/storage/distributor/distributor_total_metrics.h
@@ -15,6 +15,7 @@ class DistributorTotalMetrics : public DistributorMetricSet
 {
     std::vector<std::shared_ptr<DistributorMetricSet>> _stripes_metrics;
     DistributorMetricSet _bucket_db_updater_metrics;
+    metrics::LongValueMetric _mutatating_op_memory_usage;
     void aggregate_helper(DistributorMetricSet &total) const;
 public:
     explicit DistributorTotalMetrics(uint32_t num_distributor_stripes);
@@ -24,6 +25,12 @@ public:
     void reset() override;
     DistributorMetricSet& stripe(uint32_t stripe_index) { return *_stripes_metrics[stripe_index]; }
     DistributorMetricSet& bucket_db_updater_metrics() { return _bucket_db_updater_metrics; }
+    const metrics::LongValueMetric& mutatating_op_memory_usage() const noexcept {
+        return _mutatating_op_memory_usage;
+    }
+    metrics::LongValueMetric& mutatating_op_memory_usage() noexcept {
+        return _mutatating_op_memory_usage;
+    }
 };
 
 }

--- a/storage/src/vespa/storage/distributor/memory_usage_token.h
+++ b/storage/src/vespa/storage/distributor/memory_usage_token.h
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "memory_usage_tracker.h"
+
+namespace storage::distributor {
+
+/**
+ * RAII-style token that represents the caller holding a particular amount of
+ * allocated memory. The amount of memory the token represents can be adjusted
+ * up or down as required. Although the MemoryUsageTracker a token is bound to
+ * is thread safe, individual MemoryUsageToken instances are not thread safe.
+ */
+class MemoryUsageToken {
+    MemoryUsageTracker& _tracker;
+    // Since we're limited to 2GiB max payloads, assume that u32 suffices for bytes used
+    // for a single tracked operation. Operations with fan-outs are expected to use shared_ptrs
+    // to Document instances etc. that are common across messages to avoid duplication.
+    uint32_t _bytes_used;
+public:
+    MemoryUsageToken(MemoryUsageTracker& tracker, uint32_t bytes_used) noexcept
+        : _tracker(tracker),
+          _bytes_used(bytes_used)
+    {
+        _tracker.add_bytes_used(bytes_used);
+    }
+    ~MemoryUsageToken() {
+        _tracker.sub_bytes_used(_bytes_used);
+    }
+
+    [[nodiscard]] uint32_t bytes_used() const noexcept { return _bytes_used; }
+
+    void update(uint32_t new_usage_bytes) noexcept {
+        _tracker.sub_add_bytes_used(_bytes_used, new_usage_bytes);
+        _bytes_used = new_usage_bytes;
+    }
+};
+
+} // storage::distributor

--- a/storage/src/vespa/storage/distributor/memory_usage_tracker.h
+++ b/storage/src/vespa/storage/distributor/memory_usage_tracker.h
@@ -1,0 +1,83 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+
+namespace storage::distributor {
+
+// This would ideally use std::hardware_destructive_interference_size, but that
+// triggers compiler warnings on GCC since a fallback value is used, which in turn
+// triggers build errors for us. So use the ol' faithful 64 bytes line size...
+constexpr inline size_t cache_alignment = 64;
+
+/**
+ * A very simple, thread-safe class for keeping track of estimated memory usage
+ * across distributor stripes.
+ *
+ * In addition, the maximum observed total is tracked separately, allowing for
+ * destructive periodic sampling, akin to how metric min/max is tracked.
+ * Although current/max are individually atomically updated, they are not
+ * updated atomically _together_. Callers should not depend on this for correctness.
+ */
+class alignas(cache_alignment) MemoryUsageTracker {
+    // Invariant: these are always >= 0
+    std::atomic<ssize_t> _bytes_total;
+    std::atomic<ssize_t> _max_observed_bytes;
+
+    friend class MemoryUsageToken;
+
+    void add_bytes_used(uint32_t n_bytes) noexcept {
+        sub_add_bytes_used(0, n_bytes);
+    }
+    void sub_bytes_used(uint32_t n_bytes) noexcept {
+        sub_add_bytes_used(n_bytes, 0);
+    }
+    void sub_add_bytes_used(uint32_t old_bytes, uint32_t new_bytes) noexcept {
+        const ssize_t delta = static_cast<ssize_t>(new_bytes) - static_cast<ssize_t>(old_bytes);
+        const ssize_t my_before = _bytes_total.fetch_add(delta, std::memory_order_relaxed);
+        const ssize_t my_after = my_before + delta;
+        ssize_t cur_max = _max_observed_bytes.load(std::memory_order_relaxed);
+        // This will only contend if threads are observing increasing maximums, which should
+        // quickly settle. In uncontended cases this is expected to be on a cache line that
+        // we already hold exclusively due to the previous fetch_add.
+        while ((my_after > cur_max) &&
+               !_max_observed_bytes.compare_exchange_weak(cur_max, my_after,
+                                                          std::memory_order_relaxed, std::memory_order_relaxed))
+        {
+            // We raced, try again
+        }
+    }
+public:
+    constexpr MemoryUsageTracker() noexcept : _bytes_total(0), _max_observed_bytes(0) {}
+
+    [[nodiscard]] size_t bytes_total() const noexcept {
+        return static_cast<size_t>(_bytes_total.load(std::memory_order_relaxed));
+    }
+
+    [[nodiscard]] size_t max_observed_bytes() const noexcept {
+        return static_cast<size_t>(_max_observed_bytes.load(std::memory_order_relaxed));
+    }
+
+    struct RelaxedSnapshot {
+        size_t bytes_total = 0;
+        size_t max_observed_bytes = 0;
+    };
+
+    // Returns a snapshot that is atomic for individual values, but not _across_ values.
+    // Returned max bytes may be adjusted so that it is always >= current total bytes.
+    [[nodiscard]] RelaxedSnapshot relaxed_snapshot() const noexcept {
+        const size_t total = bytes_total();
+        // It's possible that we race with a concurrent update, so ensure max is at least
+        // as big as the sampled current total
+        const size_t adj_max = std::max(max_observed_bytes(), total);
+        return {total, adj_max};
+    }
+
+    void reset_max_observed_bytes() noexcept {
+        _max_observed_bytes.store(0, std::memory_order_relaxed);
+    }
+};
+
+} // storage::distributor

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
@@ -36,7 +36,8 @@ PutOperation::PutOperation(const DistributorNodeContext& node_ctx,
       _node_ctx(node_ctx),
       _op_ctx(op_ctx),
       _condition_probe_metrics(condition_probe_metrics),
-      _bucket_space(bucket_space)
+      _bucket_space(bucket_space),
+      _memory_usage_token(op_ctx.make_memory_usage_token(_msg->getApproxByteSize()))
 {
 }
 

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -33,8 +33,8 @@ public:
     ~PutOperation() override;
 
     void onStart(DistributorStripeMessageSender& sender) override;
-    const char* getName() const noexcept override { return "put"; };
-    std::string getStatus() const override { return ""; };
+    const char* getName() const noexcept override { return "put"; }
+    std::string getStatus() const override { return ""; }
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply>&) override;
     void onClose(DistributorStripeMessageSender& sender) override;
 
@@ -50,6 +50,7 @@ private:
     PersistenceOperationMetricSet&     _condition_probe_metrics;
     DistributorBucketSpace&            _bucket_space;
     std::shared_ptr<CheckCondition>    _check_condition;
+    MemoryUsageToken                   _memory_usage_token;
 
     void start_direct_put_dispatch(DistributorStripeMessageSender& sender);
     void start_conditional_put(DistributorStripeMessageSender& sender);

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -48,8 +48,7 @@ class UpdateMetricSet;
 */
 
 
-class TwoPhaseUpdateOperation : public SequencedOperation
-{
+class TwoPhaseUpdateOperation : public SequencedOperation {
 public:
     TwoPhaseUpdateOperation(const DistributorNodeContext& node_ctx,
                             DistributorStripeOperationContext& op_ctx,
@@ -110,7 +109,8 @@ private:
     void schedulePutsWithUpdatedDocument(
             std::shared_ptr<document::Document>,
             api::Timestamp,
-            DistributorStripeMessageSender&);
+            DistributorStripeMessageSender&,
+            uint32_t approx_byte_size);
     void applyUpdateToDocument(document::Document&) const;
     [[nodiscard]] std::shared_ptr<document::Document> createBlankDocument() const;
     void setUpdatedForTimestamp(api::Timestamp);
@@ -118,7 +118,7 @@ private:
                                const std::shared_ptr<api::StorageReply>&);
     void handleSafePathReceive(DistributorStripeMessageSender&,
                                const std::shared_ptr<api::StorageReply>&);
-    std::shared_ptr<GetOperation> create_initial_safe_path_get_operation();
+    [[nodiscard]] std::shared_ptr<GetOperation> create_initial_safe_path_get_operation();
     void handle_safe_path_received_metadata_get(DistributorStripeMessageSender&,
                                                 api::GetReply&,
                                                 const std::optional<NewestReplica>&,
@@ -127,7 +127,7 @@ private:
     void handleSafePathReceivedGet(DistributorStripeMessageSender&, api::GetReply&);
     void handleSafePathReceivedPut(DistributorStripeMessageSender&, const api::PutReply&);
     [[nodiscard]] bool shouldCreateIfNonExistent() const;
-    bool processAndMatchTasCondition(
+    [[nodiscard]] bool processAndMatchTasCondition(
             DistributorStripeMessageSender& sender,
             const document::Document& candidateDoc,
             uint64_t persisted_timestamp);
@@ -136,7 +136,7 @@ private:
     [[nodiscard]] bool hasTasCondition() const noexcept;
     void replyWithTasFailure(DistributorStripeMessageSender& sender,
                              std::string_view message);
-    bool may_restart_with_fast_path(const api::GetReply& reply);
+    [[nodiscard]] bool may_restart_with_fast_path(const api::GetReply& reply);
     [[nodiscard]] bool replica_set_unchanged_after_get_operation() const;
     void restart_with_fast_path_due_to_consistent_get_timestamps(DistributorStripeMessageSender& sender);
     // Precondition: reply has not yet been sent.
@@ -151,6 +151,7 @@ private:
     PersistenceOperationMetricSet&      _metadata_get_metrics;
     std::shared_ptr<api::UpdateCommand> _updateCmd;
     std::shared_ptr<api::UpdateReply>   _updateReply;
+    MemoryUsageToken                    _memory_usage_token;
     const DistributorNodeContext&       _node_ctx;
     DistributorStripeOperationContext&  _op_ctx;
     const DocumentSelectionParser&      _parser;

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
@@ -263,7 +263,7 @@ void GarbageCollectionOperation::merge_received_bucket_info_into_db() {
     }
     if (!_replica_info.empty()) {
         // TODO avoid two separate DB ops for this. Current API currently does not make this elegant.
-        _manager->operation_context().update_bucket_database(getBucket(), _replica_info);
+        _manager->operation_context().update_bucket_database(getBucket(), _replica_info, 0);
         update_last_gc_timestamp_in_db();
     } // else: effectively fully cancelled, no touching the DB.
 }

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
@@ -67,7 +67,7 @@ PersistenceMessageTracker::updateDB()
     }
 
     for (const auto & entry : _bucketInfo) {
-        _op_ctx.update_bucket_database(entry.first, entry.second);
+        _op_ctx.update_bucket_database(entry.first, entry.second, 0);
     }
 
     for (const auto & entry : _remapBucketInfo){


### PR DESCRIPTION
@toregge please review. Majority of added lines are from parameter plumbing and tests.

This adds a top-level `MemoryUsageTracker` utility that is shared between all distributor stripes, and a simple RAII token for individually tracked operations. Put and Update operations use the wire serialization size as a (lossy) proxy of the in-memory cost for the operations they send out. Additionally, update operations that trigger write-repair will also transitively track the extra cost incurred by the convergence-forcing implicit Put operation.

For now this memory tracking is only wired to a singular top-level value metric. Once we verify that the value of this metric correlates reasonably well with the actual RSS of the distributor process, it can be utilized for other purposes.

Since memory usage may fluctuate within the metric sampling period, explicitly track the maximum observed usage value within the period, with destructive sampling that resets it back to 0 when the metric is updated.