### PR TITLE
try tuning max java heap from number of threads

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -23,6 +23,8 @@ export NUM_CPU_LIMIT ?= $(shell nproc)
 export NUM_CPP_THREADS := $(shell echo $$(( $(NUM_CPU_LIMIT)*2/3 )))
 export NUM_MVN_THREADS := $(shell echo $$(( $(NUM_CPU_LIMIT)*2/3 )))
 
+export MAVEN_OPTS ?= -Xms1g -Xmx$(NUM_MVN_THREADS)g
+
 export BUILDKITE ?= false
 export BUILDKITE_PULL_REQUEST ?= true
 ifeq ($(BUILDKITE_PULL_REQUEST),false)

--- a/.buildkite/java.sh
+++ b/.buildkite/java.sh
@@ -20,6 +20,6 @@ PATH=/opt/vespa-deps/bin:$PATH
 
 cd "$SOURCE_DIR"
 
-echo "Running Maven build with target: $VESPA_MAVEN_TARGET"
+echo "Running Maven build with target: ${VESPA_MAVEN_TARGET} [threads: ${NUM_MVN_THREADS} opts: ${MAVEN_OPTS:-none} extra-opts: ${VESPA_MAVEN_EXTRA_OPTS:-none}]"
 read -ra MVN_EXTRA_OPTS <<< "$VESPA_MAVEN_EXTRA_OPTS"
 ./mvnw -T "$NUM_MVN_THREADS" "${MVN_EXTRA_OPTS[@]}" "$VESPA_MAVEN_TARGET"


### PR DESCRIPTION
we're seeing some non-deterministic unit tests failures with openjdk21, and these messages may be relevant:

[ERROR] Error occurred during initialization of VM, trying to use an empty MAVEN_OPTS...
[ERROR] MavenInvocationException: Error occurred during initialization of VM, try to reduce the Java heap size for the MAVEN_OPTS environment variable using -Xms:<size> and -Xmx:<size>.

from experiments it seems that *increasing* the (initially) allowed Java heap size is what we need to do; from the log the "java.sh" executes mvn with -T 42 so it probably needs lots of memory for running all these threads.  As an initial attempt I'm using (number of threads * 1GB) as max limit. 