### PR TITLE
Add simpler configuration for elementwise BM25 feature

### DIFF
--- a/searchlib/src/vespa/searchlib/features/bm25_utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/bm25_utils.cpp
@@ -42,8 +42,7 @@ Bm25Utils::lookup_param(const std::string& param, double& result) const
             result = std::stod(value.get());
             return Trinary::True;
         } catch (const std::invalid_argument& ex) {
-            LOG(warning, "Not able to convert rank property '%s': '%s' to a double value",
-                key.c_str(), value.get().c_str());
+            _error_message = std::format("Not able to convert rank property '{}': '{}' to a double value", key, value.get());
             return Trinary::Undefined;
         }
     }

--- a/searchlib/src/vespa/searchlib/features/bm25_utils.h
+++ b/searchlib/src/vespa/searchlib/features/bm25_utils.h
@@ -30,6 +30,7 @@ class Bm25Utils {
     static std::string _average_field_length;
     static std::string _b;
     static std::string _k1;
+    mutable std::string _error_message;
 public:
     struct QueryTerm {
         fef::TermFieldHandle handle;
@@ -48,6 +49,7 @@ public:
     ~Bm25Utils();
     vespalib::Trinary lookup_param(const std::string& param, double& result) const;
     vespalib::Trinary lookup_param(const std::string& param, std::optional<double>& result) const;
+    const std::string& last_error() const { return _error_message; }
     static double calculate_inverse_document_frequency(search::fef::DocumentFrequency doc_freq) noexcept;
     static double get_inverse_document_frequency(const fef::ITermFieldData &term_field,
                                                  const fef::IQueryEnvironment &env,

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.h
@@ -22,9 +22,10 @@ class ElementwiseBm25Blueprint : public fef::Blueprint {
     const fef::FieldInfo* _field;
     double _k1_param;
     double _b_param;
-    std::optional<double> _avg_element_length;
+    std::optional<double>                  _avg_element_length;
     vespalib::eval::ValueType              _output_tensor_type;
     std::unique_ptr<vespalib::eval::Value> _empty_output;
+
 public:
     ElementwiseBm25Blueprint();
     ~ElementwiseBm25Blueprint() override;

--- a/searchlib/src/vespa/searchlib/features/elementwise_utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_utils.cpp
@@ -20,18 +20,23 @@ std::string
 ElementwiseUtils::feature_name(const std::string& nested_feature_base_name, const fef::ParameterList& params)
 {
     FeatureNameBuilder builder;
-    constexpr size_t extra_params = 2;
-    builder.baseName(nested_feature_base_name);
+    builder.baseName(_elementwise_feature_base_name);
+    builder.parameter(nested_feature_name(nested_feature_base_name, params));
     size_t num_params = params.size();
-    size_t param_idx = 0;
-    for (; param_idx + extra_params < num_params; ++param_idx) {
+    size_t offset = num_params - extra_params;
+    for (size_t param_idx = offset; param_idx < num_params; ++param_idx) {
         builder.parameter(params[param_idx].getValue());
     }
-    auto nested_feature_name = builder.buildName();
-    builder.baseName(_elementwise_feature_base_name);
-    builder.clearParameters();
-    builder.parameter(nested_feature_name);
-    for (; param_idx < num_params; ++param_idx) {
+    return builder.buildName();
+}
+
+std::string
+ElementwiseUtils::nested_feature_name(const std::string& nested_feature_base_name, const fef::ParameterList& params)
+{
+    FeatureNameBuilder builder;
+    builder.baseName(nested_feature_base_name);
+    size_t num_params = params.size();
+    for (size_t param_idx = 0; param_idx + extra_params < num_params; ++param_idx) {
         builder.parameter(params[param_idx].getValue());
     }
     return builder.buildName();

--- a/searchlib/src/vespa/searchlib/features/elementwise_utils.h
+++ b/searchlib/src/vespa/searchlib/features/elementwise_utils.h
@@ -13,6 +13,7 @@ namespace search::features {
  */
 class ElementwiseUtils {
     static std::string _elementwise_feature_base_name;
+    static constexpr size_t extra_params = 2;
 public:
     static const std::string& elementwise_feature_base_name() noexcept { return _elementwise_feature_base_name; }
     /*
@@ -24,6 +25,7 @@ public:
     static std::optional<std::string> build_output_tensor_type(vespalib::eval::ValueType& output_tensor_type,
                                                                const std::string& dimension_name,
                                                                const std::string& cell_type_name);
+    static std::string nested_feature_name(const std::string& nested_feature_base_name, const fef::ParameterList& params);
 };
 
 }

--- a/searchlib/src/vespa/searchlib/fef/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprint.cpp
@@ -30,6 +30,10 @@ Blueprint::fail(const char *format, ...)
     va_start(ap, format);
     std::string msg = vespalib::make_string_va(format, ap);
     va_end(ap);
+    return fail(msg);
+}
+
+bool Blueprint::fail(const std::string &msg) {
     assert(_dependency_handler != nullptr);
     _dependency_handler->fail(msg);
     return false;

--- a/searchlib/src/vespa/searchlib/fef/blueprint.h
+++ b/searchlib/src/vespa/searchlib/fef/blueprint.h
@@ -120,6 +120,17 @@ protected:
     bool fail(const char *format, ...) __attribute__ ((format (printf,2,3)));
 
     /**
+     * Fail the setup of this blueprint with the given message. This
+     * function should be called by the @ref setup function when it
+     * fails. The failure is handled by the dependency handler to make
+     * sure we only report the first error for each feature.
+     *
+     * @return false
+     * @param msg pre-formatted message
+     **/
+    bool fail(const std::string &msg);
+
+    /**
      * Used to store a reference to the attribute during prepareSharedState
      * for later use in createExecutor
      **/

--- a/searchlib/src/vespa/searchlib/fef/parameter.h
+++ b/searchlib/src/vespa/searchlib/fef/parameter.h
@@ -15,7 +15,7 @@ namespace search::fef {
 class Parameter {
 private:
     ParameterType::Enum _type;
-    std::string    _stringVal;
+    std::string         _stringVal;
     double              _doubleVal;
     int64_t             _intVal;
     const search::fef::FieldInfo * _fieldVal;


### PR DESCRIPTION
The elementwise BM25 feature previously required configuration using the full canonical form:
  elementwise(bm25(fieldname),x,double).property = value

This commit adds support for also using the nested feature form:
  bm25(fieldname).property = value

The implementation introduces a LookupHelper that checks both the basic bm25 feature name and the full elementwise feature name when looking up configuration properties (k1, b, averageElementLength). Also, error handling is improved by capturing error messages from the lookup utilities.

@toregge please review
