### PR TITLE
Use explicit locale and charset

### DIFF
--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -36,7 +37,7 @@ public class PublicSignatureCollector extends ClassVisitor {
 
   private static String describeMethod(String name, int access, String returnType,
       List<String> argumentTypes) {
-    return String.format("%s %s %s(%s)", describeAccess(access, Util.methodFlags), returnType, name,
+    return String.format(Locale.ROOT, "%s %s %s(%s)", describeAccess(access, Util.methodFlags), returnType, name,
         String.join(", ", argumentTypes));
   }
 
@@ -45,7 +46,7 @@ public class PublicSignatureCollector extends ClassVisitor {
   }
 
   private static String describeField(String name, int access, String type) {
-    return String.format("%s %s %s", describeAccess(access, Util.fieldFlags), type, name);
+    return String.format(Locale.ROOT, "%s %s %s", describeAccess(access, Util.fieldFlags), type, name);
   }
 
   private static String internalNameToClassName(String superName) {

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/Util.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/Util.java
@@ -5,6 +5,7 @@ import org.objectweb.asm.Opcodes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class Util {
 
@@ -63,7 +64,7 @@ public class Util {
       access &= ~flag.bit;
     }
     if (access != 0) {
-      throw new IllegalArgumentException(String.format("Unexpected access bits: 0x%x", access));
+      throw new IllegalArgumentException(String.format(Locale.ROOT, "Unexpected access bits: 0x%x", access));
     }
     return result;
   }

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/mojo/AbiCheck.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/mojo/AbiCheck.java
@@ -31,11 +31,13 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.jar.JarFile;
@@ -66,7 +68,7 @@ public class AbiCheck extends AbstractMojo {
   // CLOVER:OFF
   // Testing that Gson can read JSON files is not very useful
   private static Map<String, JavaClassSignature> readSpec(File file) throws IOException {
-    try (FileReader reader = new FileReader(file)) {
+    try (FileReader reader = new FileReader(file, StandardCharsets.UTF_8)) {
       ObjectMapper mapper = new ObjectMapper();
       JavaType typeToken = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, JavaClassSignature.class);
       return mapper.readValue(reader, typeToken);
@@ -76,7 +78,7 @@ public class AbiCheck extends AbstractMojo {
 
   private static class FinalNewlineWriter extends FileWriter {
     private boolean closed = false;
-    FinalNewlineWriter(File file) throws IOException { super(file); }
+    FinalNewlineWriter(File file) throws IOException { super(file, StandardCharsets.UTF_8); }
     @Override
     public void close() throws IOException {
       if (closed) return;
@@ -104,32 +106,32 @@ public class AbiCheck extends AbstractMojo {
     if (!expected.superClass.equals(actual.superClass)) {
       match = false;
       log.error(String
-          .format("Class %s: Expected superclass %s, found %s", className, expected.superClass,
+          .format(Locale.ROOT, "Class %s: Expected superclass %s, found %s", className, expected.superClass,
               actual.superClass));
     }
     if (!SetMatcher.compare(expected.interfaces, actual.interfaces,
         item -> true,
-        item -> log.error(String.format("Class %s: Missing interface %s", className, item)),
-        item -> log.error(String.format("Class %s: Extra interface %s", className, item)))) {
+        item -> log.error(String.format(Locale.ROOT, "Class %s: Missing interface %s", className, item)),
+        item -> log.error(String.format(Locale.ROOT, "Class %s: Extra interface %s", className, item)))) {
       match = false;
     }
     if (!SetMatcher
         .compare(new HashSet<>(expected.attributes), new HashSet<>(actual.attributes),
             item -> true,
-            item -> log.error(String.format("Class %s: Missing attribute %s", className, item)),
-            item -> log.error(String.format("Class %s: Extra attribute %s", className, item)))) {
+            item -> log.error(String.format(Locale.ROOT, "Class %s: Missing attribute %s", className, item)),
+            item -> log.error(String.format(Locale.ROOT, "Class %s: Extra attribute %s", className, item)))) {
       match = false;
     }
     if (!SetMatcher.compare(expected.methods, actual.methods,
         item -> true,
-        item -> log.error(String.format("Class %s: Missing method %s", className, item)),
-        item -> log.error(String.format("Class %s: Extra method %s", className, item)))) {
+        item -> log.error(String.format(Locale.ROOT, "Class %s: Missing method %s", className, item)),
+        item -> log.error(String.format(Locale.ROOT, "Class %s: Extra method %s", className, item)))) {
       match = false;
     }
     if (!SetMatcher.compare(expected.fields, actual.fields,
         item -> true,
-        item -> log.error(String.format("Class %s: Missing field %s", className, item)),
-        item -> log.error(String.format("Class %s: Extra field %s", className, item)))) {
+        item -> log.error(String.format(Locale.ROOT, "Class %s: Missing field %s", className, item)),
+        item -> log.error(String.format(Locale.ROOT, "Class %s: Extra field %s", className, item)))) {
       match = false;
     }
     return match;
@@ -177,8 +179,8 @@ public class AbiCheck extends AbstractMojo {
       Map<String, JavaClassSignature> actual, Log log) {
     return SetMatcher.compare(expected.keySet(), actual.keySet(),
         item -> matchingClasses(item, expected.get(item), actual.get(item), log),
-        item -> log.error(String.format("Missing class: %s", item)),
-        item -> log.error(String.format("Extra class: %s", item)));
+        item -> log.error(String.format(Locale.ROOT, "Missing class: %s", item)),
+        item -> log.error(String.format(Locale.ROOT, "Extra class: %s", item)));
   }
 
   // CLOVER:OFF

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.jar.Manifest;
 
@@ -39,7 +40,7 @@ public class AnalyzeBundle {
         try {
             return parseExports(manifest);
         } catch (Exception e) {
-            throw new RuntimeException(String.format("Invalid manifest in bundle '%s'", jarFile.getPath()), e);
+            throw new RuntimeException(String.format(Locale.ROOT, "Invalid manifest in bundle '%s'", jarFile.getPath()), e);
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/ExportPackageAnnotation.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/ExportPackageAnnotation.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.plugin.classanalysis;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -28,12 +29,12 @@ public class ExportPackageAnnotation {
         requireNonNegative(micro, "micro");
         if (! QUALIFIER_PATTERN.matcher(qualifier).matches()) {
             throw new IllegalArgumentException(
-                    exportPackageError(String.format("qualifier must follow the format (alpha|digit|'_'|'-')* but was '%s'.", qualifier)));
+                    exportPackageError(String.format(Locale.ROOT, "qualifier must follow the format (alpha|digit|'_'|'-')* but was '%s'.", qualifier)));
         }
     }
 
     public String osgiVersion() {
-        return String.format("%d.%d.%d", major, minor, micro) + (qualifier.isEmpty() ? "" : "." + qualifier);
+        return String.format(Locale.ROOT, "%d.%d.%d", major, minor, micro) + (qualifier.isEmpty() ? "" : "." + qualifier);
     }
 
     private static String exportPackageError(String msg) {
@@ -42,7 +43,7 @@ public class ExportPackageAnnotation {
 
     private static void requireNonNegative(int i, String fieldName) {
         if (i < 0) {
-            throw new IllegalArgumentException(exportPackageError(String.format("%s must be non-negative but was %d.", fieldName, i)));
+            throw new IllegalArgumentException(exportPackageError(String.format(Locale.ROOT, "%s must be non-negative but was %d.", fieldName, i)));
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AbstractGenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AbstractGenerateOsgiManifestMojo.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.jar.Attributes;
@@ -210,7 +211,7 @@ abstract class AbstractGenerateOsgiManifestMojo extends AbstractMojo {
             return Analyze.analyzeClass(jarFile.getInputStream(entry), JdkVersionCheck.DISABLED, version);
         } catch (Exception e) {
             throw new MojoExecutionException(
-                    String.format("While analyzing the class '%s' in jar file '%s'", entry.getName(), jarFile.getName()), e);
+                    String.format(Locale.ROOT, "While analyzing the class '%s' in jar file '%s'", entry.getName(), jarFile.getName()), e);
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AssembleFatJarMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AssembleFatJarMojo.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -131,7 +132,7 @@ public class AssembleFatJarMojo extends AbstractMojo {
     }
 
     private static String filename(Artifact a) {
-        return a.getGroupId().equals("com.yahoo.vespa") ? "%s-jar-with-dependencies.jar".formatted(a.getArtifactId()) : a.getFile().getName();
+        return a.getGroupId().equals("com.yahoo.vespa") ? String.format(Locale.ROOT, "%s-jar-with-dependencies.jar", a.getArtifactId()) : a.getFile().getName();
     }
 
     private File outputFile() {
@@ -151,7 +152,7 @@ public class AssembleFatJarMojo extends AbstractMojo {
             var project = session.getAllProjects().stream()
                     .filter(p -> p.getGroupId().equals(installedDepsProject[0]) && p.getArtifactId().equals(installedDepsProject[1]))
                     .findAny().orElseThrow(() -> new IllegalStateException(
-                            "Cannot find %s. Build from project root with 'mvn install -pl :%s'".formatted(projectDefiningInstalledDependencies, this.project.getArtifactId())));
+                            String.format(Locale.ROOT, "Cannot find %s. Build from project root with 'mvn install -pl :%s'", projectDefiningInstalledDependencies, this.project.getArtifactId())));
             var req = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
             req.setProject(project);
             var root = dependencyGraphBuilder.buildDependencyGraph(req, null);

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -129,8 +130,8 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
                 logProvidedArtifactsIncluded(artifactsToInclude, providedArtifactsFromManifest(wantedProvidedArtifact.get().getFile()));
             } else if (! suppressWarningMissingImportPackages && jdisc_core.isEmpty()) {
                 // TODO: Remove jdisc_core clause above and instead add suppressWarning to necessary vespa modules.
-                warnOrThrow(("This project does not have '%s' as provided dependency, so the generated 'Import-Package' " +
-                        "OSGi header may be missing important packages.").formatted(wantedProvidedDependency()));
+                warnOrThrow(String.format(Locale.ROOT, "This project does not have '%s' as provided dependency, so the generated 'Import-Package' " +
+                        "OSGi header may be missing important packages.", wantedProvidedDependency()));
             }
 
             logOverlappingPackages(projectPackages, exportedPackagesFromProvidedDeps);
@@ -198,7 +199,7 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
 
     private void logNonPublicApiUsage(List<String> nonPublicApiUsed) {
         if (suppressWarningPublicApi || effectiveBundleType() != BundleType.USER || nonPublicApiUsed.isEmpty()) return;
-        warnOrThrow("This project uses packages that are not part of Vespa's public api: %s".formatted(nonPublicApiUsed));
+        warnOrThrow(String.format(Locale.ROOT, "This project uses packages that are not part of Vespa's public api: %s", nonPublicApiUsed));
     }
 
     private static String publicApi(PackageTally tally) {
@@ -298,7 +299,7 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
         List<Artifact> unsupportedArtifacts = nonJarArtifacts.stream().filter(a -> ! a.getType().equals("pom"))
                 .toList();
 
-        unsupportedArtifacts.forEach(artifact -> warnOrThrow(String.format("Unsupported artifact '%s': Type '%s' is not supported. Please file a feature request.",
+        unsupportedArtifacts.forEach(artifact -> warnOrThrow(String.format(Locale.ROOT, "Unsupported artifact '%s': Type '%s' is not supported. Please file a feature request.",
                                                                            artifact.getId(), artifact.getType())));
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateSourcesMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateSourcesMojo.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
@@ -94,7 +95,7 @@ public class GenerateSourcesMojo extends AbstractMojo {
             return parent.getVersion();
 
         String defaultConfigGenVersion = loadDefaultConfigGenVersion();
-        getLog().warn(String.format(
+        getLog().warn(String.format(Locale.ROOT,
                 "Did not find either container or container-dev artifact in project dependencies, "
                 + "using default version '%s' of the config class plugin.",
                 defaultConfigGenVersion));

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/osgi/ImportPackages.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/osgi/ImportPackages.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -33,7 +34,7 @@ public class ImportPackages {
                     Arrays.stream(version.get().split("\\.")).map(Integer::parseInt).limit(3).forEach(this.versionNumber::add);
                 } catch (NumberFormatException e) {
                     throw new IllegalArgumentException(
-                            String.format("Invalid version number '%s' for package '%s'.", version.get(), packageName), e);
+                            String.format(Locale.ROOT, "Invalid version number '%s' for package '%s'.", version.get(), packageName), e);
                 }
             }
         }
@@ -61,7 +62,7 @@ public class ImportPackages {
             } else {
                 int upperLimit = isGuavaPackage() ? INFINITE_VERSION // guava increases major version for each release
                         : versionNumber.get(0) + 1;
-                return Optional.of(String.format("[%s,%d)", version(), upperLimit));
+                return Optional.of(String.format(Locale.ROOT, "[%s,%d)", version(), upperLimit));
             }
         }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/util/TestBundleDependencyScopeTranslator.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/util/TestBundleDependencyScopeTranslator.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -77,14 +78,14 @@ public class TestBundleDependencyScopeTranslator implements Artifacts.ScopeTrans
         for (DependencyOverride override : overrides) {
             for (Artifact dependent : dependencyTrailOf(dependency, otherArtifacts)) {
                 if (override.isForArtifact(dependent)) {
-                    log.fine(() -> String.format(
+                    log.fine(() -> String.format(Locale.ROOT,
                             "Overriding scope of '%s'; scope '%s' overridden to '%s'",
                             dependency.getId(), oldScope, override.scope));
                     return override.scope;
                 }
             }
         }
-        log.fine(() -> String.format(
+        log.fine(() -> String.format(Locale.ROOT,
                 "Using default scope translation for '%s'; scope 'test' translated to 'compile'",
                 dependency.getId()));
         return Artifact.SCOPE_COMPILE;

--- a/configgen/src/main/java/com/yahoo/config/codegen/BuilderGenerator.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/BuilderGenerator.java
@@ -9,6 +9,7 @@ import com.yahoo.config.codegen.LeafCNode.UrlLeaf;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -107,17 +108,17 @@ public class BuilderGenerator {
 
     private static String getBuilderFieldDefinition(CNode node) {
         if (node.isArray) {
-            return String.format("public List<%s> %s = new ArrayList<>();", builderType(node), node.getName());
+            return String.format(Locale.ROOT, "public List<%s> %s = new ArrayList<>();", builderType(node), node.getName());
         } else if (node.isMap) {
-            return String.format("public Map<String, %s> %s = new LinkedHashMap<>();", builderType(node), node.getName());
+            return String.format(Locale.ROOT, "public Map<String, %s> %s = new LinkedHashMap<>();", builderType(node), node.getName());
         } else if (node instanceof InnerCNode) {
-            return String.format("public %s %s = new %s();", builderType(node), node.getName(), builderType(node));
+            return String.format(Locale.ROOT, "public %s %s = new %s();", builderType(node), node.getName(), builderType(node));
         } else if (node instanceof LeafCNode) {
             String boxedBuilderType = boxedBuilderType((LeafCNode) node);
             if (boxedBuilderType.startsWith("Optional<"))
-                return String.format("private %s %s = Optional.empty();", boxedBuilderType, node.getName());
+                return String.format(Locale.ROOT, "private %s %s = Optional.empty();", boxedBuilderType, node.getName());
             else
-                return String.format("private %s %s = null;", boxedBuilderType, node.getName());
+                return String.format(Locale.ROOT, "private %s %s = null;", boxedBuilderType, node.getName());
         } else {
             throw new IllegalStateException("Cannot produce builder field definition for node"); // Should not happen
         }
@@ -289,24 +290,24 @@ public class BuilderGenerator {
                 if ("UrlReference".equals(bType))
                     type = bType;
                 //
-                privateSetter = String.format("""
+                privateSetter = String.format(Locale.ROOT, """
 
                                                       private Builder %s(String %svalue) {
                                                         return %s(%s.valueOf(%svalue));
                                                       }""", name, INTERNAL_PREFIX, name, type, INTERNAL_PREFIX);
             } else if ("Optional<FileReference>".equals(bType)) {
                 //
-                privateSetter = String.format("""
+                privateSetter = String.format(Locale.ROOT, """
 
                                                       private Builder %s(FileReference %svalue) {
                                                         return %s(Optional.of(%svalue));
                                                       }""", name, INTERNAL_PREFIX, name, INTERNAL_PREFIX);
             }
 
-            String getNullGuard = bType.equals(boxedBuilderType(n)) ? String.format(
+            String getNullGuard = bType.equals(boxedBuilderType(n)) ? String.format(Locale.ROOT,
                     "\nif (%svalue == null) throw new IllegalArgumentException(\"Null value is not allowed.\");", INTERNAL_PREFIX) : "";
 
-            return String.format("public Builder %s(%s %svalue) {%s\n" +
+            return String.format(Locale.ROOT, "public Builder %s(%s %svalue) {%s\n" +
                     "  %s = %svalue;\n" + //
                     "%s", name, bType, INTERNAL_PREFIX, getNullGuard, name, INTERNAL_PREFIX, signalInitialized) +
                     "  return this;" + "\n}\n" + privateSetter;

--- a/configgen/src/main/java/com/yahoo/config/codegen/ConfigGenerator.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/ConfigGenerator.java
@@ -16,6 +16,7 @@ import com.yahoo.config.codegen.LeafCNode.ModelLeaf;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static com.yahoo.config.codegen.BuilderGenerator.getBuilder;
@@ -71,13 +72,13 @@ public class ConfigGenerator {
     private static String getFieldDefinition(CNode node) {
         String fieldDef;
         if (node instanceof LeafCNode && node.isArray) {
-            fieldDef = String.format("LeafNodeVector<%s, %s> %s;", boxedDataType(node), nodeClass(node), node.getName());
+            fieldDef = String.format(Locale.ROOT, "LeafNodeVector<%s, %s> %s;", boxedDataType(node), nodeClass(node), node.getName());
         } else if (node instanceof InnerCNode && node.isArray) {
-            fieldDef = String.format("InnerNodeVector<%s> %s;", nodeClass(node), node.getName());
+            fieldDef = String.format(Locale.ROOT, "InnerNodeVector<%s> %s;", nodeClass(node), node.getName());
         } else if (node.isMap) {
-            fieldDef = String.format("Map<String, %s> %s;", nodeClass(node), node.getName());
+            fieldDef = String.format(Locale.ROOT, "Map<String, %s> %s;", nodeClass(node), node.getName());
         } else {
-            fieldDef = String.format("%s %s;", nodeClass(node), node.getName());
+            fieldDef = String.format(Locale.ROOT, "%s %s;", nodeClass(node), node.getName());
         }
         return node.getCommentBlock("//") + "private final " + fieldDef;
     }
@@ -94,7 +95,7 @@ public class ConfigGenerator {
 
     private static String getContainsFieldsFlaggedWithRestart(CNode node, boolean isOuter) {
         if (isOuter) {
-            return String.format("private static boolean containsFieldsFlaggedWithRestart() {\n" +//
+            return String.format(Locale.ROOT, "private static boolean containsFieldsFlaggedWithRestart() {\n" +//
                     "  return %b;\n" +//
                     "}\n\n", node.needRestart());
         } else {
@@ -323,7 +324,7 @@ public class ConfigGenerator {
 
     private static String getStaticMethodsForInnerArray(InnerCNode inner) {
         final String nc = nodeClass(inner);
-        return String.format("private static InnerNodeVector<%s> createVector(List<Builder> builders) {\n" +//
+        return String.format(Locale.ROOT, "private static InnerNodeVector<%s> createVector(List<Builder> builders) {\n" +//
                 "    List<%s> elems = new ArrayList<>();\n" +//
                 "    for (Builder b : builders) {\n" +//
                 "        elems.add(new %s(b));\n" +//
@@ -334,7 +335,7 @@ public class ConfigGenerator {
 
     private static String getStaticMethodsForInnerMap(InnerCNode inner) {
         final String nc = nodeClass(inner);
-        return String.format(
+        return String.format(Locale.ROOT,
                 "private static Map<String, %s> createMap(Map<String, Builder> builders) {\n" +//
                         "  Map<String, %s> ret = new LinkedHashMap<>();\n" +//
                         "  for(String key : builders.keySet()) {\n" +//
@@ -345,9 +346,9 @@ public class ConfigGenerator {
     }
 
     private static String getEnumCode(EnumLeaf en) {
-        String enumValues = stream(en.getLegalValues()).map(e -> String.format("  public final static Enum %s = Enum.%s;", e, e)).collect(Collectors.joining("\n"));
+        String enumValues = stream(en.getLegalValues()).map(e -> String.format(Locale.ROOT, "  public final static Enum %s = Enum.%s;", e, e)).collect(Collectors.joining("\n"));
 
-        String code = String.format("%s\n" +//
+        String code = String.format(Locale.ROOT, "%s\n" +//
                         "public final static class %s extends EnumNode<%s> {\n" +//
                         "\n" +//
                         "  public %s(){\n" +//
@@ -476,7 +477,7 @@ public class ConfigGenerator {
 
         if ("int".equals(rawType)) {
             return "Integer";
-        } else if (rawType.toLowerCase().equals(rawType)) {
+        } else if (rawType.toLowerCase(Locale.ROOT).equals(rawType)) {
             return ConfiggenUtil.capitalize(rawType);
         } else if (rawType.startsWith("Optional<")) {
             return "Optional";

--- a/configgen/src/main/java/com/yahoo/config/codegen/CppClassBuilder.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/CppClassBuilder.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Arrays;
 import java.util.StringTokenizer;
@@ -58,7 +60,7 @@ public class CppClassBuilder implements ClassBuilder {
     }
 
     void writeFile(File f, String content) throws IOException {
-        FileWriter fw = new FileWriter(f);
+        FileWriter fw = new FileWriter(f, StandardCharsets.UTF_8);
         fw.write(content);
         fw.close();
     }
@@ -96,11 +98,11 @@ public class CppClassBuilder implements ClassBuilder {
         String [] parts = source.split("[-_]");
         StringBuilder sb = new StringBuilder();
         for (String s : parts) {
-            sb.append(s.substring(0, 1).toUpperCase()).append(s.substring(1));
+            sb.append(s.substring(0, 1).toUpperCase(Locale.ROOT)).append(s.substring(1));
         }
         String result = sb.toString();
         if (!capitalizeFirst) {
-            result = result.substring(0,1).toLowerCase() + result.substring(1);
+            result = result.substring(0,1).toLowerCase(Locale.ROOT) + result.substring(1);
         }
         return result;
     }

--- a/configgen/src/main/java/com/yahoo/config/codegen/DefaultValue.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/DefaultValue.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.codegen;
 
+import java.util.Locale;
+
 /**
  * An immutable class representing a default value of a config variable
  *
@@ -47,7 +49,7 @@ public class DefaultValue {
             StringBuilder sb = new StringBuilder();
             for (char c : value.toCharArray()) {
                 if (c > '\u007f') {
-                    sb.append(String.format("\\u%04X", (int) c));
+                    sb.append(String.format(Locale.ROOT, "\\u%04X", (int) c));
                 } else {
                     sb.append(c);
                 }

--- a/configgen/src/main/java/com/yahoo/config/codegen/JavaClassBuilder.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/JavaClassBuilder.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.Set;
@@ -44,7 +45,7 @@ public class JavaClassBuilder implements ClassBuilder {
     public void createConfigClasses() {
         try {
             File outFile = new File(getDestPath(destDir, javaPackage), className + ".java");
-            try (PrintStream out = new PrintStream(new FileOutputStream(outFile))) {
+            try (PrintStream out = new PrintStream(new FileOutputStream(outFile), false, StandardCharsets.UTF_8)) {
                 out.print(getConfigClass(className));
             }
         } catch (FileNotFoundException e) {

--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfig.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfig.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class generates code for a config class from a given def-file.
@@ -26,12 +27,12 @@ public class MakeConfig {
     }
 
     @SuppressWarnings("WeakerAccess") // Used by ConfigGenMojo
-    public static boolean makeConfig(MakeConfigProperties properties) throws FileNotFoundException {
+    public static boolean makeConfig(MakeConfigProperties properties) throws IOException {
         for (File specFile : properties.specFiles) {
             String name = specFile.getName();
             if (name.endsWith(".def")) name = name.substring(0, name.length() - 4);
 
-            DefParser parser = new DefParser(name, new FileReader(specFile));
+            DefParser parser = new DefParser(name, new FileReader(specFile, StandardCharsets.UTF_8));
             parser.enableSystemErr();
             InnerCNode configRoot = parser.getTree();
             checkNamespaceAndPacakge(name, configRoot, isCpp(properties));

--- a/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/MakeConfigProperties.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,7 +79,7 @@ public class MakeConfigProperties {
     }
 
     private static String checkLanguage(String lang) throws PropertyException {
-        String inputLang = lang != null ? lang.toLowerCase() : "java";
+        String inputLang = lang != null ? lang.toLowerCase(Locale.ROOT) : "java";
         if (! legalLanguages.contains(inputLang)) {
             throw new PropertyException
                     ("Unsupported code language: '" + inputLang + "'. Supported languages are: " + legalLanguages);

--- a/configgen/src/main/java/com/yahoo/config/codegen/NormalizedDefinition.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/NormalizedDefinition.java
@@ -4,9 +4,11 @@ package com.yahoo.config.codegen;
 import java.io.*;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.security.MessageDigest;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -70,15 +72,15 @@ public class NormalizedDefinition {
         line = line.trim();
         Matcher m = intPattern.matcher(line);
         if (m.matches()) {
-            String formattedMax = new DecimalFormat("#.#").format(0x7fffffff);
-            String formattedMin = new DecimalFormat("#.#").format(-0x80000000);
+            String formattedMax = new DecimalFormat("#.#", DecimalFormatSymbols.getInstance(Locale.ROOT)).format(0x7fffffff);
+            String formattedMin = new DecimalFormat("#.#", DecimalFormatSymbols.getInstance(Locale.ROOT)).format(-0x80000000);
             line = line.replaceFirst("\\[,", "["+formattedMin+",");
             line = line.replaceFirst(",\\]", ","+formattedMax+"]");
         }
         m = doublePattern.matcher(line);
         if (m.matches()) {
-            String formattedMax = new DecimalFormat("#.#").format(1e308);
-            String formattedMin = new DecimalFormat("#.#").format(-1e308);
+            String formattedMax = new DecimalFormat("#.#", DecimalFormatSymbols.getInstance(Locale.ROOT)).format(1e308);
+            String formattedMin = new DecimalFormat("#.#", DecimalFormatSymbols.getInstance(Locale.ROOT)).format(-1e308);
             line = line.replaceFirst("\\[,", "["+formattedMin+",");
             line = line.replaceFirst(",\\]", ","+formattedMax+"]");
         }
@@ -124,7 +126,7 @@ public class NormalizedDefinition {
                 md5.update(toBytes(s));
             }
         }
-        defMd5 = toHexString(md5.digest()).toLowerCase();
+        defMd5 = toHexString(md5.digest()).toLowerCase(Locale.ROOT);
         //System.out.println("md5=" + defMd5) ;
         return defMd5;
     }
@@ -144,7 +146,7 @@ public class NormalizedDefinition {
     private String toHexString(byte[] bytes) {
         StringBuilder sb =  new StringBuilder(bytes.length * 2);
         for (byte aByte : bytes) {
-            sb.append(String.format("%02x", aByte));
+            sb.append(String.format(Locale.ROOT, "%02x", aByte));
         }
         return sb.toString();
     }

--- a/configgen/src/test/java/com/yahoo/config/codegen/DefParserTest.java
+++ b/configgen/src/test/java/com/yahoo/config/codegen/DefParserTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,7 +26,7 @@ public class DefParserTest {
     @Test
     void testTraverseTree() throws IOException {
         File defFile = new File(DEF_NAME);
-        CNode root = new DefParser("test", new FileReader(defFile)).getTree();
+        CNode root = new DefParser("test", new FileReader(defFile, StandardCharsets.UTF_8)).getTree();
         assertNotNull(root);
         CNode[] children = root.getChildren();
         assertEquals(38, children.length);
@@ -62,14 +63,14 @@ public class DefParserTest {
     @Test
     void testFileWithNamespaceInFilename() throws IOException {
         File defFile = new File(TEST_DIR + "baz.bar.foo.def");
-        CNode root = new DefParser("test", new FileReader(defFile)).getTree();
+        CNode root = new DefParser("test", new FileReader(defFile, StandardCharsets.UTF_8)).getTree();
         assertEquals("31a0f9bda0e5ff929762a29569575a7e", root.defMd5);
     }
 
     @Test
     void testMd5Sum() throws IOException {
         File defFile = new File(DEF_NAME);
-        CNode root = new DefParser("test", new FileReader(defFile)).getTree();
+        CNode root = new DefParser("test", new FileReader(defFile, StandardCharsets.UTF_8)).getTree();
         assertEquals("ee37973499305fde315da46256e64b2e", root.defMd5);
     }
 

--- a/configgen/src/test/java/com/yahoo/config/codegen/NormalizedDefinitionTest.java
+++ b/configgen/src/test/java/com/yahoo/config/codegen/NormalizedDefinitionTest.java
@@ -7,6 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,7 @@ public class NormalizedDefinitionTest {
     void testNormalizingFromFile() throws IOException {
         FileReader fileReader = null;
         try {
-            fileReader = new FileReader("src/test/resources/configgen.allfeatures.def");
+            fileReader = new FileReader("src/test/resources/configgen.allfeatures.def", StandardCharsets.UTF_8);
         } catch (FileNotFoundException e) {
             e.printStackTrace();
         }

--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -22,6 +22,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * @author Tony Vaagenes
@@ -87,7 +88,7 @@ public class ApplicationMojo extends AbstractMojo {
                 throw new IllegalArgumentException("compile version (" + compileVersion + ") cannot be higher than parent version (" + parentVersion + ")");
         }
 
-        String metaData = String.format("""
+        String metaData = String.format(Locale.ROOT, """
                                         {
                                           "compileVersion": "%s",
                                           "buildTime": %d,


### PR DESCRIPTION
Make Java code locale-independent and use explicit UTF-8 encoding:
- Add Locale.ROOT to String.format() calls to ensure consistent formatting
- Specify StandardCharsets.UTF_8 in FileReader/FileWriter constructors
- Use Locale.ROOT with toLowerCase()/toUpperCase() operations
- Use DecimalFormatSymbols.getInstance(Locale.ROOT) for number formatting

This prevents locale-specific formatting issues and ensures consistent behavior across different system locales and default encodings.
