### PR TITLE
Support MessageBus request header key/value metadata

### DIFF
--- a/messagebus/abi-spec.json
+++ b/messagebus/abi-spec.json
@@ -285,7 +285,6 @@
       "public void swapState(com.yahoo.messagebus.Routable)",
       "public com.yahoo.messagebus.routing.Route getRoute()",
       "public com.yahoo.messagebus.Message setRoute(com.yahoo.messagebus.routing.Route)",
-      "public boolean hasMetadata()",
       "public void injectMetadata(com.yahoo.messagebus.MetadataInjector)",
       "public void extractMetadata(com.yahoo.messagebus.MetadataExtractor)",
       "public long getTimeReceived()",

--- a/messagebus/abi-spec.json
+++ b/messagebus/abi-spec.json
@@ -285,6 +285,9 @@
       "public void swapState(com.yahoo.messagebus.Routable)",
       "public com.yahoo.messagebus.routing.Route getRoute()",
       "public com.yahoo.messagebus.Message setRoute(com.yahoo.messagebus.routing.Route)",
+      "public boolean hasMetadata()",
+      "public void injectMetadata(com.yahoo.messagebus.MetadataInjector)",
+      "public void extractMetadata(com.yahoo.messagebus.MetadataExtractor)",
       "public long getTimeReceived()",
       "public com.yahoo.messagebus.Message setTimeReceived(long)",
       "public com.yahoo.messagebus.Message setTimeReceivedNow()",
@@ -621,6 +624,32 @@
       "public void sync()",
       "public boolean destroy()",
       "public void run()"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.messagebus.MetadataExtractor" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "interface",
+      "abstract"
+    ],
+    "methods" : [
+      "public abstract java.util.Optional extractValue(java.lang.String)"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.messagebus.MetadataInjector" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "interface",
+      "abstract"
+    ],
+    "methods" : [
+      "public abstract void injectKeyValue(java.lang.String, java.lang.String)"
     ],
     "fields" : [ ]
   },

--- a/messagebus/src/main/java/com/yahoo/messagebus/Message.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/Message.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.messagebus;
 
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.concurrent.SystemTimer;
 import com.yahoo.messagebus.routing.Route;
 
@@ -55,6 +56,50 @@ public abstract class Message extends Routable {
         this.route = new Route(route);
         return this;
     }
