### PR TITLE
Handle no active session by using a session id of -1

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -948,7 +948,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     private boolean sessionIsActiveForItsApplication(Tenant tenant, Session session) {
         Optional<ApplicationId> owner = session.getOptionalApplicationId();
         if (owner.isEmpty()) return true; // Chicken out ~(˘▾˘)~
-        return tenant.getApplicationRepo().activeSessionOf(owner.get()).equals(Optional.of(session.getSessionId()));
+        return tenant.getApplicationRepo().activeSessionOf(owner.get()).orElse(-1L).equals(session.getSessionId());
     }
 
     // ---------------- Tenant operations ----------------------------------------------------------------

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -948,6 +948,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     private boolean sessionIsActiveForItsApplication(Tenant tenant, Session session) {
         Optional<ApplicationId> owner = session.getOptionalApplicationId();
         if (owner.isEmpty()) return true; // Chicken out ~(˘▾˘)~
+        // session id is always positive, use -1 for non-existing session
         return tenant.getApplicationRepo().activeSessionOf(owner.get()).orElse(-1L).equals(session.getSessionId());
     }
 


### PR DESCRIPTION
Session ids are positive numbers, use -1 to compare when no active session.