### PR TITLE
Unpack PhraseSegmentItem inside of PhraseItem during conversion to Protobuf

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/PhraseItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/PhraseItem.java
@@ -295,7 +295,15 @@ public class PhraseItem extends CompositeIndexedItem {
         var builder = SearchProtocol.ItemPhrase.newBuilder();
         builder.setProperties(ToProtobuf.buildTermProperties(this, getIndexName()));
         for (var child : items()) {
-            builder.addChildren(child.toProtobuf());
+            if (child instanceof PhraseSegmentItem segment) {
+                // Mimic behavior of old encode function: Unpack PhraseSegmentItem
+                for (var segmentChild : segment.items()) {
+                    builder.addChildren(segmentChild.toProtobuf());
+                }
+            } else {
+                // Regular case: Just encode child
+                builder.addChildren(child.toProtobuf());
+            }
         }
         return SearchProtocol.QueryTreeItem.newBuilder()
                 .setItemPhrase(builder.build())

--- a/container-search/src/test/java/com/yahoo/prelude/query/ToProtobufTest.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/ToProtobufTest.java
@@ -481,6 +481,35 @@ public class ToProtobufTest {
     }
 
     @Test
+    void testConvertFromQueryWithPhraseSegmentItemInsidePhrase() {
+        PhraseItem phrase = new PhraseItem();
+        phrase.setIndexName("myindex");
+        phrase.addItem(new WordItem("one"));
+        PhraseSegmentItem phraseSegment = new PhraseSegmentItem("test", false, false);
+        phraseSegment.addItem(new WordItem("two"));
+        phraseSegment.addItem(new WordItem("three"));
+        phraseSegment.setIndexName("myindex");
+        phrase.addItem(phraseSegment);
+        phrase.addItem(new WordItem("four"));
+
+        // A PhraseSegmentItem inside a PhraseItem is unpacked during conversion, i.e.,
+        // its children become children of the PhraseItem
+        assertConvertsToJson(phrase, """
+            {
+              "itemPhrase": {
+                "properties": {"index": "myindex"},
+                "children": [
+                  {"itemWordTerm": {"properties": {"index": "myindex"}, "word": "one"}},
+                  {"itemWordTerm": {"properties": {"index": "myindex"}, "word": "two"}},
+                  {"itemWordTerm": {"properties": {"index": "myindex"}, "word": "three"}},
+                  {"itemWordTerm": {"properties": {"index": "myindex"}, "word": "four"}}
+                ]
+              }
+            }
+            """);
+    }
+
+    @Test
     void testConvertFromQueryWithAndSegmentItem() {
         AndSegmentItem andSegment = new AndSegmentItem("test", false, false);
         andSegment.addItem(new WordItem("foo"));


### PR DESCRIPTION
This makes the conversion to Protobuf mimic the behavior of the legacy conversion. Doing so avoids sending nested PhraseItems to the backend as these cannot be handled there.

@arnej27959 please review