### PR TITLE
Propagate linguistics profile through query items

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -337,6 +337,8 @@
       "public abstract boolean isFromQuery()",
       "public abstract boolean isStemmed()",
       "public abstract boolean isWords()",
+      "public abstract com.yahoo.search.query.QueryType getQueryType()",
+      "public abstract void setQueryType(com.yahoo.search.query.QueryType)",
       "public abstract com.yahoo.prelude.query.SegmentingRule getSegmentingRule()"
     ],
     "fields" : [ ]
@@ -1540,6 +1542,8 @@
       "public boolean isFromQuery()",
       "public boolean isStemmed()",
       "public void setStemmed(boolean)",
+      "public com.yahoo.search.query.QueryType getQueryType()",
+      "public void setQueryType(com.yahoo.search.query.QueryType)",
       "public void lock()",
       "public boolean isLocked()",
       "public int getNumWords()",
@@ -1786,6 +1790,8 @@
       "public void setOrigin(com.yahoo.prelude.query.Substring)",
       "public void disclose(com.yahoo.prelude.query.textualrepresentation.Discloser)",
       "public int getTermCount()",
+      "public com.yahoo.search.query.QueryType getQueryType()",
+      "public void setQueryType(com.yahoo.search.query.QueryType)",
       "public boolean isNormalizable()",
       "public void setNormalizable(boolean)",
       "public boolean isLowercased()",

--- a/container-search/src/main/java/com/yahoo/prelude/query/BlockItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/BlockItem.java
@@ -2,6 +2,8 @@
 package com.yahoo.prelude.query;
 
 
+import com.yahoo.search.query.QueryType;
+
 /**
  * An interface used for anything which represents a single block of query input.
  *
@@ -28,6 +30,12 @@ public interface BlockItem extends HasIndexItem {
 
     /** Returns whether this item represents normal text */
     boolean isWords();
