### PR TITLE
feat(embedder): skip blank strings in embedding operations

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/properties/RankProfileInputProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/RankProfileInputProperties.java
@@ -53,6 +53,7 @@ public class RankProfileInputProperties extends Properties {
                                                       context,
                                                       query.properties(),
                                                       deadline);
+                    if (value == null) return; // Blank text to embed - skip setting the feature
                 }
             }
             catch (IllegalArgumentException e) {

--- a/container-search/src/main/java/com/yahoo/search/query/properties/RankProfileInputProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/RankProfileInputProperties.java
@@ -53,7 +53,6 @@ public class RankProfileInputProperties extends Properties {
                                                       context,
                                                       query.properties(),
                                                       deadline);
-                    if (value == null) return; // Blank text to embed - skip setting the feature
                 }
             }
             catch (IllegalArgumentException e) {

--- a/container-search/src/main/java/com/yahoo/search/schema/internal/TensorConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/schema/internal/TensorConverter.java
@@ -87,7 +87,9 @@ public class TensorConverter {
             embedderId = entry.getKey();
             embedder = entry.getValue();
         }
-        return embedder.embed(resolve(argument, contextValues, properties), embedderContext.copy().setEmbedderId(embedderId), type);
+        var text = resolve(argument, contextValues, properties);
+        if (text.isBlank()) return null;
+        return embedder.embed(text, embedderContext.copy().setEmbedderId(embedderId), type);
     }
 
     private Embedder requireEmbedder(String embedderId) {

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTestCase.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -482,6 +483,201 @@ public class EmbeddingScriptTestCase {
         // Verify batch method was called once with all texts, not individual embed calls
         assertEquals(1, mockEmbedder.batchCallCount);
         assertEquals(0, mockEmbedder.singleCallCount);
+    }
+
+    @Test
+    public void testBlankSingleValueReturnsNull() {
+        var tester = new EmbeddingScriptTester(Map.of("emb1", new EmbeddingScriptTester.MockIndexedEmbedder("myDocument.myTensor")));
+
+        var tensorType = TensorType.fromSpec("tensor(d[4])");
+        var expression = tester.expressionFrom("input myText | embed | attribute 'myTensor'");
+
+        var adapter = new SimpleTestAdapter();
+        adapter.createField(new Field("myText", DataType.STRING));
+        var tensorField = new Field("myTensor", new TensorDataType(tensorType));
+        adapter.createField(tensorField);
+        expression.setStatementOutput(new DocumentType("myDocument"), tensorField);
+        expression.resolve(new TypeContext(adapter));
+
+        // Test empty string
+        adapter.setValue("myText", new StringFieldValue(""));
+        var context = new ExecutionContext(adapter);
+        expression.execute(context);
+        assertFalse(adapter.values.containsKey("myTensor")); // Empty string should not produce tensor
+
+        // Test whitespace-only string
+        adapter.values.clear();
+        adapter.setValue("myText", new StringFieldValue("   "));
+        context = new ExecutionContext(adapter);
+        expression.execute(context);
+        assertFalse(adapter.values.containsKey("myTensor")); // Whitespace-only string should not produce tensor
+    }
+
+    @Test
+    public void testBlankArrayElementsSkipped_2dMixedTensor() {
+        var tester = new EmbeddingScriptTester(Map.of("emb1", new EmbeddingScriptTester.MockIndexedEmbedder("myDocument.mySparseTensor")));
+
+        var tensorType = TensorType.fromSpec("tensor(passage{}, d[5])");
+        var expression = tester.expressionFrom("input myTextArray | embed | attribute 'mySparseTensor'");
+
+        var adapter = new SimpleTestAdapter();
+        adapter.createField(new Field("myTextArray", new ArrayDataType(DataType.STRING)));
+
+        var tensorField = new Field("mySparseTensor", new TensorDataType(tensorType));
+        adapter.createField(tensorField);
+
+        // Array with blank elements at index 1 and 3
+        var array = new Array<StringFieldValue>(new ArrayDataType(DataType.STRING));
+        array.add(new StringFieldValue("first"));  // index 0
+        array.add(new StringFieldValue(""));       // index 1 - blank
+        array.add(new StringFieldValue("third"));  // index 2
+        array.add(new StringFieldValue("   "));    // index 3 - whitespace only
+        array.add(new StringFieldValue("fifth"));  // index 4
+        adapter.setValue("myTextArray", array);
+        expression.setStatementOutput(new DocumentType("myDocument"), tensorField);
+        expression.resolve(new TypeContext(adapter));
+
+        var context = new ExecutionContext(adapter);
+        context.setCurrentValue(array);
+        expression.execute(context);
+
+        assertTrue(adapter.values.containsKey("mySparseTensor"));
+        var sparseTensor = (TensorFieldValue) adapter.values.get("mySparseTensor");
+        // Should have indexes 0, 2, 4 (skipping 1 and 3)
+        assertEquals(Tensor.from(tensorType, "{ '0':[102, 105, 114, 115, 116], '2':[116, 104, 105, 114, 100], '4':[102, 105, 102, 116, 104]}"),
+                     sparseTensor.getTensor().get());
+    }
+
+    @Test
+    public void testAllBlankArrayElements_2dMixedTensor() {
+        var tester = new EmbeddingScriptTester(Map.of("emb1", new EmbeddingScriptTester.MockIndexedEmbedder("myDocument.mySparseTensor")));
+
+        var tensorType = TensorType.fromSpec("tensor(passage{}, d[4])");
+        var expression = tester.expressionFrom("input myTextArray | embed | attribute 'mySparseTensor'");
+
+        var adapter = new SimpleTestAdapter();
+        adapter.createField(new Field("myTextArray", new ArrayDataType(DataType.STRING)));
+
+        var tensorField = new Field("mySparseTensor", new TensorDataType(tensorType));
+        adapter.createField(tensorField);
+
+        // Array with only blank elements
+        var array = new Array<StringFieldValue>(new ArrayDataType(DataType.STRING));
+        array.add(new StringFieldValue(""));
+        array.add(new StringFieldValue("   "));
+        adapter.setValue("myTextArray", array);
+        expression.setStatementOutput(new DocumentType("myDocument"), tensorField);
+        expression.resolve(new TypeContext(adapter));
+
+        var context = new ExecutionContext(adapter);
+        context.setCurrentValue(array);
+        expression.execute(context);
+
+        assertTrue(adapter.values.containsKey("mySparseTensor"));
+        var sparseTensor = (TensorFieldValue) adapter.values.get("mySparseTensor");
+        // Should be an empty tensor
+        assertEquals(Tensor.from(tensorType, "{}"), sparseTensor.getTensor().get());
+    }
+
+    @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public void testBlankArrayElementsSkipped_2dMappedTensor() {
+        var tester = new EmbeddingScriptTester(Map.of("emb1", new EmbeddingScriptTester.MockMappedEmbedder("myDocument.my2DSparseTensor")));
+
+        var tensorType = TensorType.fromSpec("tensor(passage{}, token{})");
+        var expression = tester.expressionFrom("input myTextArray | embed emb1 passage | attribute 'my2DSparseTensor'");
+
+        var adapter = new SimpleTestAdapter();
+        adapter.createField(new Field("myTextArray", new ArrayDataType(DataType.STRING)));
+        var tensorField = new Field("my2DSparseTensor", new TensorDataType(tensorType));
+        adapter.createField(tensorField);
+
+        // Array with blank element at index 1
+        var array = new Array<StringFieldValue>(new ArrayDataType(DataType.STRING));
+        array.add(new StringFieldValue("abc"));  // index 0
+        array.add(new StringFieldValue(""));     // index 1 - blank
+        array.add(new StringFieldValue("cde"));  // index 2
+        adapter.setValue("myTextArray", array);
+        expression.setStatementOutput(new DocumentType("myDocument"), tensorField);
+        expression.resolve(new TypeContext(adapter));
+
+        var context = new ExecutionContext(adapter);
+        context.setCurrentValue(array);
+        expression.execute(context);
+
+        assertTrue(adapter.values.containsKey("my2DSparseTensor"));
+        var sparse2DTensor = (TensorFieldValue) adapter.values.get("my2DSparseTensor");
+        // Should have passage indexes 0 and 2 (skipping 1)
+        assertEquals(Tensor.from(
+                             tensorType,
+                             "tensor(passage{},token{}):" +
+                             "{{passage:0,token:97}:97.0, " +
+                             "{passage:0,token:98}:98.0, " +
+                             "{passage:0,token:99}:99.0, " +
+                             "{passage:2,token:100}:100.0, " +
+                             "{passage:2,token:101}:101.0, " +
+                             "{passage:2,token:99}:99.0}"),
+                     sparse2DTensor.getTensor().get());
+    }
+
+    @Test
+    public void testBlankArrayElementsSkipped_3dMixedTensor() {
+        var tester = new EmbeddingScriptTester(Map.of("emb1", new EmbeddingScriptTester.MockMixedEmbedder("myDocument.mySparseTensor")));
+
+        var tensorType = TensorType.fromSpec("tensor(passage{}, token{}, d[3])");
+        var expression = tester.expressionFrom("input myTextArray | embed emb1 passage | attribute 'mySparseTensor'");
+
+        var adapter = new SimpleTestAdapter();
+        adapter.createField(new Field("myTextArray", new ArrayDataType(DataType.STRING)));
+        var tensorField = new Field("mySparseTensor", new TensorDataType(tensorType));
+        adapter.createField(tensorField);
+
+        // Array with blank element at index 0
+        var array = new Array<StringFieldValue>(new ArrayDataType(DataType.STRING));
+        array.add(new StringFieldValue(""));      // index 0 - blank
+        array.add(new StringFieldValue("first")); // index 1
+        array.add(new StringFieldValue("sec"));   // index 2
+        adapter.setValue("myTextArray", array);
+        expression.setStatementOutput(new DocumentType("myDocument"), tensorField);
+        expression.resolve(new TypeContext(adapter));
+
+        var context = new ExecutionContext(adapter);
+        context.setCurrentValue(array);
+        expression.execute(context);
+
+        assertTrue(adapter.values.containsKey("mySparseTensor"));
+        var sparseTensor = (TensorFieldValue) adapter.values.get("mySparseTensor");
+        // Should have passage indexes 1 and 2 (skipping 0)
+        assertEquals(Tensor.from(tensorType,
+                                 """
+                                 {
+                                 {passage:1, token:0, d:0}: 101,
+                                 {passage:1, token:0, d:1}: 102,
+                                 {passage:1, token:0, d:2}: 103,
+                                 {passage:1, token:1, d:0}: 104,
+                                 {passage:1, token:1, d:1}: 105,
+                                 {passage:1, token:1, d:2}: 106,
+                                 {passage:1, token:2, d:0}: 113,
+                                 {passage:1, token:2, d:1}: 114,
+                                 {passage:1, token:2, d:2}: 115,
+                                 {passage:1, token:3, d:0}: 114,
+                                 {passage:1, token:3, d:1}: 115,
+                                 {passage:1, token:3, d:2}: 116,
+                                 {passage:1, token:4, d:0}: 115,
+                                 {passage:1, token:4, d:1}: 116,
+                                 {passage:1, token:4, d:2}: 117,
+                                 {passage:2, token:0, d:0}: 114,
+                                 {passage:2, token:0, d:1}: 115,
+                                 {passage:2, token:0, d:2}: 116,
+                                 {passage:2, token:1, d:0}: 100,
+                                 {passage:2, token:1, d:1}: 101,
+                                 {passage:2, token:1, d:2}: 102,
+                                 {passage:2, token:2, d:0}:  98,
+                                 {passage:2, token:2, d:1}:  99,
+                                 {passage:2, token:2, d:2}: 100
+                                 }
+                                 """),
+                     sparseTensor.getTensor().get());
     }
 
 }


### PR DESCRIPTION
- Return null for blank single-value strings in EmbedExpression
- Filter blank array elements while preserving original chunk indexes
- Return null for blank embed text in TensorConverter (search-side)
- Skip setting query feature when embed returns null
- Add tests for blank string handling in indexing and search

FYI @thomasht86 