### PR TITLE
Change default stemming to multiple on Vespa 9

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/Schema.java
+++ b/config-model/src/main/java/com/yahoo/schema/Schema.java
@@ -65,7 +65,6 @@ public class Schema implements ImmutableSchema {
 
     private Boolean rawAsBase64 = null;
 
-    /** The stemming setting of this schema. Default is BEST. */
     private Stemming stemming = null;
 
     private final FieldSets fieldSets = new FieldSets(Optional.of(this));
@@ -204,7 +203,7 @@ public class Schema implements ImmutableSchema {
     /** Returns whether fields should be stemmed by default or not. Default is BEST. This is never null. */
     public Stemming getStemming() {
         if (stemming != null) return stemming;
-        if (inherited.isEmpty()) return Stemming.BEST;
+        if (inherited.isEmpty()) return Stemming.BEST; // TODO Vespa 9: Change default to multiple
         return requireInherited().getStemming();
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/document/SDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/SDField.java
@@ -89,7 +89,7 @@ public class SDField extends Field implements ImmutableSDField {
 
     /**
      * The stemming setting of this field, or null to use the default.
-     * Default is determined by the owning search definition.
+     * Default is determined by the owning schema.
      */
     private Stemming stemming = null;
 


### PR DESCRIPTION
If the linguistics library is configured to return multiple stems, the default should be to index all of them.

cc @radu-gheorghe 
