### PR TITLE
Automatically retry Vespa CLI visit requests on HTTP 429 responses

### DIFF
--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -56,6 +56,7 @@ type CLI struct {
 
 	now           func() time.Time
 	retryInterval time.Duration
+	sleeper       func(time.Duration)
 
 	cmd     *cobra.Command
 	config  *Config
@@ -228,6 +229,7 @@ For detailed description of flags and configuration, see 'vespa help config'.
 		exec:          &execSubprocess{},
 		now:           time.Now,
 		retryInterval: 2 * time.Second,
+		sleeper:       time.Sleep,
 
 		version: version,
 		cmd:     cmd,

--- a/client/go/internal/cli/cmd/testutil_test.go
+++ b/client/go/internal/cli/cmd/testutil_test.go
@@ -40,7 +40,8 @@ func newTestCLI(t *testing.T, envVars ...string) (*CLI, *bytes.Buffer, *bytes.Bu
 	cli.ztsFactory = func(httpClient httputil.Client, domain, url string) (vespa.Authenticator, error) {
 		return &mockAuthenticator{}, nil
 	}
-	cli.retryInterval = time.Hour // Disable waiting in tests. Waiting is short-circuited if --wait < retryInterval
+	cli.retryInterval = time.Hour          // Disable waiting in tests. Waiting is short-circuited if --wait < retryInterval
+	cli.sleeper = func(d time.Duration) {} // No-op sleeping
 	return cli, &stdout, &stderr
 }
 


### PR DESCRIPTION
@arnej27959 please review
@kkraune FYI

The Document V1 handler may turn us away at the door with a 429 at any point if there are a lot of concurrent ops.

To avoid failing the CLI when such a response is encountered, automatically retry the request. To avoid spamming the container, use a very simple randomized exponential backoff strategy.

Each time we observe a 429 we wait for a randomized duration that is +/- 50% of the current backoff value, increasing the backoff by a factor 1.5x up to a limit (max 15s wait). Once we have been able to fire off at least 1 request successfully the backoff is reset back to its initial value.

This also adds a `sleeper` field to the CLI type which allows for mocking thread sleeping (used for backoff). The test impl is by default a no-op, and the prod impl is by default `time.Sleep`.

