### PR TITLE
feat(voyage-ai-embedder): add batch embedding support for contextualized models

### DIFF
--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTester.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTester.java
@@ -202,4 +202,29 @@ public class EmbeddingScriptTester {
         }
     }
 
+    /** An embedder that tracks whether batch embed was called. Extends MockIndexedEmbedder. */
+    public static class MockBatchAwareEmbedder extends MockIndexedEmbedder {
+
+        public int batchCallCount = 0;
+        public int singleCallCount = 0;
+
+        public MockBatchAwareEmbedder(String expectedDestination) {
+            super(expectedDestination, 0);
+        }
+
+        @Override
+        public Tensor embed(String text, Context context, TensorType tensorType) {
+            singleCallCount++;
+            return super.embed(text, context, tensorType);
+        }
+
+        @Override
+        public List<Tensor> embed(List<String> texts, Context context, TensorType tensorType) {
+            batchCallCount++;
+            return texts.stream()
+                    .map(text -> super.embed(text, context, tensorType))
+                    .toList();
+        }
+    }
+
 }

--- a/linguistics/abi-spec.json
+++ b/linguistics/abi-spec.json
@@ -460,7 +460,8 @@
       "public java.util.Map asMap(java.lang.String)",
       "public abstract java.util.List embed(java.lang.String, com.yahoo.language.process.Embedder$Context)",
       "public java.lang.String decode(java.util.List, com.yahoo.language.process.Embedder$Context)",
-      "public abstract com.yahoo.tensor.Tensor embed(java.lang.String, com.yahoo.language.process.Embedder$Context, com.yahoo.tensor.TensorType)"
+      "public abstract com.yahoo.tensor.Tensor embed(java.lang.String, com.yahoo.language.process.Embedder$Context, com.yahoo.tensor.TensorType)",
+      "public java.util.List embed(java.util.List, com.yahoo.language.process.Embedder$Context, com.yahoo.tensor.TensorType)"
     ],
     "fields" : [
       "public static final java.lang.String defaultEmbedderId",

--- a/linguistics/src/main/java/com/yahoo/language/process/Embedder.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/Embedder.java
@@ -65,6 +65,19 @@ public interface Embedder {
      */
     Tensor embed(String text, Context context, TensorType tensorType);
 
+    /**
+     * Same as {@link #embed(String, Context, TensorType)}, but operates on a list of text strings.
+     * This will typically be the chunks of a multi-value document field.
+     * Embedders supporting contextualized chunk embeddings or batch processing may override this method.
+     *
+     * @see #embed(String, Context, TensorType)
+     */
+    default List<Tensor> embed(List<String> texts, Context context, TensorType tensorType) {
+        return texts.stream()
+                .map(text -> embed(text, context, tensorType))
+                .toList();
+    }
+
     class Context extends InvocationContext<Context> {
 
         public Context(String destination) {


### PR DESCRIPTION
- Add `Embedder.embed(List<String>, Context, TensorType)` for batch embedding
- EmbedExpression now calls batch method when embedding array inputs
- VoyageAIEmbedder implements batch embedding for voyage-context-3 model
- Refactor test mock response helpers to reduce duplication