### PR TITLE
fix broken hnsw debug output

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -1181,6 +1181,7 @@ HnswIndex<type>::count_reachable_nodes() const
         visitNext.setBit(nodeid);
     }
     bool runAnotherVisit = true;
+    visitNext.invalidateCachedCount();
     while (runAnotherVisit) {
         if (vespalib::steady_clock::now() > doom) {
             uint32_t pending = visitNext.countTrueBits();


### PR DESCRIPTION
The count is always cached as 0 so it always now says 100% explored but incomplete.