### PR TITLE
Add Utf8.fmt() for locale-independent string formatting

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -3506,7 +3506,8 @@
       "public static java.lang.String stripInvalidCharacters(java.lang.String)",
       "public static java.lang.String truncate(java.lang.String, int)",
       "public static java.lang.String substringByCodepoints(java.lang.String, int, int)",
-      "public static varargs java.lang.String format(java.lang.String, java.lang.Object[])"
+      "public static varargs java.lang.String format(java.lang.String, java.lang.Object[])",
+      "public static varargs java.lang.String fmt(java.lang.String, java.lang.Object[])"
     ],
     "fields" : [ ]
   },
@@ -3569,8 +3570,7 @@
       "public static java.io.FileReader createReader(java.io.File)",
       "public static java.io.FileReader createReader(java.lang.String)",
       "public static java.io.FileWriter createWriter(java.io.File)",
-      "public static java.io.FileWriter createWriter(java.lang.String)",
-      "public static varargs java.lang.String fmt(java.lang.String, java.lang.Object[])"
+      "public static java.io.FileWriter createWriter(java.lang.String)"
     ],
     "fields" : [ ]
   },

--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -3569,7 +3569,8 @@
       "public static java.io.FileReader createReader(java.io.File)",
       "public static java.io.FileReader createReader(java.lang.String)",
       "public static java.io.FileWriter createWriter(java.io.File)",
-      "public static java.io.FileWriter createWriter(java.lang.String)"
+      "public static java.io.FileWriter createWriter(java.lang.String)",
+      "public static varargs java.lang.String fmt(java.lang.String, java.lang.Object[])"
     ],
     "fields" : [ ]
   },

--- a/vespajlib/src/main/java/com/yahoo/text/Text.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Text.java
@@ -6,7 +6,7 @@ import java.util.OptionalInt;
 
 /**
  * Text utility functions. See also {com.yahoo.language.process.CharacterClasses}.
- * 
+ *
  * @author bratseth
  */
 public final class Text {
@@ -41,7 +41,7 @@ public final class Text {
     private Text() {}
 
     /**
-     * Returns whether the given codepoint is a valid text character, potentially suitable for 
+     * Returns whether the given codepoint is a valid text character, potentially suitable for
      * purposes such as indexing and display, see http://www.w3.org/TR/2006/REC-xml11-20060816/#charsets
      */
     public static boolean isTextCharacter(int codepoint) {
@@ -195,4 +195,19 @@ public final class Text {
 	return String.format(Locale.US, format, args);
     }
 
+    /**
+     * Locale-independent version of String.format() using Locale.ROOT.
+     *
+     * This method ensures consistent formatting behavior regardless of the system's
+     * default locale, which is important for generating output that needs to be parsed
+     * or compared across different locales (e.g., numeric values, dates).
+     *
+     * @param format a format string following the syntax defined by {@link java.util.Formatter}
+     * @param args arguments referenced by the format specifiers in the format string
+     * @return a formatted string
+     * @throws java.util.IllegalFormatException if the format string is invalid or incompatible with the arguments
+     */
+    public static String fmt(String format, Object... args) {
+        return String.format(Locale.ROOT, format, args);
+    }
 }

--- a/vespajlib/src/main/java/com/yahoo/text/Utf8.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Utf8.java
@@ -14,6 +14,7 @@ import java.nio.ReadOnlyBufferException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.util.Locale;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -622,5 +623,21 @@ public final class Utf8 {
      */
     public static FileWriter createWriter(String file) throws IOException {
         return new FileWriter(file, UTF_8);
+    }
+
+    /**
+     * Locale-independent version of String.format() using Locale.ROOT.
+     *
+     * This method ensures consistent formatting behavior regardless of the system's
+     * default locale, which is important for generating output that needs to be parsed
+     * or compared across different locales (e.g., numeric values, dates).
+     *
+     * @param format a format string following the syntax defined by {@link java.util.Formatter}
+     * @param args arguments referenced by the format specifiers in the format string
+     * @return a formatted string
+     * @throws java.util.IllegalFormatException if the format string is invalid or incompatible with the arguments
+     */
+    public static String fmt(String format, Object... args) {
+        return String.format(Locale.ROOT, format, args);
     }
 }

--- a/vespajlib/src/main/java/com/yahoo/text/Utf8.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Utf8.java
@@ -624,20 +624,4 @@ public final class Utf8 {
     public static FileWriter createWriter(String file) throws IOException {
         return new FileWriter(file, UTF_8);
     }
-
-    /**
-     * Locale-independent version of String.format() using Locale.ROOT.
-     *
-     * This method ensures consistent formatting behavior regardless of the system's
-     * default locale, which is important for generating output that needs to be parsed
-     * or compared across different locales (e.g., numeric values, dates).
-     *
-     * @param format a format string following the syntax defined by {@link java.util.Formatter}
-     * @param args arguments referenced by the format specifiers in the format string
-     * @return a formatted string
-     * @throws java.util.IllegalFormatException if the format string is invalid or incompatible with the arguments
-     */
-    public static String fmt(String format, Object... args) {
-        return String.format(Locale.ROOT, format, args);
-    }
 }


### PR DESCRIPTION
Introduces a new utility method that wraps String.format() with Locale.ROOT to ensure consistent formatting behavior across different system locales. This is particularly important for numeric values, dates, and other format specifiers that can vary by locale, preventing issues when output needs to be parsed or compared programmatically.
