### PR TITLE
Replace String.format with Text.format

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorDataQueue.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorDataQueue.java
@@ -6,6 +6,7 @@ import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.RemoveDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.UpdateDocumentMessage;
 import com.yahoo.messagebus.Message;
+import com.yahoo.text.Text;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -52,7 +53,7 @@ public class VisitorDataQueue extends VisitorDataHandler {
             appendSingleOpToPendingList(((RemoveDocumentMessage)m).getDocumentRemove(), token);
         } else {
             throw new UnsupportedOperationException(
-                    String.format("Expected put/remove message, got '%s' of type %s",
+                    Text.format("Expected put/remove message, got '%s' of type %s",
                                   m.toString(), m.getClass().toString()));
         }
     }

--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
@@ -6,6 +6,7 @@ import com.yahoo.document.FixedBucketSpaces;
 import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.messagebus.routing.Route;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8;
 
 import java.util.Map;
@@ -311,8 +312,8 @@ public final class VisitorParameters extends Parameters {
         sb.append("  Max buckets:        ").append(maxBucketsPerVisitor).append('\n');
         sb.append("  Priority:           ").append(getPriority().toString()).append('\n');
         if (slices > 1) {
-            sb.append("  Slice ID:           %d\n".formatted(sliceId));
-            sb.append("  Slice count:        %d\n".formatted(slices));
+            sb.append(Text.format("  Slice ID:           %d\n", sliceId));
+            sb.append(Text.format("  Slice count:        %d\n", slices));
         }
         sb.append(')');
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
@@ -36,6 +36,7 @@ import com.yahoo.messagebus.SourceSession;
 import com.yahoo.messagebus.SourceSessionParams;
 import com.yahoo.messagebus.Trace;
 import com.yahoo.messagebus.routing.RoutingTable;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.VisitorStatistics;
 import com.yahoo.vdslib.state.ClusterState;
 
@@ -859,7 +860,7 @@ public final class MessageBusVisitorSession implements VisitorSession {
     }
 
     private String formatProcessingException(Exception e, String whileProcessing) {
-        return String.format(
+        return Text.format(
                     "Got exception of type %s with message '%s' while processing %s",
                     e.getClass().getName(),
                     e.getMessage(),
@@ -867,7 +868,7 @@ public final class MessageBusVisitorSession implements VisitorSession {
     }
 
     private String formatIdentifyingVisitorErrorString(String details) {
-        return String.format(
+        return Text.format(
                     "Visitor %s (selection '%s'): %s",
                     sessionName,
                     params.getDocumentSelection(),
@@ -1101,7 +1102,7 @@ public final class MessageBusVisitorSession implements VisitorSession {
     private boolean scheduleSendCreateVisitorsIfApplicable(long delay, TimeUnit unit) {
         final long elapsedMillis = elapsedTimeMillis();
         if (!isInfiniteTimeout(sessionTimeoutMillis()) && (elapsedMillis >= sessionTimeoutMillis())) {
-            transitionTo(new StateDescription(State.TIMED_OUT, String.format("Session timeout of %d ms expired", sessionTimeoutMillis())));
+            transitionTo(new StateDescription(State.TIMED_OUT, Text.format("Session timeout of %d ms expired", sessionTimeoutMillis())));
         }
         if (!mayScheduleCreateVisitorsTask() || visitingCompleted()) {
             return false;

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/GetBucketListReply.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/GetBucketListReply.java
@@ -2,6 +2,7 @@
 package com.yahoo.documentapi.messagebus.protocol;
 
 import com.yahoo.document.BucketId;
+import com.yahoo.text.Text;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +60,7 @@ public class GetBucketListReply extends DocumentReply {
 
         @Override
         public String toString() {
-            return String.format("BucketInfo(%s: %s)", bucket, bucketInformation);
+            return Text.format("BucketInfo(%s: %s)", bucket, bucketInformation);
         }
     }
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
@@ -22,6 +22,7 @@ import com.yahoo.document.serialization.DocumentSerializer;
 import com.yahoo.document.serialization.DocumentSerializerFactory;
 import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.messagebus.Routable;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
 import com.yahoo.vdslib.VisitorStatistics;
@@ -75,7 +76,7 @@ abstract class RoutableFactories80 {
                 protoStream.checkNoSpaceLeft();
                 return buf;
             } catch (IOException | RuntimeException e) {
-                log.severe("Error during Protobuf encoding of message type %s: %s".formatted(apiClass.getSimpleName(), Exceptions.toMessageString(e)));
+                log.severe(Text.format("Error during Protobuf encoding of message type %s: %s", apiClass.getSimpleName(), Exceptions.toMessageString(e)));
                 log.log(Level.FINE, "Protobuf encode error has exception trace:", e);
                 return null;
             }
@@ -92,8 +93,8 @@ abstract class RoutableFactories80 {
             try {
                 return decoderFn.apply(in);
             } catch (RuntimeException e) {
-                throw new RuntimeException("Error during Protobuf decoding of message type %s: %s"
-                        .formatted(apiClass.getSimpleName(), e.getMessage()), e);
+                throw new RuntimeException(Text.format("Error during Protobuf decoding of message type %s: %s",
+                        apiClass.getSimpleName(), e.getMessage()), e);
             }
         }
 

--- a/documentapi/src/test/java/com/yahoo/documentapi/VisitorParametersTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/VisitorParametersTestCase.java
@@ -6,6 +6,8 @@ import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.nio.charset.StandardCharsets;
+
 public class VisitorParametersTestCase {
 
     private VisitorParameters createVisitorParameters() {
@@ -47,8 +49,8 @@ public class VisitorParametersTestCase {
         assertEquals(10001, copy.getToTimestamp());
         assertEquals("CoolVisitor", copy.getVisitorLibrary());
         assertEquals(2, copy.getLibraryParameters().size());
-        assertEquals("dudes", new String(copy.getLibraryParameters().get("groovy")));
-        assertEquals("turtles", new String(copy.getLibraryParameters().get("ninja")));
+        assertEquals("dudes", new String(copy.getLibraryParameters().get("groovy"), StandardCharsets.UTF_8));
+        assertEquals("turtles", new String(copy.getLibraryParameters().get("ninja"), StandardCharsets.UTF_8));
         assertEquals(55, copy.getMaxBucketsPerVisitor());
         assertEquals(DocumentProtocol.Priority.HIGHEST, copy.getPriority());
         assertEquals("extraterrestrial/highway", copy.getRoute().toString());

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/Messages80TestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/Messages80TestCase.java
@@ -12,6 +12,7 @@ import com.yahoo.document.TestAndSetCondition;
 import com.yahoo.document.fieldpathupdate.RemoveFieldPathUpdate;
 import com.yahoo.document.idstring.IdString;
 import com.yahoo.messagebus.Routable;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8;
 import com.yahoo.vdslib.SearchResult;
 
@@ -159,7 +160,7 @@ public class Messages80TestCase extends MessagesTestBase {
             for (var tas : tasConditions()) {
                 var msg = new PutDocumentMessage(new DocumentPut(new Document(protocol.getDocumentTypeManager().getDocumentType("testdoc"), "id:ns:testdoc::")));
                 msg.setCondition(tas.condition);
-                var msgAndCondName = "PutDocumentMessage-%s".formatted(tas.name);
+                var msgAndCondName = Text.format("PutDocumentMessage-%s", tas.name);
                 serialize(msgAndCondName, msg);
                 forEachLanguage((lang) -> {
                     var decoded = (PutDocumentMessage)deserialize(msgAndCondName, DocumentProtocol.MESSAGE_PUTDOCUMENT, lang);

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/MessagesTestBase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/MessagesTestBase.java
@@ -7,6 +7,7 @@ import com.yahoo.document.DocumentTypeManagerConfigurer;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.documentapi.messagebus.protocol.test.TestFileUtil;
 import com.yahoo.messagebus.Routable;
+import com.yahoo.text.Text;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -130,9 +131,9 @@ public abstract class MessagesTestBase {
         assertTrue(data.length > 0);
         try {
             if (fileContentIsUnchanged(path, data)) {
-                System.out.println(String.format("Serialization for '%s' is unchanged; not overwriting it", path));
+                System.out.println(Text.format("Serialization for '%s' is unchanged; not overwriting it", path));
             } else {
-                System.out.println(String.format("Serializing to '%s'..", path));
+                System.out.println(Text.format("Serializing to '%s'..", path));
                 // This only happens when protocol encoding has changed and takes place
                 // during local development, not regular test runs.
                 TestFileUtil.writeToFile(path, data);

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/TargetCachingSlobrokHostFetcherTest.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/TargetCachingSlobrokHostFetcherTest.java
@@ -4,6 +4,7 @@ package com.yahoo.documentapi.messagebus.protocol;
 import com.yahoo.jrt.slobrok.api.IMirror;
 import com.yahoo.jrt.slobrok.api.Mirror;
 import com.yahoo.messagebus.routing.RoutingContext;
+import com.yahoo.text.Text;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -26,7 +27,7 @@ import static org.mockito.Mockito.when;
 public class TargetCachingSlobrokHostFetcherTest {
 
     private static String idOfIndex(int index) {
-        return String.format("storage/cluster.foo/distributor/%d/default", index);
+        return Text.format("storage/cluster.foo/distributor/%d/default", index);
     }
 
     private static String idOfWildcardLookup() {
@@ -34,11 +35,11 @@ public class TargetCachingSlobrokHostFetcherTest {
     }
 
     private static String lookupSpecOfIndex(int index) {
-        return String.format("tcp/localhost:%d", index);
+        return Text.format("tcp/localhost:%d", index);
     }
 
     private static String resolvedSpecOfIndex(int index) {
-        return String.format("tcp/localhost:%d/default", index);
+        return Text.format("tcp/localhost:%d/default", index);
     }
 
     private static List<Mirror.Entry> dummyEntries(int... indices) {

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PriorityTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PriorityTestCase.java
@@ -3,10 +3,12 @@ package com.yahoo.documentapi.messagebus.protocol.test;
 
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol.Priority;
+import com.yahoo.text.Utf8;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -23,7 +25,7 @@ public class PriorityTestCase {
     @Test
     public void requireThat51PriorityValuesAreCorrect() throws IOException {
         String path = "test/crosslanguagefiles/5.1-Priority.txt";
-        BufferedReader in = new BufferedReader(new FileReader(path));
+        BufferedReader in = new BufferedReader(Utf8.createReader(path));
 
         List<Priority> expected = new LinkedList<Priority>(List.of(Priority.values()));
         String str;

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PriorityTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PriorityTestCase.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;

--- a/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCNetwork.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCNetwork.java
@@ -29,6 +29,7 @@ import com.yahoo.messagebus.routing.Hop;
 import com.yahoo.messagebus.routing.Route;
 import com.yahoo.messagebus.routing.RoutingNode;
 import com.yahoo.security.tls.CapabilitySet;
+import com.yahoo.text.Text;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -256,7 +257,7 @@ public class RPCNetwork implements Network, MethodHandler {
             if (!(r.getServiceAddress() instanceof RPCServiceAddress addr)) {
                 return "<non-RPC service address>";
             }
-            return String.format("%s at %s", addr.getServiceName(), addr.getConnectionSpec());
+            return Text.format("%s at %s", addr.getServiceName(), addr.getConnectionSpec());
         }).collect(Collectors.joining(", "));
     }
 
@@ -272,7 +273,7 @@ public class RPCNetwork implements Network, MethodHandler {
             replyError(ctx, ErrorCode.NETWORK_SHUTDOWN, "Network layer has performed shutdown.");
         } else if (ctx.hasError) {
             replyError(ctx, ErrorCode.HANDSHAKE_FAILED,
-                    String.format("An error occurred while resolving version of recipient(s) [%s] from host '%s'.",
+                    Text.format("An error occurred while resolving version of recipient(s) [%s] from host '%s'.",
                                   buildRecipientListString(ctx), identity.getHostname()));
         } else {
             new SendTask(owner.getProtocol(ctx.msg.getProtocol()), ctx).run();
@@ -333,7 +334,7 @@ public class RPCNetwork implements Network, MethodHandler {
         RPCServiceAddress ret = servicePool.resolve(serviceName, getMirror());
         if (ret == null) {
             return new Error(ErrorCode.NO_ADDRESS_FOR_SERVICE,
-                             String.format("The address of service '%s' could not be resolved. It is not currently " +
+                             Text.format("The address of service '%s' could not be resolved. It is not currently " +
                                            "registered with the Vespa name server. " +
                                            "The service must be having problems, or the routing configuration is wrong. " +
                                            "Address resolution attempted from host '%s'", serviceName, identity.getHostname()));
@@ -341,7 +342,7 @@ public class RPCNetwork implements Network, MethodHandler {
         RPCTarget target = targetPool.getTarget(orb, ret);
         if (target == null) {
             return new Error(ErrorCode.CONNECTION_ERROR,
-                             String.format("Failed to connect to service '%s' from host '%s'.",
+                             Text.format("Failed to connect to service '%s' from host '%s'.",
                                            serviceName, identity.getHostname()));
         }
         ret.setTarget(target); // free by freeServiceAddress()

--- a/messagebus/src/test/java/com/yahoo/messagebus/DynamicThrottlePolicyTest.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/DynamicThrottlePolicyTest.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
-import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;

--- a/messagebus/src/test/java/com/yahoo/messagebus/DynamicThrottlePolicyTest.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/DynamicThrottlePolicyTest.java
@@ -4,6 +4,7 @@ package com.yahoo.messagebus;
 import com.yahoo.concurrent.ManualTimer;
 import com.yahoo.messagebus.test.SimpleMessage;
 import com.yahoo.messagebus.test.SimpleReply;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -208,15 +210,15 @@ public class DynamicThrottlePolicyTest {
     }
 
     static void assertInRange(double lower, double actual, double upper) {
-        System.err.printf("%10.4f  <= %10.4f  <= %10.4f\n", lower, actual, upper);
+        System.err.println(Text.format("%10.4f  <= %10.4f  <= %10.4f", lower, actual, upper));
         assertTrue(lower <= actual, actual + " should be not be smaller than " + lower);
         assertTrue(upper >= actual, actual + " should be not be greater than " + upper);
     }
 
     private Summary run(long operations, int workPerSuccess, int numberOfWorkers, int maximumTasksPerWorker,
                         int workerParallelism, ManualTimer timer, DynamicThrottlePolicy... policies) {
-        System.err.printf("\n### Running %d operations of %d ticks each against %d workers with parallelism %d and queue size %d\n",
-                          operations, workPerSuccess, numberOfWorkers, workerParallelism, maximumTasksPerWorker);
+        System.err.println(Text.format("\n### Running %d operations of %d ticks each against %d workers with parallelism %d and queue size %d",
+                          operations, workPerSuccess, numberOfWorkers, workerParallelism, maximumTasksPerWorker));
 
         List<Integer> order = IntStream.range(0, policies.length).boxed().collect(Collectors.toCollection(ArrayList::new));
         MockServer resource = new MockServer(workPerSuccess, numberOfWorkers, maximumTasksPerWorker, workerParallelism);

--- a/messagebus/src/test/java/com/yahoo/messagebus/network/rpc/SlobrokTestCase.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/network/rpc/SlobrokTestCase.java
@@ -1,12 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.messagebus.network.rpc;
 
-
 import com.yahoo.jrt.ListenFailedException;
 import com.yahoo.jrt.Spec;
 import com.yahoo.jrt.slobrok.api.Mirror;
 import com.yahoo.jrt.slobrok.server.Slobrok;
 import com.yahoo.messagebus.network.Identity;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,28 +51,28 @@ public class SlobrokTestCase {
             actual = net.getMirror().lookup(pattern);
             actual.sort(cmp);
             if (actual.equals(expect)) {
-                System.out.printf("lookup successful for pattern: %s\n", pattern);
+                System.out.println(Text.format("lookup successful for pattern: %s", pattern));
                 return;
             }
             try { Thread.sleep(10); } catch (InterruptedException e) {
                 //
             }
         }
-        System.out.printf("lookup failed for pattern: %s\n", pattern);
-        System.out.printf("actual values:\n");
+        System.out.println(Text.format("lookup failed for pattern: %s", pattern));
+        System.out.println("actual values:");
         if (actual == null || actual.isEmpty()) {
-            System.out.printf("  { EMPTY }\n");
+            System.out.println("  { EMPTY }");
         } else {
             for (Mirror.Entry entry : actual) {
-                System.out.printf("  { %s, %s }\n", entry.getName(), entry.getSpecString());
+                System.out.println(Text.format("  { %s, %s }", entry.getName(), entry.getSpecString()));
             }
         }
-        System.out.printf("expected values:\n");
+        System.out.println("expected values:");
         if (expect.isEmpty()) {
-            System.out.printf("  { EMPTY }\n");
+            System.out.println("  { EMPTY }");
         } else {
             for (Mirror.Entry entry : expect) {
-                System.out.printf("  { %s, %s }\n", entry.getName(),  entry.getSpecString());
+                System.out.println(Text.format("  { %s, %s }", entry.getName(), entry.getSpecString()));
             }
         }
         assertTrue(false);

--- a/messagebus/src/test/java/com/yahoo/messagebus/network/rpc/SlobrokTestCase.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/network/rpc/SlobrokTestCase.java
@@ -14,10 +14,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 
 /**
  * @author havardpe


### PR DESCRIPTION
Standardize on using Text.format() instead of String.format() and .formatted() to ensure consistent locale and charset handling across documentapi and messagebus modules. Also adds explicit UTF-8 charset specification where appropriate.
