### PR TITLE
Add vocabs for quantizations

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ModelIdResolver.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ModelIdResolver.java
@@ -67,20 +67,25 @@ public class ModelIdResolver {
         register(m, "nomic-ai-modernbert-vocab", "https://data.vespa-cloud.com/onnx_models/nomic-ai-modernbert-embed-base/tokenizer.json", Set.of(HF_TOKENIZER));
         
         register(m, "lightonai-modernbert-large", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large/model.onnx", Set.of(ONNX_MODEL));
-        register(m, "lightonai-modernbert-large-int8", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large-int8/model.onnx", Set.of(ONNX_MODEL));                    
         register(m, "lightonai-modernbert-large-vocab", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large/tokenizer.json", Set.of(HF_TOKENIZER));
-        
+        register(m, "lightonai-modernbert-large-int8", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large-int8/model.onnx", Set.of(ONNX_MODEL));
+        register(m, "lightonai-modernbert-large-int8-vocab", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large-int8/tokenizer.json", Set.of(HF_TOKENIZER));
+
+
         register(m, "alibaba-gte-modernbert", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-base/model.onnx", Set.of(ONNX_MODEL));
-        register(m, "alibaba-gte-modernbert-int8", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-int8/model.onnx", Set.of(ONNX_MODEL));                            
         register(m, "alibaba-gte-modernbert-vocab", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-base/tokenizer.json", Set.of(HF_TOKENIZER));
+        register(m, "alibaba-gte-modernbert-int8", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-int8/model.onnx", Set.of(ONNX_MODEL));
+        register(m, "alibaba-gte-modernbert-int8-vocab", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-int8/tokenizer.json", Set.of(HF_TOKENIZER));        
                                                                                                                                                                                       
         register(m, "snowflake-arctic-embed-m-v2.0", "https://data.vespa-cloud.com/onnx_models/snowflake-arctic-embed-m-v2.0/model.onnx", Set.of(ONNX_MODEL));
+        register(m, "snowflake-arctic-embed-m-v2.0-vocab", "https://data.vespa-cloud.com/onnx_models/snowflake-arctic-embed-m-v2.0/tokenizer.json", Set.of(HF_TOKENIZER));
         register(m, "snowflake-arctic-embed-m-v2.0-int8", "https://data.vespa-cloud.com/onnx_models/snowflake-arctic-embed-m-v2.0-int8/model.onnx", Set.of(ONNX_MODEL));  
-        register(m, "snowflake-arctic-embed-m-v2.0-vocab", "https://data.vespa-cloud.com/onnx_models/snowflake-arctic-embed-m-v2.0/tokenizer.json", Set.of(HF_TOKENIZER));            
-        
+        register(m, "snowflake-arctic-embed-m-v2.0-int8-vocab", "https://data.vespa-cloud.com/onnx_models/snowflake-arctic-embed-m-v2.0-int8/tokenizer.json", Set.of(HF_TOKENIZER));
+
         register(m, "voyage-4-nano", "https://data.vespa-cloud.com/onnx_models/voyage-4-nano/model.onnx", Set.of(ONNX_MODEL));
+        register(m, "voyage-4-nano-vocab", "https://data.vespa-cloud.com/onnx_models/voyage-4-nano/tokenizer.json", Set.of(HF_TOKENIZER));
         register(m, "voyage-4-nano-int8", "https://data.vespa-cloud.com/onnx_models/voyage-4-nano-int8/model.onnx", Set.of(ONNX_MODEL));
-        register(m, "voyage-4-nano-vocab", "https://data.vespa-cloud.com/onnx_models/voyage-4-nano/tokenizer.json", Set.of(HF_TOKENIZER));  
+        register(m, "voyage-4-nano-int8-vocab", "https://data.vespa-cloud.com/onnx_models/voyage-4-nano-int8/tokenizer.json", Set.of(HF_TOKENIZER));
 
         register(m, "llama-160m-chat-v1-q6", "https://data.vespa-cloud.com/gguf_models/Llama-160M-Chat-v1.Q6_K.gguf", Set.of(GGUF_MODEL));
         register(m, "llama-3.2-1b-q4", "https://data.vespa-cloud.com/gguf_models/llama-3.2-1b-instruct-q4_k_m.gguf", Set.of(GGUF_MODEL));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ModelIdResolver.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ModelIdResolver.java
@@ -71,7 +71,6 @@ public class ModelIdResolver {
         register(m, "lightonai-modernbert-large-int8", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large-int8/model.onnx", Set.of(ONNX_MODEL));
         register(m, "lightonai-modernbert-large-int8-vocab", "https://data.vespa-cloud.com/onnx_models/lightonai-modernbert-large-int8/tokenizer.json", Set.of(HF_TOKENIZER));
 
-
         register(m, "alibaba-gte-modernbert", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-base/model.onnx", Set.of(ONNX_MODEL));
         register(m, "alibaba-gte-modernbert-vocab", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-base/tokenizer.json", Set.of(HF_TOKENIZER));
         register(m, "alibaba-gte-modernbert-int8", "https://data.vespa-cloud.com/onnx_models/alibaba-gte-modernbert-int8/model.onnx", Set.of(ONNX_MODEL));


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Even though models share tokenizer (vocab-file), we add a registration for each model explicitly. This means some tokenizer files are duplicated, but spare the user of having to reference an explicit tokenizer-model.