### PR TITLE
Add UTF-8 file reader and writer helper methods

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -3565,7 +3565,11 @@
       "public static int encode(int, byte[], int)",
       "public static void encode(int, java.nio.ByteBuffer)",
       "public static int encode(int, java.io.OutputStream)",
-      "public static int codePointAsUtf8Length(int)"
+      "public static int codePointAsUtf8Length(int)",
+      "public static java.io.FileReader createReader(java.io.File)",
+      "public static java.io.FileReader createReader(java.lang.String)",
+      "public static java.io.FileWriter createWriter(java.io.File)",
+      "public static java.io.FileWriter createWriter(java.lang.String)"
     ],
     "fields" : [ ]
   },

--- a/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
+++ b/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
@@ -80,7 +80,7 @@ public abstract class IOUtils {
         return new BufferedReader(new InputStreamReader(new FileInputStream(filename), encoding));
     }
 
-    /** Creates a buffered reader in the default encoding */
+    /** Creates a buffered reader using UTF-8 encoding */
     public static BufferedReader createReader(String filename) throws IOException {
         return new BufferedReader(new FileReader(filename, utf8Charset));
     }

--- a/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
+++ b/vespajlib/src/main/java/com/yahoo/io/IOUtils.java
@@ -82,7 +82,7 @@ public abstract class IOUtils {
 
     /** Creates a buffered reader in the default encoding */
     public static BufferedReader createReader(String filename) throws IOException {
-        return new BufferedReader(new FileReader(filename));
+        return new BufferedReader(new FileReader(filename, utf8Charset));
     }
 
     /**
@@ -108,7 +108,7 @@ public abstract class IOUtils {
      */
     public static BufferedWriter createWriter(File file, String encoding, boolean append) throws IOException {
         createDirectory(file.getAbsolutePath());
-        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file, append),encoding));
+        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file, append), encoding));
     }
 
     /**
@@ -119,7 +119,7 @@ public abstract class IOUtils {
      */
     public static BufferedWriter createWriter(String filename, boolean append) throws IOException {
         createDirectory(filename);
-        return new BufferedWriter(new FileWriter(filename, append));
+        return new BufferedWriter(new FileWriter(filename, utf8Charset, append));
     }
 
     /**
@@ -130,7 +130,7 @@ public abstract class IOUtils {
      */
     public static BufferedWriter createWriter(File file, boolean append) throws IOException {
         createDirectory(file.getAbsolutePath());
-        return new BufferedWriter(new FileWriter(file, append));
+        return new BufferedWriter(new FileWriter(file, utf8Charset, append));
     }
 
     /** Creates the directory path of this file if it does not exist */