+
+    /**
+     * <p>Returns whether a Message may have metadata it wishes to propagate to destinations.</p>
+     *
+     * <p>Note that if a Message subclass contains metadata, it has the responsibility to
+     * ensure {@link #swapState(Routable)} correctly handles this metadata.</p>
+     *
+     * <p>Should not throw exceptions.</p>
+     */
+    @Beta
+    public boolean hasMetadata() { return false; }
+
+    /**
+     * <p>At the time of serializing a Message to the underlying transport carrier the
+     * network subsystem will call {@link #hasMetadata()}. Iff it returns <code>true</code>,
+     * this method will then be subsequently invoked to inject any metadata key/value
+     * pairs the Message wants to propagate to the receiver. The newly materialized Message
+     * instance on the receiver side will have {@link #extractMetadata(MetadataExtractor)}
+     * invoked on it with an extractor that can read the values set by the sender.</p>
+     *
+     * <p>The transport carrier shall guarantee that the metadata injected will not be
+     * compressed during transport.</p>
+     *
+     * <p>Should not throw exceptions.</p>
+     *
+     * @param injector used to set metadata key/value pairs in the underlying
+     *                 message carrier.
+     */
+    @Beta
+    public void injectMetadata(MetadataInjector injector) {}
+
+    /**
+     * <p>Lets a Message subclass extract specific metadata values received via the
+     * underlying transport for this particular Message.</p>
+     *
+     * <p>This method is always invoked by the transport layer right after it has
+     * been decoded but <em>before</em> it is passed to any message handlers.</p>
+     *
+     * <p>Should not throw exceptions.</p>
+     *
+     * @param extractor used to extract values for specific keys
+     */
+    @Beta
+    public void extractMetadata(MetadataExtractor extractor) {}
 
     /**
      * <p>Returns the timestamp for when this message was last seen by message bus. If you are using this to determine

--- a/messagebus/src/main/java/com/yahoo/messagebus/Message.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/Message.java
@@ -58,21 +58,9 @@ public abstract class Message extends Routable {
     }
 
     /**
-     * <p>Returns whether a Message may have metadata it wishes to propagate to destinations.</p>
-     *
-     * <p>Note that if a Message subclass contains metadata, it has the responsibility to
-     * ensure {@link #swapState(Routable)} correctly handles this metadata.</p>
-     *
-     * <p>Should not throw exceptions.</p>
-     */
-    @Beta
-    public boolean hasMetadata() { return false; }
-
-    /**
-     * <p>At the time of serializing a Message to the underlying transport carrier the
-     * network subsystem will call {@link #hasMetadata()}. Iff it returns <code>true</code>,
-     * this method will then be subsequently invoked to inject any metadata key/value
-     * pairs the Message wants to propagate to the receiver. The newly materialized Message
+     * <p>At the time of serializing a Message to the underlying transport carrier, the
+     * network subsystem will call this method to inject any metadata key/value pairs
+     * the Message wants to propagate to the receiver. The newly materialized Message
      * instance on the receiver side will have {@link #extractMetadata(MetadataExtractor)}
      * invoked on it with an extractor that can read the values set by the sender.</p>
      *

--- a/messagebus/src/main/java/com/yahoo/messagebus/MetadataExtractor.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/MetadataExtractor.java
@@ -1,0 +1,24 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.messagebus;
+
+import com.yahoo.api.annotations.Beta;
+
+import java.util.Optional;
+
+/**
+ * Abstraction for getting metadata values without needing to know anything
+ * about how the metadata is being transported.
+ */
+@Beta
+public interface MetadataExtractor {
+
+    /**
+     * Retrieves a metadata value for a particular key, returning <code>Optional.empty()</code>
+     * if there is no mapped value for the key.
+     *
+     * @param key metadata-specific key. Should be unique for its purpose.
+     * @return the metadata value the key resolves to, or an empty Optional if no value existed.
+     */
+    Optional<String> extractValue(String key);
+
+}

--- a/messagebus/src/main/java/com/yahoo/messagebus/MetadataInjector.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/MetadataInjector.java
@@ -1,0 +1,27 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.messagebus;
+
+import com.yahoo.api.annotations.Beta;
+
+/**
+ * Abstraction for setting metadata values without needing to know anything
+ * about how the metadata is being transported.
+ */
+@Beta
+public interface MetadataInjector {
+
+    /**
+     * <p>Set a particular key/value mapping to be propagated as metadata.</p>
+     *
+     * <p>Prefer limiting both keys and values to only contain ASCII characters to
+     * maximize interoperability with other carrier protocols.</p>
+     *
+     * <p>It is unspecified whether multiple injection calls with the same key will
+     * reflect the first or last value set, so callers should not depend on this.</p>
+     *
+     * @param key   Metadata key. Should be unique for its purpose.
+     * @param value Metadata value.
+     */
+    void injectKeyValue(String key, String value);
+
+}

--- a/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCSend.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCSend.java
@@ -205,10 +205,7 @@ public abstract class RPCSend implements MethodHandler, ReplyHandler, RequestWai
             msg.getTrace().trace(TraceLevel.SEND_RECEIVE,
                     "Message (type " + msg.getType() + ") received at " + serverIdent + " for session '" + p.session + "'.");
         }
-        if (p.metadataExtractor != null) {
-            // TODO wrap in a try-catch just in case?
-            msg.extractMetadata(p.metadataExtractor);
-        }
+        msg.extractMetadata(p.metadataExtractor); // TODO wrap in a try-catch just in case?
         net.getOwner().deliverMessage(msg, p.session);
     }
 

--- a/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCSend.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCSend.java
@@ -12,6 +12,7 @@ import com.yahoo.messagebus.EmptyReply;
 import com.yahoo.messagebus.Error;
 import com.yahoo.messagebus.ErrorCode;
 import com.yahoo.messagebus.Message;
+import com.yahoo.messagebus.MetadataExtractor;
 import com.yahoo.messagebus.Protocol;
 import com.yahoo.messagebus.Reply;
 import com.yahoo.messagebus.ReplyHandler;
@@ -154,6 +155,7 @@ public abstract class RPCSend implements MethodHandler, ReplyHandler, RequestWai
         Utf8Array protocolName;
         byte [] payload;
         int traceLevel;
