### PR TITLE
reintroduce project name

### DIFF
--- a/vespa-3party-bundles/pom.xml
+++ b/vespa-3party-bundles/pom.xml
@@ -11,6 +11,7 @@
     <version>8-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
+  <name>${project.artifactId}</name>
   <artifactId>vespa-3party-bundles</artifactId>
   <version>8-SNAPSHOT</version>
   <packaging>pom</packaging>


### PR DESCRIPTION
Looks like this got removed by mistake, it's stopping the open-source release