### PR TITLE
Support per-field element gap overrides

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7405,6 +7405,8 @@
       "public void setExplorationSlack(double)",
       "public void setTargetHitsMaxAdjustmentFactor(double)",
       "public void setFilterThreshold(double)",
+      "public java.lang.Integer getElementGapForField(java.lang.String)",
+      "public void setElementGapForField(java.lang.String, java.lang.Object, com.yahoo.search.Query)",
       "public void prepare(com.yahoo.search.query.ranking.RankProperties)",
       "public com.yahoo.search.query.ranking.Matching clone()",
       "public boolean equals(java.lang.Object)",
@@ -7424,6 +7426,7 @@
       "public static final java.lang.String TARGET_HITS_MAX_ADJUSTMENT_FACTOR",
       "public static final java.lang.String FILTER_THRESHOLD",
       "public static final java.lang.String WEAKAND",
+      "public static final java.lang.String ELEMENT_GAP",
       "public java.lang.Double termwiseLimit"
     ]
   },

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5775,6 +5775,8 @@
       "public com.yahoo.search.query.ranking.Matching getMatching()",
       "public com.yahoo.search.query.ranking.SoftTimeout getSoftTimeout()",
       "public com.yahoo.search.query.ranking.Significance getSignificance()",
+      "public java.lang.Integer getElementGapForField(java.lang.String)",
+      "public void setElementGapForField(java.lang.String, java.lang.Object)",
       "public com.yahoo.search.query.Sorting getSorting()",
       "public void setSorting(com.yahoo.search.query.Sorting)",
       "public void setSorting(java.lang.String)",
@@ -5807,7 +5809,8 @@
       "public static final java.lang.String SOFTTIMEOUT",
       "public static final java.lang.String MATCHING",
       "public static final java.lang.String FEATURES",
-      "public static final java.lang.String PROPERTIES"
+      "public static final java.lang.String PROPERTIES",
+      "public static final java.lang.String ELEMENT_GAP"
     ]
   },
   "com.yahoo.search.query.Select" : {
@@ -7405,8 +7408,6 @@
       "public void setExplorationSlack(double)",
       "public void setTargetHitsMaxAdjustmentFactor(double)",
       "public void setFilterThreshold(double)",
-      "public java.lang.Integer getElementGapForField(java.lang.String)",
-      "public void setElementGapForField(java.lang.String, java.lang.Object, com.yahoo.search.Query)",
       "public void prepare(com.yahoo.search.query.ranking.RankProperties)",
       "public com.yahoo.search.query.ranking.Matching clone()",
       "public boolean equals(java.lang.Object)",
@@ -7426,7 +7427,6 @@
       "public static final java.lang.String TARGET_HITS_MAX_ADJUSTMENT_FACTOR",
       "public static final java.lang.String FILTER_THRESHOLD",
       "public static final java.lang.String WEAKAND",
-      "public static final java.lang.String ELEMENT_GAP",
       "public java.lang.Double termwiseLimit"
     ]
   },

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -53,6 +53,7 @@ public class QueryProperties extends Properties {
 
     private static final Set<String> reservedPrefix = Set.of(Model.MODEL, Presentation.PRESENTATION, Select.SELECT, Ranking.RANKING, Trace.TRACE);
 
+
     private record GetterSetter(GetProperty getter, SetProperty setter) {
         static GetterSetter of(GetProperty getter, SetProperty setter) {
             return new GetterSetter(getter, setter);
@@ -181,11 +182,10 @@ public class QueryProperties extends Properties {
         if (key.first().equals(Ranking.RANKING)) {
             Ranking ranking = query.getRanking();
             if (key.size() > 2) {
-                String rest = key.rest().rest().toString();
                 // pass the portion after "ranking.features/properties" down
-                if (key.get(1).equals(Ranking.FEATURES)) return ranking.getFeatures().getObject(rest);
-                if (key.get(1).equals(Ranking.PROPERTIES)) return ranking.getProperties().get(rest);
-                if (key.get(1).equals(Matching.ELEMENT_GAP)) return ranking.getMatching().getElementGapForField(rest);
+                if (key.get(1).equals(Ranking.FEATURES)) return ranking.getFeatures().getObject(key.rest().rest().toString());
+                if (key.get(1).equals(Ranking.PROPERTIES)) return ranking.getProperties().get(key.rest().rest().toString());
+                if (key.get(1).equals(Ranking.ELEMENT_GAP)) return ranking.getElementGapForField(key.rest().rest().toString());
             }
         }
 
@@ -227,9 +227,9 @@ public class QueryProperties extends Properties {
                                                                          profileRegistry.getTypeRegistry().getComponent("properties"),
                                                                          context));
                     return;
-                } else if (key.get(1).equals(Matching.ELEMENT_GAP)) {
-                     Ranking ranking = query.getRanking();
-                     ranking.getMatching().setElementGapForField(restKey, value, query);
+                } else if (key.get(1).equals(Ranking.ELEMENT_GAP)) {
+                    Ranking ranking = query.getRanking();
+                    ranking.setElementGapForField(restKey, value);
                 }
             }
         }

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -53,7 +53,6 @@ public class QueryProperties extends Properties {
 
     private static final Set<String> reservedPrefix = Set.of(Model.MODEL, Presentation.PRESENTATION, Select.SELECT, Ranking.RANKING, Trace.TRACE);
 
-
     private record GetterSetter(GetProperty getter, SetProperty setter) {
         static GetterSetter of(GetProperty getter, SetProperty setter) {
             return new GetterSetter(getter, setter);
@@ -182,9 +181,11 @@ public class QueryProperties extends Properties {
         if (key.first().equals(Ranking.RANKING)) {
             Ranking ranking = query.getRanking();
             if (key.size() > 2) {
+                String rest = key.rest().rest().toString();
                 // pass the portion after "ranking.features/properties" down
-                if (key.get(1).equals(Ranking.FEATURES)) return ranking.getFeatures().getObject(key.rest().rest().toString());
-                if (key.get(1).equals(Ranking.PROPERTIES)) return ranking.getProperties().get(key.rest().rest().toString());
+                if (key.get(1).equals(Ranking.FEATURES)) return ranking.getFeatures().getObject(rest);
+                if (key.get(1).equals(Ranking.PROPERTIES)) return ranking.getProperties().get(rest);
+                if (key.get(1).equals(Matching.ELEMENT_GAP)) return ranking.getMatching().getElementGapForField(rest);
             }
         }
 
@@ -226,6 +227,9 @@ public class QueryProperties extends Properties {
                                                                          profileRegistry.getTypeRegistry().getComponent("properties"),
                                                                          context));
                     return;
+                } else if (key.get(1).equals(Matching.ELEMENT_GAP)) {
+                     Ranking ranking = query.getRanking();
+                     ranking.getMatching().setElementGapForField(restKey, value, query);
                 }
             }
         }

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/Matching.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/Matching.java
@@ -6,11 +6,8 @@ import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileFieldType;
 import com.yahoo.search.query.profile.types.QueryProfileType;
