### PR TITLE
Ignore hosts.xml when deploying to hosted Vespa

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -124,7 +124,7 @@ public class DeployState implements ConfigDefinitionStore {
         this.vespaVersion = vespaVersion;
         this.previousModel = previousModel;
         this.accessLoggingEnabledByDefault = accessLoggingEnabledByDefault;
-        this.provisioner = hostProvisioner.orElse(getDefaultModelHostProvisioner(applicationPackage));
+        this.provisioner = hostProvisioner.orElseGet(() -> getDefaultModelHostProvisioner(applicationPackage));
         this.provisioned = provisioned;
         this.schemas = List.copyOf(application.schemas().values());
         this.documentModel = application.documentModel();

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -171,8 +171,7 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
             return nodeRepositoryProvisioner.get();
         }
 
-        HostProvisioner defaultHostProvisioner = DeployState.getDefaultModelHostProvisioner(applicationPackage);
-        return defaultHostProvisioner;
+        return DeployState.getDefaultModelHostProvisioner(applicationPackage);
     }
 
     private Optional<File> getAppDir(ApplicationPackage applicationPackage) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -154,17 +154,24 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
     }
 
     private HostProvisioner createHostProvisioner(ApplicationPackage applicationPackage, Provisioned provisioned) {
-        HostProvisioner defaultHostProvisioner = DeployState.getDefaultModelHostProvisioner(applicationPackage);
         // Note: nodeRepositoryProvisioner will always be present when hosted is true
         Optional<HostProvisioner> nodeRepositoryProvisioner = createNodeRepositoryProvisioner(params.getApplicationId(), provisioned);
         Optional<AllocatedHosts> allocatedHosts = applicationPackage.getAllocatedHosts();
 
-        if (allocatedHosts.isEmpty()) return nodeRepositoryProvisioner.orElse(defaultHostProvisioner);
+        if (hosted) {
+            // In hosted Vespa, always use node repository provisioner - never read hosts.xml
+            if (allocatedHosts.isEmpty()) return nodeRepositoryProvisioner.get();
+            // Nodes are already allocated by a model, and we should use them unless this model requests hosts from a
+            // previously unallocated cluster. This allows future models to stop allocate certain clusters.
+            return createStaticProvisionerForHosted(allocatedHosts.get(), nodeRepositoryProvisioner.get());
+        }
 
-        // Nodes are already allocated by a model and we should use them unless this model requests hosts from a
-        // previously unallocated cluster. This allows future models to stop allocate certain clusters.
-        if (hosted) return createStaticProvisionerForHosted(allocatedHosts.get(), nodeRepositoryProvisioner.get());
+        // Non-hosted: use nodeRepositoryProvisioner if available, otherwise fall back to hosts.xml
+        if (allocatedHosts.isEmpty() && nodeRepositoryProvisioner.isPresent()) {
+            return nodeRepositoryProvisioner.get();
+        }
 
+        HostProvisioner defaultHostProvisioner = DeployState.getDefaultModelHostProvisioner(applicationPackage);
         return defaultHostProvisioner;
     }
 

--- a/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/hosts.xml
+++ b/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/hosts.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<!-- This hosts.xml file should be ignored when deploying to Vespa Cloud / hosted Vespa.
+     It contains duplicate hostnames which would cause an error if parsed. -->
+<hosts>
+  <host name="myhost.example.com">
+    <alias>node1</alias>
+  </host>
+  <host name="myhost.example.com">
+    <alias>node2</alias>
+  </host>
+</hosts>

--- a/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/schemas/music.sd
+++ b/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/schemas/music.sd
@@ -1,0 +1,8 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+schema music {
+  document music {
+    field title type string {
+      indexing: index | summary
+    }
+  }
+}

--- a/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/services.xml
+++ b/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/services.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+
+  <container version="1.0">
+    <http>
+      <filtering>
+        <access-control domain="myDomain" write="true" />
+      </filtering>
+      <server id="foo"/>
+    </http>
+    <search/>
+    <nodes count='1'/>
+  </container>
+
+  <content id="music" version="1.0">
+    <redundancy>2</redundancy>
+    <documents>
+      <document type="music" mode="index" />
+    </documents>
+    <nodes count="4" groups="2"/>
+  </content>
+
+</services>


### PR DESCRIPTION
In hosted Vespa (Vespa Cloud), hosts.xml should be ignored since the node repository manages host allocation. Previously, hosts.xml was parsed even in hosted mode, causing deployment failures when the file contained errors like duplicate hostnames.

- Skip reading hosts.xml in PreparedModelsBuilder for hosted deployments
- Use lazy evaluation (orElseGet) in DeployState to avoid parsing hosts.xml when a host provisioner is already provided

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
