### PR TITLE
feat(embedder): add DestinationType enum to InvocationContext

### DIFF
--- a/linguistics/abi-spec.json
+++ b/linguistics/abi-spec.json
@@ -605,7 +605,7 @@
     "methods" : [
       "public static com.yahoo.language.process.InvocationContext$DestinationType[] values()",
       "public static com.yahoo.language.process.InvocationContext$DestinationType valueOf(java.lang.String)",
-      "public static com.yahoo.language.process.InvocationContext$DestinationType fromString(java.lang.String)"
+      "public static com.yahoo.language.process.InvocationContext$DestinationType fromDestination(java.lang.String)"
     ],
     "fields" : [
       "public static final enum com.yahoo.language.process.InvocationContext$DestinationType QUERY",

--- a/linguistics/abi-spec.json
+++ b/linguistics/abi-spec.json
@@ -594,6 +594,24 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.language.process.InvocationContext$DestinationType" : {
+    "superClass" : "java.lang.Enum",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "final",
+      "enum"
+    ],
+    "methods" : [
+      "public static com.yahoo.language.process.InvocationContext$DestinationType[] values()",
+      "public static com.yahoo.language.process.InvocationContext$DestinationType valueOf(java.lang.String)",
+      "public static com.yahoo.language.process.InvocationContext$DestinationType fromString(java.lang.String)"
+    ],
+    "fields" : [
+      "public static final enum com.yahoo.language.process.InvocationContext$DestinationType QUERY",
+      "public static final enum com.yahoo.language.process.InvocationContext$DestinationType DOCUMENT"
+    ]
+  },
   "com.yahoo.language.process.InvocationContext" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [ ],
@@ -607,6 +625,7 @@
       "public com.yahoo.language.Language getLanguage()",
       "public com.yahoo.language.process.InvocationContext setLanguage(com.yahoo.language.Language)",
       "public java.lang.String getDestination()",
+      "public com.yahoo.language.process.InvocationContext$DestinationType getDestinationType()",
       "public com.yahoo.language.process.InvocationContext setDestination(java.lang.String)",
       "public java.util.Optional getDeadline()",
       "public com.yahoo.language.process.InvocationContext setDeadline(com.yahoo.language.process.InvocationContext$Deadline)",

