### PR TITLE
Use explicit locale and charset in security-utils module

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/AutoReloadingX509KeyManager.java
+++ b/security-utils/src/main/java/com/yahoo/security/AutoReloadingX509KeyManager.java
@@ -14,6 +14,7 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -87,11 +88,11 @@ public class AutoReloadingX509KeyManager extends X509ExtendedKeyManager implemen
         @Override
         public void run() {
             try {
-                log.log(Level.FINE, () -> String.format("Reloading key and certificate chain (private-key='%s', certificates='%s')", privateKeyFile, certificatesFile));
+                log.log(Level.FINE, () -> String.format(Locale.ROOT, "Reloading key and certificate chain (private-key='%s', certificates='%s')", privateKeyFile, certificatesFile));
                 mutableX509KeyManager.updateKeystore(createKeystore(privateKeyFile, certificatesFile), new char[0]);
             } catch (Throwable t) {
                 log.log(Level.SEVERE,
-                        String.format("Failed to load X509 key manager (private-key='%s', certificates='%s'): %s",
+                        String.format(Locale.ROOT, "Failed to load X509 key manager (private-key='%s', certificates='%s'): %s",
                                       privateKeyFile, certificatesFile, t.getMessage()),
                         t);
             }

--- a/security-utils/src/main/java/com/yahoo/security/BaseNCodec.java
+++ b/security-utils/src/main/java/com/yahoo/security/BaseNCodec.java
@@ -3,6 +3,7 @@ package com.yahoo.security;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * <p>
@@ -70,8 +71,7 @@ public class BaseNCodec {
             Arrays.fill(reverseLut, -1); // -1 => invalid mapping
             for (int i = 0; i < alphabetChars.length; ++i) {
                 if (reverseLut[alphabetChars[i]] != -1) {
-                    throw new IllegalArgumentException("Alphabet character '%c' occurs more than once"
-                                                       .formatted(alphabetChars[i]));
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "Alphabet character '%c' occurs more than once", alphabetChars[i]));
                 }
                 reverseLut[alphabetChars[i]] = i;
             }

--- a/security-utils/src/main/java/com/yahoo/security/HKDF.java
+++ b/security-utils/src/main/java/com/yahoo/security/HKDF.java
@@ -6,6 +6,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -179,8 +180,7 @@ public final class HKDF {
             throw new IllegalArgumentException("Requested negative or zero number of HKDF output bytes");
         }
         if (wantedBytes > MAX_OUTPUT_SIZE) {
-            throw new IllegalArgumentException("Too many requested HKDF output bytes (max %d, got %d)"
-                                               .formatted(MAX_OUTPUT_SIZE, wantedBytes));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Too many requested HKDF output bytes (max %d, got %d)", MAX_OUTPUT_SIZE, wantedBytes));
         }
     }
 

--- a/security-utils/src/main/java/com/yahoo/security/KeyId.java
+++ b/security-utils/src/main/java/com/yahoo/security/KeyId.java
@@ -2,6 +2,7 @@
 package com.yahoo.security;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Objects;
 
 import static com.yahoo.security.ArrayUtils.fromUtf8Bytes;
