### PR TITLE
Unify creating string views from buffer during deserialization

### DIFF
--- a/document/src/vespa/document/serialization/util.h
+++ b/document/src/vespa/document/serialization/util.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
+#include <string.h>
 
 namespace document {
 
@@ -27,6 +29,15 @@ T readValue(Input &input) {
     T val;
     input >> val;
     return val;
+}
+
+
+template <typename Input>
+[[nodiscard]] std::string_view read_cstr(Input& stream) {
+    const char* s = stream.peek();
+    size_t sz = strnlen(s, stream.size()); // `size()` gives the _remaining_ byte count
+    stream.adjustReadPos(sz+1);
+    return std::string_view(s, sz);
 }
 
 template <typename Input>

--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -104,9 +104,8 @@ VespaDocumentDeserializer::read(FieldValue &value) {
 const DocumentType*
 VespaDocumentDeserializer::readDocType(const DocumentType &guess)
 {
-    string_view type_name(_stream.peek());
+    string_view type_name = read_cstr(_stream);
 
-    _stream.adjustReadPos(type_name.size() + 1);
     readValue<uint16_t>(_stream);  // skip version
 
     if (guess.getName() != type_name) {
@@ -121,9 +120,8 @@ VespaDocumentDeserializer::readDocType(const DocumentType &guess)
 
 void
 VespaDocumentDeserializer::read(DocumentId &value) {
-    string_view s(_stream.peek());
-    value.set(s);
-    _stream.adjustReadPos(s.size() + 1);
+    string_view id = read_cstr(_stream);
+    value.set(id);
 }
 
 void

--- a/document/src/vespa/document/update/documentupdate.cpp
+++ b/document/src/vespa/document/update/documentupdate.cpp
@@ -3,6 +3,7 @@
 #include "documentupdate.h"
 #include "documentupdateflags.h"
 #include <vespa/document/fieldvalue/fieldvalues.h>
+#include <vespa/document/serialization/util.h>
 #include <vespa/document/serialization/vespadocumentserializer.h>
 #include <vespa/document/util/serializableexceptions.h>
 #include <vespa/vespalib/objects/nbostream.h>
@@ -24,19 +25,11 @@ namespace document {
 
 namespace {
 
-std::string_view
-readCStr(nbostream & stream) {
-    const char * s = stream.peek();
-    size_t sz = strnlen(s, stream.size());
-    stream.adjustReadPos(sz+1);
-    return std::string_view(s, sz);
-}
-
 const DocumentType *
 deserializeHeader(const DocumentTypeRepo &repo, vespalib::nbostream & stream, std::string_view & documentId)
 {
-    documentId = readCStr(stream);
-    std::string_view typestr = readCStr(stream);
+    documentId = read_cstr(stream);
+    std::string_view typestr = read_cstr(stream);
     int16_t version = 0;
     stream >> version;
     const DocumentType * docType =  repo.getDocumentType(typestr);


### PR DESCRIPTION
@toregge please review

Avoids bug-prone raw buffer peeking and the need for manual stream position adjustment interleaved with the deserialization code.