--- a/linguistics/src/main/java/com/yahoo/language/process/InvocationContext.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/InvocationContext.java
@@ -19,6 +19,17 @@ import java.util.function.Supplier;
  */
 public class InvocationContext<SUBCLASS extends InvocationContext<SUBCLASS>> {
 
+    public enum DestinationType {
+        /** The embedding is for a query feature with format "query(feature)". */
+        QUERY,
+        /** The embedding is for a document field with format "schema.field". */
+        DOCUMENT;
+
+        public static DestinationType fromString(String destination) {
+            return destination.startsWith("query(") ? QUERY : DOCUMENT;
+        }
+    }
+
     private Language language = Language.UNKNOWN;
     private String destination;
     private String componentId = "unknown";
@@ -56,21 +67,13 @@ public class InvocationContext<SUBCLASS extends InvocationContext<SUBCLASS>> {
         return (SUBCLASS)this;
     }
 
-    /**
-     * Returns the name of the recipient of this invocation.
-     * <p>
-     * This is either a query feature name
-     * ("query(feature)"), or a schema and field name concatenated by a dot ("schema.field").
-     * This cannot be null.
-     */
-    public String getDestination() {return destination;}
+    /** Returns the name of the recipient of this invocation. See {@link DestinationType} for format details. */
+    public String getDestination() { return destination; }
 
-    /**
-     * Sets the name of the recipient of this invocation.
-     * <p>
-     * This is either a query feature name
-     * ("query(feature)"), or a schema and field name concatenated by a dot ("schema.field").
-     */
+    /** Returns the type of destination */
+    public DestinationType getDestinationType() { return DestinationType.fromString(destination); }
+
+    /** Sets the name of the recipient of this invocation. See {@link DestinationType} for format details. */
     @SuppressWarnings("unchecked")
     public SUBCLASS setDestination(String destination) {
         this.destination = destination;

--- a/linguistics/src/main/java/com/yahoo/language/process/InvocationContext.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/InvocationContext.java
@@ -25,7 +25,7 @@ public class InvocationContext<SUBCLASS extends InvocationContext<SUBCLASS>> {
         /** The embedding is for a document field with format "schema.field". */
         DOCUMENT;
 
-        public static DestinationType fromString(String destination) {
+        public static DestinationType fromDestination(String destination) {
             return destination.startsWith("query(") ? QUERY : DOCUMENT;
         }
     }
@@ -71,7 +71,7 @@ public class InvocationContext<SUBCLASS extends InvocationContext<SUBCLASS>> {
     public String getDestination() { return destination; }
 
     /** Returns the type of destination */
-    public DestinationType getDestinationType() { return DestinationType.fromString(destination); }
+    public DestinationType getDestinationType() { return DestinationType.fromDestination(destination); }
 
     /** Sets the name of the recipient of this invocation. See {@link DestinationType} for format details. */
     @SuppressWarnings("unchecked")

--- a/model-integration/src/main/java/ai/vespa/embedding/ColBertEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/ColBertEmbedder.java
@@ -138,7 +138,7 @@ public class ColBertEmbedder extends AbstractComponent implements Embedder {
             throw new IllegalArgumentException("Invalid colbert embedder tensor target destination. " +
                                                "Wanted a mixed 2-d mapped-indexed tensor, got " + tensorType);
         }
-        if (context.getDestination().startsWith("query")) {
+        if (context.getDestinationType() == Context.DestinationType.QUERY) {
             return embedQuery(text, context, tensorType);
         } else {
             return embedDocument(text, context, tensorType);

--- a/model-integration/src/main/java/ai/vespa/embedding/GgufEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/GgufEmbedder.java
@@ -113,7 +113,7 @@ public class GgufEmbedder extends AbstractComponent implements Embedder {
      * Tokens are assumed to be independent and that the token sequence can be safely truncated at any position.
      */
     private String prependAndTruncatePrompt(String text, Context context) {
-        if (!prependQuery.isBlank() && context.getDestination().startsWith("query")) {
+        if (!prependQuery.isBlank() && context.getDestinationType() == Context.DestinationType.QUERY) {
             text = prependQuery + " " + text;
         } else if (!prependDocument.isBlank()) {
             text = prependDocument + " " + text;

--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
@@ -167,10 +167,10 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
     }
 
     String prependInstruction(String text, Context context) {
-        if (prependQuery != null && !prependQuery.isEmpty() && context.getDestination().startsWith("query")) {
+        if (prependQuery != null && !prependQuery.isEmpty() && context.getDestinationType() == Context.DestinationType.QUERY) {
             return prependQuery + " " + text;
         }
-        if (prependDocument != null && !prependDocument.isEmpty()){
+        if (prependDocument != null && !prependDocument.isEmpty()) {
             return prependDocument + " " + text;
         }
         return text;

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -176,14 +176,6 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
         }
     }
 
-    private String detectInputType(Context context) {
-        String destination = context.getDestination();
-        if (destination != null && destination.startsWith("query(")) {
-            return "query";
-        }
-        return "document";
-    }
-
     private boolean isMultimodalModel() { return config.model().startsWith("voyage-multimodal-"); }
     private boolean isContextualModel() { return config.model().startsWith("voyage-context-"); }
 
@@ -208,7 +200,7 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
     private List<Tensor> invokeVoyageAI(List<String> texts, Context context, TensorType targetType) {
         long startTime = System.nanoTime();
         validateTensorType(targetType);
-        var inputType = detectInputType(context);
+        var inputType = context.getDestinationType() == Context.DestinationType.QUERY ? "query" : "document";
         var outputDataType = resolveOutputDataType(targetType);
         var timeoutMs = calculateTimeoutMs(context);
 

--- a/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
@@ -160,7 +160,7 @@ public class HuggingFaceEmbedderTest {
         Tensor binarizedResult = getNormalizePrefixdEmbedder().embed(input, context, TensorType.fromSpec(("tensor<int8>(x[2])")));
         assertEquals("tensor<int8>(x[2]):[125, 44]", binarizedResult.toAbbreviatedString());
 
-        var queryContext = new Embedder.Context("query.qt");
+        var queryContext = new Embedder.Context("query(qt)");
         Tensor queryResult = getNormalizePrefixdEmbedder().embed(input, queryContext, TensorType.fromSpec(("tensor<float>(x[8])")));
         assertEquals(1.0, queryResult.multiply(queryResult).sum().asDouble(), 1e-3);
         queryResult = getNormalizePrefixdEmbedder().embed(input, queryContext, TensorType.fromSpec(("tensor<float>(x[16])")));
@@ -177,7 +177,7 @@ public class HuggingFaceEmbedderTest {
         var embedder = getNormalizePrefixdEmbedder();
         var result = embedder.prependInstruction(input, context);
         assertEquals("This is a document: This is a test",  result);
-        var queryContext = new Embedder.Context("query.qt");
+        var queryContext = new Embedder.Context("query(qt)");
         var queryResult = embedder.prependInstruction(input, queryContext);
         assertEquals("Represent this text: This is a test",  queryResult);
     }


### PR DESCRIPTION
- Add DestinationType enum with QUERY and DOCUMENT values
- Add getDestinationType() method to classify destination string
- Refactor embedders to use new API instead of string prefix checks
- Fix test to use correct query destination format "query(qt)"