### PR TITLE
Revert "Bragehk/use cbor by default in vespa cli"

### DIFF
--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -7,7 +7,6 @@ toolchain go1.24.2
 require (
 	github.com/briandowns/spinner v1.23.2
 	github.com/fatih/color v1.18.0
-	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2
 	github.com/klauspost/compress v1.18.0
 	github.com/mattn/go-colorable v0.1.14
@@ -34,7 +33,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/client/go/go.sum
+++ b/client/go/go.sum
@@ -11,8 +11,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
-github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 h1:iizUGZ9pEquQS5jTGkh4AqeeHCMbfbjeb0zMt0aEFzs=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -52,8 +50,6 @@ github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
-github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
 github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=

--- a/client/go/internal/cli/cmd/query_test.go
+++ b/client/go/internal/cli/cmd/query_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vespa-engine/vespa/client/go/internal/mock"
@@ -31,7 +30,7 @@ func TestQueryVerbose(t *testing.T) {
 	cli.httpClient = client
 
 	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "-v", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "curl -H 'Accept: application/cbor, application/json;q=0.9' 'http://127.0.0.1:8080/search/?timeout=10s&yql=select+from+sources+%2A+where+title+contains+%27foo%27'\n", stderr.String())
+	assert.Equal(t, "curl 'http://127.0.0.1:8080/search/?timeout=10s&yql=select+from+sources+%2A+where+title+contains+%27foo%27'\n", stderr.String())
 	assert.Equal(t, "{\n    \"query\": \"result\"\n}\n", stdout.String())
 }
 
@@ -196,116 +195,6 @@ func assertStreamingQuery(t *testing.T, expectedOutput, body string, args ...str
 	assert.Nil(t, cli.Run(append(args, "-t", "http://127.0.0.1:8080", "query", "select something")...))
 	assert.Equal(t, "", stderr.String())
 	assert.Equal(t, expectedOutput, stdout.String())
-}
-
-func TestQueryAcceptHeader(t *testing.T) {
-	client := &mock.HTTPClient{}
-	client.NextResponseString(200, "{\"query\":\"result\"}")
-	cli, _, _ := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "application/cbor, application/json;q=0.9", client.LastRequest.Header.Get("Accept"))
-}
-
-func TestQueryAcceptHeaderCustom(t *testing.T) {
-	client := &mock.HTTPClient{}
-	client.NextResponseString(200, "{\"query\":\"result\"}")
-	cli, _, _ := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "--header", "Accept: application/json", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "application/json", client.LastRequest.Header.Get("Accept"))
-}
-
-func TestQueryCborResponse(t *testing.T) {
-	// Create CBOR-encoded response data
-	responseData := map[string]interface{}{"query": "result"}
-	cborBytes, err := cbor.Marshal(responseData)
-	require.Nil(t, err)
-
-	client := &mock.HTTPClient{}
-	response := mock.HTTPResponse{Status: 200, Header: make(http.Header)}
-	response.Header.Set("Content-Type", "application/cbor")
-	response.Body = cborBytes
-	client.NextResponse(response)
-
-	cli, stdout, stderr := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "", stderr.String())
-	assert.Equal(t, "{\n    \"query\": \"result\"\n}\n", stdout.String())
-}
-
-func TestQueryCborResponsePlain(t *testing.T) {
-	// Create CBOR-encoded response data
-	responseData := map[string]interface{}{"query": "result"}
-	cborBytes, err := cbor.Marshal(responseData)
-	require.Nil(t, err)
-
-	client := &mock.HTTPClient{}
-	response := mock.HTTPResponse{Status: 200, Header: make(http.Header)}
-	response.Header.Set("Content-Type", "application/cbor")
-	response.Body = cborBytes
-	client.NextResponse(response)
-
-	cli, stdout, stderr := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "--format=plain", "query", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "", stderr.String())
-	assert.Equal(t, "{\"query\":\"result\"}\n", stdout.String())
-}
-
-func TestQueryJsonResponse(t *testing.T) {
-	client := &mock.HTTPClient{}
-	response := mock.HTTPResponse{Status: 200, Header: make(http.Header)}
-	response.Header.Set("Content-Type", "application/json")
-	response.Body = []byte("{\"query\":\"result\"}")
-	client.NextResponse(response)
-
-	cli, stdout, stderr := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "", stderr.String())
-	assert.Equal(t, "{\n    \"query\": \"result\"\n}\n", stdout.String())
-}
-
-func TestQueryJsonResponsePlain(t *testing.T) {
-	client := &mock.HTTPClient{}
-	response := mock.HTTPResponse{Status: 200, Header: make(http.Header)}
-	response.Header.Set("Content-Type", "application/json")
-	response.Body = []byte("{\"query\":\"result\"}")
-	client.NextResponse(response)
-
-	cli, stdout, stderr := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.Nil(t, cli.Run("-t", "http://127.0.0.1:8080", "--format=plain", "query", "select from sources * where title contains 'foo'"))
-	assert.Equal(t, "", stderr.String())
-	assert.Equal(t, "{\"query\":\"result\"}\n", stdout.String())
-}
-
-func TestQueryCborErrorResponse(t *testing.T) {
-	// Create CBOR-encoded error response
-	errorData := map[string]interface{}{"error": "bad request"}
-	cborBytes, err := cbor.Marshal(errorData)
-	require.Nil(t, err)
-
-	client := &mock.HTTPClient{}
-	response := mock.HTTPResponse{Status: 400, Header: make(http.Header)}
-	response.Header.Set("Content-Type", "application/cbor")
-	response.Body = cborBytes
-	client.NextResponse(response)
-
-	cli, _, stderr := newTestCLI(t)
-	cli.httpClient = client
-
-	assert.NotNil(t, cli.Run("-t", "http://127.0.0.1:8080", "query", "select from sources * where title contains 'foo'"))
-	assert.Contains(t, stderr.String(), "invalid query")
-	assert.Contains(t, stderr.String(), "bad request")
 }
 
 func assertQuery(t *testing.T, expectedQuery string, query ...string) {

--- a/client/go/internal/ioutil/ioutil.go
+++ b/client/go/internal/ioutil/ioutil.go
@@ -11,24 +11,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
 )
