### PR TITLE
Change order of trace messages (first lazy filter, then global filter)

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -345,9 +345,6 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
         }
         global_filter = GlobalFilter::create();
     }
-    if (trace) {
-        trace->addEvent(5, "Handle global filter in query execution plan");
-    }
     if (use_lazy_filter) {
         if (lazy_filter->is_active()) {
             if (trace && trace->shouldTrace(5)) {
@@ -356,6 +353,9 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
             }
             blueprint.set_lazy_filter(*lazy_filter);
         }
+    }
+    if (trace) {
+        trace->addEvent(5, "Handle global filter in query execution plan");
     }
     blueprint.set_global_filter(*global_filter, estimated_hit_ratio);
     return true;


### PR DESCRIPTION
If lazy filtering is used, the trace message order is now reversed as follows:
- `Apply active lazy filter`
- `Handle global filter in query execution plan`

Trace doctor reports the duration of the step `Handle global filter in query execution plan` as the ANN setup time. This means that printing `Apply active lazy filter` after `Handle global filter in query execution plan` confused trace doctor, and the reported ANN setup time was always `0.000 ms`.