+        MetadataExtractor metadataExtractor;
     }
 
     @Override
@@ -202,6 +204,10 @@ public abstract class RPCSend implements MethodHandler, ReplyHandler, RequestWai
         if (msg.getTrace().shouldTrace(TraceLevel.SEND_RECEIVE)) {
             msg.getTrace().trace(TraceLevel.SEND_RECEIVE,
                     "Message (type " + msg.getType() + ") received at " + serverIdent + " for session '" + p.session + "'.");
+        }
+        if (p.metadataExtractor != null) {
+            // TODO wrap in a try-catch just in case?
+            msg.extractMetadata(p.metadataExtractor);
         }
         net.getOwner().deliverMessage(msg, p.session);
     }

--- a/messagebus/src/main/java/com/yahoo/messagebus/test/SimpleMessage.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/test/SimpleMessage.java
@@ -35,7 +35,6 @@ public class SimpleMessage extends Message {
         return value.length();
     }
 
-    @Override
     public boolean hasMetadata() {
         return fooMeta != null || barMeta != null;
     }

--- a/messagebus/src/main/java/com/yahoo/messagebus/test/SimpleMessage.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/test/SimpleMessage.java
@@ -2,6 +2,8 @@
 package com.yahoo.messagebus.test;
 
 import com.yahoo.messagebus.Message;
