### PR TITLE
Clean up lazy filtering classes

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -351,7 +351,8 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
     if (use_lazy_filter) {
         if (lazy_filter->is_active()) {
             if (trace && trace->shouldTrace(5)) {
-                    trace->addEvent(5, "Apply active lazy filter");
+                    trace->addEvent(5, vespalib::make_string("Apply active lazy filter (estimate is %f)",
+                                                                               lazy_filter->size() > 0 ? static_cast<double>(lazy_filter->count()) / lazy_filter->size() : 1.0));
             }
             blueprint.set_lazy_filter(*lazy_filter);
         }

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -399,7 +399,7 @@ public:
         return create_default_filter(constraint);
     }
     std::shared_ptr<queryeval::GlobalFilter> create_lazy_filter() const override {
-        return queryeval::GeoLocationLazyFilter::create(_location, _pre_filter_estimate);
+        return queryeval::LocationLazyFilter::create(_location, _pre_filter_estimate);
     }
     void visitMembers(vespalib::ObjectVisitor& visitor) const override {
         LeafBlueprint::visitMembers(visitor);

--- a/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/queryeval/CMakeLists.txt
@@ -33,6 +33,7 @@ vespa_add_library(searchlib_queryeval OBJECT
     isourceselector.cpp
     iterator_pack.cpp
     iterators.cpp
+    lazy_filter.cpp
     leaf_blueprints.cpp
     matching_elements_search.cpp
     monitoring_dump_iterator.cpp

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.cpp
@@ -1,0 +1,99 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "lazy_filter.h"
+#include <vespa/searchlib/common/location.h>
+
+namespace search::queryeval {
+
+GeoLocationLazyFilter::GeoLocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept
+    : _location(location),
+      _docid_limit(_location.getVec()->getCommittedDocIdLimit()),
+      _estimate(estimate)
+{
+    _pos.resize(1);  // Needed (single-value attribute), cf. LocationIterator
+}
+
+std::shared_ptr<GeoLocationLazyFilter>
+GeoLocationLazyFilter::create(const common::Location &location, const Blueprint::HitEstimate &estimate)
+{
+    return std::make_shared<GeoLocationLazyFilter>(Private(), location, estimate);
+}
+
+bool
+GeoLocationLazyFilter::is_active() const
+{
+    return true;
+}
+
+uint32_t
+GeoLocationLazyFilter::size() const
+{
+    return _docid_limit;
+}
+
+uint32_t
+GeoLocationLazyFilter::count() const
+{
+    return _estimate.empty ? _docid_limit : std::min(_docid_limit, _estimate.estHits);
+}
+
+bool
+GeoLocationLazyFilter::check(uint32_t docid) const
+{
+    if (docid >= _docid_limit) {
+        return false;
+    }
+    uint32_t num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
+    while (num_values > _pos.size()) {
+        _pos.resize(num_values);
+        num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
+    }
+
+    for (uint32_t i = 0; i < num_values; i++) {
+        int64_t docxy(_pos[i]);
+        if (_location.inside_limit(docxy)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+FallbackFilter::FallbackFilter(Private, const GlobalFilter &global_filter, const GlobalFilter &fallback)
+        : _global_filter(global_filter), _fallback(fallback)
+{
+    assert(_global_filter.is_active());
+    assert(_fallback.is_active());
+}
+
+std::shared_ptr<FallbackFilter>
+FallbackFilter::create(const GlobalFilter &global_filter, const GlobalFilter &fallback)
+{
+    return std::make_shared<FallbackFilter>(Private(), global_filter, fallback);
+}
+
+bool
+FallbackFilter::is_active() const
+{
+    return true;
+}
+
+uint32_t
+FallbackFilter::size() const
+{
+    return std::min(_global_filter.size(), _fallback.size());
+}
+
+uint32_t
+FallbackFilter::count() const
+{
+    return std::min(_global_filter.count(), _fallback.count());
+}
+
+bool
+FallbackFilter::check(uint32_t docid) const
+{
+    return _global_filter.check(docid) && _fallback.check(docid);
+}
+
+}

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.cpp
@@ -5,7 +5,7 @@
 
 namespace search::queryeval {
 
-GeoLocationLazyFilter::GeoLocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept
+LocationLazyFilter::LocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept
     : _location(location),
       _docid_limit(_location.getVec()->getCommittedDocIdLimit()),
       _estimate(estimate)
@@ -13,32 +13,32 @@ GeoLocationLazyFilter::GeoLocationLazyFilter(Private, const common::Location &lo
     _pos.resize(1);  // Needed (single-value attribute), cf. LocationIterator
 }
 
-std::shared_ptr<GeoLocationLazyFilter>
-GeoLocationLazyFilter::create(const common::Location &location, const Blueprint::HitEstimate &estimate)
+std::shared_ptr<LocationLazyFilter>
+LocationLazyFilter::create(const common::Location &location, const Blueprint::HitEstimate &estimate)
 {
-    return std::make_shared<GeoLocationLazyFilter>(Private(), location, estimate);
+    return std::make_shared<LocationLazyFilter>(Private(), location, estimate);
 }
 
 bool
-GeoLocationLazyFilter::is_active() const
+LocationLazyFilter::is_active() const
 {
     return true;
 }
 
 uint32_t
-GeoLocationLazyFilter::size() const
+LocationLazyFilter::size() const
 {
     return _docid_limit;
 }
 
 uint32_t
-GeoLocationLazyFilter::count() const
+LocationLazyFilter::count() const
 {
     return _estimate.empty ? _docid_limit : std::min(_docid_limit, _estimate.estHits);
 }
 
 bool
-GeoLocationLazyFilter::check(uint32_t docid) const
+LocationLazyFilter::check(uint32_t docid) const
 {
     if (docid >= _docid_limit) {
         return false;

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
@@ -21,7 +21,7 @@ namespace search::queryeval {
  * Not thread-safe. If an object of this class is to be used in multiple threads,
  * then a copy has to be created for every thread.
  **/
-class GeoLocationLazyFilter : public GlobalFilter {
+class LocationLazyFilter : public GlobalFilter {
 private:
     struct Private { explicit Private() = default; };
     const common::Location &_location;
@@ -30,8 +30,8 @@ private:
     mutable std::vector<search::AttributeVector::largeint_t> _pos;
 
 public:
-    GeoLocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept;
-    static std::shared_ptr<GeoLocationLazyFilter> create(const common::Location &location, const Blueprint::HitEstimate &estimate);
+    LocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept;
+    static std::shared_ptr<LocationLazyFilter> create(const common::Location &location, const Blueprint::HitEstimate &estimate);
     bool is_active() const override;
     uint32_t size() const override;
     uint32_t count() const override;

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
@@ -12,6 +12,15 @@ namespace search::common { class Location; }
 
 namespace search::queryeval {
 
+/**
+ * Class for checking whether document ids match a Location.
+ *
+ * Performs the check by accessing the contents of the attribute vector of the given Location. Hence, it is not as fast
+ * as other implementations of GlobalFilter.
+ *
+ * Not thread-safe. If an object of this class is to be used in multiple threads,
+ * then a copy has to be created for every thread.
+ **/
 class GeoLocationLazyFilter : public GlobalFilter {
 private:
     struct Private { explicit Private() = default; };
@@ -29,6 +38,13 @@ public:
     bool check(uint32_t docid) const override;
 };
 
+/**
+ * Class that combines two GlobalFilter objects into a single GlobalFilter.
+ *
+ * Corresponds to a logical 'and' of the two GlobalFilters. Evaluates the first filter first, and only if
+ * the document passes that filter, it evaluates the second filter. Intended to be used to combine a cheap (the global filter)
+ * and an expensive (the lazy filter) GlobalFilter.
+ **/
 class FallbackFilter : public GlobalFilter {
 private:
     struct Private { explicit Private() = default; };

--- a/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
+++ b/searchlib/src/vespa/searchlib/queryeval/lazy_filter.h
@@ -4,11 +4,11 @@
 
 #include "blueprint.h"
 #include "global_filter.h"
-#include <vespa/searchlib/common/location.h>
 #include <vespa/searchlib/attribute/attributevector.h>
-#include <vespa/searchcommon/attribute/iattributevector.h>
 #include <memory>
 #include <vector>
+
+namespace search::common { class Location; }
 
 namespace search::queryeval {
 
@@ -21,35 +21,12 @@ private:
     mutable std::vector<search::AttributeVector::largeint_t> _pos;
 
 public:
-    GeoLocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept
-        : _location(location),
-          _docid_limit(_location.getVec()->getCommittedDocIdLimit()),
-          _estimate(estimate) {
-          _pos.resize(1);  // Needed (single-value attribute), cf. LocationIterator
-    }
-    static std::shared_ptr<GeoLocationLazyFilter> create(const common::Location &location, const Blueprint::HitEstimate &estimate) { return std::make_shared<GeoLocationLazyFilter>(Private(), location, estimate); }
-    bool is_active() const override { return true; }
-    uint32_t size() const override { return _docid_limit; }
-    uint32_t count() const override { return _estimate.empty ? _docid_limit : std::min(_docid_limit, _estimate.estHits); }
-    bool check(uint32_t docid) const override {
-        if (docid >= _docid_limit) {
-            return false;
-        }
-        uint32_t num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
-        while (num_values > _pos.size()) {
-            _pos.resize(num_values);
-            num_values = _location.getVec()->get(docid, &_pos[0], _pos.size());
-        }
-
-        for (uint32_t i = 0; i < num_values; i++) {
-            int64_t docxy(_pos[i]);
-            if (_location.inside_limit(docxy)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    GeoLocationLazyFilter(Private, const common::Location &location, const Blueprint::HitEstimate &estimate) noexcept;
+    static std::shared_ptr<GeoLocationLazyFilter> create(const common::Location &location, const Blueprint::HitEstimate &estimate);
+    bool is_active() const override;
+    uint32_t size() const override;
+    uint32_t count() const override;
+    bool check(uint32_t docid) const override;
 };
 
 class FallbackFilter : public GlobalFilter {
@@ -58,24 +35,12 @@ private:
     const GlobalFilter &_global_filter;
     const GlobalFilter &_fallback;
 public:
-    FallbackFilter(Private, const GlobalFilter &global_filter, const GlobalFilter &fallback)
-        : _global_filter(global_filter), _fallback(fallback) {
-        assert(_global_filter.is_active());
-        assert(_fallback.is_active());
-    }
-    static std::shared_ptr<FallbackFilter> create(const GlobalFilter &global_filter, const GlobalFilter &fallback) { return std::make_shared<FallbackFilter>(Private(), global_filter, fallback); }
-    bool is_active() const override {
-        return true;
-    }
-    uint32_t size() const override {
-        return std::min(_global_filter.size(), _fallback.size());
-    }
-    uint32_t count() const override {
-        return std::min(_global_filter.count(), _fallback.count());
-    }
-    bool check(uint32_t docid) const override {
-        return _global_filter.check(docid) && _fallback.check(docid);
-    }
+    FallbackFilter(Private, const GlobalFilter &global_filter, const GlobalFilter &fallback);
+    static std::shared_ptr<FallbackFilter> create(const GlobalFilter &global_filter, const GlobalFilter &fallback);
+    bool is_active() const override;
+    uint32_t size() const override;
+    uint32_t count() const override;
+    bool check(uint32_t docid) const override;
 };
 
 } // namespace


### PR DESCRIPTION
Moves the methods to a .cpp file, adds a bit of documentation and reports the estimated hit ratio in the trace.