### PR TITLE
feat: warning when instance is set but not used in prod

### DIFF
--- a/client/go/internal/cli/cmd/prod.go
+++ b/client/go/internal/cli/cmd/prod.go
@@ -143,6 +143,9 @@ $ vespa prod deploy`,
 				// TODO: Add support for hosted
 				return fmt.Errorf("prod deploy does not support %s target", target.Type())
 			}
+			if _, ok := cli.config.get(instanceFlag); ok {
+				cli.printWarning("Instance is set in config but will be ignored for production deployments. Only deployment.xml is used to configure production instances")
+			}
 			pkg, err := cli.applicationPackageFrom(args, vespa.PackageOptions{Compiled: true})
 			if err != nil {
 				return err


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

User is now warned when instance flag is set in config but not utilized because they are deploying to production.