### PR TITLE
Add JDK 25 build support for datasketches

### DIFF
--- a/datasketches-java25/pom.xml
+++ b/datasketches-java25/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.vespa</groupId>
+    <artifactId>parent</artifactId>
+    <version>8-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.datasketches</groupId>
+  <artifactId>datasketches-memory</artifactId>
+  <version>8-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>datasketches-memory</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/datasketches-java25/src/main/java/org/apache/datasketches/memory/Memory.java
+++ b/datasketches-java25/src/main/java/org/apache/datasketches/memory/Memory.java
@@ -1,0 +1,9 @@
+package org.apache.datasketches.memory;
+
+import java.lang.foreign.MemorySegment;
+
+public class Memory {
+	public static MemorySegment wrap(byte[] b) {
+		return MemorySegment.ofArray(b);
+	}
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -381,6 +381,39 @@
                 </pluginManagement>
             </build>
         </profile>
+
+        <profile>
+            <id>ffm-native</id>
+            <activation><jdk>[25,26)</jdk></activation>
+            <properties>
+                <ffm.args></ffm.args>
+                <org.apache.datasketches.memory.vespa.version>${project.version}</org.apache.datasketches.memory.vespa.version>
+                <org.apache.datasketches.vespa.version>9.0.0</org.apache.datasketches.vespa.version>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <release>25</release>
+                                <compilerArgs>
+                                    <arg>-Xlint:all</arg>
+                                    <arg>-Xlint:-this-escape</arg>
+                                    <arg>-Xlint:-preview</arg>
+                                    <arg>-Xlint:-serial</arg>
+                                    <arg>-Xlint:-try</arg>
+                                    <arg>-Xlint:-processing</arg>
+                                    <arg>-Werror</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
         <profile>
             <id>attach-sources</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,16 @@
         <module>integration/schema-language-server/lemminx-vespa</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>java25</id>
+            <activation><jdk>[25,26)</jdk></activation>
+            <modules>
+                <module>datasketches-java25</module>
+            </modules>
+        </profile>
+    </profiles>
+
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/searchlib/pom.xml
+++ b/searchlib/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>datasketches-java</artifactId>
       <version>${org.apache.datasketches.vespa.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.datasketches</groupId>
+      <artifactId>datasketches-memory</artifactId>
+      <version>${org.apache.datasketches.memory.vespa.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Provides a stub implementation of org.apache.datasketches.memory.Memory using Java's MemorySegment API, activated automatically via Maven profile for JDK 25. This enables the project to build on newer JDK versions that require the Foreign Function & Memory API.

The ffm-native profile also configures JDK 25-specific compiler options, disabling certain lint warnings (this-escape, preview, serial, try, processing) while maintaining -Werror for stricter compilation.

Changes:
- Creates datasketches-java25 module with minimal Memory stub
- Adds ffm-native profile in parent/pom.xml with JDK 25 compiler config
- Adds java25 profile in root pom.xml to include the new module
- Updates searchlib dependencies to use the stub on JDK 25+

