### PR TITLE
Revert "Upgrade to support Java 25 bytecode" [MERGEOK]

### DIFF
--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeClassVisitor.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeClassVisitor.java
@@ -77,9 +77,9 @@ class AnalyzeClassVisitor extends ClassVisitor implements ImportCollector {
         this.name = Analyze.internalNameToClassName(name)
                 .orElseThrow(() -> new RuntimeException("Unable to resolve class name for " + name));
 
-        if (version > Opcodes.V25 && jdkVersionCheck == JdkVersionCheck.ENABLED) {
+        if (version > Opcodes.V21 && jdkVersionCheck == JdkVersionCheck.ENABLED) {
             var jdkVersion = version - 44;
-            throw new RuntimeException("Class " + name + " is compiled for Java version " + jdkVersion + ", but only Java 17 to 25 is supported");
+            throw new RuntimeException("Class " + name + " is compiled for Java version " + jdkVersion + ", but only Java 17 to 21 is supported");
         }
 
         addImportWithInternalName(superName);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,13 +71,6 @@
                             <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages>
                         </instructions>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>biz.aQute.bnd</groupId>
-                            <artifactId>biz.aQute.bndlib</artifactId>
-                            <version>7.2.0</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -100,13 +93,6 @@
                             <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${asm.vespa.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -159,13 +145,6 @@
                         <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${asm.vespa.version}</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <execution>
                             <id>mojo-descriptor</id>
@@ -211,7 +190,7 @@
                             </filter>
                         </filters>
                     </configuration>
-                </plugin>
+                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
@@ -240,13 +219,6 @@
                         <argLine>-Djava.io.tmpdir=${project.build.directory} ${ffm.args}</argLine>
                         <excludedEnvironmentVariables>VESPA_HOME,VESPA_USER</excludedEnvironmentVariables>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${asm.vespa.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -281,13 +253,6 @@
                         <useCommonAssemblyIds>true</useCommonAssemblyIds>
                         <failOnWarnings>true</failOnWarnings>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${asm.vespa.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
Reverts vespa-engine/vespa#35617


This broke in biz.aQute zip file building, we can retry after we get maven upgraded everywhere.