### PR TITLE
Support alternate property names for native proximity

### DIFF
--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_blueprint.cpp
@@ -7,7 +7,6 @@
 #include "elementwise_utils.h"
 #include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/value_codec.h>
-#include <vespa/searchlib/fef/featurenamebuilder.h>
 #include <vespa/searchlib/fef/objectstore.h>
 #include <vespa/vespalib/util/stash.h>
 
@@ -16,7 +15,6 @@ namespace search::features {
 using fef::AnyWrapper;
 using fef::Blueprint;
 using fef::FeatureExecutor;
-using fef::FeatureNameBuilder;
 using fef::FeatureType;
 using fef::FieldType;
 using fef::IQueryEnvironment;

--- a/searchlib/src/vespa/searchlib/features/nativeproximityfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/nativeproximityfeature.cpp
@@ -3,6 +3,7 @@
 #include "nativeproximityfeature.h"
 #include "valuefeature.h"
 #include "utils.h"
+#include <vespa/searchlib/fef/featurenamebuilder.h>
 #include <vespa/searchlib/fef/fieldinfo.h>
 #include <vespa/searchlib/fef/indexproperties.h>
 #include <vespa/searchlib/fef/itablemanager.h>
@@ -220,9 +221,18 @@ NativeProximityBlueprint::setup(const IIndexEnvironment & env,
         {
             param.field = false;
         }
-        param.proximityImportance = util::strToNum<feature_t>
-            (env.getProperties().lookup(getBaseName(), "proximityImportance", info->name()).
-             get(defaultProximityImportance));
+
+        std::string alt_name = FeatureNameBuilder()
+                .baseName(getBaseName())
+                .parameter(info->name())
+                .buildName();
+        std::string alt_importance = env.getProperties()
+                .lookup(alt_name, "proximityImportance")
+                .get(defaultProximityImportance);
+        std::string importance = env.getProperties()
+                .lookup(getBaseName(), "proximityImportance", info->name())
+                .get(alt_importance);
+        param.proximityImportance = util::strToNum<feature_t>(importance);
 
         if (NativeRankBlueprint::useTableNormalization(env)) {
             const Table * fp = param.proximityTable;

--- a/searchlib/src/vespa/searchlib/features/utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/utils.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "utils.hpp"
+#include <vespa/searchlib/fef/featurenamebuilder.h>
 #include <vespa/searchlib/fef/itablemanager.h>
 #include <vespa/searchlib/fef/properties.h>
 #include <vespa/searchlib/fef/itermdata.h>
@@ -150,12 +151,14 @@ const search::fef::Table *
 lookupTable(const search::fef::IIndexEnvironment & env, const std::string & featureName,
             const std::string & table, const std::string & fieldName, const std::string & fallback)
 {
+    auto alt_name = FeatureNameBuilder().baseName(featureName).parameter(fieldName).buildName();
     std::string tn1 = env.getProperties().lookup(featureName, table).get(fallback);
-    std::string tn2 = env.getProperties().lookup(featureName, table, fieldName).get(tn1);
-    const search::fef::Table * retval = env.getTableManager().getTable(tn2);
+    std::string tn2 = env.getProperties().lookup(alt_name, table).get(tn1);
+    std::string tn3 = env.getProperties().lookup(featureName, table, fieldName).get(tn2);
+    const search::fef::Table * retval = env.getTableManager().getTable(tn3);
     if (retval == nullptr) {
         LOG(warning, "Could not find the %s '%s' to be used for field '%s' in feature '%s'",
-            table.c_str(), tn2.c_str(), fieldName.c_str(), featureName.c_str());
+            table.c_str(), tn3.c_str(), fieldName.c_str(), featureName.c_str());
     }
     return retval;
 }


### PR DESCRIPTION
Allows properties to be specified using either the traditional format `featureName.propertyName.fieldName` or the alternate format `featureName(fieldName).propertyName`, with fallback to support both naming conventions. This provides more flexibility in configuring proximity importance and table lookups for native rank features.

@toregge please review
