### PR TITLE
Enable simple annotations and protobuf query trees by default

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -108,8 +108,8 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"arnej"}) default double logserverNodeMemory() { return 0.0; }
         @ModelFeatureFlag(owners = {"arnej"}) default double clusterControllerNodeMemory() { return 0.0; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean useLegacyWandQueryParsing() { return true; }
-        @ModelFeatureFlag(owners = {"arnej"}) default boolean useSimpleAnnotations() { return false; }
-        @ModelFeatureFlag(owners = {"arnej"}) default boolean sendProtobufQuerytree() { return false; }
+        @ModelFeatureFlag(owners = {"arnej"}) default boolean useSimpleAnnotations() { return true; }
+        @ModelFeatureFlag(owners = {"arnej"}) default boolean sendProtobufQuerytree() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean forwardAllLogLevels() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default int documentV1QueueSize() { return -1; /* use default from config def */ } // TODO(bjorncs, 2025-12-01) Remove after Jan 2026

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/ContainerDocproc.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/ContainerDocproc.java
@@ -53,7 +53,7 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
         super(chains);
         assert (options != null) : "Null Options for " + this + " under cluster " + cluster.getName();
         this.options = options;
-        this.useSimpleAnnotations = deployState != null && deployState.featureFlags().useSimpleAnnotations();
+        this.useSimpleAnnotations = deployState == null || deployState.featureFlags().useSimpleAnnotations();
 
         if (addSourceClientProvider) {
             addSource(cluster, "source", SessionConfig.Type.SOURCE);
@@ -88,7 +88,7 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
         }
         builder.simpleAnnotations(useSimpleAnnotations);
     }
-    
+
     @Override
     public void getConfig(SchemamappingConfig.Builder builder) {
         Map<Pair<String, String>, String> allMappings = new HashMap<>();
@@ -112,7 +112,7 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
             }
         }
     }
-    
+
     /**
      * The field name schema map that applies to this whole chain
      * @return doctype,from → to

--- a/container-core/src/main/resources/configdefinitions/container.qr-searchers.def
+++ b/container-core/src/main/resources/configdefinitions/container.qr-searchers.def
@@ -83,4 +83,4 @@ parserSettings.keepSegmentAnds bool default=false
 parserSettings.keepIdeographicPunctuation bool default=false
 
 ## send query tree as protobuf in addition to legacy format
-sendProtobufQuerytree bool default=false
+sendProtobufQuerytree bool default=true

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -62,7 +62,8 @@ public class ProtobufSerializationTest {
     @Test
     void testDocsumSerialization() {
         Query q = new Query("search/?query=test&hits=10&offset=3");
-        var builder = ProtobufSerialization.createDocsumRequestBuilder(q, "server", "summary", Set.of("f1", "f2"),true, 0.5, new QrSearchersConfig.Builder().build());
+        var builder = ProtobufSerialization.createDocsumRequestBuilder(q, "server", "summary", Set.of("f1", "f2"),true, 0.5,
+                                                                       new QrSearchersConfig.Builder().sendProtobufQuerytree(false).build());
         builder.setTimeout(0);
         var hit = new FastHit();
         hit.setGlobalId(new GlobalId(IdString.createIdString("id:ns:type::id")).getRawId());

--- a/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
+++ b/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
@@ -11,4 +11,4 @@ numthreads int default=-1
 
 # Enable lightweight annotation representation for StringFieldValue.
 # When enabled, uses SimpleIndexingAnnotations (flat arrays) instead of full SpanTree objects.
-simpleAnnotations bool default=false
+simpleAnnotations bool default=true

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -261,14 +261,14 @@ public class Flags {
             INSTANCE_ID);
 
     public static final UnboundBooleanFlag USE_SIMPLE_ANNOTATIONS = defineFeatureFlag(
-            "use-simple-annotations", false,
+            "use-simple-annotations", true,
             List.of("arnej"), "2025-11-13", "2026-12-31",
             "Enable lightweight annotation representation for StringFieldValue",
             "Takes effect at redeployment",
             INSTANCE_ID);
 
     public static final UnboundBooleanFlag SEND_PROTOBUF_QUERYTREE = defineFeatureFlag(
-            "send-protobuf-querytree", false,
+            "send-protobuf-querytree", true,
             List.of("arnej"), "2025-10-06", "2026-03-31",
             "If true, send query tree as protobuf in addition to legacy format",
             "Takes effect at redeployment",


### PR DESCRIPTION
Changes the default values for two feature flags from false to true:
- useSimpleAnnotations: enables lightweight annotation representation using flat arrays instead of full SpanTree objects
- sendProtobufQuerytree: enables sending query trees in protobuf format in addition to the legacy format

This affects model context defaults, config definitions, and flag definitions across the codebase.

@hmusum please review
@andreer FYI
