### PR TITLE
fix profiling tags

### DIFF
--- a/config-lib/doc/cloudconfig-model-plugins.html
+++ b/config-lib/doc/cloudconfig-model-plugins.html
@@ -290,7 +290,7 @@ and can be used to retrieve the config once the producers have been added to the
 Before using it, however, the topology must be frozen by calling
 <code>freezeModelTopology</code>.
 </p><p>
-Use <a href="https://docs.vespa.ai/en/reference/tools-self-managing.html#vespa-get-config">vespa-get-config</a>
+Use <a href="https://docs.vespa.ai/en/reference/operations/tools-self-managing.html#vespa-get-config">vespa-get-config</a>
 to retrieve in the payload format:
 </p>
 <pre>

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
@@ -191,6 +191,7 @@ AndNotBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
         auto termwise_search = (helper.first_termwise == 0)
                                ? AndNotSearch::create(helper.get_termwise_children(), termwise_strict)
                                : OrSearch::create(helper.get_termwise_children(), termwise_strict);
+        termwise_search->set_id(id());
         helper.insert_termwise(std::move(termwise_search), termwise_strict);
         auto rearranged = helper.get_result();
         if (rearranged.size() == 1) {
@@ -293,6 +294,7 @@ AndBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
         bool termwise_strict = ((helper.first_termwise < childCnt()) &&
                                 getChild(helper.first_termwise).strict());
         auto termwise_search = AndSearch::create(helper.get_termwise_children(), termwise_strict);
+        termwise_search->set_id(id());
         helper.insert_termwise(std::move(termwise_search), termwise_strict);
         auto rearranged = helper.get_result();
         if (rearranged.size() == 1) {
@@ -392,6 +394,7 @@ OrBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
         bool termwise_strict = ((helper.first_termwise < childCnt()) &&
                                 getChild(helper.first_termwise).strict());
         auto termwise_search = OrSearch::create(helper.get_termwise_children(), termwise_strict);
+        termwise_search->set_id(id());
         helper.insert_termwise(std::move(termwise_search), termwise_strict);
         auto rearranged = helper.get_result();
         if (rearranged.size() == 1) {

--- a/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.h
@@ -48,7 +48,10 @@ public:
       : _profiler(profiler), _search(std::move(search)),
         _initRange_tag(initRange_tag), _doSeek_tag(doSeek_tag),
         _doUnpack_tag(doUnpack_tag), _get_hits_tag(get_hits_tag),
-        _or_hits_into_tag(or_hits_into_tag), _and_hits_into_tag(and_hits_into_tag) {}
+        _or_hits_into_tag(or_hits_into_tag), _and_hits_into_tag(and_hits_into_tag)
+    {
+        set_id(_search->id());
+    }
     ~ProfiledIterator() override;
     void initRange(uint32_t begin_id, uint32_t end_id) override;
     void doSeek(uint32_t docid) override;

--- a/searchlib/src/vespa/searchlib/queryeval/termwise_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/termwise_search.cpp
@@ -19,7 +19,10 @@ struct TermwiseSearch : public SearchIterator {
     }
 
     TermwiseSearch(SearchIterator::UP search_in)
-        : search(std::move(search_in)), result(), my_beginid(0), my_first_hit(0) {}
+        : search(std::move(search_in)), result(), my_beginid(0), my_first_hit(0)
+    {
+        set_id(search->id());
+    }
     ~TermwiseSearch() override;
 
     Trinary is_strict() const override { return IS_STRICT ? Trinary::True : Trinary::False; }
@@ -51,6 +54,10 @@ struct TermwiseSearch : public SearchIterator {
     void visitMembers(vespalib::ObjectVisitor &visitor) const override {
         visit(visitor, "search", *search);
         visit(visitor, "strict", IS_STRICT);
+    }
+    void transform_children(std::function<SearchIterator::UP(SearchIterator::UP)> f) override
+    {
+        search = f(std::move(search));
     }
 };
 


### PR DESCRIPTION
- let profiling decorator copy enum value (should fix the empty multi-bit-vector tag issue)

- let extra termwise nodes copy enum value (avoid unattributed cost by assigning it to parent)

- let termwise wrapper implement transform_children (attribute detailed cost to termwise nodes)

@arnej27959 please review