-
-// cborDecMode is configured to decode maps with string keys for JSON compatibility.
-var cborDecMode cbor.DecMode
-
-func init() {
-	var err error
-	cborDecMode, err = cbor.DecOptions{
-		DefaultMapType: reflect.TypeOf(map[string]interface{}(nil)),
-	}.DecMode()
-	if err != nil {
-		panic("failed to initialize CBOR decoder mode: " + err.Error())
-	}
-}
 
 // Exists returns true if the given path exists.
 func Exists(path string) bool {
@@ -84,32 +68,6 @@ func ReaderToJSON(reader io.Reader) string {
 
 // StringToJSON returns string s as indented JSON.
 func StringToJSON(s string) string { return ReaderToJSON(strings.NewReader(s)) }
-
-// CBORToJSON converts CBOR data to indented JSON string.
-func CBORToJSON(data []byte) (string, error) {
-	var v interface{}
-	if err := cborDecMode.Unmarshal(data, &v); err != nil {
-		return "", err
-	}
-	jsonBytes, err := json.MarshalIndent(v, "", "    ")
-	if err != nil {
-		return "", err
-	}
-	return string(jsonBytes), nil
-}
-
-// CBORToJSONCompact converts CBOR data to compact JSON string.
-func CBORToJSONCompact(data []byte) (string, error) {
-	var v interface{}
-	if err := cborDecMode.Unmarshal(data, &v); err != nil {
-		return "", err
-	}
-	jsonBytes, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	return string(jsonBytes), nil
-}
 
 // AtomicWriteFile atomically writes data to filename.
 func AtomicWriteFile(filename string, data []byte) error {


### PR DESCRIPTION
Reverts vespa-engine/vespa#35713

Looks like -Inf in response is not handled, from system test Cli::test_cli__INDEXED on 8.640.8 (https://factory.vespa.ai/testrun/21824485090/test/Cli::test_cli__INDEXED):

```
[12:31:06.698] Error: failed to decode CBOR response: json: unsupported value: -Inf
[12:31:06.698] JSON::ParserError: 859: unexpected token at ''
[12:31:06.698] Testcase failed, skipping log checks
```