+import com.yahoo.messagebus.MetadataExtractor;
+import com.yahoo.messagebus.MetadataInjector;
 import com.yahoo.text.Utf8String;
 
 /**
@@ -10,6 +12,9 @@ import com.yahoo.text.Utf8String;
 public class SimpleMessage extends Message {
 
     private String value;
+
+    private String fooMeta;
+    private String barMeta;
 
     public SimpleMessage(String value) {
         this.value = value;
@@ -30,11 +35,48 @@ public class SimpleMessage extends Message {
         return value.length();
     }
 
+    @Override
+    public boolean hasMetadata() {
+        return fooMeta != null || barMeta != null;
+    }
+
+    @Override
+    public void injectMetadata(MetadataInjector injector) {
+        if (fooMeta != null) {
+            injector.injectKeyValue("foo", fooMeta);
+        }
+        if (barMeta != null) {
+            injector.injectKeyValue("bar", barMeta);
+        }
+    }
+
+    @Override
+    public void extractMetadata(MetadataExtractor extractor) {
+        extractor.extractValue("foo").ifPresent(v -> fooMeta = v);
+        extractor.extractValue("bar").ifPresent(v -> barMeta = v);
+    }
+
     public String getValue() {
         return value;
     }
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getFooMeta() {
+        return fooMeta;
+    }
+
+    public void setFooMeta(String fooMeta) {
+        this.fooMeta = fooMeta;
+    }
+
+    public String getBarMeta() {
+        return barMeta;
+    }
+
+    public void setBarMeta(String barMeta) {
+        this.barMeta = barMeta;
     }
 }

--- a/messagebus/src/tests/simple-roundtrip/simple-roundtrip.cpp
+++ b/messagebus/src/tests/simple-roundtrip/simple-roundtrip.cpp
@@ -61,8 +61,10 @@ TEST_F(SimpleRoundtripTest, simple_roundtrip_test) {
     ASSERT_TRUE(msg);
     EXPECT_TRUE(msg->getProtocol() == SimpleProtocol::NAME);
     EXPECT_TRUE(msg->getType() == SimpleProtocol::MESSAGE);
-    EXPECT_FALSE(msg->hasMetadata());
-    EXPECT_TRUE(dynamic_cast<SimpleMessage&>(*msg).getValue() == "test message");
+    auto* as_simple_msg = dynamic_cast<SimpleMessage*>(msg.get());
+    ASSERT_TRUE(as_simple_msg);
+    EXPECT_FALSE(as_simple_msg->hasMetadata());
+    EXPECT_EQ(as_simple_msg->getValue(), "test message");
 
     // forward message on proxy
     dynamic_cast<SimpleMessage&>(*msg).setValue("test message pxy");
@@ -73,8 +75,10 @@ TEST_F(SimpleRoundtripTest, simple_roundtrip_test) {
     ASSERT_TRUE(msg);
     EXPECT_TRUE(msg->getProtocol() == SimpleProtocol::NAME);
     EXPECT_TRUE(msg->getType() == SimpleProtocol::MESSAGE);
-    EXPECT_FALSE(msg->hasMetadata());
-    EXPECT_TRUE(dynamic_cast<SimpleMessage&>(*msg).getValue() == "test message pxy");
+    as_simple_msg = dynamic_cast<SimpleMessage*>(msg.get());
+    ASSERT_TRUE(as_simple_msg);
+    EXPECT_FALSE(as_simple_msg->hasMetadata());
+    EXPECT_EQ(as_simple_msg->getValue(), "test message pxy");
 
     // send reply on server
     auto sr = std::make_unique<SimpleReply>("test reply");

--- a/messagebus/src/tests/simple-roundtrip/simple-roundtrip.cpp
+++ b/messagebus/src/tests/simple-roundtrip/simple-roundtrip.cpp
@@ -9,7 +9,9 @@
 #include <vespa/messagebus/messagebus.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
-using namespace mbus;
+using namespace ::testing;
+
+namespace mbus {
 
 RoutingSpec getRouting() {
     return RoutingSpec()
@@ -19,12 +21,11 @@ RoutingSpec getRouting() {
                   .addRoute(RouteSpec("test").addHop("pxy").addHop("dst")));
 }
 
-TEST(SimpleRoundtripTest, simple_roundtrip_test) {
-
+struct SimpleRoundtripTest : Test {
     Slobrok     slobrok;
-    TestServer  srcNet(Identity("test/src"), getRouting(), slobrok);
-    TestServer  pxyNet(Identity("test/pxy"), getRouting(), slobrok);
-    TestServer  dstNet(Identity("test/dst"), getRouting(), slobrok);
+    TestServer  srcNet{Identity("test/src"), getRouting(), slobrok};
+    TestServer  pxyNet{Identity("test/pxy"), getRouting(), slobrok};
+    TestServer  dstNet{Identity("test/dst"), getRouting(), slobrok};
 
     Receptor    src;
     Receptor    pxy;
@@ -34,11 +35,24 @@ TEST(SimpleRoundtripTest, simple_roundtrip_test) {
     IntermediateSession::UP is = pxyNet.mb.createIntermediateSession("session", true, pxy, pxy);
     DestinationSession::UP  ds = dstNet.mb.createDestinationSession("session", true, dst);
 
-    // wait for slobrok registration
-    ASSERT_TRUE(srcNet.waitSlobrok("test/pxy/session"));
-    ASSERT_TRUE(srcNet.waitSlobrok("test/dst/session"));
-    ASSERT_TRUE(pxyNet.waitSlobrok("test/dst/session"));
+    SimpleRoundtripTest();
+    ~SimpleRoundtripTest() override;
 
+    void SetUp() override {
+        // wait for slobrok registration
+        ASSERT_TRUE(srcNet.waitSlobrok("test/pxy/session"));
+        ASSERT_TRUE(srcNet.waitSlobrok("test/dst/session"));
+        ASSERT_TRUE(pxyNet.waitSlobrok("test/dst/session"));
+    }
+
+    void do_test_header_kvs_are_propagated(const std::optional<std::string>& foo_meta,
+                                           const std::optional<std::string>& bar_meta);
+};
+
+SimpleRoundtripTest::SimpleRoundtripTest()  = default;
+SimpleRoundtripTest::~SimpleRoundtripTest() = default;
+
+TEST_F(SimpleRoundtripTest, simple_roundtrip_test) {
     // send message on client
     ss->send(std::make_unique<SimpleMessage>("test message"), "test");
 
@@ -47,6 +61,7 @@ TEST(SimpleRoundtripTest, simple_roundtrip_test) {
     ASSERT_TRUE(msg);
     EXPECT_TRUE(msg->getProtocol() == SimpleProtocol::NAME);
     EXPECT_TRUE(msg->getType() == SimpleProtocol::MESSAGE);
+    EXPECT_FALSE(msg->hasMetadata());
     EXPECT_TRUE(dynamic_cast<SimpleMessage&>(*msg).getValue() == "test message");
 
     // forward message on proxy
@@ -58,6 +73,7 @@ TEST(SimpleRoundtripTest, simple_roundtrip_test) {
     ASSERT_TRUE(msg);
     EXPECT_TRUE(msg->getProtocol() == SimpleProtocol::NAME);
     EXPECT_TRUE(msg->getType() == SimpleProtocol::MESSAGE);
+    EXPECT_FALSE(msg->hasMetadata());
     EXPECT_TRUE(dynamic_cast<SimpleMessage&>(*msg).getValue() == "test message pxy");
 
     // send reply on server
@@ -83,5 +99,55 @@ TEST(SimpleRoundtripTest, simple_roundtrip_test) {
     EXPECT_TRUE(reply->getType() == SimpleProtocol::REPLY);
     EXPECT_TRUE(dynamic_cast<SimpleReply&>(*reply).getValue() == "test reply pxy");
 }
+
+void SimpleRoundtripTest::do_test_header_kvs_are_propagated(const std::optional<std::string>& foo_meta,
+                                                            const std::optional<std::string>& bar_meta) {
+    auto msg_to_send = std::make_unique<SimpleMessage>("test message");
+    msg_to_send->set_foo_meta(foo_meta);
+    msg_to_send->set_bar_meta(bar_meta);
+    const bool has_meta = msg_to_send->hasMetadata();
+    ss->send(std::move(msg_to_send), "test");
+
+    Message::UP msg = pxy.getMessage();
+    auto* as_simple_msg = dynamic_cast<SimpleMessage*>(msg.get());
+    ASSERT_TRUE(as_simple_msg);
+    EXPECT_EQ(as_simple_msg->hasMetadata(), has_meta);
+    EXPECT_EQ(as_simple_msg->foo_meta(), foo_meta);
+    EXPECT_EQ(as_simple_msg->bar_meta(), bar_meta);
+    is->forward(std::move(msg));
+
+    msg = dst.getMessage();
+    as_simple_msg = dynamic_cast<SimpleMessage*>(msg.get());
+    ASSERT_TRUE(as_simple_msg);
+    EXPECT_EQ(as_simple_msg->hasMetadata(), has_meta);
+    EXPECT_EQ(as_simple_msg->foo_meta(), foo_meta);
+    EXPECT_EQ(as_simple_msg->bar_meta(), bar_meta);
+
+    // Avoid dangling messages
+    auto sr = std::make_unique<SimpleReply>("test reply");
+    msg->swapState(*sr);
+    ds->reply(std::move(sr));
+
+    Reply::UP reply = pxy.getReply();
+    ASSERT_TRUE(reply);
+    is->forward(std::move(reply));
+
+    reply = src.getReply();
+    ASSERT_TRUE(reply);
+}
+
+TEST_F(SimpleRoundtripTest, empty_kv_map_is_propagated) {
+    do_test_header_kvs_are_propagated(std::nullopt, std::nullopt);
+}
+
+TEST_F(SimpleRoundtripTest, single_header_kv_is_propagated) {
+    do_test_header_kvs_are_propagated("marve", std::nullopt);
+}
+
+TEST_F(SimpleRoundtripTest, multiple_header_kvs_are_propagated) {
+    do_test_header_kvs_are_propagated("marve", "fleksnes");
+}
+
+} // mbus
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/messagebus/src/tests/simpleprotocol/simpleprotocol.cpp
+++ b/messagebus/src/tests/simpleprotocol/simpleprotocol.cpp
@@ -29,7 +29,8 @@ TEST(SimpleProtocolTest, simpleprotocol_test) {
     {
         // test SimpleMessage
         EXPECT_EQ(104u, sizeof(Message));
-        EXPECT_EQ(120u + sizeof(std::string), sizeof(SimpleMessage));
+        constexpr size_t dummy_metadata_overhead = sizeof(std::optional<std::string>) * 2;
+        EXPECT_EQ(sizeof(Message) + 16u + dummy_metadata_overhead + sizeof(std::string), sizeof(SimpleMessage));
         auto msg = std::make_unique<SimpleMessage>("test");
         EXPECT_TRUE(!msg->isReply());
         EXPECT_TRUE(msg->getProtocol() == SimpleProtocol::NAME);

--- a/messagebus/src/vespa/messagebus/message.h
+++ b/messagebus/src/vespa/messagebus/message.h
@@ -151,18 +151,9 @@ public:
     virtual uint32_t getApproxSize() const { return 1; }
 
     /**
-     * Returns whether a Message may have metadata it wishes to propagate to destinations.
-     *
-     * Note that if a Message subclass contains metadata, it has the responsibility to
-     * ensure swapState(Routable) correctly handles this metadata.
-     */
-    [[nodiscard]] virtual bool hasMetadata() const noexcept { return false; }
-
-    /**
-     * At the time of serializing a Message to the underlying transport carrier the
-     * network subsystem will call hasMetadata(). Iff it returns true, this method will
-     * then be subsequently invoked to inject any metadata key/value pairs the Message
-     * wants to propagate to the receiver.
+     * At the time of serializing a Message to the underlying transport carrier, the
+     * network subsystem will always call this method to inject any metadata key/value
+     * pairs the Message wants to propagate to the receiver.
      *
      * The newly materialized Message instance on the receiver side will have
      * extractMetadata(MetadataExtractor) invoked on it with an extractor that can read

--- a/messagebus/src/vespa/messagebus/message.h
+++ b/messagebus/src/vespa/messagebus/message.h
@@ -6,6 +6,9 @@
 
 namespace mbus {
 
+class MetadataInjector;
+class MetadataExtractor;
+
 /**
  * A Message is a question, a Reply is the answer.
  */
