### PR TITLE
Do not add authorization header multiple times

### DIFF
--- a/client/go/internal/cli/auth/zts/zts.go
+++ b/client/go/internal/cli/auth/zts/zts.go
@@ -64,7 +64,7 @@ func (c *Client) Authenticate(request *http.Request) error {
 	if request.Header == nil {
 		request.Header = make(http.Header)
 	}
-	request.Header.Add("Authorization", "Bearer "+c.token.Value)
+	request.Header.Set("Authorization", "Bearer "+c.token.Value)
 	return nil
 }
 


### PR DESCRIPTION
Adding the header for each request will eventually cause this error:
Error: visit failed: Invalid document operation: 431 Request Header Fields Too Large

@andreer please review
@evgiz FYI

