### PR TITLE
update generated metric set doc path

### DIFF
--- a/metrics/src/main/java/ai/vespa/metrics/docs/DocumentationGenerator.java
+++ b/metrics/src/main/java/ai/vespa/metrics/docs/DocumentationGenerator.java
@@ -43,7 +43,7 @@ public class DocumentationGenerator {
         metrics.forEach((metricType, metricArray) -> writeMetricDocumentation(path, metricArray, metricType));
 
         var metricSets = getMetricSets();
-        metricSets.forEach((name, metricSet) -> writeMetricSetDocumentation(path, name, metricSet, metrics));
+        metricSets.forEach((name, metricSet) -> writeMetricSetDocumentation(path + "/operations/metrics", name, metricSet, metrics));
 
         UnitDocumentation.writeUnitDocumentation(path, Unit.values());
     }


### PR DESCRIPTION
fix for https://github.com/vespa-engine/documentation/actions/runs/20200939649/job/57992044468 - these files have moved

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	en/reference/default-metric-set.html
	en/reference/vespa-metric-set.html
```

... or @bratseth 