### PR TITLE
Add `InspectorDataSource` adaptor for `Inspector`

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -89,6 +89,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.data.access.InspectorDataSource" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [
+      "com.yahoo.data.disclosure.DataSource"
+    ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(com.yahoo.data.access.Inspector)",
+      "public void emit(com.yahoo.data.disclosure.DataSink)"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.data.access.ObjectTraverser" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [ ],

--- a/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
+++ b/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
@@ -14,6 +14,7 @@ import com.yahoo.data.disclosure.DataSource;
 public class InspectorDataSource implements DataSource {
 
     private final Inspector inspector;
+    private final byte[] invalid = new byte[]{};
 
     public InspectorDataSource(Inspector inspector) {
         this.inspector = inspector;
@@ -39,7 +40,12 @@ public class InspectorDataSource implements DataSource {
                 sink.doubleValue(inspector.asDouble());
             }
             case STRING -> {
-                sink.stringValue(inspector.asString(), inspector.asUtf8());
+                var utf8 = inspector.asUtf8(invalid);
+                if (utf8 != invalid) {
+                    sink.stringValue(utf8);
+                } else {
+                    sink.stringValue(inspector.asString());
+                }
             }
             case DATA -> {
                 sink.dataValue(inspector.asData());

--- a/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
+++ b/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
@@ -1,0 +1,62 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.data.access;
+
+import com.yahoo.data.disclosure.DataSink;
+import com.yahoo.data.disclosure.DataSource;
+
+/**
+ * Walks a tree of objects implementing {@link Inspector} and emits to a {@link DataSink}.
+ *
+ * @author johsol
+ */
+public class InspectorDataSource implements DataSource {
+
+    private final Inspector inspector;
+
+    public InspectorDataSource(Inspector inspector) {
+        this.inspector = inspector;
+    }
+
+    @Override
+    public void emit(DataSink sink) {
+        walk(sink, inspector);
+    }
+
+    private void walk(DataSink sink, Inspector inspector) {
+        switch (inspector.type()) {
+            case EMPTY -> {
+                sink.emptyValue();
+            }
+            case BOOL -> {
+                sink.booleanValue(inspector.asBool());
+            }
+            case LONG -> {
+                sink.longValue(inspector.asLong());
+            }
+            case DOUBLE -> {
+                sink.doubleValue(inspector.asDouble());
+            }
+            case STRING -> {
+                sink.stringValue(inspector.asString());
+            }
+            case DATA -> {
+                sink.dataValue(inspector.asData());
+            }
+            case ARRAY -> {
+                sink.startArray();
+                for (int i = 0; i < inspector.entryCount(); i++) {
+                    walk(sink, inspector.entry(i));
+                }
+                sink.endArray();
+            }
+            case OBJECT -> {
+                sink.startObject();
+                for (var field : inspector.fields()) {
+                    sink.fieldName(field.getKey());
+                    walk(sink, field.getValue());
+                }
+                sink.endObject();
+            }
+        }
+    }
+}

--- a/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
+++ b/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.data.access;
 
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.data.disclosure.DataSink;
 import com.yahoo.data.disclosure.DataSource;
 
@@ -9,6 +10,7 @@ import com.yahoo.data.disclosure.DataSource;
  *
  * @author johsol
  */
+@Beta
 public class InspectorDataSource implements DataSource {
 
     private final Inspector inspector;

--- a/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
+++ b/vespajlib/src/main/java/com/yahoo/data/access/InspectorDataSource.java
@@ -37,7 +37,7 @@ public class InspectorDataSource implements DataSource {
                 sink.doubleValue(inspector.asDouble());
             }
             case STRING -> {
-                sink.stringValue(inspector.asString());
+                sink.stringValue(inspector.asString(), inspector.asUtf8());
             }
             case DATA -> {
                 sink.dataValue(inspector.asData());

--- a/vespajlib/src/test/java/com/yahoo/data/access/InspectorDataSourceTest.java
+++ b/vespajlib/src/test/java/com/yahoo/data/access/InspectorDataSourceTest.java
@@ -1,0 +1,67 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.data.access;
+
+import com.yahoo.data.access.slime.SlimeAdapter;
+import com.yahoo.data.disclosure.slime.SlimeDataSink;
+import com.yahoo.slime.Slime;
+import com.yahoo.slime.SlimeUtils;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author johsol
+ */
+public class InspectorDataSourceTest {
+
+    private void assertSlime(Slime expected, Slime actual) {
+        assertTrue(expected.get().equalTo(actual.get()),
+                () -> "Expected " + SlimeUtils.toJson(expected) +
+                        " but got " + SlimeUtils.toJson(actual));
+    }
+
+    @Test
+    public void testValuesInObjectIsPreserved() {
+        var expected = SlimeUtils.jsonToSlime("{ int: 1024, " +
+                "  bool: true," +
+                "  double: 3.5," +
+                "  my_null: null," +
+                "  string: 'hello' }");
+
+        var inspector = new SlimeAdapter(expected.get());
+        var dataSource = new InspectorDataSource(inspector);
+        var actual = SlimeDataSink.buildSlime(dataSource);
+        assertSlime(expected, actual);
+    }
+
+    @Test
+    public void testValuesInArrayIsPreserved() {
+        var expected = SlimeUtils.jsonToSlime("[1, true, 2.5, 'foo', null]");
+
+        var inspector = new SlimeAdapter(expected.get());
+        var dataSource = new InspectorDataSource(inspector);
+        var actual = SlimeDataSink.buildSlime(dataSource);
+        assertSlime(expected, actual);
+    }
+
+    @Test
+    public void testNestedObjectAndArrayArePreserved() {
+        var expected = SlimeUtils.jsonToSlime("{ nums: [1, 2], meta: { ok: true } }");
+
+        var inspector = new SlimeAdapter(expected.get());
+        var dataSource = new InspectorDataSource(inspector);
+        var actual = SlimeDataSink.buildSlime(dataSource);
+        assertSlime(expected, actual);
+    }
+
+    @Test
+    public void testArrayOfObjectsArePreserved() {
+        var expected = SlimeUtils.jsonToSlime("[ { id: 1 }, { id: 2 } ]");
+
+        var inspector = new SlimeAdapter(expected.get());
+        var dataSource = new InspectorDataSource(inspector);
+        var actual = SlimeDataSink.buildSlime(dataSource);
+        assertSlime(expected, actual);
+    }
+
+}


### PR DESCRIPTION
- Working towards rendering JSON using the data disclosure API.
- On emit, this class walks the inspector and emits the underlying structure.
- Most classes implementing `JsonProducer` use the `Inspector` interface, so those classes can use this class to adapt their inspector to a data source.

@andreer please review
@havardpe fyi
