### PR TITLE
Explicitly consider `OVERLOAD` a non-fatal (resendable) error in backend visitor.

### DIFF
--- a/storage/src/tests/visiting/visitortest.cpp
+++ b/storage/src/tests/visiting/visitortest.cpp
@@ -717,6 +717,10 @@ TEST_F(VisitorTest, no_visitor_notification_for_transient_failures) {
     // time when initiating remote migrations et al.
     getMessagesAndReply(1, getSession(0), meta, api::ReturnCode::WRONG_DISTRIBUTION);
     ASSERT_EQ(0, meta.infoMessages.size());
+    // OVERLOAD should not be reported (TODO reconsider this?)
+    getMessagesAndReply(1, getSession(0), meta, static_cast<api::ReturnCode::Result>(
+            documentapi::DocumentProtocol::ERROR_OVERLOAD));
+    ASSERT_EQ(0, meta.infoMessages.size());
 
     // Complete message successfully to finish the visitor.
     getMessagesAndReply(1, getSession(0), meta, api::ReturnCode::OK);

--- a/storage/src/vespa/storageapi/messageapi/returncode.cpp
+++ b/storage/src/vespa/storageapi/messageapi/returncode.cpp
@@ -62,6 +62,7 @@ ReturnCode::isBusy() const
         case mbus::ErrorCode::SESSION_BUSY:
         case mbus::ErrorCode::TIMEOUT:
         case Protocol::ERROR_BUSY:
+        case Protocol::ERROR_OVERLOAD:
             return true;
         default:
             return false;
@@ -112,13 +113,16 @@ ReturnCode::isCriticalForMaintenance() const
 bool
 ReturnCode::isCriticalForVisitor() const
 {
+    if (_result == static_cast<uint32_t>(Protocol::ERROR_OVERLOAD)) {
+        return false;
+    }
     return isCriticalForMaintenance();
 }
 
 bool
 ReturnCode::isCriticalForVisitorDispatcher() const
 {
-    return isCriticalForMaintenance();
+    return isCriticalForVisitor();
 }
 
 bool


### PR DESCRIPTION
@toregge please review
@bjorncs FYI

This avoids failing the entire visitor session during reindexing if a document processor returns `OVERLOAD` (usually from an upstream service request failure). The individual document messages triggering overload will be resent with a bounded exponential backoff until the visitor timeout is reached.

