### PR TITLE
chore: upgrade to Jetty 12.1

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -207,6 +207,8 @@
                                         <include>org.eclipse.jetty:jetty-jmx:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-server:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-util:${jetty.vespa.version}:test</include>
+                                        <include>org.eclipse.jetty.compression:jetty-compression-common:${jetty.vespa.version}:test</include>
+                                        <include>org.eclipse.jetty.compression:jetty-compression-gzip:${jetty.vespa.version}:test</include>
                                         <include>org.hamcrest:hamcrest:${hamcrest.vespa.version}:test</include>
                                         <include>org.hamcrest:hamcrest-core:${hamcrest.vespa.version}:test</include>
                                         <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyConnectionLogger.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyConnectionLogger.java
@@ -277,8 +277,8 @@ class JettyConnectionLogger extends EventsHandler implements Connection.Listener
             return new ConnectionInfo(
                     UUID.randomUUID(),
                     endpoint.getCreatedTimeStamp(),
-                    endpoint.getLocalAddress(),
-                    endpoint.getRemoteAddress());
+                    (InetSocketAddress) endpoint.getLocalSocketAddress(),
+                    (InetSocketAddress) endpoint.getRemoteSocketAddress());
         }
 
         synchronized UUID uuid() { return uuid; }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -58,6 +58,7 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
     private final Deque<JDiscContext> contexts = new ConcurrentLinkedDeque<>();
 
     @Inject // ServerProvider implementors must use com.google.inject.Inject
+    @SuppressWarnings("removal")
     public JettyHttpServer(Metric metric,
                            MetricReceiver metricReceiver,
                            ServerConfig serverConfig,
@@ -234,6 +235,7 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
         return new TlsClientAuthenticationEnforcer(cfg.tlsClientAuthEnforcer(), handler);
     }
 
+    @SuppressWarnings("removal")
     private static GzipHandler newGzipHandler(Handler handler) {
         var h = new GzipHandler(new org.eclipse.jetty.server.handler.gzip.GzipRequestCleanupHandler(handler));
         h.setInflateBufferSize(8 * 1024);

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/ProxyProtocolIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/ProxyProtocolIT.java
@@ -12,7 +12,7 @@ import com.yahoo.text.Text;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.BeforeAll;
@@ -181,7 +181,6 @@ class ProxyProtocolIT {
                 cause = e;
             } finally {
                 client.stop();
-                client.destroy();
             }
         }
         throw cause;
@@ -194,7 +193,7 @@ class ProxyProtocolIT {
         ssl.setSslContext(new SslContextBuilder().withTrustStore(certificateFile).build());
         var connector = new ClientConnector();
         connector.setSslContextFactory(ssl);
-        HttpClient client = new HttpClient(new HttpClientTransportOverHTTP(connector));
+        HttpClient client = new HttpClient(new HttpClientTransportDynamic(connector));
         int timeout = 20 * 1000;
         client.setConnectTimeout(timeout);
         client.setIdleTimeout(timeout);

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -109,7 +109,7 @@
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
         <jetty.vespa.version>12.1.5</jetty.vespa.version>
-        <jetty.client.vespa.version>12.1.5</jetty.client.vespa.version>
+        <jetty.client.vespa.version>${jetty.vespa.version}</jetty.client.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>
         <jimfs.vespa.version>1.3.0</jimfs.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -108,7 +108,7 @@
         <io-perfmark.vespa.version>0.27.0</io-perfmark.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.1.5</jetty.vespa.version>
+        <jetty.vespa.version>12.1.6</jetty.vespa.version>
         <jetty.client.vespa.version>${jetty.vespa.version}</jetty.client.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -108,8 +108,8 @@
         <io-perfmark.vespa.version>0.27.0</io-perfmark.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.0.30</jetty.vespa.version>
-        <jetty.client.vespa.version>12.0.22</jetty.client.vespa.version>
+        <jetty.vespa.version>12.1.5</jetty.vespa.version>
+        <jetty.client.vespa.version>12.1.5</jetty.client.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>
         <jimfs.vespa.version>1.3.0</jimfs.vespa.version>

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -162,6 +162,8 @@ org.codehaus.plexus:plexus-io:${plexus-io.vespa.version}
 org.codehaus.plexus:plexus-utils:${plexus-utils.vespa.version}
 org.eclipse.collections:eclipse-collections-api:${eclipse-collections.vespa.version}
 org.eclipse.collections:eclipse-collections:${eclipse-collections.vespa.version}
+org.eclipse.jetty.compression:jetty-compression-common:${jetty.vespa.version}
+org.eclipse.jetty.compression:jetty-compression-gzip:${jetty.vespa.version}
 org.eclipse.jetty.http2:jetty-http2-client-transport:${jetty.client.vespa.version}
 org.eclipse.jetty.http2:jetty-http2-client:${jetty.client.vespa.version}
 org.eclipse.jetty.http2:jetty-http2-common:${jetty.vespa.version}

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/JettyCluster.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/JettyCluster.java
@@ -289,21 +289,21 @@ class JettyCluster implements Cluster {
         }
 
         @Override
-        public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise) {
-            instance.resolve(host, port, new Promise.Wrapper<List<InetSocketAddress>>(promise) {
+        public void resolve(String host, int port, Map<String, Object> context, Promise<List<InetSocketAddress>> promise) {
+            instance.resolve(host, port, context, new Promise.Wrapper<>(promise) {
                 @Override
                 public void succeeded(List<InetSocketAddress> result) {
                     if (result.size() <= 1) {
-                        getPromise().succeeded(result);
+                        getWrapped().succeeded(result);
                         return;
                     }
                     List<InetSocketAddress> ipv4Addresses = result.stream()
                             .filter(addr -> addr.getAddress() instanceof Inet4Address).collect(Collectors.toList());
                     if (ipv4Addresses.isEmpty()) {
-                        getPromise().succeeded(result);
+                        getWrapped().succeeded(result);
                         return;
                     }
-                    getPromise().succeeded(ipv4Addresses);
+                    getWrapped().succeeded(ipv4Addresses);
                 }
             });
         }


### PR DESCRIPTION
Keep using the legacy `GzipHandler` for now.

FYI @hmusum 