### PR TITLE
Ensure locale-independent formatting

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
@@ -5,6 +5,7 @@ import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.distribution.Group;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeType;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
 import com.yahoo.vespa.clustercontroller.core.ClusterStateHistoryEntry;
 import com.yahoo.vespa.clustercontroller.core.ContentCluster;
@@ -223,7 +224,7 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
     private static void renderClusterFeedBlockIfPresent(ClusterStateBundle state, VdsClusterHtmlRenderer.Table table) {
         if (state.clusterFeedIsBlocked()) { // Implies FeedBlock != null
             table.appendRaw("<h3 style=\"color: red\">Cluster feeding is blocked!</h3>\n");
-            table.appendRaw(String.format("<p>Summary: <strong>%s</strong></p>\n",
+            table.appendRaw(Text.format("<p>Summary: <strong>%s</strong></p>\n",
                                           escaped(state.getFeedBlockOrNull().getDescription())));
         }
     }
@@ -246,7 +247,7 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
         if (!hasMaintenance && outOfSync.get() == 0.0) {
             table.appendRaw("<p>Cluster is currently in sync.</p>\n");
         } else {
-            table.appendRaw("<p>Cluster is currently <strong>%.2f%% out of sync</strong>.</p>\n".formatted(outOfSync.get() * 100.0));
+            table.appendRaw(Text.format("<p>Cluster is currently <strong>%.2f%% out of sync</strong>.</p>\n", outOfSync.get() * 100.0));
             if (hasMaintenance) {
                 // It is intentional that a cluster with no pending buckets but with nodes in maintenance mode rather
                 // emits "0% out of sync" with a caveat rather than "in sync", as we don't know the latter for sure.
@@ -323,7 +324,7 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
           .append(options.clusterFeedBlockEnabled()).append("</td></tr>");
         sb.append("<tr><td><nobr>Feed block limits</nobr></td><td align=\"right\">")
           .append(options.clusterFeedBlockLimit().entrySet().stream()
-                                       .map(kv -> String.format("%s: %.2f%%", escaped(kv.getKey()), kv.getValue() * 100.0))
+                                       .map(kv -> Text.format("%s: %.2f%%", escaped(kv.getKey()), kv.getValue() * 100.0))
                                        .sorted()
                                        .collect(Collectors.joining("<br/>"))).append("</td></tr>");
         sb.append("<tr><td><nobr>Feed block noise level (low watermark limit will be feed block limit minus this value)</nobr></td><td align=\"right\">")

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core.status.statuspage;
 
 import com.yahoo.document.FixedBucketSpaces;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.NodeType;
@@ -263,7 +264,7 @@ public class VdsClusterHtmlRenderer {
                             .collect(Collectors.joining(", "));
                     return Optional.of(new NodeMessage(
                             MessageSeverity.ERROR,
-                            String.format("<strong>Node is blocking feed: %s</strong>", HtmlTable.escape(exhaustionsDesc))));
+                            Text.format("<strong>Node is blocking feed: %s</strong>", HtmlTable.escape(exhaustionsDesc))));
                 }
             }
             return Optional.empty();
@@ -296,10 +297,10 @@ public class VdsClusterHtmlRenderer {
                 TreeMap<Integer, NodeInfo> distributorNodeInfos,
                 List<Map.Entry<Integer, ContentNodeErrorStats.DistributorErrorStats>> distributorsWithRpcErrors) {
             var sb = new StringBuilder();
-            sb.append(String.format("The following %d distributor(s) are reporting <strong>network-related errors</strong> towards this node:<br>\n",
+            sb.append(Text.format("The following %d distributor(s) are reporting <strong>network-related errors</strong> towards this node:<br>\n",
                     distributorsWithRpcErrors.size()));
             for (var node : distributorsWithRpcErrors) {
-                sb.append("<strong>%d</strong> (%.2f%% of all requests are failing)".formatted(node.getKey(), node.getValue().networkErrorRatio() * 100.0));
+                sb.append(Text.format("<strong>%d</strong> (%.2f%% of all requests are failing)", node.getKey(), node.getValue().networkErrorRatio() * 100.0));
                 var distrInfo = distributorNodeInfos.get(node.getKey());
                 // If the distributor in question has not converged to the latest state version,
                 // point an accusing finger at the content node with connectivity problems.
@@ -365,7 +366,7 @@ public class VdsClusterHtmlRenderer {
 
             var usage = usages.get(resourceType);
             if (usage != null && usage.getUsage() != null) {
-                row.addCell(new HtmlTable.Cell(String.format("%.2f", usage.getUsage() * 100.0)));
+                row.addCell(new HtmlTable.Cell(Text.format("%.2f", usage.getUsage() * 100.0)));
                 double limit = feedBlockLimits.getOrDefault(resourceType, 1.0);
                 // Mark as error if limit exceeded, warn if within 5% of exceeding
                 if (usage.getUsage() > limit) {
@@ -398,8 +399,8 @@ public class VdsClusterHtmlRenderer {
 
         private void addClusterStateVersion(ClusterStateBundle state, NodeInfo nodeInfo, HtmlTable.Row row) {
             String cellContent = (nodeInfo.getClusterStateVersionActivationAcked() == state.getVersion() || !state.deferredActivation())
-                    ? String.format("%d", nodeInfo.getClusterStateVersionBundleAcknowledged())
-                    : String.format("%d (%d)", nodeInfo.getClusterStateVersionBundleAcknowledged(),
+                    ? Text.format("%d", nodeInfo.getClusterStateVersionBundleAcknowledged())
+                    : Text.format("%d (%d)", nodeInfo.getClusterStateVersionBundleAcknowledged(),
                                                nodeInfo.getClusterStateVersionActivationAcked());
             row.addCell(new HtmlTable.Cell(cellContent));
             if (nodeInfo.getClusterStateVersionBundleAcknowledged() < state.getVersion() - 2) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
@@ -270,7 +271,7 @@ public class ResourcesReductionValidatorTest {
     private static String containerServices(int nodes, NodeResources resources) {
         String resourcesStr = resources == null ?
                 "" :
-                String.format("        <resources vcpu='%.0f' memory='%.0fG' disk='%.0fG'/>",
+                Text.format("        <resources vcpu='%.0f' memory='%.0fG' disk='%.0fG'/>",
                         resources.vcpu(), resources.memoryGiB(), resources.diskGb());
         return "<services version='1.0'>" +
                 "  <container id='default' version='1.0'>" +
@@ -284,7 +285,7 @@ public class ResourcesReductionValidatorTest {
     private static String contentServices(int nodes, NodeResources resources) {
         String resourcesStr = resources == null ?
                               "" :
-                              String.format("        <resources vcpu='%.0f' memory='%.0fG' disk='%.0fG'/>",
+                              Text.format("        <resources vcpu='%.0f' memory='%.0fG' disk='%.0fG'/>",
                                             resources.vcpu(), resources.memoryGiB(), resources.diskGb());
         return "<services version='1.0'>" +
                "  <content id='default' version='1.0'>" +

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/UrlDownloader.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/UrlDownloader.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.proxy.filedistribution;
 
+import com.yahoo.text.Text;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,7 +68,7 @@ class UrlDownloader {
                 Files.move(tempFile, target);
                 new RequestTracker().trackRequest(downloadDir);
                 log.log(Level.FINE, () -> "URL '" + uri + "' available at " + target);
-                log.log(Level.INFO, String.format("Download of URL '%s' done in %.3f seconds",
+                log.log(Level.INFO, Text.format("Download of URL '%s' done in %.3f seconds",
                                                   uri, (System.currentTimeMillis() - start) / 1000.0));
                 return Optional.of(target.toFile());
             } else {

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -7,6 +7,7 @@ import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.container.di.ComponentDeconstructor;
 import com.yahoo.container.di.componentgraph.Provider;
 import com.yahoo.jdisc.SharedResource;
+import com.yahoo.text.Text;
 import com.yahoo.yolean.UncheckedInterruptedException;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
@@ -115,7 +116,7 @@ public class Deconstructor implements ComponentDeconstructor {
         @Override
         public void run() {
             long start = System.currentTimeMillis();
-            log.info(String.format("Starting deconstruction of %d components and %d bundles from generation %d",
+            log.info(Text.format("Starting deconstruction of %d components and %d bundles from generation %d",
                     components.size(), bundles.size(), generation));
             for (var component : components) {
                 log.log(FINE, () -> "Starting deconstruction of " + component);
@@ -147,7 +148,7 @@ public class Deconstructor implements ComponentDeconstructor {
                     log.log(SEVERE, "Could not uninstall bundle " + bundle);
                 }
             }
-            log.info(String.format("Completed deconstruction in %.3f seconds", (System.currentTimeMillis() - start) / 1000D));
+            log.info(Text.format("Completed deconstruction in %.3f seconds", (System.currentTimeMillis() - start) / 1000D));
             // NOTE: It could be tempting to refresh packages here, but if active bundles were using any of
             //       the removed ones, they would switch wiring in the middle of a generation's lifespan.
             //       This would happen if the dependent active bundle has not been rebuilt with a new version

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectionThrottler.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectionThrottler.java
@@ -2,6 +2,7 @@
 package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.http.ConnectorConfig;
+import com.yahoo.text.Text;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.SelectorManager;
 import org.eclipse.jetty.server.AbstractConnector;
@@ -88,13 +89,13 @@ class ConnectionThrottler extends ContainerLifeCycle implements SelectorManager.
             if (isThrottling) return;
             List<String> reasons = getThrottlingReasons();
             if (reasons.isEmpty()) return;
-            log.warning(String.format("Throttling new connection. Reasons: %s", reasons));
+            log.warning(Text.format("Throttling new connection. Reasons: %s", reasons));
             isThrottling = true;
             if (connector.isAccepting()) {
                 connector.setAccepting(false);
             }
             if (idleTimeout != null) {
-                log.warning(String.format("Applying idle timeout to existing connections: timeout=%sms", idleTimeout));
+                log.warning(Text.format("Applying idle timeout to existing connections: timeout=%sms", idleTimeout));
                 connector.getConnectedEndPoints()
                         .forEach(endPoint -> endPoint.setIdleTimeout(idleTimeout.toMillis()));
             }
@@ -107,13 +108,13 @@ class ConnectionThrottler extends ContainerLifeCycle implements SelectorManager.
             if (!isThrottling) return;
             List<String> reasons = getThrottlingReasons();
             if (!reasons.isEmpty()) {
-                log.warning(String.format("Throttling continued. Reasons: %s", reasons));
+                log.warning(Text.format("Throttling continued. Reasons: %s", reasons));
                 scheduler.schedule(this::unthrottleIfBelowThresholds, 1, TimeUnit.SECONDS);
                 return;
             }
             if (idleTimeout != null) {
                 long originalTimeout = connector.getIdleTimeout();
-                log.info(String.format("Reverting idle timeout for existing connections: timeout=%sms", originalTimeout));
+                log.info(Text.format("Reverting idle timeout for existing connections: timeout=%sms", originalTimeout));
                 connector.getConnectedEndPoints()
                         .forEach(endPoint -> endPoint.setIdleTimeout(originalTimeout));
             }
@@ -162,7 +163,7 @@ class ConnectionThrottler extends ContainerLifeCycle implements SelectorManager.
         public Optional<String> isThresholdExceeded() {
             double heapUtilization = (runtime.maxMemory() - runtime.freeMemory()) / (double) runtime.maxMemory();
             if (heapUtilization > maxHeapUtilization) {
-                return Optional.of(String.format("Max heap utilization exceeded: %f%%>%f%%", heapUtilization*100, maxHeapUtilization*100));
+                return Optional.of(Text.format("Max heap utilization exceeded: %f%%>%f%%", heapUtilization*100, maxHeapUtilization*100));
             }
             return Optional.empty();
         }
@@ -186,7 +187,7 @@ class ConnectionThrottler extends ContainerLifeCycle implements SelectorManager.
             synchronized (monitor) {
                 int acceptRate = rateStatistic.getRate();
                 if (acceptRate > maxAcceptRate) {
-                    return Optional.of(String.format("Max accept rate exceeded: %d>%d", acceptRate, maxAcceptRate));
+                    return Optional.of(Text.format("Max accept rate exceeded: %d>%d", acceptRate, maxAcceptRate));
                 }
                 return Optional.empty();
             }
@@ -225,7 +226,7 @@ class ConnectionThrottler extends ContainerLifeCycle implements SelectorManager.
             synchronized (monitor) {
                 int totalConnections = connectionOpened + connectionsAccepting.size();
                 if (totalConnections > maxConnections) {
-                    return Optional.of(String.format("Max connection exceeded: %d>%d", totalConnections, maxConnections));
+                    return Optional.of(Text.format("Max connection exceeded: %d>%d", totalConnections, maxConnections));
                 }
                 return Optional.empty();
             }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -14,6 +14,7 @@ import com.yahoo.jdisc.service.CurrentContainer;
 import com.yahoo.jdisc.service.ServerProvider;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.metrics.simple.MetricSettings;
+import com.yahoo.text.Text;
 import org.eclipse.jetty.jmx.ConnectorServer;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
@@ -161,7 +162,7 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
         pool.setMaxThreads(maxThreads);
         int minThreads = config.minWorkerThreads() >= 0 ? config.minWorkerThreads() : 16 + cpus;
         pool.setMinThreads(minThreads);
-        log.info(String.format("Threadpool size: min=%d, max=%d", minThreads, maxThreads));
+        log.info(Text.format("Threadpool size: min=%d, max=%d", minThreads, maxThreads));
     }
 
     private static JMXServiceURL createJmxLoopbackOnlyServiceUrl(int port) {
@@ -200,7 +201,7 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
                 var sslContextFactory = sslConnectionFactory.getSslContextFactory();
                 String protocols = Arrays.toString(sslContextFactory.getSelectedProtocols());
                 String cipherSuites = Arrays.toString(sslContextFactory.getSelectedCipherSuites());
-                log.info(String.format("TLS for port '%d': %s with %s", localPort, protocols, cipherSuites));
+                log.info(Text.format("TLS for port '%d': %s with %s", localPort, protocols, cipherSuites));
             }
         }
     }
@@ -208,11 +209,11 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
     @Override
     public void close() {
         try {
-            log.log(Level.INFO, String.format("Shutting down Jetty server (graceful=%b, timeout=%.1fs)",
+            log.log(Level.INFO, Text.format("Shutting down Jetty server (graceful=%b, timeout=%.1fs)",
                     isGracefulShutdownEnabled(), server.getStopTimeout()/1000d));
             long start = System.currentTimeMillis();
             server.stop();
-            log.log(Level.INFO, String.format("Jetty server shutdown completed in %.3f seconds",
+            log.log(Level.INFO, Text.format("Jetty server shutdown completed in %.3f seconds",
                     (System.currentTimeMillis()-start)/1000D));
         } catch (final Exception e) {
             log.log(Level.SEVERE, "Jetty server shutdown threw an unexpected exception.", e);

--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/MbusServerProvider.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/MbusServerProvider.java
@@ -8,6 +8,7 @@ import com.yahoo.jdisc.service.CurrentContainer;
 import com.yahoo.messagebus.IntermediateSessionParams;
 import com.yahoo.messagebus.jdisc.MbusServer;
 import com.yahoo.messagebus.shared.SharedIntermediateSession;
+import com.yahoo.text.Text;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,7 +52,7 @@ public class MbusServerProvider implements Provider<MbusServer> {
         server.close();
         server.release();
         sessionRef.getReference().close();
-        log.log(Level.INFO, String.format("Mbus server deconstruction completed in %.3f seconds",
+        log.log(Level.INFO, Text.format("Mbus server deconstruction completed in %.3f seconds",
                 (System.currentTimeMillis()-start)/1000D));
     }
 

--- a/container-search/src/main/java/ai/vespa/search/llm/LLMSearcher.java
+++ b/container-search/src/main/java/ai/vespa/search/llm/LLMSearcher.java
@@ -19,6 +19,7 @@ import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.result.EventStream;
 import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.searchchain.Execution;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8;
 
 import java.io.ByteArrayOutputStream;
@@ -283,7 +284,7 @@ public class LLMSearcher extends Searcher {
             return "Time to first token: " + timeToFirstToken + " ms, " +
                    "Generation time: " + generationTime + " ms, " +
                    "Generated tokens: " + tokens + " " +
-                   String.format("(%.2f tokens/sec)", tokens / (generationTime / 1000.0));
+                   Text.format("(%.2f tokens/sec)", tokens / (generationTime / 1000.0));
         }
 
     }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerSimulationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/LoadBalancerSimulationTest.java
@@ -4,6 +4,7 @@ package com.yahoo.search.dispatch;
 import com.yahoo.search.dispatch.searchcluster.Group;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.test.ManualClock;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -141,10 +142,10 @@ public class LoadBalancerSimulationTest {
             // Coefficient of variation
             double coefficientOfVariation = mean > 0 ? stdDev / mean : 0.0;
 
-            System.out.println("  Mean: " + String.format("%.2f", mean));
-            System.out.println("  Standard Deviation: " + String.format("%.2f", stdDev));
+            System.out.println("  Mean: " + Text.format("%.2f", mean));
+            System.out.println("  Standard Deviation: " + Text.format("%.2f", stdDev));
             System.out.println("  Max-Min Difference: " + maxMinDiff);
-            System.out.println("  Coefficient of Variation: " + String.format("%.4f", coefficientOfVariation));
+            System.out.println("  Coefficient of Variation: " + Text.format("%.4f", coefficientOfVariation));
         }
     }
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReceiver.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReceiver.java
@@ -8,6 +8,7 @@ import com.yahoo.jrt.Method;
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.security.tls.Capability;
+import com.yahoo.text.Text;
 import net.jpountz.xxhash.StreamingXXHash64;
 import net.jpountz.xxhash.XXHashFactory;
 import java.io.File;
@@ -271,7 +272,7 @@ public class FileReceiver {
                 retval = 1;
             }
             double completeness = (double) session.currentFileSize / (double) session.fileSize;
-            log.log(Level.FINEST, () -> String.format("%.1f percent of '%s' downloaded", completeness * 100, reference.value()));
+            log.log(Level.FINEST, () -> Text.format("%.1f percent of '%s' downloaded", completeness * 100, reference.value()));
             downloads.setDownloadStatus(reference, completeness);
         }
         req.returnValues().add(new Int32Value(retval));

--- a/model-integration/src/main/java/ai/vespa/llm/clients/LocalLLM.java
+++ b/model-integration/src/main/java/ai/vespa/llm/clients/LocalLLM.java
@@ -10,6 +10,7 @@ import ai.vespa.llm.completion.Prompt;
 import ai.vespa.llm.completion.StringPrompt;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
+import com.yahoo.text.Text;
 import de.kherud.llama.LlamaModel;
 import de.kherud.llama.ModelParameters;
 import de.kherud.llama.Pair;
@@ -73,7 +74,7 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
         long startLoad = System.nanoTime();
         model = new LlamaModel(modelParams);
         long loadTime = System.nanoTime() - startLoad;
-        logger.fine(() -> String.format("Loaded model %s in %.2f sec", modelFile, (loadTime*1.0/1000000000)));
+        logger.fine(() -> Text.format("Loaded model %s in %.2f sec", modelFile, (loadTime*1.0/1000000000)));
 
         // Executor for continuously batching requests that are fed to LLM to maximizing compute utilization.
         executor = new ThreadPoolExecutor(
@@ -94,7 +95,7 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
         maxTokens = config.maxTokens();
         maxPromptTokens = config.maxPromptTokens();
         contextSizePerRequest = config.contextSize() / config.parallelRequests();
-        logger.fine(() -> String.format("Context size per request: %d", contextSizePerRequest));
+        logger.fine(() -> Text.format("Context size per request: %d", contextSizePerRequest));
         contextOverflowPolicy = config.contextOverflowPolicy();
     }
 
@@ -187,14 +188,14 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
 
         var numPromptTokens = promptTokens.length;
         var numRequestTokens = numPromptTokens + maxTokens;
-        logger.fine(() -> String.format("Prompt tokens: %d, max tokens: %d, request tokens: %d",
+        logger.fine(() -> Text.format("Prompt tokens: %d, max tokens: %d, request tokens: %d",
                 numPromptTokens, maxTokens, numRequestTokens));
 
         // Do something when context size is too small for this request
         if (numRequestTokens > contextSizePerRequest) {
             switch (contextOverflowPolicy) {
                 case FAIL:
-                    var errorMessage = String.format(
+                    var errorMessage = Text.format(
                             "Context size per request (%d tokens) is too small " +
                                     "to fit the prompt (%d) and completion (%d) tokens.",
                             contextSizePerRequest, promptTokens.length, maxTokens);
@@ -264,6 +265,6 @@ public class LocalLLM extends AbstractComponent implements LanguageModel {
     private String rejectedExecutionErrorMessage(String prefix) {
         int activeCount = executor.getActiveCount();
         int queueSize = executor.getQueue().size();
-        return String.format("%s, %d active, %d in queue", prefix, activeCount, queueSize);
+        return Text.format("%s, %d active, %d in queue", prefix, activeCount, queueSize);
     }
 }

--- a/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
@@ -8,6 +8,7 @@ import com.yahoo.language.process.InvocationContext;
 import com.yahoo.language.process.TimeoutException;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
+import com.yahoo.text.Text;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -504,7 +505,7 @@ public class VoyageAIEmbedderTest {
             embedding.append(valueGenerator.apply(i));
         }
         embedding.append("]");
-        return """
+        return  """
                 {
                   "object": "list",
                   "data": [{"object": "embedding", "embedding": %s, "index": 0}],
@@ -515,7 +516,7 @@ public class VoyageAIEmbedderTest {
     }
 
     private static String createSuccessResponse(int dimensions) { return createFloatSuccessResponse(dimensions); }
-    private static String createFloatSuccessResponse(int dimensions) { return createSuccessResponse(dimensions, i -> "%.6f".formatted(Math.sin(i * 0.1))); }
+    private static String createFloatSuccessResponse(int dimensions) { return createSuccessResponse(dimensions, i -> Text.format("%.6f", Math.sin(i * 0.1))); }
     private static String createInt8SuccessResponse(int dimensions) { return createSuccessResponse(dimensions, i -> String.valueOf(i % 128)); }
     private static String createBinarySuccessResponse(int dimensions) { return createInt8SuccessResponse(dimensions); }
 }

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/benchmarks/ResultMetrics.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/benchmarks/ResultMetrics.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate.benchmarks;
 
+import com.yahoo.text.Text;
 import java.util.Map;
 
 /**
@@ -76,7 +77,7 @@ public class ResultMetrics {
     }
 
     private static String latencyToString(double averageLatency) {
-        return String.format("%.2fms", averageLatency);
+        return Text.format("%.2fms", averageLatency);
     }
 
     private static double toLatency(int index) {

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/FloatBucketResultNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/FloatBucketResultNode.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.expression;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.objects.Deserializer;
 import com.yahoo.vespa.objects.ObjectVisitor;
 import com.yahoo.vespa.objects.Serializer;
@@ -114,7 +115,7 @@ public class FloatBucketResultNode extends BucketResultNode {
             return 1;
         }
         // should not be possible
-        throw new IllegalArgumentException(String.format("bad comparison [%f,%f> versus [%f,%f>",
+        throw new IllegalArgumentException(Text.format("bad comparison [%f,%f> versus [%f,%f>",
                                                          f1, t1, f2, t2));
     }
 

--- a/searchlib/src/test/java/com/yahoo/searchlib/aggregation/hll/HyperLogLogPrecisionBenchmark.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/aggregation/hll/HyperLogLogPrecisionBenchmark.java
@@ -7,6 +7,7 @@ import net.jpountz.xxhash.XXHashFactory;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -37,7 +38,7 @@ public class HyperLogLogPrecisionBenchmark {
             long min = samples.stream().min(Long::compare).get();
             long max = samples.stream().max(Long::compare).get();
             double standardDeviation = getStandardDeviation(samples, average);
-            System.out.printf("%d; %.2f; %.4f; %.4f; %d; %d\n", val, average, standardDeviation / average, standardDeviation, min, max);
+            System.out.printf(Locale.US, "%d; %.2f; %.4f; %.4f; %d; %d\n", val, average, standardDeviation / average, standardDeviation, min, max);
         }
     }
 

--- a/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -505,11 +506,11 @@ public class Utf8TestCase {
 
         Map.of("ascii", ascii, "unicode", unicode).forEach((type, b) -> {
             long time1 = benchmark(() -> decode(Utf8::toString, b, iterations));
-            System.out.printf("Utf8::toString of %s string took %d ms\n", type, time1);
+            System.out.printf(Locale.US, "Utf8::toString of %s string took %d ms\n", type, time1);
             long time2 = benchmark(() -> decode((b1) -> new String(b1, StandardCharsets.UTF_8), b, iterations));
-            System.out.printf("String::new of %s string took %d ms\n", type, time2);
+            System.out.printf(Locale.US, "String::new of %s string took %d ms\n", type, time2);
             double change = ((double) time2 / (double) time1) - 1;
-            System.out.printf("Change = %.02f%%\n", change * 100);
+            System.out.printf(Locale.US, "Change = %.02f%%\n", change * 100);
         });
     }
 
@@ -522,11 +523,11 @@ public class Utf8TestCase {
 
         Map.of("ascii", ascii, "unicode", unicode).forEach((type, s) -> {
             long time1 = benchmark(() -> encode(Utf8::toBytes, s, iterations));
-            System.out.printf("Utf8::toBytes of %s string took %d ms\n", type, time1);
+            System.out.printf(Locale.US, "Utf8::toBytes of %s string took %d ms\n", type, time1);
             long time2 = benchmark(() -> encode((s1) -> s1.getBytes(StandardCharsets.UTF_8), s, iterations));
-            System.out.printf("String::getBytes of %s string took %d ms\n", type, time2);
+            System.out.printf(Locale.US, "String::getBytes of %s string took %d ms\n", type, time2);
             double change = ((double) time2 / (double) time1) - 1;
-            System.out.printf("Change = %.02f%%\n", change * 100);
+            System.out.printf(Locale.US, "Change = %.02f%%\n", change * 100);
         });
     }
 

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/SingletonManager.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/SingletonManager.java
@@ -6,6 +6,7 @@ import com.yahoo.concurrent.UncheckedTimeoutException;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.path.Path;
 import com.yahoo.protect.Process;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.curator.api.VespaCurator.SingletonWorker;
 
 import java.time.Clock;
@@ -314,7 +315,7 @@ class SingletonManager {
         private void cleanOrphans() {
             List<String> orphans = null;
             try {
-                // Only the ephemerals owned by this client session are listed here, and this client should only ever attempt this lock from this thread, i.e., 0 or 1 nodes. 
+                // Only the ephemerals owned by this client session are listed here, and this client should only ever attempt this lock from this thread, i.e., 0 or 1 nodes.
                 for (String orphan : orphans = curator.framework().getZookeeperClient().getZooKeeper().getEphemerals(path.getAbsolute()))
                     curator.delete(path.append(orphan));
             }
@@ -430,7 +431,7 @@ class SingletonManager {
                     long durationMillis = Duration.between(start, clock.instant()).toMillis();
                     metric.set(ACTIVATION_MILLIS, durationMillis, context);
                     logger.log(INFO, "Activation completed " + (failed ? "un" : "") +
-                                     "successfully in %.3f seconds".formatted(durationMillis * 1e-3));
+                                     Text.format("successfully in %.3f seconds", durationMillis * 1e-3));
                     if (failed) metric.add(ACTIVATION_FAILURES, 1, context);
                     else isActive = true;
                     ping();
@@ -453,7 +454,7 @@ class SingletonManager {
                     long durationMillis = Duration.between(start, clock.instant()).toMillis();
                     metric.set(DEACTIVATION_MILLIS, durationMillis, context);
                     logger.log(INFO, "Deactivation completed " + (failed ? "un" : "") +
-                                     "successfully in %.3f seconds".formatted(durationMillis * 1e-3));
+                                     Text.format("successfully in %.3f seconds", durationMillis * 1e-3));
                     if (failed) metric.add(DEACTIVATION_FAILURES, 1, context);
                     isActive = false;
                     ping();


### PR DESCRIPTION
Replace String.format() and .formatted() with Text.format() to prevent locale-dependent number formatting (e.g., decimal separators) in log messages, error messages, and status pages. This ensures consistent output across different system locales, particularly important for machine-parseable logs and UI output.

In test files, explicitly use Locale.US with printf() to maintain consistent test output formatting.

@bratseth FYI
