### PR TITLE
Skip unnecessary GenericJsonModel roundtrip when building Prometheus response

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/HostnameDimensionProcessor.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/HostnameDimensionProcessor.java
@@ -1,0 +1,23 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.metricsproxy.http.application;
+
+import ai.vespa.metricsproxy.metric.model.MetricsPacket;
+import ai.vespa.metricsproxy.metric.model.processing.MetricsProcessor;
+
+import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
+
+public class HostnameDimensionProcessor implements MetricsProcessor {
+
+    private static final String HOSTNAME_DIMENSION_NAME = "hostname";
+    private final String hostname;
+
+    public HostnameDimensionProcessor(String hostname) {
+        this.hostname = hostname;
+    }
+
+    @Override
+    public void process(MetricsPacket.Builder builder) {
+        builder.putDimension(toDimensionId(HOSTNAME_DIMENSION_NAME), hostname);
+    }
+
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/metrics/MetricsV2Handler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/metrics/MetricsV2Handler.java
@@ -6,6 +6,7 @@ import ai.vespa.metricsproxy.core.MetricsManager;
 import ai.vespa.metricsproxy.http.MetricsJsonResponse;
 import ai.vespa.metricsproxy.http.ValuesFetcher;
 import ai.vespa.metricsproxy.http.application.ClusterIdDimensionProcessor;
+import ai.vespa.metricsproxy.http.application.HostnameDimensionProcessor;
 import ai.vespa.metricsproxy.http.application.Node;
 import ai.vespa.metricsproxy.http.application.PublicDimensionsProcessor;
 import ai.vespa.metricsproxy.http.application.ServiceIdDimensionProcessor;
@@ -36,7 +37,7 @@ import static com.yahoo.jdisc.Response.Status.OK;
  *
  * @author gjoranv
  */
-public class MetricsV2Handler  extends HttpHandlerBase {
+public class MetricsV2Handler extends HttpHandlerBase {
 
     public static final String V2_PATH = "/metrics/v2";
     public static final String VALUES_PATH = V2_PATH + "/values";
@@ -67,6 +68,7 @@ public class MetricsV2Handler  extends HttpHandlerBase {
             List<MetricsPacket> metrics = processAndBuild(valuesFetcher.fetchMetricsAsBuilders(consumer),
                                                           new ServiceIdDimensionProcessor(),
                                                           new ClusterIdDimensionProcessor(),
+                                                          new HostnameDimensionProcessor(nodeInfoConfig.hostname()),
                                                           new PublicDimensionsProcessor());
 
             Node localNode = new Node(nodeInfoConfig.role(), nodeInfoConfig.hostname(), 0, "");

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
@@ -31,12 +31,17 @@ public class PrometheusUtil {
     public static PrometheusModel toPrometheusModel(List<MetricsPacket> metricsPackets,
                                                     ApplicationDimensions applicationDimensions,
                                                     NodeDimensions nodeDimensions) {
-        Set<MetricId> metricNames = new HashSet<>();
-        for (MetricsPacket metricsPacket : metricsPackets) {
-            metricNames.addAll(metricsPacket.metrics().keySet());
-        }
+        return toPrometheusModel(metricsPackets.stream(), applicationDimensions, nodeDimensions);
+    }
 
-        Map<ServiceId, List<MetricsPacket>> packetsByService = metricsPackets.stream()
+    public static PrometheusModel toPrometheusModel(Stream<MetricsPacket> metricsPacketsStream,
+                                                    ApplicationDimensions applicationDimensions,
+                                                    NodeDimensions nodeDimensions) {
+        Set<MetricId> metricNames = new HashSet<>();
+
+        // Collect both metric names and packets grouped by service in a single pass
+        Map<ServiceId, List<MetricsPacket>> packetsByService = metricsPacketsStream
+                .peek(packet -> metricNames.addAll(packet.metrics().keySet()))
                 .collect(Collectors.groupingBy(MetricsPacket::service));
 
         var labelKeys = new ArrayList<String>();

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
@@ -149,15 +149,6 @@ public class ApplicationMetricsHandlerTest {
     }
 
     @Test
-    public void prometheus_response_contains_hostname() {
-        String response = testDriver.sendRequest(PROMETHEUS_VALUES_URI).readAll();
-        long hostnameCount = Arrays.stream(response.split("\n"))
-                .filter(line -> line.contains("hostname="))
-                .count();
-        assertEquals(3, hostnameCount);
-    }
-
-    @Test
     public void prometheus_response_obeys_format() {
         String response = testDriver.sendRequest(PROMETHEUS_VALUES_URI).readAll();
         Arrays.stream(response.split("\n"))

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/metrics/MetricsV2HandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/metrics/MetricsV2HandlerTest.java
@@ -3,14 +3,20 @@ package ai.vespa.metricsproxy.http.metrics;
 
 import ai.vespa.metricsproxy.metric.model.json.GenericApplicationModel;
 import ai.vespa.metricsproxy.metric.model.json.GenericJsonModel;
+import ai.vespa.metricsproxy.metric.model.json.GenericService;
 import com.yahoo.container.jdisc.RequestHandlerTestDriver;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.Executors;
 
 import static ai.vespa.metricsproxy.http.metrics.MetricsV2Handler.V2_PATH;
 import static ai.vespa.metricsproxy.http.metrics.MetricsV2Handler.VALUES_PATH;
+import static ai.vespa.metricsproxy.metric.model.json.JacksonUtil.objectMapper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author gjoranv
@@ -42,6 +48,24 @@ public class MetricsV2HandlerTest extends MetricsHandlerTestBase<GenericApplicat
     @Override
     GenericJsonModel getGenericJsonModel(GenericApplicationModel genericApplicationModel) {
         return genericApplicationModel.nodes.get(0);
+    }
+
+    @Test
+    public void hostname_is_added() {
+        GenericJsonModel jsonModel = getGenericJsonModel(getResponseAsJsonModel(DEFAULT_CONSUMER));
+        GenericService dummyService = jsonModel.services.get(0);
+        String hostname = dummyService.metrics.get(0).dimensions.get("hostname");
+        assertEquals("my-hostname", hostname);
+    }
+
+    private GenericApplicationModel getResponseAsJsonModel(String consumer) {
+        String response = testDriver.sendRequest(VALUES_URI + "?consumer=" + consumer).readAll();
+        try {
+            return objectMapper().readValue(response, GenericApplicationModel.class);
+        } catch (IOException e) {
+            fail("Failed to create json model: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
     }
 
     private static NodeInfoConfig nodeInfoConfig() {


### PR DESCRIPTION
Also add hostname dimension on the individual node response instead of the concatenated application response

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
