### PR TITLE
Allow properties to be referened by aliases in query profiles

### DIFF
--- a/container-core/src/main/java/com/yahoo/processing/request/CompoundName.java
+++ b/container-core/src/main/java/com/yahoo/processing/request/CompoundName.java
@@ -176,7 +176,7 @@ public final class CompoundName {
 
     /**
      * Returns a compound name which has the given name components prepended to this name,
-     * in the given order, i.e new ComponentName("c").prepend("a","b") will yield "a.b.c".
+     * in the given order, i.e. new ComponentName("c").prepend("a","b") will yield "a.b.c".
      *
      * @param nameParts if name is empty this returns <code>this</code>
      */
@@ -227,7 +227,7 @@ public final class CompoundName {
     public CompoundName rest() { return rest; }
 
     /**
-     * Returns the name starting after the n first components (i.e dots).
+     * Returns the name starting after the n first components (i.e. dots).
      * This may be the empty name.
      *
      * @throws IllegalArgumentException if this does not have at least that many components

--- a/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileXMLReader.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileXMLReader.java
@@ -196,10 +196,10 @@ public class QueryProfileXMLReader {
 
     private void readInheritedTypes(Element element,QueryProfileType type, QueryProfileTypeRegistry registry) {
         String inheritedString = element.getAttribute("inherits");
-        if (inheritedString.equals("")) return;
+        if (inheritedString.isEmpty()) return;
         for (String inheritedId : inheritedString.split(" ")) {
             inheritedId = inheritedId.trim();
-            if (inheritedId.equals("")) continue;
+            if (inheritedId.isEmpty()) continue;
             QueryProfileType inheritedType = registry.getComponent(inheritedId);
             if (inheritedType == null)
                 throw new IllegalArgumentException("Could not resolve inherited query profile type '" + inheritedId);
@@ -249,7 +249,7 @@ public class QueryProfileXMLReader {
         if (inheritedString.isEmpty()) return;
         for (String inheritedId : inheritedString.split(" ")) {
             inheritedId = inheritedId.trim();
-            if (inheritedId.equals("")) continue;
+            if (inheritedId.isEmpty()) continue;
             QueryProfile inheritedProfile = registry.getComponent(inheritedId);
             if (inheritedProfile == null)
                 throw new IllegalArgumentException("Could not resolve inherited query profile '" +
@@ -266,6 +266,7 @@ public class QueryProfileXMLReader {
             String name = field.getAttribute("name");
             if (name.isEmpty())
                 throw new IllegalArgumentException("A field in " + sourceDescription + " has no 'name' attribute");
+
             try {
                 Boolean overridable = getBooleanAttribute("overridable", null, field);
                 if (overridable != null)

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/Diversity.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/Diversity.java
@@ -8,7 +8,7 @@ import com.yahoo.search.query.profile.types.QueryProfileType;
 import java.util.Objects;
 
 /**
- * <p>The diversity settings during match phase of a query.
+ * <p>The settings used to achieve diversity in the match phase of a query.
  * These are the same settings for diversity during match phase that can be set in a rank profile
  * and is used for achieving guaranteed diversity at the cost of slightly higher cost as more hits must be
  * considered compared to plain match-phase.</p>

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/MatchPhase.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/MatchPhase.java
@@ -32,7 +32,7 @@ public class MatchPhase implements Cloneable {
     public static final String MAX_FILTER_COVERAGE = "maxFilterCoverage";
 
     static {
-        argumentType =new QueryProfileType(Ranking.MATCH_PHASE);
+        argumentType = new QueryProfileType(Ranking.MATCH_PHASE);
         argumentType.setStrict(true);
         argumentType.setBuiltin(true);
         argumentType.addField(new FieldDescription(ATTRIBUTE, "string"));


### PR DESCRIPTION
I originally did not do this to make the correspondence between (full) property names and the query object hierarchy salient. However, this instead causes confusion when migrating a query using aliases into a query profile, and with fewer Java-enabled developers around I think the net balance of this tradeoff has switched signs.
