### PR TITLE
Uses the same conditions for adding TritonOnnxRuntime and Triton sidecar.

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidatorTest.java
@@ -3,14 +3,21 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.api.ConfigChangeRestartAction.ConfigChange;
+import com.yahoo.config.model.api.OnnxModelCost;
+import com.yahoo.config.model.api.OnnxModelOptions;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,39 +28,39 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
 
     private static final String SERVICES_XML_WITH_ONE_CLUSTER = """
-            <services version='1.0'>
-              <container id='cluster1' version='1.0'>
-              </container>
-            </services>
-            """;
+        <services version='1.0'>
+          <container id='cluster1' version='1.0'>
+          </container>
+        </services>
+        """;
 
     // Clusters must have different ports
     private static final String SERVICES_XML_TWO_CLUSTERS = """
-            <services version='1.0'>
-              <container id='cluster1' version='1.0'>
-                <http>
-                  <server id='server1' port='8080'/>
-                </http>
-              </container>
-              <container id='other-cluster' version='1.0'>
-                <http>
-                  <server id='server2' port='8081'/>
-                </http>
-              </container>
-            </services>
-            """;
+        <services version='1.0'>
+          <container id='cluster1' version='1.0'>
+            <http>
+              <server id='server1' port='8080'/>
+            </http>
+          </container>
+          <container id='other-cluster' version='1.0'>
+            <http>
+              <server id='server2' port='8081'/>
+            </http>
+          </container>
+        </services>
+        """;
 
     private static final String SERVICES_XML_OTHER_CLUSTER = """
-            <services version='1.0'>
-              <container id='other-cluster' version='1.0'>
-              </container>
-            </services>
-            """;
+        <services version='1.0'>
+          <container id='other-cluster' version='1.0'>
+          </container>
+        </services>
+        """;
 
     @Test
     void restart_when_triton_runtime_enabled() {
-        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER,false);
-        var next = createModel(SERVICES_XML_WITH_ONE_CLUSTER,true);
+        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
+        var next = createModel(SERVICES_XML_WITH_ONE_CLUSTER, true);
         var result = validateModel(previous, next);
 
         assertEquals(1, result.size());
@@ -66,7 +73,7 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
 
     @Test
     void restart_when_triton_runtime_disabled() {
-        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER,true);
+        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, true);
         var next = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
         var result = validateModel(previous, next);
 
@@ -89,7 +96,7 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
 
     @Test
     void no_restart_when_triton_runtime_remains_disabled() {
-        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER,false);
+        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
         var next = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
         var result = validateModel(previous, next);
 
@@ -115,19 +122,32 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
     }
 
     private static List<ConfigChangeAction> validateModel(VespaModel current, VespaModel next) {
-        return ValidationTester.validateChanges(new RestartOnDeployForTritonOnnxRuntimeValidator(),
-                                                next,
-                                                deployStateBuilder(false).previousModel(current).build());
+        return ValidationTester.validateChanges(
+                new RestartOnDeployForTritonOnnxRuntimeValidator(),
+                next,
+                deployStateBuilder(false).previousModel(current).build());
     }
-    
+
     private static VespaModel createModel(String servicesXml, boolean useTriton) {
         var builder = deployStateBuilder(useTriton);
         return new VespaModelCreatorWithMockPkg(null, servicesXml).create(builder);
     }
 
     private static DeployState.Builder deployStateBuilder(boolean useTriton) {
-        return new DeployState.Builder()
-                .properties(new TestProperties().setUseTriton(useTriton));
-    }
+        var deployStateBuilder = new DeployState.Builder().properties(new TestProperties().setUseTriton(useTriton));
 
+        // Need a model and cloud to enable Triton.
+        if (useTriton) {
+            var mockModelCost = new OnnxModelCost.DisabledOnnxModelCost() {
+                @Override
+                public Map<String, ModelInfo> models() {
+                    return Map.of("modernbert", new ModelInfo("modernbert", 1, 1, OnnxModelOptions.empty()));
+                }
+            };
+            deployStateBuilder.onnxModelCost(mockModelCost);
+            deployStateBuilder.zone(new Zone(SystemName.PublicCd, Environment.dev, RegionName.defaultName()));
+        }
+
+        return deployStateBuilder;
+    }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adds shouldUseTriton method with conditions whether to use Triton for ONNX inference - to add TritonOnnxRuntime and Triton sidecar to config model.
This should fix the issue when TritonOnnxRuntime was used without Triton sidecar.