### PR TITLE
Remove `shouldBeReady` optimization that is not always correct

### DIFF
--- a/persistence/src/vespa/persistence/spi/clusterstate.cpp
+++ b/persistence/src/vespa/persistence/spi/clusterstate.cpp
@@ -47,10 +47,6 @@ ClusterState::shouldBeReady(const Bucket& b) const {
         return Trinary::Undefined;
     }
 
-    if (_distribution->getReadyCopies() >= _distribution->getRedundancy()) {
-        return Trinary::True; // all copies should be ready
-    }
-
     std::vector<uint16_t> idealNodes;
     _distribution->getIdealNodes(lib::NodeType::STORAGE, *_state,
                                  b.getBucketId(), idealNodes,


### PR DESCRIPTION
@toregge please review. Let's see if removing this has a measurable impact...

It is not always the case that having a distribution config where the replication count is equal to the searchable copies count means that it's safe to assume _all_ replicas should be moved to the ready sub DB.

Example:
 1. Start with a flat cluster with `redundancy=2`, `searchable-copies=1`.
 2. Move to 2 groups with _intra_-group `redundancy` and `searchable-copies` of 1, and where all nodes from the flat topology are moved to the same leaf group to maintain coverage during group repopulation. This topology means that the _cluster-global_ distribution config becomes `redundancy=2` and `searchable-copies=2`, i.e. equal.

At reconfiguration point 2) the optimization would erroneously trigger and immediately start indexing _all_ replicas within the group, including all those that have not yet been moved to the other group (which would likely be most of the redundant replicas). This may cause nodes to exceed their resource limits if they are not sized to hold 2x index data in memory and/or disk.

