### PR TITLE
Support only try-deleting a tenant znode tree

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -37,7 +37,9 @@ import com.yahoo.vespa.config.server.session.SessionRepository;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.transaction.CuratorOperations;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.Flags;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.state.ConnectionState;
@@ -109,6 +111,7 @@ public class TenantRepository {
     private final FileDistributionFactory fileDistributionFactory;
     private final ExecutorService deployHelperExecutor;
     private final FlagSource flagSource;
+    private final BooleanFlag softDeleteTenantFlag;
     private final HostProvisionerProvider hostProvisionerProvider;
     private final ConfigserverConfig configserverConfig;
     private final ConfigServerDB configServerDB;
@@ -199,6 +202,7 @@ public class TenantRepository {
         this.zkSessionWatcherExecutor = zkSessionWatcherExecutor;
         this.fileDistributionFactory = fileDistributionFactory;
         this.flagSource = flagSource;
+        this.softDeleteTenantFlag = Flags.SOFT_DELETE_TENANT.bindTo(flagSource);
         this.hostProvisionerProvider = hostProvisionerProvider;
         this.configServerDB = configServerDB;
         this.zone = zone;
@@ -479,9 +483,24 @@ public class TenantRepository {
             log.log(Level.INFO, "Closing tenant '" + name + "'");
             notifyRemovedTenant(name);
             tenant.close();
-            curator.delete(tenant.getPath());
+            if (softDeleteTenantFlag.with(name).value()) {
+                // Because each config server has a PathDirectoryCache on the `sessions` and `applications` children:
+                //  1. Once the first config server (say cfg1) reaches this point, the caches on cfg2-3 will recreate
+                //    `sessions` and `applications` immediately after they are deleted by this tryDelete(), likely
+                //    failing this deletion.
+                //  2. Once the next config server (say cfg2) also reaches this point, the caches on cfg3 will recreate
+                //     `sessions` and `applications`, possibly failing this deletion.
+                //  3. Once the last config server (cfg3) reaches this point, the delete should succeed.
+                if (curator.tryDelete(tenant.getPath())) {
+                    log.log(Level.INFO, "Deleted tenant '" + name + "'");
+                } else {
+                    log.log(Level.INFO, "Deleted tenant '" + name + "' (" + tenant.getPath() + " to be removed by other cfgs)");
+                }
+            } else {
+                curator.delete(tenant.getPath());
+                log.log(Level.INFO, "Deleted tenant '" + name + "'");
+            }
         }
-        log.log(Level.INFO, "Deleted tenant '" + name + "'");
     }
 
     /**

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -58,6 +58,13 @@ public class Flags {
             "Takes effect on next deployment of the application",
             INSTANCE_ID, VESPA_VERSION);
 
+    public static final UnboundBooleanFlag SOFT_DELETE_TENANT = defineFeatureFlag(
+            "soft-delete-tenant", false,
+            List.of("hakonhall"), "2026-01-20", "2026-03-20",
+            "When deleting /config/v2/tenants/TENANT recursively - whether to give up (true) or retry (false) on NotEmptyException",
+            "Takes effect immediately",
+            TENANT_ID);
+
     public static final UnboundBooleanFlag LOCKED_GCP_PROVISION = defineFeatureFlag(
             "locked-gcp-provision", true,
             List.of("hakonhall"), "2025-08-05", "2026-02-15",


### PR DESCRIPTION
Adds support to:
 - When a tenant is removed, as the last step, delete `/config/v2/tenants/TENANT` recursively.  However if children are created concurrently, the deletion gives up.  As it is today, the deletion retries by iteration ad infinitum.  It used to be that it retried by recursion, which led to StackOverflowError, JDK bug, and a deadlocked cfg.
 - The change is guarded by a soft-delete-tenant flag.

The theory is that once the first config server decides to delete an unused tenant, it cleans up almost everything except for TENANT and a few children nodes.  Eventually, the last config server to decide to remove the unused tenant will actually be the last one to remove e.g. directory caches.  The directory caches on e.g. a `sessions` subdirectory recreates that node as soon as it is deleted, and will therefore be a reason the first config servers fails to clean up TENANT.  But this last config server should be able to :shrug: .

The great benefit of this versus the current, is that the current has been observed to retry deletion more than 5900 times (well, we have made one improvement since).  This starvation is short-circuited with this new try-delete.

One subtlety is that the config server has an endpoint to delete a tenant.  That config server will likely fail with this new code, but succeed with the old.
 - The endpoint is likely unused.  Perhaps we should remove it?
 - Even if that request ends up with not deleting TENANT, if the tenant is unused, it will eventually be cleaned up per above by TenantsMaintainer.
 - It should be possible to guarantee the deletion by issuing the request once against each cfg.

Another subtlety is whether a dangling TENANT node may have some secondary and confusing effects on the cfg.  For instance restarting the cfg will see the TENANT and register it as a tenant, likely creating some required directories. ... until it figures it is unused again and tries to delete it.