### PR TITLE
Add `JsonGeneratorDataSink` and make `QuantileAggregationResult` a `DataSource`

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -3,6 +3,7 @@ package com.yahoo.search.rendering;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.yahoo.data.disclosure.DataSink;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -115,10 +116,6 @@ record JsonGeneratorDataSink(JsonGenerator gen) implements DataSink {
 
     @Override
     public void dataValue(byte[] data) {
-        try {
-            gen.writeBinary(data);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+       throw new NotImplementedException();
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -93,7 +93,43 @@ record JsonGeneratorDataSink(JsonGenerator gen) implements DataSink {
     }
 
     @Override
+    public void intValue(int v) {
+        try {
+            gen.writeNumber(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void shortValue(short v) {
+        try {
+            gen.writeNumber(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void byteValue(byte v) {
+        try {
+            gen.writeNumber(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
     public void doubleValue(double v) {
+        try {
+            gen.writeNumber(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void floatValue(float v) {
         try {
             gen.writeNumber(v);
         } catch (IOException e) {

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -3,7 +3,6 @@ package com.yahoo.search.rendering;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.yahoo.data.disclosure.DataSink;
-import org.apache.commons.lang3.NotImplementedException;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -152,6 +151,6 @@ record JsonGeneratorDataSink(JsonGenerator gen) implements DataSink {
 
     @Override
     public void dataValue(byte[] data) {
-       throw new NotImplementedException();
+       throw new UnsupportedOperationException("Not implemented");
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -1,0 +1,124 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.rendering;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.yahoo.data.disclosure.DataSink;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A sink that generates JSON from objects that implement {@link com.yahoo.data.disclosure.DataSource}.
+ *
+ * @author johsol
+ */
+record JsonGeneratorDataSink(JsonGenerator gen) implements DataSink {
+
+    @Override
+    public void fieldName(String utf16, byte[] utf8) {
+        try {
+            if (utf8 != null) {
+                gen.writeFieldName(new String(utf8, StandardCharsets.UTF_8));
+            } else {
+                gen.writeFieldName(utf16);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void startObject() {
+        try {
+            gen.writeStartObject();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void endObject() {
+        try {
+            gen.writeEndObject();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void startArray() {
+        try {
+            gen.writeStartArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void endArray() {
+        try {
+            gen.writeEndArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void emptyValue() {
+        try {
+            gen.writeNull();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void booleanValue(boolean v) {
+        try {
+            gen.writeBoolean(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void longValue(long v) {
+        try {
+            gen.writeNumber(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void doubleValue(double v) {
+        try {
+            gen.writeNumber(v);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void stringValue(String utf16, byte[] utf8) {
+        try {
+            if (utf8 != null) {
+                gen.writeUTF8String(utf8, 0, utf8.length);
+            } else {
+                gen.writeString(utf16);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void dataValue(byte[] data) {
+        try {
+            gen.writeBinary(data);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.rendering;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.UTF8JsonGenerator;
 import com.yahoo.data.disclosure.DataSink;
 
 import java.io.IOException;
@@ -139,10 +140,12 @@ record JsonGeneratorDataSink(JsonGenerator gen) implements DataSink {
     @Override
     public void stringValue(String utf16, byte[] utf8) {
         try {
-            if (utf8 != null) {
-                gen.writeUTF8String(utf8, 0, utf8.length);
-            } else {
+            if (utf16 != null) {
                 gen.writeString(utf16);
+            } else if (gen instanceof UTF8JsonGenerator utf8Gen) {
+                utf8Gen.writeUTF8String(utf8, 0, utf8.length);
+            } else {
+                gen.writeString(new String(utf8, StandardCharsets.UTF_8));
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -19,10 +19,10 @@ record JsonGeneratorDataSink(JsonGenerator gen) implements DataSink {
     @Override
     public void fieldName(String utf16, byte[] utf8) {
         try {
-            if (utf8 != null) {
-                gen.writeFieldName(new String(utf8, StandardCharsets.UTF_8));
-            } else {
+            if (utf16 != null) {
                 gen.writeFieldName(utf16);
+            } else {
+                gen.writeFieldName(new String(utf8, StandardCharsets.UTF_8));
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/container-search/src/test/java/com/yahoo/search/rendering/JsonGeneratorDataSinkTest.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/JsonGeneratorDataSinkTest.java
@@ -1,0 +1,232 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.rendering;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.yahoo.slime.Slime;
+import com.yahoo.slime.SlimeUtils;
+import com.yahoo.test.json.Jackson;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.FLUSH_AFTER_WRITE_VALUE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author johsol
+ */
+public class JsonGeneratorDataSinkTest {
+
+    private static JsonFactory createGeneratorFactory() {
+        return Jackson.createMapper(new JsonFactoryBuilder()
+                        .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()))
+                .disable(FLUSH_AFTER_WRITE_VALUE).getFactory();
+    }
+
+    /**
+     * Gathers json produced by JsonGenerator.
+     */
+    static class SlimeOutputStream extends ByteArrayOutputStream {
+        Slime toSlime() {
+            return SlimeUtils.jsonToSlime(toString(StandardCharsets.UTF_8));
+        }
+    }
+
+    private void assertSlime(Slime expected, Slime actual) {
+        assertTrue(expected.get().equalTo(actual.get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(actual));
+    }
+
+    @Test
+    public void testGenerateObject() throws IOException {
+        var factory = createGeneratorFactory();
+        var out = new SlimeOutputStream();
+        var gen = factory.createGenerator(out, JsonEncoding.UTF8);
+        var sink = new JsonGeneratorDataSink(gen);
+
+        sink.startObject();
+        sink.fieldName("my_long");
+        sink.longValue(8);
+        sink.fieldName("my_bool");
+        sink.booleanValue(true);
+        sink.fieldName("my_empty");
+        sink.emptyValue();
+        sink.fieldName("my_string");
+        sink.stringValue("some_string");
+        sink.fieldName("my_double");
+        sink.doubleValue(3.14);
+        sink.endObject();
+
+        gen.flush();
+
+        var expected = SlimeUtils.jsonToSlime("{ my_long: 8," +
+                                              "  my_bool: true," +
+                                              "  my_empty: null," +
+                                              "  my_string: 'some_string'," +
+                                              "  my_double: 3.14 }");
+        assertSlime(expected, out.toSlime());
+    }
+
+    @Test
+    public void testGenerateArray() throws IOException {
+        var factory = createGeneratorFactory();
+        var out = new SlimeOutputStream();
+        var gen = factory.createGenerator(out, JsonEncoding.UTF8);
+        var sink = new JsonGeneratorDataSink(gen);
+
+        sink.startArray();
+        sink.longValue(8);
+        sink.booleanValue(true);
+        sink.emptyValue();
+        sink.stringValue("my_string");
+        sink.doubleValue(3.14);
+        sink.endArray();
+
+        gen.flush();
+
+        assertSlime(SlimeUtils.jsonToSlime("[ 8, true, null, 'my_string', 3.14 ]"), out.toSlime());
+    }
+
+    @Test
+    public void testGenerateComplexObject() throws IOException {
+        var factory = createGeneratorFactory();
+        var out = new SlimeOutputStream();
+        var gen = factory.createGenerator(out, JsonEncoding.UTF8);
+        var sink = new JsonGeneratorDataSink(gen);
+
+        sink.startObject();
+
+        // utf16 field name, array value
+        sink.fieldName("numbers", null);
+        sink.startArray();
+        sink.longValue(1);
+        sink.longValue(2);
+        sink.longValue(3);
+        sink.endArray();
+
+        // utf8 field name, nested object
+        sink.fieldName(null, "nested".getBytes(StandardCharsets.UTF_8));
+        sink.startObject();
+        sink.fieldName("flag", null);
+        sink.booleanValue(true);
+
+        sink.fieldName(null, "text".getBytes(StandardCharsets.UTF_8));
+        sink.stringValue(null, "æøå".getBytes(StandardCharsets.UTF_8));
+        sink.endObject();
+
+        sink.endObject();
+
+        gen.flush();
+
+        var expected = SlimeUtils.jsonToSlime(
+                "{ " +
+                "  numbers: [1, 2, 3]," +
+                "  nested: { flag: true, text: 'æøå' }" +
+                "}"
+        );
+        assertSlime(expected, out.toSlime());
+    }
+
+    @Test
+    public void testGenerateComplexArray() throws IOException {
+        var factory = createGeneratorFactory();
+        var out = new SlimeOutputStream();
+        var gen = factory.createGenerator(out, JsonEncoding.UTF8);
+        var sink = new JsonGeneratorDataSink(gen);
+
+        sink.startArray();
+
+        // First element: object
+        sink.startObject();
+        sink.fieldName("id", null);
+        sink.longValue(1);
+        sink.fieldName("label", null);
+        sink.stringValue("first", null);
+        sink.endObject();
+
+        // Second element: primitives
+        sink.longValue(42);
+        sink.booleanValue(false);
+
+        // Third element: nested array
+        sink.startArray();
+        sink.stringValue("a", null);
+        sink.stringValue("b", null);
+        sink.endArray();
+
+        sink.endArray();
+
+        gen.flush();
+
+        var expected = SlimeUtils.jsonToSlime(
+                "[" +
+                        "  { id: 1, label: 'first' }," +
+                        "  42," +
+                        "  false," +
+                        "  [ 'a', 'b' ]" +
+                        "]"
+        );
+        assertSlime(expected, out.toSlime());
+    }
+
+    @Test
+    public void testGenerateLongVariations() throws IOException {
+        var factory = createGeneratorFactory();
+        var out = new SlimeOutputStream();
+        var gen = factory.createGenerator(out, JsonEncoding.UTF8);
+        var sink = new JsonGeneratorDataSink(gen);
+
+        sink.startArray();
+        sink.byteValue((byte) 1);
+        sink.shortValue((short) 2);
+        sink.intValue(3);
+        sink.longValue(4L);
+        sink.endArray();
+
+        gen.flush();
+
+        var expected = SlimeUtils.jsonToSlime("[ 1, 2, 3, 4 ]");
+        assertSlime(expected, out.toSlime());
+    }
+
+    @Test
+    public void testGenerateDoubleVariations() throws IOException {
+        var factory = createGeneratorFactory();
+        var out = new SlimeOutputStream();
+        var gen = factory.createGenerator(out, JsonEncoding.UTF8);
+        var sink = new JsonGeneratorDataSink(gen);
+
+        sink.startArray();
+        sink.doubleValue(1.5);
+        sink.floatValue(2.5f);
+        sink.endArray();
+
+        gen.flush();
+
+        var expected = SlimeUtils.jsonToSlime("[ 1.5, 2.5 ]");
+        assertSlime(expected, out.toSlime());
+    }
+
+    @Test
+    public void testGenerateDataValueThrows() throws IOException {
+        var factory = createGeneratorFactory();
+        var gen = factory.createGenerator(new OutputStream() {
+            @Override
+            public void write(int i) {
+                // no-op
+                // no-op
+            }
+        }, JsonEncoding.UTF8);
+
+        var sink = new JsonGeneratorDataSink(gen);
+        assertThrows(UnsupportedOperationException.class, () -> sink.dataValue(new byte[]{}));
+    }
+}

--- a/searchlib/src/main/java/com/yahoo/searchlib/aggregation/QuantileAggregationResult.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/aggregation/QuantileAggregationResult.java
@@ -2,6 +2,8 @@
 package com.yahoo.searchlib.aggregation;
 
 import com.yahoo.data.JsonProducer;
+import com.yahoo.data.disclosure.DataSink;
+import com.yahoo.data.disclosure.DataSource;
 import com.yahoo.searchlib.expression.FloatResultNode;
 import com.yahoo.searchlib.expression.ResultNode;
 import com.yahoo.vespa.objects.Deserializer;
@@ -70,7 +72,7 @@ public class QuantileAggregationResult extends AggregationResult {
      *
      * @param entries
      */
-    public record QuantileResult(List<Entry> entries) implements JsonProducer {
+    public record QuantileResult(List<Entry> entries) implements JsonProducer, DataSource {
 
         @Override
         public StringBuilder writeJson(StringBuilder target) {
@@ -89,6 +91,20 @@ public class QuantileAggregationResult extends AggregationResult {
         @Override
         public String toJson() {
             return JsonProducer.super.toJson();
+        }
+
+        @Override
+        public void emit(DataSink sink) {
+            sink.startArray();
+            for (var entry : entries) {
+                sink.startObject();
+                sink.fieldName("quantile");
+                sink.doubleValue(entry.quantile);
+                sink.fieldName("value");
+                sink.doubleValue(entry.value);
+                sink.endObject();
+            }
+            sink.endArray();
         }
 
         public record Entry(double quantile, double value) {

--- a/searchlib/src/main/java/com/yahoo/searchlib/aggregation/QuantileAggregationResult.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/aggregation/QuantileAggregationResult.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.aggregation;
 
-import com.yahoo.data.JsonProducer;
 import com.yahoo.data.disclosure.DataSink;
 import com.yahoo.data.disclosure.DataSource;
 import com.yahoo.searchlib.expression.FloatResultNode;
@@ -72,26 +71,7 @@ public class QuantileAggregationResult extends AggregationResult {
      *
      * @param entries
      */
-    public record QuantileResult(List<Entry> entries) implements JsonProducer, DataSource {
-
-        @Override
-        public StringBuilder writeJson(StringBuilder target) {
-            target.append('[');
-            for (int i = 0; i < entries.size(); i++) {
-                Entry entry = entries.get(i);
-                target.append("{\"quantile\":").append(entry.quantile).append(",\"value\":").append(entry.value).append('}');
-                if (i < entries.size() - 1) {
-                    target.append(',');
-                }
-            }
-            target.append(']');
-            return target;
-        }
-
-        @Override
-        public String toJson() {
-            return JsonProducer.super.toJson();
-        }
+    public record QuantileResult(List<Entry> entries) implements DataSource {
 
         @Override
         public void emit(DataSink sink) {

--- a/searchlib/src/test/java/com/yahoo/searchlib/aggregation/QuantileAggregationResultTest.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/aggregation/QuantileAggregationResultTest.java
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.aggregation;
+
+import com.yahoo.data.disclosure.slime.SlimeDataSink;
+import com.yahoo.slime.Slime;
+import org.junit.Test;
+import com.yahoo.slime.SlimeUtils;
+
+import java.util.List;
+
+import static com.yahoo.slime.SlimeUtils.toJson;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author johsol
+ */
+public class QuantileAggregationResultTest {
+
+    private void assertSlime(Slime expected, Slime actual) {
+        assertTrue("Expected " + toJson(expected) + " but got " + toJson(actual),
+                expected.get().equalTo(actual.get()));
+    }
+
+    @Test
+    public void testQuantileResultDataSourceEmitsCorrectly() {
+        QuantileAggregationResult quantiles = new QuantileAggregationResult();
+        quantiles.updateSketch(1);
+        quantiles.updateSketch(1);
+        quantiles.updateSketch(2);
+        quantiles.updateSketch(2);
+        quantiles.updateSketch(3);
+        quantiles.setQuantiles(List.of(0.0, 0.5, 1.0));
+
+        Slime output = SlimeDataSink.buildSlime(quantiles.getQuantileResults());
+        assertSlime(SlimeUtils.jsonToSlime("[{quantile: 0.0, value: 1.0}," +
+                                           " {quantile: 0.5, value: 2.0}," +
+                                           " {quantile: 1.0, value: 3.0}]"), output);
+    }
+
+}


### PR DESCRIPTION
Adds `JsonGeneratorDataSink` which encapsulates and delegates the `DataSink` API to Jackson's generator.

`QuantileAggregationResult` was the initial candidate for testing the `DataSource` API.

@andreer fyi