### PR TITLE
refactor(voyage-ai-embedder): remove inputTypeOverride parameter

### DIFF
--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -159,7 +159,6 @@ VoyageAIEmbedder =
    element model { xsd:string } &
    element api-key-secret-ref { xsd:string } &
    element endpoint { xsd:string }? &
-   element input-type-override { "auto" | "query" | "document" }? &
    element truncate { xsd:boolean }?
 
 OnnxModelExecutionParams =

--- a/config-model/src/test/cfg/application/voyageai-embedder/services.xml
+++ b/config-model/src/test/cfg/application/voyageai-embedder/services.xml
@@ -10,7 +10,6 @@
             <model>voyage-3.5</model>
             <api-key-secret-ref>voyage_api_key</api-key-secret-ref>
             <endpoint>https://api.voyageai.com/v1/embeddings</endpoint>
-            <input-type-override>query</input-type-override>
             <truncate>true</truncate>
         </component>
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
@@ -34,7 +34,6 @@ public class VoyageAIEmbedderTest {
         assertEquals("voyage-3.5", config.model());
         assertEquals("voyage_api_key", config.apiKeySecretRef());
         assertEquals("https://api.voyageai.com/v1/embeddings", config.endpoint());
-        assertEquals(VoyageAiEmbedderConfig.InputTypeOverride.Enum.query, config.inputTypeOverride());
         assertTrue(config.truncate());
     }
 
@@ -53,7 +52,6 @@ public class VoyageAIEmbedderTest {
         assertEquals("voyage-3.5", config.model());
         assertEquals("https://api.voyageai.com/v1/embeddings", config.endpoint()); // Default endpoint
         assertEquals(3, config.maxRetries()); // Default retries
-        assertEquals(VoyageAiEmbedderConfig.InputTypeOverride.Enum.auto, config.inputTypeOverride()); // Default auto-detect
         assertTrue(config.truncate()); // Default truncate
     }
 
@@ -73,27 +71,6 @@ public class VoyageAIEmbedderTest {
         // Should fail because api-key-secret-ref is required
         Exception exception = assertThrows(IllegalArgumentException.class, () -> buildModelFromXml(servicesXml));
         assertTrue(exception.getMessage().contains("api-key-secret-ref"));
-    }
-
-
-    @Test
-    void testVoyageAIEmbedderInvalidInputType() {
-        String servicesXml = """
-                <?xml version="1.0" encoding="utf-8" ?>
-                <services version="1.0">
-                    <container id="container" version="1.0">
-                        <component id="voyage" type="voyage-ai-embedder">
-                            <model>voyage-3</model>
-                            <api-key-secret-ref>key</api-key-secret-ref>
-                            <input-type-override>invalid</input-type-override>
-                        </component>
-                    </container>
-                </services>
-                """;
-
-        // Should fail because input type must be 'auto', 'query' or 'document'
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> buildModelFromXml(servicesXml));
-        assertTrue(exception.getMessage().contains("input-type-override"));
     }
 
     @Test

--- a/configdefinitions/src/vespa/voyage-ai-embedder.def
+++ b/configdefinitions/src/vespa/voyage-ai-embedder.def
@@ -23,8 +23,5 @@ timeout int default=60000
 
 # Input Processing
 
-# Input type: auto-detect from context, or force specific type (query/document)
-inputTypeOverride enum { auto, query, document } default=auto
-
 # Truncate inputs that exceed model's maximum token limit
 truncate bool default=true

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -176,14 +176,8 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
     }
 
     private String detectInputType(Context context) {
-        String override = config.inputTypeOverride().toString().toLowerCase();
-        if (!override.equals("auto")) {
-            return override;  // "query" or "document"
-        }
-
-        // Auto-detect from context destination
         String destination = context.getDestination();
-        if (destination != null && destination.toLowerCase().contains("query")) {
+        if (destination != null && destination.startsWith("query(")) {
             return "query";
         }
         return "document";


### PR DESCRIPTION
Remove the inputTypeOverride configuration parameter as it is unnecessary given that destination format is well-defined and unambiguous.

The auto-detection logic now uses startsWith("query(") instead of contains("query") to precisely match query destination format "query(featureName)", preventing false positives from field names containing "query".