### PR TITLE
Change ConfigOptions timeout methods to return Duration

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -101,9 +101,9 @@ public class ConfigserverCluster extends TreeConfigProducer
             builder.configModelPluginDir(pluginDir);
         }
         if (options.zookeeperBarrierTimeout().isPresent()) {
-            builder.zookeeper(new ConfigserverConfig.Zookeeper.Builder().barrierTimeout(options.zookeeperBarrierTimeout().get()));
+            builder.zookeeper(new ConfigserverConfig.Zookeeper.Builder().barrierTimeout(options.zookeeperBarrierTimeout().get().toSeconds()));
         }
-        options.applicationLockTimeoutSeconds().ifPresent(builder::applicationLockTimeoutSeconds);
+        options.applicationLockTimeoutSeconds().ifPresent(timeout -> builder.applicationLockTimeoutSeconds(timeout.toSeconds()));
         if (options.rpcPort().isPresent()) {
             builder.rpcport(options.rpcPort().get());
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.configserver.option;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -23,8 +24,8 @@ public interface ConfigOptions {
     Optional<Boolean> hostedVespa();
     ConfigServer[] allConfigServers();
     int[] configServerZookeeperIds();
-    Optional<Long> zookeeperBarrierTimeout(); //in seconds
-    Optional<Long> applicationLockTimeoutSeconds();
+    Optional<Duration> zookeeperBarrierTimeout();
+    Optional<Duration> applicationLockTimeoutSeconds();
     Optional<String> environment();
     Optional<String> region();
     Optional<String> system();

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.container.configserver;
 
 import com.yahoo.vespa.model.container.configserver.option.ConfigOptions;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -18,7 +19,7 @@ public class TestOptions implements ConfigOptions {
     private Optional<Boolean> useVespaVersionInRequest = Optional.empty();
     private Optional<Boolean> hostedVespa = Optional.empty();
     private static final String zooKeeperSnapshotMethod = "gz";
-    private Optional<Long> applicationLockTimeoutSeconds = Optional.empty();
+    private Optional<Duration> applicationLockTimeoutSeconds = Optional.empty();
 
     @Override
     public Optional<Integer> rpcPort() {
@@ -54,10 +55,10 @@ public class TestOptions implements ConfigOptions {
     }
 
     @Override
-    public Optional<Long> zookeeperBarrierTimeout() { return Optional.empty(); }
+    public Optional<Duration> zookeeperBarrierTimeout() { return Optional.empty(); }
 
     @Override
-    public Optional<Long> applicationLockTimeoutSeconds() { return applicationLockTimeoutSeconds; }
+    public Optional<Duration> applicationLockTimeoutSeconds() { return applicationLockTimeoutSeconds; }
 
     @Override
     public Optional<String> environment() { return environment; }
@@ -103,7 +104,7 @@ public class TestOptions implements ConfigOptions {
     }
 
     public TestOptions applicationLockTimeoutSeconds(long timeout) {
-        this.applicationLockTimeoutSeconds = Optional.of(timeout);
+        this.applicationLockTimeoutSeconds = Optional.of(Duration.ofSeconds(timeout));
         return this;
     }
 

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/ConfigEnvironmentVariables.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/ConfigEnvironmentVariables.java
@@ -3,6 +3,7 @@ package com.yahoo.container.standalone;
 
 import com.yahoo.vespa.model.container.configserver.option.ConfigOptions;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
@@ -42,15 +43,17 @@ public class ConfigEnvironmentVariables implements ConfigOptions {
     }
 
     @Override
-    public Optional<Long> zookeeperBarrierTimeout() {
+    public Optional<Duration> zookeeperBarrierTimeout() {
         return  Optional.ofNullable(System.getenv("VESPA_CONFIGSERVER_ZOOKEEPER_BARRIER_TIMEOUT"))
-                        .map(Long::parseLong);
+                        .map(Long::parseLong)
+                        .map(Duration::ofSeconds);
     }
 
     @Override
-    public Optional<Long> applicationLockTimeoutSeconds() {
+    public Optional<Duration> applicationLockTimeoutSeconds() {
         return Optional.ofNullable(System.getenv("VESPA_CONFIGSERVER_APPLICATION_LOCK_TIMEOUT_SECONDS"))
-                       .map(Long::parseLong);
+                       .map(Long::parseLong)
+                       .map(Duration::ofSeconds);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Refactored `ConfigOptions.zookeeperBarrierTimeout()` to return `Optional<Duration>` instead of `Optional<Long>`
- Refactored `ConfigOptions.applicationLockTimeoutSeconds()` to return `Optional<Duration>` instead of `Optional<Long>`
- Updated all implementations (`ConfigEnvironmentVariables`, `TestOptions`) to convert seconds to Duration
- Updated `ConfigserverCluster` to convert Duration back to seconds when building ConfigserverConfig

## Benefits
- Better type safety using Java's standard Duration type
- More self-documenting API
- Aligns with downstream consumers that already use Duration
- Maintains backward compatibility with underlying config definitions

## Test plan
- [x] Compiled all affected modules (config-model, standalone-container, configserver)
- [x] Ran ConfigserverClusterTest - all tests pass
- [x] No semantic changes - values are still stored/used as seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)