### PR TITLE
Check for empty metrics response

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcher.java
@@ -53,9 +53,16 @@ public class RemoteHealthStatusFetcher extends HttpMetricFetcher {
     }
 
 
-    private HealthMetric parse(InputStream data) {
+    HealthMetric parse(InputStream data) {
         try {
             JsonNode o = Jackson.mapper().readTree(data);
+            if (!o.isObject()) {
+                throw new IllegalArgumentException("Expected JSON object");
+            }
+
+            if (o.isEmpty()) {
+                return HealthMetric.getUnknown("Empty metrics response");
+            }
             JsonNode status = o.get("status");
             String code = status.get("code").asText();
             String message = "";

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcher.java
@@ -64,11 +64,12 @@ public class RemoteHealthStatusFetcher extends HttpMetricFetcher {
                 return HealthMetric.getUnknown("Empty metrics response");
             }
             JsonNode status = o.get("status");
-            String code = status.get("code").asText();
-            String message = "";
-            if (status.has("message")) {
-                message = status.get("message").textValue();
+            if (status == null || !status.has("code")) {
+                return HealthMetric.getUnknown("Missing status or code in response");
             }
+
+            String code = status.get("code").asText();
+            String message = status.path("message").asText("");
             return HealthMetric.get(code, message);
 
         } catch (Exception e) {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcherTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcherTest.java
@@ -1,0 +1,65 @@
+package ai.vespa.metricsproxy.service;
+
+import ai.vespa.metricsproxy.metric.HealthMetric;
+import ai.vespa.metricsproxy.metric.model.StatusCode;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RemoteHealthStatusFetcherTest {
+
+  private final RemoteHealthStatusFetcher fetcher = new RemoteHealthStatusFetcher(null, 0);
+
+  @Test
+  public void testParseValidJson() {
+    String json = "{\"status\": {\"code\": \"UP\", \"message\": \"Service is healthy\"}}";
+    InputStream data = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+
+    HealthMetric result = fetcher.parse(data);
+
+    assertEquals(StatusCode.UP, result.getStatus());
+    assertEquals("Service is healthy", result.getMessage());
+  }
+
+  @Test
+  public void testParseMissingStatusField() {
+    String json = "{}";
+    InputStream data = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+
+    HealthMetric result = fetcher.parse(data);
+
+    assertEquals(StatusCode.UNKNOWN, result.getStatus());
+    assertTrue(result.getMessage().contains("Empty metrics response"));
+  }
+
+  @Test
+  public void testParseInvalidJson() {
+    String invalidJson = "{invalid json}";
+    InputStream data = new ByteArrayInputStream(invalidJson.getBytes(StandardCharsets.UTF_8));
+
+    HealthMetric result = fetcher.parse(data);
+
+    assertEquals(StatusCode.UNKNOWN, result.getStatus());
+    assertTrue(result.getMessage().contains("Not able to parse json"));
+  }
+
+  @Test
+  public void testParseUnreadableInput() {
+    InputStream unreadableStream = new InputStream() {
+      @Override
+      public int read() {
+        throw new RuntimeException("Stream error");
+      }
+    };
+
+    HealthMetric result = fetcher.parse(unreadableStream);
+
+    assertEquals(StatusCode.UNKNOWN, result.getStatus());
+    assertTrue(result.getMessage().contains("Not able to parse json"));
+  }
+}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This is due to the logging from the metrics proxy when the response is an empty object `{}`: 
```
Failed to parse json response from metrics page:java.lang.NullPointerException: Cannot invoke "com.fasterxml.jackson.databind.JsonNode.get(String)" because "status" is null:java.io.BufferedInputStream@6c5ce356
 