### PR TITLE
Avoid recursion on KeeperException.NotEmptyException

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainer.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.config.server.maintenance;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.flags.FlagSource;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -33,10 +32,12 @@ public class TenantsMaintainer extends ConfigServerMaintainer {
     protected double maintain() {
         if ( ! applicationRepository.configserverConfig().hostedVespa()) return 1.0;
 
-        log.log(Level.INFO, "Starting deletion of unused tenants");
+        log.log(Level.FINE, "Starting deletion of unused tenants");
         try {
             Set<TenantName> tenants = applicationRepository.deleteUnusedTenants(ttlForUnusedTenant, clock.instant());
-            log.log(Level.INFO, "Deleted tenants " + tenants);
+            if (!tenants.isEmpty()) {
+                log.log(Level.INFO, "Deleted tenants " + tenants);
+            }
         } catch (StackOverflowError e) {
             log.log(Level.WARNING, "Stack overflow when deleting tenants", e);
             return 0.0;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -470,23 +470,16 @@ public class TenantRepository {
         // Deletes the tenant tree from ZooKeeper (application and session status for the tenant)
         // and triggers Tenant.close().
         try (Lock lock = tenantLocks.lock(name)) {
-            Path path = tenants.get(name).getPath();
-            closeTenant(name);
-            curator.delete(path);
-        }
-        log.log(Level.INFO, "Deleted tenant '" + name + "'");
-    }
-
-    private void closeTenant(TenantName name) {
-        try (Lock lock = tenantLocks.lock(name)) {
             Tenant tenant = tenants.remove(name);
             if (tenant == null)
                 throw new IllegalArgumentException("Closing '" + name + "' failed, tenant does not exist");
 
-            log.log(Level.FINE, "Closing tenant '" + name + "'");
+            log.log(Level.INFO, "Closing tenant '" + name + "'");
             notifyRemovedTenant(name);
             tenant.close();
+            curator.delete(tenant.getPath());
         }
+        log.log(Level.INFO, "Deleted tenant '" + name + "'");
     }
 
     /**

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -299,12 +299,54 @@ public class Curator extends AbstractComponent implements AutoCloseable {
 
     public void delete(Path path, int expectedVersion, boolean recursive) {
         try {
-            if (recursive) framework().delete().guaranteed().deletingChildrenIfNeeded().withVersion(expectedVersion).forPath(path.getAbsolute());
-            else           framework().delete().guaranteed()                           .withVersion(expectedVersion).forPath(path.getAbsolute());
+            if (recursive) deleteRecursively(path, expectedVersion);
+            else           framework().delete().guaranteed().withVersion(expectedVersion).forPath(path.getAbsolute());
         } catch (KeeperException.NoNodeException e) {
             // Do nothing
         } catch (Exception e) {
             throw new RuntimeException("Could not delete " + path.getAbsolute(), e);
+        }
+    }
+
+    private void deleteRecursively(Path path, int expectedVersion) {
+        // This method avoids using Curator's recursive delete (deletingChildrenIfNeeded())
+        // because it calls ZKPaths.deleteChildren() RECURSIVELY on KeeperException.NotEmptyException.
+        //
+        // This recursion is believed to be the cause of an incident:
+        //   1. Each of the 3 config servers had a PathChildrenCache (PCC) on `/config/v2/tenants/TENANT/sessions`,
+        //      and one on `/config/v2/tenants//TENANT/applications`.
+        //   2. On config server "cfg1" the tenant was deleted, so the two PCCs were closed and TENANT was deleted.
+        //   3. But because the other two cfgs have PCCs on sessions and applications, the PCC will compete to
+        //      recreate these nodes via watchers.  Each time cfg1 tried to delete TENANT after one of these 4 PCC
+        //      had recreated sessions or applications, the Curator implementation would get a NotEmptyException,
+        //      and retry the deletion of the children via a recursion (+1 stack frame).
+        //   4. The incident heap dump had a stack frame depth of 5900 in ZKPaths.  A StackOverflowError was thrown,
+        //      triggering JDK-8318888, and deadlocking the config server.
+        //
+        // This implementation uses iteration instead of recursion on NotEmptyException.
+
+        while (true) {
+            final List<String> children;
+            try {
+                children = framework().getChildren().forPath(path.getAbsolute());
+            } catch (KeeperException.NoNodeException e) {
+                return;
+            } catch (Exception e) {
+                throw new RuntimeException("Could not get children of " + path.getAbsolute());
+            }
+
+            for (var child : children) {
+                deleteRecursively(path.append(child), -1);
+            }
+
+            try {
+                framework().delete().guaranteed().withVersion(expectedVersion).forPath(path.getAbsolute());
+                return;
+            } catch (KeeperException.NotEmptyException e) {
+                // retry by iteration
+            } catch (Exception e) {
+                throw new RuntimeException("Could not delete " + path.getAbsolute(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Avoid using Curator's recursive delete because it recurses on KeeperException.NotEmptyException.  The recursion may cause StackOverflowError, JDK-8318888, and deadlock of the config server.  This PR implements an equivalent using iteration.