### PR TITLE
Use time when status changed instead of create time for a session

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -456,8 +456,10 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         Tenant tenant = tenantRepository.getTenant(application.tenant());
         if (tenant == null) return Optional.empty();
 
-        Optional<Instant> activatedTime = getActiveSession(tenant, application).map(Session::getActivatedTime);
-        log.log(Level.FINEST, application + " last activated " + activatedTime.orElse(Instant.EPOCH));
+        Optional<Session> activeSession = getActiveSession(tenant, application);
+        Optional<Instant> activatedTime = activeSession.map(Session::statusChanged);
+        long sessionId = activeSession.map(Session::getSessionId).orElse(-1L);
+        log.log(Level.FINE, application + " last activated " + activatedTime.orElse(Instant.EPOCH) + ", active session: " + sessionId);
         return activatedTime;
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
@@ -110,8 +110,8 @@ public abstract class Session implements Comparable<Session>  {
         return sessionZooKeeperClient.readCreateTime();
     }
 
-    public Instant getActivatedTime() {
-        return sessionZooKeeperClient.readActivatedTime();
+    public Instant statusChanged() {
+        return sessionZooKeeperClient.readStatusChanged();
     }
 
     /** Returns application id read from ZooKeeper. Will throw RuntimeException if not found */

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
@@ -285,7 +285,7 @@ public class SessionZooKeeperClient {
                    });
     }
 
-    public Instant readActivatedTime() {
+    public Instant readStatusChanged() {
         Optional<Stat> statData = curator.getStat(sessionStatusPath);
         return statData.map(s -> Instant.ofEpochMilli(s.getMtime())).orElse(Instant.EPOCH);
     }


### PR DESCRIPTION
When checking if a session has expired, use time for last session status change instead of create time if it is later than create time This should make sure that we don't expire a session that has recently been active, but wait for session lifetime until expiring it