### PR TITLE
Upgrade to support Java 25 bytecode

### DIFF
--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeClassVisitor.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeClassVisitor.java
@@ -77,9 +77,9 @@ class AnalyzeClassVisitor extends ClassVisitor implements ImportCollector {
         this.name = Analyze.internalNameToClassName(name)
                 .orElseThrow(() -> new RuntimeException("Unable to resolve class name for " + name));
 
-        if (version > Opcodes.V21 && jdkVersionCheck == JdkVersionCheck.ENABLED) {
+        if (version > Opcodes.V25 && jdkVersionCheck == JdkVersionCheck.ENABLED) {
             var jdkVersion = version - 44;
-            throw new RuntimeException("Class " + name + " is compiled for Java version " + jdkVersion + ", but only Java 17 to 21 is supported");
+            throw new RuntimeException("Class " + name + " is compiled for Java version " + jdkVersion + ", but only Java 17 to 25 is supported");
         }
 
         addImportWithInternalName(superName);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,6 +71,13 @@
                             <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages>
                         </instructions>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>biz.aQute.bnd</groupId>
+                            <artifactId>biz.aQute.bndlib</artifactId>
+                            <version>7.2.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -93,6 +100,13 @@
                             <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${asm.vespa.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -145,6 +159,13 @@
                         <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${asm.vespa.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>mojo-descriptor</id>
@@ -190,7 +211,7 @@
                             </filter>
                         </filters>
                     </configuration>
-                 </plugin>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
@@ -219,6 +240,13 @@
                         <argLine>-Djava.io.tmpdir=${project.build.directory} ${ffm.args}</argLine>
                         <excludedEnvironmentVariables>VESPA_HOME,VESPA_USER</excludedEnvironmentVariables>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${asm.vespa.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -253,6 +281,13 @@
                         <useCommonAssemblyIds>true</useCommonAssemblyIds>
                         <failOnWarnings>true</failOnWarnings>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${asm.vespa.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
Update the Maven build infrastructure to handle Java 25 class files:
- Raises maximum allowed opcode version from V21 to V25
- Adds explicit ASM library dependencies to Maven plugins (compiler, surefire, assembly, bundle-plugin) to ensure they use bytecode analyzers that understand Java 25 opcodes
- Updates error messages to reflect Java 17-25 support range

@bjorncs FYI
