### PR TITLE
Revert "fix(config-model): ensure apply-on-restart has an actual effect"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -457,7 +457,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     @Override
     public void getConfig(ComponentsConfig.Builder builder) {
-        builder.setApplyOnRestart(getDeferChangesUntilRestart());
+        builder.setApplyOnRestart(getDeferChangesUntilRestart()); //  Sufficient to set on one config
         builder.components.addAll(ComponentsConfigGenerator.generate(getAllComponents()));
         builder.components(new ComponentsConfig.Components.Builder().id("com.yahoo.container.core.config.HandlersConfigurerDi$RegistriesHack"));
     }
@@ -493,10 +493,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     @Override
     public void getConfig(ApplicationMetadataConfig.Builder builder) {
-        // Setting this for the ComponentsConfig only is not sufficient due to a workaround in ConfigRetriever for an unknown bug.
-        // It's assumed that this config is always used by container clusters (StateHandler)
-        builder.setApplyOnRestart(getDeferChangesUntilRestart());
-
         if (applicationMetaData != null)
             builder.name(applicationMetaData.getApplicationId().application().value()).
                     timestamp(applicationMetaData.getDeployTimestamp()).


### PR DESCRIPTION
Reverts vespa-engine/vespa#35605

Caused instability in certain Vespa Cloud integration tests, most likely due to a race between services restart and reconfiguration.