### PR TITLE
fix eval: explicitly define a move-ctor for LabelBlockStream, as it's not there implicitly

### DIFF
--- a/eval/src/vespa/eval/streamed/streamed_value_utils.cpp
+++ b/eval/src/vespa/eval/streamed/streamed_value_utils.cpp
@@ -4,6 +4,8 @@
 
 namespace vespalib::eval {
 
+LabelBlockStream::LabelBlockStream(LabelBlockStream&&) noexcept = default;
+
 LabelBlockStream::~LabelBlockStream() = default;
 
 } // namespace

--- a/eval/src/vespa/eval/streamed/streamed_value_utils.h
+++ b/eval/src/vespa/eval/streamed/streamed_value_utils.h
@@ -69,6 +69,8 @@ public:
         _current_address(num_mapped_dims)
     {}
 
+    LabelBlockStream(LabelBlockStream&&) noexcept;
+
     ~LabelBlockStream();
 };
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

----

This patch adds an explicit defaulted definition for move-ctor of `LabelBlockStream` as it's not there implicitly due to `LabelBlockStream` having a user-defined destructor, which leads to move-construction falling back to copy-construction here https://github.com/vespa-engine/vespa/blob/0432d5a94fa6409f1b21423821404d1ce5146fae/eval/src/vespa/eval/streamed/streamed_value_index.cpp#L95 and excessive allocations/deallocations of `StringIdVector _current_address` therefore

See https://godbolt.org/z/b31M4sW67 for the brief reference