+
+    /** Returns the query parsing type that created this, or null if none. */
+    QueryType getQueryType();
+
+    /** Sets the query parsing type that created this. */
+    void setQueryType(QueryType type);
 
     /**
      * If the block has to be resegmented, what operator should be chosen if it

--- a/container-search/src/main/java/com/yahoo/prelude/query/SegmentItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SegmentItem.java
@@ -3,6 +3,7 @@ package com.yahoo.prelude.query;
 
 
 import com.yahoo.prelude.query.textualrepresentation.Discloser;
+import com.yahoo.search.query.QueryType;
 
 import java.util.Objects;
 
@@ -21,7 +22,8 @@ public abstract class SegmentItem extends CompositeItem implements BlockItem {
     private final String value;
     private final boolean isFromQuery;
     private boolean isFromUser;
-    private boolean stemmed;
+    private boolean   stemmed;
+    private QueryType type = null;
     private SegmentingRule segmentingRule = SegmentingRule.LANGUAGE_DEFAULT;
     private final Substring origin;
 
@@ -81,6 +83,14 @@ public abstract class SegmentItem extends CompositeItem implements BlockItem {
     public void setStemmed(boolean stemmed) {
         this.stemmed = stemmed;
     }
+
+    /** Returns the query parsing type that created this, or null if none. */
+    @Override
+    public QueryType getQueryType() { return type; }
+
+    /** Sets the query parsing type that created this. */
+    @Override
+    public void setQueryType(QueryType type) { this.type = type; }
 
     public void lock() {
         locked = true;

--- a/container-search/src/main/java/com/yahoo/prelude/query/TaggableItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/TaggableItem.java
@@ -21,7 +21,7 @@ public interface TaggableItem {
      * This is used to influence ranking features taking proximity into account: nativeRank and a subset of the
      * fieldMatch features.
      * <p>
-     * By default consecutive query terms are 'somewhat' connected, meaning ranking features will score higher in documents
+     * By default, consecutive query terms are 'somewhat' connected, meaning ranking features will score higher in documents
      * where the terms are found close to each other. This effect can be increased or decreased by manipulating the
      * connectivity value. Typical use is to increase the connectivity between terms in the query that we believe are
      * semantically connected. E.g., in the query 'new york hotel', it is a good idea to increase the connectivity between

--- a/container-search/src/main/java/com/yahoo/prelude/query/TermItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/TermItem.java
@@ -2,6 +2,7 @@
 package com.yahoo.prelude.query;
 
 import com.yahoo.prelude.query.textualrepresentation.Discloser;
+import com.yahoo.search.query.QueryType;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -24,6 +25,8 @@ public abstract class TermItem extends SimpleIndexedItem implements BlockItem {
 
     /** The substring which is the raw form of the source of this token, or null if none. */
     private Substring origin;
+
+    private QueryType type = null;
 
     private SegmentingRule segmentingRule = SegmentingRule.LANGUAGE_DEFAULT;
 
@@ -103,6 +106,14 @@ public abstract class TermItem extends SimpleIndexedItem implements BlockItem {
 
     @Override
     public int getTermCount() { return 1; }
+
+    /** Returns the query parsing type that created this, or null if none. */
+    @Override
+    public QueryType getQueryType() { return type; }
+
+    /** Sets the query parsing type that created this. */
+    @Override
+    public void setQueryType(QueryType type) { this.type = type; }
 
     /** Returns whether accent removal is a meaningful and possible operation for this word. */
     public boolean isNormalizable() { return normalizable; }

--- a/container-search/src/main/java/com/yahoo/prelude/query/WordItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/WordItem.java
@@ -61,10 +61,12 @@ public class WordItem extends TermItem {
         setWord(word);
     }
 
+    @Override
     public ItemType getItemType() {
         return ItemType.WORD;
     }
 
+    @Override
     public String getName() {
         return "WORD";
     }

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/AbstractParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/AbstractParser.java
@@ -368,11 +368,14 @@ public abstract class AbstractParser implements CustomParser {
             WordItem w = new WordItem(token.toString(), true, token.substring);
             w.setWords(false);
             w.setFromSpecialToken(true);
+            w.setQueryType(environment.getType());
             return w;
         }
 
         if (language == Language.UNKNOWN) {
-            return new WordItem(normalizedToken, true, token.substring);
+            var word = new WordItem(normalizedToken, true, token.substring);
+            word.setQueryType(environment.getType());
+            return word;
         }
 
         Segmenter segmenter = environment.getLinguistics().getSegmenter();
@@ -387,20 +390,25 @@ public abstract class AbstractParser implements CustomParser {
         }
 
         if (segments.size() == 1) {
-            return new WordItem(segments.get(0), "", true, token.substring);
+            var word = new WordItem(segments.get(0), "", true, token.substring);
+            word.setQueryType(environment.getType());
+            return word;
         }
 
         CompositeItem composite;
         if (indexFacts.getIndex(indexName).getPhraseSegmenting() || quoted) {
             composite = new PhraseSegmentItem(token.toString(), normalizedToken, true, false, token.substring);
+            ((PhraseSegmentItem)composite).setQueryType(environment.getType());
         }
         else {
             composite = new AndSegmentItem(token.toString(), true, false);
+            ((AndSegmentItem)composite).setQueryType(environment.getType());
         }
         int n = 0;
         WordItem previous = null;
         for (String segment : segments) {
             WordItem w = new WordItem(segment, "", true, token.substring);
+            w.setQueryType(environment.getType());
             w.setFromSegmented(true);
             w.setSegmentIndex(n++);
             w.setStemmed(false);

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/LinguisticsParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/LinguisticsParser.java
@@ -70,10 +70,12 @@ public final class LinguisticsParser extends AbstractParser {
             for (int i = 0; i < token.getNumStems(); i++)
                 alternatives.add(new WordAlternativesItem.Alternative(token.getStem(i), 1.0));
             item = new WordAlternativesItem(defaultIndex, true, new Substring(token.getOrig()), alternatives);
+            item.setQueryType(environment.getType());
             item.setNormalizable(false); // Disable downstream normalizing
             item.setLowercased(true); // Disable downstream lowercasing
         }
         item.setIndexName(defaultIndex);
+        item.setQueryType(environment.getType());
         return item;
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/TokenizeParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/TokenizeParser.java
@@ -36,12 +36,17 @@ public final class TokenizeParser extends AbstractParser {
 
     /** Returns the item representing this token if it is searchable, and null otherwise */
     private Item toTerm(Token token) {
-        if (token.kind == WORD)
+        if (token.kind == WORD) {
             return segment("", token, false);
-        else if (token.kind == NUMBER)
-            return new IntItem(token.image);
-        else
+        }
+        else if (token.kind == NUMBER) {
+            var item = new IntItem(token.image);
+            item.setQueryType(environment.getType());
+            return item;
+        }
+        else {
             return null;
+        }
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
@@ -176,7 +176,7 @@ public class StemmingSearcher extends Searcher {
         if (item.isFromQuery() && !item.isStemmed()) {
             Index index = context.indexFacts.getIndex(item.getIndexName());
             StemMode stemMode = index.getStemMode();
-            if (stemMode != StemMode.NONE) return stem(queryType, item, context, index);
+            if (stemMode != StemMode.NONE) return stem(item, context, index);
         }
         return (Item) item;
     }
@@ -197,8 +197,8 @@ public class StemmingSearcher extends Searcher {
     }
 
     // The rewriting logic is here
-    private Item stem(QueryType queryType, BlockItem current, StemContext context, Index index) {
-        var parameters = new LinguisticsParameters(linguisticsProfile(queryType, index),
+    private Item stem(BlockItem current, StemContext context, Index index) {
+        var parameters = new LinguisticsParameters(linguisticsProfile(index, current),
                                                    context.language, index.getStemMode(), index.getNormalize(),
                                                    index.isLowercase());
         Item blockAsItem = (Item)current;
@@ -445,11 +445,12 @@ public class StemmingSearcher extends Searcher {
         return Optional.empty();
     }
 
-    private String linguisticsProfile(QueryType queryType, Index index) {
-        String queryAssignedProfile = queryType.getProfile();
-        if (queryAssignedProfile != null) return queryAssignedProfile;
-        if (index == null) return null;
-        return index.getLinguisticsProfile();
+    private String linguisticsProfile(Index index, BlockItem current) {
+        if (current.getQueryType() != null && current.getQueryType().getProfile() != null)
+            return current.getQueryType().getProfile();
+        if (index != null)
+            return index.getLinguisticsProfile();
+        return null;
     }
 
     private static class Connectivity {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -34,6 +34,7 @@ import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.Location;
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.AndSegmentItem;
+import com.yahoo.prelude.query.BlockItem;
 import com.yahoo.prelude.query.BoolItem;
 import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.DocumentFrequency;
@@ -943,12 +944,14 @@ public class YqlParser implements Parser {
         Language language = decideParsingLanguage(ast, wordData);
         String grammar = getAnnotation(ast, USER_INPUT_GRAMMAR, String.class,
                                        Query.Type.WEAKAND.toString(), "The overall query type of the user input");
+        QueryType queryType = buildQueryType(ast);
         if (USER_INPUT_GRAMMAR_RAW.equals(grammar)) {
-            return instantiateWordItem(defaultIndex, wordData, ast, null, SegmentWhen.NEVER, true, language);
+            return assignQueryType(instantiateWordItem(defaultIndex, wordData, ast, null, SegmentWhen.NEVER, true, language),
+                                   queryType);
         } else if (USER_INPUT_GRAMMAR_SEGMENT.equals(grammar)) {
-            return instantiateWordItem(defaultIndex, wordData, ast, null, SegmentWhen.ALWAYS, false, language);
+            return assignQueryType(instantiateWordItem(defaultIndex, wordData, ast, null, SegmentWhen.ALWAYS, false, language),
+                                   queryType);
         } else {
-            QueryType queryType = buildQueryType(ast);
             Item item = parseUserInput(queryType, defaultIndex, wordData, language, allowEmpty);
             propagateUserInputAnnotationsRecursively(ast, item);
 
@@ -970,6 +973,12 @@ public class YqlParser implements Parser {
         }
     }
 
+    private Item assignQueryType(Item item, QueryType queryType) {
+        if (item instanceof BlockItem)
+            ((BlockItem)item).setQueryType(queryType);
+        return item;
+    }
+
     private QueryType buildQueryType(OperatorNode<ExpressionOperator> ast) {
         var queryType = QueryType.from(Query.Type.WEAKAND);
         if (userQuery != null) {
@@ -985,6 +994,8 @@ public class YqlParser implements Parser {
 
         String grammar = getAnnotation(ast, USER_INPUT_GRAMMAR, String.class,
                                        null, "The overall query type of the user input");
+        if (USER_INPUT_GRAMMAR_RAW.equals(grammar) || USER_INPUT_GRAMMAR_SEGMENT.equals(grammar))
+            grammar = "linguistics"; // raw and segment are not separate types since they don't cause parsing - use linguistics to annotate the term
         if (grammar != null)
             queryType = QueryType.from(grammar);
 

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
@@ -217,17 +217,26 @@ public class StemmingSearcherTestCase {
         var indexModel = new IndexModel(schema);
         var mockLinguistics = new MockLinguistics();
 
+        // Assign profile=p1 by schema
         var yql = "select * from sources * where userInput(@query)";
         var query = new Query("?yql=" + QueryTestCase.httpEncode(yql) + "&query=" + QueryTestCase.httpEncode("hello"));
         search(mockLinguistics, indexModel, query);
         assertEquals("p1", mockLinguistics.lastLinguisticsProfile);
 
+        // Assign profile=p2 by model.type
         yql = "select * from sources * where userInput(@query)";
         query = new Query("?yql=" + QueryTestCase.httpEncode(yql) + "&query=" + QueryTestCase.httpEncode("hello") +
-                          "&model.type.profile=p2");
+                          "&model.type.profile=p2&model.type.isYqlDefault");
         search(mockLinguistics, indexModel, query);
         assertEquals("p2", mockLinguistics.lastLinguisticsProfile,
                      "Query setting overrides profile from schema");
+
+        // Assign profile=p3 by grammar.type
+        yql = "select * from sources * where {grammar.profile:'p3'}userInput(@query)";
+        query = new Query("?yql=" + QueryTestCase.httpEncode(yql) + "&query=" + QueryTestCase.httpEncode("hello"));
+        search(mockLinguistics, indexModel, query);
+        assertEquals("p3", mockLinguistics.lastLinguisticsProfile,
+                     "YQL grammar setting overrides profile from schema");
     }
 
     private Result search(Linguistics linguistics, IndexModel indexModel, Query query) {


### PR DESCRIPTION
When setting a linguistics profile in YQL through
'grammar.profile', it is natural to expect that profile to be applied when the terms produced by the userInput with this grammar annotation. However, this does not happen because the linguistics processing happens during stemming, which is downstream from parsing.

This lets block items that were produced by some parser remember the query type that produced them, and lets the stemming searcher apply the profile from that type when available.

cc @radu-gheorghe