### PR TITLE
Specify UTF-8 charset and ROOT locale

### DIFF
--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -11,6 +11,7 @@ import com.yahoo.vespa.zookeeper.tls.VespaZookeeperTlsContextUtils;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -82,7 +83,7 @@ public class Configurator {
                                           VespaTlsConfig vespaTlsConfig) throws IOException {
         String dynamicConfigPath = config.dynamicReconfiguration() ? parseConfigFile(configFilePath).get("dynamicConfigFile") : null;
         Map<String, String> dynamicConfig = dynamicConfigPath != null ? parseConfigFile(Paths.get(dynamicConfigPath)) : Map.of();
-        try (FileWriter writer = new FileWriter(configFilePath.toFile())) {
+        try (FileWriter writer = new FileWriter(configFilePath.toFile(), StandardCharsets.UTF_8)) {
             writer.write(transformConfigToString(config, vespaTlsConfig, dynamicConfig));
         }
     }
@@ -153,7 +154,7 @@ public class Configurator {
     }
 
     private void writeMyIdFile(ZookeeperServerConfig config) throws IOException {
-        try (FileWriter writer = new FileWriter(getDefaults().underVespaHome(config.myidFile()))) {
+        try (FileWriter writer = new FileWriter(getDefaults().underVespaHome(config.myidFile()), StandardCharsets.UTF_8)) {
             writer.write(config.myid() + "\n");
         }
     }

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -21,6 +21,7 @@ import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
@@ -145,8 +146,8 @@ public class ConfiguratorTest {
         assertEquals(originalConfig.size(), dynamicConfig.size() + staticConfig.size());
         File dynFile = folder.newFile();
         staticConfig.put("dynamicConfigFile", dynFile.getAbsolutePath());
-        Files.write(cfgFile.toPath(), Configurator.transformConfigToString(staticConfig).getBytes());
-        Files.write(dynFile.toPath(), Configurator.transformConfigToString(dynamicConfig).getBytes());
+        Files.write(cfgFile.toPath(), Configurator.transformConfigToString(staticConfig).getBytes(StandardCharsets.UTF_8));
+        Files.write(dynFile.toPath(), Configurator.transformConfigToString(dynamicConfig).getBytes(StandardCharsets.UTF_8));
 
         configurator.writeConfigToDisk(VespaTlsConfig.tlsDisabled());
         // Next generation of config should not mark this as a joiner either.

--- a/zookeeper-server/zookeeper-server/src/main/java/org/apache/zookeeper/server/VespaNettyServerCnxnFactory.java
+++ b/zookeeper-server/zookeeper-server/src/main/java/org/apache/zookeeper/server/VespaNettyServerCnxnFactory.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.zookeeper.Configurator;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 /**
@@ -26,12 +27,12 @@ public class VespaNettyServerCnxnFactory extends NettyServerCnxnFactory {
         super();
         this.isSecure = Configurator.VespaNettyServerCnxnFactory_isSecure;
         boolean portUnificationEnabled = Boolean.getBoolean(NettyServerCnxnFactory.PORT_UNIFICATION_KEY);
-        log.info(String.format("For %h: isSecure=%b, portUnification=%b", this, isSecure, portUnificationEnabled));
+        log.info(String.format(Locale.ROOT, "For %h: isSecure=%b, portUnification=%b", this, isSecure, portUnificationEnabled));
     }
 
     @Override
     public void configure(InetSocketAddress addr, int maxClientCnxns, int backlog, boolean secure) throws IOException {
-        log.info(String.format("For %h: configured() invoked with parameter 'secure'=%b, overridden to %b", this, secure, isSecure));
+        log.info(String.format(Locale.ROOT, "For %h: configured() invoked with parameter 'secure'=%b, overridden to %b", this, secure, isSecure));
         super.configure(addr, maxClientCnxns, backlog, isSecure);
     }
 }


### PR DESCRIPTION
Adds explicit StandardCharsets.UTF_8 to FileWriter constructors and getBytes() calls, and Locale.ROOT to String.format() calls to avoid platform-dependent behavior.
