### PR TITLE
Improve cost estimation with merge factor

### DIFF
--- a/searchlib/src/vespa/searchcommon/attribute/i_search_context.h
+++ b/searchlib/src/vespa/searchcommon/attribute/i_search_context.h
@@ -32,6 +32,13 @@ public:
     virtual HitEstimate calc_hit_estimate() const = 0;
 
     /**
+     * What is the extra cost to produce each hit because we have to
+     * merge posting lists?
+     * Default implementation: no extra cost.
+     */
+    virtual double posting_list_merge_factor() const { return 1.0; }
+
+    /**
      * Creates an attribute search iterator associated with this
      * search context.
      *

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -160,7 +160,8 @@ public:
             return {estimate_when_unknown(), lookup_cost(indirections), lookup_strict_cost(indirections)};
         } else {
             double rel_est = abs_to_rel_est(_hit_estimate.est_hits(), docid_limit);
-            return {rel_est, btree_cost(rel_est), btree_strict_cost(rel_est)};
+            double merge_factor = _search_context->posting_list_merge_factor();
+            return {rel_est, btree_cost(rel_est), btree_strict_cost(rel_est, merge_factor)};
         }
     }
 

--- a/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.cpp
@@ -4,7 +4,7 @@
 #include "i_enum_store_dictionary.h"
 #include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/vespalib/datastore/i_unique_store_dictionary_read_snapshot.h>
-
+#include <cmath>
 
 namespace search::attribute {
 
@@ -60,6 +60,10 @@ EnumHintSearchContext::calc_hit_estimate() const
     return (_uniqueValues == 0u)
         ? HitEstimate(0u)
         : HitEstimate::unknown(std::max(uint64_t(_docIdLimit), _numValues));
+}
+
+double EnumHintSearchContext::posting_list_merge_factor() const {
+    return std::log2(1.0 + _uniqueValues);
 }
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.h
@@ -41,6 +41,7 @@ protected:
 
     void fetchPostings(const queryeval::ExecuteInfo & execInfo, bool strict) override;
     HitEstimate calc_hit_estimate() const override;
+    double posting_list_merge_factor() const override;
     uint32_t get_committed_docid_limit() const noexcept { return _docIdLimit; }
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -115,6 +115,18 @@ ImportedSearchContext::calc_hit_estimate() const
     }
 }
 
+double ImportedSearchContext::posting_list_merge_factor() const {
+    uint32_t target_est_hits = _target_search_context->calc_hit_estimate().est_hits();
+    // The reasoning here is as follows: for each hit in the parent,
+    // we will get a posting list with hits for this context, and
+    // these lists have to be merged.  A single posting list gives no
+    // extra merging, so should give a factor of 1, and the cost
+    // should be logarithmic.  It's possible we should have a scale factor
+    // on target_est_hits (need to do some careful measurements for that).
+    double extra_factor = std::log2(1.0 + target_est_hits);
+    return extra_factor * _target_search_context->posting_list_merge_factor();
+}
+
 std::unique_ptr<queryeval::SearchIterator>
 ImportedSearchContext::createIterator(fef::TermFieldMatchData* matchData, bool strict) {
     if (_zero_hits.load(std::memory_order_relaxed)) {

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -34,7 +34,7 @@ class ImportedSearchContext : public ISearchContext {
         BITVECTOR
     };
     const ImportedAttributeVector&                  _imported_attribute;
-    std::string                                _queryTerm;
+    std::string                                     _queryTerm;
     bool                                            _useSearchCache;
     std::shared_ptr<BitVectorSearchCache::Entry>    _searchCacheLookup;
     IDocumentMetaStoreContext::IReadGuard::SP       _dmsReadGuardFallback;
@@ -78,6 +78,8 @@ public:
     std::unique_ptr<queryeval::SearchIterator>
     createIterator(fef::TermFieldMatchData* matchData, bool strict) override;
     HitEstimate calc_hit_estimate() const override;
+    double posting_list_merge_factor() const override;
+
     void fetchPostings(const queryeval::ExecuteInfo &execInfo, bool strict) override;
     bool valid() const override;
     Int64Range getAsIntegerTerm() const override;

--- a/searchlib/src/vespa/searchlib/attribute/ipostinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/ipostinglistsearchcontext.h
@@ -32,6 +32,7 @@ public:
     virtual void fetchPostings(const queryeval::ExecuteInfo & execInfo, bool strict) = 0;
     virtual std::unique_ptr<queryeval::SearchIterator> createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) = 0;
     virtual HitEstimate calc_hit_estimate() const = 0;
+    virtual double posting_list_merge_factor() const = 0;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -127,6 +127,7 @@ protected:
 
     unsigned int singleHits() const;
     HitEstimate calc_hit_estimate() const override;
+    double posting_list_merge_factor() const override;
     void applyRangeLimit(long rangeLimit);
     struct FillPart;
 };

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -11,7 +11,7 @@
 #include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/searchlib/common/bitvectoriterator.h>
 #include <vespa/searchlib/common/growablebitvector.h>
-
+#include <cmath>
 
 using search::queryeval::EmptySearch;
 using search::queryeval::SearchIterator;
@@ -299,6 +299,18 @@ PostingListSearchContextT<DataT>::calc_hit_estimate() const
         return HitEstimate::unknown(_docIdLimit);
     }
     return HitEstimate(std::min(numHits, size_t(std::numeric_limits<uint32_t>::max())));
+}
+
+template <typename DataT>
+double
+PostingListSearchContextT<DataT>::posting_list_merge_factor() const {
+    // The reasoning here is as follows: for each unique value, we
+    // will get a posting list with hits, and these lists have to be
+    // merged.  A single posting list gives no extra merging, so
+    // should give a factor of 1, and the cost should be logarithmic.
+    // It's possible we should have a scale factor on _uniqueValues
+    // (need to do some careful measurements for that).
+    return std::log2(1.0 + _uniqueValues);
 }
 
 template <typename DataT>

--- a/searchlib/src/vespa/searchlib/attribute/search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/search_context.cpp
@@ -19,6 +19,14 @@ SearchContext::calc_hit_estimate() const
     return HitEstimate::unknown(std::max(uint64_t(_attr.getNumDocs()), _attr.getStatus().getNumValues()));
 }
 
+double SearchContext::posting_list_merge_factor() const {
+    if (_plsc != nullptr) {
+        return _plsc->posting_list_merge_factor();
+    } else {
+        return 1.0;
+    }
+}
+
 std::unique_ptr<SearchIterator>
 SearchContext::createIterator(fef::TermFieldMatchData* matchData, bool strict)
 {

--- a/searchlib/src/vespa/searchlib/attribute/search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/search_context.h
@@ -33,6 +33,8 @@ public:
     ~SearchContext() override = default;
 
     HitEstimate calc_hit_estimate() const override;
+    double posting_list_merge_factor() const override;
+
     std::unique_ptr<queryeval::SearchIterator> createIterator(fef::TermFieldMatchData* matchData, bool strict) override;
     void fetchPostings(const queryeval::ExecuteInfo& execInfo, bool strict) override;
     bool valid() const override { return false; }

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
@@ -142,6 +142,7 @@ public:
     void fetchPostings(const queryeval::ExecuteInfo &execInfo, bool strict) override;
     std::unique_ptr<queryeval::SearchIterator> createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) override;
     HitEstimate calc_hit_estimate() const override;
+    double posting_list_merge_factor() const override { return 1.0; }
     uint32_t get_committed_docid_limit() const noexcept override;
 };
 

--- a/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
+++ b/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
@@ -105,6 +105,11 @@ inline double btree_strict_cost(double my_est) {
     return my_est;
 }
 
+// Strict cost of matching in merged btree posting lists (e.g. range or prefix)
+inline double btree_strict_cost(double my_est, double merge_factor) {
+    return my_est * merge_factor;
+}
+
 // Non-strict cost of matching in a btree posting list (e.g. fast-search attribute or memory index field).
 // Test used: IteratorBenchmark::analyze_btree_iterator_non_strict
 inline double btree_cost(double my_est) {


### PR DESCRIPTION
When matching against multiple enum values (e.g., range or prefix queries), posting lists must be merged, which adds computational cost. This change introduces a posting_list_merge_factor() method that estimates this extra cost using log2(1 + unique_values), reflecting the logarithmic complexity of merging N posting lists. The factor is integrated into the strict cost calculation in flow tuning to improve query plan optimization.

For imported attributes, the factor accounts for both the target attribute's merge cost and the additional merging needed for each parent document hit.

@havardpe FYI
