### PR TITLE
Avoid cluster controller orchestration decisisions based on stale topology info

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -30,8 +30,8 @@ public final class ContentCluster {
 
     private int slobrokGenerationCount = 0;
     private Distribution distribution;
-    // See `orchestrationDecisionGeneration()` below for semantics on this value
-    private long orchestrationDecisionGeneration = 0;
+    // See `orchestrationGeneration()` below for semantics on this value
+    private long orchestrationGeneration = 0;
 
     public ContentCluster(String clusterName, Collection<ConfiguredNode> configuredNodes, Distribution distribution) {
         this(clusterName, configuredNodes, distribution, -1);
@@ -142,8 +142,8 @@ public final class ContentCluster {
      * @return orchestration generation that only has useful semantics on this particular
      *         cluster controller instance for the lifetime of the process.
      */
-    public long orchestrationDecisionGeneration() {
-        return this.orchestrationDecisionGeneration;
+    public long orchestrationGeneration() {
+        return this.orchestrationGeneration;
     }
 
     /**
@@ -152,8 +152,8 @@ public final class ContentCluster {
      * The existing node(s) will first have to come back up and allow the cluster to get
      * back into sync.
      */
-    public void bumpOrchestrationDecisionGeneration() {
-        this.orchestrationDecisionGeneration++;
+    public void bumpOrchestrationGeneration() {
+        this.orchestrationGeneration++;
     }
 
     /**

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -492,7 +492,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         eventLog.setMaxSize(options.eventLogMaxSize(), options.eventNodeLogMaxSize());
         if (changesDistributionConfig(options.storageDistribution())) {
             // Distribution config changes must invalidate any assumptions used for wanted states set on nodes
-            cluster.bumpOrchestrationDecisionGeneration();
+            cluster.bumpOrchestrationGeneration();
         }
         cluster.setDistribution(options.storageDistribution());
         cluster.setNodes(options.nodes(), databaseContext.getNodeStateUpdateListener());
@@ -1023,7 +1023,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
                 stateVersionTracker.setVersionRetrievedFromZooKeeper(database.getLatestSystemStateVersion());
                 // A freshly elected leader can't depend on potentially arbitrarily stale node
                 // state meta information from any of its previous terms.
-                cluster.bumpOrchestrationDecisionGeneration();
+                cluster.bumpOrchestrationGeneration();
                 ClusterStateBundle previousBundle = database.getLatestClusterStateBundle();
                 database.loadStartTimestamps(cluster);
                 database.loadWantedStates(databaseContext);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
@@ -35,9 +35,9 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
     private final List<Pair<GetNodeStateRequest, Long>> pendingNodeStateRequests = new LinkedList<>();
     private NodeState reportedState;
     private NodeState wantedState;
-    // Must have a lower initial value than ContentCluster#orchestrationDecisionGeneration
+    // Must have a lower initial value than ContentCluster#orchestrationGeneration
     // to prevent confusion when that number is incremented.
-    private long wantedStateOrchestrationDecisionGeneration = -1;
+    private long wantedStateOrchestrationGeneration = -1;
 
     /** Whether this node has been configured to be retired and should therefore always return retired as its wanted state */
     private boolean configuredRetired;
@@ -286,13 +286,13 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
      * it means the wanted state of the node was set by this controller in a cluster
      * configuration (topology, redundancy, ...) that is the same as the current one.
      *
-     * @see ContentCluster#orchestrationDecisionGeneration()
+     * @see ContentCluster#orchestrationGeneration()
      */
-    public long wantedStateOrchestrationDecisionGeneration() {
-        return wantedStateOrchestrationDecisionGeneration;
+    public long wantedStateOrchestrationGeneration() {
+        return wantedStateOrchestrationGeneration;
     }
-    public void setWantedStateOrchestrationDecisionGeneration(long generation) {
-        wantedStateOrchestrationDecisionGeneration = generation;
+    public void setWantedStateOrchestrationGeneration(long generation) {
+        wantedStateOrchestrationGeneration = generation;
     }
 
     public long getTimeOfFirstFailingConnectionAttempt() {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
@@ -35,6 +35,9 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
     private final List<Pair<GetNodeStateRequest, Long>> pendingNodeStateRequests = new LinkedList<>();
     private NodeState reportedState;
     private NodeState wantedState;
+    // Must have a lower initial value than ContentCluster#orchestrationDecisionGeneration
+    // to prevent confusion when that number is incremented.
+    private long wantedStateOrchestrationDecisionGeneration = -1;
 
     /** Whether this node has been configured to be retired and should therefore always return retired as its wanted state */
     private boolean configuredRetired;
@@ -276,6 +279,21 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
 
     /** Returns the wanted state set directly by a user (i.e. not configured) */
     public NodeState getUserWantedState() { return wantedState; }
+
+    /**
+     * Returns a value that can be compared for equality against the ContentCluster's
+     * current orchestration decision generation. If (and only if) the two are equal
+     * it means the wanted state of the node was set by this controller in a cluster
+     * configuration (topology, redundancy, ...) that is the same as the current one.
+     *
+     * @see ContentCluster#orchestrationDecisionGeneration()
+     */
+    public long wantedStateOrchestrationDecisionGeneration() {
+        return wantedStateOrchestrationDecisionGeneration;
+    }
+    public void setWantedStateOrchestrationDecisionGeneration(long generation) {
+        wantedStateOrchestrationDecisionGeneration = generation;
+    }
 
     public long getTimeOfFirstFailingConnectionAttempt() {
         return timeOfFirstFailingConnectionAttempt;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -593,7 +593,7 @@ public class NodeStateChangeChecker {
         return nodeInfos.stream().allMatch(nodeInfo -> {
             // Only consider node a match if its wanted state decision was made in the
             // same orchestration context that the current decision will be made in.
-            return nodeInfo.wantedStateOrchestrationDecisionGeneration() == cluster.orchestrationDecisionGeneration();
+            return nodeInfo.wantedStateOrchestrationGeneration() == cluster.orchestrationGeneration();
         });
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
@@ -161,7 +161,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
             NodeListener stateListener,
             boolean probe) {
         if (result.allowed()) {
-            setNewWantedState(nodeInfo, newWantedState, stateListener, probe);
+            setNewWantedState(nodeInfo, newWantedState, stateListener, cluster, probe);
         }
 
         // True if the wanted state was or has just been set to newWantedState
@@ -210,16 +210,18 @@ public class SetNodeStateRequest extends Request<SetResponse> {
         if (newWantedState.getState() != currentWantedState.getState() ||
                 !Objects.equals(newWantedState.getDescription(),
                         currentWantedState.getDescription())) {
-            setNewWantedState(nodeInfo, newWantedState, stateListener, probe);
+            setNewWantedState(nodeInfo, newWantedState, stateListener, cluster, probe);
         }
     }
 
     private static void setNewWantedState(NodeInfo nodeInfo,
                                           NodeState newWantedState,
                                           NodeListener stateListener,
+                                          ContentCluster cluster,
                                           boolean probe) {
         if (probe) return;
         nodeInfo.setWantedState(newWantedState);
+        nodeInfo.setWantedStateOrchestrationDecisionGeneration(cluster.orchestrationDecisionGeneration());
         stateListener.handleNewWantedNodeState(nodeInfo, newWantedState);
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
@@ -221,7 +221,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
                                           boolean probe) {
         if (probe) return;
         nodeInfo.setWantedState(newWantedState);
-        nodeInfo.setWantedStateOrchestrationDecisionGeneration(cluster.orchestrationDecisionGeneration());
+        nodeInfo.setWantedStateOrchestrationGeneration(cluster.orchestrationGeneration());
         stateListener.handleNewWantedNodeState(nodeInfo, newWantedState);
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
@@ -130,7 +130,7 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
 
     private void writeOrchestrationGeneration(StringBuilder sb) {
         sb.append("<p>Internal orchestration generation: ")
-          .append(cluster.orchestrationDecisionGeneration())
+          .append(cluster.orchestrationGeneration())
           .append("</p>\n");
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
@@ -93,6 +93,7 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
         }
         // State of master election
         masterElectionHandler.writeHtmlState(content);
+        writeOrchestrationGeneration(content);
         // Overview of current config
         writeHtmlState(content, options);
         // Event log
@@ -125,6 +126,12 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
             }
             sb.append("</table>\n");
         }
+    }
+
+    private void writeOrchestrationGeneration(StringBuilder sb) {
+        sb.append("<p>Internal orchestration generation: ")
+          .append(cluster.orchestrationDecisionGeneration())
+          .append("</p>\n");
     }
 
     private static void writeClusterStates(StringBuilder sb, ClusterStateBundle clusterStates) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -416,7 +416,7 @@ public class NodeStateChangeCheckerTest {
                 currentClusterStateVersion));
         // Pretend we got a reconfig or leadership change, causing our knowledge of the old world
         // to be too spotty to trust.
-        cluster.bumpOrchestrationDecisionGeneration();
+        cluster.bumpOrchestrationGeneration();
         // Denied for node1 in group 0, since node 0 in group 0 is in maintenance with an outdated context
         settingToMaintenanceIsNotAllowed(1, cluster, clusterStateWith0InMaintenance,
                 NodeStateChangeChecker.STALE_ORCHESTRATOR_CONTEXT_MSG);
@@ -1032,14 +1032,14 @@ public class NodeStateChangeCheckerTest {
         NodeState nodeState = new NodeState(STORAGE, state);
         var nodeInfo = cluster.clusterInfo().getStorageNodeInfo(nodeIndex);
         nodeInfo.setWantedState(nodeState.setDescription(description));
-        nodeInfo.setWantedStateOrchestrationDecisionGeneration(cluster.orchestrationDecisionGeneration());
+        nodeInfo.setWantedStateOrchestrationGeneration(cluster.orchestrationGeneration());
     }
 
     private void setDistributorNodeWantedState(ContentCluster cluster, int nodeIndex, State state, String description) {
         NodeState nodeState = new NodeState(DISTRIBUTOR, state);
         var nodeInfo = cluster.clusterInfo().getDistributorNodeInfo(nodeIndex);
         nodeInfo.setWantedState(nodeState.setDescription(description));
-        nodeInfo.setWantedStateOrchestrationDecisionGeneration(cluster.orchestrationDecisionGeneration());
+        nodeInfo.setWantedStateOrchestrationGeneration(cluster.orchestrationGeneration());
     }
 
     private Result evaluateTransition(ContentCluster cluster, Node node, ClusterState clusterState,

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -151,7 +151,7 @@ public class NodeStateChangeCheckerTest {
     void testSafeMaintenanceDisallowedWhenOtherStorageNodeInFlatClusterIsSuspended(int maxNumberOfGroupsAllowedToBeDown) {
         // Nodes 0-3, storage node 0 being in maintenance with "Orchestrator" description.
         ContentCluster cluster = createCluster(4, maxNumberOfGroupsAllowedToBeDown);
-        setStorageNodeWantedStateToMaintenance(cluster, 0);
+        setStorageNodeWantedStateToOrchestratorMaintenance(cluster, 0);
         ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
                 "version:%d distributor:4 storage:4 .0.s:m",
                 currentClusterStateVersion));
@@ -175,7 +175,7 @@ public class NodeStateChangeCheckerTest {
         {
             int nodeIndex = 0;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, defaultAllUpClusterState());
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // Node in group 0 in maintenance, set storage node in group 1 to maintenance
@@ -183,7 +183,7 @@ public class NodeStateChangeCheckerTest {
             ClusterState clusterState = clusterState(String.format("version:%d distributor:4 .0.s:d storage:4 .0.s:m", currentClusterStateVersion));
             int nodeIndex = 1;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // Nodes in group 0 and 1 in maintenance, try to set storage node in group 2 to maintenance while storage node 2 is down, should fail
@@ -222,7 +222,7 @@ public class NodeStateChangeCheckerTest {
         {
             int nodeIndex = 0;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, defaultAllUpClusterState());
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // One node in group 0 in maintenance, try to set another storage node in group 0 to maintenance, should fail
@@ -259,7 +259,7 @@ public class NodeStateChangeCheckerTest {
             ClusterState clusterState = defaultAllUpClusterState(8);
             int nodeIndex = 0;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // 1 Node in group 0 in maintenance, try to set node 1 in group 0 to maintenance
@@ -267,7 +267,7 @@ public class NodeStateChangeCheckerTest {
             ClusterState clusterState = clusterState(String.format("version:%d distributor:8 .0.s:d storage:8 .0.s:m", currentClusterStateVersion));
             int nodeIndex = 1;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // 2 nodes in group 0 in maintenance, try to set storage node 2 in group 1 to maintenance
@@ -275,7 +275,7 @@ public class NodeStateChangeCheckerTest {
             ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m", currentClusterStateVersion));
             int nodeIndex = 2;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // 2 nodes in group 0 and 1 in group 1 in maintenance, try to set storage node 4 in group 2 to maintenance, should fail (different group)
@@ -283,7 +283,6 @@ public class NodeStateChangeCheckerTest {
             ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m", currentClusterStateVersion));
             int nodeIndex = 4;
             settingToMaintenanceIsNotAllowed(nodeIndex, cluster, clusterState, "At most 2 groups can have wanted state: [0, 1]");
-
         }
 
         // 2 nodes in group 0 and 1 in group 1 in maintenance, try to set storage node 3 in group 1 to maintenance
@@ -291,7 +290,7 @@ public class NodeStateChangeCheckerTest {
             ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m", currentClusterStateVersion));
             int nodeIndex = 3;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
-            setStorageNodeWantedStateToMaintenance(cluster, nodeIndex);
+            setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
         }
 
         // 2 nodes in group 0 and 2 nodes in group 1 in maintenance, try to set storage node 4 in group 2 to maintenance, should fail
@@ -403,6 +402,27 @@ public class NodeStateChangeCheckerTest {
             // description Orchestrator, and it is in the same group
             settingToMaintenanceIsAllowed(1, cluster, clusterStateWith0InMaintenance);
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 1})
+    void safe_maintenance_disallowed_when_existing_node_state_set_in_outdated_context(int maxNumberOfGroupsAllowedToBeDown) {
+        // Nodes 0-3, storage node 0 being in maintenance with "Orchestrator" description.
+        // 2 groups: nodes 0-1 is group 0, 2-3 is group 1.
+        ContentCluster cluster = createCluster(4, 2, maxNumberOfGroupsAllowedToBeDown);
+        setStorageNodeWantedStateToOrchestratorMaintenance(cluster, 0);
+        ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+                "version:%d distributor:4 storage:4 .0.s:m",
+                currentClusterStateVersion));
+        // Pretend we got a reconfig or leadership change, causing our knowledge of the old world
+        // to be too spotty to trust.
+        cluster.bumpOrchestrationDecisionGeneration();
+        // Denied for node1 in group 0, since node 0 in group 0 is in maintenance with an outdated context
+        settingToMaintenanceIsNotAllowed(1, cluster, clusterStateWith0InMaintenance,
+                NodeStateChangeChecker.STALE_ORCHESTRATOR_CONTEXT_MSG);
+        // Renew the state context generation for node 0; should now be allowed
+        setStorageNodeWantedStateToOrchestratorMaintenance(cluster, 0);
+        settingToMaintenanceIsAllowed(1, cluster, clusterStateWith0InMaintenance);
     }
 
     @ParameterizedTest
@@ -1004,22 +1024,22 @@ public class NodeStateChangeCheckerTest {
         return result;
     }
 
-    private void setStorageNodeWantedStateToMaintenance(ContentCluster cluster, int nodeIndex) {
+    private void setStorageNodeWantedStateToOrchestratorMaintenance(ContentCluster cluster, int nodeIndex) {
         setStorageNodeWantedState(cluster, nodeIndex, MAINTENANCE, "Orchestrator");
     }
 
     private void setStorageNodeWantedState(ContentCluster cluster, int nodeIndex, State state, String description) {
         NodeState nodeState = new NodeState(STORAGE, state);
-        cluster.clusterInfo()
-               .getStorageNodeInfo(nodeIndex)
-               .setWantedState(nodeState.setDescription(description));
+        var nodeInfo = cluster.clusterInfo().getStorageNodeInfo(nodeIndex);
+        nodeInfo.setWantedState(nodeState.setDescription(description));
+        nodeInfo.setWantedStateOrchestrationDecisionGeneration(cluster.orchestrationDecisionGeneration());
     }
 
     private void setDistributorNodeWantedState(ContentCluster cluster, int nodeIndex, State state, String description) {
         NodeState nodeState = new NodeState(DISTRIBUTOR, state);
-        cluster.clusterInfo()
-               .getDistributorNodeInfo(nodeIndex)
-               .setWantedState(nodeState.setDescription(description));
+        var nodeInfo = cluster.clusterInfo().getDistributorNodeInfo(nodeIndex);
+        nodeInfo.setWantedState(nodeState.setDescription(description));
+        nodeInfo.setWantedStateOrchestrationDecisionGeneration(cluster.orchestrationDecisionGeneration());
     }
 
     private Result evaluateTransition(ContentCluster cluster, Node node, ClusterState clusterState,

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -1281,15 +1281,11 @@ public class StateChangeTest extends FleetControllerTest {
                                  """);
     }
 
-    class DistributionConfigInBundleFixture {
-        StorDistributionConfig bootstrapConfig;
+    class BaseFixture {
         FleetControllerOptions.Builder options;
 
-        DistributionConfigInBundleFixture(boolean enableConfigInBundle) throws Exception {
-            bootstrapConfig = DistributionBuilder.configForFlatCluster(7);
-            options = defaultOptions()
-                    .setIncludeDistributionConfigInClusterStateBundles(enableConfigInBundle)
-                    .setDistributionConfig(bootstrapConfig);
+        BaseFixture(FleetControllerOptions.Builder options) throws Exception {
+            this.options = options;
             initialize(options);
             ctrl.tick();
         }
@@ -1298,6 +1294,93 @@ public class StateChangeTest extends FleetControllerTest {
             ctrl.updateOptions(options.setDistributionConfig(newConfig).build());
             ctrl.tick(); // Propagate options internally
             ctrl.tick(); // New options actually take effect
+        }
+
+        // Only makes sense for tests with more than 1 controller
+        void winLeadership() throws Exception {
+            Map<Integer, Integer> leaderVotes = new HashMap<>();
+            leaderVotes.put(0, 0);
+            leaderVotes.put(1, 0);
+            leaderVotes.put(2, 0);
+            ctrl.handleFleetData(leaderVotes);
+            ctrl.tick();
+        }
+
+        void loseLeadership() throws Exception {
+            // Receive leadership loss event; other nodes not voting for us anymore.
+            Map<Integer, Integer> leaderVotes = new HashMap<>();
+            leaderVotes.put(0, 0);
+            leaderVotes.put(1, 1);
+            leaderVotes.put(2, 1);
+            ctrl.handleFleetData(leaderVotes);
+            ctrl.tick();
+        }
+    }
+
+    @Test
+    void changed_distribution_topology_bumps_internal_orchestration_generation() throws Exception {
+        var cfgBefore = DistributionBuilder.configForFlatCluster(6);
+        var f = new BaseFixture(defaultOptions().setDistributionConfig(cfgBefore));
+
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+
+        var cfgAfter = DistributionBuilder.configForFlatCluster(7);
+        f.updateWithNewConfig(cfgAfter);
+
+        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        assertThat(changeGenAfter, greaterThan(orchestrationGenBefore));
+    }
+
+    @Test
+    void changed_distribution_redundancy_bumps_internal_orchestration_generation() throws Exception {
+        int redundancy = 1;
+        int searchableCopies = 1;
+        int nodeCount = 7;
+        var cfgBefore = DistributionBuilder.configForFlatCluster(redundancy, searchableCopies, nodeCount);
+        var f = new BaseFixture(defaultOptions().setDistributionConfig(cfgBefore));
+
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+
+        var cfgAfter = DistributionBuilder.configForFlatCluster(redundancy+1, searchableCopies, nodeCount);
+        f.updateWithNewConfig(cfgAfter);
+
+        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        assertThat(changeGenAfter, greaterThan(orchestrationGenBefore));
+    }
+
+    @Test
+    void unchanged_distribution_config_does_not_bump_internal_orchestration_generation() throws Exception {
+        var cfgBefore = DistributionBuilder.configForFlatCluster(6);
+        var f = new BaseFixture(defaultOptions().setDistributionConfig(cfgBefore));
+
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+
+        var cfgAfter = DistributionBuilder.configForFlatCluster(6); // Same structure as before
+        f.updateWithNewConfig(cfgAfter);
+
+        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        assertThat(changeGenAfter, equalTo(orchestrationGenBefore));
+    }
+
+    @Test
+    void leadership_win_bumps_internal_orchestration_generation() throws Exception {
+        var f = new BaseFixture(optionsWithZeroTransitionTime().setCount(3));
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+
+        f.winLeadership();
+
+        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        assertThat(changeGenAfter, greaterThan(orchestrationGenBefore));
+    }
+
+    class DistributionConfigInBundleFixture extends BaseFixture {
+        StorDistributionConfig bootstrapConfig;
+
+        DistributionConfigInBundleFixture(boolean enableConfigInBundle) throws Exception {
+            super(defaultOptions()
+                    .setIncludeDistributionConfigInClusterStateBundles(enableConfigInBundle)
+                    .setDistributionConfig(DistributionBuilder.configForFlatCluster(7)));
+            bootstrapConfig = DistributionBuilder.configForFlatCluster(7);
         }
     }
 
@@ -1389,10 +1472,9 @@ public class StateChangeTest extends FleetControllerTest {
 
     // TODO ideally we'd break this out so it doesn't depend on fields in the parent test instance, but
     // fleet controller tests have a _lot_ of state, so risk of duplicating a lot of that...
-    class RemoteTaskFixture {
+    class RemoteTaskFixture extends BaseFixture {
         RemoteTaskFixture(FleetControllerOptions.Builder options) throws Exception {
-            initialize(options);
-            ctrl.tick();
+            super(options);
         }
 
         MockTask scheduleTask(MockTask task) throws Exception {
@@ -1439,26 +1521,6 @@ public class StateChangeTest extends FleetControllerTest {
                 ctrl.tick(); // Process activation ACKs
             }
             ctrl.tick(); // Iff ACKs were received, process version dependent task(s)
-        }
-
-        // Only makes sense for tests with more than 1 controller
-        void winLeadership() throws Exception {
-            Map<Integer, Integer> leaderVotes = new HashMap<>();
-            leaderVotes.put(0, 0);
-            leaderVotes.put(1, 0);
-            leaderVotes.put(2, 0);
-            ctrl.handleFleetData(leaderVotes);
-            ctrl.tick();
-        }
-
-        void loseLeadership() throws Exception {
-            // Receive leadership loss event; other nodes not voting for us anymore.
-            Map<Integer, Integer> leaderVotes = new HashMap<>();
-            leaderVotes.put(0, 0);
-            leaderVotes.put(1, 1);
-            leaderVotes.put(2, 1);
-            ctrl.handleFleetData(leaderVotes);
-            ctrl.tick();
         }
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -1321,10 +1321,10 @@ public class StateChangeTest extends FleetControllerTest {
             StorDistributionConfig cfgBefore, StorDistributionConfig cfgAfter) throws Exception {
         var f = new BaseFixture(defaultOptions().setDistributionConfig(cfgBefore));
 
-        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationGeneration();
         f.updateWithNewConfig(cfgAfter);
 
-        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        long changeGenAfter = ctrl.getCluster().orchestrationGeneration();
         assertThat(changeGenAfter, greaterThan(orchestrationGenBefore));
     }
 
@@ -1332,10 +1332,10 @@ public class StateChangeTest extends FleetControllerTest {
             StorDistributionConfig cfgBefore, StorDistributionConfig cfgAfter) throws Exception {
         var f = new BaseFixture(defaultOptions().setDistributionConfig(cfgBefore));
 
-        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationGeneration();
         f.updateWithNewConfig(cfgAfter);
 
-        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        long changeGenAfter = ctrl.getCluster().orchestrationGeneration();
         assertThat(changeGenAfter, equalTo(orchestrationGenBefore));
     }
 
@@ -1413,11 +1413,11 @@ public class StateChangeTest extends FleetControllerTest {
     @Test
     void leadership_win_bumps_internal_orchestration_generation() throws Exception {
         var f = new BaseFixture(optionsWithZeroTransitionTime().setCount(3));
-        long orchestrationGenBefore = ctrl.getCluster().orchestrationDecisionGeneration();
+        long orchestrationGenBefore = ctrl.getCluster().orchestrationGeneration();
 
         f.winLeadership();
 
-        long changeGenAfter = ctrl.getCluster().orchestrationDecisionGeneration();
+        long changeGenAfter = ctrl.getCluster().orchestrationGeneration();
         assertThat(changeGenAfter, greaterThan(orchestrationGenBefore));
     }
 

--- a/vdslib/src/main/java/com/yahoo/vdslib/distribution/Group.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/distribution/Group.java
@@ -277,7 +277,8 @@ public class Group implements Comparable<Group> {
         public boolean equals(Object o) {
             if (o == this) return true;
             if ( ! (o instanceof Distribution other)) return false;
-            return (distributionSpec == other.distributionSpec && preCalculatedResults.length == other.preCalculatedResults.length);
+            return (Arrays.equals(distributionSpec, other.distributionSpec) &&
+                    preCalculatedResults.length == other.preCalculatedResults.length);
         }
 
         @Override

--- a/vdslib/src/test/java/com/yahoo/vdslib/distribution/GroupTestCase.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/distribution/GroupTestCase.java
@@ -12,6 +12,7 @@ import java.util.StringTokenizer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -197,6 +198,22 @@ public class GroupTestCase {
         assertEquals("/mario/toad", toad.getUnixStylePath());
         assertEquals("/mario/yoshi", yoshi.getUnixStylePath());
         assertEquals("/luigi", luigi.getUnixStylePath());
+    }
+
+    @Test
+    public void group_distribution_equality_considers_spec_and_max_redundancy() throws Exception {
+        var a0 = new Group.Distribution("*", 1);
+        assertEquals(a0, a0); // Trivially so (casually ignore the linter self-equals warning)
+        var a1 = new Group.Distribution("*", 1);
+        assertEquals(a0, a1); // Same semantics, must be object reference invariant
+        assertEquals(a1, a0);
+        var b0 = new Group.Distribution("*", 2);
+        assertNotEquals(a0, b0);
+        var c0 = new Group.Distribution("*|*", 2);
+        var c1 = new Group.Distribution("*|*", 2);
+        assertEquals(c0, c1);
+        assertNotEquals(b0, c0);
+        assertNotEquals(a0, c0);
     }
 
 }


### PR DESCRIPTION
@hakonhall @hmusum please review

This adds an internal value that represents the current generation of a cluster controller instance's node orchestration decision "context" (distribution config, leadership, ...).

Naming is hard, so for now I've decided to refer to this as an "orchestration decision generation". Another name I considered was "node meta-state generation", but that sounds very generic and implies it's used for more things than it currently is.

Generations can be compared to ensure that decisions are not made based on arbitrary, stale contexts. This is used to avoid ABA-style situations where the cluster controller may otherwise make suboptimal orchestration decisions based on wanted states set when the cluster had an incompatible orchestration configuration (e.g. flat vs grouped)

This generation is monotonically increasing within the process' lifetime.

Note that this is currently an entirely _transient_ value, so a controller restart or leadership reelection will invalidate the existing generation even if there may have been no material changes to the underlying state of the cluster. This does not affect correctness, but may cause the orchestration process to take more time than necessary in situations where this happens. ZK persistence can be added later if required, but this will necessarily add more complexity.

This currently doesn't cover cluster state changes made by the cluster controller _within_ the same config+leadership state, so it doesn't cover all possible stale edge cases. But it's a start.