### PR TITLE
Add `SlimeDataSink` for testing

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
+++ b/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
@@ -32,7 +32,7 @@ public class SlimeDataSink implements DataSink {
         this.rootInserter = inserter;
     }
 
-    static Slime buildSlime(DataSource source) {
+    public static Slime buildSlime(DataSource source) {
         var slime = new Slime();
         var inserter = new SlimeInserter(slime);
         var sink = new SlimeDataSink(inserter);

--- a/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
+++ b/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
@@ -31,17 +31,13 @@ public class SlimeDataSink implements DataSink {
         return slime;
     }
 
-    private Cursor top() {
-        return stack.peek();
-    }
-
     private Inserter makeInserter() {
         if (stack.isEmpty()) {
             return new SlimeInserter(slime);
-        } else if (top().type() == Type.OBJECT) {
-            return new ObjectInserter(top(), key);
+        } else if (stack.peek().type() == Type.OBJECT) {
+            return new ObjectInserter(stack.peek(), key);
         } else {
-            return new ArrayInserter(top());
+            return new ArrayInserter(stack.peek());
         }
     }
 

--- a/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
+++ b/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
@@ -1,0 +1,156 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.data.disclosure.slime;
+
+import com.yahoo.data.disclosure.DataSink;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Slime;
+import com.yahoo.slime.Type;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Slime builder that objects implementing {@link com.yahoo.data.disclosure.DataSource} can emit into.
+ * <p>
+ * This class is intended for testing. Should not be used in production.
+ *
+ * @author johsol
+ */
+public class SlimeDataSink implements DataSink {
+
+    private Slime slime = new Slime();
+    private Cursor root;
+    private Deque<Cursor> stack = new ArrayDeque<>();
+    private String key;
+
+    public Slime getSlime() {
+        return slime;
+    }
+
+    private boolean topIsObject() {
+        return !stack.isEmpty() && stack.peek().type() == Type.OBJECT;
+    }
+
+    private Cursor top() {
+        return stack.peek();
+    }
+
+    @Override
+    public void fieldName(String utf16, byte[] utf8) {
+        if (utf16 != null) {
+            key = utf16;
+        } else {
+            // since this class is intended for testing we convert the string to utf16 in this case
+            key = new String(utf8, StandardCharsets.UTF_8);
+        }
+    }
+
+    @Override
+    public void startObject() {
+        if (root == null) {
+            root = slime.setObject();
+            stack.push(root);
+        } else {
+            if (topIsObject()) {
+                var obj = top().setObject(key);
+                stack.push(obj);
+            } else {
+                var obj = top().addObject();
+                stack.push(obj);
+            }
+        }
+    }
+
+    @Override
+    public void endObject() {
+        if (!stack.isEmpty()) {
+            stack.pop();
+        }
+    }
+
+    @Override
+    public void startArray() {
+        if (root == null) {
+            root = slime.setArray();
+            stack.push(root);
+        } else {
+            if (topIsObject()) {
+                var obj = top().setArray(key);
+                stack.push(obj);
+            } else {
+                var arr = top().addArray();
+                stack.push(arr);
+            }
+        }
+    }
+
+    @Override
+    public void endArray() {
+        if (!stack.isEmpty()) {
+            stack.pop();
+        }
+    }
+
+    @Override
+    public void emptyValue() {
+        if (topIsObject()) {
+            top().setNix(key);
+        } else {
+            top().addNix();
+        }
+    }
+
+    @Override
+    public void booleanValue(boolean v) {
+        if (topIsObject()) {
+            top().setBool(key, v);
+        } else {
+            top().addBool(v);
+        }
+    }
+
+    @Override
+    public void longValue(long v) {
+        if (topIsObject()) {
+            top().setLong(key, v);
+        } else {
+            top().addLong(v);
+        }
+    }
+
+    @Override
+    public void doubleValue(double v) {
+        if (topIsObject()) {
+            top().setDouble(key, v);
+        } else {
+            top().addDouble(v);
+        }
+    }
+
+    @Override
+    public void stringValue(String utf16, byte[] utf8) {
+        String v;
+        if (utf16 != null) {
+            v = utf16;
+        } else {
+            // since this class is intended for testing we convert the string to utf16 in this case
+            v = new String(utf8, StandardCharsets.UTF_8);
+        }
+
+        if (topIsObject()) {
+            top().setString(key, v);
+        } else {
+            top().addString(v);
+        }
+    }
+
+    @Override
+    public void dataValue(byte[] data) {
+        if (topIsObject()) {
+            top().setData(key, data);
+        } else {
+            top().addData(data);
+        }
+    }
+}

--- a/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
+++ b/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/SlimeDataSink.java
@@ -2,6 +2,7 @@
 package com.yahoo.data.disclosure.slime;
 
 import com.yahoo.data.disclosure.DataSink;
+import com.yahoo.data.disclosure.DataSource;
 import com.yahoo.slime.ArrayInserter;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inserter;
@@ -23,17 +24,25 @@ import java.util.Deque;
  */
 public class SlimeDataSink implements DataSink {
 
-    private Slime slime = new Slime();
+    private Inserter rootInserter;
     private Deque<Cursor> stack = new ArrayDeque<>();
     private String key;
 
-    public Slime getSlime() {
+    public SlimeDataSink(Inserter inserter) {
+        this.rootInserter = inserter;
+    }
+
+    static Slime buildSlime(DataSource source) {
+        var slime = new Slime();
+        var inserter = new SlimeInserter(slime);
+        var sink = new SlimeDataSink(inserter);
+        source.emit(sink);
         return slime;
     }
 
     private Inserter makeInserter() {
         if (stack.isEmpty()) {
-            return new SlimeInserter(slime);
+            return rootInserter;
         } else if (stack.peek().type() == Type.OBJECT) {
             return new ObjectInserter(stack.peek(), key);
         } else {

--- a/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/package-info.java
+++ b/vespajlib/src/main/java/com/yahoo/data/disclosure/slime/package-info.java
@@ -1,0 +1,6 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+@ExportPackage
+package com.yahoo.data.disclosure.slime;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
@@ -49,7 +49,7 @@ public class SlimeDataSinkTestCase {
         var expected = SlimeUtils.jsonToSlime("{ int: 1024, " +
                                               "  bool: true," +
                                               "  double: 3.5," +
-                                              "  string: \"hello\" }");
+                                              "  string: 'hello' }");
 
         expected.get().setData("data", bytes);
         expected.get().setNix("empty");
@@ -70,7 +70,7 @@ public class SlimeDataSinkTestCase {
         sink.emptyValue();
         sink.endArray();
 
-        var expected = SlimeUtils.jsonToSlime("[1, true, 2.5, \"foo\"]");
+        var expected = SlimeUtils.jsonToSlime("[1, true, 2.5, 'foo']");
         var arr = expected.get();
         arr.addData(bytes);
         arr.addNix();
@@ -182,7 +182,7 @@ public class SlimeDataSinkTestCase {
         {
             var sink = new SlimeDataSink();
             sink.stringValue("some_string");
-            var expected = SlimeUtils.jsonToSlime("\"some_string\"");
+            var expected = SlimeUtils.jsonToSlime("'some_string'");
             assertSlime(expected, sink.getSlime());
         }
     }

--- a/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
@@ -1,0 +1,193 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.data.disclosure.slime;
+
+import com.yahoo.slime.Slime;
+import com.yahoo.slime.SlimeUtils;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author johsol
+ */
+public class SlimeDataSinkTestCase {
+
+    @Test
+    public void testValuesInObject() {
+        var sink = new SlimeDataSink();
+        sink.startObject();
+
+        sink.fieldName("int");
+        sink.intValue(1024);
+
+        sink.fieldName("bool");
+        sink.booleanValue(true);
+
+        sink.fieldName("empty");
+        sink.emptyValue();
+
+        sink.fieldName("double");
+        sink.doubleValue(3.5);
+
+        sink.fieldName("string");
+        sink.stringValue("hello");
+
+        byte[] bytes = new byte[]{1, 2, 3};
+        sink.fieldName("data");
+        sink.dataValue(bytes);
+
+        sink.endObject();
+
+        var expected = new Slime();
+        var obj = expected.setObject();
+        obj.setLong("int", 1024);
+        obj.setBool("bool", true);
+        obj.setNix("empty");
+        obj.setDouble("double", 3.5);
+        obj.setString("string", "hello");
+        obj.setData("data", bytes);
+
+        assertTrue(expected.get().equalTo(sink.getSlime().get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+    }
+
+    @Test
+    public void testValuesInArray() {
+        var sink = new SlimeDataSink();
+        sink.startArray();
+        // [1, true, nix, 2.5, "foo", byte[9,8]]
+        sink.longValue(1L);
+        sink.booleanValue(true);
+        sink.emptyValue();
+        sink.doubleValue(2.5);
+        sink.stringValue("foo");
+        byte[] bytes = new byte[]{9, 8};
+        sink.dataValue(bytes);
+        sink.endArray();
+
+        var expected = new Slime();
+        var arr = expected.setArray();
+        arr.addLong(1L);
+        arr.addBool(true);
+        arr.addNix();
+        arr.addDouble(2.5);
+        arr.addString("foo");
+        arr.addData(bytes);
+
+        assertTrue(expected.get().equalTo(sink.getSlime().get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+    }
+
+    @Test
+    public void testNestedObjectAndArray() {
+        var sink = new SlimeDataSink();
+        sink.startObject();
+
+        // nums: [1, 2]
+        sink.fieldName("nums");
+        sink.startArray();
+        sink.longValue(1L);
+        sink.longValue(2L);
+        sink.endArray();
+
+        // meta: { ok: true }
+        sink.fieldName("meta");
+        sink.startObject();
+        sink.fieldName("ok");
+        sink.booleanValue(true);
+        sink.endObject();
+
+        sink.endObject();
+
+        var expected = new Slime();
+        var root = expected.setObject();
+        var nums = root.setArray("nums");
+        nums.addLong(1L);
+        nums.addLong(2L);
+        var meta = root.setObject("meta");
+        meta.setBool("ok", true);
+
+        assertTrue(expected.get().equalTo(sink.getSlime().get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+    }
+
+    @Test
+    public void testArrayOfObjects() {
+        var sink = new SlimeDataSink();
+
+        // [{ "id": 1 }, { "id2", 2 }]
+        sink.startArray();
+
+        sink.startObject();
+        sink.fieldName("id");
+        sink.longValue(1L);
+        sink.endObject();
+
+        sink.startObject();
+        sink.fieldName("id");
+        sink.longValue(2L);
+        sink.endObject();
+
+        sink.endArray();
+
+        var expected = new Slime();
+        var arr = expected.setArray();
+        var o1 = arr.addObject();
+        o1.setLong("id", 1L);
+        var o2 = arr.addObject();
+        o2.setLong("id", 2L);
+
+        assertTrue(expected.get().equalTo(sink.getSlime().get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+    }
+
+    @Test
+    public void testHandlesFieldNameUtf8AndUtf16() {
+        var sink = new SlimeDataSink();
+
+        // { "utf8_name": 1, "utf16_name": 2 }
+        sink.startObject();
+        sink.fieldName("utf8_name".getBytes(StandardCharsets.UTF_8));
+        sink.intValue(1);
+        sink.fieldName("utf16_name".getBytes(StandardCharsets.UTF_8));
+        sink.intValue(2);
+        sink.endObject();
+
+        var expected = new Slime();
+        var obj = expected.setObject();
+        obj.setLong("utf8_name", 1);
+        obj.setLong("utf16_name", 2);
+
+        assertTrue(expected.get().equalTo(sink.getSlime().get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+    }
+
+    @Test
+    public void testNumericDefaultDelegates() {
+        var sink = new SlimeDataSink();
+        sink.startArray();
+        sink.intValue(10);
+        sink.shortValue((short) 20);
+        sink.byteValue((byte) 30);
+        sink.floatValue(1.5f);
+        sink.endArray();
+
+        var expected = new Slime();
+        var arr = expected.setArray();
+        arr.addLong(10);
+        arr.addLong(20);
+        arr.addLong(30);
+        arr.addDouble(1.5f); // floatValue delegates to doubleValue
+
+        assertTrue(expected.get().equalTo(sink.getSlime().get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+    }
+}

--- a/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.data.disclosure.slime;
 
 import com.yahoo.slime.Slime;
+import com.yahoo.slime.SlimeInserter;
 import com.yahoo.slime.SlimeUtils;
 import org.junit.Test;
 
@@ -16,13 +17,14 @@ public class SlimeDataSinkTestCase {
 
     private void assertSlime(Slime expected, Slime actual) {
         assertTrue(expected.get().equalTo(actual.get()),
-                    () -> "Expected " + SlimeUtils.toJson(expected) +
-                            " but got " + SlimeUtils.toJson(actual));
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(actual));
     }
 
     @Test
     public void testValuesInObject() {
-        var sink = new SlimeDataSink();
+        var slime = new Slime();
+        var sink = new SlimeDataSink(new SlimeInserter(slime));
         sink.startObject();
 
         sink.fieldName("int");
@@ -47,18 +49,19 @@ public class SlimeDataSinkTestCase {
         sink.endObject();
 
         var expected = SlimeUtils.jsonToSlime("{ int: 1024, " +
-                                              "  bool: true," +
-                                              "  double: 3.5," +
-                                              "  string: 'hello' }");
+                "  bool: true," +
+                "  double: 3.5," +
+                "  string: 'hello' }");
 
         expected.get().setData("data", bytes);
         expected.get().setNix("empty");
-        assertSlime(expected, sink.getSlime());
+        assertSlime(expected, slime);
     }
 
     @Test
     public void testValuesInArray() {
-        var sink = new SlimeDataSink();
+        var slime = new Slime();
+        var sink = new SlimeDataSink(new SlimeInserter(slime));
         sink.startArray();
         // [1, true, nix, 2.5, "foo", byte[9,8]]
         sink.longValue(1L);
@@ -75,12 +78,13 @@ public class SlimeDataSinkTestCase {
         arr.addData(bytes);
         arr.addNix();
 
-        assertSlime(expected, sink.getSlime());
+        assertSlime(expected, slime);
     }
 
     @Test
     public void testNestedObjectAndArray() {
-        var sink = new SlimeDataSink();
+        var slime = new Slime();
+        var sink = new SlimeDataSink(new SlimeInserter(slime));
         sink.startObject();
 
         // nums: [1, 2]
@@ -100,12 +104,13 @@ public class SlimeDataSinkTestCase {
         sink.endObject();
 
         var expected = SlimeUtils.jsonToSlime("{ nums: [1, 2], meta: { ok: true } }");
-        assertSlime(expected, sink.getSlime());
+        assertSlime(expected, slime);
     }
 
     @Test
     public void testArrayOfObjects() {
-        var sink = new SlimeDataSink();
+        var slime = new Slime();
+        var sink = new SlimeDataSink(new SlimeInserter(slime));
 
         // [{ "id": 1 }, { "id2", 2 }]
         sink.startArray();
@@ -123,12 +128,13 @@ public class SlimeDataSinkTestCase {
         sink.endArray();
 
         var expected = SlimeUtils.jsonToSlime("[ { id: 1 }, { id: 2 } ]");
-        assertSlime(expected, sink.getSlime());
+        assertSlime(expected, slime);
     }
 
     @Test
     public void testHandlesFieldNameUtf8AndUtf16() {
-        var sink = new SlimeDataSink();
+        var slime = new Slime();
+        var sink = new SlimeDataSink(new SlimeInserter(slime));
 
         // { "utf8_name": 1, "utf16_name": 2 }
         sink.startObject();
@@ -139,12 +145,14 @@ public class SlimeDataSinkTestCase {
         sink.endObject();
 
         var expected = SlimeUtils.jsonToSlime("{ utf8_name: 1, utf16_name: 2 }");
-        assertSlime(expected, sink.getSlime());
+        assertSlime(expected, slime);
     }
 
     @Test
     public void testNumericDefaultDelegates() {
-        var sink = new SlimeDataSink();
+        var slime = new Slime();
+        var sink = new SlimeDataSink(new SlimeInserter(slime));
+
         sink.startArray();
         sink.intValue(10);
         sink.shortValue((short) 20);
@@ -153,37 +161,41 @@ public class SlimeDataSinkTestCase {
         sink.endArray();
 
         var expected = SlimeUtils.jsonToSlime("[ 10, 20, 30, 1.5 ]");
-        assertSlime(expected, sink.getSlime());
+        assertSlime(expected, slime);
     }
 
     @Test
     public void testLeafValues() {
         {
-            var sink = new SlimeDataSink();
+            var slime = new Slime();
+            var sink = new SlimeDataSink(new SlimeInserter(slime));
             sink.intValue(1);
             var expected = SlimeUtils.jsonToSlime("1");
-            assertSlime(expected, sink.getSlime());
+            assertSlime(expected, slime);
         }
 
         {
-            var sink = new SlimeDataSink();
+            var slime = new Slime();
+            var sink = new SlimeDataSink(new SlimeInserter(slime));
             sink.booleanValue(true);
             var expected = SlimeUtils.jsonToSlime("true");
-            assertSlime(expected, sink.getSlime());
+            assertSlime(expected, slime);
         }
 
         {
-            var sink = new SlimeDataSink();
+            var slime = new Slime();
+            var sink = new SlimeDataSink(new SlimeInserter(slime));
             sink.doubleValue(3.14);
             var expected = SlimeUtils.jsonToSlime("3.14");
-            assertSlime(expected, sink.getSlime());
+            assertSlime(expected, slime);
         }
 
         {
-            var sink = new SlimeDataSink();
+            var slime = new Slime();
+            var sink = new SlimeDataSink(new SlimeInserter(slime));
             sink.stringValue("some_string");
             var expected = SlimeUtils.jsonToSlime("'some_string'");
-            assertSlime(expected, sink.getSlime());
+            assertSlime(expected, slime);
         }
     }
 }

--- a/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
@@ -14,6 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class SlimeDataSinkTestCase {
 
+    private void assertSlime(Slime expected, Slime actual) {
+        assertTrue(expected.get().equalTo(actual.get()),
+                    () -> "Expected " + SlimeUtils.toJson(expected) +
+                            " but got " + SlimeUtils.toJson(actual));
+    }
+
     @Test
     public void testValuesInObject() {
         var sink = new SlimeDataSink();
@@ -49,9 +55,7 @@ public class SlimeDataSinkTestCase {
         obj.setString("string", "hello");
         obj.setData("data", bytes);
 
-        assertTrue(expected.get().equalTo(sink.getSlime().get()),
-                () -> "Expected " + SlimeUtils.toJson(expected) +
-                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+        assertSlime(expected, sink.getSlime());
     }
 
     @Test
@@ -77,9 +81,7 @@ public class SlimeDataSinkTestCase {
         arr.addString("foo");
         arr.addData(bytes);
 
-        assertTrue(expected.get().equalTo(sink.getSlime().get()),
-                () -> "Expected " + SlimeUtils.toJson(expected) +
-                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+        assertSlime(expected, sink.getSlime());
     }
 
     @Test
@@ -111,9 +113,7 @@ public class SlimeDataSinkTestCase {
         var meta = root.setObject("meta");
         meta.setBool("ok", true);
 
-        assertTrue(expected.get().equalTo(sink.getSlime().get()),
-                () -> "Expected " + SlimeUtils.toJson(expected) +
-                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+        assertSlime(expected, sink.getSlime());
     }
 
     @Test
@@ -142,9 +142,7 @@ public class SlimeDataSinkTestCase {
         var o2 = arr.addObject();
         o2.setLong("id", 2L);
 
-        assertTrue(expected.get().equalTo(sink.getSlime().get()),
-                () -> "Expected " + SlimeUtils.toJson(expected) +
-                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+        assertSlime(expected, sink.getSlime());
     }
 
     @Test
@@ -164,9 +162,7 @@ public class SlimeDataSinkTestCase {
         obj.setLong("utf8_name", 1);
         obj.setLong("utf16_name", 2);
 
-        assertTrue(expected.get().equalTo(sink.getSlime().get()),
-                () -> "Expected " + SlimeUtils.toJson(expected) +
-                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+        assertSlime(expected, sink.getSlime());
     }
 
     @Test
@@ -186,8 +182,37 @@ public class SlimeDataSinkTestCase {
         arr.addLong(30);
         arr.addDouble(1.5f); // floatValue delegates to doubleValue
 
-        assertTrue(expected.get().equalTo(sink.getSlime().get()),
-                () -> "Expected " + SlimeUtils.toJson(expected) +
-                        " but got " + SlimeUtils.toJson(sink.getSlime()));
+        assertSlime(expected, sink.getSlime());
+    }
+
+    @Test
+    public void testLeafValues() {
+        {
+            var sink = new SlimeDataSink();
+            sink.intValue(1);
+            var expected = SlimeUtils.jsonToSlime("1");
+            assertSlime(expected, sink.getSlime());
+        }
+
+        {
+            var sink = new SlimeDataSink();
+            sink.booleanValue(true);
+            var expected = SlimeUtils.jsonToSlime("true");
+            assertSlime(expected, sink.getSlime());
+        }
+
+        {
+            var sink = new SlimeDataSink();
+            sink.doubleValue(3.14);
+            var expected = SlimeUtils.jsonToSlime("3.14");
+            assertSlime(expected, sink.getSlime());
+        }
+
+        {
+            var sink = new SlimeDataSink();
+            sink.stringValue("some_string");
+            var expected = SlimeUtils.jsonToSlime("\"some_string\"");
+            assertSlime(expected, sink.getSlime());
+        }
     }
 }

--- a/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/data/disclosure/slime/SlimeDataSinkTestCase.java
@@ -46,15 +46,13 @@ public class SlimeDataSinkTestCase {
 
         sink.endObject();
 
-        var expected = new Slime();
-        var obj = expected.setObject();
-        obj.setLong("int", 1024);
-        obj.setBool("bool", true);
-        obj.setNix("empty");
-        obj.setDouble("double", 3.5);
-        obj.setString("string", "hello");
-        obj.setData("data", bytes);
+        var expected = SlimeUtils.jsonToSlime("{ int: 1024, " +
+                                              "  bool: true," +
+                                              "  double: 3.5," +
+                                              "  string: \"hello\" }");
 
+        expected.get().setData("data", bytes);
+        expected.get().setNix("empty");
         assertSlime(expected, sink.getSlime());
     }
 
@@ -65,21 +63,17 @@ public class SlimeDataSinkTestCase {
         // [1, true, nix, 2.5, "foo", byte[9,8]]
         sink.longValue(1L);
         sink.booleanValue(true);
-        sink.emptyValue();
         sink.doubleValue(2.5);
         sink.stringValue("foo");
         byte[] bytes = new byte[]{9, 8};
         sink.dataValue(bytes);
+        sink.emptyValue();
         sink.endArray();
 
-        var expected = new Slime();
-        var arr = expected.setArray();
-        arr.addLong(1L);
-        arr.addBool(true);
-        arr.addNix();
-        arr.addDouble(2.5);
-        arr.addString("foo");
+        var expected = SlimeUtils.jsonToSlime("[1, true, 2.5, \"foo\"]");
+        var arr = expected.get();
         arr.addData(bytes);
+        arr.addNix();
 
         assertSlime(expected, sink.getSlime());
     }
@@ -105,14 +99,7 @@ public class SlimeDataSinkTestCase {
 
         sink.endObject();
 
-        var expected = new Slime();
-        var root = expected.setObject();
-        var nums = root.setArray("nums");
-        nums.addLong(1L);
-        nums.addLong(2L);
-        var meta = root.setObject("meta");
-        meta.setBool("ok", true);
-
+        var expected = SlimeUtils.jsonToSlime("{ nums: [1, 2], meta: { ok: true } }");
         assertSlime(expected, sink.getSlime());
     }
 
@@ -135,13 +122,7 @@ public class SlimeDataSinkTestCase {
 
         sink.endArray();
 
-        var expected = new Slime();
-        var arr = expected.setArray();
-        var o1 = arr.addObject();
-        o1.setLong("id", 1L);
-        var o2 = arr.addObject();
-        o2.setLong("id", 2L);
-
+        var expected = SlimeUtils.jsonToSlime("[ { id: 1 }, { id: 2 } ]");
         assertSlime(expected, sink.getSlime());
     }
 
@@ -157,11 +138,7 @@ public class SlimeDataSinkTestCase {
         sink.intValue(2);
         sink.endObject();
 
-        var expected = new Slime();
-        var obj = expected.setObject();
-        obj.setLong("utf8_name", 1);
-        obj.setLong("utf16_name", 2);
-
+        var expected = SlimeUtils.jsonToSlime("{ utf8_name: 1, utf16_name: 2 }");
         assertSlime(expected, sink.getSlime());
     }
 
@@ -175,13 +152,7 @@ public class SlimeDataSinkTestCase {
         sink.floatValue(1.5f);
         sink.endArray();
 
-        var expected = new Slime();
-        var arr = expected.setArray();
-        arr.addLong(10);
-        arr.addLong(20);
-        arr.addLong(30);
-        arr.addDouble(1.5f); // floatValue delegates to doubleValue
-
+        var expected = SlimeUtils.jsonToSlime("[ 10, 20, 30, 1.5 ]");
         assertSlime(expected, sink.getSlime());
     }
 


### PR DESCRIPTION
This PR adds a simple data sink that makes a Slime object. It is needed for unit testing of objects that implement `DataSource` later.

@andreer fyi