### PR TITLE
Simplify OS_MAJOR_VERSION flag

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -98,7 +98,6 @@ public class PermanentFlags {
             "Value 0 means use lowest major version available. " +
             "Common values: 8 (AlmaLinux 8), 9 (AlmaLinux 9).",
             "Takes effect when a host is provisioned",
-            SYSTEM, CLOUD, ENVIRONMENT, ZONE_ID, // Note: will be used by controller
             CLAVE, NODE_TYPE, CLOUD_ACCOUNT, HOSTNAME);
 
     public static final UnboundJacksonFlag<SharedHost> SHARED_HOST = defineJacksonFlag(


### PR DESCRIPTION
* This feature flag will only be used by configservers where the zone-specific conditions are pre-resolved. If necessary we will use a different flag to control which major version the controller itself will use.