@@ -146,6 +149,47 @@ public:
      * @return 1
      */
     virtual uint32_t getApproxSize() const { return 1; }
+
+    /**
+     * Returns whether a Message may have metadata it wishes to propagate to destinations.
+     *
+     * Note that if a Message subclass contains metadata, it has the responsibility to
+     * ensure swapState(Routable) correctly handles this metadata.
+     */
+    [[nodiscard]] virtual bool hasMetadata() const noexcept { return false; }
+
+    /**
+     * At the time of serializing a Message to the underlying transport carrier the
+     * network subsystem will call hasMetadata(). Iff it returns true, this method will
+     * then be subsequently invoked to inject any metadata key/value pairs the Message
+     * wants to propagate to the receiver.
+     *
+     * The newly materialized Message instance on the receiver side will have
+     * extractMetadata(MetadataExtractor) invoked on it with an extractor that can read
+     * the values set by the sender.
+     *
+     * The transport carrier shall guarantee that the metadata injected will not be
+     * compressed during transport.
+     *
+     * @param injector used to set metadata key/value pairs in the underlying
+     *                 message carrier.
+     */
+    virtual void injectMetadata(MetadataInjector& injector) const {
+        (void)injector; // no-op by default
+    }
+
+    /**
+     * Lets a Message subclass extract specific metadata values received via the
+     * underlying transport for this particular Message.
+     *
+     * This method is always invoked by the transport layer right after it has
+     * been decoded but _before_ it is passed to any message handlers.
+     *
+     * @param extractor used to extract values for specific keys
+     */
+    virtual void extractMetadata(const MetadataExtractor& extractor) {
+        (void)extractor; // no-op by default
+    }
 
     /**
      * Sets whether or not this message can be resent.

--- a/messagebus/src/vespa/messagebus/metadata_extractor.h
+++ b/messagebus/src/vespa/messagebus/metadata_extractor.h
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <optional>
+
+namespace mbus {
+
+/**
+ * Abstraction for getting metadata values without needing to know anything
+ * about how the metadata is being transported.
+ */
+class MetadataExtractor {
+public:
+    virtual ~MetadataExtractor() = default;
+
+    /**
+     * Retrieves a metadata value for a particular key, returning an empty optional
+     * if there is no mapped value for the key.
+     *
+     * @param key metadata-specific key. Should be unique for its purpose.
+     * @return the metadata value the key resolves to, or an empty optional if no value existed.
+     */
+    [[nodiscard]] virtual std::optional<std::string> extract_value(std::string_view key) const = 0;
+};
+
+}

