### PR TITLE
Make string operations locale-independent in clustercontroller

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/StateRestApiV2Handler.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/StateRestApiV2Handler.java
@@ -11,6 +11,7 @@ import com.yahoo.vespa.clustercontroller.core.restapiv2.ClusterControllerStateRe
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.server.RestApiHandler;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -63,7 +64,7 @@ public class StateRestApiV2Handler extends JDiscHttpRequestHandler implements Ca
 
     private static Set<String> parseTags(String tags) {
         Set<String> set = new HashSet<>();
-        for(String s : tags.toLowerCase().split(" ")) {
+        for(String s : tags.toLowerCase(Locale.ROOT).split(" ")) {
             set.add(s.trim());
         }
         return set;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
@@ -5,6 +5,7 @@ import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vespa.config.content.StorDistributionConfig;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -319,19 +320,19 @@ public class ClusterStateBundle {
     @Override
     public String toString() {
         String feedBlockedStr = clusterFeedIsBlocked()
-                ? String.format(", feed blocked: '%s'", feedBlock.description)
+                ? String.format(Locale.ROOT, ", feed blocked: '%s'", feedBlock.description)
                 : "";
         String distributionConfigStr = (distributionConfig != null)
-                ? ", distribution config: %s".formatted(distributionConfig.highLevelDescription())
+                ? String.format(Locale.ROOT, ", distribution config: %s", distributionConfig.highLevelDescription())
                 : "";
         if (derivedBucketSpaceStates.isEmpty()) {
-            return String.format("ClusterStateBundle('%s'%s%s%s)", baselineState,
+            return String.format(Locale.ROOT, "ClusterStateBundle('%s'%s%s%s)", baselineState,
                     deferredActivation ? " (deferred activation)" : "",
                     feedBlockedStr, distributionConfigStr);
         }
         Map<String, AnnotatedClusterState> orderedStates = new TreeMap<>(derivedBucketSpaceStates);
-        return String.format("ClusterStateBundle('%s', %s%s%s%s)", baselineState, orderedStates.entrySet().stream()
-                .map(e -> String.format("%s '%s'", e.getKey(), e.getValue()))
+        return String.format(Locale.ROOT, "ClusterStateBundle('%s', %s%s%s%s)", baselineState, orderedStates.entrySet().stream()
+                .map(e -> String.format(Locale.ROOT, "%s '%s'", e.getKey(), e.getValue()))
                 .collect(Collectors.joining(", ")),
                 deferredActivation ? " (deferred activation)" : "",
                 feedBlockedStr, distributionConfigStr);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateHistoryEntry.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateHistoryEntry.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.vdslib.state.ClusterState;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -97,7 +98,7 @@ public class ClusterStateHistoryEntry {
     // String representation only used for test expectation failures and debugging output.
     // Actual status page history entry rendering emits formatted date/time.
     public String toString() {
-        return String.format("state '%s' at time %d", getStateString(BASELINE), time);
+        return String.format(Locale.ROOT, "state '%s' at time %d", getStateString(BASELINE), time);
     }
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeErrorStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeErrorStats.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.clustercontroller.core.hostinfo.ResponseStats;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -154,7 +155,7 @@ public class ContentNodeErrorStats {
 
     @Override
     public String toString() {
-        return String.format("{statsFromDistributors=[%s]}",
+        return String.format(Locale.ROOT, "{statsFromDistributors=[%s]}",
                              Arrays.toString(statsFromDistributors.entrySet().toArray()));
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeStats.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import java.util.Locale;
 import com.yahoo.vespa.clustercontroller.core.hostinfo.StorageNode;
 
 import java.util.Arrays;
@@ -171,7 +172,7 @@ public class ContentNodeStats {
 
     @Override
     public String toString() {
-        return String.format("{index=%d, bucketSpaces=[%s]}",
+        return String.format(Locale.ROOT, "{index=%d, bucketSpaces=[%s]}",
                 nodeIndex, Arrays.toString(bucketSpaces.entrySet().toArray()));
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
@@ -9,6 +9,7 @@ import com.yahoo.vdslib.distribution.Group;
 import com.yahoo.vdslib.distribution.GroupVisitor;
 import com.yahoo.vespa.config.content.StorDistributionConfig;
 
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -68,7 +69,7 @@ public class DistributionConfigBundle {
     public int searchableCopies() { return config.ready_copies(); }
 
     public String highLevelDescription() {
-        return "%d nodes; %d groups; redundancy %d; searchable-copies %d".formatted(
+        return String.format(Locale.ROOT, "%d nodes; %d groups; redundancy %d; searchable-copies %d", 
                 totalNodeCount(), totalLeafGroupCount(), redundancy(), searchableCopies());
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiff.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiff.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -58,7 +59,7 @@ public class DistributionDiff {
 
     private static void addIfDiffers(IntegerDiff diff, String name, List<String> diffs) {
         if (diff.differs()) {
-            diffs.add("%s: %d -> %d".formatted(name, diff.before, diff.after));
+            diffs.add(String.format(Locale.ROOT, "%s: %d -> %d", name, diff.before, diff.after));
         }
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculator.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -65,7 +66,7 @@ public class DistributionDiffCalculator {
             // "invalid" is the fixed index string value of the root group. If the root group contains
             // any nodes at all, there will not be any nested groups by definition, as only leaf groups
             // may contain nodes.
-            String name = "invalid".equals(g.index()) ? "root group" : "group %s".formatted(g.index());
+            String name = "invalid".equals(g.index()) ? "root group" : String.format(Locale.ROOT, "group %s", g.index());
             groups.put(name, new GroupNodes(g.nodes().stream().map(n -> n.index()).collect(Collectors.toSet())));
         }
         return groups;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/EventDiffCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/EventDiffCalculator.java
@@ -11,6 +11,7 @@ import com.yahoo.vdslib.state.State;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -128,7 +129,7 @@ public class EventDiffCalculator {
                 // distributionConfigTo must be non-null
                 events.add(createClusterEvent(
                         "Cluster controller is now the authoritative source for distribution config. " +
-                        "Active config: %s".formatted(params.distributionConfigTo.highLevelDescription()), params));
+                        String.format(Locale.ROOT, "Active config: %s", params.distributionConfigTo.highLevelDescription()), params));
             } else if (params.distributionConfigTo == null) {
                 events.add(createClusterEvent(
                         "Cluster controller is no longer the authoritative source for distribution config", params));
@@ -136,7 +137,7 @@ public class EventDiffCalculator {
                 // Distribution config was present in both old and new; emit a human-readable diff.
                 String configDiff = DistributionDiffCalculator.computeDiff(params.distributionConfigFrom, params.distributionConfigTo).toString();
                 if (!configDiff.isEmpty()) {
-                    events.add(createClusterEvent("Distribution config changed: %s".formatted(configDiff), params));
+                    events.add(createClusterEvent(String.format(Locale.ROOT, "Distribution config changed: %s", configDiff), params));
                 }
             }
         }
@@ -146,7 +147,7 @@ public class EventDiffCalculator {
         // TODO should we emit any events when description changes?
         if (feedBlockStateHasChanged(params)) {
             if (params.feedBlockTo != null) {
-                events.add(createClusterEvent(String.format("Cluster feed blocked due to resource exhaustion: %s",
+                events.add(createClusterEvent(String.format(Locale.ROOT, "Cluster feed blocked due to resource exhaustion: %s",
                         params.feedBlockTo.getDescription()), params));
             } else {
                 events.add(createClusterEvent("Cluster feed no longer blocked", params));
@@ -220,11 +221,11 @@ public class EventDiffCalculator {
 
         for (var ex : setSubtraction(fromBlockSet, toBlockSet)) {
             var info = cluster.getNodeInfo(ex.node);
-            events.add(createNodeEvent(info, String.format("Removed resource exhaustion: %s", ex.toExhaustionRemovedDescription()), params));
+            events.add(createNodeEvent(info, String.format(Locale.ROOT, "Removed resource exhaustion: %s", ex.toExhaustionRemovedDescription()), params));
         }
         for (var ex : setSubtraction(toBlockSet, fromBlockSet)) {
             var info = cluster.getNodeInfo(ex.node);
-            events.add(createNodeEvent(info, String.format("Added resource exhaustion: %s", ex.toExhaustionAddedDescription()), params));
+            events.add(createNodeEvent(info, String.format(Locale.ROOT, "Added resource exhaustion: %s", ex.toExhaustionAddedDescription()), params));
         }
     }
 
@@ -246,10 +247,10 @@ public class EventDiffCalculator {
             } else if (isMayHaveMergesPendingDownEdge(prevReason, currReason)) {
                 events.add(createNodeEvent(info, "Node no longer has merges pending", params));
             } else if (isMaintenanceGracePeriodExceededDownEdge(prevReason, currReason, nodeFrom, nodeTo)) {
-                events.add(createNodeEvent(info, String.format("Exceeded implicit maintenance mode grace period of " +
+                events.add(createNodeEvent(info, String.format(Locale.ROOT, "Exceeded implicit maintenance mode grace period of " +
                         "%d milliseconds. Marking node down.", params.maxMaintenanceGracePeriodTimeMs), params));
             }
-            events.add(createNodeEvent(info, String.format("Altered node state in cluster state from '%s' to '%s'",
+            events.add(createNodeEvent(info, String.format(Locale.ROOT, "Altered node state in cluster state from '%s' to '%s'",
                     nodeFrom.toString(true), nodeTo.toString(true)), params));
         }
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/EventLog.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/EventLog.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
@@ -118,7 +119,7 @@ public class EventLog implements EventLogInterface {
               .append(RealTimer.printDate(currentTime - recentTimePeriod, tz)).append(".</p>\n");
         }
         sb.append("<table border=\"1\" cellspacing=\"0\">\n")
-          .append("<tr><td>Date (").append(tz.getDisplayName(false, TimeZone.SHORT))
+          .append("<tr><td>Date (").append(tz.getDisplayName(false, TimeZone.SHORT, Locale.ROOT))
                 .append(")</td><td>Type</td><td>Node</td><td>Bucket space</td><td>Event</td></tr>\n");
         int nr = 0;
         Iterator<Event> eventIterator = events.descendingIterator();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -317,7 +318,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         var previouslyExhausted = calc.enumerateNodeResourceExhaustions(nodeInfo);
         var nowExhausted        = calc.resourceExhaustionsFromHostInfo(nodeInfo, newHostInfo);
         if (!previouslyExhausted.equals(nowExhausted)) {
-            context.log(logger, Level.FINE, () -> String.format("Triggering state recomputation due to change in cluster feed block: %s -> %s",
+            context.log(logger, Level.FINE, () -> String.format(Locale.ROOT, "Triggering state recomputation due to change in cluster feed block: %s -> %s",
                                             previouslyExhausted, nowExhausted));
             stateChangeHandler.setStateChangedFlag();
         }
@@ -444,7 +445,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         Set<ConfiguredNode> nodes = new HashSet<>(cluster.clusterInfo().getConfiguredNodes().values());
         // TODO wouldn't it be better to always get bundle information from the state broadcaster?
         var currentBundle = stateVersionTracker.getVersionedClusterStateBundle();
-        context.log(logger, Level.FINE, () -> String.format("All distributors have ACKed cluster state version %d", currentBundle.getVersion()));
+        context.log(logger, Level.FINE, () -> String.format(Locale.ROOT, "All distributors have ACKed cluster state version %d", currentBundle.getVersion()));
         stateChangeHandler.handleAllDistributorsInSync(currentBundle.getBaselineClusterState(), nodes, database, dbContext);
         convergedStates.add(currentBundle);
     }
@@ -700,13 +701,13 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         }
 
         final RemoteClusterControllerTask.Context taskContext = createRemoteTaskProcessingContext();
-        context.log(logger, Level.FINEST, () -> String.format("Processing remote task of type '%s'", task.getClass().getName()));
+        context.log(logger, Level.FINEST, () -> String.format(Locale.ROOT, "Processing remote task of type '%s'", task.getClass().getName()));
         task.doRemoteFleetControllerTask(taskContext);
         if (taskMayBeCompletedImmediately(task)) {
-            context.log(logger, Level.FINEST, () -> String.format("Done processing remote task of type '%s'", task.getClass().getName()));
+            context.log(logger, Level.FINEST, () -> String.format(Locale.ROOT, "Done processing remote task of type '%s'", task.getClass().getName()));
             task.notifyCompleted();
         } else {
-            context.log(logger, Level.FINEST, () -> String.format("Remote task of type '%s' queued until state recomputation", task.getClass().getName()));
+            context.log(logger, Level.FINEST, () -> String.format(Locale.ROOT, "Remote task of type '%s' queued until state recomputation", task.getClass().getName()));
             tasksPendingStateRecompute.add(task);
         }
 
@@ -755,7 +756,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
     private static <E> String stringifyListWithLimits(List<E> list, int limit) {
         if (list.size() > limit) {
             var sub = list.subList(0, limit);
-            return String.format("%s (... and %d more)",
+            return String.format(Locale.ROOT, "%s (... and %d more)",
                     sub.stream().map(E::toString).collect(Collectors.joining(", ")),
                     list.size() - limit);
         } else {
@@ -768,7 +769,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         if (nodes.isEmpty()) {
             return "";
         }
-        return String.format("the following nodes have not converged to at least version %d: %s",
+        return String.format(Locale.ROOT, "the following nodes have not converged to at least version %d: %s",
                 taskConvergeVersion, stringifyListWithLimits(nodes, options.maxDivergentNodesPrintedInTaskErrorMessages()));
     }
 
@@ -786,13 +787,13 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
             VersionDependentTaskCompletion taskCompletion = taskCompletionQueue.peek();
             // TODO expose and use monotonic clock instead of system clock
             if (publishedVersion >= taskCompletion.getMinimumVersion()) {
-                context.log(logger, Level.FINE, () -> String.format("Deferred task of type '%s' has minimum version %d, published is %d; completing",
+                context.log(logger, Level.FINE, () -> String.format(Locale.ROOT, "Deferred task of type '%s' has minimum version %d, published is %d; completing",
                                                     taskCompletion.getTask().getClass().getName(), taskCompletion.getMinimumVersion(), publishedVersion));
                 taskCompletion.getTask().notifyCompleted();
                 taskCompletionQueue.remove();
             } else if (taskCompletion.getDeadlineTimePointMs() <= now) {
                 var details = buildNodesNotYetConvergedMessage(taskCompletion.getMinimumVersion());
-                context.log(logger, Level.WARNING, () -> String.format("Deferred task of type '%s' has exceeded wait deadline; completing with failure (details: %s)",
+                context.log(logger, Level.WARNING, () -> String.format(Locale.ROOT, "Deferred task of type '%s' has exceeded wait deadline; completing with failure (details: %s)",
                                                        taskCompletion.getTask().getClass().getName(), details));
                 taskCompletion.getTask().handleFailure(RemoteClusterControllerTask.Failure.of(
                         RemoteClusterControllerTask.FailureCondition.DEADLINE_EXCEEDED, details));
@@ -1029,7 +1030,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
                 database.loadWantedStates(databaseContext);
                 // TODO determine if we need any specialized handling here if feed block is set in the loaded bundle
 
-                context.log(logger, Level.INFO, () -> String.format("Loaded previous cluster state bundle from ZooKeeper: %s", previousBundle));
+                context.log(logger, Level.INFO, () -> String.format(Locale.ROOT, "Loaded previous cluster state bundle from ZooKeeper: %s", previousBundle));
                 stateVersionTracker.setClusterStateBundleRetrievedFromZooKeeper(previousBundle);
 
                 eventLog.add(new ClusterEvent(ClusterEvent.Type.MASTER_ELECTION, "This node just became fleetcontroller master. Bumped version to "

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerContext.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerContext.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import java.util.Locale;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,7 +23,7 @@ public interface FleetControllerContext {
             var args = new Object[1 + rest.length];
             args[0] = first;
             System.arraycopy(rest, 0, args, 1, rest.length);
-            return String.format(format, args);
+            return String.format(Locale.ROOT, format, args);
         });
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -12,6 +12,7 @@ import com.yahoo.vespa.clustercontroller.utils.util.MetricReporter;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -53,7 +54,7 @@ public class MetricUpdater {
     private Duration stateVersionConvergenceGracePeriod = Duration.ofSeconds(30);
 
     public MetricUpdater(MetricReporter metricReporter, Timer timer, int controllerIndex, String clusterName) {
-        this.metricReporter = new ComponentMetricReporter(metricReporter, "%s.".formatted(CLUSTER_CONTROLLER));
+        this.metricReporter = new ComponentMetricReporter(metricReporter, String.format(Locale.ROOT, "%s.", CLUSTER_CONTROLLER));
         this.metricReporter.addDimension(CONTROLLER_INDEX, String.valueOf(controllerIndex));
         this.metricReporter.addDimension(CLUSTER, clusterName);
         this.metricReporter.addDimension(CLUSTER_ID, clusterName);
@@ -88,7 +89,7 @@ public class MetricUpdater {
         int effectiveStateVersion = (state.getVersion() > 0) ? state.getVersion() : -1;
         boolean convergenceDeadlinePassed = lastStateBroadcastTimePoint.plus(stateVersionConvergenceGracePeriod).isBefore(now);
         for (NodeType type : NodeType.getTypes()) {
-            dimensions.put(NODE_TYPE, type.toString().toLowerCase());
+            dimensions.put(NODE_TYPE, type.toString().toLowerCase(Locale.ROOT));
             MetricReporter.Context context = createContext(dimensions);
             Map<State, Integer> nodeCounts = new HashMap<>();
             for (State s : State.values()) {
@@ -108,7 +109,7 @@ public class MetricUpdater {
                 }
             }
             for (State s : State.values()) {
-                String name = s.toString().toLowerCase() + ".count";
+                String name = s.toString().toLowerCase(Locale.ROOT) + ".count";
                 metricReporter.set(name, nodeCounts.get(s), context);
             }
 
@@ -155,10 +156,10 @@ public class MetricUpdater {
 
     private void resetNodeStateAndResourceUsageMetricsToZero() {
         for (NodeType type : NodeType.getTypes()) {
-            Map<String, String> dimensions = Map.of(NODE_TYPE, type.toString().toLowerCase());
+            Map<String, String> dimensions = Map.of(NODE_TYPE, type.toString().toLowerCase(Locale.ROOT));
             MetricReporter.Context context = createContext(dimensions);
             for (State s : State.values()) {
-                String name = s.toString().toLowerCase() + ".count";
+                String name = s.toString().toLowerCase(Locale.ROOT) + ".count";
                 metricReporter.set(name, 0, context);
             }
             metricReporter.set(NODES_NOT_CONVERGED, 0, context);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -446,7 +447,7 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
                 && (wentDownAtClusterState == null || wentDownAtClusterState.getVersion() < stateBundle.getVersion())
                 && !stateBundle.getBaselineClusterState().getNodeState(node).getState().oneOf("dsm"))
             {
-                log.log(Level.FINE, () -> String.format("Clearing going down timestamp of node %s after " +
+                log.log(Level.FINE, () -> String.format(Locale.ROOT, "Clearing going down timestamp of node %s after " +
                         "receiving ack of cluster state bundle %s", node, stateBundle));
                 wentDownWithStartTime = 0;
             }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -134,7 +135,7 @@ public class NodeStateChangeChecker {
             return Optional.empty();
         }
         if (metrics.docs.isEmpty() || metrics.docs.get().getLast() == null) {
-            log.log(Level.WARNING, "Host info inconsistency: storage node %d reports entry count but not document count".formatted(nodeIndex));
+            log.log(Level.WARNING, String.format(Locale.ROOT, "Host info inconsistency: storage node %d reports entry count but not document count", nodeIndex));
             return Optional.of(disallow("The storage node host info reports stored entry count, but not document count"));
         }
         long lastEntries = metrics.entries.get().getLast();
@@ -142,20 +143,20 @@ public class NodeStateChangeChecker {
         if (lastEntries != 0) {
             long buckets    = metrics.buckets.map(Metrics.Value::getLast).orElse(-1L);
             long tombstones = lastEntries - lastDocs; // docs are a subset of entries, so |docs| <= |entries|
-            return Optional.of(disallow("The storage node stores %d documents and %d tombstones across %d buckets".formatted(lastDocs, tombstones, buckets)));
+            return Optional.of(disallow(String.format(Locale.ROOT, "The storage node stores %d documents and %d tombstones across %d buckets", lastDocs, tombstones, buckets)));
         }
         // At this point we believe we have zero entries. Cross-check with visible doc count; it should
         // always be present when an entry count of zero is present and transitively always be zero.
         if (lastDocs != 0) {
-            log.log(Level.WARNING, "Host info inconsistency: storage node %d reports 0 entries, but %d documents".formatted(nodeIndex, lastDocs));
-            return Optional.of(disallow("The storage node reports 0 entries, but %d documents".formatted(lastDocs)));
+            log.log(Level.WARNING, String.format(Locale.ROOT, "Host info inconsistency: storage node %d reports 0 entries, but %d documents", nodeIndex, lastDocs));
+            return Optional.of(disallow(String.format(Locale.ROOT, "The storage node reports 0 entries, but %d documents", lastDocs)));
         }
         return Optional.of(allow());
     }
 
     private static Result checkLegacyZeroBucketsStoredOnContentNode(long lastBuckets) {
         if (lastBuckets != 0) {
-            return disallow("The storage node manages %d buckets".formatted(lastBuckets));
+            return disallow(String.format(Locale.ROOT, "The storage node manages %d buckets", lastBuckets));
         }
         return allow();
     }
@@ -342,7 +343,7 @@ public class NodeStateChangeChecker {
             return Optional.of(allow());
         }
 
-        return Optional.of(disallow(String.format("At most %d groups can have wanted state: %s",
+        return Optional.of(disallow(String.format(Locale.ROOT, "At most %d groups can have wanted state: %s",
                                                   maxNumberOfGroupsAllowedToBeDown,
                                                   sortSetIntoList(retiredAndNotUpGroups))));
     }
@@ -402,13 +403,13 @@ public class NodeStateChangeChecker {
             var storageNodeInfo = clusterInfo.getStorageNodeInfo(index);
             State storageNodeWantedState = storageNodeInfo.getUserWantedState().getState();
             if (storageNodeWantedState != UP) {
-                return disallow(message.formatted(storageNodeInfo.type(), index, storageNodeWantedState));
+                return disallow(String.format(Locale.ROOT, message, storageNodeInfo.type(), index, storageNodeWantedState));
             }
 
             var distributorNodeInfo = clusterInfo.getDistributorNodeInfo(index);
             State distributorWantedState = distributorNodeInfo.getUserWantedState().getState();
             if (distributorWantedState != UP) {
-                return disallow(message.formatted(distributorNodeInfo.type(), index, distributorWantedState));
+                return disallow(String.format(Locale.ROOT, message, distributorNodeInfo.type(), index, distributorWantedState));
             }
         }
 
@@ -477,12 +478,12 @@ public class NodeStateChangeChecker {
             State wantedState = nodeInfo.getUserWantedState().getState();
             if (wantedState != UP && wantedState != RETIRED)
                 return disallow("Another " + nodeInfo.type() + " wants state " +
-                                wantedState.toString().toUpperCase() + ": " + nodeInfo.getNodeIndex());
+                                wantedState.toString().toUpperCase(Locale.ROOT) + ": " + nodeInfo.getNodeIndex());
 
             State state = clusterState.getNodeState(nodeInfo.getNode()).getState();
             if (state != UP && state != RETIRED)
                 return disallow("Another " + nodeInfo.type() + " has state " +
-                                state.toString().toUpperCase() + ": " + nodeInfo.getNodeIndex());
+                                state.toString().toUpperCase(Locale.ROOT) + ": " + nodeInfo.getNodeIndex());
         }
 
         return allow();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RealTimer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RealTimer.java
@@ -37,7 +37,7 @@ public class RealTimer implements Timer {
     }
 
     public static String printDateNoMilliSeconds(long time, TimeZone tz) {
-        Calendar cal = Calendar.getInstance(tz);
+        Calendar cal = Calendar.getInstance(tz, Locale.ROOT);
         cal.setTimeInMillis(time);
         return String.format(Locale.ENGLISH, "%04d-%02d-%02d %02d:%02d:%02d",
                 cal.get(Calendar.YEAR),
@@ -49,7 +49,7 @@ public class RealTimer implements Timer {
     }
 
     public static String printDate(long time, TimeZone tz) {
-        Calendar cal = Calendar.getInstance(tz);
+        Calendar cal = Calendar.getInstance(tz, Locale.ROOT);
         cal.setTimeInMillis(time);
         return String.format(Locale.ENGLISH, "%04d-%02d-%02d %02d:%02d:%02d.%03d",
                              cal.get(Calendar.YEAR),

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.clustercontroller.core.hostinfo.HostInfo;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -79,7 +80,7 @@ public class ResourceExhaustionCalculator {
 
     public static String decoratedMessage(ContentCluster cluster, String msg) {
         // Disambiguate content cluster and add a user-friendly documentation link to the error message
-        return "in content cluster '%s': %s. See https://docs.vespa.ai/en/writing/feed-block.html".formatted(cluster.getName(), msg);
+        return String.format(Locale.ROOT, "in content cluster '%s': %s. See https://docs.vespa.ai/en/writing/feed-block.html", cluster.getName(), msg);
     }
 
     public ClusterStateBundle.FeedBlock inferContentClusterFeedBlockOrNull(ContentCluster cluster) {
@@ -97,7 +98,7 @@ public class ResourceExhaustionCalculator {
                 .map(NodeResourceExhaustion::toExhaustionAddedDescription)
                 .collect(Collectors.joining(", "));
         if (exhaustions.size() > maxDescriptions) {
-            description += String.format(" (... and %d more)", exhaustions.size() - maxDescriptions);
+            description += String.format(Locale.ROOT, " (... and %d more)", exhaustions.size() - maxDescriptions);
         }
         description = decoratedMessage(cluster, description);
         // FIXME we currently will trigger a cluster state recomputation even if the number of

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/StateChangeHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/StateChangeHandler.java
@@ -10,6 +10,7 @@ import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
 import com.yahoo.vespa.clustercontroller.core.listeners.NodeListener;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -68,7 +69,7 @@ public class StateChangeHandler {
                 final NodeState nodeState = currentState.getNodeState(node);
                 if (nodeInfo != null && nodeState != null) {
                     if (nodeState.getStartTimestamp() > nodeInfo.getStartTimestamp()) {
-                        log.log(FINE, () -> String.format("Storing away new start timestamp for node %s (%d)", node, nodeState.getStartTimestamp()));
+                        log.log(FINE, () -> String.format(Locale.ROOT, "Storing away new start timestamp for node %s (%d)", node, nodeState.getStartTimestamp()));
                         nodeInfo.setStartTimestamp(nodeState.getStartTimestamp());
                     }
                     if (nodeState.getStartTimestamp() > 0) {
@@ -122,7 +123,7 @@ public class StateChangeHandler {
                                            NodeListener nodeListener) {
         NodeState currentState = currentClusterState.getNodeState(node.getNode());
         Level level = (currentState.equals(reportedState) && node.getVersion() == 0) ? FINEST : FINE;
-        log.log(level, () -> String.format("Got nodestate reply from %s: %s (Current state is %s)",
+        log.log(level, () -> String.format(Locale.ROOT, "Got nodestate reply from %s: %s (Current state is %s)",
                                            node, node.getReportedState().getTextualDifference(reportedState), currentState.toString(true)));
         long currentTime = timer.getCurrentTimeInMillis();
 
@@ -149,11 +150,11 @@ public class StateChangeHandler {
             int oldCount = currentState.getMinUsedBits();
             int newCount = reportedState.getMinUsedBits();
             log.log(FINE,
-                    () -> String.format("Altering node state to reflect that min distribution bit count has changed from %d to %d", oldCount, newCount));
-            eventLog.add(NodeEvent.forBaseline(node, String.format("Altered min distribution bit count from %d to %d", oldCount, newCount),
+                    () -> String.format(Locale.ROOT, "Altering node state to reflect that min distribution bit count has changed from %d to %d", oldCount, newCount));
+            eventLog.add(NodeEvent.forBaseline(node, String.format(Locale.ROOT, "Altered min distribution bit count from %d to %d", oldCount, newCount),
                          NodeEvent.Type.CURRENT, currentTime), isMaster);
         } else {
-            log.log(FINE, () -> String.format("Not altering state of %s in cluster state because new state is too similar: %s",
+            log.log(FINE, () -> String.format(Locale.ROOT, "Not altering state of %s in cluster state because new state is too similar: %s",
                                               node, currentState.getTextualDifference(reportedState)));
         }
 
@@ -201,19 +202,19 @@ public class StateChangeHandler {
 
         stateMayHaveChanged = true;
 
-        log.log(FINE, () -> String.format("Got new wanted nodestate for %s: %s", node, currentState.getTextualDifference(proposedState)));
+        log.log(FINE, () -> String.format(Locale.ROOT, "Got new wanted nodestate for %s: %s", node, currentState.getTextualDifference(proposedState)));
         // Should be checked earlier before state was set in cluster
         assert(proposedState.getState().validWantedNodeState(node.getNode().getType()));
         long timeNow = timer.getCurrentTimeInMillis();
         NodeState currentReported = node.getReportedState();
         if (proposedState.above(currentReported)) {
-            eventLog.add(NodeEvent.forBaseline(node, String.format("Wanted state %s, but we cannot force node into that " +
+            eventLog.add(NodeEvent.forBaseline(node, String.format(Locale.ROOT, "Wanted state %s, but we cannot force node into that " +
                     "state yet as it is currently in %s", proposedState, currentReported),
                     NodeEvent.Type.REPORTED, timeNow), isMaster);
             return;
         }
         if ( ! proposedState.similarTo(currentState)) {
-            eventLog.add(NodeEvent.forBaseline(node, String.format("Node state set to %s.", proposedState),
+            eventLog.add(NodeEvent.forBaseline(node, String.format(Locale.ROOT, "Node state set to %s.", proposedState),
                     NodeEvent.Type.WANTED, timeNow), isMaster);
         }
     }
@@ -268,8 +269,7 @@ public class StateChangeHandler {
             triggeredAnyTimers = true;
 
         if (nodeInitProgressHasTimedOut(currentTime, node, currentStateInSystem, lastReportedState)) {
-            eventLog.add(NodeEvent.forBaseline(node, String.format(
-                        "%d milliseconds without initialize progress. Marking node down. " +
+            eventLog.add(NodeEvent.forBaseline(node, String.format(Locale.ROOT, "%d milliseconds without initialize progress. Marking node down. " +
                         "Premature crash count is now %d.",
                         currentTime - node.getInitProgressTime(),
                         node.getPrematureCrashCount() + 1),
@@ -337,8 +337,7 @@ public class StateChangeHandler {
             && !lastReportedState.getState().equals(DOWN)
             && node.lastSeenInSlobrok() + maxSlobrokDisconnectGracePeriod <= currentTime)
         {
-            final String desc = String.format(
-                    "Set node down as it has been missing for %d ms which " +
+            final String desc = String.format(Locale.ROOT, "Set node down as it has been missing for %d ms which " +
                     "is more than the max limit of %d ms.",
                     currentTime - node.lastSeenInSlobrok(),
                     maxSlobrokDisconnectGracePeriod);
@@ -377,7 +376,7 @@ public class StateChangeHandler {
                                                  final NodeState reportedState,
                                                  final NodeListener nodeListener) {
         final long timeNow = timer.getCurrentTimeInMillis();
-        log.log(FINE, () -> String.format("Finding new cluster state entry for %s switching state %s", node, currentState.getTextualDifference(reportedState)));
+        log.log(FINE, () -> String.format(Locale.ROOT, "Finding new cluster state entry for %s switching state %s", node, currentState.getTextualDifference(reportedState)));
 
         if (handleReportedNodeCrashEdge(node, currentState, reportedState, nodeListener, timeNow)) {
             return;
@@ -402,7 +401,7 @@ public class StateChangeHandler {
                 && reportedState.getState().oneOf("ds")
                 && isNotControlledShutdown(reportedState))
         {
-            eventLog.add(NodeEvent.forBaseline(node, String.format("Stop or crash during initialization. " +
+            eventLog.add(NodeEvent.forBaseline(node, String.format(Locale.ROOT, "Stop or crash during initialization. " +
                     "Premature crash count is now %d.", node.getPrematureCrashCount() + 1),
                     NodeEvent.Type.CURRENT, timeNow), isMaster);
             handlePrematureCrash(node, nodeListener);
@@ -420,8 +419,7 @@ public class StateChangeHandler {
         if (currentState.getState().equals(INITIALIZING) &&
             (reportedState.getState().equals(INITIALIZING) && reportedState.getInitProgress() < currentState.getInitProgress()))
         {
-            eventLog.add(NodeEvent.forBaseline(node, String.format(
-                        "Stop or crash during initialization detected from reverse initializing progress." +
+            eventLog.add(NodeEvent.forBaseline(node, String.format(Locale.ROOT, "Stop or crash during initialization detected from reverse initializing progress." +
                         " Progress was %g but is now %g. Premature crash count is now %d.",
                         currentState.getInitProgress(), reportedState.getInitProgress(),
                         node.getPrematureCrashCount() + 1),
@@ -441,7 +439,7 @@ public class StateChangeHandler {
             if (node.getUpStableStateTime() + stableStateTimePeriod > timeNow && isNotControlledShutdown(reportedState)) {
                 log.log(FINE, () -> "Stable state: " + node.getUpStableStateTime() + " + " + stableStateTimePeriod + " > " + timeNow);
                 eventLog.add(NodeEvent.forBaseline(node,
-                        String.format("Stopped or possibly crashed after %d ms, which is before " +
+                        String.format(Locale.ROOT, "Stopped or possibly crashed after %d ms, which is before " +
                                       "stable state time period. Premature crash count is now %d.",
                                 timeNow - node.getUpStableStateTime(), node.getPrematureCrashCount() + 1),
                         NodeEvent.Type.CURRENT,

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.logging.Level;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Logger;
@@ -106,13 +107,13 @@ public class SystemStateBroadcaster {
                 if (reply.getReturnCode() != ErrorCode.NO_SUCH_METHOD) {
                     context.log(log,
                                 Level.FINE,
-                                () -> String.format("Activation NACK for node %s with version %d, message %s",
+                                () -> String.format(Locale.ROOT, "Activation NACK for node %s with version %d, message %s",
                                                     info, version, reply.getReturnMessage()));
                     success = false;
                 } else {
                     context.log(log,
                                 Level.FINE,
-                                () -> String.format("Node %s did not understand state activation RPC; " +
+                                () -> String.format(Locale.ROOT, "Node %s did not understand state activation RPC; " +
                                                     "implicitly treating state %d as activated on node",
                                                     info, version));
                 }
@@ -121,14 +122,14 @@ public class SystemStateBroadcaster {
                 // Avoid spamming the logs since this will happen on all resends until (presumably) the controller
                 // loses election status.
                 // TODO this should trigger a loss of current controller's leadership!
-                reportNodeError(nodeOk, info, String.format("Activation of version %d did not take effect, node %s " +
+                reportNodeError(nodeOk, info, String.format(Locale.ROOT, "Activation of version %d did not take effect, node %s " +
                                 "reports it has an actual pending version of %d. Racing with another controller?",
                                 version, info, reply.getActualVersion()));
                 success = false;
             } else {
                 context.log(log,
                             Level.FINE,
-                            () -> String.format("Node %s reports successful activation of state version %d",
+                            () -> String.format(Locale.ROOT, "Node %s reports successful activation of state version %d",
                                                 info, version));
             }
             info.setSystemStateVersionActivationAcked(version, success);
@@ -153,13 +154,13 @@ public class SystemStateBroadcaster {
                     if (info.getNewestSystemStateVersionSent() == version) {
                         boolean nodeOk = nodeReportsSelfAsAvailable(info);
                         reportNodeError(nodeOk, info,
-                                String.format("Got error response %d: %s from %s setdistributionstates request.",
+                                String.format(Locale.ROOT, "Got error response %d: %s from %s setdistributionstates request.",
                                         req.getReply().getReturnCode(), req.getReply().getReturnMessage(), info));
                     }
                 }
             } else {
                 info.setClusterStateBundleVersionAcknowledged(version, true);
-                context.log(log, Level.FINE, () -> String.format("Node %s ACKed system state version %d.", info, version));
+                context.log(log, Level.FINE, () -> String.format(Locale.ROOT, "Node %s ACKed system state version %d.", info, version));
                 lastErrorReported.remove(info.getNode());
             }
         }
@@ -237,7 +238,7 @@ public class SystemStateBroadcaster {
             if (clusterStateBundle.deferredActivation()) {
                 context.log(log,
                             Level.FINE,
-                            () -> String.format("All distributors have ACKed cluster state " +
+                            () -> String.format(Locale.ROOT, "All distributors have ACKed cluster state " +
                                                 "version %d, sending activation", currentStateVersion));
             } else {
                 markCurrentClusterStateAsConverged(database, dbContext, fleetController);
@@ -258,7 +259,7 @@ public class SystemStateBroadcaster {
         } else {
             context.log(log,
                         Level.FINE,
-                        () -> String.format("distributors still need activation in state %d (last converged: %d)",
+                        () -> String.format(Locale.ROOT, "distributors still need activation in state %d (last converged: %d)",
                                             currentStateVersion, lastClusterStateVersionConverged));
         }
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.clustercontroller.core.listeners.NodeListener;
 import org.apache.zookeeper.KeeperException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -257,7 +258,7 @@ public class DatabaseHandler {
                 didWork |= performZooKeeperWrites();
             }
         } catch (CasWriteFailed e) {
-            fleetControllerContext.log(logger, Level.WARNING, String.format("CaS write to ZooKeeper failed, another controller " +
+            fleetControllerContext.log(logger, Level.WARNING, String.format(Locale.ROOT, "CaS write to ZooKeeper failed, another controller " +
                                                                             "has likely taken over ownership: %s", e.getMessage()));
             // Clear DB and master election state. This shall trigger a full re-fetch of all
             // version and election-related metadata.

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
@@ -11,6 +11,7 @@ import org.apache.zookeeper.data.Stat;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Logger;
@@ -124,7 +125,7 @@ public final class MasterDataGatherer {
                     } else {
                         // May happen when pending data watch error callbacks are triggered concurrently with
                         // internal voting state having already been cleared due to connectivity issues.
-                        log.log(Level.INFO, String.format("Fleetcontroller %d: ignoring removal of vote from node %d " +
+                        log.log(Level.INFO, String.format(Locale.ROOT, "Fleetcontroller %d: ignoring removal of vote from node %d " +
                                 "since it was not present in existing vote mapping", nodeIndex, index));
                     }
                 } else {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
@@ -205,7 +206,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (KeeperException.BadVersionException e) {
-            throw new CasWriteFailed(String.format("version mismatch in cluster state version znode (expected %d): %s",
+            throw new CasWriteFailed(String.format(Locale.ROOT, "version mismatch in cluster state version znode (expected %d): %s",
                     lastKnownStateVersionZNodeVersion, e.getMessage()), e);
         } catch (Exception e) {
             maybeLogExceptionWarning(e, "Failed to store latest system state version used " + version);
@@ -350,14 +351,14 @@ public class ZooKeeperDatabase extends Database {
         try{
             context.log(log,
                         Level.FINE,
-                        () -> String.format("Storing published state bundle %s at '%s' with expected znode version %d",
+                        () -> String.format(Locale.ROOT, "Storing published state bundle %s at '%s' with expected znode version %d",
                                             stateBundle, paths.publishedStateBundle(), lastKnownStateBundleZNodeVersion));
             var stat = session.setData(paths.publishedStateBundle(), encodedBundle, lastKnownStateBundleZNodeVersion);
             lastKnownStateBundleZNodeVersion = stat.getVersion();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (KeeperException.BadVersionException e) {
-            throw new CasWriteFailed(String.format("version mismatch in cluster state bundle znode (expected %d): %s",
+            throw new CasWriteFailed(String.format(Locale.ROOT, "version mismatch in cluster state bundle znode (expected %d): %s",
                     lastKnownStateBundleZNodeVersion, e.getMessage()), e);
         } catch (Exception e) {
             maybeLogExceptionWarning(e, "Failed to store last published cluster state bundle in ZooKeeper");

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Request.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Request.java
@@ -7,6 +7,8 @@ import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.InternalFailu
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.StateRestApiException;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.UnknownMasterException;
 
+import java.util.Locale;
+
 public abstract class Request<Result> extends RemoteClusterControllerTask {
 
     public enum MasterState {
@@ -63,7 +65,7 @@ public abstract class Request<Result> extends RemoteClusterControllerTask {
 
     private static String failureStringWithPossibleMessage(String prefix, String message) {
         if (message != null && !message.isEmpty()) {
-            return String.format("%s: %s", prefix, message);
+            return String.format(Locale.ROOT, "%s: %s", prefix, message);
         }
         return prefix;
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
@@ -20,6 +20,7 @@ import com.yahoo.vespa.clustercontroller.utils.staterestapi.requests.SetUnitStat
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.response.SetResponse;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.response.UnitState;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -71,7 +72,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
     static NodeState getRequestedNodeState(Map<String, UnitState> newStates, Node n) throws StateRestApiException {
         UnitState newState = newStates.get("user");
         if (newState == null) throw new InvalidContentException("No new user state given in request");
-        State state = switch (newState.id().toLowerCase()) {
+        State state = switch (newState.id().toLowerCase(Locale.ROOT)) {
             case "up" -> State.UP;
             case "retired" -> State.RETIRED;
             case "maintenance" -> State.MAINTENANCE;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/RPCCommunicator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/RPCCommunicator.java
@@ -24,6 +24,7 @@ import com.yahoo.vespa.clustercontroller.core.SetClusterStateRequest;
 import com.yahoo.vespa.clustercontroller.core.Timer;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -113,7 +114,7 @@ public class RPCCommunicator implements Communicator {
     public void getNodeState(NodeInfo node, Waiter<GetNodeStateRequest> externalWaiter) {
         Target connection = getConnection(node);
         if ( ! connection.isValid()) {
-            log.log(Level.FINE, () -> String.format("Connection to '%s' could not be created.", node.getRpcAddress()));
+            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Connection to '%s' could not be created.", node.getRpcAddress()));
         }
         NodeState currentState = node.getReportedState();
         Request req = new Request("getnodestate3");
@@ -140,7 +141,7 @@ public class RPCCommunicator implements Communicator {
 
         Target connection = getConnection(node);
         if ( ! connection.isValid()) {
-            log.log(Level.FINE, () -> String.format("Connection to '%s' could not be created.", node.getRpcAddress()));
+            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Connection to '%s' could not be created.", node.getRpcAddress()));
             return;
         }
         Request req = new Request(SET_DISTRIBUTION_STATES_RPC_METHOD_NAME);
@@ -151,7 +152,7 @@ public class RPCCommunicator implements Communicator {
         v.add(new Int32Value(encodedBundle.getCompression().uncompressedSize()));
         v.add(new DataValue(encodedBundle.getCompression().data()));
 
-        log.log(Level.FINE, () -> String.format("Sending '%s' RPC to %s for state version %d",
+        log.log(Level.FINE, () -> String.format(Locale.ROOT, "Sending '%s' RPC to %s for state version %d",
                 req.methodName(), node.getRpcAddress(), stateBundle.getVersion()));
         RPCSetClusterStateRequest stateRequest = new RPCSetClusterStateRequest(node, req, baselineState.getVersion());
         waiter.setRequest(stateRequest);
@@ -166,14 +167,14 @@ public class RPCCommunicator implements Communicator {
 
         Target connection = getConnection(node);
         if ( ! connection.isValid()) {
-            log.log(Level.FINE, () -> String.format("Connection to '%s' could not be created.", node.getRpcAddress()));
+            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Connection to '%s' could not be created.", node.getRpcAddress()));
             return;
         }
 
         var req = new Request(ACTIVATE_CLUSTER_STATE_VERSION_RPC_METHOD_NAME);
         req.parameters().add(new Int32Value(clusterStateVersion));
 
-        log.log(Level.FINE, () -> String.format("Sending '%s' RPC to %s for state version %d",
+        log.log(Level.FINE, () -> String.format(Locale.ROOT, "Sending '%s' RPC to %s for state version %d",
                 req.methodName(), node.getRpcAddress(), clusterStateVersion));
         var activationRequest = new RPCActivateClusterStateVersionRequest(node, req, clusterStateVersion);
         waiter.setRequest(activationRequest);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/LegacyIndexPageRequestHandler.java
@@ -117,7 +117,7 @@ public class LegacyIndexPageRequestHandler implements StatusPageServer.RequestHa
             TimeZone tz = TimeZone.getTimeZone("UTC");
             sb.append("<h3 id=\"clusterstatehistory\">Cluster state history</h3>\n");
             sb.append("<table border=\"1\" cellspacing=\"0\"><tr>\n")
-              .append("  <th>Creation date (").append(tz.getDisplayName(false, TimeZone.SHORT)).append(")</th>\n")
+              .append("  <th>Creation date (").append(tz.getDisplayName(false, TimeZone.SHORT, Locale.ROOT)).append(")</th>\n")
               .append("  <th>Bucket space</th>\n")
               .append("  <th>Cluster state</th>\n")
               .append("</tr>\n");

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/HtmlTable.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/HtmlTable.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core.status.statuspage;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * Helper class in order to write HTML tables
@@ -142,7 +143,7 @@ public class HtmlTable {
                     sb.append(" bgcolor=\"#").append(getColor(properties.backgroundColor)).append('"');
                 }
                 if (properties.contentAlignment != null) {
-                    sb.append(" align=\"").append(properties.contentAlignment.name().toLowerCase()).append('"');
+                    sb.append(" align=\"").append(properties.contentAlignment.name().toLowerCase(Locale.ROOT)).append('"');
                 }
                 if (properties.colSpan != null) {
                     int colSpan = properties.colSpan;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/StatusPageResponse.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/StatusPageResponse.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.status.statuspage;
 
+import java.nio.charset.StandardCharsets;
 import com.google.common.html.HtmlEscapers;
 
 import java.io.BufferedWriter;
@@ -42,7 +43,7 @@ public class StatusPageResponse {
     public ByteArrayOutputStream getOutputStream() { return output; }
 
     public BufferedWriter createBufferedWriter() {
-        return new BufferedWriter(new OutputStreamWriter(output));
+        return new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
     }
 
     public void writeContent(String content) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
@@ -459,7 +460,7 @@ public class VdsClusterHtmlRenderer {
                 }
             } else {
                 row.addCell(new HtmlTable.Cell("Cluster " +
-                        state.getClusterState().name().toLowerCase()).addProperties(ERROR_PROPERTY));
+                        state.getClusterState().name().toLowerCase(Locale.ROOT)).addProperties(ERROR_PROPERTY));
             }
         }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
@@ -12,6 +12,7 @@ import com.yahoo.vespa.clustercontroller.core.listeners.NodeListener;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
@@ -136,7 +137,7 @@ public class ClusterFixture {
 
     public ClusterFixture assignDummyRpcAddresses() {
         cluster.getNodeInfos().forEach(ni -> {
-            ni.setRpcAddress(String.format("tcp/%s.%d.local:0",
+            ni.setRpcAddress(String.format(Locale.ROOT, "tcp/%s.%d.local:0",
                     ni.isStorage() ? "storage" : "distributor",
                     ni.getNodeIndex()));
         });

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DummyVdsNode.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DummyVdsNode.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -431,7 +432,7 @@ public class DummyVdsNode {
                     activatedClusterStateVersion = activateVersion;
                     timer.notifyAll();
                 } else {
-                    log.log(Level.FINE, () -> String.format("Dummy node %s: got a mismatching activation (request version %d, " +
+                    log.log(Level.FINE, () -> String.format(Locale.ROOT, "Dummy node %s: got a mismatching activation (request version %d, " +
                             "actual %d), not marking version as active", this, activateVersion, actualVersion));
                 }
             }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -176,7 +177,7 @@ public class MasterElectionTest extends FleetControllerTest {
             lastState = currentState;
             if (currentState.getVersion() <= last.getVersion()) {
                 throw new IllegalStateException(
-                        String.format("Cluster state version strict increase invariant broken! " +
+                        String.format(Locale.ROOT, "Cluster state version strict increase invariant broken! " +
                                       "Old state was '%s', new state is '%s'", last, currentState));
             }
         }
@@ -409,7 +410,7 @@ public class MasterElectionTest extends FleetControllerTest {
         // at ACKing a previous one.
         this.nodes.stream().filter(DummyVdsNode::isDistributor).forEach(node -> {
             node.setNodeState(new NodeState(NodeType.DISTRIBUTOR, State.UP),
-                    String.format("{\"cluster-state-version\":%d}", ackVersion));
+                    String.format(Locale.ROOT, "{\"cluster-state-version\":%d}", ackVersion));
         });
         waitForStateInAllSpaces("version:\\d+ distributor:10 storage:10");
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.yahoo.vespa.clustercontroller.core.MetricDimensionNames.CLUSTER;
@@ -75,7 +76,7 @@ public class MetricReporterTest {
     }
 
     private static String metricName(String subName) {
-        return "%s.%s".formatted(CLUSTER_CONTROLLER, subName);
+        return String.format(Locale.ROOT, "%s.%s", CLUSTER_CONTROLLER, subName);
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -879,12 +880,12 @@ public class NodeStateChangeCheckerTest {
             // accidentally use the wrong dimension.
             return Stream.of("default", "global")
                     .map(bucketSpace ->
-                        """
+                        String.format(Locale.ROOT, """
                         {
                             "name":"vds.datastored.bucket_space.%s",
                             "values":{"last":%d},
                             "dimensions":{"bucketSpace":"%s"}
-                        },""".formatted(metric, (lastValueOrNull + (bucketSpace.equals("default") ? 0 : 123)), bucketSpace))
+                        },""", metric, (lastValueOrNull + (bucketSpace.equals("default") ? 0 : 123)), bucketSpace))
                     .collect(Collectors.joining("\n"));
         }
         return "";

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/ClusterEventWithDescription.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/ClusterEventWithDescription.java
@@ -5,6 +5,8 @@ import com.yahoo.vespa.clustercontroller.core.ClusterEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
+
 public class ClusterEventWithDescription extends BaseMatcher<ClusterEvent> {
     private final String expected;
 
@@ -22,7 +24,7 @@ public class ClusterEventWithDescription extends BaseMatcher<ClusterEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("ClusterEvent with description '%s'", expected));
+        description.appendText(String.format(Locale.ROOT, "ClusterEvent with description '%s'", expected));
     }
 
     @Override
@@ -31,7 +33,7 @@ public class ClusterEventWithDescription extends BaseMatcher<ClusterEvent> {
             return;
         }
         ClusterEvent other = (ClusterEvent)item;
-        description.appendText(String.format("got description '%s'", other.getDescription()));
+        description.appendText(String.format(Locale.ROOT, "got description '%s'", other.getDescription()));
     }
 
     public static ClusterEventWithDescription clusterEventWithDescription(String description) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventForNode.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventForNode.java
@@ -6,6 +6,8 @@ import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
+
 public class EventForNode extends BaseMatcher<NodeEvent> {
     private final Node expected;
 
@@ -20,13 +22,13 @@ public class EventForNode extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("NodeEvent for node %s", expected));
+        description.appendText(String.format(Locale.ROOT, "NodeEvent for node %s", expected));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format("got node %s", other.getNode().getNode()));
+        description.appendText(String.format(Locale.ROOT, "got node %s", other.getNode().getNode()));
     }
 
     public static EventForNode eventForNode(Node expected) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTimeIs.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTimeIs.java
@@ -5,6 +5,8 @@ import com.yahoo.vespa.clustercontroller.core.Event;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
+
 public class EventTimeIs extends BaseMatcher<Event> {
     private final long expected;
 
@@ -22,13 +24,13 @@ public class EventTimeIs extends BaseMatcher<Event> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("Event with time %d", expected));
+        description.appendText(String.format(Locale.ROOT, "Event with time %d", expected));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         Event other = (Event)item;
-        description.appendText(String.format("event time is %d", other.getTimeMs()));
+        description.appendText(String.format(Locale.ROOT, "event time is %d", other.getTimeMs()));
     }
 
     public static EventTimeIs eventTimeIs(long time) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTypeIs.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTypeIs.java
@@ -5,6 +5,8 @@ import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
+
 public class EventTypeIs extends BaseMatcher<NodeEvent> {
     private final NodeEvent.Type expected;
 
@@ -22,13 +24,13 @@ public class EventTypeIs extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("NodeEvent with description '%s'", expected));
+        description.appendText(String.format(Locale.ROOT, "NodeEvent with description '%s'", expected));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format("got description '%s'", other.getDescription()));
+        description.appendText(String.format(Locale.ROOT, "got description '%s'", other.getDescription()));
     }
 
     public static EventTypeIs eventTypeIs(NodeEvent.Type type) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasMetricContext.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasMetricContext.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.clustercontroller.utils.util.MetricReporter;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -28,12 +29,12 @@ public class HasMetricContext extends BaseMatcher<MetricReporter.Context> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("Context with dimensions %s", dimensions));
+        description.appendText(String.format(Locale.ROOT, "Context with dimensions %s", dimensions));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
-        description.appendText(String.format("Context dimensions are %s", item.toString()));
+        description.appendText(String.format(Locale.ROOT, "Context dimensions are %s", item.toString()));
     }
 
     public static class Dimension {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasStateReasonForNode.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasStateReasonForNode.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.clustercontroller.core.NodeStateReason;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class HasStateReasonForNode extends BaseMatcher<Map<Node, NodeStateReason>> {
@@ -27,7 +28,7 @@ public class HasStateReasonForNode extends BaseMatcher<Map<Node, NodeStateReason
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("has node state reason %s", expected.toString()));
+        description.appendText(String.format(Locale.ROOT, "has node state reason %s", expected.toString()));
     }
 
     @Override
@@ -35,7 +36,7 @@ public class HasStateReasonForNode extends BaseMatcher<Map<Node, NodeStateReason
         @SuppressWarnings("unchecked")
         Map<Node, NodeStateReason> other = (Map<Node, NodeStateReason>)item;
         if (other.containsKey(node)) {
-            description.appendText(String.format("has reason %s", other.get(node).toString()));
+            description.appendText(String.format(Locale.ROOT, "has reason %s", other.get(node).toString()));
         } else {
             description.appendText("has no entry for node");
         }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventForBucketSpace.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventForBucketSpace.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
 import java.util.Optional;
 
 public class NodeEventForBucketSpace extends BaseMatcher<NodeEvent> {
@@ -24,13 +25,13 @@ public class NodeEventForBucketSpace extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("NodeEvent for bucket space '%s'", bucketSpace.orElse("null")));
+        description.appendText(String.format(Locale.ROOT, "NodeEvent for bucket space '%s'", bucketSpace.orElse("null")));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format("got bucket space '%s'", other.getBucketSpace().orElse("null")));
+        description.appendText(String.format(Locale.ROOT, "got bucket space '%s'", other.getBucketSpace().orElse("null")));
     }
 
     public static NodeEventForBucketSpace nodeEventForBucketSpace(String bucketSpace) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventWithDescription.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventWithDescription.java
@@ -5,6 +5,8 @@ import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+import java.util.Locale;
+
 public class NodeEventWithDescription extends BaseMatcher<NodeEvent> {
     private final String expected;
 
@@ -22,7 +24,7 @@ public class NodeEventWithDescription extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format("NodeEvent with description '%s'", expected));
+        description.appendText(String.format(Locale.ROOT, "NodeEvent with description '%s'", expected));
     }
 
     @Override
@@ -31,7 +33,7 @@ public class NodeEventWithDescription extends BaseMatcher<NodeEvent> {
             return;
         }
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format("got description '%s'", other.getDescription()));
+        description.appendText(String.format(Locale.ROOT, "got description '%s'", other.getDescription()));
     }
 
     public static NodeEventWithDescription nodeEventWithDescription(String description) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -127,7 +128,7 @@ public class SetNodeStateTest extends StateRestApiTest {
     private String musicClusterExpectedUserStateString(String groupName,
                                                        String generatedState, String unitState,
                                                        String userState, String userReason) {
-        return """
+        return String.format(Locale.ROOT, """
                {
                  "attributes" : {
                    "hierarchical-group" : "%s"
@@ -146,7 +147,7 @@ public class SetNodeStateTest extends StateRestApiTest {
                      "reason" : "%s"
                    }
                  }
-               }""".formatted(groupName, generatedState, unitState, userState, userReason);
+               }""", groupName, generatedState, unitState, userState, userReason);
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.clustercontroller.core.ClusterStateBundleUtil;
 import com.yahoo.vespa.clustercontroller.core.DistributionBuilder;
 import com.yahoo.vespa.clustercontroller.core.StateMapping;
 import org.junit.jupiter.api.Test;
+import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
@@ -45,7 +46,7 @@ public class SlimeClusterStateBundleCodecTest {
             allDownStates.append(" .").append(i).append(".s:d");
         }
         // Exact same state set string repeated twice; perfect compression fodder.
-        return ClusterStateBundleUtil.makeBundle(String.format("distributor:100%s storage:100%s",
+        return ClusterStateBundleUtil.makeBundle(String.format(Locale.ROOT, "distributor:100%s storage:100%s",
                 allDownStates, allDownStates));
     }
 

--- a/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/requests/SetUnitStateRequest.java
+++ b/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/requests/SetUnitStateRequest.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.InvalidConten
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.response.UnitState;
 
 import java.util.Map;
+import java.util.Locale;
 
 public interface SetUnitStateRequest extends UnitRequest {
 
@@ -23,9 +24,9 @@ public interface SetUnitStateRequest extends UnitRequest {
 
         public static Condition fromString(String value) throws InvalidContentException {
             try {
-                return Condition.valueOf(value.toUpperCase());
+                return Condition.valueOf(value.toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException e) {
-                throw new InvalidContentException(String.format("Invalid value for condition: '%s', expected one of 'force', 'safe'", value));
+                throw new InvalidContentException(String.format(Locale.ROOT, "Invalid value for condition: '%s', expected one of 'force', 'safe'", value));
             }
         }
     }
@@ -57,7 +58,7 @@ public interface SetUnitStateRequest extends UnitRequest {
             } else if (value.equalsIgnoreCase(NO_WAIT.name)) {
                 return NO_WAIT;
             }
-            throw new InvalidContentException(String.format("Invalid value for response-wait: '%s', expected one of '%s', '%s'",
+            throw new InvalidContentException(String.format(Locale.ROOT, "Invalid value for response-wait: '%s', expected one of '%s', '%s'",
                     value, WAIT_UNTIL_CLUSTER_ACKED.name, NO_WAIT.name));
         }
     }


### PR DESCRIPTION
Add explicit Locale.ROOT parameter to String.format() calls and toLowerCase() operations throughout the clustercontroller module. This ensures consistent string formatting and case conversion behavior regardless of the system's default locale.
