### PR TITLE
Revert "Default to `snapshots-enabled`"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -282,7 +282,7 @@ public class Flags {
             TENANT_ID, CONSOLE_USER_EMAIL);
 
     public static final UnboundBooleanFlag SNAPSHOTS_ENABLED = defineFeatureFlag(
-            "snapshots-enabled", true,
+            "snapshots-enabled", false,
             List.of("olaa"), "2024-10-22", "2026-02-01",
             "Whether node snapshots should be created when host storage is discarded",
             "Takes effect immediately");


### PR DESCRIPTION
Reverts vespa-engine/vespa#35539

I'm in the process of removing the flag. But until then, the default should stay the same. Snapshotting is not applicable in all systems