--- a/messagebus/src/vespa/messagebus/metadata_injector.h
+++ b/messagebus/src/vespa/messagebus/metadata_injector.h
@@ -1,0 +1,32 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string_view>
+
+namespace mbus {
+
+/**
+ * Abstraction for setting metadata values without needing to know anything
+ * about how the metadata is being transported.
+ */
+class MetadataInjector {
+public:
+    virtual ~MetadataInjector() = default;
+
+    /**
+     * Set a particular key/value mapping to be propagated as metadata.
+     *
+     * Prefer limiting both keys and values to only contain ASCII characters to
+     * maximize interoperability with other carrier protocols.
+     *
+     * It is unspecified whether multiple injection calls with the same key will
+     * reflect the first or last value set, so callers should not depend on this.
+     *
+     * @param key   Metadata key. Should be unique for its purpose.
+     * @param value Metadata value.
+     */
+    virtual void inject_key_value(std::string_view key, std::string_view value) = 0;
+};
+
+}

--- a/messagebus/src/vespa/messagebus/network/rpcsend.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcsend.cpp
@@ -54,7 +54,21 @@ private:
     mutable Blob _payload;
 };
 
-}
+// MetadataExtractor for use when there's no metadata header present, but we still
+// want to give the illusion that an empty one was provided.
+class AlwaysEmptyMetadataExtractor final : public MetadataExtractor {
+public:
+    ~AlwaysEmptyMetadataExtractor() override = default;
+    std::optional<std::string> extract_value(std::string_view) const override {
+        return std::nullopt;
+    }
+    [[nodiscard]] static const AlwaysEmptyMetadataExtractor& instance() noexcept {
+        static const AlwaysEmptyMetadataExtractor sentinel;
+        return sentinel;
+    }
+};
+
+} // namespace
 
 RPCSend::RPCSend()
     : _net(nullptr),
