### PR TITLE
fix(config-model): use current cluster instance when marking for restart [MERGEOK]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidator.java
@@ -20,29 +20,25 @@ public class DataplaneProxyChangeValidator implements ChangeValidator {
 
     @Override
     public void validate(ChangeContext context) {
-        var previousClustersWithProxy = findClustersWithDataplaneProxy(context.previousModel());
-        var nextClustersWithProxy = findClustersWithDataplaneProxy(context.model());
-        var nextClusters = findAllClusters(context.model());
+        var previousClusters = findAllClusters(context.previousModel());
+        var currentClusters = findAllClusters(context.model());
 
-        // Detect additions
-        for (var entry : nextClustersWithProxy.entrySet()) {
-            if (!previousClustersWithProxy.containsKey(entry.getKey())) {
-                var cluster = entry.getValue();
-                cluster.setDeferChangesUntilRestart(true);
-                var message = "Token endpoint was enabled for cluster '%s', services require restart"
-                        .formatted(entry.getKey());
-                context.require(createRestartAction(cluster, message));
-            }
-        }
+        for (var entry : currentClusters.entrySet()) {
+            var clusterId = entry.getKey();
+            var currentCluster = entry.getValue();
 
-        // Detect removals
-        for (var clusterId : previousClustersWithProxy.keySet()) {
-            if (!nextClustersWithProxy.containsKey(clusterId)) {
-                var cluster = nextClusters.get(clusterId);
-                cluster.setDeferChangesUntilRestart(true);
-                var message = "Token endpoint was disabled for cluster '%s', services require restart"
-                        .formatted(clusterId);
-                context.require(createRestartAction(cluster, message));
+            var previousCluster = previousClusters.get(clusterId);
+            if (previousCluster == null) continue;
+
+            boolean hadProxy = hasDataplaneProxy(previousCluster);
+            boolean hasProxy = hasDataplaneProxy(currentCluster);
+
+            if (hadProxy != hasProxy) {
+                currentCluster.setDeferChangesUntilRestart(true);
+                var message = hasProxy
+                        ? "Token endpoint was enabled for cluster '%s', services require restart"
+                        : "Token endpoint was disabled for cluster '%s', services require restart";
+                context.require(createRestartAction(currentCluster, message.formatted(clusterId)));
             }
         }
     }
@@ -52,11 +48,9 @@ public class DataplaneProxyChangeValidator implements ChangeValidator {
                 .collect(Collectors.toMap(ApplicationContainerCluster::id, cluster -> cluster));
     }
 
-    private static Map<ClusterSpec.Id, ApplicationContainerCluster> findClustersWithDataplaneProxy(VespaModel model) {
-        return model.getContainerClusters().values().stream()
-                .filter(cluster -> cluster.getAllComponents().stream()
-                        .anyMatch(component -> component.getClassId().getName().equals(DataplaneProxy.COMPONENT_CLASS)))
-                .collect(Collectors.toMap(ApplicationContainerCluster::id, cluster -> cluster));
+    private static boolean hasDataplaneProxy(ApplicationContainerCluster cluster) {
+        return cluster.getAllComponents().stream()
+                .anyMatch(component -> component.getClassId().getName().equals(DataplaneProxy.COMPONENT_CLASS));
     }
 
     private static VespaRestartAction createRestartAction(ApplicationContainerCluster cluster, String message) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidatorTest.java
@@ -37,6 +37,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -96,6 +97,9 @@ public class DataplaneProxyChangeValidatorTest {
         assertEquals(1, result.size());
         assertTrue(result.get(0).getMessage().contains("Token endpoint was enabled"));
         assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        assertTrue(getDeferChangesUntilRestart(next));
+        assertFalse(getDeferChangesUntilRestart(previous));
     }
 
     @Test
@@ -107,6 +111,9 @@ public class DataplaneProxyChangeValidatorTest {
         assertEquals(1, result.size());
         assertTrue(result.get(0).getMessage().contains("Token endpoint was disabled"));
         assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        assertTrue(getDeferChangesUntilRestart(next));
+        assertFalse(getDeferChangesUntilRestart(previous));
     }
 
     @Test
@@ -116,6 +123,9 @@ public class DataplaneProxyChangeValidatorTest {
         var result = validateModel(previous, next);
 
         assertTrue(result.isEmpty());
+
+        assertFalse(getDeferChangesUntilRestart(next));
+        assertFalse(getDeferChangesUntilRestart(previous));
     }
 
     @Test
@@ -125,6 +135,9 @@ public class DataplaneProxyChangeValidatorTest {
         var result = validateModel(previous, next);
 
         assertTrue(result.isEmpty());
+
+        assertFalse(getDeferChangesUntilRestart(next));
+        assertFalse(getDeferChangesUntilRestart(previous));
     }
 
     private List<ConfigChangeAction> validateModel(VespaModel current, VespaModel next) {
@@ -151,6 +164,10 @@ public class DataplaneProxyChangeValidatorTest {
                                 new EndpointCertificateSecrets("CERT", "KEY"))))
                 .zone(new Zone(SystemName.PublicCd, Environment.dev, RegionName.defaultName()))
                 .endpoints(endpoints);
+    }
+
+    private static boolean getDeferChangesUntilRestart(VespaModel model) {
+        return model.getContainerClusters().get("default").getDeferChangesUntilRestart();
     }
 }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
