### PR TITLE
Return empty flush target list until load is done.  MERGEOK

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -781,6 +781,9 @@ DocumentDB::getDocsums(const DocsumRequest & request)
 IFlushTarget::List
 DocumentDB::getFlushTargets()
 {
+    if (!_state->get_load_done()) {
+        return {};
+    }
     IFlushTarget::List flushTargets = _subDBs.getFlushTargets();
     return _jobTrackers.trackFlushTargets(flushTargets);
 }


### PR DESCRIPTION
@vekterli or @arnej27959 : please review

This fixes a [regression](https://github.com/vespa-engine/vespa/pull/35686#discussion_r2738822562) introduced in #35699.