@@ -295,8 +309,10 @@ RPCSend::doRequest(FRT_RPCRequest *req)
                               make_string("Message (type %d) received at %s for session '%s'.",
                                           msg->getType(), _serverIdent.c_str(), string(params->getSession()).c_str()));
     }
-    if (auto meta_extractor = params->get_metadata_extractor_once()) {
+    if (auto meta_extractor = params->steal_metadata_extractor()) {
         msg->extractMetadata(*meta_extractor);
+    } else {
+        msg->extractMetadata(AlwaysEmptyMetadataExtractor::instance());
     }
     _net->getOwner().deliverMessage(std::move(msg), params->getSession());
 }

--- a/messagebus/src/vespa/messagebus/network/rpcsend.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcsend.cpp
@@ -7,6 +7,7 @@
 #include <vespa/messagebus/tracelevel.h>
 #include <vespa/messagebus/emptyreply.h>
 #include <vespa/messagebus/errorcode.h>
+#include <vespa/messagebus/metadata_extractor.h>
 #include <vespa/fnet/channel.h>
 #include <vespa/fnet/frt/reflection.h>
 #include <vespa/vespalib/util/stringfmt.h>
@@ -293,6 +294,9 @@ RPCSend::doRequest(FRT_RPCRequest *req)
         msg->getTrace().trace(TraceLevel::SEND_RECEIVE,
                               make_string("Message (type %d) received at %s for session '%s'.",
                                           msg->getType(), _serverIdent.c_str(), string(params->getSession()).c_str()));
+    }
+    if (auto meta_extractor = params->get_metadata_extractor_once()) {
+        msg->extractMetadata(*meta_extractor);
     }
     _net->getOwner().deliverMessage(std::move(msg), params->getSession());
 }

--- a/messagebus/src/vespa/messagebus/network/rpcsend.h
+++ b/messagebus/src/vespa/messagebus/network/rpcsend.h
@@ -18,6 +18,7 @@ namespace mbus {
 class Error;
 class Route;
 class Message;
+class MetadataExtractor;
 class RPCServiceAddress;
 class IProtocol;
 
@@ -48,6 +49,7 @@ public:
         virtual std::string_view getRoute() const = 0;
         virtual std::string_view getSession() const = 0;
         virtual BlobRef getPayload() const = 0;
+        virtual std::unique_ptr<MetadataExtractor> get_metadata_extractor_once() noexcept = 0;
     };
 protected:
     RPCNetwork *_net;

--- a/messagebus/src/vespa/messagebus/network/rpcsend.h
+++ b/messagebus/src/vespa/messagebus/network/rpcsend.h
@@ -49,7 +49,7 @@ public:
         virtual std::string_view getRoute() const = 0;
         virtual std::string_view getSession() const = 0;
         virtual BlobRef getPayload() const = 0;
