### PR TITLE
Log maintenance operation throttler config parameters when enabled

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -216,6 +216,9 @@ FileStorManager::on_configure(const StorFilestorConfig& config)
         _metrics->initDiskMetrics(numStripes, computeAllPossibleHandlerThreads(*_config));
         auto op_dyn_params = dynamic_throttle_params_from_config(_config->asyncOperationThrottler, numThreads);
         auto maintenance_dyn_params = dynamic_throttle_params_from_config(_config->maintenanceOperationThrottler, numStripes);
+        if (use_dynamic_operation_throttling) {
+            LOG(info, "Using maintenance operation throttling: %s", maintenance_dyn_params.to_string().c_str());
+        }
 
         _filestorHandler = std::make_unique<FileStorHandlerImpl>(numThreads, numStripes, *this, *_metrics,
                                                                  _compReg, op_dyn_params, maintenance_dyn_params);
@@ -235,6 +238,10 @@ FileStorManager::on_configure(const StorFilestorConfig& config)
         auto updated_op_dyn_throttle_params = dynamic_throttle_params_from_config(config.asyncOperationThrottler, _threads.size());
         const uint32_t num_stripes = std::max(1u, static_cast<uint32_t>(_threads.size()) / 2);
         auto updated_maintenance_dyn_throttle_params = dynamic_throttle_params_from_config(_config->maintenanceOperationThrottler, num_stripes);
+        if (use_dynamic_operation_throttling) {
+            LOG(info, "Using maintenance operation throttling (reconfig): %s",
+                updated_maintenance_dyn_throttle_params.to_string().c_str());
+        }
         _filestorHandler->reconfigure_dynamic_operation_throttler(updated_op_dyn_throttle_params);
         _filestorHandler->reconfigure_dynamic_maintenance_throttler(updated_maintenance_dyn_throttle_params);
     }

--- a/vespalib/src/vespa/vespalib/util/shared_operation_throttler.cpp
+++ b/vespalib/src/vespa/vespalib/util/shared_operation_throttler.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cassert>
+#include <format>
 #include <functional>
 #include <mutex>
 
@@ -525,6 +526,15 @@ DynamicOperationThrottler::Token::operator=(Token&& rhs) noexcept
     rhs._throttler = nullptr;
     rhs._operation_resource_usage = 0;
     return *this;
+}
+
+std::string
+DynamicOperationThrottler::DynamicThrottleParams::to_string() const {
+    return std::format("DynamicThrottleParams(window_size_increment={}, min_window_size={}, "
+                       "max_window_size={}, resize_rate={}, window_size_decrement_factor={}, "
+                       "window_size_backoff={})",
+                       window_size_increment, min_window_size, max_window_size,
+                       resize_rate, window_size_decrement_factor, window_size_backoff);
 }
 
 }

--- a/vespalib/src/vespa/vespalib/util/shared_operation_throttler.h
+++ b/vespalib/src/vespa/vespalib/util/shared_operation_throttler.h
@@ -4,7 +4,7 @@
 #include "time.h"
 #include <functional>
 #include <memory>
-#include <optional>
+#include <string>
 #include <limits.h>
 
 namespace vespalib {
@@ -118,6 +118,8 @@ public:
 
         bool operator==(const DynamicThrottleParams&) const noexcept = default;
         bool operator!=(const DynamicThrottleParams&) const noexcept = default;
+
+        [[nodiscard]] std::string to_string() const;
     };
 
     // No-op if underlying throttler does not use a dynamic policy, or if the supplied


### PR DESCRIPTION
@toregge please review

It's otherwise very hard to know if maintenance throttling is explicitly enabled (it is currently not enabled by default)