@@ -22,8 +23,7 @@ public class KeyId {
 
     private KeyId(byte[] keyIdBytes) {
         if (keyIdBytes.length > MAX_KEY_ID_UTF8_LENGTH) {
-            throw new IllegalArgumentException("Key ID is too large to be encoded (max is %d, got %d)"
-                                               .formatted(MAX_KEY_ID_UTF8_LENGTH, keyIdBytes.length));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Key ID is too large to be encoded (max is %d, got %d)", MAX_KEY_ID_UTF8_LENGTH, keyIdBytes.length));
         }
         verifyByteStringRoundtripsAsValidUtf8(keyIdBytes);
         this.keyIdBytes = keyIdBytes;
@@ -75,7 +75,7 @@ public class KeyId {
 
     @Override
     public String toString() {
-        return "KeyId(%s)".formatted(asString());
+        return String.format(Locale.ROOT, "KeyId(%s)", asString());
     }
 
     private static void verifyByteStringRoundtripsAsValidUtf8(byte[] byteStr) {

--- a/security-utils/src/main/java/com/yahoo/security/SealedSharedKey.java
+++ b/security-utils/src/main/java/com/yahoo/security/SealedSharedKey.java
@@ -3,6 +3,7 @@ package com.yahoo.security;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Objects;
 
 import static com.yahoo.security.ArrayUtils.hex;
@@ -30,8 +31,7 @@ public record SealedSharedKey(int version, KeyId keyId, byte[] enc, byte[] ciphe
 
     public SealedSharedKey {
         if (enc.length > MAX_ENC_CONTEXT_LENGTH) {
-            throw new IllegalArgumentException("Encryption context is too large to be encoded (max is %d, got %d)"
-                                               .formatted(MAX_ENC_CONTEXT_LENGTH, enc.length));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Encryption context is too large to be encoded (max is %d, got %d)", MAX_ENC_CONTEXT_LENGTH, enc.length));
         }
     }
 
@@ -78,8 +78,7 @@ public record SealedSharedKey(int version, KeyId keyId, byte[] enc, byte[] ciphe
         // u8 token version || u8 length(key id) || key id || u8 length(enc) || enc || ciphertext
         int version = Byte.toUnsignedInt(decoded.get());
         if (version < 1 || version > CURRENT_TOKEN_VERSION) {
-            throw new IllegalArgumentException("Token had unexpected version. Expected value in [1, %d], was %d"
-                                               .formatted(CURRENT_TOKEN_VERSION, version));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Token had unexpected version. Expected value in [1, %d], was %d", CURRENT_TOKEN_VERSION, version));
         }
         int keyIdLen = Byte.toUnsignedInt(decoded.get());
         byte[] keyIdBytes = new byte[keyIdLen];

--- a/security-utils/src/main/java/com/yahoo/security/SecretSharedKey.java
+++ b/security-utils/src/main/java/com/yahoo/security/SecretSharedKey.java
@@ -2,6 +2,7 @@
 package com.yahoo.security;
 
 import javax.crypto.SecretKey;
+import java.util.Locale;
 
 /**
  * A SecretSharedKey represents a pairing of both the secret and public parts of
@@ -18,7 +19,7 @@ public record SecretSharedKey(SecretKey secretKey, SealedSharedKey sealedSharedK
     // via an implicitly generated method. Only print the sealed key (which is entirely public).
     @Override
     public String toString() {
-        return "SharedSecretKey(sealed: %s)".formatted(sealedSharedKey.toTokenString());
+        return String.format(Locale.ROOT, "SharedSecretKey(sealed: %s)", sealedSharedKey.toTokenString());
     }
 
     /**

--- a/security-utils/src/main/java/com/yahoo/security/SharedKeyResealingSession.java
+++ b/security-utils/src/main/java/com/yahoo/security/SharedKeyResealingSession.java
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.interfaces.XECPublicKey;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -139,7 +140,7 @@ public class SharedKeyResealingSession {
 
     public static ResealingResponse reseal(ResealingRequest request, PrivateKeyProvider privateKeyProvider) {
         var privKey = privateKeyProvider.privateKeyForId(request.sealedKey.keyId()).orElseThrow(
-                () -> new IllegalArgumentException("Could not find a private key for key ID '%s'".formatted(request.sealedKey.keyId())));
+                () -> new IllegalArgumentException(String.format(Locale.ROOT, "Could not find a private key for key ID '%s'", request.sealedKey.keyId())));
 
         var secretShared = SharedKeyGenerator.fromSealedKey(request.sealedKey, privKey);
         var resealed = SharedKeyGenerator.reseal(secretShared, request.ephemeralPubKey, KeyId.ofString("resealed-token")); // TODO key id

--- a/security-utils/src/main/java/com/yahoo/security/SslContextBuilder.java
+++ b/security-utils/src/main/java/com/yahoo/security/SslContextBuilder.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -57,7 +58,7 @@ public class SslContextBuilder {
     public SslContextBuilder withTrustStore(Path pemEncodedCaCertificates) {
         this.trustStoreSupplier = () -> {
             List<X509Certificate> caCertificates =
-                    X509CertificateUtils.certificateListFromPem(new String(Files.readAllBytes(pemEncodedCaCertificates)));
+                    X509CertificateUtils.certificateListFromPem(new String(Files.readAllBytes(pemEncodedCaCertificates), StandardCharsets.UTF_8));
             return createTrustStore(caCertificates);
         };
         return this;
@@ -102,8 +103,8 @@ public class SslContextBuilder {
     public SslContextBuilder withKeyStore(Path privateKeyPemFile, Path certificatesPemFile) {
         this.keyStoreSupplier =
                 () ->  {
-                    PrivateKey privateKey = KeyUtils.fromPemEncodedPrivateKey(new String(Files.readAllBytes(privateKeyPemFile)));
-                    List<X509Certificate> certificates = X509CertificateUtils.certificateListFromPem(new String(Files.readAllBytes(certificatesPemFile)));
+                    PrivateKey privateKey = KeyUtils.fromPemEncodedPrivateKey(new String(Files.readAllBytes(privateKeyPemFile), StandardCharsets.UTF_8));
+                    List<X509Certificate> certificates = X509CertificateUtils.certificateListFromPem(new String(Files.readAllBytes(certificatesPemFile), StandardCharsets.UTF_8));
                     return KeyStoreBuilder.withType(KeyStoreType.JKS)
                             .withKeyEntry("default", privateKey, certificates)
                             .build();

--- a/security-utils/src/main/java/com/yahoo/security/hpke/Hpke.java
+++ b/security-utils/src/main/java/com/yahoo/security/hpke/Hpke.java
@@ -5,6 +5,7 @@ import java.security.KeyPair;
 import java.security.interfaces.XECPrivateKey;
 import java.security.interfaces.XECPublicKey;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static com.yahoo.security.ArrayUtils.concat;
 import static com.yahoo.security.hpke.Constants.BASE_NONCE_LABEL;
@@ -163,16 +164,13 @@ public final class Hpke {
 
     static void verifyInputLengthRestrictions(byte[] psk, byte[] pskId, byte[] info) {
         if (psk.length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException("Input PSK length (%d) greater than max length (%d)"
-                                               .formatted(psk.length, MAX_INPUT_LENGTH));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Input PSK length (%d) greater than max length (%d)", psk.length, MAX_INPUT_LENGTH));
         }
         if (pskId.length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException("Input PSK ID length (%d) greater than max length (%d)"
-                                               .formatted(pskId.length, MAX_INPUT_LENGTH));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Input PSK ID length (%d) greater than max length (%d)", pskId.length, MAX_INPUT_LENGTH));
         }
         if (info.length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException("Input info length (%d) greater than max length (%d)"
-                                               .formatted(info.length, MAX_INPUT_LENGTH));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Input info length (%d) greater than max length (%d)", info.length, MAX_INPUT_LENGTH));
         }
     }
 

--- a/security-utils/src/main/java/com/yahoo/security/tls/CapabilitySet.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/CapabilitySet.java
@@ -7,6 +7,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,7 +81,7 @@ public class CapabilitySet implements ToCapabilitySet {
             var capability = Capability.fromName(name).orElse(null);
             if (capability != null) caps.add(capability);
             else if (predefinedSet != null) caps.addAll(predefinedSet.caps);
-            else log.warning("Cannot find capability or capability set with name '%s'".formatted(name));
+            else log.warning(String.format(Locale.ROOT, "Cannot find capability or capability set with name '%s'", name));
         }
         return new CapabilitySet(caps);
     }

--- a/security-utils/src/main/java/com/yahoo/security/tls/ConfigFileBasedTlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/ConfigFileBasedTlsContext.java
@@ -20,6 +20,7 @@ import java.security.KeyStore;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -171,7 +172,7 @@ public class ConfigFileBasedTlsContext implements TlsContext {
                     reloadKeyManager(options, this.keyManager);
                 }
             } catch (Throwable t) {
-                log.log(Level.SEVERE, String.format("Failed to reload crypto material (path='%s'): %s", tlsOptionsConfigFile, t.getMessage()), t);
+                log.log(Level.SEVERE, String.format(Locale.ROOT, "Failed to reload crypto material (path='%s'): %s", tlsOptionsConfigFile, t.getMessage()), t);
             }
         }
     }

--- a/security-utils/src/main/java/com/yahoo/security/tls/DefaultTlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/DefaultTlsContext.java
@@ -10,6 +10,7 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,10 +62,10 @@ public class DefaultTlsContext implements TlsContext {
                 .toArray(String[]::new);
         if (allowedCiphers.length == 0) {
             throw new IllegalStateException(
-                    String.format("None of the accepted ciphers are supported (supported=%s, accepted=%s)",
+                    String.format(Locale.ROOT, "None of the accepted ciphers are supported (supported=%s, accepted=%s)",
                                   supportedCiphers, acceptedCiphers));
         }
-        log.log(Level.FINE, () -> String.format("Allowed cipher suites that are supported: %s", List.of(allowedCiphers)));
+        log.log(Level.FINE, () -> String.format(Locale.ROOT, "Allowed cipher suites that are supported: %s", List.of(allowedCiphers)));
         return allowedCiphers;
     }
 
@@ -75,10 +76,10 @@ public class DefaultTlsContext implements TlsContext {
                 .toArray(String[]::new);
         if (allowedProtocols.length == 0) {
             throw new IllegalStateException(
-                    String.format("None of the accepted protocols are supported (supported=%s, accepted=%s)",
+                    String.format(Locale.ROOT, "None of the accepted protocols are supported (supported=%s, accepted=%s)",
                             supportedProtocols, acceptedProtocols));
         }
-        log.log(Level.FINE, () -> String.format("Allowed protocols that are supported: %s", Arrays.toString(allowedProtocols)));
+        log.log(Level.FINE, () -> String.format(Locale.ROOT, "Allowed protocols that are supported: %s", Arrays.toString(allowedProtocols)));
         return allowedProtocols;
     }
 

--- a/security-utils/src/main/java/com/yahoo/security/tls/PeerAuthorizer.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/PeerAuthorizer.java
@@ -7,6 +7,7 @@ import com.yahoo.security.X509CertificateUtils;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -39,7 +40,7 @@ public class PeerAuthorizer {
         Set<CapabilitySet> grantedCapabilities = new HashSet<>();
         String cn = X509CertificateUtils.getSubjectCommonName(cert).orElse(null);
         List<String> sans = getSubjectAlternativeNames(cert);
-        log.fine(() -> String.format("Subject info from x509 certificate: CN=[%s], 'SAN=%s", cn, sans));
+        log.fine(() -> String.format(Locale.ROOT, "Subject info from x509 certificate: CN=[%s], 'SAN=%s", cn, sans));
         for (PeerPolicy peerPolicy : authorizedPeers.peerPolicies()) {
             if (matchesPolicy(peerPolicy, cn, sans)) {
                 matchedPolicies.add(peerPolicy.policyName());

--- a/security-utils/src/main/java/com/yahoo/security/tls/PeerAuthorizerTrustManager.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/PeerAuthorizerTrustManager.java
@@ -14,6 +14,7 @@ import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -105,7 +106,7 @@ class PeerAuthorizerTrustManager extends X509ExtendedTrustManager {
                     () -> "Warning: unable to provide ConnectionAuthContext as no SSLSession is available");
         }
         if (result.authorized()) {
-            log.fine(() -> String.format("Verification result: %s", result));
+            log.fine(() -> String.format(Locale.ROOT, "Verification result: %s", result));
         } else {
             String errorMessage = "Authorization failed: " + createInfoString(certChain[0], authType, isVerifyingClient);
             log.warning(errorMessage);
@@ -116,7 +117,7 @@ class PeerAuthorizerTrustManager extends X509ExtendedTrustManager {
     }
 
     private String createInfoString(X509Certificate certificate, String authType, boolean isVerifyingClient) {
-        return String.format("DN='%s', SANs=%s, authType='%s', isVerifyingClient='%b', mode=%s",
+        return String.format(Locale.ROOT, "DN='%s', SANs=%s, authType='%s', isVerifyingClient='%b', mode=%s",
                 certificate.getSubjectX500Principal(), X509CertificateUtils.getSubjectAlternativeNames(certificate),
                 authType, isVerifyingClient, mode);
     }

--- a/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
@@ -60,7 +61,7 @@ public interface TlsContext extends AutoCloseable {
                 .collect(toSet());
         if (enabledCiphers.isEmpty()) {
             throw new IllegalArgumentException(
-                    String.format("Non of the allowed ciphers are supported (allowed=%s, supported=%s)",
+                    String.format(Locale.ROOT, "Non of the allowed ciphers are supported (allowed=%s, supported=%s)",
                                   ALLOWED_CIPHER_SUITES, Arrays.toString(supportedCiphers)));
 
         }
@@ -79,7 +80,7 @@ public interface TlsContext extends AutoCloseable {
                 .collect(toSet());
         if (enabledProtocols.isEmpty()) {
             throw new IllegalArgumentException(
-                    String.format("Non of the allowed protocols are supported (allowed=%s, supported=%s)",
+                    String.format(Locale.ROOT, "Non of the allowed protocols are supported (allowed=%s, supported=%s)",
                                   ALLOWED_PROTOCOLS, Arrays.toString(supportedProtocols)));
         }
         return enabledProtocols;

--- a/security-utils/src/main/java/com/yahoo/security/tls/TransportSecurityOptionsJsonSerializer.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/TransportSecurityOptionsJsonSerializer.java
@@ -15,6 +15,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -181,6 +182,6 @@ class TransportSecurityOptionsJsonSerializer {
     }
 
     private static IllegalArgumentException missingFieldException(String fieldName) {
-        return new IllegalArgumentException(String.format("'%s' missing", fieldName));
+        return new IllegalArgumentException(String.format(Locale.ROOT, "'%s' missing", fieldName));
     }
 }

--- a/security-utils/src/main/java/com/yahoo/security/token/Token.java
+++ b/security-utils/src/main/java/com/yahoo/security/token/Token.java
@@ -3,6 +3,7 @@ package com.yahoo.security.token;
 
 import com.yahoo.security.HKDF;
 
+import java.util.Locale;
 import java.util.Objects;
 
 import static com.yahoo.security.ArrayUtils.toUtf8Bytes;
@@ -68,7 +69,7 @@ public class Token {
     public String toString() {
         // Avoid leaking raw token secret as part of toString() output
         // Fingerprint first, since that's the most important bit.
-        return "Token(fingerprint: %s, domain: %s)".formatted(fingerprint, domain);
+        return String.format(Locale.ROOT, "Token(fingerprint: %s, domain: %s)", fingerprint, domain);
     }
 
     /**

--- a/security-utils/src/main/java/com/yahoo/security/token/TokenDomain.java
+++ b/security-utils/src/main/java/com/yahoo/security/token/TokenDomain.java
@@ -2,6 +2,7 @@
 package com.yahoo.security.token;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import static com.yahoo.security.ArrayUtils.fromUtf8Bytes;
 import static com.yahoo.security.ArrayUtils.toUtf8Bytes;
@@ -49,7 +50,7 @@ public record TokenDomain(byte[] checkHashContext) {
 
     @Override
     public String toString() {
-        return "'%s'".formatted(fromUtf8Bytes(checkHashContext));
+        return String.format(Locale.ROOT, "'%s'", fromUtf8Bytes(checkHashContext));
     }
 
     public static TokenDomain of(String checkHashContext) {

--- a/security-utils/src/main/java/com/yahoo/security/token/TokenGenerator.java
+++ b/security-utils/src/main/java/com/yahoo/security/token/TokenGenerator.java
@@ -4,6 +4,7 @@ package com.yahoo.security.token;
 import com.yahoo.security.Base62;
 
 import java.security.SecureRandom;
+import java.util.Locale;
 
 /**
  * <p>
@@ -33,7 +34,7 @@ public class TokenGenerator {
         }
         byte[] tokenRand = new byte[nRandomBytes];
         CSPRNG.nextBytes(tokenRand);
-        return new Token(domain, "%s%s".formatted(prefix, Base62.codec().encode(tokenRand)));
+        return new Token(domain, String.format(Locale.ROOT, "%s%s", prefix, Base62.codec().encode(tokenRand)));
     }
 
 }

--- a/security-utils/src/test/java/com/yahoo/security/AutoReloadingX509KeyManagerTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/AutoReloadingX509KeyManagerTest.java
@@ -25,6 +25,7 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,12 +45,12 @@ public class AutoReloadingX509KeyManagerTest {
     void crypto_material_is_reloaded_when_scheduler_task_is_executed() throws IOException {
         KeyPair keyPair = KeyUtils.generateKeypair(KeyAlgorithm.EC);
         Path privateKeyFile = File.createTempFile("junit", null, tempDirectory).toPath();
-        Files.write(privateKeyFile, KeyUtils.toPem(keyPair.getPrivate()).getBytes());
+        Files.write(privateKeyFile, KeyUtils.toPem(keyPair.getPrivate()).getBytes(UTF_8));
 
         Path certificateFile = File.createTempFile("junit", null, tempDirectory).toPath();
         BigInteger serialNumberInitialCertificate = BigInteger.ONE;
         X509Certificate initialCertificate = generateCertificate(keyPair, serialNumberInitialCertificate);
-        Files.write(certificateFile, X509CertificateUtils.toPem(initialCertificate).getBytes());
+        Files.write(certificateFile, X509CertificateUtils.toPem(initialCertificate).getBytes(UTF_8));
 
         ScheduledExecutorService scheduler = Mockito.mock(ScheduledExecutorService.class);
         ArgumentCaptor<Runnable> updaterTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -64,7 +65,7 @@ public class AutoReloadingX509KeyManagerTest {
 
         BigInteger serialNumberUpdatedCertificate = BigInteger.TEN;
         X509Certificate updatedCertificate = generateCertificate(keyPair, serialNumberUpdatedCertificate);
-        Files.write(certificateFile, X509CertificateUtils.toPem(updatedCertificate).getBytes());
+        Files.write(certificateFile, X509CertificateUtils.toPem(updatedCertificate).getBytes(UTF_8));
 
         updaterTaskCaptor.getValue().run(); // run update task in ReloadingX509KeyManager
 

--- a/security-utils/src/test/java/com/yahoo/security/HKDFTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/HKDFTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Locale;
 
 import static com.yahoo.security.ArrayUtils.hex;
 import static com.yahoo.security.ArrayUtils.unhex;
@@ -284,7 +285,7 @@ public class HKDFTest {
         for (var salt : salts) {
             var hkdf = HKDF.extractedFrom(unhex(salt), ikm);
             var okm = hkdf.expand(32, info);
-            assertEquals(expectedOkm, hex(okm), "Failed for salt %s".formatted(salt));
+            assertEquals(expectedOkm, hex(okm), String.format(Locale.ROOT, "Failed for salt %s", salt));
         }
     }
 

--- a/security-utils/src/test/java/com/yahoo/security/YBase64Test.java
+++ b/security-utils/src/test/java/com/yahoo/security/YBase64Test.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,9 +19,9 @@ class YBase64Test {
     void encodesAndDecodesCorrectly() {
         var base64Encoded = "+abcd/01234=";
         byte[] raw = Base64.getDecoder().decode(base64Encoded);
-        assertEquals("+abcd/01234=", new String(Base64.getEncoder().encode(raw)));
+        assertEquals("+abcd/01234=", new String(Base64.getEncoder().encode(raw), UTF_8));
         byte[] ybase64Decoded = YBase64.encode(raw);
-        assertEquals(".abcd_01234-", new String(ybase64Decoded));
+        assertEquals(".abcd_01234-", new String(ybase64Decoded, UTF_8));
         assertArrayEquals(raw, YBase64.decode(ybase64Decoded));
     }
 

--- a/security-utils/src/test/java/com/yahoo/security/tls/ConfigFileBasedTlsContextTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/tls/ConfigFileBasedTlsContextTest.java
@@ -20,6 +20,7 @@ import java.security.cert.X509Certificate;
 
 import static com.yahoo.security.KeyAlgorithm.EC;
 import static com.yahoo.security.SignatureAlgorithm.SHA256_WITH_ECDSA;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.EPOCH;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,17 +37,17 @@ public class ConfigFileBasedTlsContextTest {
     void can_create_sslcontext_from_credentials() throws IOException, InterruptedException {
         KeyPair keyPair = KeyUtils.generateKeypair(EC);
         Path privateKeyFile = File.createTempFile("junit", null, tempDirectory).toPath();
-        Files.write(privateKeyFile, KeyUtils.toPem(keyPair.getPrivate()).getBytes());
+        Files.write(privateKeyFile, KeyUtils.toPem(keyPair.getPrivate()).getBytes(UTF_8));
 
         X509Certificate certificate = X509CertificateBuilder
                 .fromKeypair(keyPair, new X500Principal("CN=dummy"), EPOCH, EPOCH.plus(1, DAYS), SHA256_WITH_ECDSA, BigInteger.ONE)
                 .build();
         Path certificateChainFile = File.createTempFile("junit", null, tempDirectory).toPath();
         String certificatePem = X509CertificateUtils.toPem(certificate);
-        Files.write(certificateChainFile, certificatePem.getBytes());
+        Files.write(certificateChainFile, certificatePem.getBytes(UTF_8));
 
         Path caCertificatesFile = File.createTempFile("junit", null, tempDirectory).toPath();
-        Files.write(caCertificatesFile, certificatePem.getBytes());
+        Files.write(caCertificatesFile, certificatePem.getBytes(UTF_8));
 
         TransportSecurityOptions options = new TransportSecurityOptions.Builder()
                 .withCertificates(certificateChainFile, privateKeyFile)

--- a/security-utils/src/test/java/com/yahoo/security/tls/GlobPatternTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/tls/GlobPatternTest.java
@@ -4,6 +4,7 @@ package com.yahoo.security.tls;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -82,7 +83,7 @@ class GlobPatternTest {
         GlobPattern p = globPattern(pattern, boundaries);
         assertTrue(
                 p.matches(value),
-                () -> String.format("Expected '%s' with boundaries '%s' to match '%s'",
+                () -> String.format(Locale.ROOT, "Expected '%s' with boundaries '%s' to match '%s'",
                         pattern, Arrays.toString(p.boundaries()), value));
     }
 
@@ -90,7 +91,7 @@ class GlobPatternTest {
         GlobPattern p = globPattern(pattern, boundaries);
         assertFalse(
                 p.matches(value),
-                () -> String.format("Expected '%s' with boundaries '%s' to not match '%s'",
+                () -> String.format(Locale.ROOT, "Expected '%s' with boundaries '%s' to not match '%s'",
                         pattern, Arrays.toString(p.boundaries()), value));
     }
 

--- a/security-utils/src/test/java/com/yahoo/security/tls/TransportSecurityOptionsJsonSerializerTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/tls/TransportSecurityOptionsJsonSerializerTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import static com.yahoo.security.tls.RequiredPeerCredential.Field.CN;
 import static com.yahoo.security.tls.RequiredPeerCredential.Field.SAN_DNS;
 import static com.yahoo.security.tls.RequiredPeerCredential.Field.SAN_URI;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -58,7 +59,7 @@ public class TransportSecurityOptionsJsonSerializerTest {
         TransportSecurityOptions deserializedOptions = serializer.deserialize(new ByteArrayInputStream(out.toByteArray()));
         assertEquals(options, deserializedOptions);
         Path expectedJsonFile = Paths.get("src/test/resources/transport-security-options-with-authz-rules.json");
-        assertJsonEquals(new String(Files.readAllBytes(expectedJsonFile)), out.toString());
+        assertJsonEquals(new String(Files.readAllBytes(expectedJsonFile), UTF_8), out.toString(UTF_8));
     }
 
     @Test
@@ -74,8 +75,8 @@ public class TransportSecurityOptionsJsonSerializerTest {
         try (OutputStream out = Files.newOutputStream(outputFile.toPath())) {
             new TransportSecurityOptionsJsonSerializer().serialize(out, options);
         }
-        String expectedOutput = new String(Files.readAllBytes(TEST_CONFIG_FILE));
-        String actualOutput = new String(Files.readAllBytes(outputFile.toPath()));
+        String expectedOutput = new String(Files.readAllBytes(TEST_CONFIG_FILE), UTF_8);
+        String actualOutput = new String(Files.readAllBytes(outputFile.toPath()), UTF_8);
         assertJsonEquals(expectedOutput, actualOutput);
     }
 
@@ -92,8 +93,8 @@ public class TransportSecurityOptionsJsonSerializerTest {
         }
 
         String expectedOutput = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/transport-security-options-with-disable-hostname-validation-set-to-false.json")));
-        String actualOutput = new String(Files.readAllBytes(outputFile.toPath()));
+                Paths.get("src/test/resources/transport-security-options-with-disable-hostname-validation-set-to-false.json")), UTF_8);
+        String actualOutput = new String(Files.readAllBytes(outputFile.toPath()), UTF_8);
         assertJsonEquals(expectedOutput, actualOutput);
     }
 

--- a/security-utils/src/test/java/com/yahoo/security/tls/UriGlobPatternTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/tls/UriGlobPatternTest.java
@@ -3,6 +3,8 @@ package com.yahoo.security.tls;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,12 +28,12 @@ class UriGlobPatternTest {
 
     private void assertMatches(String pattern, String value) {
         assertTrue(new UriGlobPattern(pattern).matches(value),
-                () -> String.format("Expected '%s' to match '%s'", pattern, value));
+                () -> String.format(Locale.ROOT, "Expected '%s' to match '%s'", pattern, value));
     }
 
     private void assertNotMatches(String pattern, String value) {
         assertFalse(new UriGlobPattern(pattern).matches(value),
-                () -> String.format("Expected '%s' to not match '%s'", pattern, value));
+                () -> String.format(Locale.ROOT, "Expected '%s' to not match '%s'", pattern, value));
     }
 
 }


### PR DESCRIPTION
Replace implicit locale and charset usage to avoid platform-dependent behavior:
- Add Locale.ROOT to String.format() calls for locale-independent formatting
- Replace .formatted() with String.format(Locale.ROOT, ...)
- Add StandardCharsets.UTF_8 for explicit charset when converting bytes to strings