-        virtual std::unique_ptr<MetadataExtractor> get_metadata_extractor_once() noexcept = 0;
+        virtual std::unique_ptr<MetadataExtractor> steal_metadata_extractor() noexcept = 0;
     };
 protected:
     RPCNetwork *_net;

--- a/messagebus/src/vespa/messagebus/testlib/simplemessage.cpp
+++ b/messagebus/src/vespa/messagebus/testlib/simplemessage.cpp
@@ -2,6 +2,8 @@
 
 #include "simplemessage.h"
 #include "simpleprotocol.h"
+#include <vespa/messagebus/metadata_extractor.h>
+#include <vespa/messagebus/metadata_injector.h>
 
 namespace mbus {
 
@@ -72,6 +74,28 @@ uint32_t
 SimpleMessage::getApproxSize() const
 {
     return _value.size();
+}
+
+bool SimpleMessage::hasMetadata() const noexcept {
+    return _foo_meta || _bar_meta;
+}
+
+void SimpleMessage::injectMetadata(MetadataInjector& injector) const {
+    if (_foo_meta) {
+        injector.inject_key_value("foo", *_foo_meta);
+    }
+    if (_bar_meta) {
+        injector.inject_key_value("bar", *_bar_meta);
+    }
+}
+
+void SimpleMessage::extractMetadata(const MetadataExtractor& extractor) {
+    if (auto v = extractor.extract_value("foo")) {
+        _foo_meta = v;
+    }
+    if (auto v = extractor.extract_value("bar")) {
+        _bar_meta = v;
+    }
 }
 
 } // namespace mbus

--- a/messagebus/src/vespa/messagebus/testlib/simplemessage.h
+++ b/messagebus/src/vespa/messagebus/testlib/simplemessage.h
@@ -3,14 +3,17 @@
 #pragma once
 
 #include <vespa/messagebus/message.h>
+#include <optional>
 
 namespace mbus {
 
 class SimpleMessage : public Message {
 private:
-    string   _value;
-    bool     _hasSeqId;
-    uint64_t _seqId;
+    string                     _value;
+    bool                       _hasSeqId;
+    uint64_t                   _seqId;
+    std::optional<std::string> _foo_meta;
+    std::optional<std::string> _bar_meta;
 
 public:
     SimpleMessage(const string &str);
@@ -27,6 +30,16 @@ public:
     uint32_t getApproxSize() const override;
     uint8_t priority() const override { return 8; }
     string toString() const override { return _value; }
+
+    void set_foo_meta(std::optional<std::string> s) noexcept { _foo_meta = std::move(s); }
+    void set_bar_meta(std::optional<std::string> s) noexcept { _bar_meta = std::move(s); }
+
+    const std::optional<std::string>& foo_meta() const noexcept { return _foo_meta; }
+    const std::optional<std::string>& bar_meta() const noexcept { return _bar_meta; }
+
+    bool hasMetadata() const noexcept override;
+    void injectMetadata(MetadataInjector&) const override;
+    void extractMetadata(const MetadataExtractor&) override;
 };
 
 } // namespace mbus

--- a/messagebus/src/vespa/messagebus/testlib/simplemessage.h
+++ b/messagebus/src/vespa/messagebus/testlib/simplemessage.h
@@ -37,7 +37,7 @@ public:
     const std::optional<std::string>& foo_meta() const noexcept { return _foo_meta; }
     const std::optional<std::string>& bar_meta() const noexcept { return _bar_meta; }
 
-    bool hasMetadata() const noexcept override;
+    bool hasMetadata() const noexcept;
     void injectMetadata(MetadataInjector&) const override;
     void extractMetadata(const MetadataExtractor&) override;
 };


### PR DESCRIPTION
@havardpe please review

This adds a dedicated header KV mapping to the MessageBus `Message` class. This mapping is empty by default.

Wire transmission of headers uses the existing reserved (for exactly this purpose) header blob field of the RPCv2 messaging RPC as a carrier of a binary Slime object payload. The object contains a single sub-object "kvs" that is a string -> string mapping of the message headers.

This is forwards and backwards compatible since the RPC blob fields are entirely ignored by older versions, and new versions will interpret a missing header blob as if no headers are present (this is also how a `Message` without header KVs is encoded with these changes).
