### PR TITLE
(schema language server) handle term string argument in foreach

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -14,6 +14,7 @@ import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.LabelA
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.EnumArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.ExpressionArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.FieldArgument;
+import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.IdentifierArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.IntegerArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.StringArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.SymbolArgument;
@@ -38,11 +39,19 @@ public class BuiltInFunctions {
     public static final Map<String, GenericFunction> rankExpressionBuiltInFunctions = new HashMap<>() {{
         // ==== Query features ====
         put("query", new GenericFunction("query", new FunctionSignature(new SymbolArgument(SymbolType.QUERY_INPUT, "value"))));
-        put("term", new GenericFunction("term", new IntegerArgument(), Set.of(
-            "", // empty is not actually allowed, but here for completion
-            "significance",
-            "weight",
-            "connectedness"
+        put("term", new GenericFunction("term", List.of(
+            new FunctionSignature(new IntegerArgument(), Set.of(
+                "", // empty is not actually allowed, but here for completion
+                "significance",
+                "weight",
+                "connectedness"
+            )),
+            new FunctionSignature(new IdentifierArgument(), Set.of(
+                "", // empty is not actually allowed, but here for completion
+                "significance",
+                "weight",
+                "connectedness"
+            ))
         )));
         put("queryTermCount", new GenericFunction("queryTermCount"));
         

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/argument/IdentifierArgument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/argument/IdentifierArgument.java
@@ -1,0 +1,129 @@
+package ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument;
+
+import java.util.Optional;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+import ai.vespa.schemals.common.SchemaDiagnostic;
+import ai.vespa.schemals.context.ParseContext;
+import ai.vespa.schemals.parser.rankingexpression.ast.IDENTIFIER;
+import ai.vespa.schemals.parser.rankingexpression.ast.args;
+import ai.vespa.schemals.parser.rankingexpression.ast.expression;
+import ai.vespa.schemals.parser.rankingexpression.ast.feature;
+import ai.vespa.schemals.tree.Node;
+import ai.vespa.schemals.tree.rankingexpression.RankNode;
+
+/**
+ * An argument that must be an identifier bound by an enclosing foreach loop.
+ *
+ * In Vespa ranking expressions, foreach loops bind a variable that can be used
+ * in nested expressions like term(N) where N is the loop variable.
+ */
+public class IdentifierArgument implements Argument {
+
+    private String displayStr;
+
+    public IdentifierArgument(String displayStr) {
+        this.displayStr = displayStr;
+    }
+
+    public IdentifierArgument() {
+        this("identifier");
+    }
+
+    @Override
+    public int getStrictness() {
+        return 5;  // Between IntegerArgument (6) and StringArgument (2)
+    }
+
+    @Override
+    public boolean validateArgument(RankNode node) {
+        Node leaf = node.getSchemaNode().findFirstLeaf();
+        return leaf.isASTInstance(IDENTIFIER.class);
+    }
+
+    @Override
+    public Optional<Diagnostic> parseArgument(ParseContext context, RankNode node) {
+        ArgumentUtils.removeNodeSymbols(context, node);
+
+        Node leaf = node.getSchemaNode().findFirstLeaf();
+        String identifierName = leaf.getText();
+
+        // Find enclosing foreach and validate that this identifier is bound by it
+        Optional<String> foreachVariable = findEnclosingForeachVariable(node.getSchemaNode());
+
+        if (foreachVariable.isEmpty() || !foreachVariable.get().equals(identifierName)) {
+            return Optional.of(new SchemaDiagnostic.Builder()
+                .setRange(leaf.getRange())
+                .setMessage("Identifier '" + identifierName + "' is unbound.")
+                .setSeverity(DiagnosticSeverity.Error)
+                .build());
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Finds the variable name bound by an enclosing foreach loop.
+     *
+     * foreach has the signature: foreach(dimension, variable, feature, condition, operation)
+     * The second argument is the variable name.
+     */
+    private Optional<String> findEnclosingForeachVariable(Node node) {
+        // Walk up to find a feature node that is a foreach call
+        Node current = node.getParent();
+        while (current != null) {
+            if (current.isASTInstance(feature.class)) {
+                // Check if this feature is a foreach
+                if (current.size() > 0) {
+                    Node identifierNode = current.get(0);
+                    String featureName = identifierNode.getText();
+
+                    if ("foreach".equals(featureName)) {
+                        // Find the args node and get the second argument (variable name)
+                        return extractForeachVariable(current);
+                    }
+                }
+            }
+            current = current.getParent();
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Extracts the variable name from the second argument of a foreach feature node.
+     */
+    private Optional<String> extractForeachVariable(Node foreachNode) {
+        // Find the args child
+        for (int i = 0; i < foreachNode.size(); i++) {
+            Node child = foreachNode.get(i);
+            if (child.isASTInstance(args.class)) {
+                // The second child of args is the variable (after the dimension keyword)
+                // args contains: expression, expression, expression, ...
+                // Position 1 is the variable name
+                int expressionIndex = 0;
+                for (int j = 0; j < child.size(); j++) {
+                    Node argChild = child.get(j);
+                    // Skip non-expression nodes (commas, etc.)
+                    if (argChild.isASTInstance(expression.class)) {
+                        if (expressionIndex == 1) {
+                            // This is the variable argument
+                            Node leaf = argChild.findFirstLeaf();
+                            if (leaf != null) {
+                                return Optional.of(leaf.getText());
+                            }
+                        }
+                        expressionIndex++;
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String displayString() {
+        return displayStr;
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -238,6 +238,7 @@ public class SchemaParserTest {
             "src/test/sdfiles/single/defaultdefault.sd",
             "src/test/sdfiles/single/elementwise.sd",
             "src/test/sdfiles/single/embed.sd",
+            "src/test/sdfiles/single/foreachterm.sd",
             "src/test/sdfiles/single/rankprofilebuiltin.sd",
             "src/test/sdfiles/single/structinfieldset.sd",
             "src/test/sdfiles/single/subqueries.sd",
@@ -324,6 +325,7 @@ public class SchemaParserTest {
             new BadFileTestCase("src/test/sdfiles/single/rankprofilefuncs.sd", 2),
             new BadFileTestCase("src/test/sdfiles/single/rankproperties.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/tensorGenerate.sd", 2),
+            new BadFileTestCase("src/test/sdfiles/single/foreachterm_bad.sd", 1),
         };
 
         return Arrays.stream(tests)

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/foreachterm.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/foreachterm.sd
@@ -1,0 +1,13 @@
+schema foreachterm {
+    document foreachterm {
+        field title type string {
+            indexing: index | summary
+        }
+    }
+
+    rank-profile test-profile {
+        first-phase {
+            expression: foreach(terms, N, term(N).significance, true, max)
+        }
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/foreachterm_bad.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/foreachterm_bad.sd
@@ -1,0 +1,16 @@
+schema foreachtermBad {
+    document foreachtermBad {
+        field title type string {
+            indexing: index | summary
+        }
+    }
+
+    rank-profile test-profile {
+        first-phase {
+            expression: foreach(terms, A, term(A).significance, true, max)
+        }
+        second-phase {
+            expression: term(bar).significance
+        }
+    }
+}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

`term()` accepts only INTEGER, but it should also accept identifier inside a `foreach()` expression.

<img width="858" height="298" alt="image" src="https://github.com/user-attachments/assets/637e70e1-cfb9-494a-bd0b-a05e4d8589ea" />

Don't know if other expressions also might need same handling. 
Written with Claude and my limited understanding of the LSP code, so feel very free to reject or suggest changes. 