@@ -291,7 +291,7 @@ public abstract class IOUtils {
         int lineCount = 0;
 
         try {
-            reader = createReader(file,"utf8");
+            reader = createReader(file);
             while (reader.readLine() != null)
                 lineCount++;
             return lineCount;
@@ -314,7 +314,7 @@ public abstract class IOUtils {
         try {
             List<String> lines = new java.util.ArrayList<>();
 
-            reader = createReader(fileName,"utf8");
+            reader = createReader(fileName);
             String line;
 
             while (null != (line = reader.readLine()))

--- a/vespajlib/src/main/java/com/yahoo/text/Utf8.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Utf8.java
@@ -1,6 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.text;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
@@ -558,4 +562,31 @@ public final class Utf8 {
         }
     }
 
+    public static FileReader createReader(File file) throws FileNotFoundException {
+        try {
+            return new FileReader(file, UTF_8);
+        } catch (FileNotFoundException ex) {
+            throw ex;
+        } catch (IOException ex) {
+            throw new FileNotFoundException(ex.getMessage());
+        }
+    }
+
+    public static FileReader createReader(String file) throws FileNotFoundException {
+        try {
+            return new FileReader(file, UTF_8);
+        } catch (FileNotFoundException ex) {
+            throw ex;
+        } catch (IOException ex) {
+            throw new FileNotFoundException(ex.getMessage());
+        }
+    }
+
+    public static FileWriter createWriter(File file) throws IOException {
+        return new FileWriter(file, UTF_8);
+    }
+
+    public static FileWriter createWriter(String file) throws IOException {
+        return new FileWriter(file, UTF_8);
+    }
 }

--- a/vespajlib/src/main/java/com/yahoo/text/Utf8.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Utf8.java
@@ -562,6 +562,14 @@ public final class Utf8 {
         }
     }
 
+    /**
+     * Create a FileReader for reading text files using UTF-8 encoding.
+     *
+     * @param file the file to be opened for reading
+     * @return a FileReader configured to use UTF-8 charset
+     * @throws FileNotFoundException if the file does not exist, is a directory
+     *         rather than a regular file, or cannot be opened for reading
+     */
     public static FileReader createReader(File file) throws FileNotFoundException {
         try {
             return new FileReader(file, UTF_8);
@@ -572,6 +580,14 @@ public final class Utf8 {
         }
     }
 
+    /**
+     * Create a FileReader for reading text files using UTF-8 encoding.
+     *
+     * @param file the name of the file to be opened for reading
+     * @return a FileReader configured to use UTF-8 charset
+     * @throws FileNotFoundException if the named file does not exist, is a directory
+     *         rather than a regular file, or cannot be opened for reading
+     */
     public static FileReader createReader(String file) throws FileNotFoundException {
         try {
             return new FileReader(file, UTF_8);
@@ -582,10 +598,28 @@ public final class Utf8 {
         }
     }
 
+    /**
+     * Create a FileWriter for writing text files using UTF-8 encoding.
+     *
+     * @param file the file to be opened for writing
+     * @return a FileWriter configured to use UTF-8 charset
+     * @throws IOException if the file exists but is a directory rather than
+     *         a regular file, does not exist but cannot be created, or cannot
+     *         be opened for any other reason
+     */
     public static FileWriter createWriter(File file) throws IOException {
         return new FileWriter(file, UTF_8);
     }
 
+    /**
+     * Create a FileWriter for writing text files using UTF-8 encoding.
+     *
+     * @param file the name of the file to be opened for writing
+     * @return a FileWriter configured to use UTF-8 charset
+     * @throws IOException if the named file exists but is a directory rather than
+     *         a regular file, does not exist but cannot be created, or cannot
+     *         be opened for any other reason
+     */
     public static FileWriter createWriter(String file) throws IOException {
         return new FileWriter(file, UTF_8);
     }

--- a/vespajlib/src/main/java/com/yahoo/vespa/VersionTagger.java
+++ b/vespajlib/src/main/java/com/yahoo/vespa/VersionTagger.java
@@ -1,13 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa;
 
+import com.yahoo.text.Utf8;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
@@ -46,7 +46,7 @@ public class VersionTagger {
     private Map<String, String> readVtagMap(String path) {
         Map<String, String> map = new HashMap<>();
         try {
-            BufferedReader in = new BufferedReader(new FileReader(path));
+            BufferedReader in = new BufferedReader(Utf8.createReader(path));
             String line;
             while ((line = in.readLine()) != null) {
                 if (line.isBlank()) continue;

--- a/vespajlib/src/test/java/com/yahoo/tensor/serialization/SerializationTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/serialization/SerializationTestCase.java
@@ -7,12 +7,12 @@ import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.test.json.Jackson;
+import com.yahoo.text.Utf8;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,7 +34,7 @@ public class SerializationTestCase {
         if (!testSpec.exists()) {
             testSpec = new File("../" + testPath);
         }
-        try(BufferedReader br = new BufferedReader(new FileReader(testSpec))) {
+        try(BufferedReader br = new BufferedReader(Utf8.createReader(testSpec))) {
             String test = br.readLine();
             while (test != null) {
                 tests.add(test);

--- a/vespajlib/src/test/java/com/yahoo/text/JsonMicroBenchmarkTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/text/JsonMicroBenchmarkTestCase.java
@@ -15,6 +15,7 @@ import java.util.TreeMap;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.yahoo.text.Utf8;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -484,7 +485,7 @@ public class JsonMicroBenchmarkTestCase {
 
     @SuppressWarnings("unused")
     private void dumpToFile(String path, String b) throws IOException {
-        FileWriter f = new FileWriter(path);
+        FileWriter f = Utf8.createWriter(path);
         f.write(b);
         f.close();
     }

--- a/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
@@ -4,11 +4,18 @@ package com.yahoo.text;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
@@ -559,6 +566,100 @@ public class Utf8TestCase {
         r.run();
         long end = System.currentTimeMillis();
         return end - start;
+    }
+
+    @Test
+    public void testCreateReaderWithFile() throws IOException {
+        File tempFile = File.createTempFile("utf8test", ".txt");
+        try {
+            String testContent = "Test UTF-8: \u5370\u57df\u60c5\u5831 \u00e9\u00e8";
+            Files.writeString(tempFile.toPath(), testContent, StandardCharsets.UTF_8);
+
+            FileReader reader = Utf8.createReader(tempFile);
+            BufferedReader br = new BufferedReader(reader);
+            String readContent = br.readLine();
+            br.close();
+
+            assertEquals(testContent, readContent);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    @Test
+    public void testCreateReaderWithString() throws IOException {
+        File tempFile = File.createTempFile("utf8test", ".txt");
+        try {
+            String testContent = "Test UTF-8: \u5370\u57df\u60c5\u5831 \u00e9\u00e8";
+            Files.writeString(tempFile.toPath(), testContent, StandardCharsets.UTF_8);
+
+            FileReader reader = Utf8.createReader(tempFile.getAbsolutePath());
+            BufferedReader br = new BufferedReader(reader);
+            String readContent = br.readLine();
+            br.close();
+
+            assertEquals(testContent, readContent);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void testCreateReaderWithNonExistentFile() throws FileNotFoundException {
+        File nonExistent = new File("/tmp/this-file-should-not-exist-" + System.nanoTime() + ".txt");
+        Utf8.createReader(nonExistent);
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void testCreateReaderWithNonExistentString() throws FileNotFoundException {
+        String nonExistent = "/tmp/this-file-should-not-exist-" + System.nanoTime() + ".txt";
+        Utf8.createReader(nonExistent);
+    }
+
+    @Test
+    public void testCreateWriterWithFile() throws IOException {
+        File tempFile = File.createTempFile("utf8test", ".txt");
+        try {
+            String testContent = "Test UTF-8: \u5370\u57df\u60c5\u5831 \u00e9\u00e8";
+
+            FileWriter writer = Utf8.createWriter(tempFile);
+            BufferedWriter bw = new BufferedWriter(writer);
+            bw.write(testContent);
+            bw.close();
+
+            String readContent = Files.readString(tempFile.toPath(), StandardCharsets.UTF_8);
+            assertEquals(testContent, readContent);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    @Test
+    public void testCreateWriterWithString() throws IOException {
+        File tempFile = File.createTempFile("utf8test", ".txt");
+        try {
+            String testContent = "Test UTF-8: \u5370\u57df\u60c5\u5831 \u00e9\u00e8";
+
+            FileWriter writer = Utf8.createWriter(tempFile.getAbsolutePath());
+            BufferedWriter bw = new BufferedWriter(writer);
+            bw.write(testContent);
+            bw.close();
+
+            String readContent = Files.readString(tempFile.toPath(), StandardCharsets.UTF_8);
+            assertEquals(testContent, readContent);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testCreateWriterWithDirectory() throws IOException {
+        File tempDir = Files.createTempDirectory("utf8test").toFile();
+        try {
+            Utf8.createWriter(tempDir);
+        } finally {
+            tempDir.delete();
+        }
     }
 
 }


### PR DESCRIPTION
Introduces new Utf8.createReader() and Utf8.createWriter() helper methods that explicitly use UTF-8 encoding when creating FileReaders and FileWriters. Updates IOUtils and migrates existing code to use explicit UTF-8 encoding instead of relying on platform default encoding.

@bjorncs please review
