### PR TITLE
feat(embedder): add request count and failure metrics

### DIFF
--- a/linguistics/abi-spec.json
+++ b/linguistics/abi-spec.json
@@ -443,6 +443,8 @@
     "methods" : [
       "public abstract void sampleEmbeddingLatency(double, com.yahoo.language.process.Embedder$Context)",
       "public abstract void sampleSequenceLength(long, com.yahoo.language.process.Embedder$Context)",
+      "public abstract void sampleRequestCount(com.yahoo.language.process.Embedder$Context)",
+      "public abstract void sampleRequestFailure(com.yahoo.language.process.Embedder$Context, int)",
       "public static com.yahoo.language.process.Embedder$Runtime testInstance()"
     ],
     "fields" : [ ]

--- a/linguistics/src/main/java/com/yahoo/language/process/Embedder.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/Embedder.java
@@ -116,11 +116,17 @@ public interface Embedder {
         void sampleEmbeddingLatency(double millis, Context ctx);
         /** Add a sample embedding length to this */
         void sampleSequenceLength(long length, Context ctx);
+        /** Add a sample request count to this */
+        void sampleRequestCount(Context ctx);
+        /** Add a sample request failure to this */
+        void sampleRequestFailure(Context ctx, int statusCode);
 
         static Runtime testInstance() {
             return new Runtime() {
                 @Override public void sampleEmbeddingLatency(double millis, Context ctx) { }
                 @Override public void sampleSequenceLength(long length, Context ctx) { }
+                @Override public void sampleRequestCount(Context ctx) { }
+                @Override public void sampleRequestFailure(Context ctx, int statusCode) { }
             };
         }
     }

