### PR TITLE
Allow specifying only groups and group size for content node resources

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
@@ -130,9 +130,17 @@ public class NodesSpecification {
         int defaultMinGroups =                           nodes.from().orElse(1) / groupSize.to().orElse(nodes.from().orElse(1));
         int defaultMaxGroups = groupSize.isEmpty() ? 1 : nodes.to().orElse(1) / groupSize.from().orElse(1);
 
+        // Allow use of groups and group-size if count is not specified
+        if (groupsAndGroupSizeButNoNodeCount(groups, groupSize, nodes))
+            nodes = IntRange.of(groupSize.from().orElse(1) * groups.from().orElse(1), groupSize.to().orElse(1) * groups.to().orElse(1));
+
         var min = new ClusterResources(nodes.from().orElse(1), groups.from().orElse(defaultMinGroups), nodeResources(nodesElement).getFirst());
         var max = new ClusterResources(nodes.to().orElse(1), groups.to().orElse(defaultMaxGroups), nodeResources(nodesElement).getSecond());
         return new ResourceConstraints(min, max, groupSize);
+    }
+
+    private static boolean groupsAndGroupSizeButNoNodeCount(IntRange groups, IntRange groupSize, IntRange nodes) {
+        return !groups.isEmpty() && !groupSize.isEmpty() && nodes.isEmpty();
     }
 
     private static IntRange rangeFrom(ModelElement element, String name) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecificationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecificationTest.java
@@ -167,9 +167,61 @@ public class NodesSpecificationTest {
         assertEquals(30, spec.minResources().nodes());
         assertEquals( 3, spec.minResources().groups());
         assertEquals(30, spec.maxResources().nodes());
-        assertEquals( 30, spec.maxResources().groups());
+        assertEquals(30, spec.maxResources().groups());
         assertTrue(spec.groupSize().from().isEmpty());
         assertEquals(10, spec.groupSize().to().getAsInt());
+    }
+
+
+    @Test
+    void testVariableGroupCount() {
+        var spec = nodesSpecification("<nodes groups='[1,2]' group-size='3'/>");
+        assertEquals( 3, spec.minResources().nodes());
+        assertEquals( 1, spec.minResources().groups());
+        assertEquals( 6, spec.maxResources().nodes());
+        assertEquals( 2, spec.maxResources().groups());
+        assertEquals( 3, spec.groupSize().from().getAsInt());
+        assertEquals( 3, spec.groupSize().to().getAsInt());
+    }
+
+    @Test
+    void testVariableGroupCount2() {
+        var spec = nodesSpecification("<nodes groups='[,4]' group-size='3'/>");
+        assertEquals( 3, spec.minResources().nodes());
+        assertEquals( 1, spec.minResources().groups()); // No lower limit means 1
+        assertEquals(12, spec.maxResources().nodes());
+        assertEquals( 4, spec.maxResources().groups());
+        assertEquals( 3, spec.groupSize().from().getAsInt());
+        assertEquals( 3, spec.groupSize().to().getAsInt());
+    }
+
+    @Test
+    void testVariableGroupCount3() {
+        var spec = nodesSpecification("<nodes groups='[1, ]' group-size='3'/>");
+        assertEquals(3, spec.minResources().nodes());
+        assertEquals(1, spec.minResources().groups());
+        assertEquals(3, spec.maxResources().nodes());
+        assertEquals(1, spec.maxResources().groups()); // No upper limit means 1
+        assertEquals(3, spec.groupSize().from().getAsInt());
+        assertEquals(3, spec.groupSize().to().getAsInt());
+    }
+
+    @Test
+    void testVariableNodeCount() {
+        var spec = nodesSpecification("<nodes count='[,10]' groups='2'/>");
+        assertEquals( 1, spec.minResources().nodes()); // No lower limit means 1
+        assertEquals( 2, spec.minResources().groups());
+        assertEquals(10, spec.maxResources().nodes());
+        assertEquals( 2, spec.maxResources().groups());
+    }
+
+    @Test
+    void testVariableNodeCount2() {
+        var spec = nodesSpecification("<nodes count='[1,]' groups='2'/>");
+        assertEquals(1, spec.minResources().nodes());
+        assertEquals(2, spec.minResources().groups());
+        assertEquals(1, spec.maxResources().nodes()); // No upper limit means 1
+        assertEquals(2, spec.maxResources().groups());
     }
 
     private NodesSpecification nodesSpecification(String nodesElement) {


### PR DESCRIPTION
When specifying group size it feels more natural to change the number of groups than nodes, especially when using autoscaling. This PR add support for this, when node count is not set
