### PR TITLE
feat(jdisc): read application secrets from environment variables by default

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SecretsProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SecretsProvider.java
@@ -5,24 +5,52 @@ import ai.vespa.secret.Secret;
 import ai.vespa.secret.Secrets;
 import com.yahoo.container.di.componentgraph.Provider;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
 
+/**
+ * The default {@link Secrets} provider instance if no other is configured.
+ *
+ * @author Lester Solbakken
+ * @author bjorncs
+ */
 public class SecretsProvider implements Provider<Secrets> {
 
-    private static final UnavailableSecrets instance = new UnavailableSecrets();
+    private static final EnvironmentSecrets instance = new EnvironmentSecrets();
 
-    @Override
-    public Secrets get() { return instance; }
+    @Override public Secrets get() { return instance; }
+    @Override public void deconstruct() { }
 
-    @Override
-    public void deconstruct() { }
-
-    private static final class UnavailableSecrets implements Secrets {
+    /** Implementation of {@link Secrets} that reads secret values from environment variables. */
+    static class EnvironmentSecrets implements Secrets {
+        private static final Logger log = Logger.getLogger(EnvironmentSecrets.class.getName());
+        private final AtomicBoolean firstCall = new AtomicBoolean(true);
 
         @Override
         public Secret get(String key) {
-            throw new UnsupportedOperationException("Secrets is not available");
+            if (firstCall.compareAndSet(true, false)) {
+                log.info("Using environment variable based 'Secrets' implementation");
+            }
+            var envName = toEnvName(key);
+            var value = System.getenv(envName);
+            if (value == null || value.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Secret '%s' not found. Set environment variable '%s'".formatted(key, envName));
+            }
+            return () -> value;
         }
 
+        static String toEnvName(String key) {
+            var result = new StringBuilder();
+            for (int i = 0; i < key.length(); i++) {
+                char c = key.charAt(i);
+                if (Character.isUpperCase(c) && i > 0 && Character.isLowerCase(key.charAt(i - 1))) {
+                    result.append('_');
+                }
+                result.append(Character.toUpperCase(c));
+            }
+            return "VESPA_SECRET_" + result;
+        }
     }
 
 }

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/SecretsProviderTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/SecretsProviderTest.java
@@ -24,6 +24,7 @@ class SecretsProviderTest {
     void converts_snake_case_to_env_name() {
         assertEquals("VESPA_SECRET_VOYAGE_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("voyage_api_key"));
         assertEquals("VESPA_SECRET_OPEN_AI_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("open_ai_api_key"));
+        assertEquals("VESPA_SECRET_OPENAI_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("OPENAI_API_KEY"));
     }
 
     @Test

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/SecretsProviderTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/SecretsProviderTest.java
@@ -1,0 +1,38 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.container.jdisc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author bjorncs
+ */
+class SecretsProviderTest {
+
+    @Test
+    void converts_camelCase_to_env_name() {
+        assertEquals("VESPA_SECRET_VOYAGE_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("voyageApiKey"));
+        assertEquals("VESPA_SECRET_OPEN_AI_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("openAiApiKey"));
+        assertEquals("VESPA_SECRET_SECRET", SecretsProvider.EnvironmentSecrets.toEnvName("secret"));
+        assertEquals("VESPA_SECRET_NAME", SecretsProvider.EnvironmentSecrets.toEnvName("NAME"));
+        assertEquals("VESPA_SECRET_OPEN_AIKEY", SecretsProvider.EnvironmentSecrets.toEnvName("openAIKey"));
+    }
+
+    @Test
+    void converts_snake_case_to_env_name() {
+        assertEquals("VESPA_SECRET_VOYAGE_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("voyage_api_key"));
+        assertEquals("VESPA_SECRET_OPEN_AI_API_KEY", SecretsProvider.EnvironmentSecrets.toEnvName("open_ai_api_key"));
+    }
+
+    @Test
+    void throws_on_missing_env_var() {
+        var provider = new SecretsProvider();
+        var secrets = provider.get();
+        var exception = assertThrows(IllegalArgumentException.class, () -> secrets.get("nonExistentKey"));
+        assertEquals("Secret 'nonExistentKey' not found. Set environment variable 'VESPA_SECRET_NON_EXISTENT_KEY'",
+                     exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
Provide a fallback implementation that reads secrets from environment variables. Convert key names to `VESPA_SECRET_<UPPER_SNAKE_CASE>` format.

FYI @gjoranv @bratseth 