-import com.yahoo.search.result.ErrorMessage;
 
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -35,7 +32,6 @@ public class Matching implements Cloneable {
     public static final String TARGET_HITS_MAX_ADJUSTMENT_FACTOR = "targetHitsMaxAdjustmentFactor";
     public static final String FILTER_THRESHOLD = "filterThreshold";
     public static final String WEAKAND = "weakand";
-    public static final String ELEMENT_GAP = "elementGap";
 
     static {
         argumentType = new QueryProfileType(Ranking.MATCHING);
@@ -70,7 +66,6 @@ public class Matching implements Cloneable {
     private Double targetHitsMaxAdjustmentFactor = null;
     private Double filterThreshold = null;
     private WeakAnd weakAnd = new WeakAnd();
-    private Map<String, Integer> elementGap = new HashMap<>();
 
     public Double getTermwiseLimit() { return termwiseLimit; }
     public Integer getNumThreadsPerSearch() { return numThreadsPerSearch; }
@@ -129,28 +124,6 @@ public class Matching implements Cloneable {
         filterThreshold = threshold;
     }
 
-    /** Returns the element gap value for the given field, or null if not set */
-    public Integer getElementGapForField(String fieldName) {
-        return elementGap.get(fieldName);
-    }
-
-    /** Sets the element gap value for the given field */
-    public void setElementGapForField(String fieldName, Object value, com.yahoo.search.Query parent) {
-        if (value == null) {
-            elementGap.remove(fieldName);
-        } else if (value instanceof Integer gap)  {
-            elementGap.put(fieldName, gap);
-        } else {
-            try {
-                elementGap.put(fieldName, Integer.parseInt(String.valueOf(value)));
-            } catch (NumberFormatException e) {
-                parent.errors().add(ErrorMessage.createInvalidQueryParameter(
-                        "Element gap value for field '" + fieldName + "' could not be converted from '"
-                        + value + "' to integer"));
-            }
-        }
-    }
-
     /** Internal operation - DO NOT USE */
     public void prepare(RankProperties rankProperties) {
         if (termwiseLimit != null) {
@@ -186,9 +159,6 @@ public class Matching implements Cloneable {
         if (filterThreshold != null) {
             rankProperties.put("vespa.matching.filter_threshold", String.valueOf(filterThreshold));
         }
-        for (Map.Entry<String, Integer> entry : elementGap.entrySet()) {
-            rankProperties.put("vespa.matching.element_gap." + entry.getKey(), String.valueOf(entry.getValue()));
-        }
         weakAnd.prepare(rankProperties);
     }
 
@@ -197,7 +167,6 @@ public class Matching implements Cloneable {
         try {
             var clone =  (Matching) super.clone();
             clone.weakAnd = this.weakAnd.clone();
-            clone.elementGap = new HashMap<>(this.elementGap);
             return clone;
         }
         catch (CloneNotSupportedException e) {
@@ -221,14 +190,14 @@ public class Matching implements Cloneable {
                Objects.equals(explorationSlack, matching.explorationSlack) &&
                Objects.equals(targetHitsMaxAdjustmentFactor, matching.targetHitsMaxAdjustmentFactor) &&
                Objects.equals(filterThreshold, matching.filterThreshold) &&
-               Objects.equals(weakAnd, matching.weakAnd) &&
-               Objects.equals(elementGap, matching.elementGap);
+               Objects.equals(weakAnd, matching.weakAnd);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(termwiseLimit, numThreadsPerSearch, numSearchPartitions, minHitsPerThread,
                             postFilterThreshold, approximateThreshold, filterFirstThreshold, filterFirstExploration,
-                            explorationSlack, targetHitsMaxAdjustmentFactor, filterThreshold, weakAnd, elementGap);
+                            explorationSlack, targetHitsMaxAdjustmentFactor, filterThreshold, weakAnd);
     }
 }
+


### PR DESCRIPTION
Enables setting element gap values per field through the query API via ranking.elementGap.<fieldname> parameters. Element gaps are used for both matching (NEAR/ONEAR) and ranking.

@toregge and/or @bratseth please review
