### PR TITLE
Upgrade Jetty server version to 12.0.30

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -115,7 +115,7 @@
         <java-jwt.vespa.version>4.4.0</java-jwt.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.0.29</jetty.vespa.version>
+        <jetty.vespa.version>12.0.30</jetty.vespa.version>
         <jetty.client.vespa.version>12.0.22</jetty.client.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#35403 this was not the actual issue, ref https://github.com/vespa-engine/vespa/pull/35405