### PR TITLE
Shutdown config proxy listener first

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ConfigProxyRpcServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/ConfigProxyRpcServer.java
@@ -66,13 +66,15 @@ public class ConfigProxyRpcServer implements Runnable, TargetWatcher {
     }
 
     void shutdown() {
+        supervisor.transport().shutdown().join();
         try {
-            rpcExecutor.shutdownNow();
-            rpcExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            rpcExecutor.shutdown();
+            if (!rpcExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                rpcExecutor.shutdownNow();
+            }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        supervisor.transport().shutdown().join();
     }
 
     Spec getSpec() {


### PR DESCRIPTION
Try to avoid getting new config requests while we are shutting down, we will not be able to handle them and it leads to log noise