### PR TITLE
add total http latency percentiles

### DIFF
--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/testutils/TestDriver.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/testutils/TestDriver.java
@@ -16,6 +16,7 @@ import com.yahoo.jdisc.http.server.jetty.JettyHttpServer;
 import com.yahoo.jdisc.http.server.jetty.JettyHttpServerContext;
 import com.yahoo.jdisc.http.server.jetty.VoidConnectionLog;
 import com.yahoo.jdisc.http.server.jetty.VoidRequestLog;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.security.SslContextBuilder;
 
 import javax.net.ssl.SSLContext;
@@ -94,6 +95,7 @@ public class TestDriver implements AutoCloseable {
                         bind(FilterBindings.class).toInstance(new FilterBindings.Builder().setStrictFiltering(serverConfig.strictFiltering()).build());
                         bind(ConnectionLog.class).toInstance(new VoidConnectionLog());
                         bind(RequestLog.class).toInstance(new VoidRequestLog());
+                        bind(MetricReceiver.class).toInstance(MetricReceiver.nullImplementation);
                     }
                 },
                 new ConnectorFactoryRegistryModule(connectorConfig));

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceIT.java
@@ -11,6 +11,7 @@ import com.yahoo.jdisc.application.GuiceRepository;
 import com.yahoo.jdisc.http.ServerConfig;
 import com.yahoo.jdisc.http.server.jetty.testutils.ConnectorFactoryRegistryModule;
 import com.yahoo.jdisc.test.ServerProviderConformanceTest;
+import com.yahoo.metrics.simple.MetricReceiver;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpGet;
@@ -776,6 +777,7 @@ public class HttpServerConformanceIT extends ServerProviderConformanceTest {
                             bind(ServerConfig.class).toInstance(new ServerConfig(new ServerConfig.Builder()));
                             bind(ConnectionLog.class).toInstance(new VoidConnectionLog());
                             bind(RequestLog.class).toInstance(new VoidRequestLog());
+                            bind(MetricReceiver.class).toInstance(MetricReceiver.nullImplementation);
                         }
                     },
                     new ConnectorFactoryRegistryModule());


### PR DESCRIPTION
We really should have percentiles on this - total http latency is perhaps our most important metric, this is what the customer experiences when using Vespa.