### PR TITLE
Add `JsonDataSource` and `RenderTarget` to `JsonRenderer`

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7910,6 +7910,21 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.rendering.JsonDataSource" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [
+      "com.yahoo.data.disclosure.DataSource"
+    ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.String)",
+      "public static com.yahoo.search.rendering.JsonDataSource fromJson(java.lang.String)",
+      "public void emit(com.yahoo.data.disclosure.DataSink)"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.rendering.JsonRenderer$FieldConsumer" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonDataSource.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonDataSource.java
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.rendering;
+
+import com.yahoo.data.access.slime.SlimeAdapter;
+import com.yahoo.data.disclosure.DataSink;
+import com.yahoo.data.disclosure.DataSource;
+import com.yahoo.slime.SlimeUtils;
+
+/**
+ * Parses JSON to inspector and emits the inspector to the sink.
+ *
+ * @author johsol
+ */
+public class JsonDataSource implements DataSource {
+
+    private final String json;
+
+    public JsonDataSource(String json) {
+        this.json = json;
+    }
+
+    public static JsonDataSource fromJson(String json) {
+        return new JsonDataSource(json);
+    }
+
+    @Override
+    public void emit(DataSink sink) {
+        var inspector = new SlimeAdapter(SlimeUtils.jsonToSlime(json).get());
+        inspector.emit(sink);
+    }
+}


### PR DESCRIPTION
- To support `JsonProducer` when we are emitting `CBOR`, the `JsonDataSource` is added to be able to parse JSON into the data source API.
- Wired into `JsonRenderer` by introducing `RenderTarget` enum.
- Tests `JsonProducer` path through `JsonRenderer`.

@andreer please review
@arnej27959 fyi
@havardpe fyi