### PR TITLE
Clean up lazy filtering a bit

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -317,7 +317,7 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
         return false;
     }
 
-    std::shared_ptr<search::queryeval::LazyFilter> lazy_filter;
+    std::shared_ptr<search::queryeval::GlobalFilter> lazy_filter;
     if (use_lazy_filter) {
         if (trace && trace->shouldTrace(5)) {
             trace->addEvent(5, "Calculate lazy filter");

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -354,32 +354,6 @@ public:
         (void) distance_threshold;
         return {};
     }
-    std::vector<Neighbor> find_top_k_with_lazy_filter(Stats &stats,
-                                                 uint32_t k,
-                                                 const search::tensor::BoundDistanceFunction &df,
-                                                 const GlobalFilter& filter,
-                                                 search::queryeval::LazyFilter *lazy_filter,
-                                                 bool low_hit_ratio, double exploration, uint32_t explore_k,
-                                                 double exploration_slack,
-                                                 const vespalib::Doom& doom,
-                                                 double distance_threshold) const override
-    {
-        stats.count_computed_distance();
-        stats.count_visited_node();
-        stats.count_visited_node();
-        (void) stats;
-        (void) k;
-        (void) df;
-        (void) explore_k;
-        (void) exploration_slack;
-        (void) filter;
-        (void) lazy_filter;
-        (void) low_hit_ratio;
-        (void) exploration;
-        (void) doom;
-        (void) distance_threshold;
-        return {};
-    }
 
     search::tensor::DistanceFunctionFactory &distance_function_factory() const override {
         static search::tensor::DistanceFunctionFactory::UP my_dist_fun = search::tensor::make_distance_function_factory(search::attribute::DistanceMetric::Euclidean, vespalib::eval::CellType::DOUBLE);

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -397,7 +397,7 @@ public:
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
-    std::shared_ptr<queryeval::LazyFilter> create_lazy_filter() const override {
+    std::shared_ptr<queryeval::GlobalFilter> create_lazy_filter() const override {
         return queryeval::GeoLocationLazyFilter::create(_location, _pre_filter_estimate);
     }
     void visitMembers(vespalib::ObjectVisitor& visitor) const override {

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -349,12 +349,14 @@ class LocationPostFilterBlueprint : public ComplexLeafBlueprint
 private:
     const IAttributeVector  &_attribute;
     common::Location _location;
+    HitEstimate _pre_filter_estimate;
 
 public:
     LocationPostFilterBlueprint(const FieldSpec &field, const IAttributeVector &attribute, const Location &loc)
         : ComplexLeafBlueprint(field),
           _attribute(attribute),
-          _location(loc)
+          _location(loc),
+          _pre_filter_estimate()
     {
         uint32_t estHits = 0;
         if (loc.valid()) {
@@ -369,6 +371,8 @@ public:
     ~LocationPostFilterBlueprint() override;
 
     const common::Location &location() const { return _location; }
+
+    void set_pre_filter_estimate(const HitEstimate &estimate) { _pre_filter_estimate = estimate; }
 
     void sort(queryeval::InFlow in_flow) override {
         resolve_strict(in_flow);
@@ -394,7 +398,7 @@ public:
         return create_default_filter(constraint);
     }
     std::shared_ptr<queryeval::LazyFilter> create_lazy_filter() const override {
-        return queryeval::GeoLocationLazyFilter::create(_location);
+        return queryeval::GeoLocationLazyFilter::create(_location, _pre_filter_estimate);
     }
     void visitMembers(vespalib::ObjectVisitor& visitor) const override {
         LeafBlueprint::visitMembers(visitor);
@@ -426,6 +430,7 @@ make_location_blueprint(const FieldSpec &field, const IAttributeVector &attribut
             location.bounding_box.x.high,
             location.bounding_box.y.high);
     auto pre_filter = std::make_unique<LocationPreFilterBlueprint>(field, attribute, rangeVector, scParams);
+    post_filter->set_pre_filter_estimate(pre_filter->getState().estimate());
     if (!pre_filter->should_use()) {
         LOG(debug, "only use post filter");
         return post_filter;

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -7,7 +7,7 @@
 #include "field_spec.hpp"
 #include "flow_tuning.h"
 #include "full_search.h"
-#include "lazy_filter.h"
+#include "global_filter.h"
 #include "leaf_blueprints.h"
 #include "matching_elements_search.h"
 #include "orsearch.h"
@@ -204,7 +204,7 @@ Blueprint::set_global_filter(const GlobalFilter &, double)
 }
 
 void
-Blueprint::set_lazy_filter(const LazyFilter &)
+Blueprint::set_lazy_filter(const GlobalFilter &)
 {
 }
 
@@ -374,9 +374,9 @@ Blueprint::create_default_filter(FilterConstraint constraint)
     }
 }
 
-std::shared_ptr<LazyFilter>
+std::shared_ptr<GlobalFilter>
 Blueprint::create_lazy_filter() const {
-    return InactiveLazyFilter::create();
+    return GlobalFilter::create();
 }
 
 std::string
@@ -671,7 +671,7 @@ IntermediateBlueprint::set_global_filter(const GlobalFilter &global_filter, doub
 }
 
 void
-IntermediateBlueprint::set_lazy_filter(const LazyFilter &lazy_filter)
+IntermediateBlueprint::set_lazy_filter(const GlobalFilter &lazy_filter)
 {
     for (auto & child : _children) {
         child->set_lazy_filter(lazy_filter);
@@ -689,7 +689,7 @@ IntermediateBlueprint::createSearchImpl(fef::MatchData &md) const
     return createIntermediateSearch(std::move(subSearches), md);
 }
 
-std::shared_ptr<LazyFilter>
+std::shared_ptr<GlobalFilter>
 IntermediateBlueprint::create_lazy_filter() const {
     for (const auto & child : _children) {
         auto lazy_filter = child->create_lazy_filter();
@@ -698,7 +698,7 @@ IntermediateBlueprint::create_lazy_filter() const {
         }
     }
 
-    return InactiveLazyFilter::create();
+    return GlobalFilter::create();
 }
 
 IntermediateBlueprint::IntermediateBlueprint() noexcept = default;

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -44,7 +44,6 @@ class EmptyBlueprint;
 class AlwaysTrueBlueprint;
 class QueryEvalStats;
 class NearestNeighborBlueprint;
-class LazyFilter;
 
 /**
  * A Blueprint is an intermediate representation of a search. More
@@ -389,7 +388,7 @@ public:
      */
     virtual void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio);
 
-    virtual void set_lazy_filter(const LazyFilter &lazy_filter);
+    virtual void set_lazy_filter(const GlobalFilter &lazy_filter);
 
     virtual const State &getState() const = 0;
     const Blueprint &root() const;
@@ -448,7 +447,7 @@ public:
     static SearchIteratorUP create_first_child_filter(std::span<const UP> children, FilterConstraint constraint);
     static SearchIteratorUP create_default_filter(FilterConstraint constraint);
 
-    virtual std::shared_ptr<LazyFilter> create_lazy_filter() const;
+    virtual std::shared_ptr<GlobalFilter> create_lazy_filter() const;
 
     // for debug dumping
     std::string asString() const;
@@ -545,7 +544,7 @@ public:
     void optimize(Blueprint* &self, OptimizePass pass) override;
     void sort(InFlow in_flow) override;
     void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
-    void set_lazy_filter(const LazyFilter &lazy_filter) override;
+    void set_lazy_filter(const GlobalFilter &lazy_filter) override;
 
     IndexList find(const IPredicate & check) const;
     size_t childCnt() const { return _children.size(); }
@@ -558,7 +557,7 @@ public:
     Blueprint::UP removeLastChild() { return removeChild(childCnt() - 1); }
     SearchIteratorUP createSearchImpl(fef::MatchData &md) const override;
 
-    std::shared_ptr<LazyFilter> create_lazy_filter() const override;
+    std::shared_ptr<GlobalFilter> create_lazy_filter() const override;
 
     virtual HitEstimate combine(const std::vector<HitEstimate> &data) const = 0;
     virtual FieldSpecBaseList exposeFields() const = 0;

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
@@ -12,26 +12,7 @@
 
 namespace search::queryeval {
 
-class LazyFilter : public GlobalFilter {
-public:
-    std::shared_ptr<const LazyFilter> shared_from_this() const { return std::static_pointer_cast<const LazyFilter>(GlobalFilter::shared_from_this()); }
-    virtual std::shared_ptr<LazyFilter> clone() const = 0;
-};
-
-class InactiveLazyFilter : public LazyFilter {
-private:
-    struct Private { explicit Private() = default; };
-public:
-    InactiveLazyFilter(Private) noexcept {}
-    static std::shared_ptr<InactiveLazyFilter> create() { return std::make_shared<InactiveLazyFilter>(Private()); }
-    bool is_active() const override { return false; }
-    uint32_t size() const override { abort(); }
-    uint32_t count() const override { abort(); }
-    bool check(uint32_t /*docid*/) const override { abort(); }
-    std::shared_ptr<LazyFilter> clone() const override { return create(); }
-};
-
-class GeoLocationLazyFilter : public LazyFilter {
+class GeoLocationLazyFilter : public GlobalFilter {
 private:
     struct Private { explicit Private() = default; };
     const common::Location &_location;
@@ -68,9 +49,6 @@ public:
         }
 
         return false;
-    }
-    std::shared_ptr<LazyFilter> clone() const override {
-        return create(_location, _estimate);
     }
 };
 

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
@@ -35,13 +35,13 @@ public:
         if (docid >= _docid_limit) {
             return false;
         }
-        uint32_t _num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
-        while (_num_values > _pos.size()) {
-            _pos.resize(_num_values);
-            _num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
+        uint32_t num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
+        while (num_values > _pos.size()) {
+            _pos.resize(num_values);
+            num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
         }
 
-        for (uint32_t i = 0; i < _num_values; i++) {
+        for (uint32_t i = 0; i < num_values; i++) {
             int64_t docxy(_pos[i]);
             if (_location.inside_limit(docxy)) {
                 return true;

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -138,7 +138,7 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
 }
 
 void
-NearestNeighborBlueprint::set_lazy_filter(const LazyFilter &lazy_filter) {
+NearestNeighborBlueprint::set_lazy_filter(const GlobalFilter &lazy_filter) {
     _lazy_filter = lazy_filter.shared_from_this();
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -148,9 +148,9 @@ NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighborInd
     uint32_t k = _adjusted_target_hits;
     const auto &df = _distance_calc->function();
     if (_lazy_filter && _lazy_filter->is_active()) { // Global filter might or might not be active
-        std::shared_ptr<const LazyFilter> use_filter = _lazy_filter;
+        std::shared_ptr<const GlobalFilter> use_filter = _lazy_filter;
         if (_global_filter->is_active()) { // Both global filter and lazy filter
-            use_filter = FallbackLazyFilter::create(*_global_filter, *_lazy_filter);
+            use_filter = FallbackFilter::create(*_global_filter, *_lazy_filter);
         }
         bool low_hit_ratio = (static_cast<double>(use_filter->count()) / _attr_tensor.get_num_docs()) < _hnsw_params.filter_first_upper_limit;
         _found_hits = nns_index->find_top_k_with_filter(_nni_stats, k, df, *use_filter, low_hit_ratio, _hnsw_params.filter_first_exploration,

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -139,7 +139,7 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
 
 void
 NearestNeighborBlueprint::set_lazy_filter(const LazyFilter &lazy_filter) {
-    _lazy_filter = lazy_filter.clone();
+    _lazy_filter = lazy_filter.shared_from_this();
 }
 
 void
@@ -147,12 +147,13 @@ NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighborInd
 {
     uint32_t k = _adjusted_target_hits;
     const auto &df = _distance_calc->function();
-    if (_lazy_filter && _lazy_filter->is_active()) { // global filter might or might not be active
-        bool low_hit_ratio = false;
-        if (_global_filter_hit_ratio.has_value()) {
-            low_hit_ratio = _global_filter_hit_ratio.value() < _hnsw_params.filter_first_upper_limit;
+    if (_lazy_filter && _lazy_filter->is_active()) { // Global filter might or might not be active
+        std::shared_ptr<const LazyFilter> use_filter = _lazy_filter;
+        if (_global_filter->is_active()) { // Both global filter and lazy filter
+            use_filter = FallbackLazyFilter::create(*_global_filter, *_lazy_filter);
         }
-        _found_hits = nns_index->find_top_k_with_lazy_filter(_nni_stats, k, df, *_global_filter, _lazy_filter.get(), low_hit_ratio, _hnsw_params.filter_first_exploration,
+        bool low_hit_ratio = (static_cast<double>(use_filter->count()) / _attr_tensor.get_num_docs()) < _hnsw_params.filter_first_upper_limit;
+        _found_hits = nns_index->find_top_k_with_filter(_nni_stats, k, df, *use_filter, low_hit_ratio, _hnsw_params.filter_first_exploration,
                                                         k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _doom, _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K_WITH_FILTER;
     } else if (_global_filter->is_active()) {

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -53,7 +53,7 @@ private:
     bool _global_filter_set;
     std::optional<uint32_t> _global_filter_hits;
     std::optional<double> _global_filter_hit_ratio;
-    std::shared_ptr<const LazyFilter> _lazy_filter;
+    std::shared_ptr<const GlobalFilter> _lazy_filter;
     const vespalib::Doom& _doom;
     MatchingPhase _matching_phase;
     search::tensor::NearestNeighborIndex::Stats _nni_stats;
@@ -77,7 +77,7 @@ public:
     uint32_t get_adjusted_target_hits() const { return _adjusted_target_hits; }
     bool want_global_filter(GlobalFilterLimits& limits) const override;
     void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
-    void set_lazy_filter(const LazyFilter &lazy_filter) override;
+    void set_lazy_filter(const GlobalFilter &lazy_filter) override;
     Algorithm get_algorithm() const { return _algorithm; }
     double get_distance_threshold() const { return _hnsw_params.distance_threshold; }
     const HnswParams& get_hnsw_params() const { return _hnsw_params; }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -53,7 +53,7 @@ private:
     bool _global_filter_set;
     std::optional<uint32_t> _global_filter_hits;
     std::optional<double> _global_filter_hit_ratio;
-    std::shared_ptr<LazyFilter> _lazy_filter;
+    std::shared_ptr<const LazyFilter> _lazy_filter;
     const vespalib::Doom& _doom;
     MatchingPhase _matching_phase;
     search::tensor::NearestNeighborIndex::Stats _nni_stats;

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
@@ -18,7 +18,6 @@
 #include <vespa/eval/eval/typed_cells.h>
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/queryeval/global_filter.h>
-#include <vespa/searchlib/queryeval/lazy_filter.h>
 #include <vespa/vespalib/datastore/array_store.h>
 #include <vespa/vespalib/datastore/atomic_entry_ref.h>
 #include <vespa/vespalib/datastore/compaction_spec.h>
@@ -71,7 +70,7 @@ template <>
 class GlobalFilterWrapper<HnswIndexType::SINGLE> {
     const search::queryeval::GlobalFilter *_filter;
 public:
-    explicit GlobalFilterWrapper(const search::queryeval::GlobalFilter *filter, search::queryeval::LazyFilter *)
+    explicit GlobalFilterWrapper(const search::queryeval::GlobalFilter *filter)
         : _filter(filter)
     {
     }
@@ -90,68 +89,13 @@ class GlobalFilterWrapper<HnswIndexType::MULTI> {
     const search::queryeval::GlobalFilter *_filter;
     uint32_t            _docid_limit;
 public:
-    explicit GlobalFilterWrapper(const search::queryeval::GlobalFilter *filter, search::queryeval::LazyFilter *)
+    explicit GlobalFilterWrapper(const search::queryeval::GlobalFilter *filter)
         : _filter(filter),
           _docid_limit(filter ? filter->size() : 0u)
     {
     }
 
     [[nodiscard]] bool check(uint32_t docid) const noexcept { return !_filter || (docid < _docid_limit && _filter->check(docid)); }
-    static void clamp_nodeid_limit(uint32_t&) { }
-};
-
-template <HnswIndexType type>
-class LazyFilterWrapper;
-
-template <>
-class LazyFilterWrapper<HnswIndexType::SINGLE> {
-    const search::queryeval::GlobalFilter *_filter;
-    search::queryeval::LazyFilter *_lazy_filter;
-public:
-    explicit LazyFilterWrapper(const search::queryeval::GlobalFilter *filter, search::queryeval::LazyFilter *lazy_filter)
-        : _filter(filter), _lazy_filter(lazy_filter)
-    {
-    }
-
-    [[nodiscard]] bool check(uint32_t docid) const noexcept {
-        if (_filter && !_filter->check(docid)) {
-            return false;
-        }
-        if (_lazy_filter && !_lazy_filter->check(docid)) {
-            return false;
-        }
-        return true;
-    }
-
-    void clamp_nodeid_limit(uint32_t& nodeid_limit) {
-        if (_filter) {
-            nodeid_limit = std::min(nodeid_limit, _filter->size());
-        }
-    }
-};
-
-template <>
-class LazyFilterWrapper<HnswIndexType::MULTI> {
-    const search::queryeval::GlobalFilter *_filter;
-    uint32_t            _docid_limit;
-    search::queryeval::LazyFilter *_lazy_filter;
-public:
-    explicit LazyFilterWrapper(const search::queryeval::GlobalFilter *filter, search::queryeval::LazyFilter *lazy_filter)
-        : _filter(filter),
-          _docid_limit(filter ? filter->size() : 0u),
-          _lazy_filter(lazy_filter)
-    {
-    }
-
-    [[nodiscard]] bool check(uint32_t docid) const noexcept {
-        if (_filter && (docid >= _docid_limit || !_filter->check(docid))) {
-            return false;
-        }
-        if (_lazy_filter && !_lazy_filter->check(docid)) {
-            return false;
-        }
-        return true;
-    }
     static void clamp_nodeid_limit(uint32_t&) { }
 };
 
@@ -265,29 +209,28 @@ protected:
      * Performs a greedy search in the given layer to find the candidate that is nearest the input vector.
      */
     HnswCandidate find_nearest_in_layer(Stats &stats, const BoundDistanceFunction &df, const HnswCandidate& entry_point, uint32_t level) const __attribute__((noinline));
-    template <class VisitedTracker, class FilterWrapper, class BestNeighbors>
+    template <class VisitedTracker, class BestNeighbors>
     void search_layer_helper(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
-                             uint32_t level, const GlobalFilter *filter, search::queryeval::LazyFilter *lazy_filter, uint32_t nodeid_limit,
+                             uint32_t level, const GlobalFilter *filter, uint32_t nodeid_limit,
                              const vespalib::Doom* const doom, uint32_t estimated_visited_nodes) const __attribute__((noinline));
-    template <class VisitedTracker, class FilterWrapper, class BestNeighbors>
+    template <class VisitedTracker, class BestNeighbors>
     void search_layer_filter_first_helper(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
-                                          double exploration, uint32_t level, const GlobalFilter *filter, search::queryeval::LazyFilter *lazy_filter, uint32_t nodeid_limit,
+                                          double exploration, uint32_t level, const GlobalFilter *filter, uint32_t nodeid_limit,
                                           const vespalib::Doom* const doom, uint32_t estimated_visited_nodes) const __attribute__((noinline));
-    template <class VisitedTracker, class FilterWrapper>
+    template <class VisitedTracker>
     void exploreNeighborhood(Stats &stats, HnswTraversalCandidate &cand, std::deque<uint32_t> &found, VisitedTracker &visited, double exploration, uint32_t level,
-                             const FilterWrapper& filter_wrapper, uint32_t nodeid_limit) const;
-    template <class VisitedTracker, class FilterWrapper>
+                             const internal::GlobalFilterWrapper<type>& filter_wrapper, uint32_t nodeid_limit) const;
+    template <class VisitedTracker>
     void exploreNeighborhoodByOneHop(Stats &stats, std::deque<uint32_t> &todo, std::deque<uint32_t> &found, VisitedTracker &visited, uint32_t level,
-                                     const FilterWrapper& filter_wrapper, uint32_t nodeid_limit,
+                                     const internal::GlobalFilterWrapper<type>& filter_wrapper, uint32_t nodeid_limit,
                                      uint32_t max_neighbors_to_find) const;
-    template <class FilterWrapper, class BestNeighbors>
+    template <class BestNeighbors>
     void search_layer(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors,
-                      uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter = nullptr, search::queryeval::LazyFilter *lazy_filter = nullptr) const;
-    template <class FilterWrapper, class BestNeighbors>
+                      uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter = nullptr) const;
+    template <class BestNeighbors>
     void search_layer_filter_first(Stats &stats, const BoundDistanceFunction &df, uint32_t neighbors_to_find, double exploration_slack, BestNeighbors& best_neighbors, double exploration,
-                                   uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter = nullptr, search::queryeval::LazyFilter *lazy_filter = nullptr) const;
-    template <class FilterWrapper>
-    std::vector<Neighbor> top_k_by_docid(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter *filter, search::queryeval::LazyFilter *lazy_filter, bool low_hit_ratio, double exploration,
+                                   uint32_t level, const vespalib::Doom* const doom, const GlobalFilter *filter = nullptr) const;
+    std::vector<Neighbor> top_k_by_docid(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
                                          uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const;
 
     internal::PreparedAddDoc internal_prepare_add(uint32_t docid, VectorBundle input_vectors,
@@ -333,14 +276,8 @@ public:
     std::vector<Neighbor> find_top_k_with_filter(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter &filter, bool low_hit_ratio, double exploration,
                                                  uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const override;
 
-    std::vector<Neighbor> find_top_k_with_lazy_filter(Stats &stats, uint32_t k, const BoundDistanceFunction &df, const GlobalFilter &filter, search::queryeval::LazyFilter *lazy_filter, bool low_hit_ratio, double exploration,
-                                                      uint32_t explore_k, double exploration_slack, const vespalib::Doom& doom, double distance_threshold) const override;
-
     DistanceFunctionFactory &distance_function_factory() const override { return *_distance_ff; }
 
-    template <class FilterWrapper>
-    SearchBestNeighbors top_k_candidates(Stats &stats, const BoundDistanceFunction &df, uint32_t k, double exploration_slack, const GlobalFilter *filter, search::queryeval::LazyFilter *lazy_filter, bool low_hit_ratio, double exploration,
-                                         const vespalib::Doom& doom) const;
     SearchBestNeighbors top_k_candidates(Stats &stats, const BoundDistanceFunction &df, uint32_t k, double exploration_slack, const GlobalFilter *filter, bool low_hit_ratio, double exploration,
                                          const vespalib::Doom& doom) const;
 

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
@@ -28,10 +28,7 @@ namespace vespalib::slime { struct Inserter; }
 namespace search::fileutil { class LoadedBuffer; }
 
 namespace search { class AddressSpaceUsage; }
-namespace search::queryeval {
-class GlobalFilter;
-class LazyFilter;
-}
+namespace search::queryeval { class GlobalFilter; }
 
 namespace search::tensor {
 
@@ -136,18 +133,6 @@ public:
                                                          uint32_t k,
                                                          const BoundDistanceFunction &df,
                                                          const GlobalFilter &filter,
-                                                         bool low_hit_ratio,
-                                                         double exploration,
-                                                         uint32_t explore_k,
-                                                         double exploration_slack,
-                                                         const vespalib::Doom& doom,
-                                                         double distance_threshold) const = 0;
-
-    virtual std::vector<Neighbor> find_top_k_with_lazy_filter(Stats &stats,
-                                                         uint32_t k,
-                                                         const BoundDistanceFunction &df,
-                                                         const GlobalFilter &filter,
-                                                         search::queryeval::LazyFilter *lazy_filter,
                                                          bool low_hit_ratio,
                                                          double exploration,
                                                          uint32_t explore_k,


### PR DESCRIPTION
This removes the LazyFilter class and makes the lazy filters implement GlobalFilter instead. Moreover, it restores `hnsw_index.h`, `hnsw_index.cpp`, `nearest_neighbor_index.h`, and `tensorattribute_test.cpp` to the state they were in before lazy filtering was added.

@toregge please review