### PR TITLE
Avoid locale-dependent behavior

### DIFF
--- a/searchlib/src/main/java/com/yahoo/searchlib/aggregation/hll/SketchMerger.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/aggregation/hll/SketchMerger.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.aggregation.hll;
 
+import com.yahoo.text.Text;
+
 /**
  * This class is responsible for merging any combinations of two {@link Sketch} instances.
  */
@@ -24,7 +26,7 @@ public class SketchMerger {
             return mergeSparseWithSparse(asSparse(left), asSparse(right));
         } else {
             throw new IllegalArgumentException(
-                    String.format("Invalid sketch types: left=%s, right=%s", right.getClass(), left.getClass()));
+                    Text.format("Invalid sketch types: left=%s, right=%s", right.getClass(), left.getClass()));
         }
     }
 

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/RawResultNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/RawResultNode.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.objects.Deserializer;
 import com.yahoo.vespa.objects.ObjectVisitor;
 import com.yahoo.vespa.objects.Serializer;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -81,7 +82,7 @@ public class RawResultNode extends SingleResultNode {
 
     @Override
     public String getString() {
-        return new String(value.getData());
+        return new String(value.getData(), StandardCharsets.UTF_8);
     }
 
     @Override

--- a/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/fieldmatch/FieldMatchMetrics.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/fieldmatch/FieldMatchMetrics.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static java.lang.Math.*;
 
@@ -93,7 +94,7 @@ public final class FieldMatchMetrics implements Cloneable {
      */
     public float get(String name) {
         try {
-            Method getter = getClass().getMethod("get" + name.substring(0, 1).toUpperCase() + name.substring(1));
+            Method getter = getClass().getMethod("get" + name.substring(0, 1).toUpperCase(Locale.ROOT) + name.substring(1));
             return ((Number)getter.invoke(this)).floatValue();
         }
         catch (NoSuchMethodException e) {
@@ -521,7 +522,7 @@ public final class FieldMatchMetrics implements Cloneable {
                 if ( m.getParameterTypes().length != 0 ) continue;
 
                 Object value = m.invoke(this, new Object[0]);
-                b.append(m.getName().substring(3, 4).toLowerCase() + m.getName().substring(4) + ": " + value + "\n");
+                b.append(m.getName().substring(3, 4).toLowerCase(Locale.ROOT) + m.getName().substring(4) + ": " + value + "\n");
             }
             return b.toString();
         }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/FeatureList.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/FeatureList.java
@@ -6,6 +6,7 @@ import com.yahoo.searchlib.rankingexpression.parser.ParseException;
 import com.yahoo.searchlib.rankingexpression.parser.RankingExpressionParser;
 import com.yahoo.searchlib.rankingexpression.parser.TokenMgrException;
 import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
+import com.yahoo.text.Utf8;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -50,7 +51,7 @@ public class FeatureList implements Iterable<ReferenceNode> {
      * @throws FileNotFoundException Thrown if the file specified could not be found.
      */
     public FeatureList(File file) throws ParseException, FileNotFoundException {
-        features.addAll(parse(new FileReader(file)));
+        features.addAll(parse(Utf8.createReader(file)));
     }
 
     /**

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/RankingExpression.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/RankingExpression.java
@@ -11,6 +11,7 @@ import com.yahoo.searchlib.rankingexpression.rule.SerializationContext;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
 import com.yahoo.text.Text;
+import com.yahoo.text.Utf8;
 import static com.yahoo.searchlib.rankingexpression.Reference.RANKING_EXPRESSION_WRAPPER;
 
 import java.io.File;
@@ -145,7 +146,7 @@ public class RankingExpression implements Serializable {
     public RankingExpression(File file) throws ParseException {
         try {
             name = file.getName().split("\\.")[0];
-            root = parse(new FileReader(file));
+            root = parse(Utf8.createReader(file));
         }
         catch (FileNotFoundException e) {
             throw new IllegalArgumentException("Could not create a ranking expression", e);

--- a/searchlib/src/main/java/com/yahoo/searchlib/tensor/EvaluateTensorConformance.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/tensor/EvaluateTensorConformance.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 
 import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -46,7 +47,7 @@ public class EvaluateTensorConformance {
 
     void evaluateStdIn() {
         int count = 0;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8))) {
             String test = br.readLine();
             while (test != null) {
                 boolean success = testCase(test, count);

--- a/searchlib/src/main/java/com/yahoo/searchlib/treenet/TreeNetConverter.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/treenet/TreeNetConverter.java
@@ -2,6 +2,7 @@
 package com.yahoo.searchlib.treenet;
 
 import com.yahoo.searchlib.treenet.parser.TreeNetParser;
+import com.yahoo.text.Utf8;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -22,7 +23,7 @@ public class TreeNetConverter {
             System.exit(1);
         }
         try {
-            TreeNetParser parser = new TreeNetParser(new FileReader(args[0]));
+            TreeNetParser parser = new TreeNetParser(Utf8.createReader(args[0]));
             System.out.println(parser.treeNet().toRankingExpression());
         } catch (FileNotFoundException e) {
             System.err.println("Could not find file '" + args[0] + "'.");

--- a/searchlib/src/test/java/com/yahoo/searchlib/aggregation/GroupingSerializationTest.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/aggregation/GroupingSerializationTest.java
@@ -5,6 +5,7 @@ import com.yahoo.document.DocumentId;
 import com.yahoo.document.GlobalId;
 import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.searchlib.aggregation.hll.SparseSketch;
+import java.nio.charset.StandardCharsets;
 import com.yahoo.searchlib.expression.AddFunctionNode;
 import com.yahoo.searchlib.expression.AttributeNode;
 import com.yahoo.searchlib.expression.CatFunctionNode;
@@ -42,6 +43,7 @@ import com.yahoo.searchlib.expression.TimeStampFunctionNode;
 import com.yahoo.searchlib.expression.XorBitFunctionNode;
 import com.yahoo.searchlib.expression.XorFunctionNode;
 import com.yahoo.searchlib.expression.ZCurveFunctionNode;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.objects.BufferSerializer;
 import com.yahoo.vespa.objects.Identifiable;
 import com.yahoo.vespa.objects.ObjectDumper;
@@ -221,7 +223,7 @@ public class GroupingSerializationTest {
             t.assertMatch(new VdsHit());
             //TODO Verify the two structures below
             t.assertMatch(new VdsHit("100", new byte[0], 50.0));
-            t.assertMatch(new VdsHit("100", "rawsummary".getBytes(), 50.0));
+            t.assertMatch(new VdsHit("100", "rawsummary".getBytes(StandardCharsets.UTF_8), 50.0));
             t.assertMatch(new HitsAggregationResult());
             t.assertMatch(new HitsAggregationResult()
                     .setMaxHits(5)
@@ -240,9 +242,9 @@ public class GroupingSerializationTest {
             //TODO Verify content
             t.assertMatch(new HitsAggregationResult()
                     .setMaxHits(3)
-                    .addHit(new VdsHit("10", "100".getBytes(), 1.0))
-                    .addHit(new VdsHit("20", "200".getBytes(), 2.0))
-                    .addHit(new VdsHit("30", "300".getBytes(), 3.0))
+                    .addHit(new VdsHit("10", "100".getBytes(StandardCharsets.UTF_8), 1.0))
+                    .addHit(new VdsHit("20", "200".getBytes(StandardCharsets.UTF_8), 2.0))
+                    .addHit(new VdsHit("30", "300".getBytes(StandardCharsets.UTF_8), 3.0))
                     .setExpression(new ConstantNode(new IntegerResultNode(5))));
         }
     }
@@ -351,7 +353,7 @@ public class GroupingSerializationTest {
 
     private static GlobalId createGlobalId(int docId) {
         return new GlobalId(
-                new DocumentId(String.format("id:test:type::%d", docId)).getGlobalId());
+                new DocumentId(Text.format("id:test:type::%d", docId)).getGlobalId());
     }
 
     private static ExpressionNode createDummyExpression() {
@@ -407,7 +409,7 @@ public class GroupingSerializationTest {
             Identifiable deserializedObject = Identifiable.create(new BufferSerializer(originalData));
 
             if (!deserializedObject.equals(expectedObject)) {
-                fail(String.format("Serialized object in file '%s' does not equal expected values.\n" +
+                fail(Text.format("Serialized object in file '%s' does not equal expected values.\n" +
                                 "==================================================\n" +
                                 "Expected:\n" +
                                 "==================================================\n" +
@@ -427,7 +429,7 @@ public class GroupingSerializationTest {
             byte[] newData = new byte[buffer.limit()];
             buffer.get(newData);
             if (!Arrays.equals(newData, originalData)) {
-                fail(String.format("Serialized object data does not match the original serialized data from file.\n" +
+                fail(Text.format("Serialized object data does not match the original serialized data from file.\n" +
                                 "==================================================\n" +
                                 "Original:\n" +
                                 "==================================================\n" +

--- a/searchlib/src/test/java/com/yahoo/searchlib/expression/ExpressionTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/expression/ExpressionTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.searchlib.expression;
 
 import com.yahoo.io.GrowableByteBuffer;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.objects.BufferSerializer;
 import com.yahoo.vespa.objects.Identifiable;
@@ -9,6 +10,7 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -708,7 +710,7 @@ public class ExpressionTestCase {
     private void compareAllPairwise(ResultNode... orderedNodes) {
         for (int i = 0; i < orderedNodes.length; ++i) {
             for (int j = 0; j < orderedNodes.length; ++j) {
-                var ctx = String.format("lhs(i=%d): %s, rhs(j=%d): %s", i, orderedNodes[i], j, orderedNodes[j]);
+                var ctx = Text.format("lhs(i=%d): %s, rhs(j=%d): %s", i, orderedNodes[i], j, orderedNodes[j]);
                 if (j < i) {
                     assertTrue(ctx, orderedNodes[i].compareTo(orderedNodes[j]) > 0);
                 } else if (j > i) {

--- a/searchlib/src/test/java/com/yahoo/searchlib/gbdt/GbdtConverterTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/gbdt/GbdtConverterTestCase.java
@@ -91,7 +91,7 @@ public class GbdtConverterTestCase {
     private static void assertConvert(String gbdtModelFile, String expectedExpression)
             throws ParseException, UnsupportedEncodingException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
         GbdtConverter.main(new String[] { gbdtModelFile });
         String actualExpression = out.toString(StandardCharsets.UTF_8);
         assertEquals(expectedExpression, actualExpression);
@@ -100,7 +100,7 @@ public class GbdtConverterTestCase {
 
     private static void assertError(String expected, String[] args) throws UnsupportedEncodingException {
         ByteArrayOutputStream err = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(err));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
         try {
             GbdtConverter.main(args);
             fail();

--- a/searchlib/src/test/java/com/yahoo/searchlib/gbdt/GbdtModelTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/gbdt/GbdtModelTestCase.java
@@ -2,10 +2,12 @@
 package com.yahoo.searchlib.gbdt;
 
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
+import com.yahoo.text.Utf8;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 
 import static org.junit.Assert.*;
@@ -52,7 +54,7 @@ public class GbdtModelTestCase {
 
     private static String readFile(String file) throws IOException {
         StringBuilder ret = new StringBuilder();
-        BufferedReader in = new BufferedReader(new FileReader(file));
+        BufferedReader in = new BufferedReader(Utf8.createReader(file));
         while (true) {
             String str = in.readLine();
             if (str == null) {

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/RankingExpressionTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/RankingExpressionTestCase.java
@@ -12,6 +12,7 @@ import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
 import com.yahoo.searchlib.rankingexpression.rule.SerializationContext;
 import com.yahoo.searchlib.rankingexpression.rule.TensorFunctionNode;
 import com.yahoo.tensor.functions.Reduce;
+import com.yahoo.text.Utf8;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -23,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -253,7 +255,7 @@ public class RankingExpressionTestCase {
 
     @Test
     public void testParse() throws ParseException, IOException {
-        BufferedReader reader = new BufferedReader(new FileReader("src/tests/rankingexpression/rankingexpressionlist"));
+        BufferedReader reader = new BufferedReader(Utf8.createReader("src/tests/rankingexpression/rankingexpressionlist"));
         String line;
         int lineNumber = 0;
         while ((line = reader.readLine()) != null) {

--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/Benchmark.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/Benchmark.java
@@ -7,13 +7,16 @@ import com.yahoo.searchlib.rankingexpression.parser.ParseException;
 import com.yahoo.searchlib.rankingexpression.rule.CompositeNode;
 import com.yahoo.searchlib.rankingexpression.rule.ExpressionNode;
 import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
+import com.yahoo.text.Utf8;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * @author Simon Thoresen Hult
@@ -31,7 +34,7 @@ public final class Benchmark {
         }
         List<Result> res = new ArrayList<Result>();
         try {
-            BufferedReader in = new BufferedReader(new FileReader(args[0]));
+            BufferedReader in = new BufferedReader(Utf8.createReader(args[0]));
             StringBuilder str = new StringBuilder();
             String line;
             while ((line = in.readLine()) != null) {
@@ -56,7 +59,7 @@ public final class Benchmark {
                     System.exit(1);
                 }
             }
-            System.out.format("%1$-16s : %2$8.04f ms (%3$-6.04f)\n",
+            System.out.format(Locale.ROOT, "%1$-16s : %2$8.04f ms (%3$-6.04f)\n",
                               lhs.name, lhs.millis, res.get(0).millis / lhs.millis);
         }
     }

--- a/searchlib/src/test/java/com/yahoo/searchlib/treenet/TreeNetParserTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/treenet/TreeNetParserTestCase.java
@@ -4,6 +4,8 @@ package com.yahoo.searchlib.treenet;
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
 import com.yahoo.searchlib.treenet.parser.ParseException;
 import com.yahoo.searchlib.treenet.parser.TreeNetParser;
+import com.yahoo.text.Text;
+import com.yahoo.text.Utf8;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -11,6 +13,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -24,8 +28,8 @@ public class TreeNetParserTestCase {
     @Test
     public void testRankingExpression() {
         for (int i = 1; i <= 8; ++i) {
-            String inputFile  = String.format("src/test/files/treenet%02d.model", i);
-            String outputFile = String.format("src/test/files/ranking%02d.expression", i);
+            String inputFile  = Text.format("src/test/files/treenet%02d.model", i);
+            String outputFile = Text.format("src/test/files/ranking%02d.expression", i);
             String input = readFile(inputFile);
             String expression = convertModel(inputFile, input);
             if (WRITE_FILES) {
@@ -60,7 +64,7 @@ public class TreeNetParserTestCase {
     private String readFile(String file) {
         try {
             StringBuilder ret = new StringBuilder();
-            BufferedReader in = new BufferedReader(new FileReader(file));
+            BufferedReader in = new BufferedReader(Utf8.createReader(file));
             while (true) {
                 String str = in.readLine();
                 if (str == null) {
@@ -76,7 +80,7 @@ public class TreeNetParserTestCase {
 
     private void writeFile(String file, String content) {
         try {
-            FileWriter out = new FileWriter(file);
+            FileWriter out = new FileWriter(file, StandardCharsets.UTF_8);
             out.write(content);
             out.close();
         } catch (IOException e) {


### PR DESCRIPTION
Replace implicit locale and charset handling with explicit specifications:
- Add Locale.ROOT to String.format(), toUpperCase(), and toLowerCase() calls
- Use StandardCharsets.UTF_8 when converting bytes to strings
- Replace FileReader with InputStreamReader or Utf8.createReader() for UTF-8
- Replace some String.format() with Text.format() utility

This ensures consistent behavior across different system locales and platforms, avoiding potential bugs from platform-dependent defaults.
