### PR TITLE
Fix QueryRewrite OR-handling

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/QueryRewrite.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/QueryRewrite.java
@@ -4,6 +4,7 @@ package com.yahoo.prelude.querytransform;
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.EquivItem;
+import com.yahoo.prelude.query.FalseItem;
 import com.yahoo.prelude.query.HasIndexItem;
 import com.yahoo.prelude.query.IndexedItem;
 import com.yahoo.prelude.query.Item;
@@ -180,9 +181,13 @@ public class QueryRewrite {
                     }
                     break;
                 case RECALLS_NOTHING:
-                    if ((item instanceof OrItem) || (item instanceof EquivItem) && item.items().size() > 1) {
-                        item.removeItem(i);
-                    } else if ((item instanceof AndItem) || (item instanceof NearItem) || (item instanceof WeakAndItem)) {
+                    if (item instanceof OrItem || item instanceof EquivItem || item instanceof WeakAndItem) {
+                        if (item.items().size() > 1) {
+                            item.removeItem(i);
+                        } else {
+                            return Recall.RECALLS_NOTHING;
+                        }
+                    } else if ((item instanceof AndItem) || (item instanceof NearItem)) {
                         return Recall.RECALLS_NOTHING;
                     } else if (item instanceof RankItem) {
                         if (i == 0) return Recall.RECALLS_NOTHING;
@@ -218,7 +223,7 @@ public class QueryRewrite {
             return item.isRanked();
         }
     }
-    
+
     private static Item collapseSingleComposites(Item item) {
         if (!(item instanceof CompositeItem parent)) {
             return item;

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerTestCase.java
@@ -338,6 +338,10 @@ public class QueryCanonicalizerTestCase {
         and.addItem(new FalseItem());
         root.addItem(new WordItem("i1")); // ... which causes the OR to collapse, leaving this
         assertCanonicalized("i1", null, root);
+        root = new OrItem();
+        root.addItem(new FalseItem());
+        root.addItem(new FalseItem());
+        assertCanonicalized(null, "No query", root);
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/QueryRewriteTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/QueryRewriteTestCase.java
@@ -172,4 +172,11 @@ public class QueryRewriteTestCase {
         assertEquals("3", a.getItem(4).toString());
     }
 
+    @Test
+    void requireNoEmptyOr() {
+        assertRewritten("title:word RANK (text:other AND sddocname:foo)", "qux", "title:word");
+        assertRewritten("(sddocname:foo OR sddocname:bar) AND title:word", "qux", "NULL");
+        assertRewritten("(sddocname:qux AND text:ok) OR ((sddocname:foo OR sddocname:bar) AND title:word)", "qux", "text:ok");
+    }
+
 }


### PR DESCRIPTION
* Logic bug was causing rewrite to end up with empty OR; was (a) || (b) && c but probably meant (a || b) && c
* Instead of replacing or ignoring last child of an or-like expression, return the RECALLS_NOTHING marker
* Also fix unrelated bug: WeakAnd should be or-like not and-like

@bjorncs or @bratseth please review
