### PR TITLE
Make sure to delete deactivated sessions

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -61,7 +61,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -95,7 +94,6 @@ import static com.yahoo.vespa.curator.Curator.CompletionWaiter;
 import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 import static com.yahoo.yolean.Exceptions.uncheck;
 import static java.nio.file.Files.createTempDirectory;
-import static java.nio.file.Files.readAttributes;
 
 /**
  *
@@ -236,12 +234,8 @@ public class SessionRepository {
         return List.copyOf(localSessionCache.values());
     }
 
-    private LocalSession getSessionFromFile(long sessionId) {
-        SessionZooKeeperClient sessionZKClient = createSessionZooKeeperClient(sessionId);
-        File sessionDir = getAndValidateExistingSessionAppDir(sessionId);
-        ApplicationPackage applicationPackage = FilesApplicationPackage.fromDir(sessionDir, inheritableApplications.toMap());
-        return new LocalSession(tenantName, sessionId, applicationPackage, sessionZKClient);
-    }
+    // Public for testing
+    public Map<Long, RemoteSession> remoteSessionCache() { return remoteSessionCache; }
 
     public List<Long> getLocalSessionsIdsFromFileSystem() {
         File[] sessions = tenantFileSystemDirs.sessionsPath().listFiles(sessionApplicationsFilter);
@@ -377,12 +371,16 @@ public class SessionRepository {
     }
 
     public RemoteSession createRemoteSession(long sessionId) {
-        SessionZooKeeperClient sessionZKClient = createSessionZooKeeperClient(sessionId);
-        RemoteSession session = new RemoteSession(tenantName, sessionId, sessionZKClient);
+        RemoteSession session = createRemoteSessionInternal(sessionId);
         loadSessionIfActive(session);
         remoteSessionCache.put(sessionId, session);
         updateSessionStateWatcher(sessionId);
         return session;
+    }
+
+    private RemoteSession createRemoteSessionInternal(long sessionId) {
+        SessionZooKeeperClient sessionZKClient = createSessionZooKeeperClient(sessionId);
+        return new RemoteSession(tenantName, sessionId, sessionZKClient);
     }
 
     public void deactivateSession(long sessionId) {
@@ -442,8 +440,7 @@ public class SessionRepository {
     }
 
     private boolean hasStatusDeleted(long sessionId) {
-        SessionZooKeeperClient sessionZKClient = createSessionZooKeeperClient(sessionId);
-        RemoteSession session = new RemoteSession(tenantName, sessionId, sessionZKClient);
+        RemoteSession session = createRemoteSessionInternal(sessionId);
         return session.getStatus() == Session.Status.DELETE;
     }
 
@@ -629,42 +626,23 @@ public class SessionRepository {
         int deletedLocalSessions = 0;
         for (Long sessionId : sortedSessions) {
             try {
-                Session session = remoteSessionCache.get(sessionId);
-                Instant createTime;
-                Optional<Instant> localSessionCreateTime = Optional.empty();
-                boolean deleteRemoteSession = true;
-                if (session == null) {
-                    // If remote session is missing (deleted from zookeeper) it will only be present in file system,
-                    // so use local session and its creation time from file system
-                    var localSession = getOptionalSessionFromFileSystem(sessionId);
-                    if (localSession.isEmpty()) continue;
-
-                    session = localSession.get();
-                    createTime = localSessionCreated((LocalSession) session);
-                    localSessionCreateTime= Optional.of(createTime);
-                    deleteRemoteSession = false;
-                } else {
-                    createTime = session.getCreateTime();
-                }
-
+                // Don't use remoteSessionCache to get sessions, since a session
+                // that was deactivated when the config server was started
+                // will not be present in the cache
+                Session session = createRemoteSessionInternal(sessionId);
                 Optional<ApplicationId> applicationId = session.getOptionalApplicationId();
                 try (var ignored = lockApplication(applicationId)) {
                     Session.Status status = session.getStatus();
                     boolean activeForApplication = sessionIsActiveForApplication.test(session);
                     if (status == ACTIVATE && activeForApplication) continue;
 
-                    boolean hasExpired = hasExpired(session);
-                    log.log(Level.FINE, "Session " + sessionId + ", status " + status + ", has expired: " + hasExpired);
-                    if (! hasExpired) continue;
+                    if (! hasExpired(session)) continue;
 
-                    log.log(Level.FINE, "session " + sessionId + ", status " + status +
-                            ", remote session created " + createTime +
-                            ", local session created " + localSessionCreateTime);
-                    if (deleteRemoteSession) {
-                        log.log(Level.FINE, () -> "Remote session " + sessionId + " for " + tenantName + " has expired, deleting it");
-                        deleteRemoteSessionFromZooKeeper(session);
-                        deletedRemoteSessions++;
-                    }
+                    Instant createTime = session.getCreateTime();
+                    log.log(Level.FINE, "Session " + sessionId + " for " + tenantName + ", status " + status +
+                            ", has expired" + ", session created " + createTime);
+                    deleteRemoteSessionFromZooKeeper(session);
+                    deletedRemoteSessions++;
 
                     if (localSessionCanBeDeleted(status, createTime, activeForApplication)) {
                         log.log(Level.FINE, () -> "Local session " + sessionId + " for " + tenantName + " has expired, deleting it");
@@ -692,15 +670,6 @@ public class SessionRepository {
     private ApplicationLock lockApplication(Optional<ApplicationId> applicationId) {
         return applicationId.map(id -> new ApplicationLock(Optional.of(tenantApplications.lock(id))))
                 .orElseGet(() -> new ApplicationLock(Optional.empty()));
-    }
-
-    private Optional<LocalSession> getOptionalSessionFromFileSystem(long sessionId) {
-        try {
-            return Optional.of(getSessionFromFile(sessionId));
-        } catch (Exception e) {
-            log.log(Level.FINE, () -> "could not get session from file: " + sessionId + ": " + e.getMessage());
-        }
-        return Optional.empty();
     }
 
     private boolean isOldAndCanBeDeleted(Instant createTime) {
@@ -740,11 +709,6 @@ public class SessionRepository {
                 && created.plus(expiryTime).isBefore(clock.instant());
     }
 
-    private Instant localSessionCreated(LocalSession session) {
-        File sessionDir = tenantFileSystemDirs.getUserApplicationDir(session.getSessionId());
-        return sessionDir.exists() ? created(sessionDir) : Instant.EPOCH;
-    }
-
     private Set<Long> findNewSessionsInFileSystem() {
         File[] sessions = tenantFileSystemDirs.sessionsPath().listFiles(sessionApplicationsFilter);
         Set<Long> newSessions = new HashSet<>();
@@ -761,16 +725,6 @@ public class SessionRepository {
             }
         }
         return newSessions;
-    }
-
-    private Instant created(File file) {
-        BasicFileAttributes fileAttributes;
-        try {
-            fileAttributes = readAttributes(file.toPath(), BasicFileAttributes.class);
-            return fileAttributes.creationTime().toInstant();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     private void ensureSessionPathDoesNotExist(long sessionId) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/SessionRepositoryTest.java
@@ -170,7 +170,7 @@ public class SessionRepositoryTest {
     }
 
     // If reading a session throws an exception when bootstrapping SessionRepository it should fail,
-    // to make sure config server does not comes up and serves invalid/old config or, if this is hosted,
+    // to make sure config server does not come up and serves invalid/old config or, if this is hosted,
     // serves empty config (takes down services on all nodes belonging to an application)
     @Test
     public void testInvalidSessionWhenBootstrappingSessionRepo() throws Exception {

--- a/vespajlib/src/main/java/com/yahoo/transaction/Transaction.java
+++ b/vespajlib/src/main/java/com/yahoo/transaction/Transaction.java
@@ -33,12 +33,12 @@ public interface Transaction extends AutoCloseable {
 
     /**
      * Returns the operations of this.
-     * Ownership of the returned list is transferred to the caller. The ist may be ready only.
+     * Ownership of the returned list is transferred to the caller. The list may be read-only.
      */
     List<Operation> operations();
 
     /**
-     * Checks whether or not the transaction is able to commit in its current state and do any transient preparatory
+     * Checks whether the transaction is able to commit in its current state and do any transient preparatory
      * work to commit.
      *
      * @throws IllegalStateException if the transaction cannot be committed


### PR DESCRIPTION
A deactivated session could end up not being deleted when:
* Deactivation happened, and session was not old enough to be deleted before config server was stopped (e.g. for an upgrade)
* When starting config server, deactivated sessions are not added to remote session cache
* Code deleting sessions look only at sessions from session cache, so would never delete such sessions

Changes:
* Added unit test for this scenario (failed before changes done here)
* Always create a remote session based on session id (in the scenario above there would be session files in file system making sure we find the session), and if so there will be data in zookeeper about e.g. time session was created and/or session status changed).
* Simplify code greatly, since we now always have a session and don't need to look in file system for e.g. time created
