### PR TITLE
Refactor test to use subdirectory

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFilesTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFilesTest.java
@@ -304,19 +304,20 @@ public class UserConfiguredFilesTest {
 
     @Test
     void require_that_using_empty_dir_fails(@TempDir Path tempDir) {
-        String relativeTempDir = tempDir.toString().substring(tempDir.toString().lastIndexOf("target") + 7);
+        Path foobarDir = tempDir.resolve("foobar");
+        foobarDir.toFile().mkdir();
         ApplicationPackage applicationPackage =
                 new MockApplicationPackage.Builder()
-                        .withRoot(tempDir.toFile().getParentFile())
-                        .withFiles(Map.of(com.yahoo.path.Path.fromString(tempDir.toFile().getAbsolutePath()), ""))
+                        .withRoot(tempDir.toFile())
+                        .withFiles(Map.of(com.yahoo.path.Path.fromString(foobarDir.toAbsolutePath().toString()), ""))
                         .build();
 
         var logger = new TestDeployLogger();
         def.addPathDef("pathVal");
-        builder.setField("pathVal", relativeTempDir);
-        fileRegistry.pathToRef.put(relativeTempDir, new FileReference("bazshash"));
+        builder.setField("pathVal", "foobar");
+        fileRegistry.pathToRef.put("foobar", new FileReference("bazshash"));
         userConfiguredFiles(applicationPackage, logger).register(producer);
-        assertEquals("Directory '" + relativeTempDir + "' is empty", logger.log);
+        assertEquals("Directory 'foobar' is empty", logger.log);
     }
 
     @Test


### PR DESCRIPTION
The require_that_using_empty_dir_fails test previously extracted a relative path using string manipulation with hardcoded "target" substring search and offset. Now it creates a "foobar" subdirectory from tempDir, making the test more robust and independent of the temp directory structure.
