### PR TITLE
Implement `dataValue()` for `JsonGeneratorDataSink`

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonGeneratorDataSink.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.rendering;
 
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.Base64Variants;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.json.UTF8JsonGenerator;
 import com.yahoo.data.disclosure.DataSink;
@@ -16,12 +18,22 @@ import java.nio.charset.StandardCharsets;
  */
 class JsonGeneratorDataSink implements DataSink {
 
+    private static final byte[] HEX_DIGITS_ASCII = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+    private static final boolean RAW_AS_BASE64_DISABLED = false;
+
     private JsonGenerator gen;
     private boolean wantUtf8;
+    boolean enableRawAsBase64;
+    private final Base64Variant base64Variant = Base64Variants.getDefaultVariant();
 
     public JsonGeneratorDataSink(JsonGenerator gen) {
+        this(gen, RAW_AS_BASE64_DISABLED);
+    }
+
+    public JsonGeneratorDataSink(JsonGenerator gen, boolean enableRawAsBase64) {
         this.gen = gen;
         this.wantUtf8 = gen instanceof UTF8JsonGenerator;
+        this.enableRawAsBase64 = enableRawAsBase64;
     }
 
     @Override
@@ -168,6 +180,44 @@ class JsonGeneratorDataSink implements DataSink {
 
     @Override
     public void dataValue(byte[] data) {
-       throw new UnsupportedOperationException("Not implemented");
+        try {
+            if (enableRawAsBase64) {
+                gen.writeBinary(base64Variant, data, 0, data.length);
+            } else {
+                if (wantUtf8) {
+                    gen.writeUTF8String(toHexUtf8(data), 0, 2 + data.length * 2);
+                } else {
+                    gen.writeString(toHexString(data));
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static byte[] toHexUtf8(byte[] data) {
+        byte[] out = new byte[2 + data.length * 2];
+        int p = 0;
+        out[p++] = '0';
+        out[p++] = 'x';
+        for (byte b : data) {
+            int v = b & 0xFF;
+            out[p++] = HEX_DIGITS_ASCII[v >>> 4];
+            out[p++] = HEX_DIGITS_ASCII[v & 0x0F];
+        }
+        return out;
+    }
+
+    private static String toHexString(byte[] data) {
+        char[] chars = new char[2 + data.length * 2];
+        int p = 0;
+        chars[p++] = '0';
+        chars[p++] = 'x';
+        for (byte b : data) {
+            int v = b & 0xFF;
+            chars[p++] = (char) HEX_DIGITS_ASCII[v >>> 4];
+            chars[p++] = (char) HEX_DIGITS_ASCII[v & 0x0F];
+        }
+        return new String(chars);
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -564,7 +564,8 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
         this.timeSource = timeSource;
     }
 
-    private static class WithBase64 extends JsonRender.StringEncoder {
+    /** package-private because used in testing JsonGeneratorDataSinkTest */
+    static class WithBase64 extends JsonRender.StringEncoder {
         private final static Base64.Encoder encoder = Base64.getEncoder();
         @Override
         protected void encodeDATA(byte[] value) {
@@ -609,14 +610,14 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
             this.settings.tensorOptions = tensorOptions;
             this.settings.jsonDeepMaps = jsonMaps;
             // if this is subclass, generator will be null, must mirror that behavior
-            this.dataSink = (generator == null) ? null : new JsonGeneratorDataSink(generator);
+            this.dataSink = (generator == null) ? null : new JsonGeneratorDataSink(generator, settings.enableRawAsBase64);
         }
 
         FieldConsumer(JsonGenerator generator, FieldConsumerSettings settings) {
             this.generator = generator;
             this.settings = settings;
             // if this is subclass, generator will be null, must mirror that behavior
-            this.dataSink = (generator == null) ? null : new JsonGeneratorDataSink(generator);
+            this.dataSink = (generator == null) ? null : new JsonGeneratorDataSink(generator, settings.enableRawAsBase64);
         }
 
         /**


### PR DESCRIPTION
- Based on `WithBase64.toJsonString()`
- Test uses `WithBase64` to assert the same output for binary data for both `enableRawAsBase64` set or not.

@arnej27959 please review
@andreer fyi
@havardpe fyi