### PR TITLE
Use locale-independent operations in document module

### DIFF
--- a/document/src/main/java/com/yahoo/document/ArrayDataType.java
+++ b/document/src/main/java/com/yahoo/document/ArrayDataType.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.objects.Ids;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * @author Einar M R Rosenvinge
@@ -17,7 +18,7 @@ public class ArrayDataType extends CollectionDataType {
 
     public ArrayDataType(DataType nestedType) {
         super("Array<"+nestedType.getName()+">", 0, nestedType);
-        setId(getName().toLowerCase().hashCode());
+        setId(getName().toLowerCase(Locale.ROOT).hashCode());
     }
 
     public ArrayDataType(DataType nestedType, int code) {

--- a/document/src/main/java/com/yahoo/document/MapDataType.java
+++ b/document/src/main/java/com/yahoo/document/MapDataType.java
@@ -7,6 +7,7 @@ import com.yahoo.document.datatypes.MapFieldValue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Represents a map type.
@@ -26,7 +27,7 @@ public class MapDataType extends DataType {
 
     public MapDataType(DataType keyType, DataType valueType) {
         this(keyType, valueType, 0);
-        setId(getName().toLowerCase().hashCode());
+        setId(getName().toLowerCase(Locale.ROOT).hashCode());
     }
 
     @Override

--- a/document/src/main/java/com/yahoo/document/WeightedSetDataType.java
+++ b/document/src/main/java/com/yahoo/document/WeightedSetDataType.java
@@ -5,6 +5,8 @@ import com.yahoo.document.datatypes.WeightedSet;
 import com.yahoo.vespa.objects.Ids;
 import com.yahoo.vespa.objects.ObjectVisitor;
 
+import java.util.Locale;
+
 /**
  * @author Einar M R Rosenvinge
  */
@@ -34,7 +36,7 @@ public class WeightedSetDataType extends CollectionDataType {
             if ((nestedType == STRING) && createIfNonExistent && removeIfZero) { // the tag type definition
                 setId(TAG_ID);
             } else {
-                setId(getName().toLowerCase().hashCode());
+                setId(getName().toLowerCase(Locale.ROOT).hashCode());
             }
         }
         int code = getId();

--- a/document/src/main/java/com/yahoo/document/annotation/AnnotationReferenceDataType.java
+++ b/document/src/main/java/com/yahoo/document/annotation/AnnotationReferenceDataType.java
@@ -4,6 +4,8 @@ package com.yahoo.document.annotation;
 import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.FieldValue;
 
+import java.util.Locale;
+
 /**
  * A data type describing a field value having a reference to an annotation of a given type.
  *
@@ -45,7 +47,7 @@ public class AnnotationReferenceDataType extends DataType {
 
     private int createId() {
         //TODO: This should be Java's hashCode(), since all other data types use it, and using something else here will probably lead to collisions
-        return getName().toLowerCase().hashCode();
+        return getName().toLowerCase(Locale.ROOT).hashCode();
     }
 
     @Override

--- a/document/src/main/java/com/yahoo/document/datatypes/ReferenceFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/ReferenceFieldValue.java
@@ -8,6 +8,7 @@ import com.yahoo.document.ReferenceDataType;
 import com.yahoo.document.serialization.FieldReader;
 import com.yahoo.document.serialization.FieldWriter;
 import com.yahoo.document.serialization.XmlStream;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.objects.Ids;
 
 import java.util.Objects;
@@ -67,7 +68,7 @@ public class ReferenceFieldValue extends FieldValue {
     private static void requireIdOfMatchingType(ReferenceDataType referenceType, DocumentId id) {
         String expectedTypeName = referenceType.getTargetType().getName();
         if (!id.getDocType().equals(expectedTypeName)) {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(Text.format(
                     "Can't assign document ID '%s' (of type '%s') to reference of document type '%s'",
                     id, id.getDocType(), expectedTypeName));
         }
@@ -105,7 +106,7 @@ public class ReferenceFieldValue extends FieldValue {
         } else if (o instanceof DocumentId) {
             setDocumentId((DocumentId) o);
         } else {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(Text.format(
                     "Can't assign value of type '%s' to field of type '%s'. Expected value of type '%s'",
                     o.getClass().getName(), getClass().getName(), DocumentId.class.getName()));
         }
@@ -113,7 +114,7 @@ public class ReferenceFieldValue extends FieldValue {
 
     private void assignFromFieldValue(ReferenceFieldValue rhs) {
         if (!getDataType().equals(rhs.getDataType())) {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(Text.format(
                     "Can't assign reference of type %s to reference of type %s",
                     rhs.getDataType().getName(), getDataType().getName()));
         }

--- a/document/src/main/java/com/yahoo/document/datatypes/StringFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/StringFieldValue.java
@@ -18,6 +18,7 @@ import com.yahoo.text.Text;
 import com.yahoo.vespa.objects.Ids;
 
 import java.util.Collection;
+import java.util.Locale;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +82,7 @@ public class StringFieldValue extends FieldValue implements DataSource {
         if ( ! Text.isValidTextString(value)) {
             if (replaceInvalidUnicode) return Text.stripInvalidCharacters(value);
             else throw new IllegalArgumentException("The string field value contains illegal code point 0x" +
-                                                    Integer.toHexString(Text.validateTextString(value).getAsInt()).toUpperCase());
+                                                    Integer.toHexString(Text.validateTextString(value).getAsInt()).toUpperCase(Locale.ROOT));
         }
         return value;
     }

--- a/document/src/main/java/com/yahoo/document/idstring/IdString.java
+++ b/document/src/main/java/com/yahoo/document/idstring/IdString.java
@@ -4,6 +4,7 @@ package com.yahoo.document.idstring;
 import com.yahoo.api.annotations.Beta;
 import com.yahoo.text.Text;
 import com.yahoo.text.Utf8String;
+import java.util.Locale;
 
 /**
  * To be used with DocumentId constructor.
@@ -81,7 +82,7 @@ public abstract class IdString {
     private static void validateTextString(String id) {
         if ( ! Text.isValidTextString(id)) {
             throw new IllegalArgumentException("Unparseable id '" + id + "': Contains illegal code point 0x" +
-                    Integer.toHexString(Text.validateTextString(id).getAsInt()).toUpperCase());
+                    Integer.toHexString(Text.validateTextString(id).getAsInt()).toUpperCase(Locale.ROOT));
         }
     }
 

--- a/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
+++ b/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
@@ -47,6 +47,7 @@ import com.yahoo.document.update.TensorAddUpdate;
 import com.yahoo.document.update.TensorModifyUpdate;
 import com.yahoo.document.update.TensorRemoveUpdate;
 import com.yahoo.document.update.ValueUpdate;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.objects.FieldBase;
 import com.yahoo.vespa.objects.Serializer;
 
@@ -55,6 +56,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -139,7 +141,7 @@ public class DocumentUpdateJsonSerializer {
 
             for (FieldPathUpdate update : fieldPathUpdates) {
                 if (writeArithmeticFieldPathUpdate(update, generator)) continue;
-                generator.writeFieldName(update.getUpdateType().name().toLowerCase());
+                generator.writeFieldName(update.getUpdateType().name().toLowerCase(Locale.ROOT));
 
                 if (update instanceof AssignFieldPathUpdate assignUp) {
                     if (assignUp.getExpression() != null) {
@@ -321,7 +323,7 @@ public class DocumentUpdateJsonSerializer {
 
         @Override
         public void write(FieldBase field, FieldValue value) {
-            throw new JsonSerializationException(String.format("Serialization of field values of type %s is not supported", value.getClass().getName()));
+            throw new JsonSerializationException(Text.format("Serialization of field values of type %s is not supported", value.getClass().getName()));
         }
 
         @Override

--- a/document/src/main/java/com/yahoo/document/json/JsonReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonReader.java
@@ -14,6 +14,7 @@ import com.yahoo.document.TestAndSetCondition;
 import com.yahoo.document.json.document.DocumentParser;
 import com.yahoo.document.json.readers.DocumentParseInfo;
 import com.yahoo.document.json.readers.VespaJsonDocumentReader;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -197,7 +198,7 @@ public class JsonReader {
     private static DocumentType getDocumentTypeFromString(String docTypeString, DocumentTypeManager typeManager) {
         final DocumentType docType = typeManager.getDocumentType(docTypeString);
         if (docType == null)
-            throw new IllegalArgumentException(String.format("Document type %s does not exist", docTypeString));
+            throw new IllegalArgumentException(Text.format("Document type %s does not exist", docTypeString));
         return docType;
     }
 

--- a/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
@@ -20,6 +20,8 @@ import com.yahoo.document.json.JsonReaderException;
 import com.yahoo.document.json.ParsedDocumentOperation;
 import com.yahoo.document.json.TokenBuffer;
 import com.yahoo.document.update.FieldUpdate;
+import com.yahoo.text.Text;
+import java.util.Locale;
 
 import static com.yahoo.document.json.readers.AddRemoveCreator.createAdds;
 import static com.yahoo.document.json.readers.AddRemoveCreator.createRemoves;
@@ -174,7 +176,7 @@ public class VespaJsonDocumentReader {
 
         buffer.next();
         while (localNesting <= buffer.nesting()) {
-            String fieldPathOperation = buffer.currentName().toLowerCase();
+            String fieldPathOperation = buffer.currentName().toLowerCase(Locale.ROOT);
             FieldPathUpdate fieldPathUpdate;
             if (fieldPathOperation.equals(UPDATE_ASSIGN)) {
                 fieldPathUpdate = readAssignFieldPathUpdate(update.getType(), fieldPath, buffer);
@@ -223,7 +225,7 @@ public class VespaJsonDocumentReader {
         AssignFieldPathUpdate fieldPathUpdate = new AssignFieldPathUpdate(documentType, fieldPath);
         String arithmeticSign = SingleValueReader.UPDATE_OPERATION_TO_ARITHMETIC_SIGN.get(fieldPathOperation);
         double value = Double.parseDouble(buffer.currentText());
-        String expression = String.format("$value %s %s", arithmeticSign, value);
+        String expression = Text.format("$value %s %s", arithmeticSign, value);
         fieldPathUpdate.setExpression(expression);
         return fieldPathUpdate;
     }

--- a/document/src/main/java/com/yahoo/document/select/Result.java
+++ b/document/src/main/java/com/yahoo/document/select/Result.java
@@ -3,6 +3,8 @@ package com.yahoo.document.select;
 
 import com.yahoo.document.select.rule.AttributeNode;
 
+import java.util.Locale;
+
 /**
  * @author Simon Thoresen Hult
  */
@@ -17,7 +19,7 @@ public enum Result {
 
     @Override
     public String toString() {
-        return name().toLowerCase();
+        return name().toLowerCase(Locale.ROOT);
     }
     
     /**

--- a/document/src/main/java/com/yahoo/document/select/rule/AttributeNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/AttributeNode.java
@@ -20,6 +20,7 @@ import com.yahoo.document.select.Visitor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * @author Simon Thoresen Hult
@@ -120,9 +121,9 @@ public class AttributeNode implements ExpressionNode {
         } else if (function.equalsIgnoreCase("hash")) {
             return BobHash.hash(value.toString());
         } else if (function.equalsIgnoreCase("lowercase")) {
-            return value.toString().toLowerCase();
+            return value.toString().toLowerCase(Locale.ROOT);
         } else if (function.equalsIgnoreCase("uppercase")) {
-            return value.toString().toUpperCase();
+            return value.toString().toUpperCase(Locale.ROOT);
         }
         throw new IllegalStateException("Function '" + function + "' is not supported.");
     }

--- a/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLFieldReader.java
+++ b/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLFieldReader.java
@@ -21,6 +21,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 
@@ -412,7 +413,7 @@ public class VespaXMLFieldReader extends VespaXMLReader implements FieldReader {
             if (isBase64EncodedElement(reader)) {
                 value.assign(Base64.getMimeDecoder().decode(reader.getElementText()));
             } else {
-                value.assign(reader.getElementText().getBytes());
+                value.assign(reader.getElementText().getBytes(StandardCharsets.UTF_8));
             }
         } catch (XMLStreamException e) {
             throw newException(field, e);

--- a/document/src/test/java/com/yahoo/document/DocumentIdTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentIdTestCase.java
@@ -1,12 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document;
 
+import java.nio.charset.StandardCharsets;
 import com.yahoo.document.idstring.IdIdString;
 import com.yahoo.document.idstring.IdString;
+import com.yahoo.text.Utf8;
 import com.yahoo.vespa.objects.BufferSerializer;
 import org.junit.Before;
 import org.junit.Test;
-
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -108,7 +109,7 @@ public class DocumentIdTestCase {
     public void testCalculateGlobalId() throws IOException {
 
         String file = "src/tests/cpp-globalidbucketids.txt";
-        BufferedReader fr = new BufferedReader(new FileReader(file));
+        BufferedReader fr = new BufferedReader(Utf8.createReader(file));
         String line;
         String[] split_line;
         String[] split_gid;
@@ -140,7 +141,7 @@ public class DocumentIdTestCase {
         for(int i=0; i<b.length;i++){
             String ss = s.substring(2*i,2*i+2);
             assertEquals(Integer.valueOf(ss, 16).intValue(),(((int)b[i])+256)%256);
-        }       
+        }
     }
 
     //Compares bucketId with C++ implementation located in
@@ -148,7 +149,7 @@ public class DocumentIdTestCase {
     @Test
     public void testGetBucketId() throws IOException{
         String file = "src/tests/cpp-globalidbucketids.txt";
-        BufferedReader fr = new BufferedReader(new FileReader(file));
+        BufferedReader fr = new BufferedReader(Utf8.createReader(file));
         String line;
         String[] split_line;
         BucketId bid;
@@ -231,7 +232,7 @@ public class DocumentIdTestCase {
 
     @Test
     public void testSerializedDocumentIdCanContainNonTextCharacter() {
-        String strId = new String(new byte[]{105, 100, 58, 97, 58, 98, 58, 58, 7, 99}); // "id:a:b::0x7c"
+        String strId = new String(new byte[]{105, 100, 58, 97, 58, 98, 58, 58, 7, 99}, StandardCharsets.UTF_8); // "id:a:b::0x7c"
         DocumentId docId = DocumentId.createFromSerialized(strId);
         {
             assertEquals(strId, docId.toString());
@@ -247,7 +248,7 @@ public class DocumentIdTestCase {
 
     @Test
     public void testSerializedDocumentIdCannotContainZeroByte() {
-        String strId = new String(new byte[]{105, 100, 58, 97, 58, 98, 58, 58, 0, 99}); // "id:a:b::0x0c"
+        String strId = new String(new byte[]{105, 100, 58, 97, 58, 98, 58, 58, 0, 99}, StandardCharsets.UTF_8); // "id:a:b::0x0c"
         try {
             DocumentId.createFromSerialized(strId);
             fail("Expected an IllegalArgumentException to be thrown");

--- a/document/src/test/java/com/yahoo/document/DocumentSerializationTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentSerializationTestCase.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document;
 
+import java.nio.charset.StandardCharsets;
 import com.yahoo.document.annotation.AbstractTypesTest;
 import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.BoolFieldValue;
@@ -99,9 +100,9 @@ public class DocumentSerializationTestCase extends AbstractTypesTest {
             doc.setFieldValue("doublefield", new DoubleFieldValue(98374532.398820));
             doc.setFieldValue("bytefield", new ByteFieldValue(254));
             doc.setFieldValue("boolfield", new BoolFieldValue(true));
-            byte[] rawData = "RAW DATA".getBytes();
+            byte[] rawData = "RAW DATA".getBytes(StandardCharsets.UTF_8);
             assertEquals(8, rawData.length);
-            doc.setFieldValue(docType.getField("rawfield"),new Raw(ByteBuffer.wrap("RAW DATA".getBytes())));
+            doc.setFieldValue(docType.getField("rawfield"),new Raw(ByteBuffer.wrap("RAW DATA".getBytes(StandardCharsets.UTF_8))));
             Document docInDoc = new Document(docInDocType, "id:ns:docindoc::http://doc.in.doc/");
             docInDoc.setFieldValue("stringindocfield", "Elvis is dead");
             doc.setFieldValue(docType.getField("docfield"), docInDoc);
@@ -166,8 +167,8 @@ public class DocumentSerializationTestCase extends AbstractTypesTest {
             // Todo add cpp serialization
             // assertEquals(new BoolFieldValue(true), doc.getFieldValue("boolfield"));
             ByteBuffer bbuffer = ((Raw)doc.getFieldValue("rawfield")).getByteBuffer();
-            if (!Arrays.equals("RAW DATA".getBytes(), bbuffer.array())) {
-                System.err.println("Expected 'RAW DATA' but got '" + new String(bbuffer.array()) + "'.");
+            if (!Arrays.equals("RAW DATA".getBytes(StandardCharsets.UTF_8), bbuffer.array())) {
+                System.err.println("Expected 'RAW DATA' but got '" + new String(bbuffer.array(), StandardCharsets.UTF_8) + "'.");
                 fail();
             }
             if (test.version > 6) {

--- a/document/src/test/java/com/yahoo/document/DocumentTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTestCase.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document;
 
+import java.nio.charset.StandardCharsets;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.BoolFieldValue;
@@ -666,7 +667,7 @@ public class DocumentTestCase extends DocumentTestCaseBase {
         assertEquals(new StringFieldValue("http://this.is.a.test/"), doc.getFieldValue("urifield"));
         //NOTE: The value really is unsigned 254, which becomes signed -2:
         assertEquals(new ByteFieldValue(-2), doc.getFieldValue("bytefield"));
-        ByteBuffer raw = ByteBuffer.wrap("RAW DATA".getBytes());
+        ByteBuffer raw = ByteBuffer.wrap("RAW DATA".getBytes(StandardCharsets.UTF_8));
         assertEquals(new Raw(raw), doc.getFieldValue("rawfield"));
 
         Document docindoc = (Document)doc.getFieldValue("docfield");
@@ -713,7 +714,7 @@ public class DocumentTestCase extends DocumentTestCaseBase {
 
         doc.setFieldValue("boolfield", new BoolFieldValue(true));
         doc.setFieldValue("bytefield", new ByteFieldValue((byte)254));
-        doc.setFieldValue("rawfield", new Raw(ByteBuffer.wrap("RAW DATA".getBytes())));
+        doc.setFieldValue("rawfield", new Raw(ByteBuffer.wrap("RAW DATA".getBytes(StandardCharsets.UTF_8))));
         doc.setFieldValue("intfield", new IntegerFieldValue(5));
         doc.setFieldValue("floatfield", new FloatFieldValue(-9.23f));
         doc.setFieldValue("stringfield", new StringFieldValue("This is a string."));
@@ -784,7 +785,7 @@ public class DocumentTestCase extends DocumentTestCaseBase {
             assertTrue(true);
         }
 
-        buf = BufferSerializer.wrap("Hello world".getBytes());
+        buf = BufferSerializer.wrap("Hello world".getBytes(StandardCharsets.UTF_8));
         try {
             new Document(DocumentDeserializerFactory.createHead(docMan, buf.getBuf()));
             fail();

--- a/document/src/test/java/com/yahoo/document/DocumentTestCaseBase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTestCaseBase.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document;
 
+import java.nio.charset.StandardCharsets;
 import com.yahoo.document.datatypes.FloatFieldValue;
 import com.yahoo.document.datatypes.Raw;
 
@@ -74,7 +75,7 @@ public class DocumentTestCaseBase {
         doc.setFieldValue(byteField.getName(), (byte)30);
         doc.setFieldValue(intField.getName(), 50);
 
-        ByteBuffer buf = ByteBuffer.allocate(7).put("hei der".getBytes());
+        ByteBuffer buf = ByteBuffer.allocate(7).put("hei der".getBytes(StandardCharsets.UTF_8));
         buf.flip();
 
         doc.setFieldValue(rawField, new Raw(buf));

--- a/document/src/test/java/com/yahoo/document/datatypes/StringTestCase.java
+++ b/document/src/test/java/com/yahoo/document/datatypes/StringTestCase.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.datatypes;
 
+import java.nio.charset.StandardCharsets;
 import com.yahoo.document.DataType;
 import com.yahoo.document.Document;
 import com.yahoo.document.DocumentType;
@@ -43,7 +44,7 @@ public class StringTestCase extends AbstractTypesTest {
         data.put((byte)0);
         data.put((byte)(foo.length() + 1));
 
-        data.put(foo.getBytes());
+        data.put(foo.getBytes(StandardCharsets.UTF_8));
         data.put((byte)0);
 
         int positionAfterPut = data.position();
@@ -103,7 +104,7 @@ public class StringTestCase extends AbstractTypesTest {
         data.put((byte)0);
         data.putInt(length | 0x80000000);
 
-        data.put(blah.getBytes());
+        data.put(blah.getBytes(StandardCharsets.UTF_8));
         data.put((byte)0);
 
         positionAfterPut = data.position();

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -48,6 +48,7 @@ import com.yahoo.document.update.TensorModifyUpdate;
 import com.yahoo.document.update.TensorRemoveUpdate;
 import com.yahoo.document.update.ValueUpdate;
 import com.yahoo.io.GrowableByteBuffer;
+import com.yahoo.text.Text;
 import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.MappedTensor;
 import com.yahoo.tensor.MixedTensor;
@@ -571,7 +572,7 @@ public class JsonReaderTestCase {
                 new Tuple2<>(UPDATE_MULTIPLY,
                         ArithmeticValueUpdate.Operator.MUL) };
         for (Tuple2<String, Operator> operator : operations) {
-            DocumentUpdate doc = parseUpdate("""
+            DocumentUpdate doc = parseUpdate(Text.format("""
                                              {
                                                "update": "id:unittest:testset::whee",
                                                "fields": {
@@ -583,7 +584,7 @@ public class JsonReaderTestCase {
                                                  }
                                                }
                                              }
-                                             """.formatted(operator.first));
+                                             """, operator.first));
 
             Map<String, Tuple2<Number, Operator>> matches = new HashMap<>();
             FieldUpdate x = doc.getFieldUpdate("actualset");
@@ -906,14 +907,14 @@ public class JsonReaderTestCase {
     }
 
     private String fieldStringFromBase64RawContent(String base64data) throws IOException {
-        Document doc = docFromJson("""
+        Document doc = docFromJson(Text.format("""
                                    {
                                      "put": "id:unittest:testraw::whee",
                                      "fields": {
                                        "actualraw": "%s"
                                      }
                                    }
-                                   """.formatted(base64data));
+                                   """, base64data));
         FieldValue f = doc.getFieldValue(doc.getField("actualraw"));
         assertSame(Raw.class, f.getClass());
         Raw s = (Raw) f;
@@ -2777,15 +2778,15 @@ public class JsonReaderTestCase {
         return createPutWithTensor(inputTensor, "sparse_tensor");
     }
     private DocumentPut createPutWithTensor(String inputTensor, String tensorFieldName) {
-        JsonReader streaming = createReader("""
+        JsonReader streaming = createReader(Text.format("""
                                          {
                                            "fields": {
                                              "%s": %s
                                            }
                                          }
-                                         """.formatted(tensorFieldName, inputTensor));
+                                         """, tensorFieldName, inputTensor));
         DocumentPut lazyParsed = (DocumentPut) streaming.readSingleDocumentStreaming(DocumentOperationType.PUT, TENSOR_DOC_ID).operation();
-        JsonReader reader = createReader("""
+        JsonReader reader = createReader(Text.format("""
                                          [
                                            {
                                              "put": "%s",
@@ -2793,7 +2794,7 @@ public class JsonReaderTestCase {
                                                "%s": %s
                                              }
                                            }
-                                         ]""".formatted(TENSOR_DOC_ID, tensorFieldName, inputTensor));
+                                         ]""", TENSOR_DOC_ID, tensorFieldName, inputTensor));
         DocumentPut bufferParsed = (DocumentPut) reader.next();
         assertEquals(lazyParsed, bufferParsed);
         return bufferParsed;
@@ -2883,16 +2884,16 @@ public class JsonReaderTestCase {
     }
 
     private DocumentUpdate createTensorUpdate(String operation, String tensorJson, String tensorFieldName) {
-        JsonReader streaming = createReader("""
+        JsonReader streaming = createReader(Text.format("""
                                             {
                                               "fields": {
                                                 "%s": {
                                                    "%s": %s
                                                 }
                                               }
-                                            }""".formatted(tensorFieldName, operation, tensorJson));
+                                            }""", tensorFieldName, operation, tensorJson));
         DocumentUpdate lazyParsed = (DocumentUpdate) streaming.readSingleDocumentStreaming(DocumentOperationType.UPDATE, TENSOR_DOC_ID).operation();
-        JsonReader reader = createReader("""
+        JsonReader reader = createReader(Text.format("""
                                          [
                                            {
                                              "update": "%s",
@@ -2902,7 +2903,7 @@ public class JsonReaderTestCase {
                                                }
                                              }
                                            }
-                                         ]""".formatted(TENSOR_DOC_ID, tensorFieldName, operation, tensorJson));
+                                         ]""", TENSOR_DOC_ID, tensorFieldName, operation, tensorJson));
         DocumentUpdate bufferParsed = (DocumentUpdate) reader.next();
         assertEquals(lazyParsed, bufferParsed);
         return bufferParsed;

--- a/document/src/test/java/com/yahoo/vespaxmlparser/VespaXmlUpdateReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/VespaXmlUpdateReaderTestCase.java
@@ -258,7 +258,7 @@ public class VespaXmlUpdateReaderTestCase {
 
     private static String printStackTrace(Throwable t) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        t.printStackTrace(new PrintStream(out));
+        t.printStackTrace(new PrintStream(out, true, StandardCharsets.UTF_8));
         return new String(out.toByteArray(), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
Replace locale-dependent toLowerCase/toUpperCase with explicit Locale.ROOT variants to ensure consistent behavior across different system locales. Also replace String.format with Text.format for consistency with Vespa text handling utilities.

