### PR TITLE
Expose node flavor hardware resource info to distributors via config

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
@@ -3,7 +3,11 @@ package com.yahoo.vespa.model.search;
 
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.vespa.config.search.core.ProtonConfig;
-import com.yahoo.vespa.model.Host;
+import com.yahoo.vespa.model.utils.ResourceUtils;
+
+import static com.yahoo.vespa.model.utils.ResourceUtils.MiB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.GiB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.GB;
 
 import static java.lang.Long.min;
 import static java.lang.Long.max;
@@ -20,9 +24,6 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
     private final static double MEMORY_GAIN_AS_FRACTION_OF_MEMORY = 0.08;
     private final static double MIN_MEMORY_PER_FLUSH_THREAD_GB = 11.0;
     private final static double TLS_SIZE_FRACTION = 0.02;
-    final static long MiB = 1024 * 1024;
-    public final static long GiB = MiB * 1024;
-    public final static long GB = 1_000_000_000;
     private final NodeResources resources;
     private final int threadsPerSearch;
 
@@ -52,7 +53,7 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
     private void setHwInfo(ProtonConfig.Builder builder) {
         builder.hwinfo.disk.shared(true);
         builder.hwinfo.cpu.cores((int)resources.vcpu());
-        builder.hwinfo.memory.size((long)(usableMemoryGb() * GiB));
+        builder.hwinfo.memory.size((long)(usableMemoryGb() * GiB)); // TODO Gb vs GiB?!
         builder.hwinfo.disk.size((long)(resources.diskGb() * GB));
     }
 
