### PR TITLE
Support nested items under SameElement

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1500,7 +1500,9 @@
   },
   "com.yahoo.prelude.query.SameElementItem" : {
     "superClass" : "com.yahoo.prelude.query.NonReducibleCompositeItem",
-    "interfaces" : [ ],
+    "interfaces" : [
+      "com.yahoo.prelude.query.HasIndexItem"
+    ],
     "attributes" : [
       "public"
     ],
@@ -1513,6 +1515,8 @@
       "public java.lang.String getName()",
       "public java.lang.String getFieldName()",
       "public void setIndexName(java.lang.String)",
+      "public java.lang.String getIndexName()",
+      "public int getNumWords()",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()"
     ],
@@ -1832,7 +1836,7 @@
     "methods" : [
       "public void <init>()",
       "public abstract boolean visit(com.yahoo.prelude.query.Item)",
-      "public void onExit()"
+      "public void onExit(com.yahoo.prelude.query.Item)"
     ],
     "fields" : [ ]
   },

--- a/container-search/src/main/java/com/yahoo/prelude/query/HasIndexItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/HasIndexItem.java
@@ -10,7 +10,7 @@ public interface HasIndexItem {
 
     String getIndexName();
 
-    /** Returns how many phrase words does this item contain */
+    /** Returns how many phrase words this item contains. */
     int getNumWords();
 
 }

