### PR TITLE
Johsol/switch case rank expression

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/expressiontransforms/ExpressionTransforms.java
+++ b/config-model/src/main/java/com/yahoo/schema/expressiontransforms/ExpressionTransforms.java
@@ -30,6 +30,7 @@ public class ExpressionTransforms {
                         new TokenTransformer(),
                         new ConstantDereferencer(),
                         new ConstantTensorTransformer(),
+                        new SwitchTransformer(),
                         new FunctionInliner(),
                         new FunctionShadower(),
                         new TensorMaxMinTransformer(),

--- a/config-model/src/main/java/com/yahoo/schema/expressiontransforms/SwitchTransformer.java
+++ b/config-model/src/main/java/com/yahoo/schema/expressiontransforms/SwitchTransformer.java
@@ -1,0 +1,60 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.expressiontransforms;
+
+import com.yahoo.searchlib.rankingexpression.rule.CompositeNode;
+import com.yahoo.searchlib.rankingexpression.rule.ExpressionNode;
+import com.yahoo.searchlib.rankingexpression.rule.IfNode;
+import com.yahoo.searchlib.rankingexpression.rule.OperationNode;
+import com.yahoo.searchlib.rankingexpression.rule.Operator;
+import com.yahoo.searchlib.rankingexpression.rule.SwitchNode;
+import com.yahoo.searchlib.rankingexpression.transform.ExpressionTransformer;
+import com.yahoo.searchlib.rankingexpression.transform.TransformContext;
+
+/**
+ * Transforms switch nodes into equivalent nested if-expressions.
+ *
+ * Transformation:
+ *   switch(d) { case v1: r1, case v2: r2, default: def }
+ * becomes:
+ *   if(d == v1, r1, if(d == v2, r2, def))
+ *
+ * @author johsol
+ */
+public class SwitchTransformer extends ExpressionTransformer<TransformContext> {
+
+    @Override
+    public ExpressionNode transform(ExpressionNode node, TransformContext context) {
+        if (node instanceof CompositeNode composite) {
+            node = transformChildren(composite, context);
+        }
+
+        if (node instanceof SwitchNode switchNode) {
+            node = transformSwitchNode(switchNode);
+        }
+
+        return node;
+    }
+
+    /**
+     * Transforms a switch node into an equivalent nested if-expression.
+     *
+     * The expression:
+     *   switch(d) { case v1: r1, case v2: r2, default: def }
+     * becomes:
+     *   if(d == v1, r1, if(d == v2, r2, def))
+     */
+    private ExpressionNode transformSwitchNode(SwitchNode switchNode) {
+        ExpressionNode root = switchNode.getDefaultResult();
+        var discriminant = switchNode.getDiscriminant();
+
+        for (int i = switchNode.getCaseValues().size() - 1; i >= 0; i--) {
+            var value = switchNode.getCaseValues().get(i);
+            var result = switchNode.getCaseResults().get(i);
+            ExpressionNode condition = new OperationNode(discriminant, Operator.equal, value);
+            root = new IfNode(condition, result, root);
+        }
+
+        return root;
+    }
+
+}

--- a/config-model/src/test/java/com/yahoo/schema/expressiontransforms/SwitchTransformerTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/expressiontransforms/SwitchTransformerTestCase.java
@@ -1,0 +1,151 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.expressiontransforms;
+
+import com.yahoo.searchlib.rankingexpression.RankingExpression;
+import com.yahoo.searchlib.rankingexpression.evaluation.MapContext;
+import com.yahoo.searchlib.rankingexpression.evaluation.MapTypeContext;
+import com.yahoo.searchlib.rankingexpression.transform.TransformContext;
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests transformation of switch expressions to nested if expressions.
+ *
+ * @author johsol
+ */
+public class SwitchTransformerTestCase {
+
+    @Test
+    public void testSwitchWithSingleCase() throws Exception {
+        assertTransformed("if (a == 5, 100, 0)",
+                          "switch(a) { case 5: 100, default: 0 }");
+    }
+
+    @Test
+    public void testSwitchWithMultipleCases() throws Exception {
+        assertTransformed("if (a == 1, 100, if (a == 2, 200, if (a == 3, 300, 0)))",
+                          "switch(a) { case 1: 100, case 2: 200, case 3: 300, default: 0 }");
+    }
+
+    @Test
+    public void testSwitchWithExpressionDiscriminant() throws Exception {
+        assertTransformed("if (a + b == 10, 1, if (a + b == 20, 2, 0))",
+                          "switch(a + b) { case 10: 1, case 20: 2, default: 0 }");
+    }
+
+    @Test
+    public void testSwitchWithExpressionResults() throws Exception {
+        assertTransformed("if (a == 1, a * 10, if (a == 2, a * 20, a * 5))",
+                          "switch(a) { case 1: a * 10, case 2: a * 20, default: a * 5 }");
+    }
+
+    @Test
+    public void testSwitchPreservesEvaluationSemantics() throws Exception {
+        var context = new MapContext();
+        context.put("x", 50);
+
+        var original = new RankingExpression("switch(x) { case 100: 10000, case 50: 2500, case 1: 1, default: 0 }");
+        var transformed = transform(original);
+
+        assertEquals(2500.0, original.evaluate(context).asDouble(), 0.0001, "Original evaluates correctly");
+        assertEquals(2500.0, transformed.evaluate(context).asDouble(), 0.0001, "Transformed evaluates correctly");
+    }
+
+    @Test
+    public void testSwitchDefault() throws Exception {
+        var context = new MapContext();
+        context.put("x", 99);
+
+        var original = new RankingExpression("switch(x) { case 100: 10000, case 50: 2500, default: 0 }");
+        var transformed = transform(original);
+
+        assertEquals(0.0, original.evaluate(context).asDouble(), 0.0001, "Original uses default");
+        assertEquals(0.0, transformed.evaluate(context).asDouble(), 0.0001, "Transformed uses default");
+    }
+
+    @Test
+    public void testSwitchWithFloatingPointCases() throws Exception {
+        assertTransformed("if (a == 1.5, 10, if (a == 2.5, 20, 0))",
+                          "switch(a) { case 1.5: 10, case 2.5: 20, default: 0 }");
+    }
+
+    @Test
+    public void testSwitchInComplexExpression() throws Exception {
+        assertTransformed("a + if (b == 1, 10, if (b == 2, 20, 0))",
+                          "a + switch(b) { case 1: 10, case 2: 20, default: 0 }");
+    }
+
+    @Test
+    public void testNestedSwitchTransformation() throws Exception {
+        assertTransformed("if (a == 1, if (b == 1, 11, if (b == 2, 12, 0)), if (a == 2, if (b == 1, 21, if (b == 2, 22, 0)), 0))",
+                          "switch(a) { case 1: switch(b) { case 1: 11, case 2: 12, default: 0 }, case 2: switch(b) { case 1: 21, case 2: 22, default: 0 }, default: 0 }");
+    }
+
+    @Test
+    public void testTransformationStructure() throws Exception {
+        var original = new RankingExpression("switch(x) { case 1: 10, case 2: 20, default: 0 }");
+        var transformed = transform(original);
+        var root = transformed.getRoot();
+
+        assertEquals("com.yahoo.searchlib.rankingexpression.rule.IfNode",
+                     root.getClass().getName(),
+                     "Root should be IfNode");
+    }
+
+    @Test
+    public void testComplexDiscriminant() throws Exception {
+        var original = new RankingExpression("switch(a + b) { case 1: 10, case 2: 20, default: 0 }");
+        var transformed = transform(original);
+
+        var context = new MapContext();
+        context.put("a", 1.0);
+        context.put("b", 0.0);
+        assertEquals(10.0, transformed.evaluate(context).asDouble(), 0.0001, "First case matches");
+
+        context.put("b", 1.0); // a+b = 2
+        assertEquals(20.0, transformed.evaluate(context).asDouble(), 0.0001, "Second case matches");
+
+        context.put("a", 5.0); // a+b = 6, no match
+        assertEquals(0.0, transformed.evaluate(context).asDouble(), 0.0001, "Default case");
+    }
+
+    @Test
+    public void testFirstMatchingCaseWins() throws Exception {
+        var context = new MapContext();
+        context.put("a", 1.0);
+        context.put("b", 1.0);
+
+        // a=1, b=1, so a+b=2. Both case expressions "a+b" and "2" evaluate to 2.
+        var original = new RankingExpression("switch(2) { case 1: 10, case a + b: 20, case 2: 30, default: 0 }");
+        var transformed = transform(original);
+
+        assertEquals(20.0, original.evaluate(context).asDouble(), 0.0001, "Original: first matching case wins");
+        assertEquals(20.0, transformed.evaluate(context).asDouble(), 0.0001, "Transformed: first matching case wins");
+    }
+
+    /**
+     * Transforms switch expression to nested ifs.
+     */
+    private RankingExpression transform(RankingExpression expression) {
+        var typeContext = new MapTypeContext();
+        return new SwitchTransformer().transform(expression, new TransformContext(Map.of(), typeContext));
+    }
+
+    /**
+     * Asserts that the input is transformed into expected.
+     */
+    private void assertTransformed(String expected, String input) throws Exception {
+        var transformedExpression = transform(new RankingExpression(input));
+        assertEquals(new RankingExpression(expected), transformedExpression, "Transformed as expected");
+
+        var context = new MapContext();
+        var inputExpression = new RankingExpression(input);
+        assertEquals(inputExpression.evaluate(context).asDouble(),
+                     transformedExpression.evaluate(context).asDouble(),
+                     0.0001,
+                     "Transform and original input are equivalent");
+    }
+
+}

--- a/integration/schema-language-server/language-server/src/main/ccc/rankingexpression/RankingExpressionParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/rankingexpression/RankingExpressionParser.ccc
@@ -111,6 +111,9 @@ TOKEN :
 
     <IF: "if"> |
     <IN: "in"> |
+    <SWITCH: "switch"> |
+    <CASE: "case"> |
+    <SWITCHDEFAULT: "default"> |
     <F: "f"> |
 
     <NOT: "!"> |
@@ -296,6 +299,7 @@ ExpressionNode value() :
       ( value = constantPrimitive(neg)                             |
         (
           SCAN 2 value = ifExpression()                        |
+          SCAN 2 value = switchExpression()                    |
           SCAN 4 value = function()                            |
           value = feature()                                          |
           value = legacyQueryFeature()                               |
@@ -324,6 +328,28 @@ IfNode ifExpression() :
     {
         thisProduction.expressionNode = new IfNode(condition, ifTrue, ifFalse, trueProbability);
         return (IfNode)thisProduction.expressionNode;
+    }
+;
+
+SwitchNode switchExpression() :
+{
+    ExpressionNode discriminant;
+    List<ExpressionNode> caseValues = new ArrayList<ExpressionNode>();
+    List<ExpressionNode> caseResults = new ArrayList<ExpressionNode>();
+    ExpressionNode caseValue, caseResult;
+    ExpressionNode defaultResult;
+}
+
+    ( <SWITCH> <LBRACE> discriminant = expression() <RBRACE>
+      <LCURLY>
+      ( <CASE> caseValue = expression() <COLON> caseResult = expression() <COMMA>
+        { caseValues.add(caseValue); caseResults.add(caseResult); }
+      )+
+      <SWITCHDEFAULT> <COLON> defaultResult = expression()
+      <RCURLY> )
+    {
+        thisProduction.expressionNode = new SwitchNode(discriminant, caseValues, caseResults, defaultResult);
+        return (SwitchNode)thisProduction.expressionNode;
     }
 ;
 
@@ -1072,6 +1098,9 @@ String identifierStr() :
     func = binaryFunctionName() { return func.toString(); } |
     <IF>                        { return lastConsumedToken.toString(); }     |
     <IN>                        { return lastConsumedToken.toString(); }     |
+    <SWITCH>                    { return lastConsumedToken.toString(); }     |
+    <CASE>                      { return lastConsumedToken.toString(); }     |
+    <SWITCHDEFAULT>             { return lastConsumedToken.toString(); }     |
     <IDENTIFIER>                { return lastConsumedToken.toString(); }     |
     <TRUE>                      { return lastConsumedToken.toString(); }     |
     <FALSE>                     { return lastConsumedToken.toString(); }

--- a/searchlib/abi-spec.json
+++ b/searchlib/abi-spec.json
@@ -959,6 +959,7 @@
       "public final com.yahoo.searchlib.rankingexpression.rule.Operator binaryOperator()",
       "public final com.yahoo.searchlib.rankingexpression.rule.ExpressionNode value()",
       "public final com.yahoo.searchlib.rankingexpression.rule.IfNode ifExpression()",
+      "public final com.yahoo.searchlib.rankingexpression.rule.SwitchNode switchExpression()",
       "public final com.yahoo.searchlib.rankingexpression.rule.ReferenceNode feature()",
       "public final com.yahoo.searchlib.rankingexpression.rule.ReferenceNode legacyQueryFeature()",
       "public final java.lang.String outs()",
@@ -1094,6 +1095,9 @@
       "public static final int STRING",
       "public static final int IF",
       "public static final int IN",
+      "public static final int SWITCH",
+      "public static final int CASE",
+      "public static final int SWITCHDEFAULT",
       "public static final int F",
       "public static final int NOT",
       "public static final int AND",
@@ -1709,6 +1713,29 @@
       "public com.yahoo.tensor.TensorType type(com.yahoo.tensor.evaluation.TypeContext)",
       "public com.yahoo.searchlib.rankingexpression.evaluation.Value evaluate(com.yahoo.searchlib.rankingexpression.evaluation.Context)",
       "public com.yahoo.searchlib.rankingexpression.rule.SetMembershipNode setChildren(java.util.List)",
+      "public int hashCode()",
+      "public bridge synthetic com.yahoo.searchlib.rankingexpression.rule.CompositeNode setChildren(java.util.List)"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.searchlib.rankingexpression.rule.SwitchNode" : {
+    "superClass" : "com.yahoo.searchlib.rankingexpression.rule.CompositeNode",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "final"
+    ],
+    "methods" : [
+      "public void <init>(com.yahoo.searchlib.rankingexpression.rule.ExpressionNode, java.util.List, java.util.List, com.yahoo.searchlib.rankingexpression.rule.ExpressionNode)",
+      "public com.yahoo.searchlib.rankingexpression.rule.ExpressionNode getDiscriminant()",
+      "public java.util.List getCaseValues()",
+      "public java.util.List getCaseResults()",
+      "public com.yahoo.searchlib.rankingexpression.rule.ExpressionNode getDefaultResult()",
+      "public java.util.List children()",
+      "public java.lang.StringBuilder toString(java.lang.StringBuilder, com.yahoo.searchlib.rankingexpression.rule.SerializationContext, java.util.Deque, com.yahoo.searchlib.rankingexpression.rule.CompositeNode)",
+      "public com.yahoo.tensor.TensorType type(com.yahoo.tensor.evaluation.TypeContext)",
+      "public com.yahoo.searchlib.rankingexpression.evaluation.Value evaluate(com.yahoo.searchlib.rankingexpression.evaluation.Context)",
+      "public com.yahoo.searchlib.rankingexpression.rule.SwitchNode setChildren(java.util.List)",
       "public int hashCode()",
       "public bridge synthetic com.yahoo.searchlib.rankingexpression.rule.CompositeNode setChildren(java.util.List)"
     ],

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SwitchNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SwitchNode.java
@@ -104,7 +104,7 @@ public final class SwitchNode extends CompositeNode {
     public TensorType type(TypeContext<Reference> context) {
         validateDiscriminantCaseCompatibility(context);
 
-        // Check that all case results
+        // Check that all case results have compatible types
         TensorType resultType = caseResults.get(0).type(context);
         for (int i = 1; i < caseResults.size(); i++) {
             TensorType caseType = caseResults.get(i).type(context);

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SwitchNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SwitchNode.java
@@ -1,0 +1,209 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.rankingexpression.rule;
+
+import com.yahoo.api.annotations.Beta;
+import com.yahoo.searchlib.rankingexpression.Reference;
+import com.yahoo.searchlib.rankingexpression.evaluation.Context;
+import com.yahoo.searchlib.rankingexpression.evaluation.Value;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.tensor.evaluation.TypeContext;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A switch expression which selects a result based on matching a discriminant value against cases.
+ *
+ * Syntax: switch(discriminant) { case value1: result1, case value2: result2, default: defaultResult }
+ *
+ * @author johsol
+ */
+@Beta
+public final class SwitchNode extends CompositeNode {
+
+    private final ExpressionNode discriminant;
+    private final List<ExpressionNode> caseValues;
+    private final List<ExpressionNode> caseResults;
+    private final ExpressionNode defaultResult;
+
+    /**
+     * Creates a new switch expression node.
+     *
+     * @param discriminant the expression to evaluate and match against case values
+     * @param caseValues the list of values to match against (one per case)
+     * @param caseResults the list of results to return for each matching case
+     * @param defaultResult the result to return if no case matches
+     * @throws IllegalArgumentException if the number of case values doesn't match the number of case results,
+     *                                  or if there are no cases
+     * @throws NullPointerException if any argument is null or if caseValues/caseResults contain null elements
+     */
+    public SwitchNode(ExpressionNode discriminant,
+                      List<ExpressionNode> caseValues,
+                      List<ExpressionNode> caseResults,
+                      ExpressionNode defaultResult) {
+        this.discriminant = Objects.requireNonNull(discriminant, "discriminant cannot be null");
+        Objects.requireNonNull(caseValues, "caseValues cannot be null");
+        Objects.requireNonNull(caseResults, "caseResults cannot be null");
+        this.defaultResult = Objects.requireNonNull(defaultResult, "defaultResult cannot be null");
+
+        if (caseValues.size() != caseResults.size()) {
+            throw new IllegalArgumentException("Number of case values (" + caseValues.size() +
+                                               ") must match number of case results (" + caseResults.size() + ")");
+        }
+
+        if (caseValues.isEmpty()) {
+            throw new IllegalArgumentException("Switch must have at least one case");
+        }
+
+        this.caseValues = List.copyOf(caseValues);
+        this.caseResults = List.copyOf(caseResults);
+    }
+
+    public ExpressionNode getDiscriminant() { return discriminant; }
+
+    public List<ExpressionNode> getCaseValues() { return caseValues; }
+
+    public List<ExpressionNode> getCaseResults() { return caseResults; }
+
+    public ExpressionNode getDefaultResult() { return defaultResult; }
+
+    @Override
+    public List<ExpressionNode> children() {
+        List<ExpressionNode> children = new ArrayList<>();
+        children.add(discriminant);
+        children.addAll(caseValues);
+        children.addAll(caseResults);
+        children.add(defaultResult);
+        return children;
+    }
+
+    @Override
+    public StringBuilder toString(StringBuilder string, SerializationContext context, Deque<String> path, CompositeNode parent) {
+        string.append("switch(");
+        discriminant.toString(string, context, path, this);
+        string.append(") { ");
+
+        for (int i = 0; i < caseValues.size(); i++) {
+            string.append("case ");
+            caseValues.get(i).toString(string, context, path, this);
+            string.append(": ");
+            caseResults.get(i).toString(string, context, path, this);
+            string.append(", ");
+        }
+
+        string.append("default: ");
+        defaultResult.toString(string, context, path, this);
+        string.append(" }");
+
+        return string;
+    }
+
+    @Override
+    public TensorType type(TypeContext<Reference> context) {
+        validateDiscriminantCaseCompatibility(context);
+
+        // Check that all case results
+        TensorType resultType = caseResults.get(0).type(context);
+        for (int i = 1; i < caseResults.size(); i++) {
+            TensorType caseType = caseResults.get(i).type(context);
+            final TensorType previousResultType = resultType;
+            final int caseIndex = i;
+            final TensorType currentCaseType = caseType;
+            resultType = resultType.dimensionwiseGeneralizationWith(caseType).orElseThrow(() ->
+                new IllegalArgumentException("A switch expression must produce compatible types in all cases, " +
+                                             "but case 0 has type " + previousResultType + " while case " + caseIndex +
+                                             " has type " + currentCaseType +
+                                             "\ncase 0: " + caseResults.get(0) +
+                                             "\ncase " + caseIndex + ": " + caseResults.get(caseIndex))
+            );
+        }
+
+        // Check default is compatible with case results
+        TensorType defaultType = defaultResult.type(context);
+        final TensorType finalResultType = resultType;
+        final TensorType finalDefaultType = defaultType;
+        return resultType.dimensionwiseGeneralizationWith(defaultType).orElseThrow(() ->
+            new IllegalArgumentException("A switch expression must produce compatible types in all cases, " +
+                                         "but the case results have type " + finalResultType + " while the " +
+                                         "default has type " + finalDefaultType +
+                                         "\ncase results: " + caseResults.get(0) +
+                                         "\ndefault: " + defaultResult)
+        );
+    }
+
+    /**
+     * Validates that the discriminant type is compatible with each case value type.
+     */
+    private void validateDiscriminantCaseCompatibility(TypeContext<Reference> context) {
+        TensorType discriminantType = discriminant.type(context);
+
+        for (int i = 0; i < caseValues.size(); i++) {
+            TensorType caseValueType = caseValues.get(i).type(context);
+            int caseIndex = i;
+            discriminantType.dimensionwiseGeneralizationWith(caseValueType).orElseThrow(() ->
+                new IllegalArgumentException("A switch expression requires the discriminant and case values to have compatible types, " +
+                                             "but the discriminant has type " + discriminantType +
+                                             " while case " + caseIndex + " has type " + caseValueType +
+                                             "\ndiscriminant: " + discriminant +
+                                             "\ncase " + caseIndex + " value: " + caseValues.get(caseIndex))
+            );
+        }
+    }
+
+    @Override
+    public Value evaluate(Context context) {
+        Value discriminantValue = discriminant.evaluate(context);
+
+        for (int i = 0; i < caseValues.size(); i++) {
+            Value caseValue = caseValues.get(i).evaluate(context);
+            if (discriminantValue.equals(caseValue)) {
+                return caseResults.get(i).evaluate(context);
+            }
+        }
+
+        return defaultResult.evaluate(context);
+    }
+
+    @Override
+    public SwitchNode setChildren(List<ExpressionNode> children) {
+        int numCases = validateChildrenStructure(children);
+
+        ExpressionNode discriminant = children.get(0);
+        List<ExpressionNode> caseValues = children.subList(1, 1 + numCases);
+        List<ExpressionNode> caseResults = children.subList(1 + numCases, 1 + numCases + numCases);
+        ExpressionNode defaultResult = children.get(children.size() - 1);
+
+        return new SwitchNode(discriminant, caseValues, caseResults, defaultResult);
+    }
+
+    /**
+     * Validates that the children list has the correct structure for a switch node.
+     * Expected structure: [discriminant, caseValue1, ..., caseValueN, caseResult1, ..., caseResultN, defaultResult]
+     *
+     * Returns number of cases.
+     */
+    private static int validateChildrenStructure(List<ExpressionNode> children) {
+        if (children.size() < 4) {
+            throw new IllegalArgumentException("Switch must have at least 4 children " +
+                                               "(discriminant, 1 case value, 1 case result, default), but got " +
+                                               children.size());
+        }
+
+        // After removing discriminant (first) and default (last), remaining must be even
+        int remainingChildren = children.size() - 2;
+        if (remainingChildren % 2 != 0) {
+            throw new IllegalArgumentException("Invalid number of children: " + children.size() + ". " +
+                                               "Expected structure: 1 discriminant + N case values + N case results + 1 default");
+        }
+
+        return remainingChildren / 2;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash("switch", discriminant, caseValues, caseResults, defaultResult);
+    }
+
+}

--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -86,6 +86,9 @@ TOKEN :
 
     <IF: "if"> |
     <IN: "in"> |
+    <SWITCH: "switch"> |
+    <CASE: "case"> |
+    <SWITCHDEFAULT: "default"> |
     <F: "f"> |
 
     <NOT: "!"> |
@@ -253,6 +256,7 @@ ExpressionNode value() :
       [ LOOKAHEAD(2) <SUB>                                  { neg = true; } ]
       ( value = constantPrimitive(neg)                             |
         (
+          LOOKAHEAD(2) value = switchExpression()                    |
           LOOKAHEAD(2) value = ifExpression()                        |
           LOOKAHEAD(4) value = function()                            |
           value = feature()                                          |
@@ -279,6 +283,27 @@ IfNode ifExpression() :
       <COMMA> ifTrue = expression() <COMMA> ifFalse = expression() ( <COMMA> trueProbability = doubleNumber() )? <RBRACE> )
     {
         return new IfNode(condition, ifTrue, ifFalse, trueProbability);
+    }
+}
+
+SwitchNode switchExpression() :
+{
+    ExpressionNode discriminant;
+    List<ExpressionNode> caseValues = new ArrayList<ExpressionNode>();
+    List<ExpressionNode> caseResults = new ArrayList<ExpressionNode>();
+    ExpressionNode caseValue, caseResult;
+    ExpressionNode defaultResult;
+}
+{
+    ( <SWITCH> <LBRACE> discriminant = expression() <RBRACE>
+      <LCURLY>
+      ( <CASE> caseValue = expression() <COLON> caseResult = expression() <COMMA>
+        { caseValues.add(caseValue); caseResults.add(caseResult); }
+      )+
+      <SWITCHDEFAULT> <COLON> defaultResult = expression()
+      <RCURLY> )
+    {
+        return new SwitchNode(discriminant, caseValues, caseResults, defaultResult);
     }
 }
 
@@ -925,6 +950,9 @@ String identifier() :
     func = binaryFunctionName() { return func.toString(); } |
     <IF>                        { return token.image; }     |
     <IN>                        { return token.image; }     |
+    <SWITCH>                    { return token.image; }     |
+    <CASE>                      { return token.image; }     |
+    <SWITCHDEFAULT>             { return token.image; }     |
     <IDENTIFIER>                { return token.image; }     |
     <TRUE>                      { return token.image; }     |
     <FALSE>                     { return token.image; }

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/RankingExpressionTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/RankingExpressionTestCase.java
@@ -312,6 +312,37 @@ public class RankingExpressionTestCase {
     }
 
     @Test
+    public void testSwitch() throws ParseException {
+        RankingExpression expression = new RankingExpression("switch(x) { case 1: a, case 2: b, default: c }");
+        assertTrue(expression.getRoot() instanceof com.yahoo.searchlib.rankingexpression.rule.SwitchNode);
+    }
+
+    @Test
+    public void testSwitchSerialization() throws ParseException {
+        assertParse("switch(x) { case 1: 2, default: 3 }",
+                    "switch(x) { case 1: 2, default: 3 }");
+        assertParse("switch(x) { case 1: 2, case 3: 4, default: 5 }",
+                    "switch(x) { case 1: 2, case 3: 4, default: 5 }");
+        assertParse("switch(query(model)) { case \"a\": 1, case \"b\": 2, default: 0 }",
+                    "switch(query(model)) { case \"a\": 1, case \"b\": 2, default: 0 }");
+    }
+
+    @Test
+    public void testSwitchModelSelection() throws ParseException {
+        // Issue #33096 use case - multiple model selection
+        RankingExpression expression = new RankingExpression(
+            "switch(query(l2_rel_model)) { " +
+            "  case \"model1\": xgboost(\"model1.json\"), " +
+            "  case \"model2\": xgboost(\"model2.json\"), " +
+            "  case \"model3\": xgboost(\"model3.json\"), " +
+            "  default: 0 " +
+            "}");
+        assertTrue(expression.getRoot() instanceof com.yahoo.searchlib.rankingexpression.rule.SwitchNode);
+        assertEquals("switch(query(l2_rel_model)) { case \"model1\": xgboost(\"model1.json\"), case \"model2\": xgboost(\"model2.json\"), case \"model3\": xgboost(\"model3.json\"), default: 0 }",
+                     expression.toString());
+    }
+
+    @Test
     public void testFileImporting() throws ParseException {
         RankingExpression expression = new RankingExpression(new File("src/test/files/simple.expression"));
         assertEquals("simple: a + b", expression.toString());

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -115,6 +115,14 @@ public class EvaluationTestCase {
         tester.assertEvaluates(2.5, "if(1.0-1.1, 2.5, 3.5)");
         tester.assertEvaluates(3.5, "if(1.0-1.0, 2.5, 3.5)");
 
+        // Switch expressions
+        tester.assertEvaluates(0.5, "switch(one) { case 1: one_half, case 2: a_quarter, default: 0 }");
+        tester.assertEvaluates(0.25, "switch(2) { case 1: one_half, case 2: a_quarter, default: 0 }");
+        tester.assertEvaluates(0, "switch(3) { case 1: one_half, case 2: a_quarter, default: 0 }");
+        tester.assertEvaluates(1, "switch(foo) { case \"foo\": 1, case \"bar\": 2, default: 0 }");
+        tester.assertEvaluates(2, "switch(\"bar\") { case \"foo\": 1, case \"bar\": 2, default: 0 }");
+        tester.assertEvaluates(0, "switch(\"baz\") { case \"foo\": 1, case \"bar\": 2, default: 0 }");
+
         // Conditionals with branch probabilities
         RankingExpression e = tester.assertEvaluates(3.5, "if(1.0-1.0, 2.5, 3.5, 0.3)");
         assertEquals(0.3d, ((IfNode) e.getRoot()).getTrueProbability(), tolerance);

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/rule/SwitchNodeTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/rule/SwitchNodeTestCase.java
@@ -1,0 +1,114 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.rankingexpression.rule;
+
+import com.yahoo.searchlib.rankingexpression.RankingExpression;
+import com.yahoo.searchlib.rankingexpression.Reference;
+import com.yahoo.searchlib.rankingexpression.evaluation.DoubleValue;
+import com.yahoo.searchlib.rankingexpression.evaluation.MapTypeContext;
+import com.yahoo.searchlib.rankingexpression.parser.ParseException;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.tensor.evaluation.TypeContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for SwitchNode data structure.
+ *
+ * @author johsol
+ */
+public class SwitchNodeTestCase {
+
+    @Test
+    public void requireThatAccessorsWork() {
+        var discriminant = new ReferenceNode("x");
+        List<ExpressionNode> caseValues = List.of(new ConstantNode(new DoubleValue(1.0)), new ConstantNode(new DoubleValue(2.0)));
+        List<ExpressionNode> caseResults = List.of(new ConstantNode(new DoubleValue(10.0)), new ConstantNode(new DoubleValue(20.0)));
+        var defaultResult = new ConstantNode(new DoubleValue(0.0));
+
+        SwitchNode node = new SwitchNode(discriminant, caseValues, caseResults, defaultResult);
+
+        assertEquals(discriminant, node.getDiscriminant());
+        assertEquals(caseValues, node.getCaseValues());
+        assertEquals(caseResults, node.getCaseResults());
+        assertEquals(defaultResult, node.getDefaultResult());
+        assertEquals(2, node.getCaseValues().size());
+    }
+
+    @Test
+    public void requireThatTypeValidationAcceptsCompatibleResultTypes() {
+        MapTypeContext context = new MapTypeContext();
+        context.setType(ref("x1"), TensorType.fromSpec("tensor(x[])"));
+        context.setType(ref("x2"), TensorType.fromSpec("tensor(x[10])"));
+
+        // All case results have compatible types
+        assertSwitchType("tensor(x[])", "switch(1) { case 1: query(x1), case 2: query(x2), default: query(x1) }", context);
+    }
+
+    @Test
+    public void requireThatTypeValidationRejectsIncompatibleResultTypes() {
+        MapTypeContext context = new MapTypeContext();
+        context.setType(ref("x1"), TensorType.fromSpec("tensor(x[])"));
+        context.setType(ref("y1"), TensorType.fromSpec("tensor(y[])"));
+
+        // Case results have incompatible types (different dimensions)
+        assertTypeError("switch(1) { case 1: query(x1), case 2: query(y1), default: query(x1) }", context);
+    }
+
+    @Test
+    public void requireThatTypeValidationRejectsIncompatibleDefaultType() {
+        MapTypeContext context = new MapTypeContext();
+        context.setType(ref("x1"), TensorType.fromSpec("tensor(x[])"));
+        context.setType(ref("y1"), TensorType.fromSpec("tensor(y[])"));
+
+        // Default has incompatible type with case results
+        assertTypeError("switch(1) { case 1: query(x1), default: query(y1) }", context);
+    }
+
+    @Test
+    public void requireThatTypeValidationAcceptsCompatibleDiscriminantAndCases() {
+        MapTypeContext context = new MapTypeContext();
+        context.setType(ref("tensor1"), TensorType.fromSpec("tensor(x[10])"));
+
+        // Discriminant and case values have compatible types
+        assertSwitchType("tensor(x[10])", "switch(query(tensor1)) { case query(tensor1): query(tensor1), default: query(tensor1) }", context);
+    }
+
+    @Test
+    public void requireThatTypeValidationRejectsIncompatibleDiscriminantAndCase() {
+        MapTypeContext context = new MapTypeContext();
+        context.setType(ref("tensor1"), TensorType.fromSpec("tensor(x[10])"));
+        context.setType(ref("tensor2"), TensorType.fromSpec("tensor(y[5])"));
+
+        // Discriminant and case value have incompatible types (different dimensions)
+        assertTypeError("switch(query(tensor1)) { case query(tensor2): 1, default: 0 }", context);
+    }
+
+    private Reference ref(String name) {
+        return Reference.simple("query", name);
+    }
+
+    private void assertSwitchType(String expectedType, String expression, TypeContext<Reference> context) {
+        try {
+            TensorType actualType = new RankingExpression(expression).type(context);
+            assertEquals(TensorType.fromSpec(expectedType), actualType);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertTypeError(String expression, TypeContext<Reference> context) {
+        try {
+            new RankingExpression(expression).type(context);
+            fail("Expected type validation to fail for: " + expression);
+        } catch (IllegalArgumentException expected) {
+            // Expected - type validation correctly rejected the expression
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/searchlib/src/tests/rankingexpression/rankingexpressionlist
+++ b/searchlib/src/tests/rankingexpression/rankingexpressionlist
@@ -115,6 +115,10 @@ if (foo in [bar, baz, cox], 6, 9)
 if (foo in [ bar ], 6, 9); if (foo in [bar], 6, 9)
 if (foo in [ bar,  baz ], 6, 9); if (foo in [bar, baz], 6, 9)
 if (foo in [ bar,  baz,  cox ], 6, 9); if (foo in [bar, baz, cox], 6, 9)
+switch(x) { case 1: 2, default: 3 }
+switch(x) { case 1: 2, case 3: 4, default: 5 }
+switch(query(model)) { case "a": 1, case "b": 2, default: 0 }
+switch(x) { case 1: a, case 2: b, default: c }
 feature;                                    feature
 fe@ture;                                    fe@ture
 featur@;                                    featur@


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Syntax:

```txt
switch (EXPR) {
  [case EXPR: EXPR,]+
  default: EXPR
}
```

Transformation in config model:

```txt
The expression:
  switch(d) { case v1: r1, case v2: r2, default: def }
becomes:
  if(d == v1, r1, if(d == v2, r2, def))
```