### PR TITLE
Fix crash when attribute is missing

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
@@ -292,7 +292,7 @@ DocumentRetriever::populate(DocumentIdT lid, Document & doc, const Field::Set & 
 {
     for (const Field* field : attributeFields) {
         AttributeGuard::UP attr = _attr_manager.getAttribute(field->getName());
-        if (lid < (*attr)->getCommittedDocIdLimit()) {
+        if (attr && attr->get() && lid < (*attr)->getCommittedDocIdLimit()) {
             DocumentFieldRetriever::populate(lid, doc, *field, **attr);
         } else {
             doc.remove(*field);


### PR DESCRIPTION
Add null-pointer safety checks for attribute lookup in DocumentRetriever to prevent dereferencing null pointers when an attribute doesn't exist. The code now validates both the AttributeGuard and the underlying attribute before accessing the committed document ID limit.

This should fix https://github.com/vespa-engine/vespa/issues/35534
