### PR TITLE
Fix top-level distributor memory usage metric aggregation

### DIFF
--- a/storage/src/tests/distributor/top_level_distributor_test.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test.cpp
@@ -758,7 +758,7 @@ TEST_F(TopLevelDistributorTest, gc_timestamps_not_reset_to_current_time_when_gc_
 
 TEST_F(TopLevelDistributorTest, memory_usage_is_propagated_to_dedicated_metric) {
     EXPECT_EQ(memory_usage_tracker().bytes_total(), 0);
-    EXPECT_EQ(_distributor->total_metrics().mutatating_op_memory_usage().getCount(), 0);
+    EXPECT_EQ(total_distributor_metrics().mutatating_op_memory_usage.getCount(), 0);
     MemoryUsageToken t(memory_usage_tracker(), 54321);
     {
         // Will count towards the maximum, but not the current at sampling time
@@ -767,9 +767,9 @@ TEST_F(TopLevelDistributorTest, memory_usage_is_propagated_to_dedicated_metric) 
     EXPECT_EQ(memory_usage_tracker().bytes_total(), 54321);
     EXPECT_EQ(memory_usage_tracker().max_observed_bytes(), 54321+10000);
     update_top_level_metrics();
-    EXPECT_EQ(_distributor->total_metrics().mutatating_op_memory_usage().getCount(), 1);
-    EXPECT_EQ(_distributor->total_metrics().mutatating_op_memory_usage().getLast(), 54321);
-    EXPECT_EQ(_distributor->total_metrics().mutatating_op_memory_usage().getMaximum(), 54321+10000);
+    EXPECT_EQ(total_distributor_metrics().mutatating_op_memory_usage.getCount(), 1);
+    EXPECT_EQ(total_distributor_metrics().mutatating_op_memory_usage.getLast(), 54321);
+    EXPECT_EQ(total_distributor_metrics().mutatating_op_memory_usage.getMaximum(), 54321+10000);
     // Sampling is destructive for max memory usage within period
     EXPECT_EQ(memory_usage_tracker().max_observed_bytes(), 0);
 }

--- a/storage/src/vespa/storage/distributor/distributor_total_metrics.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_total_metrics.cpp
@@ -7,10 +7,7 @@ namespace storage::distributor {
 DistributorTotalMetrics::DistributorTotalMetrics(uint32_t num_distributor_stripes)
     : DistributorMetricSet(),
       _stripes_metrics(),
-      _bucket_db_updater_metrics(),
-      _mutatating_op_memory_usage("mutating_op_memory_usage", {},
-             "Estimated amount of memory used by active mutating operations "
-             "across all distributor stripes, in bytes", this)
+      _top_level_metrics()
 {
     _stripes_metrics.reserve(num_distributor_stripes);
     for (uint32_t i = 0; i < num_distributor_stripes; ++i) {
@@ -21,10 +18,10 @@ DistributorTotalMetrics::DistributorTotalMetrics(uint32_t num_distributor_stripe
 DistributorTotalMetrics::~DistributorTotalMetrics() = default;
 
 void
-DistributorTotalMetrics::aggregate_helper(DistributorMetricSet &total) const
+DistributorTotalMetrics::aggregate_helper(DistributorMetricSet& total) const
 {
-    _bucket_db_updater_metrics.addToPart(total);
-    for (auto &stripe_metrics : _stripes_metrics) {
+    _top_level_metrics.addToPart(total);
+    for (auto& stripe_metrics : _stripes_metrics) {
         stripe_metrics->addToPart(total);
     }
 }
@@ -37,7 +34,7 @@ DistributorTotalMetrics::aggregate()
 }
 
 void
-DistributorTotalMetrics::addToSnapshot(Metric& m, std::vector<Metric::UP> &ownerList) const
+DistributorTotalMetrics::addToSnapshot(Metric& m, std::vector<Metric::UP>& ownerList) const
 {
     DistributorMetricSet total;
     aggregate_helper(total);
@@ -48,8 +45,8 @@ void
 DistributorTotalMetrics::reset()
 {
     DistributorMetricSet::reset();
-    _bucket_db_updater_metrics.reset();
-    for (auto &stripe_metrics : _stripes_metrics) {
+    _top_level_metrics.reset();
+    for (auto& stripe_metrics : _stripes_metrics) {
         stripe_metrics->reset();
     }
 }

--- a/storage/src/vespa/storage/distributor/distributor_total_metrics.h
+++ b/storage/src/vespa/storage/distributor/distributor_total_metrics.h
@@ -11,11 +11,9 @@ namespace storage::distributor {
  * metric framework, while managing a DistributorMetricSet for each
  * stripe and an extra one for the top level bucket db updater.
  */
-class DistributorTotalMetrics : public DistributorMetricSet
-{
+class DistributorTotalMetrics : public DistributorMetricSet {
     std::vector<std::shared_ptr<DistributorMetricSet>> _stripes_metrics;
-    DistributorMetricSet _bucket_db_updater_metrics;
-    metrics::LongValueMetric _mutatating_op_memory_usage;
+    DistributorMetricSet _top_level_metrics;
     void aggregate_helper(DistributorMetricSet &total) const;
 public:
     explicit DistributorTotalMetrics(uint32_t num_distributor_stripes);
@@ -23,14 +21,9 @@ public:
     void aggregate();
     void addToSnapshot(Metric& m, std::vector<Metric::UP> &ownerList) const override;
     void reset() override;
-    DistributorMetricSet& stripe(uint32_t stripe_index) { return *_stripes_metrics[stripe_index]; }
-    DistributorMetricSet& bucket_db_updater_metrics() { return _bucket_db_updater_metrics; }
-    const metrics::LongValueMetric& mutatating_op_memory_usage() const noexcept {
-        return _mutatating_op_memory_usage;
-    }
-    metrics::LongValueMetric& mutatating_op_memory_usage() noexcept {
-        return _mutatating_op_memory_usage;
-    }
+    DistributorMetricSet& stripe(uint32_t stripe_index) noexcept { return *_stripes_metrics[stripe_index]; }
+    DistributorMetricSet& top_level_metrics() noexcept { return _top_level_metrics; }
+    const DistributorMetricSet& top_level_metrics() const noexcept { return _top_level_metrics; }
 };
 
 }

--- a/storage/src/vespa/storage/distributor/distributormetricsset.cpp
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.cpp
@@ -50,6 +50,9 @@ DistributorMetricSet::DistributorMetricSet()
               {{"logdefault"},{"yamasdefault"}},
               "Number of bytes stored in all buckets controlled by "
               "this distributor", this),
+      mutatating_op_memory_usage("mutating_op_memory_usage", {},
+             "Estimated amount of memory used by active mutating operations "
+             "across all distributor stripes, in bytes", this),
       mutable_dbs("mutable", this),
       read_only_dbs("read_only", this)
 {}

--- a/storage/src/vespa/storage/distributor/distributormetricsset.h
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.h
@@ -38,6 +38,7 @@ public:
     metrics::DoubleAverageMetric  recoveryModeTime;
     metrics::LongValueMetric      docsStored;
     metrics::LongValueMetric      bytesStored;
+    metrics::LongValueMetric      mutatating_op_memory_usage;
     BucketDbMetrics               mutable_dbs;
     BucketDbMetrics               read_only_dbs;
 

--- a/storage/src/vespa/storage/distributor/top_level_distributor.cpp
+++ b/storage/src/vespa/storage/distributor/top_level_distributor.cpp
@@ -128,7 +128,7 @@ TopLevelDistributor::~TopLevelDistributor()
 DistributorMetricSet&
 TopLevelDistributor::getMetrics()
 {
-    return _total_metrics->bucket_db_updater_metrics();
+    return _total_metrics->top_level_metrics();
 }
 
 void
@@ -438,15 +438,17 @@ TopLevelDistributor::propagate_and_aggregate_metrics_from_stripes()
 
 void
 TopLevelDistributor::update_top_level_metrics() {
-    propagate_and_aggregate_metrics_from_stripes();
     // We only track current and max, so pretend min == current
     auto mut_mem_usage = _shared_memory_usage_tracker.relaxed_snapshot();
     _shared_memory_usage_tracker.reset_max_observed_bytes(); // Destructive sampling of max
     // It's a bit of a cheat to have last != max with count == 1 (since diverging values
     // should only be observable with multiple metric samples), but it is what it is.
     // These will be emitted as distinct time series at a higher level either way.
-    _total_metrics->mutatating_op_memory_usage().addTotalValueBatch(
+    metrics().mutatating_op_memory_usage.addTotalValueBatch(
             mut_mem_usage.bytes_total, 1, mut_mem_usage.bytes_total, mut_mem_usage.max_observed_bytes);
+    // Must be done _after_ setting top-level metrics explicitly, since aggregation patches
+    // in the combined view of top-level and strip-level metrics.
+    propagate_and_aggregate_metrics_from_stripes();
 }
 
 void

--- a/storage/src/vespa/storage/distributor/top_level_distributor.h
+++ b/storage/src/vespa/storage/distributor/top_level_distributor.h
@@ -89,9 +89,6 @@ public:
     void start_stripe_pool();
 
     DistributorMetricSet& getMetrics();
-    const DistributorTotalMetrics& total_metrics() const noexcept {
-        return *_total_metrics;
-    }
 
     const NodeIdentity& node_identity() const noexcept { return _node_identity; }
 


### PR DESCRIPTION
@toregge please review

The distributor has to wrangle metric snapshotting in a very particular manner to present a unified view of metrics across all stripes and itself. Due to some confusing naming of the top level metric set, the memory usage metric was not wired in a way that it would be properly propagated to snapshots.

Annoyingly, the previous wiring had the expected results for the _first_ snapshot taken (but not subsequent ones), making it seem like it worked fine during local testing 😬.

With this commit the wiring should be fixed and metric set naming has been updated to more accurately reflect semantics, reducing the potential for future confusion and exciting debugging sessions.

