### PR TITLE
Generate prometheus ids on the fly

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/DimensionId.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/DimensionId.java
@@ -14,17 +14,16 @@ public final class DimensionId {
 
     private static final Map<String, DimensionId> dictionary = new CopyOnWriteHashMap<>();
     public final String id;
-    private final String idForPrometheus;
+
     private DimensionId(String id) {
         this.id = id;
-        idForPrometheus = PrometheusUtil.sanitize(id);
     }
 
     public static DimensionId toDimensionId(String id) {
-        return dictionary.computeIfAbsent(id, key -> new DimensionId(key));
+        return dictionary.computeIfAbsent(id, DimensionId::new);
     }
 
-    public String getIdForPrometheus() { return idForPrometheus; }
+    public String getIdForPrometheus() { return PrometheusUtil.sanitize(id); }
 
     @Override
     public boolean equals(Object o) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/MetricId.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/MetricId.java
@@ -15,16 +15,15 @@ public class MetricId {
     private static final Map<String, MetricId> dictionary = new CopyOnWriteHashMap<>();
     public static final MetricId empty = toMetricId("");
     public final String id;
-    private final String idForPrometheus;
+
     private MetricId(String id) {
         this.id = id;
-        idForPrometheus = PrometheusUtil.sanitize(id);
     }
 
     public static MetricId toMetricId(String id) {
         return dictionary.computeIfAbsent(id, MetricId::new);
     }
-    public String getIdForPrometheus() { return idForPrometheus; }
+    public String getIdForPrometheus() { return PrometheusUtil.sanitize(id); }
 
     @Override
     public boolean equals(Object o) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/ServiceId.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/ServiceId.java
@@ -11,15 +11,14 @@ import java.util.Objects;
 public class ServiceId {
 
     public final String id;
-    private final String idForPrometheus;
+
     private ServiceId(String id) {
         this.id = id;
-        idForPrometheus = PrometheusUtil.sanitize(id);
     }
 
     public static ServiceId toServiceId(String id) { return new ServiceId(id); }
 
-    public String getIdForPrometheus() { return idForPrometheus; }
+    public String getIdForPrometheus() { return PrometheusUtil.sanitize(id); }
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Avoid storing prometheus id in id classes, they are used in long-lived objects and this will reduce memory usage a bit
