### PR TITLE
fix(rpms): only mirror 'noarch' RPMs  during x86_64 architecture

### DIFF
--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -19,12 +19,21 @@ fi
 RPMARCH=$1
 ALLOWED_ARCHS=("x86_64" "aarch64")
 
-if [[ ! ${ALLOWED_ARCHS[@]} =~ $RPMARCH ]]; then
-  echo "Architecture $RPMARCH not in allowed archs: ${ALLOWED_ARCHS[@]}"
+ARCH_VALID=false
+for archname in "${ALLOWED_ARCHS[@]}"; do
+  if [[ "$archname" == "$RPMARCH" ]]; then
+    ARCH_VALID=true
+    break
+  fi
+done
+
+if [[ "$ARCH_VALID" != "true" ]]; then
+  echo "Architecture $RPMARCH not in allowed archs: ${ALLOWED_ARCHS[*]}"
   exit 1
 fi
 
-readonly MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly MYDIR
 
 # Copr repo
 dnf config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-8/group_vespa-vespa-epel-8.repo
@@ -36,46 +45,49 @@ curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.tx
 dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
 rm -f /tmp/vespa-open-source-rpms.repo
 
-readonly COPR_PACKAGES=$(mktemp)
-trap "rm -f $COPR_PACKAGES" EXIT
-readonly DLDIR=$(mktemp -d)
-trap "rm -rf $DLDIR" EXIT
+COPR_PACKAGES=$(mktemp)
+DLDIR=$(mktemp -d)
+readonly COPR_PACKAGES DLDIR
 
-cd $DLDIR
+# shellcheck disable=SC2064
+trap "rm -rf \"${COPR_PACKAGES}\" \"$DLDIR\"" EXIT
+
+cd "$DLDIR" || exit 1
 
 readonly DNF="dnf -y -q --forcearch $RPMARCH"
 
 COPR_RPM_ARCH_FILTER="${RPMARCH}"
-if [[ $RPMARCH = "x86_64" ]]; then
+if [[ "${RPMARCH}" = "x86_64" ]]; then
   echo "Including 'noarch' packages to the mirroring process."
   COPR_RPM_ARCH_FILTER="${COPR_RPM_ARCH_FILTER}|noarch"
-fi  
+fi
 
 $DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa --showduplicates 'vespa*' | grep "Available Packages" -A 100000 | tail -n +2 | sed '/\.src\ */d' | sed -E "s/\.(${COPR_RPM_ARCH_FILTER})\ */-/" | awk '{print $1}' | grep -v 8.363.17 | grep -v '.src$' > $COPR_PACKAGES
 
 echo "Packages on Copr:"
-cat $COPR_PACKAGES
+cat "$COPR_PACKAGES"
 echo
 
-for pv in $(cat $COPR_PACKAGES); do
-  if ! $DNF list --disablerepo='*' --enablerepo=vespa-open-source-rpms $pv &> /dev/null; then
+# shellcheck disable=SC2013
+for pv in $(cat "$COPR_PACKAGES"); do
+  if ! $DNF list --disablerepo='*' --enablerepo=vespa-open-source-rpms "$pv" &> /dev/null; then
     # Need one extra check here for noarch packages
-    if ! dnf -y -q --forcearch noarch list --disablerepo='*' --enablerepo=vespa-open-source-rpms $pv &> /dev/null; then
+    if ! dnf -y -q --forcearch noarch list --disablerepo='*' --enablerepo=vespa-open-source-rpms "$pv" &> /dev/null; then
       echo "$pv not found on in archive. Downloading..."
-      $DNF download --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa $pv
+      $DNF download --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa "$pv"
       echo "$pv downloaded."
     fi
   fi
 done
 echo
 
-if ! ls *.rpm &> /dev/null; then
+if ! ls -- *.rpm &> /dev/null; then
   echo "All packages already in archive."
   exit 0
 fi
 
 echo "RPMs missing in archive:"
-ls -lh  *.rpm
+ls -lh  -- *.rpm
 echo
 
 
@@ -86,8 +98,7 @@ for rpm in *.rpm; do
   [ -e "$rpm" ] || continue
   echo "Uploading $rpm ..."
   if [ "${DRY_RUN:-false}" != "true" ]; then
-    $MYDIR/upload-rpm-to-cloudsmith.sh $rpm
-    if [ $? -ne 0 ]; then
+    if ! "$MYDIR/upload-rpm-to-cloudsmith.sh" "$rpm" ; then
       echo "Could not upload $rpm"
       UPLOAD_FAILED=true
     else

--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -45,7 +45,13 @@ cd $DLDIR
 
 readonly DNF="dnf -y -q --forcearch $RPMARCH"
 
-$DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa --showduplicates 'vespa*' | grep "Available Packages" -A 100000 | tail -n +2 | sed '/\.src\ */d' | sed -E "s/\.($RPMARCH|noarch)\ */-/" | awk '{print $1}' | grep -v 8.363.17 | grep -v '.src$' > $COPR_PACKAGES
+COPR_RPM_ARCH_FILTER="${RPMARCH}"
+if [[ $RPMARCH = "x86_64" ]]; then
+  echo "Including 'noarch' packages to the mirroring process."
+  COPR_RPM_ARCH_FILTER="${COPR_RPM_ARCH_FILTER}|noarch"
+fi  
+
+$DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa --showduplicates 'vespa*' | grep "Available Packages" -A 100000 | tail -n +2 | sed '/\.src\ */d' | sed -E "s/\.(${COPR_RPM_ARCH_FILTER})\ */-/" | awk '{print $1}' | grep -v 8.363.17 | grep -v '.src$' > $COPR_PACKAGES
 
 echo "Packages on Copr:"
 cat $COPR_PACKAGES


### PR DESCRIPTION
This ensures we do NOT attempt mirroring the packages twice. Resolves some _possible_ race condition issues.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
