### PR TITLE
Add flag to control OS major version

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -20,6 +20,7 @@ import static com.yahoo.vespa.flags.Dimension.APPLICATION;
 import static com.yahoo.vespa.flags.Dimension.ARCHITECTURE;
 import static com.yahoo.vespa.flags.Dimension.CERTIFICATE_PROVIDER;
 import static com.yahoo.vespa.flags.Dimension.CLAVE;
+import static com.yahoo.vespa.flags.Dimension.CLOUD;
 import static com.yahoo.vespa.flags.Dimension.CLOUD_ACCOUNT;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_ID;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_TYPE;
@@ -29,6 +30,7 @@ import static com.yahoo.vespa.flags.Dimension.FLAVOR;
 import static com.yahoo.vespa.flags.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 import static com.yahoo.vespa.flags.Dimension.NODE_TYPE;
+import static com.yahoo.vespa.flags.Dimension.SYSTEM;
 import static com.yahoo.vespa.flags.Dimension.TENANT_ID;
 import static com.yahoo.vespa.flags.Dimension.VESPA_VERSION;
 import static com.yahoo.vespa.flags.Dimension.ZONE_ID;
@@ -89,6 +91,15 @@ public class PermanentFlags {
             "keep-provisioned-expired-hosts-max", 0,
             "The maximum number of provisioned expired hosts to keep for investigation of provisioning issues.",
             "Takes effect on next run of ProvisionedExpirer");
+
+    public static final UnboundIntFlag OS_MAJOR_VERSION = defineIntFlag(
+            "os-major-version", 0,
+            "The OS major version to use for provisioned hosts. " +
+            "Value 0 means use lowest major version available. " +
+            "Common values: 8 (AlmaLinux 8), 9 (AlmaLinux 9).",
+            "Takes effect when a host is provisioned",
+            SYSTEM, CLOUD, ENVIRONMENT, ZONE_ID, // Note: will be used by controller
+            CLAVE, NODE_TYPE, CLOUD_ACCOUNT, HOSTNAME);
 
     public static final UnboundJacksonFlag<SharedHost> SHARED_HOST = defineJacksonFlag(
             "shared-host", SharedHost.createDisabled(), SharedHost.class,


### PR DESCRIPTION
Introduces os-major-version flag allowing operators to specify which major OS version (e.g., AlmaLinux 8 or 9) to use when provisioning hosts. Default value of 0 uses the lowest available version.

@hakonhall please review
@esolitos FYI
