### PR TITLE
Rename Java distribution spec "asterix" (sic) to "wildcard"

### DIFF
--- a/vdslib/src/main/java/com/yahoo/vdslib/distribution/Group.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/distribution/Group.java
@@ -218,16 +218,16 @@ public class Group implements Comparable<Group> {
                 }
             }
             // Verify sanity of the distribution spec
-            int firstAsterix = distributionSpec.length;
+            int firstWildcard = distributionSpec.length;
             for (int i=0; i<distributionSpec.length; ++i) {
-                if (i > firstAsterix) {
+                if (i > firstWildcard) {
                     if (distributionSpec[i] != 0) {
-                        throw new ParseException("Illegal distribution spec \"" + serialized + "\". Asterix specification must be tailing the specification.", i);
+                        throw new ParseException("Illegal distribution spec \"" + serialized + "\". Wildcard specification must be tailing the specification.", i);
                     }
                     continue;
                 }
-                if (i < firstAsterix && distributionSpec[i] == 0) {
-                    firstAsterix = i;
+                if (i < firstWildcard && distributionSpec[i] == 0) {
+                    firstWildcard = i;
                     continue;
                 }
                 if (distributionSpec[i] <= 0 || distributionSpec[i] >= 256) {
@@ -239,7 +239,7 @@ public class Group implements Comparable<Group> {
             if (maxRedundancy <= 0 || maxRedundancy > 255) {
                 throw new IllegalArgumentException("The max redundancy (" + maxRedundancy + ") must be a positive number in the range 1-255.");
             }
-            int asterixCount = distributionSpec.length - firstAsterix;
+            int wildcardCount = distributionSpec.length - firstWildcard;
             int[][] preCalculations = new int[maxRedundancy + 1][];
             for (int i=1; i<=maxRedundancy; ++i) {
                 List<Integer> spec = new ArrayList<>();
@@ -247,14 +247,14 @@ public class Group implements Comparable<Group> {
                     spec.add(k);
                 }
                 int remainingRedundancy = i;
-                for (int j=0; j<firstAsterix; ++j) {
+                for (int j=0; j<firstWildcard; ++j) {
                     spec.set(j, Math.min(remainingRedundancy, spec.get(j)));
                     remainingRedundancy -= spec.get(j);
                 }
-                int divided = remainingRedundancy / asterixCount;
-                remainingRedundancy = remainingRedundancy % asterixCount;
-                for (int j=firstAsterix; j<spec.size(); ++j) {
-                    spec.set(j, divided + (j - firstAsterix < remainingRedundancy ? 1 : 0));
+                int divided = remainingRedundancy / wildcardCount;
+                remainingRedundancy = remainingRedundancy % wildcardCount;
+                for (int j=firstWildcard; j<spec.size(); ++j) {
+                    spec.set(j, divided + (j - firstWildcard < remainingRedundancy ? 1 : 0));
                 }
                 while (spec.get(spec.size() - 1) == 0) {
                     spec.remove(spec.size() - 1);

--- a/vdslib/src/test/java/com/yahoo/vdslib/distribution/GroupTestCase.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/distribution/GroupTestCase.java
@@ -52,8 +52,8 @@ public class GroupTestCase {
         assertDistribution("*|*|*|*", 5, "2,1,1,1");
 
         assertDistributionFailure("2|*", 0, "The max redundancy (0) must be a positive number in the range 1-255.");
-        assertDistributionFailure("*|2", 3, "Illegal distribution spec \"*|2\". Asterix specification must be tailing the specification.");
-        assertDistributionFailure("*|2|*", 3, "Illegal distribution spec \"*|2|*\". Asterix specification must be tailing the specification.");
+        assertDistributionFailure("*|2", 3, "Illegal distribution spec \"*|2\". Wildcard specification must be tailing the specification.");
+        assertDistributionFailure("*|2|*", 3, "Illegal distribution spec \"*|2|*\". Wildcard specification must be tailing the specification.");
         assertDistributionFailure("0|*", 3, "Illegal distribution spec \"0|*\". Copy counts must be in the range 1-255.");
         assertDistributionFailure("1|0|*", 3, "Illegal distribution spec \"1|0|*\". Copy counts must be in the range 1-255.");
         assertDistributionFailure("1|a|*", 3, "Illegal distribution spec \"1|a|*\". Copy counts must be integer values in the range 1-255.");


### PR DESCRIPTION
@hmusum please review

The Romans conquered the C++ implementation years ago, but the Gauls managed to hold out here for a while longer...
