### PR TITLE
feat searchlib: Improve HNSW-index loading times

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.h
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.h
@@ -39,6 +39,10 @@ private:
         return _reader->readHostOrder();
     }
 
+    void next_N_ints(uint32_t* buf, size_t n) {
+        _reader->readNHostOrder(buf, n);
+    }
+
 public:
     HnswIndexLoader(HnswGraph<type>& graph, IdMapping& id_mapping, std::unique_ptr<ReaderType> reader);
     virtual ~HnswIndexLoader();

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
@@ -34,6 +34,8 @@ HnswIndexLoader<ReaderType, type>::HnswIndexLoader(HnswGraph<type>& graph, IdMap
       _id_mapping(id_mapping)
 {
     init();
+
+    graph.nodes.ensure_size(_num_nodes);
 }
 
 template <typename ReaderType, HnswIndexType type>

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
@@ -35,7 +35,7 @@ HnswIndexLoader<ReaderType, type>::HnswIndexLoader(HnswGraph<type>& graph, IdMap
 {
     init();
 
-    graph.nodes.ensure_size(_num_nodes);
+    graph.nodes.reserve(_num_nodes);
 }
 
 template <typename ReaderType, HnswIndexType type>

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
@@ -52,9 +52,9 @@ HnswIndexLoader<ReaderType, type>::load_next()
             _graph.make_node(_nodeid, docid, subspace, num_levels);
             for (uint32_t level = 0; level < num_levels; ++level) {
                 uint32_t num_links = next_int();
-                _link_array.clear();
-                while (num_links-- > 0) {
-                    _link_array.push_back(next_int());
+                _link_array.resize(num_links);
+                if (num_links != 0) {
+                    next_N_ints(_link_array.data(), num_links);
                 }
                 _graph.set_link_array(_nodeid, level, _link_array);
             }

--- a/searchlib/src/vespa/searchlib/test/vector_buffer_reader.h
+++ b/searchlib/src/vespa/searchlib/test/vector_buffer_reader.h
@@ -28,6 +28,12 @@ public:
         _pos += sizeof(uint32_t);
         return result;
     }
+
+    void readNHostOrder(uint32_t* buf, size_t n) {
+        assert(_pos + sizeof(uint32_t) * n <= _data.size());
+        std::memcpy(buf, _data.data() + _pos, sizeof(uint32_t) * n);
+        _pos += sizeof(uint32_t) * n;
+    }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/util/fileutil.h
+++ b/searchlib/src/vespa/searchlib/util/fileutil.h
@@ -96,6 +96,10 @@ public:
         read(&result, sizeof(result));
         return result;
     }
+
+    void readNHostOrder(T* buf, size_t n) {
+        read(buf, sizeof(T) * n);
+    }
 };
 
 template <typename T>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

----

This patch aims to improve loading times of HNSW-index by reserving appropriate amount of graph nodes beforehand and reducing amount of virtual read calls by reading links_array in a batch.

In my setup with

```
field some_binary_embeddings type tensor<int8>(d0{},d1[128]) {
    indexing: attribute | index
    index {
        hnsw {
            max-links-per-node: 16
            neighbors-to-explore-at-insert: 100
        }
    }
    attribute {
        distance-metric: hamming
    }
}
```
and ~330kk of docs this patch improves loading time of the index by a factor of ~1.45