@@ -103,7 +104,7 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
 
     /** Returns the memory we can expect will be available for the content node processes */
     private double usableMemoryGb() {
-        return resources.memoryGiB() - Host.memoryOverheadGb;
+        return ResourceUtils.usableMemoryGb(resources);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/utils/ResourceUtils.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/utils/ResourceUtils.java
@@ -1,0 +1,39 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.utils;
+
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.vespa.model.Host;
+
+/**
+ * Very simple utility functionality for adjusting or converting resource values.
+ *
+ * @author vekterli
+ */
+public class ResourceUtils {
+
+    public final static long MiB = 1024 * 1024;
+    public final static long GiB = MiB * 1024;
+    public final static long GB  = 1_000_000_000;
+
+    /**
+     * Returns the amount of actually usable memory (in GiB) once the fixed
+     * host overhead has been accounted for.
+     *
+     * @param memoryGiB Non-adjusted host memory in GiB
+     * @return memory in GiB after host overhead has been subtracted
+     */
+    public static double usableMemoryGb(double memoryGiB) {
+        // Assume, for simplicity, that we can't have negative amounts of RAM.
+        // TODO Gb or GiB...? Units need to match since these are floats of how
+        //  many GiBs (or GBs!) there are, not the number of bytes...!
+        return Math.max(memoryGiB - Host.memoryOverheadGb, 0);
+    }
+
+    /**
+     * Returns {@link #usableMemoryGb(double)} from {@link NodeResources#memoryGiB()}.
+     */
+    public static double usableMemoryGb(NodeResources resources) {
+        return usableMemoryGb(resources.memoryGiB());
+    }
+
+}

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -68,7 +68,7 @@ import static com.yahoo.config.provision.NodeResources.DiskSpeed;
 import static com.yahoo.config.provision.NodeResources.StorageType;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import static com.yahoo.vespa.model.Host.memoryOverheadGb;
-import static com.yahoo.vespa.model.search.NodeResourcesTuning.GiB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.GiB;
 import static com.yahoo.vespa.model.test.utils.ApplicationPackageUtils.generateSchemas;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -44,8 +44,12 @@ import com.yahoo.vespa.model.routing.DocumentProtocol;
 import com.yahoo.vespa.model.routing.Routing;
 import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
+import com.yahoo.vespa.model.utils.ResourceUtils;
 import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
+
+import static com.yahoo.vespa.model.utils.ResourceUtils.GiB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.GB;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -1727,6 +1731,35 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(2, inferSearchNodeInitializerThreadsFromFlag(null)); // Default is number of doc types
         assertEquals(2, inferSearchNodeInitializerThreadsFromFlag(0)); // Default is number of doc types
         assertEquals(8, inferSearchNodeInitializerThreadsFromFlag(8));
+    }
+
+    private static void assertResourceSettingsPropagated(StorDistributormanagerConfig.Hwinfo hw, NodeResources expected) {
+        assertEquals((long)Math.ceil(expected.vcpu()), hw.cpu().cores()); // rounded up
+        assertEquals((long)(ResourceUtils.usableMemoryGb(expected.memoryGiB()) * GiB), hw.memory().size());
+        assertEquals((long)(expected.diskGb() * GB), hw.disk().size());
+    }
+
+    @Test
+    void present_node_resources_are_propagate_to_distributor_config() throws Exception {
+        var resources = new NodeResources(9.5/*vCPU*/, 16/*mem*/, 300/*disk*/, 100/*bandwidth*/);
+        var flavor = new Flavor("chocolate_and_pistachio", resources);
+        var cc = createOneNodeCluster(new TestProperties(), Optional.of(flavor));
+
+        var builder = new StorDistributormanagerConfig.Builder();
+        cc.getDistributorNodes().getConfig(builder);
+        cc.getDistributorNodes().getChildren().get("0").getConfig(builder);
+        assertResourceSettingsPropagated(builder.build().hwinfo(), resources);
+    }
+
+    @Test
+    void non_present_node_resources_emit_default_values_in_distributor_config() throws Exception {
+        var emptyResources = new NodeResources(0/*vCPU*/, 0/*mem*/, 0/*disk*/, 0/*bandwidth*/);
+        var cc = createOneNodeCluster(new TestProperties(), Optional.empty());
+
+        var builder = new StorDistributormanagerConfig.Builder();
+        cc.getDistributorNodes().getConfig(builder);
+        cc.getDistributorNodes().getChildren().get("0").getConfig(builder);
+        assertResourceSettingsPropagated(builder.build().hwinfo(), emptyResources);
     }
 
     private String servicesWithGroups(int groupCount, double minGroupUpRatio) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/NodeResourcesTuningTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/NodeResourcesTuningTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import static com.yahoo.vespa.model.Host.memoryOverheadGb;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static com.yahoo.vespa.model.search.NodeResourcesTuning.MiB;
-import static com.yahoo.vespa.model.search.NodeResourcesTuning.GiB;
-import static com.yahoo.vespa.model.search.NodeResourcesTuning.GB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.MiB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.GiB;
+import static com.yahoo.vespa.model.utils.ResourceUtils.GB;
 
 /**
  * @author geirst

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -185,3 +185,20 @@ priority_merge_out_of_sync_copies int default=120
 ## TODO GC as it has no effect
 use_btree_database bool default=true
 
+##
+## Node hardware info; this is a subset of what's present in `proton.def`, allowing
+## distributor processes to make an informed decision about how to scale internal
+## resource pools and limits. Content nodes already get their HW info directly from
+## Proton, as it owns the content node components.
+## If there is no host flavor associated with the node, these fields will be zero
+## and the node will fall back to default (and/or locally inferred) values.
+##
+
+## The size of the disk partition (in bytes) on which the node's basedir is located.
+hwinfo.disk.size long default = 0 restart
+
+## The size of physical memory (in bytes) available to the distributor.
+hwinfo.memory.size long default = 0 restart
+
+## The number of cores on the cpu.
+hwinfo.cpu.cores int default = 0 restart


### PR DESCRIPTION
@hmusum please review

Wire CPU/memory/disk info to the distributor via its main `stor-distributormanager` config. Content nodes do not receive explicit HW info via config, but instead get this "injected" from the parent Proton component which gets a superset of this information via its `proton.def` config.

Note that this PR just makes the resource information available (iff present) via config, it does not add any distributor-side wiring.