### PR TITLE
fix: add cd-vespa-cloud.com to data plane cors allowed list

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/DataplaneProxyService.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/DataplaneProxyService.java
@@ -257,6 +257,7 @@ public final class DataplaneProxyService extends AbstractComponent {
             String corsMap = isDevEnvironment ? """
                     map $http_origin $allow_origin {
                             ~^https://.*\\.vespa-cloud.com$ $http_origin;
+                            ~^https://.*\\.cd-vespa-cloud.com$ $http_origin;
                             ~^https?://localhost(:\\d+)?$ $http_origin;
                             default "";
                         }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