--- a/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
+++ b/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
@@ -212,7 +212,9 @@ public enum ContainerMetrics implements VespaMetrics {
     SERVER_STARTED_MILLIS("serverStartedMillis", Unit.MILLISECOND, "Time since the service was started"),
 
     EMBEDDER_LATENCY("embedder.latency", Unit.MILLISECOND, "Time spent creating an embedding"),
-    EMBEDDER_SEQUENCE_LENGTH("embedder.sequence_length", Unit.BYTE, "Size of sequence produced by tokenizer");
+    EMBEDDER_SEQUENCE_LENGTH("embedder.sequence_length", Unit.ITEM, "Number of tokens in the input sequence"),
+    EMBEDDER_REQUEST_COUNT("embedder.request.count", Unit.REQUEST, "Number of embedder API requests"),
+    EMBEDDER_REQUEST_FAILURE_COUNT("embedder.request.failure.count", Unit.REQUEST, "Number of failed embedder API requests");
 
     private final String name;
     private final Unit unit;

--- a/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
@@ -177,6 +177,8 @@ public class Vespa9VespaMetricSet {
         // Embedders
         addMetric(metrics, ContainerMetrics.EMBEDDER_LATENCY, EnumSet.of(max, sum, count));
         addMetric(metrics, ContainerMetrics.EMBEDDER_SEQUENCE_LENGTH, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_COUNT, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_FAILURE_COUNT, EnumSet.of(max, sum, count));
 
         return metrics;
     }

--- a/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
@@ -241,6 +241,8 @@ public class VespaMetricSet {
         // Embedders
         addMetric(metrics, ContainerMetrics.EMBEDDER_LATENCY, EnumSet.of(max, sum, count));
         addMetric(metrics, ContainerMetrics.EMBEDDER_SEQUENCE_LENGTH, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_COUNT, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_FAILURE_COUNT, EnumSet.of(max, sum, count));
 
         // Deprecated metrics. TODO: Remove on Vespa 9.
         addMetric(metrics, ContainerMetrics.SERVER_REJECTED_REQUESTS, EnumSet.of(rate, count));

--- a/model-integration/src/main/java/ai/vespa/embedding/EmbedderRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/EmbedderRuntime.java
@@ -6,6 +6,7 @@ import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.Embedder;
+import com.yahoo.metrics.simple.Counter;
 import com.yahoo.metrics.simple.Gauge;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.metrics.simple.Point;
@@ -20,12 +21,16 @@ public class EmbedderRuntime implements Embedder.Runtime {
 
     private final Gauge embedLatency;
     private final Gauge sequenceLength;
+    private final Counter requestCount;
+    private final Counter requestFailureCount;
     private final Map<MetricDimensions, Point> metricPointCache = new ConcurrentHashMap<>();
 
     @Inject
     public EmbedderRuntime(MetricReceiver metrics) {
         embedLatency = metrics.declareGauge(ContainerMetrics.EMBEDDER_LATENCY.baseName());
         sequenceLength = metrics.declareGauge(ContainerMetrics.EMBEDDER_SEQUENCE_LENGTH.baseName());
+        requestCount = metrics.declareCounter(ContainerMetrics.EMBEDDER_REQUEST_COUNT.baseName());
+        requestFailureCount = metrics.declareCounter(ContainerMetrics.EMBEDDER_REQUEST_FAILURE_COUNT.baseName());
     }
 
     @Override
@@ -38,12 +43,29 @@ public class EmbedderRuntime implements Embedder.Runtime {
         sequenceLength.sample(length, metricPoint(ctx));
     }
 
+    @Override
+    public void sampleRequestCount(Embedder.Context ctx) {
+        requestCount.add(1, metricPoint(ctx));
+    }
+
+    @Override
+    public void sampleRequestFailure(Embedder.Context ctx, int statusCode) {
+        requestFailureCount.add(1, failureMetricPoint(ctx, statusCode));
+    }
+
     private Point metricPoint(Embedder.Context ctx) {
         var dimensions = new MetricDimensions(ctx.getEmbedderId(), ctx.getLanguage(), ctx.getDestination());
         return metricPointCache.computeIfAbsent(
                 dimensions, d -> new Point(Map.of("embedder", d.embedderId(),
                                                   "language", d.language().languageCode(),
                                                   "destination", d.destination())));
+    }
+
+    private Point failureMetricPoint(Embedder.Context ctx, int statusCode) {
+        return new Point(Map.of("embedder", ctx.getEmbedderId(),
+                                "language", ctx.getLanguage().languageCode(),
+                                "destination", ctx.getDestination(),
+                                "statusCode", String.valueOf(statusCode)));
     }
 
     private record MetricDimensions(String embedderId, Language language, String destination) {}

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -208,10 +208,6 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
         };
     }
 
-    private void sampleMetrics(long startTimeNanos, Context context) {
-        runtime.sampleEmbeddingLatency((System.nanoTime() - startTimeNanos) / 1_000_000_000.0, context);
-    }
-
     private List<Tensor> invokeVoyageAI(List<String> texts, Context context, TensorType targetType) {
         long startTime = System.nanoTime();
         validateTensorType(targetType);
@@ -223,28 +219,33 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
         var responseBody = context.computeCachedValueIfAbsent(cacheKey, () -> {
             var jsonRequest = createJsonRequest(texts, inputType, outputDataType);
             log.fine(() -> "VoyageAI request: " + jsonRequest);
-            return doRequest(jsonRequest, timeoutMs);
+            return doRequest(jsonRequest, timeoutMs, context);
         });
 
-        var tensors = toTensors(responseBody, targetType, outputDataType);
-        sampleMetrics(startTime, context);
+        var tensors = toTensors(responseBody, targetType, outputDataType, context);
+        var latency = Duration.ofNanos(System.nanoTime() - startTime);
+        runtime.sampleEmbeddingLatency(latency.toMillis(), context);
         return tensors;
     }
 
-    private List<Tensor> toTensors(String responseBody, TensorType targetType, String outputDtype) {
+    private List<Tensor> toTensors(String responseBody, TensorType targetType, String outputDtype, Context context) {
         try {
+            Response response;
             List<List<Number>> embeddings;
             if (isContextualModel()) {
-                var response = objectMapper.readValue(responseBody, ContextualResponse.class);
-                embeddings = response.data.get(0).data.stream()
-                        .map(EmbeddingData::embedding)
+                var contextualResponse = objectMapper.readValue(responseBody, ContextualResponse.class);
+                response = contextualResponse;
+                embeddings = contextualResponse.data.get(0).data.stream()
+                        .map(TextEmbeddingData::embedding)
                         .toList();
             } else {
-                var response = objectMapper.readValue(responseBody, VoyageAIResponse.class);
-                embeddings = response.data.stream()
-                        .map(EmbeddingData::embedding)
+                var voyageResponse = objectMapper.readValue(responseBody, TextResponse.class);
+                response = voyageResponse;
+                embeddings = voyageResponse.data.stream()
+                        .map(TextEmbeddingData::embedding)
                         .toList();
             }
+            runtime.sampleSequenceLength(response.usage().totalTokens(), context);
             String dimensionName = targetType.dimensions().get(0).name();
             return embeddings.stream()
                     .map(embedding -> switch (outputDtype) {
@@ -267,7 +268,7 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             request = ContextualRequest.of(
                     texts, config.model(), inputType, config.dimensions(), outputDataType);
         } else {
-            request = VoyageAIRequest.of(
+            request = TextRequest.of(
                     texts.get(0), config.model(), inputType, config.truncate(), config.dimensions(), outputDataType);
         }
         try {
@@ -277,7 +278,7 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
         }
     }
 
-    private String doRequest(String jsonRequest, long timeoutMs) {
+    private String doRequest(String jsonRequest, long timeoutMs, Context context) {
         var httpRequest = new Request.Builder()
                 .url(resolvedEndpoint)
                 .header("Authorization", "Bearer " + apiKey.current())
@@ -292,22 +293,29 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             var responseBody = response.body() != null ? response.body().string() : "";
             log.fine(() -> "VoyageAI response with code " + response.code() + ": " + responseBody);
             if (response.isSuccessful()) {
+                runtime.sampleRequestCount(context);
                 return responseBody;
             } else if (response.code() == 429) {
+                runtime.sampleRequestFailure(context, response.code());
                 throw new OverloadException("VoyageAI API rate limited (429)");
             } else if (response.code() == 401) {
+                runtime.sampleRequestFailure(context, response.code());
                 throw new RuntimeException("VoyageAI API authentication failed. Please check your API key: " + responseBody);
             } else if (response.code() == 400) {
+                runtime.sampleRequestFailure(context, response.code());
                 String errorMessage = parseErrorDetail(responseBody).orElse(responseBody);
                 throw new InvalidInputException("VoyageAI API bad request (400): " + errorMessage);
             } else {
+                runtime.sampleRequestFailure(context, response.code());
                 throw new RuntimeException("VoyageAI API request failed with status " + response.code() + ": " + responseBody);
             }
         } catch (InterruptedIOException e) {
             // Covers both OkHttp timeout (InterruptedIOException) and socket timeout (SocketTimeoutException extends InterruptedIOException)
+            runtime.sampleRequestFailure(context, 0);
             throw new TimeoutException(
                     "VoyageAI API call timed out after " + timeoutMs + "ms", e);
         } catch (IOException e) {
+            runtime.sampleRequestFailure(context, 0);
             throw new RuntimeException("VoyageAI API call failed: " + e.getMessage(), e);
         }
     }
@@ -409,10 +417,24 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
         }
     }
 
-    // ===== Request/Response DTOs =====
+    // ===== Generic Request/Response DTOs =====
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record VoyageAIRequest(
+    private record Usage(@JsonProperty("total_tokens") int totalTokens) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static abstract class Response {
+        @JsonProperty("usage") private Usage usage;
+        Usage usage() { return usage; }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ErrorResponse(@JsonProperty("detail") String detail) {}
+
+    // ===== Text Request/Response DTOs =====
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record TextRequest(
             @JsonProperty("input") List<String> input,
             @JsonProperty("model") String model,
             @JsonProperty("input_type") String inputType,
@@ -420,25 +442,21 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("output_dimension") @JsonInclude(JsonInclude.Include.NON_NULL) Integer outputDimension,
             @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype) {
 
-        static VoyageAIRequest of(String texts, String model, String inputType,
-                                  boolean truncation, Integer outputDimension, String outputDtype) {
-            return new VoyageAIRequest(List.of(texts), model, inputType, truncation, outputDimension, outputDtype);
+        static TextRequest of(String texts, String model, String inputType,
+                              boolean truncation, Integer outputDimension, String outputDtype) {
+            return new TextRequest(List.of(texts), model, inputType, truncation, outputDimension, outputDtype);
         }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record VoyageAIResponse(
-            @JsonProperty("data") List<EmbeddingData> data,
-            @JsonProperty("model") String model,
-            @JsonProperty("usage") Usage usage) {}
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record EmbeddingData(
+    private record TextEmbeddingData(
             @JsonProperty("embedding") List<Number> embedding,
             @JsonProperty("index") int index) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record Usage(@JsonProperty("total_tokens") int totalTokens) {}
+    private static class TextResponse extends Response {
+        @JsonProperty("data") List<TextEmbeddingData> data;
+    }
 
     // ===== Contextual Request/Response DTOs =====
 
@@ -458,10 +476,12 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ContextualResponse(@JsonProperty("data") List<ContextualDocumentResult> data) {}
+    private static class ContextualResponse extends Response {
+        @JsonProperty("data") List<ContextualDocumentResult> data;
+    }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ContextualDocumentResult(@JsonProperty("data") List<EmbeddingData> data) {}
+    private record ContextualDocumentResult(@JsonProperty("data") List<TextEmbeddingData> data) {}
 
     // ===== Multimodal Request DTOs =====
 
@@ -482,23 +502,20 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record MultimodalInput(@JsonProperty("content") List<ContentItem> content) {
+    private record MultimodalInput(@JsonProperty("content") List<MultimodalContentItem> content) {
 
         static MultimodalInput of(String text) {
-            return new MultimodalInput(List.of(ContentItem.of(text)));
+            return new MultimodalInput(List.of(MultimodalContentItem.of(text)));
         }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ContentItem(
+    private record MultimodalContentItem(
             @JsonProperty("type") String type,
             @JsonProperty("text") String text) {
 
-        static ContentItem of(String text) { return new ContentItem("text", text); }
+        static MultimodalContentItem of(String text) { return new MultimodalContentItem("text", text); }
     }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ErrorResponse(@JsonProperty("detail") String detail) {}
 
     // ===== Cache Key =====
 

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -286,6 +286,7 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
                 .post(RequestBody.create(jsonRequest, MediaType.get("application/json; charset=utf-8")))
                 .build();
 
+        runtime.sampleRequestCount(context);
         var call = httpClient.newCall(httpRequest);
         call.timeout().timeout(timeoutMs, TimeUnit.MILLISECONDS);
 
@@ -293,7 +294,6 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             var responseBody = response.body() != null ? response.body().string() : "";
             log.fine(() -> "VoyageAI response with code " + response.code() + ": " + responseBody);
             if (response.isSuccessful()) {
-                runtime.sampleRequestCount(context);
                 return responseBody;
             } else if (response.code() == 429) {
                 runtime.sampleRequestFailure(context, response.code());

--- a/model-integration/src/test/java/ai/vespa/embedding/ColBertEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/ColBertEmbedderTest.java
@@ -323,8 +323,9 @@ public class ColBertEmbedderTest {
             embeddingsDone++;
         }
 
-        @Override
-        public void sampleSequenceLength(long length, Embedder.Context ctx) { }
+        @Override public void sampleSequenceLength(long length, Embedder.Context ctx) { }
+        @Override public void sampleRequestCount(Embedder.Context ctx) { }
+        @Override public void sampleRequestFailure(Embedder.Context ctx, int statusCode) { }
 
     }
 


### PR DESCRIPTION
- Add embedder.request.count and embedder.request.failure.count metrics
- VoyageAIEmbedder now reports token usage via embedder.sequence_length
- Refactor response DTOs with common base class for usage field