--- a/container-search/src/main/java/com/yahoo/prelude/query/NonReducibleCompositeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/NonReducibleCompositeItem.java
@@ -13,7 +13,6 @@ import java.util.Optional;
  */
 public abstract class NonReducibleCompositeItem extends CompositeItem {
 
-
     @Override
     public final Optional<Item> extractSingleChild() {
         return Optional.empty();

--- a/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
@@ -5,24 +5,20 @@ import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
 import com.yahoo.protect.Validator;
 
 import java.nio.ByteBuffer;
-import java.util.Iterator;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
- * This represents a query where all terms are required to match in the same element id.
- * The primary use case is to allow efficient search in arrays and maps of struct.
- * The common path is the field name containing the struct.
+ * A query item where all terms are required to match in the same value of a multi-value field.
  *
  * @author baldersheim
  */
-public class SameElementItem extends NonReducibleCompositeItem {
+public class SameElementItem extends NonReducibleCompositeItem implements HasIndexItem{
 
     private String fieldName;
 
-    public SameElementItem(String commonPath) {
-        Validator.ensureNonEmpty("Field name", commonPath);
-        this.fieldName = commonPath;
+    public SameElementItem(String fieldName) {
+        Validator.ensureNonEmpty("Field name", fieldName);
+        this.fieldName = fieldName;
     }
 
     @Override
@@ -56,6 +52,16 @@ public class SameElementItem extends NonReducibleCompositeItem {
     @Override
     public void setIndexName(String index) {
         fieldName = index;
+    }
+
+    @Override
+    public String getIndexName() {
+        return fieldName;
+    }
+
+    @Override
+    public int getNumWords() {
+        return getItemCount();
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/prelude/query/ToolBox.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/ToolBox.java
@@ -19,8 +19,8 @@ public final class ToolBox {
          * sub-items of the given item, return false to ignore the sub-items.
          *
          * @param item each item in the query tree
-         * @return whether or not to visit the sub-items of the argument item
-         *         (and then invoke the {@link #onExit()} method)
+         * @return whether to visit the sub-items of the argument item
+         *         (and then invoke the {@link #onExit(item)} method)
          */
         public abstract boolean visit(Item item);
 
@@ -29,7 +29,7 @@ public final class ToolBox {
          * visit() if there are no sub-items or visit() returned false.
          * This default implementation does nothing.
          */
-        public void onExit() {}
+        public void onExit(Item item) {}
 
     }
 
@@ -43,7 +43,7 @@ public final class ToolBox {
         } else {
             visitor.visit(item);
         }
-        visitor.onExit();
+        visitor.onExit(item);
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/prelude/query/WeakAndItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/WeakAndItem.java
@@ -36,7 +36,7 @@ public final class WeakAndItem extends NonReducibleCompositeItem {
     }
 
     /**
-     * Make a WeakAnd item with no children. You can mention a common index or you can mention it on each child.
+     * Make a WeakAnd item with no children. You can mention a common index, or you can mention it on each child.
      *
      * @param index the index to search
      * @param n the target for minimum number of hits to produce;

--- a/container-search/src/main/java/com/yahoo/prelude/query/WordItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/WordItem.java
@@ -81,7 +81,7 @@ public class WordItem extends TermItem {
         putString(getEncodedWord(), buffer);
     }
 
-    /** Returns the word for encoding. By default simply the word */
+    /** Returns the word for encoding. By default, simply the word. */
     protected String getEncodedWord() {
         return getIndexedString();
     }
@@ -133,7 +133,7 @@ public class WordItem extends TermItem {
         this.segmentIndex = segmentIndex;
     }
 
-    /** Word items uses a empty heading instead of "WORD " */
+    /** Word items uses an empty heading instead of "WORD " */
     @Override
     protected void appendHeadingString(StringBuilder buffer) {}
 

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/ValidatePredicateSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/ValidatePredicateSearcher.java
@@ -91,8 +91,6 @@ public class ValidatePredicateSearcher extends Searcher {
             return indexFacts.getIndex(indexName);
         }
 
-        @Override
-        public void onExit() {}
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateFuzzySearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateFuzzySearcher.java
@@ -87,9 +87,6 @@ public class ValidateFuzzySearcher extends Searcher {
             return indexFacts.getIndex(indexName);
         }
 
-        @Override
-        public void onExit() {}
-
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateNearestNeighborSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateNearestNeighborSearcher.java
@@ -143,9 +143,6 @@ public class ValidateNearestNeighborSearcher extends Searcher {
             return item + " field is not a tensor";
         }
 
-        @Override
-        public void onExit() {}
-
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateSameElementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateSameElementSearcher.java
@@ -3,7 +3,14 @@
 package com.yahoo.search.searchers;
 
 import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.NearItem;
+import com.yahoo.prelude.query.ONearItem;
+import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.PhraseItem;
+import com.yahoo.prelude.query.RankItem;
 import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.ToolBox;
 import com.yahoo.search.Query;
@@ -42,52 +49,47 @@ public class ValidateSameElementSearcher extends Searcher {
 
         public Optional<ErrorMessage> errorMessage = Optional.empty();
 
-        private final Query query;
-        private final Execution execution;
+        private boolean inSameElement = false;
 
         public SameElementVisitor(Query query, Execution execution) {
-            this.query = query;
-            this.execution = execution;
         }
 
         @Override
         public boolean visit(Item item) {
-            if (item instanceof SameElementItem sameElement) {
-                String error = ensureValid(sameElement);
-                if (error != null)
-                    errorMessage = Optional.of(ErrorMessage.createIllegalQuery(error));
+            if (inSameElement && ! isValidSameItemChild(item)) {
+                errorMessage = Optional.of(ErrorMessage.createIllegalQuery("SameElementItem cannot contain '" + item + "'"));
+                return false;
             }
+            if (item instanceof SameElementItem)
+                inSameElement = true;
             return true;
         }
 
-        /**
-         * Checks, and if necessary, makes this item valid.
-         *
-         * @return an error message if it is invalid, null if valid
-         */
-        private String ensureValid(SameElementItem sameItem) {
-            if (sameItem.items().stream().noneMatch(child -> child instanceof AndItem)) return null; // shortcut
+        @Override
+        public void onExit(Item item) {
+            if (item instanceof SameElementItem)
+                inSameElement = false;
+        }
 
-            List<Item> flattened = flattenedItems(sameItem);
-            removeItems(sameItem);
-            flattened.forEach(item -> sameItem.addItem(item));
+
+            /** Returns an error message if it is invalid, null if valid. */
+        private String valid(SameElementItem sameItem) {
+            for (Item child : sameItem.items()) {
+                if ( ! isValidSameItemChild(child))
+                    return "SameElementItem cannot contain '" + child + "'";
+            }
             return null;
         }
 
-        private List<Item> flattenedItems(SameElementItem sameItem) {
-            List<Item> flattened = new ArrayList<>();
-            for (Item child : sameItem.items()) {
-                if (child instanceof AndItem and)
-                    flattened.addAll(and.items());
-                else
-                    flattened.add(child);
-            }
-            return flattened;
-        }
-
-        private void removeItems(SameElementItem sameItem) {
-            for (int i = sameItem.getItemCount() - 1; i >= 0; i--)
-                sameItem.removeItem(i);
+        private boolean isValidSameItemChild(Item child) {
+            if ( ! (child instanceof CompositeItem)) return true;
+            if (child instanceof AndItem) return true;
+            if (child instanceof OrItem) return true;
+            if (child instanceof NearItem) return true;
+            if (child instanceof EquivItem) return true;
+            if (child instanceof RankItem) return true;
+            if (child instanceof PhraseItem) return true;
+            return false;
         }
 
     }

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateSameElementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateSameElementSearcher.java
@@ -7,7 +7,6 @@ import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.NearItem;
-import com.yahoo.prelude.query.ONearItem;
 import com.yahoo.prelude.query.OrItem;
 import com.yahoo.prelude.query.PhraseItem;
 import com.yahoo.prelude.query.RankItem;
@@ -21,8 +20,6 @@ import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.yolean.chain.Before;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -76,6 +76,7 @@ import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.FalseItem;
 import com.yahoo.prelude.query.FuzzyItem;
 import com.yahoo.prelude.query.ExactStringItem;
+import com.yahoo.prelude.query.HasIndexItem;
 import com.yahoo.prelude.query.IndexedItem;
 import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
@@ -134,7 +135,7 @@ public class VespaSerializer {
                                                     this.getClass().getSimpleName() + ", not yet implemented.");
         }
 
-        abstract boolean serialize(StringBuilder destination, ITEM item, boolean includeField);
+        abstract boolean serialize(StringBuilder destination, ITEM item, Boolean includeField);
 
     }
 
@@ -160,7 +161,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, AndSegmentItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, AndSegmentItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, AndSegmentItem item, Boolean includeField) {
             Substring origin = item.getOrigin();
             String image;
             int offset;
@@ -176,10 +177,7 @@ public class VespaSerializer {
                 length = origin.end - origin.start;
             }
 
-            if (includeField) {
-                destination.append(normalizeIndexName(item.getIndexName())).append(" contains ");
-            }
-
+            serializeField(item, includeField, destination);
             destination.append("({");
             serializeOrigin(destination, image, offset, length);
             destination.append(", ").append(AND_SEGMENTING).append(": true");
@@ -207,7 +205,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, AndItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, AndItem item, Boolean includeField) {
             destination.append("(");
             return true;
         }
@@ -219,7 +217,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, WeightedSetItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, WeightedSetItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, WeightedSetItem item, Boolean includeField) {
             serializeWeightedSetContents(destination, DOT_PRODUCT, item);
             return false;
         }
@@ -232,9 +230,9 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, EquivItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, EquivItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, EquivItem item, Boolean includeField) {
             String annotations = leafAnnotations(item);
-            destination.append(getIndexName(item.getItem(0))).append(" contains ");
+            serializeField(item.getItem(0), includeField, destination);
             if (!annotations.isEmpty()) {
                 destination.append("({").append(annotations).append("}");
             }
@@ -268,9 +266,8 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, NearItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, NearItem item, boolean includeField) {
-            if (includeField)
-                destination.append(getIndexName(item.getItem(0))).append(" contains ");
+        boolean serialize(StringBuilder destination, NearItem item, Boolean includeField) {
+            serializeField(item.getItem(0), includeField, destination);
             serializeItemListWithoutField(NEAR, item, nearAnnotations(item), destination);
             return false;
         }
@@ -291,7 +288,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, UriItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, UriItem uriItem, boolean includeField) {
+        boolean serialize(StringBuilder destination, UriItem uriItem, Boolean includeField) {
             String annotations = uriAnnotations(uriItem);
 
             if (includeField)
@@ -344,7 +341,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, NotItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, NotItem item, Boolean includeField) {
             destination.append("(");
             return true;
         }
@@ -356,7 +353,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, NullItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, NullItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, NullItem item, Boolean includeField) {
             throw new NullItemException("NullItem encountered in query tree. This is usually a symptom of an invalid " +
                                         "query or an error in a query transformer.");
         }
@@ -369,7 +366,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, IntItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, IntItem intItem, boolean includeField) {
+        boolean serialize(StringBuilder destination, IntItem intItem, Boolean includeField) {
             if (intItem.getFromLimit().number().equals(intItem.getToLimit().number())) {
                 destination.append(normalizeIndexName(intItem.getIndexName())).append(" = ");
                 annotatedNumberImage(intItem, intItem.getFromLimit().number().toString(), destination);
@@ -466,7 +463,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, BoolItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, BoolItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, BoolItem item, Boolean includeField) {
             destination.append(normalizeIndexName(item.getIndexName())).append(" = ");
             destination.append(item.stringValue());
             return false;
@@ -478,7 +475,7 @@ public class VespaSerializer {
         @Override
         void onExit(StringBuilder destination, TrueItem item) { }
         @Override
-        boolean serialize(StringBuilder destination, TrueItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, TrueItem item, Boolean includeField) {
             destination.append("true");
             return false;
         }
@@ -488,7 +485,7 @@ public class VespaSerializer {
         @Override
         void onExit(StringBuilder destination, FalseItem item) { }
         @Override
-        boolean serialize(StringBuilder destination, FalseItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, FalseItem item, Boolean includeField) {
             destination.append("false");
             return false;
         }
@@ -500,10 +497,9 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, RegExpItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, RegExpItem regexp, boolean includeField) {
+        boolean serialize(StringBuilder destination, RegExpItem regexp, Boolean includeField) {
             String annotations = leafAnnotations(regexp);
-            if (includeField)
-                destination.append(normalizeIndexName(regexp.getIndexName())).append(" matches ");
+            destination.append(normalizeIndexName(regexp.getIndexName())).append(" matches ");
             annotatedTerm(destination, regexp, annotations);
             return false;
         }
@@ -515,11 +511,10 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, FuzzyItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, FuzzyItem fuzzy, boolean includeField) {
+        boolean serialize(StringBuilder destination, FuzzyItem fuzzy, Boolean includeField) {
             String annotations = fuzzyAnnotations(fuzzy);
 
-            if (includeField)
-                destination.append(normalizeIndexName(fuzzy.getIndexName())).append(" contains ");
+            serializeField(fuzzy, includeField, destination);
 
             if (!annotations.isEmpty()) {
                 destination.append('(').append(annotations);
@@ -575,8 +570,8 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, ONearItem item, boolean includeField) {
-            destination.append(getIndexName(item.getItem(0))).append(" contains ");
+        boolean serialize(StringBuilder destination, ONearItem item, Boolean includeField) {
+            serializeField(item.getItem(0), includeField, destination);
             serializeItemListWithoutField(ONEAR, item, NearSerializer.nearAnnotations(item), destination);
             return false;
         }
@@ -596,7 +591,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, OrItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, OrItem item, Boolean includeField) {
             destination.append("(");
             return true;
         }
@@ -626,15 +621,13 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, PhraseSegmentItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, PhraseSegmentItem phrase, boolean includeField) {
+        boolean serialize(StringBuilder destination, PhraseSegmentItem phrase, Boolean includeField) {
             Substring origin = phrase.getOrigin();
             String image;
             int offset;
             int length;
 
-            if (includeField) {
-                destination.append(normalizeIndexName(phrase.getIndexName())).append(" contains ");
-            }
+            serializeField(phrase, includeField, destination);
             if (origin == null) {
                 image = phrase.getRawWord();
                 offset = 0;
@@ -668,9 +661,8 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, PhraseItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, PhraseItem phrase, boolean includeField) {
-            if (includeField)
-                destination.append(normalizeIndexName(phrase.getIndexName())).append(" contains ");
+        boolean serialize(StringBuilder destination, PhraseItem phrase, Boolean includeField) {
+            serializeField(phrase, includeField, destination);
             serializeItemListWithoutField(PHRASE, phrase, leafAnnotations(phrase), destination);
             return false;
         }
@@ -683,22 +675,23 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, SameElementItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, SameElementItem item, boolean includeField) {
-            if (includeField) {
-                destination.append(normalizeIndexName(item.getFieldName())).append(" contains ");
-            }
+        boolean serialize(StringBuilder destination, SameElementItem item, Boolean includeField) {
+            serializeField(item, includeField, destination);
 
             destination.append(SAME_ELEMENT);
-            if (item.getItemCount() == 1 && item.getItem(0) instanceof CompositeItem)
-                return true; // serialize nested content in the normal way
-
-            destination.append('(');
-            for (int i = 0; i < item.getItemCount(); ++i) {
-                if (i > 0)
-                    destination.append(", ");
-                VespaSerializer.serialize(item.getItem(i), includeField, destination);
+            if (item.getItemCount() == 1 && item.getItem(0) instanceof AndItem || item.getItem(0) instanceof OrItem) {
+                // serialize nested content without extra parenthesis
+                VespaSerializer.serialize(item.getItem(0), null, destination);
             }
-            destination.append(')');
+            else {
+                destination.append('(');
+                for (int i = 0; i < item.getItemCount(); ++i) {
+                    if (i > 0)
+                        destination.append(", ");
+                    VespaSerializer.serialize(item.getItem(i), null, destination);
+                }
+                destination.append(')');
+            }
 
             return false;
         }
@@ -711,7 +704,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, GeoLocationItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, GeoLocationItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, GeoLocationItem item, Boolean includeField) {
             String annotations = leafAnnotations(item);
             if (!annotations.isEmpty()) {
                 destination.append("({").append(annotations).append("}");
@@ -739,7 +732,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, NearestNeighborItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, NearestNeighborItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, NearestNeighborItem item, Boolean includeField) {
             destination.append("{");
             int initLen = destination.length();
             destination.append(leafAnnotations(item));
@@ -808,7 +801,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, PredicateQueryItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, PredicateQueryItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, PredicateQueryItem item, Boolean includeField) {
             destination.append("predicate(").append(item.getIndexName()).append(',');
             appendFeatures(destination, item.getFeatures());
             destination.append(',');
@@ -863,7 +856,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, RangeItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, RangeItem range, boolean includeField) {
+        boolean serialize(StringBuilder destination, RangeItem range, Boolean includeField) {
             String annotations = leafAnnotations(range);
             if (!annotations.isEmpty()) {
                 destination.append("{").append(annotations).append("}");
@@ -900,7 +893,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, RankItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, RankItem item, Boolean includeField) {
             destination.append(RANK).append('(');
             return true;
 
@@ -914,7 +907,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, WordAlternativesItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, WordAlternativesItem alternatives, boolean includeField) {
+        boolean serialize(StringBuilder destination, WordAlternativesItem alternatives, Boolean includeField) {
             int initLen = 0;
             StringBuilder annotations = new StringBuilder(leafAnnotations(alternatives));
 
@@ -931,9 +924,7 @@ public class VespaSerializer {
             boolean isFromQuery = alternatives.isFromQuery();
             boolean needsAnnotations = !annotations.isEmpty() || origin != null || !isFromQuery;
 
-            if (includeField) {
-                destination.append(normalizeIndexName(alternatives.getIndexName())).append(" contains ");
-            }
+            serializeField(alternatives, includeField, destination);
 
             if (needsAnnotations) {
                 destination.append("({");
@@ -984,7 +975,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WandItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, WandItem item, Boolean includeField) {
             serializeWeightedSetContents(destination, WAND, item, specificAnnotations(item));
             return false;
         }
@@ -1030,7 +1021,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WeakAndItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, WeakAndItem item, Boolean includeField) {
             if (needsAnnotationBlock(item)) {
                 destination.append("({");
             }
@@ -1053,7 +1044,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WeightedSetItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, WeightedSetItem item, Boolean includeField) {
             serializeWeightedSetContents(destination, WEIGHTED_SET, item);
             return false;
         }
@@ -1067,7 +1058,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, StringInItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, StringInItem item, Boolean includeField) {
             destination.append(item.getIndexName()).append(" in (");
             int initLen = destination.length();
             List<String> tokens = new ArrayList<>(item.getTokens());
@@ -1089,7 +1080,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, NumericInItem item, boolean includeField) {
+        boolean serialize(StringBuilder destination, NumericInItem item, Boolean includeField) {
             destination.append(item.getIndexName()).append(" in (");
             int initLen = destination.length();
             List<Long> tokens = new ArrayList<>(item.getTokens());
@@ -1112,9 +1103,8 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WordItem item, boolean includeField) {
-            if (includeField)
-                destination.append(normalizeIndexName(item.getIndexName())).append(" contains ");
+        boolean serialize(StringBuilder destination, WordItem item, Boolean includeField) {
+            serializeField(item, includeField, destination);
             VespaSerializer.annotatedTerm(destination, item, getAllAnnotations(item).toString());
             return false;
         }
@@ -1218,17 +1208,17 @@ public class VespaSerializer {
 
     private static class VespaVisitor extends QueryVisitor {
 
-        final boolean includeField;
+        final Boolean includeField;
         final StringBuilder destination;
         final Deque<SerializerWrapper> state = new ArrayDeque<>();
 
-        VespaVisitor(boolean includeField, StringBuilder destination) {
+        VespaVisitor(Boolean includeField, StringBuilder destination) {
             this.includeField = includeField;
             this.destination = destination;
         }
 
         @Override
-        public void onExit() {
+        public void onExit(Item item) {
             SerializerWrapper w = state.removeFirst();
             w.type.onExit(destination, w.item);
             w = state.peekFirst();
@@ -1360,12 +1350,6 @@ public class VespaSerializer {
         return hex;
     }
 
-    static String getIndexName(Item item) {
-        if (!(item instanceof IndexedItem))
-            throw new IllegalArgumentException("Expected IndexedItem, got " + item.getClass());
-        return normalizeIndexName(((IndexedItem) item).getIndexName());
-    }
-
     public static String serialize(Query query) {
         return serialize(query, "");
     }
@@ -1400,7 +1384,7 @@ public class VespaSerializer {
         serialize(item, true, out);
     }
 
-    private static void serialize(Item item, boolean includeField, StringBuilder out) {
+    private static void serialize(Item item, Boolean includeField, StringBuilder out) {
         VespaVisitor visitor = new VespaVisitor(includeField, out);
         ToolBox.visit(visitor, item);
     }
@@ -1566,14 +1550,6 @@ public class VespaSerializer {
         return annotation.toString();
     }
 
-    private static String normalizeIndexName(String indexName) {
-        if (indexName.isEmpty()) {
-            return "default";
-        } else {
-            return indexName;
-        }
-    }
-
     private static void annotatedTerm(StringBuilder destination, IndexedItem w, String annotations) {
         if (!annotations.isEmpty()) {
             destination.append("({").append(annotations).append("}");
@@ -1598,6 +1574,25 @@ public class VespaSerializer {
         destination.append(')');
         if (!annotations.isEmpty())
             destination.append(')');
+    }
+
+    private static void serializeField(Item item, Boolean includeField, StringBuilder destination) {
+        if (!(item instanceof HasIndexItem indexItem))
+            throw new IllegalArgumentException("Expected HasIndexItem, got " + item.getClass());
+        String indexName = normalizeIndexName(indexItem.getIndexName(), includeField);
+        if ( ! indexName.isEmpty()) {
+            destination.append(indexName).append(" contains ");
+        }
+    }
+
+    private static String normalizeIndexName(String indexName, Boolean includeField) {
+        if (includeField == null) return indexName; // We're in a context (sameElement) where both including and not including a field name is valid
+        if ( ! includeField) return ""; // We're in a context where the field name should not be included even if set
+        return indexName.isEmpty() ? "default" : indexName; // We're in a context where a field name must be included
+    }
+
+    private static String normalizeIndexName(String indexName) {
+        return normalizeIndexName(indexName, true);
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -269,10 +269,6 @@ public class YqlParser implements Parser {
             return true;
         }
 
-        @Override
-        public void onExit() {
-            // NOP
-        }
     };
 
     public YqlParser(ParserEnvironment environment) {
@@ -421,7 +417,7 @@ public class YqlParser implements Parser {
             case PREDICATE: return buildPredicate(ast);
             case RANK: return buildRank(ast, currentField);
             case WEAK_AND: return buildWeakAnd(ast);
-            case USER_INPUT: return buildUserInput(ast);
+            case USER_INPUT: return buildUserInput(ast, currentField);
             case NON_EMPTY: return ensureNonEmpty(ast);
             default: {
                 if (currentField != null)
@@ -929,7 +925,7 @@ public class YqlParser implements Parser {
         return userQuery.getModel().getQueryTree().getRoot();
     }
 
-    private Item buildUserInput(OperatorNode<ExpressionOperator> ast) {
+    private Item buildUserInput(OperatorNode<ExpressionOperator> ast, String currentField) {
         // TODO: Add support for default arguments if property results in nothing
         List<OperatorNode<ExpressionOperator>> args = ast.getArgument(1);
         String wordData = getStringContents(args.get(0));
@@ -938,7 +934,9 @@ public class YqlParser implements Parser {
         if (allowEmpty && (wordData == null || wordData.isEmpty())) return new NullItem();
 
         String defaultIndex = getAnnotation(ast, USER_INPUT_DEFAULT_INDEX,
-                                            String.class, "default", "default index for user input terms");
+                                            String.class,
+                                            currentField != null ? null : "default", // if there's a current field, we're in sameElement
+                                            "default index for user input terms");
         Language language = decideParsingLanguage(ast, wordData);
         String grammar = getAnnotation(ast, USER_INPUT_GRAMMAR, String.class,
                                        Query.Type.WEAKAND.toString(), "The overall query type of the user input");
@@ -2235,10 +2233,6 @@ public class YqlParser implements Parser {
             return true;
         }
 
-        @Override
-        public void onExit() {
-            // intentionally left blank
-        }
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/search/searchers/ValidateSameElementTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/ValidateSameElementTestCase.java
@@ -2,7 +2,10 @@ package com.yahoo.search.searchers;
 
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.EquivItem;
+import com.yahoo.prelude.query.OrItem;
 import com.yahoo.prelude.query.SameElementItem;
+import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -10,6 +13,7 @@ import com.yahoo.search.searchchain.Execution;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author bratseth
@@ -17,33 +21,40 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ValidateSameElementTestCase {
 
     @Test
-    public void oneAndIsFlattened() {
-        var root = new SameElementItem("myField");
-        var and = new AndItem();
-        and.addItem(new WordItem("a"));
-        and.addItem(new WordItem("b"));
-        root.addItem(and);
-        assertEquals("myField:{(AND a b)}", root.toString());
-        var processedRoot = search(root).hits().getQuery().getModel().getQueryTree().getRoot();
-        assertEquals("myField:{a b}", processedRoot.toString());
-    }
-
-    @Test
-    public void multipleAndsAreFlattened() {
+    public void testValidSameElement() {
         var root = new SameElementItem("myField");
         root.addItem(new WordItem("a"));
         var and1 = new AndItem();
         and1.addItem(new WordItem("and1_a"));
         and1.addItem(new WordItem("and1_b"));
         root.addItem(and1);
-        root.addItem(new WordItem("b"));
-        var and2 = new AndItem();
-        and2.addItem(new WordItem("and2_a"));
-        root.addItem(and2);
+        root.addItem(new EquivItem(new WordItem("b")));
+        var or2 = new OrItem();
+        or2.addItem(new WordItem("or2_a"));
+        root.addItem(or2);
         root.addItem(new WordItem("c"));
-        assertEquals("myField:{a (AND and1_a and1_b) b (AND and2_a) c}", root.toString());
+        assertEquals("myField:{a (AND and1_a and1_b) (EQUIV b) (OR or2_a) c}", root.toString());
         var processedRoot = search(root).hits().getQuery().getModel().getQueryTree().getRoot();
-        assertEquals("myField:{a and1_a and1_b b and2_a c}", processedRoot.toString());
+        assertEquals("myField:{a (AND and1_a and1_b) (EQUIV b) (OR or2_a) c}", processedRoot.toString());
+    }
+
+    @Test
+    public void testInvalidSameElement() {
+        var root = new SameElementItem("myField");
+        root.addItem(new WordItem("a"));
+        var and1 = new AndItem();
+        and1.addItem(new WordItem("and1_a"));
+        var weakAnd = new WeakAndItem();
+        weakAnd.addItem(new WordItem("a"));
+        weakAnd.addItem(new WordItem("b"));
+        and1.addItem(weakAnd);
+        and1.addItem(new WordItem("and1_b"));
+        root.addItem(and1);
+        root.addItem(new EquivItem(new WordItem("b")));
+        assertEquals("myField:{a (AND and1_a (WEAKAND(100) a b) and1_b) (EQUIV b)}", root.toString());
+        var result = search(root);
+        assertNotNull(result.hits().getError());
+        assertEquals("SameElementItem cannot contain '(WEAKAND(100) a b)'", result.hits().getError().getDetailedMessage());
     }
 
     private Result search(CompositeItem root) {

--- a/container-search/src/test/java/com/yahoo/search/searchers/ValidateSameElementTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/ValidateSameElementTestCase.java
@@ -4,6 +4,7 @@ import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.RankItem;
 import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordItem;
@@ -12,8 +13,7 @@ import com.yahoo.search.Result;
 import com.yahoo.search.searchchain.Execution;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author bratseth
@@ -33,14 +33,40 @@ public class ValidateSameElementTestCase {
         or2.addItem(new WordItem("or2_a"));
         root.addItem(or2);
         root.addItem(new WordItem("c"));
-        assertEquals("myField:{a (AND and1_a and1_b) (EQUIV b) (OR or2_a) c}", root.toString());
-        var processedRoot = search(root).hits().getQuery().getModel().getQueryTree().getRoot();
-        assertEquals("myField:{a (AND and1_a and1_b) (EQUIV b) (OR or2_a) c}", processedRoot.toString());
+        var result = search(root);
+        assertNull(result.hits().getError());
     }
 
     @Test
     public void testInvalidSameElement() {
         var root = new SameElementItem("myField");
+        addChildrenWithWeakAnd(root);
+        var result = search(root);
+        assertNotNull(result.hits().getError());
+        assertEquals("SameElementItem cannot contain '(WEAKAND(100) a b)'", result.hits().getError().getDetailedMessage());
+    }
+
+    @Test
+    public void testInvalidNestedSameElement() {
+        var root = new RankItem();
+        var child1 = new SameElementItem("myField");
+        root.addItem(child1);
+        root.addItem(new WordItem("myField"));
+        addChildrenWithWeakAnd(child1);
+        var result = search(root);
+        assertNotNull(result.hits().getError());
+        assertEquals("SameElementItem cannot contain '(WEAKAND(100) a b)'", result.hits().getError().getDetailedMessage());
+    }
+
+    @Test
+    public void testNoSameElement() {
+        var root = new RankItem();
+        addChildrenWithWeakAnd(root);
+        var result = search(root);
+        assertNull(result.hits().getError());
+    }
+
+    private void addChildrenWithWeakAnd(CompositeItem root) {
         root.addItem(new WordItem("a"));
         var and1 = new AndItem();
         and1.addItem(new WordItem("and1_a"));
@@ -51,10 +77,6 @@ public class ValidateSameElementTestCase {
         and1.addItem(new WordItem("and1_b"));
         root.addItem(and1);
         root.addItem(new EquivItem(new WordItem("b")));
-        assertEquals("myField:{a (AND and1_a (WEAKAND(100) a b) and1_b) (EQUIV b)}", root.toString());
-        var result = search(root);
-        assertNotNull(result.hits().getError());
-        assertEquals("SameElementItem cannot contain '(WEAKAND(100) a b)'", result.hits().getError().getDetailedMessage());
     }
 
     private Result search(CompositeItem root) {

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -161,6 +161,12 @@ public class VespaSerializerTestCase {
     }
 
     @Test
+    void testEquivInNear() {
+        parseAndConfirm("default contains ({distance: 5}near(\"A\", equiv(\"B\", \"C\")))",
+                        "default CONTAINS ({distance:5,exclusionDistance:5}near('A', !equiv('B', 'C')))");
+    }
+
+    @Test
     void testNearestNeighbor() {
         parseAndConfirm("{label: \"foo\", targetHits: 1000}nearestNeighbor(semantic_embedding, my_property)");
         parseAndConfirm("{targetHits: 42}nearestNeighbor(semantic_embedding, my_property)");

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/metrics/MetricsV2Handler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/metrics/MetricsV2Handler.java
@@ -15,7 +15,6 @@ import ai.vespa.metricsproxy.service.VespaServices;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.container.handler.metrics.ErrorResponse;
 import com.yahoo.container.handler.metrics.HttpHandlerBase;
-import com.yahoo.container.handler.metrics.JsonResponse;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.restapi.Path;
 


### PR DESCRIPTION
- YQL serialize indexes inside sameElement only when set explicitly
- Don't flatten SameElement children
- Fail SameElement queries containing unsupported children
