### PR TITLE
Use explicit locale and charset

### DIFF
--- a/vespajlib/src/main/java/ai/vespa/json/Json.java
+++ b/vespajlib/src/main/java/ai/vespa/json/Json.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -53,13 +54,13 @@ public class Json implements Iterable<Json> {
     public Json f(String field) { return field(field); }
     public Json field(String field) {
         requireType(Type.OBJECT);
-        return new Json(inspector.field(field), path.isEmpty() ? field : "%s.%s".formatted(path, field));
+        return new Json(inspector.field(field), path.isEmpty() ? field : String.format(Locale.ROOT, "%s.%s", path, field));
     }
 
     public Json a(int index) { return entry(index); }
     public Json entry(int index) {
         requireType(ARRAY);
-        return new Json(inspector.entry(index), "%s[%d]".formatted(path, index));
+        return new Json(inspector.entry(index), String.format(Locale.ROOT, "%s[%d]", path, index));
     }
 
     public int length() { return inspector.children(); }
@@ -103,7 +104,7 @@ public class Json implements Iterable<Json> {
         try {
             return Instant.parse(asString());
         } catch (DateTimeParseException e) {
-            throw new InvalidJsonException("Expected JSON member '%s' to be a valid timestamp: %s".formatted(path, e.getMessage()));
+            throw new InvalidJsonException(String.format(Locale.ROOT, "Expected JSON member '%s' to be a valid timestamp: %s", path, e.getMessage()));
         }
     }
     public Instant asInstant(Instant defaultValue) {
@@ -171,14 +172,13 @@ public class Json implements Iterable<Json> {
 
     private InvalidJsonException createInvalidTypeException(Type... expected) {
         var expectedTypesString = Arrays.stream(expected).map(this::toString).collect(joining("' or '", "'", "'"));
-        var pathString = path.isEmpty() ? "JSON" : "JSON member '%s'".formatted(path);
+        var pathString = path.isEmpty() ? "JSON" : String.format(Locale.ROOT, "JSON member '%s'", path);
         return new InvalidJsonException(
-                "Expected %s to be a %s but got '%s'"
-                        .formatted(pathString, expectedTypesString, toString(inspector.type())));
+                String.format(Locale.ROOT, "Expected %s to be a %s but got '%s'", pathString, expectedTypesString, toString(inspector.type())));
     }
 
     private InvalidJsonException createMissingMemberException() {
-        return new InvalidJsonException(path.isEmpty() ? "Missing JSON" : "Missing JSON member '%s'".formatted(path));
+        return new InvalidJsonException(path.isEmpty() ? "Missing JSON" : String.format(Locale.ROOT, "Missing JSON member '%s'", path));
     }
 
     private String toString(Type type) {

--- a/vespajlib/src/main/java/ai/vespa/net/CidrBlock.java
+++ b/vespajlib/src/main/java/ai/vespa/net/CidrBlock.java
@@ -38,7 +38,7 @@ public class CidrBlock {
         this.prefixLength = prefixLength;
         this.addressLength = 8 * address.length;
         if (prefixLength > addressLength) throw new IllegalArgumentException(
-                String.format("Prefix size (%s) cannot be longer than address length (%s)", prefixLength, addressLength));
+                String.format(java.util.Locale.ROOT, "Prefix size (%s) cannot be longer than address length (%s)", prefixLength, addressLength));
 
         this.addressInteger = inetAddressToBigInteger(address);
     }

--- a/vespajlib/src/main/java/ai/vespa/utils/BytesQuantity.java
+++ b/vespajlib/src/main/java/ai/vespa/utils/BytesQuantity.java
@@ -63,7 +63,7 @@ public class BytesQuantity {
         var matcher = PATTERN.matcher(value);
         if (!matcher.matches())
             throw new IllegalArgumentException(
-                    "Bytes quantity '%s' does not match pattern '%s'".formatted(value, PATTERN.pattern()));
+                    String.format(Locale.ROOT, "Bytes quantity '%s' does not match pattern '%s'", value, PATTERN.pattern()));
         var digits = Long.parseLong(matcher.group("digits"));
         var unit = Unit.fromString(matcher.group("unit"));
         return BytesQuantity.of(digits, unit);

--- a/vespajlib/src/main/java/ai/vespa/validation/PathValidator.java
+++ b/vespajlib/src/main/java/ai/vespa/validation/PathValidator.java
@@ -2,6 +2,7 @@
 package ai.vespa.validation;
 
 import java.nio.file.Path;
+import java.util.Locale;
 
 /**
  * Path validations
@@ -18,7 +19,7 @@ public class PathValidator {
      */
     public static void validateChildOf(Path root, Path path) {
         if (!path.normalize().startsWith(root)) {
-            throw new IllegalArgumentException("Invalid path %s".formatted(path));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid path %s", path));
         }
     }
 

--- a/vespajlib/src/main/java/ai/vespa/validation/Validation.java
+++ b/vespajlib/src/main/java/ai/vespa/validation/Validation.java
@@ -4,6 +4,7 @@ package ai.vespa.validation;
 import com.yahoo.yolean.Exceptions;
 
 import java.util.Objects;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -73,7 +74,7 @@ public class Validation {
     public static void requireNonNulls(Object... objs) {
         for (int i = 0; i < objs.length; i++) {
             int effectivelyFinal = i;
-            Objects.requireNonNull(objs[i], () -> "Argument at index %d is null".formatted(effectivelyFinal));
+            Objects.requireNonNull(objs[i], () -> String.format(Locale.ROOT, "Argument at index %d is null", effectivelyFinal));
         }
     }
 

--- a/vespajlib/src/main/java/com/yahoo/config/ini/Ini.java
+++ b/vespajlib/src/main/java/com/yahoo/config/ini/Ini.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Scanner;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -52,13 +53,13 @@ public record Ini(SortedMap<String, SortedMap<String, String>> entries) {
 
     /** Write the text representation of this to given output */
     public void write(OutputStream output) {
-        PrintStream printer = new PrintStream(output, true);
+        PrintStream printer = new PrintStream(output, true, StandardCharsets.UTF_8);
         entries.forEach((section, sectionEntries) -> {
             if (!section.isEmpty()) {
-                printer.printf("[%s]\n", section);
+                printer.printf(Locale.ROOT, "[%s]\n", section);
             }
             sectionEntries.forEach((key, value) -> {
-                printer.printf("%s = %s\n", key, quote(value));
+                printer.printf(Locale.ROOT, "%s = %s\n", key, quote(value));
             });
             if (!section.equals(entries.lastKey())) {
                 printer.println();

--- a/vespajlib/src/main/java/com/yahoo/javacc/UnicodeUtilities.java
+++ b/vespajlib/src/main/java/com/yahoo/javacc/UnicodeUtilities.java
@@ -168,7 +168,7 @@ public class UnicodeUtilities {
             } else if (c == '\\') {
                 token.append("\\\\");
             } else {
-                token.append("\\u").append(String.format("%04x", c & 0xffff));
+                token.append("\\u").append(String.format(java.util.Locale.ROOT, "%04x", c & 0xffff));
             }
             token.append("\"");
         }

--- a/vespajlib/src/main/java/com/yahoo/net/AcceptHeaderMatcher.java
+++ b/vespajlib/src/main/java/com/yahoo/net/AcceptHeaderMatcher.java
@@ -163,7 +163,7 @@ public class AcceptHeaderMatcher {
                     if (isTokenChar(ch)) {
                         yield lexToken();
                     }
-                    throw new IllegalArgumentException("failed to lex next token at index %d".formatted(tokStart));
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "failed to lex next token at index %d", tokStart));
                 }
             };
         }
@@ -336,7 +336,7 @@ public class AcceptHeaderMatcher {
             String type = token();
             expectAndAdvance(TokenType.FWD_SLASH);
             String subtype = token();
-            return new MediaType(type, subtype, "%s/%s".formatted(type, subtype));
+            return new MediaType(type, subtype, String.format(Locale.ROOT, "%s/%s", type, subtype));
         }
 
         /**
@@ -421,7 +421,7 @@ public class AcceptHeaderMatcher {
 
         private Token expectAndAdvance(TokenType expectedType) {
             if (mismatches(expectedType)) {
-                throw new IllegalArgumentException("Expected token of type %s, got %s".formatted(expectedType, lexer.peek().type));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Expected token of type %s, got %s", expectedType, lexer.peek().type));
             }
             return advance();
         }

--- a/vespajlib/src/main/java/com/yahoo/stream/CustomCollectors.java
+++ b/vespajlib/src/main/java/com/yahoo/stream/CustomCollectors.java
@@ -96,7 +96,7 @@ public class CustomCollectors {
         private static final long serialVersionUID = 1L;
 
         DuplicateKeyException(Object key) {
-            super(String.format("Duplicate keys: %s", key));
+            super(String.format(java.util.Locale.ROOT, "Duplicate keys: %s", key));
         }
     }
 }

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static com.yahoo.text.Ascii7BitMatcher.charsAndNumbers;
@@ -74,7 +75,7 @@ public class TensorType {
         }
 
         @Override
-        public String toString() { return name().toLowerCase(); }
+        public String toString() { return name().toLowerCase(Locale.ROOT); }
 
         public static Value fromId(String valueTypeString) {
             for (Value value : values()) {

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/CellOrder.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/CellOrder.java
@@ -26,7 +26,7 @@ public class CellOrder<NAMETYPE extends Name> extends PrimitiveTensorFunction<NA
         MIN;
 
         @Override
-        public String toString() { return name().toLowerCase(); }
+        public String toString() { return name().toLowerCase(java.util.Locale.ROOT); }
     }
 
     private final TensorFunction<NAMETYPE> argument;

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -18,6 +18,7 @@ import com.yahoo.tensor.MappedTensor;
 import com.yahoo.tensor.MixedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
+import java.util.Locale;
 import com.yahoo.tensor.TensorType;
 import java.util.Iterator;
 import java.util.function.Function;
@@ -544,7 +545,7 @@ public class JsonFormat {
     }
 
     public static double decodeNumberString(String input) {
-        String s = input.toLowerCase();
+        String s = input.toLowerCase(Locale.ROOT);
         if (s.equals("infinity") || s.equals("+infinity") || s.equals("inf") || s.equals("+inf")) {
             return Double.POSITIVE_INFINITY;
         }

--- a/vespajlib/src/main/java/com/yahoo/text/Ascii.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Ascii.java
@@ -7,6 +7,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.Locale;
 import java.util.TreeSet;
 
 /**
@@ -81,7 +82,7 @@ public class Ascii {
             default:
                 ByteBuffer buf = charset.encode(CharBuffer.wrap(Character.toChars(c)));
                 while (buf.hasRemaining()) {
-                    out.append(ESCAPE_CHAR).append(String.format("x%02X", buf.get()));
+                    out.append(ESCAPE_CHAR).append(String.format(Locale.ROOT, "x%02X", buf.get()));
                 }
                 break;
             }

--- a/vespajlib/src/main/java/com/yahoo/vespa/VersionTagger.java
+++ b/vespajlib/src/main/java/com/yahoo/vespa/VersionTagger.java
@@ -13,6 +13,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -79,7 +80,7 @@ public class VersionTagger {
         String vtagmapPath = args[0];
         String packageName = args[1];
         String dirName = args[2] + "/" + packageName.replaceAll("\\.", "/");
-        Format format = args.length >= 4 ? Format.valueOf(args[3].toUpperCase()) : Format.SIMPLE;
+        Format format = args.length >= 4 ? Format.valueOf(args[3].toUpperCase(Locale.ROOT)) : Format.SIMPLE;
         File outDir = new File(dirName);
         if (!outDir.isDirectory() && !outDir.mkdirs()) {
             throw new IOException("could not create directory " + outDir);
@@ -90,18 +91,18 @@ public class VersionTagger {
         Path outPath = Path.of(outFile);
         Path tmpPath = Path.of(outFile + ".tmp");
         var out = Files.newOutputStream(tmpPath);
-        OutputStreamWriter writer = new OutputStreamWriter(out);
+        OutputStreamWriter writer = new OutputStreamWriter(out, java.nio.charset.StandardCharsets.UTF_8);
         System.err.println("generating: " + outFile);
 
         Map<String, String> vtagMap = readVtagMap(vtagmapPath);
-        writer.write(String.format("package %s;\n\n", packageName));
+        writer.write(String.format(Locale.ROOT, "package %s;\n\n", packageName));
 
         if (format == Format.VTAG) {
             writer.write("import java.time.Instant;\n");
             writer.write("import com.yahoo.component.Version;\n");
         }
 
-        writer.write(String.format("\npublic class %s {\n", className));
+        writer.write(String.format(Locale.ROOT, "\npublic class %s {\n", className));
         if (!vtagMap.containsKey(V_TAG_PKG)) {
             throw new RuntimeException("V_TAG_PKG not present in map file");
         }
@@ -109,9 +110,9 @@ public class VersionTagger {
             case SIMPLE:
                 String version = vtagMap.get(V_TAG_PKG);
                 String elements[] = version.split("\\.");
-                writer.write(String.format("    public static final int major = %s;\n", elements[0]));
-                writer.write(String.format("    public static final int minor = %s;\n", elements[1]));
-                writer.write(String.format("    public static final int micro = %s;\n", elements[2]));
+                writer.write(String.format(Locale.ROOT, "    public static final int major = %s;\n", elements[0]));
+                writer.write(String.format(Locale.ROOT, "    public static final int minor = %s;\n", elements[1]));
+                writer.write(String.format(Locale.ROOT, "    public static final int micro = %s;\n", elements[2]));
                 break;
             case VTAG:
                 long commitDateSecs = 0;
@@ -119,7 +120,7 @@ public class VersionTagger {
                     var key = entry.getKey();
                     var value = entry.getValue();
                     try {
-                        writer.write(String.format("    public static final String %s = \"%s\";\n", key, value));
+                        writer.write(String.format(Locale.ROOT, "    public static final String %s = \"%s\";\n", key, value));
                         if ("V_TAG_COMMIT_DATE".equals(key)) {
                             commitDateSecs = Long.parseLong(value);
                         }

--- a/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
@@ -84,7 +84,7 @@ public class Exceptions {
         try {
             runnable.run();
         } catch (IOException e) {
-            String message = String.format(format, (Object[]) args);
+            String message = String.format(java.util.Locale.ROOT, format, (Object[]) args);
             throw new UncheckedIOException(message, e);
         }
     }
@@ -141,7 +141,7 @@ public class Exceptions {
         try {
             return supplier.get();
         } catch (IOException e) {
-            String message = String.format(format, (Object[]) args);
+            String message = String.format(java.util.Locale.ROOT, format, (Object[]) args);
             throw new UncheckedIOException(message, e);
         }
     }

--- a/vespajlib/src/test/java/ai/vespa/validation/PathValidatorTest.java
+++ b/vespajlib/src/test/java/ai/vespa/validation/PathValidatorTest.java
@@ -31,6 +31,6 @@ public class PathValidatorTest {
     private void assertInvalid(Path path, Path root) {
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class,
                                                                          () -> PathValidator.validateChildOf(root, path));
-        assertEquals("Invalid path %s".formatted(path), illegalArgumentException.getMessage());
+        assertEquals(String.format(java.util.Locale.ROOT, "Invalid path %s", path), illegalArgumentException.getMessage());
     }
 }

--- a/vespajlib/src/test/java/com/yahoo/compress/CompressorTest.java
+++ b/vespajlib/src/test/java/com/yahoo/compress/CompressorTest.java
@@ -15,7 +15,7 @@ class CompressorTest {
 
     @Test
     void compresses_and_decompresses_input_using_zstd() {
-        byte[] inputData = "The quick brown fox jumps over the lazy dog".getBytes();
+        byte[] inputData = "The quick brown fox jumps over the lazy dog".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         Compressor compressor = new Compressor(CompressionType.ZSTD);
         Compressor.Compression compression = compressor.compress(CompressionType.ZSTD, inputData, Optional.empty());
         assertEquals(inputData.length, compression.uncompressedSize());

--- a/vespajlib/src/test/java/com/yahoo/compress/LZ4CompressorTest.java
+++ b/vespajlib/src/test/java/com/yahoo/compress/LZ4CompressorTest.java
@@ -13,7 +13,7 @@ public class LZ4CompressorTest {
 
     @Test
     public void can_compress_and_decompress_partial_buffer_range() {
-        byte[] toCompress = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes();
+        byte[] toCompress = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         int compressBytes = 30;
         Compressor compressor = new Compressor();
         Compressor.Compression compressed = compressor.compress(CompressionType.LZ4, toCompress, Optional.of(compressBytes));

--- a/vespajlib/src/test/java/com/yahoo/compress/ZstdCompressorTest.java
+++ b/vespajlib/src/test/java/com/yahoo/compress/ZstdCompressorTest.java
@@ -13,7 +13,7 @@ class ZstdCompressorTest {
 
     @Test
     void compresses_and_decompresses_input() {
-        byte[] inputData = "The quick brown fox jumps over the lazy dog".getBytes();
+        byte[] inputData = "The quick brown fox jumps over the lazy dog".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         ZstdCompressor compressor = new ZstdCompressor();
         byte[] compressedData = compressor.compress(inputData, 0, inputData.length);
         byte[] decompressedData = compressor.decompress(compressedData, 0, compressedData.length);
@@ -26,7 +26,7 @@ class ZstdCompressorTest {
         for (int i = 0; i < 100; i++) {
             builder.append("The quick brown fox jumps over the lazy dog").append('\n');
         }
-        byte[] inputData = builder.toString().getBytes();
+        byte[] inputData = builder.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
         ZstdCompressor compressor = new ZstdCompressor();
         byte[] compressedData = compressor.compress(inputData, 0, inputData.length);
         assertTrue(

--- a/vespajlib/src/test/java/com/yahoo/compress/ZstdOutputStreamTest.java
+++ b/vespajlib/src/test/java/com/yahoo/compress/ZstdOutputStreamTest.java
@@ -16,7 +16,7 @@ class ZstdOutputStreamTest {
 
     @Test
     void output_stream_compresses_input() throws IOException {
-        byte[] inputData = "The quick brown fox jumps over the lazy dog".getBytes();
+        byte[] inputData = "The quick brown fox jumps over the lazy dog".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         ByteArrayOutputStream arrayOut = new ByteArrayOutputStream();
         try (ZstdOutputStream zstdOut = new ZstdOutputStream(arrayOut, 12)) {
             zstdOut.write(inputData[0]);
@@ -35,7 +35,7 @@ class ZstdOutputStreamTest {
         for (int i = 0; i < 100; i++) {
             builder.append("The quick brown fox jumps over the lazy dog").append('\n');
         }
-        byte[] inputData = builder.toString().getBytes();
+        byte[] inputData = builder.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
         ByteArrayOutputStream arrayOut = new ByteArrayOutputStream();
         try (ZstdOutputStream zstdOut = new ZstdOutputStream(arrayOut)) {
             zstdOut.write(inputData);

--- a/vespajlib/src/test/java/com/yahoo/net/UrlTokenizerTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/net/UrlTokenizerTestCase.java
@@ -23,7 +23,7 @@ public class UrlTokenizerTestCase {
             if (c == '%') {
                 continue; // escape
             }
-            String img = String.format("a%ca", c);
+            String img = String.format(java.util.Locale.ROOT, "a%ca", c);
             if ((c >= '0' && c <= '9') ||
                 (c >= 'a' && c <= 'z') ||
                 (c >= 'A' && c <= 'Z') ||

--- a/vespajlib/src/test/java/com/yahoo/tensor/MatrixDotProductBenchmark.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/MatrixDotProductBenchmark.java
@@ -82,7 +82,7 @@ public class MatrixDotProductBenchmark {
 
     public static void main(String[] args) {
         double time = new MatrixDotProductBenchmark().benchmark(10000, matrix(10, 55, TensorType.Dimension.Type.mapped), TensorType.Dimension.Type.mapped);
-        System.out.printf("Matrixes, 10*55 size matrixes. Time per sum(join): %1$8.3f ms\n", time);
+        System.out.printf(java.util.Locale.ROOT, "Matrixes, 10*55 size matrixes. Time per sum(join): %1$8.3f ms\n", time);
     }
 
 }

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorDataSourceTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorDataSourceTestCase.java
@@ -202,7 +202,7 @@ public class TensorDataSourceTestCase {
             } else {
                 // All other patterns support all cell types
                 for (TensorType.Value cellType : cellTypes) {
-                    String cellTypeSuffix = "_" + cellType.toString().toLowerCase();
+                    String cellTypeSuffix = "_" + cellType.toString().toLowerCase(java.util.Locale.ROOT);
                     TensorType type = new TensorType(cellType, pattern.dimensions);
                     Tensor sampleTensor = createSampleTensor(type, pattern.dimensions);
 

--- a/vespajlib/src/test/java/com/yahoo/tensor/TensorFunctionBenchmark.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TensorFunctionBenchmark.java
@@ -11,6 +11,7 @@ import com.yahoo.tensor.functions.TensorFunction;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 
@@ -139,76 +140,76 @@ public class TensorFunctionBenchmark {
                 5000, vectorSize, vectors(100, vectorSize, TensorType.Dimension.Type.indexedUnbound, false),
                 TensorType.Dimension.Type.indexedUnbound, false, false
         );
-        System.out.printf("Indexed unbound vectors,                     time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Indexed unbound vectors,                     time per join: %1$8.3f ms\n", time);
         time = new TensorFunctionBenchmark().benchmark(
                 5000, vectorSize, matrix(100, vectorSize, TensorType.Dimension.Type.indexedUnbound, false),
                 TensorType.Dimension.Type.indexedUnbound, false, false
         );
-        System.out.printf("Indexed unbound matrix,                      time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Indexed unbound matrix,                      time per join: %1$8.3f ms\n", time);
 
         // ---------------- Indexed bound:
         time = new TensorFunctionBenchmark().benchmark(
                 5000, vectorSize, vectors(100, vectorSize, TensorType.Dimension.Type.indexedBound, false),
                 TensorType.Dimension.Type.indexedBound, false, false
         );
-        System.out.printf("Indexed bound vectors,                       time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Indexed bound vectors,                       time per join: %1$8.3f ms\n", time);
 
         time = new TensorFunctionBenchmark().benchmark(
                 5000, vectorSize, matrix(100, vectorSize, TensorType.Dimension.Type.indexedBound, false),
                 TensorType.Dimension.Type.indexedBound, false, false
         );
-        System.out.printf("Indexed bound matrix,                        time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Indexed bound matrix,                        time per join: %1$8.3f ms\n", time);
 
         // ---------------- Mapped:
         time = new TensorFunctionBenchmark().benchmark(
                 500, vectorSize, vectors(100, vectorSize, TensorType.Dimension.Type.mapped, false),
                 TensorType.Dimension.Type.mapped, false, false
         );
-        System.out.printf("Mapped vectors,                              time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Mapped vectors,                              time per join: %1$8.3f ms\n", time);
 
         time = new TensorFunctionBenchmark().benchmark(
                 100, vectorSize, matrix(100, vectorSize, TensorType.Dimension.Type.mapped, false),
                 TensorType.Dimension.Type.mapped, false, false
         );
-        System.out.printf("Mapped matrix,                               time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Mapped matrix,                               time per join: %1$8.3f ms\n", time);
 
         // ---------------- Mapped with string labels:
         time = new TensorFunctionBenchmark().benchmark(
                 500, vectorSize, vectors(100, vectorSize, TensorType.Dimension.Type.mapped, true),
                 TensorType.Dimension.Type.mapped, false, true
         );
-        System.out.printf("Mapped vectors with string labels,           time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Mapped vectors with string labels,           time per join: %1$8.3f ms\n", time);
 
         time = new TensorFunctionBenchmark().benchmark(
                 100, vectorSize, matrix(100, vectorSize, TensorType.Dimension.Type.mapped, true),
                 TensorType.Dimension.Type.mapped, false, true
         );
-        System.out.printf("Mapped matrix with string labels,            time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Mapped matrix with string labels,            time per join: %1$8.3f ms\n", time);
 
         // ---------------- Indexed (unbound) with extra space (sidesteps current special-case optimizations):
         time = new TensorFunctionBenchmark().benchmark(
                 50, vectorSize, vectors(100, vectorSize, TensorType.Dimension.Type.indexedUnbound, false),
                 TensorType.Dimension.Type.indexedUnbound, true, false
         );
-        System.out.printf("Indexed vectors, x space                     time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Indexed vectors, x space                     time per join: %1$8.3f ms\n", time);
 
         time = new TensorFunctionBenchmark().benchmark(
                 50, vectorSize, matrix(100, vectorSize, TensorType.Dimension.Type.indexedUnbound, false),
                 TensorType.Dimension.Type.indexedUnbound, true, false
         );
-        System.out.printf("Indexed matrix, x space                      time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Indexed matrix, x space                      time per join: %1$8.3f ms\n", time);
 
         // ---------------- Mapped with extra space (sidesteps current special-case optimizations) with string labels:
         time = new TensorFunctionBenchmark().benchmark(
                 100, vectorSize, vectors(100, vectorSize, TensorType.Dimension.Type.mapped, true),
                 TensorType.Dimension.Type.mapped, true, true
         );
-        System.out.printf("Mapped vectors, x space with string labels   time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Mapped vectors, x space with string labels   time per join: %1$8.3f ms\n", time);
 
         time = new TensorFunctionBenchmark().benchmark(
                 100, vectorSize, matrix(100, vectorSize, TensorType.Dimension.Type.mapped, true),
                 TensorType.Dimension.Type.mapped, true, true
         );
-        System.out.printf("Mapped matrix, x space with string labels    time per join: %1$8.3f ms\n", time);
+        System.out.printf(Locale.ROOT, "Mapped matrix, x space with string labels    time per join: %1$8.3f ms\n", time);
     }
 }

--- a/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
@@ -55,7 +55,7 @@ public class JsonFormatTestCase {
         Tensor decoded = JsonFormat.decode(tensor.type(), json);
         assertEquals(tensor, decoded);
 
-        json = "{}".getBytes(); // short form variant of the above
+        json = "{}".getBytes(java.nio.charset.StandardCharsets.UTF_8); // short form variant of the above
         decoded = JsonFormat.decode(tensor.type(), json);
         assertEquals(tensor, decoded);
     }

--- a/vespajlib/src/test/java/com/yahoo/text/AsciiTest.java
+++ b/vespajlib/src/test/java/com/yahoo/text/AsciiTest.java
@@ -4,6 +4,7 @@ package com.yahoo.text;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -48,21 +49,21 @@ public class AsciiTest {
                 expected = "\\t";
                 break;
             default:
-                expected = String.format("\\x%02X", i);
+                expected = String.format(Locale.ROOT, "\\x%02X", i);
                 break;
             }
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
         for (int i = 0x80; i < 0xC0; ++i) {
-            String expected = String.format("\\xC2\\x%02X", i);
+            String expected = String.format(Locale.ROOT, "\\xC2\\x%02X", i);
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
         for (int i = 0xC0; i < 0x0100; ++i) {
-            String expected = String.format("\\xC3\\x%02X", i - 0x40);
+            String expected = String.format(Locale.ROOT, "\\xC3\\x%02X", i - 0x40);
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
         for (int i = 0x0100; i < 0x0140; ++i) {
-            String expected = String.format("\\xC4\\x%02X", i - 0x80);
+            String expected = String.format(Locale.ROOT, "\\xC4\\x%02X", i - 0x80);
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
     }
@@ -89,15 +90,15 @@ public class AsciiTest {
     @Test
     public void requireThatUtf8SequencesAreUnescaped() {
         for (int i = 0x80; i < 0xC0; ++i) {
-            String str = String.format("\\xC2\\x%02X", i);
+            String str = String.format(Locale.ROOT, "\\xC2\\x%02X", i);
             assertDecodeUtf8(new StringBuilder().appendCodePoint(i).toString(), str);
         }
         for (int i = 0xC0; i < 0x0100; ++i) {
-            String str = String.format("\\xC3\\x%02X", i - 0x40);
+            String str = String.format(Locale.ROOT, "\\xC3\\x%02X", i - 0x40);
             assertDecodeUtf8(new StringBuilder().appendCodePoint(i).toString(), str);
         }
         for (int i = 0x0100; i < 0x0140; ++i) {
-            String str = String.format("\\xC4\\x%02X", i - 0x80);
+            String str = String.format(Locale.ROOT, "\\xC4\\x%02X", i - 0x80);
             assertDecodeUtf8(new StringBuilder().appendCodePoint(i).toString(), str);
         }
     }

--- a/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/text/Utf8TestCase.java
@@ -507,7 +507,7 @@ public class Utf8TestCase {
     @Test
     @Ignore
     public void benchmarkDecoding() {
-        byte[] ascii = "This is just sort of random mix.".getBytes();
+        byte[] ascii = "This is just sort of random mix.".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         byte[] unicode = "This is just sort of random mix. \u5370\u57df\u60c5\u5831\u53EF\u4EE5\u6709x\u00e9\u00e8".getBytes(StandardCharsets.UTF_8);
         int iterations = 100_000; // Use 100_000+ for benchmarking
 
@@ -551,7 +551,7 @@ public class Utf8TestCase {
         String res = null;
         for (int i = 0; i < iterations; i++) {
             // Append counter to avoid String cache
-            byte[] counter = String.valueOf(i).getBytes();
+            byte[] counter = String.valueOf(i).getBytes(java.nio.charset.StandardCharsets.UTF_8);
             byte[] result = new byte[b.length + counter.length];
             System.arraycopy(b, 0, result, 0, b.length);
             System.arraycopy(counter, 0, result, b.length, counter.length);


### PR DESCRIPTION
Make Java code locale-independent and use explicit UTF-8 encoding:
 - Add Locale.ROOT to String.format() calls to ensure consistent formatting
 - Use StandardCharsets.UTF_8 with String.getBytes()
 - Add Locale.ROOT to System.out.printf() calls
 - Add Locale.ROOT to String.toLowerCase() calls
 - Add Locale.ROOT to String.toUpperCase() calls
 - Use StandardCharsets.UTF_8 when contructing a PrintStream
 - Use StandardCharsets.UTF_8 when contructing a OutputStreamWriter

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
