### PR TITLE
Calculate transient disk usage also when the index collection

### DIFF
--- a/searchcore/src/vespa/searchcorespi/index/disk_indexes.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/disk_indexes.cpp
@@ -84,7 +84,7 @@ DiskIndexes::get_transient_size(IndexDiskLayout& layout, IndexDiskDir index_disk
      * Only report transient size related to a valid fusion index. This ensures
      * that transient size is reported once per index collection.
      */
-    if (!index_disk_dir.valid() || !index_disk_dir.is_fusion_index()) {
+    if (!index_disk_dir.valid() || !index_disk_dir.is_fusion_index_or_first_flush_index()) {
         return 0u;
     }
     uint64_t transient_size = 0u;

--- a/searchcore/src/vespa/searchcorespi/index/index_disk_dir.h
+++ b/searchcore/src/vespa/searchcorespi/index/index_disk_dir.h
@@ -33,6 +33,7 @@ public:
     }
     bool valid() const noexcept { return _id != 0u; }
     bool is_fusion_index() const noexcept { return _fusion; }
+    bool is_fusion_index_or_first_flush_index() const noexcept { return _fusion || _id == 1u; }
     uint64_t get_id() const noexcept { return _id; }
 };
 


### PR DESCRIPTION
doesn't have a fusion index.

@vekterli : please review
