### PR TITLE
Add annotation for limiting sameElement to specific IDs

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1522,6 +1522,8 @@
       "public java.lang.String getFieldName()",
       "public void setIndexName(java.lang.String)",
       "public java.lang.String getIndexName()",
+      "public java.util.List getElementFilter()",
+      "public void setElementFilter(java.util.List)",
       "public int getNumWords()",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()"

--- a/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
@@ -5,6 +5,8 @@ import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
 import com.yahoo.protect.Validator;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -15,6 +17,7 @@ import java.util.Objects;
 public class SameElementItem extends NonReducibleCompositeItem implements HasIndexItem {
 
     private String fieldName;
+    private List<Integer> elementFilter = new ArrayList<>();
 
     public SameElementItem(String fieldName) {
         Validator.ensureNonEmpty("Field name", fieldName);
@@ -59,6 +62,37 @@ public class SameElementItem extends NonReducibleCompositeItem implements HasInd
         return fieldName;
     }
 
+    /**
+     * Returns the element filter. If set, only the element ids in the element filter is required to match.
+     */
+    public List<Integer> getElementFilter() {
+        return elementFilter;
+    }
+
+    /**
+     * Set an element filter. The filter can not contain null values or negative numbers.
+     * <p>
+     * The filter will be deduplicates and sorted.
+     */
+    public void setElementFilter(List<Integer> filter) {
+        if (filter == null || filter.isEmpty()) {
+            elementFilter = new ArrayList<>();
+            return;
+        }
+        elementFilter = filter.stream()
+                .peek(val -> {
+                    if (val == null) {
+                        throw new IllegalArgumentException("elementFilter cannot contain null values");
+                    }
+                    if (val < 0) {
+                        throw new IllegalArgumentException("elementFilter values must be non-negative, got: " + val);
+                    }
+                })
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
     @Override
     public int getNumWords() {
         return getItemCount();
@@ -81,6 +115,9 @@ public class SameElementItem extends NonReducibleCompositeItem implements HasInd
         var props = SearchProtocol.TermItemProperties.newBuilder();
         props.setIndex(fieldName);
         builder.setProperties(props.build());
+        for (var filter : elementFilter) {
+            builder.addElementFilter(filter);
+        }
         for (var child : items()) {
             builder.addChildren(child.toProtobuf(context));
         }

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -783,39 +783,31 @@ public class YqlParser implements Parser {
             List<Integer> filter = new ArrayList<>();
             if (elementFilterObj instanceof List<?> list) {
                 for (Object val : list) {
-                    if (val instanceof Integer intVal) {
-                        filter.add(intVal);
-                    } else if (val instanceof Long longVal) {
-                        if (longVal > Integer.MAX_VALUE) {
-                            throw new IllegalArgumentException(
-                                    "elementFilter values must fit in int32 range, got: " + longVal);
-                        }
-                        filter.add(longVal.intValue());
-                    } else if (val instanceof Double || val instanceof Float) {
-                        throw new IllegalArgumentException(
-                                "elementFilter values must be integers, not floating point numbers. Got: " + val);
-                    } else {
-                        throw new IllegalArgumentException(
-                                "elementFilter values must be integers, got: " + val.getClass().getSimpleName());
-                    }
+                    filter.add(convertToIntForElementFilter(val));
                 }
-            } else if (elementFilterObj instanceof Integer singleInt) {
-                filter.add(singleInt);
-            } else if (elementFilterObj instanceof Long singleLong) {
-                if (singleLong > Integer.MAX_VALUE) {
-                    throw new IllegalArgumentException(
-                            "elementFilter values must fit in int32 range, got: " + singleLong);
-                }
-                filter.add(singleLong.intValue());
-            } else if (elementFilterObj instanceof Double || elementFilterObj instanceof Float) {
-                throw new IllegalArgumentException(
-                        "elementFilter must be an integer or list of integers, not a floating point number");
             } else {
-                throw new IllegalArgumentException(
-                        "elementFilter must be an integer or list of integers, got: " +
-                        elementFilterObj.getClass().getSimpleName());
+                filter.add(convertToIntForElementFilter(elementFilterObj));
             }
             sameElement.setElementFilter(filter);
+        }
+    }
+
+    /** Element filter accepts Integer. Allows Long that is within Integer size. */
+    private int convertToIntForElementFilter(Object val) {
+        if (val instanceof Integer intVal) {
+            return intVal;
+        } else if (val instanceof Long longVal) {
+            if (longVal > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException(
+                        "elementFilter values must fit in int32 range, got: " + longVal);
+            }
+            return longVal.intValue();
+        } else if (val instanceof Double || val instanceof Float) {
+            throw new IllegalArgumentException(
+                    "elementFilter values must be integers, not floating point numbers. Got: " + val);
+        } else {
+            throw new IllegalArgumentException(
+                    "elementFilter values must be integers, got: " + val.getClass().getSimpleName());
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -484,7 +484,7 @@ public class YqlParserTestCase {
 
         // Test floating point number
         assertParseFail("select * from sources * where myfield contains ({elementFilter:1.5} sameElement(name contains 'John'))",
-                new IllegalArgumentException("elementFilter must be an integer or list of integers, not a floating point number"));
+                new IllegalArgumentException("elementFilter values must be integers, not floating point numbers. Got: 1.5"));
 
         // Test floating point in array
         assertParseFail("select * from sources * where myfield contains ({elementFilter:[1,2.5,3]} sameElement(name contains 'John'))",

--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
@@ -128,7 +128,9 @@ private:
     void buildSameElement(ProtonSameElement &n) {
         if (n.numFields() == 1) {
             auto se = std::make_unique<SameElementBlueprint>(n.field(0).fieldSpec(),
-                                                             n.descendants_index_handles, n.is_expensive());
+                                                             n.descendants_index_handles,
+                                                             n.is_expensive(),
+                                                             n.get_element_filter()); // Copy element filter
             for (auto* node : n.getChildren()) {
                 se->addChild(build(_requestContext, *node, _context, _global_layout));
             }

--- a/searchlib/src/protobuf/search_protocol.proto
+++ b/searchlib/src/protobuf/search_protocol.proto
@@ -314,6 +314,7 @@ message ItemPhrase {
 message ItemSameElement {
     TermItemProperties properties = 1;
     repeated QueryTreeItem children = 2;
+    repeated uint32 element_filter = 3;
 }
 
 // special-purpose leaf nodes:

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -435,7 +435,7 @@ struct MyPhrase : Phrase {
 };
 
 struct MySameElement : SameElement {
-    MySameElement(const string & f, int32_t i, Weight w) : SameElement(f, i, w) {}
+    MySameElement(const string & f, int32_t i, Weight w, std::vector<uint32_t> element_filter) : SameElement(f, i, w, std::move(element_filter)) {}
     ~MySameElement() override;
 };
 

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -843,7 +843,7 @@ TEST(QueryBuilderTest, require_that_empty_intermediate_node_can_be_added) {
 }
 
 TEST(QueryBuilderTest, control_size_of_SimpleQueryStackDumpIterator) {
-    EXPECT_EQ(160u, sizeof(SimpleQueryStackDumpIterator));
+    EXPECT_EQ(184u, sizeof(SimpleQueryStackDumpIterator));
 }
 
 TEST(QueryBuilderTest, test_query_parsing_error) {

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -70,11 +70,14 @@ protected:
 
     SameElementQueryNodeTest();
     ~SameElementQueryNodeTest() override;
-    static bool evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv);
-    static std::vector<uint32_t> get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv);
+    static bool evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter = std::vector<uint32_t>());
+    static std::vector<uint32_t> get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter = std::vector<uint32_t>());
     std::vector<std::vector<uint32_t>> extract_element_ids(QueryTweak query_tweak,
-                                                           const std::vector<std::vector<uint32_t>>& elementsvv);
-    static std::unique_ptr<Query> make_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv);
+                                                           const std::vector<std::vector<uint32_t>>& elementsvv,
+                                                           std::vector<uint32_t> element_filter = std::vector<uint32_t>());
+    static std::unique_ptr<Query> make_query(QueryTweak query_tweak,
+                                             const std::vector<std::vector<uint32_t>>& elementsvv,
+                                             std::vector<uint32_t> element_filter = std::vector<uint32_t>());
 };
 
 SameElementQueryNodeTest::SameElementQueryNodeTest()
@@ -85,25 +88,25 @@ SameElementQueryNodeTest::SameElementQueryNodeTest()
 SameElementQueryNodeTest::~SameElementQueryNodeTest() = default;
 
 bool
-SameElementQueryNodeTest::evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter)
 {
-    auto query = make_query(query_tweak, elementsvv);
+    auto query = make_query(query_tweak, elementsvv, std::move(element_filter));
     return query->getRoot().evaluate();
 }
 
 std::vector<uint32_t>
-SameElementQueryNodeTest::get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter)
 {
-    auto query = make_query(query_tweak, elementsvv);
+    auto query = make_query(query_tweak, elementsvv, std::move(element_filter));
     std::vector<uint32_t> result;
     query->getRoot().get_element_ids(result);
     return result;
 }
 
 std::vector<std::vector<uint32_t>>
-SameElementQueryNodeTest::extract_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::extract_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter)
 {
-    auto query = make_query(query_tweak, elementsvv);
+    auto query = make_query(query_tweak, elementsvv, std::move(element_filter));
     auto md = MatchData::makeTestInstance(elementsvv.size(), 1);
     constexpr uint32_t docid = 2;
     IndexEnvironment index_env;
@@ -118,7 +121,9 @@ SameElementQueryNodeTest::extract_element_ids(QueryTweak query_tweak, const std:
 }
 
 std::unique_ptr<Query>
-SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::make_query(QueryTweak query_tweak,
+                                     const std::vector<std::vector<uint32_t>>& elementsvv,
+                                     std::vector<uint32_t> element_filter)
 {
     QueryBuilder<SimpleQueryNodeTypes> builder;
     auto num_terms = elementsvv.size();
@@ -135,7 +140,7 @@ SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<s
         default:
             break;
     }
-    builder.addSameElement(top_arity, "field", 0, Weight(0));
+    builder.addSameElement(top_arity, "field", 0, Weight(0), std::move(element_filter));
     for (uint32_t idx = 0; idx < elementsvv.size(); ++idx) {
         switch (query_tweak) {
             case QueryTweak::AND:
@@ -367,4 +372,60 @@ TEST_F(SameElementQueryNodeTest, rank_below_same_element)
               extract_element_ids(QueryTweak::RANK, elementsvv5));
     EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 4, 6,9 }, { 4, 9 } }),
               extract_element_ids(QueryTweak::RANK, elementsvv9));
+}
+
+TEST_F(SameElementQueryNodeTest, element_filter_simple)
+{
+    std::vector<std::vector<uint32_t>> elementsvv({ { 5, 7, 10, 12 }, { 4, 7, 12, 14} });
+
+    std::vector<uint32_t> element_filter({ 5 });
+    EXPECT_FALSE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<uint32_t>{}), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { }, { } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+
+    std::vector<uint32_t> element_filter2({ 7 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<uint32_t>{ 7 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 7 }, { 7 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+}
+
+TEST_F(SameElementQueryNodeTest, element_filter_with_multiple_ids)
+{
+    std::vector<std::vector<uint32_t>> elementsvv({ { 5, 7, 10, 12 }, { 4, 7, 12, 14} });
+    std::vector<uint32_t> element_filter({ 4, 5, 6, 7, 9, 10, 12, 13 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<uint32_t>{ 7, 12 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 7, 12 }, { 7, 12 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+}
+
+TEST_F(SameElementQueryNodeTest, element_filter_for_indexing)
+{
+    std::vector<std::vector<uint32_t>> elementsvv({ { 4, 7, 12, 14} });
+
+    std::vector<uint32_t> element_filter({ 4 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<uint32_t>{ 4 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 4 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+
+    std::vector<uint32_t> element_filter2({ 5 });
+    EXPECT_FALSE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<uint32_t>{ }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+
+    std::vector<uint32_t> element_filter3({ 3, 14 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter3));
+    EXPECT_EQ((std::vector<uint32_t>{ 14 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter3));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 14 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter3));
+
+    std::vector<uint32_t> element_filter4({ 3, 13 });
+    EXPECT_FALSE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter4));
+    EXPECT_EQ((std::vector<uint32_t>{ }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter4));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter4));
 }

--- a/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
@@ -360,7 +360,8 @@ public:
     bool handle(const ItemSameElement& item) {
         auto d = fillTermProperties(item.properties());
         uint32_t arity = item.children_size();
-        auto &term = _builder.addSameElement(arity, d.index_view, d.uniqueId, d.weight);
+        std::vector<uint32_t> element_filter(item.element_filter().cbegin(), item.element_filter().cend());
+        auto &term = _builder.addSameElement(arity, d.index_view, d.uniqueId, d.weight, std::move(element_filter));
         if (d.noRankFlag) term.setRanked(false);
         if (d.noPositionDataFlag) term.setPositionData(false);
         for (const auto &child : item.children()) {

--- a/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
@@ -294,6 +294,7 @@ bool handle(const ItemSameElement& item, QueryStackIterator::Data& _d) {
     fillTermProperties(item.properties(), _d);
     _d.itemType = ParseItem::ItemType::ITEM_SAME_ELEMENT;
     _d.arity = item.children_size();
+    _d._element_filter = std::vector<uint32_t>(item.element_filter().cbegin(), item.element_filter().cend());
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/parsequery/parse.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace search::query {
 
@@ -55,6 +56,7 @@ public:
         uint32_t exploreAdditionalHits = 0;
         uint32_t fuzzy_max_edit_distance = 0;
         uint32_t fuzzy_prefix_lock_length = 0;
+        std::vector<uint32_t> _element_filter;
 
         void clear();
     };
@@ -90,6 +92,8 @@ public:
     // fuzzy match arguments (see also: has_prefix_match_semantics() for fuzzy prefix matching)
     [[nodiscard]] uint32_t fuzzy_max_edit_distance() const noexcept { return _d.fuzzy_max_edit_distance; }
     [[nodiscard]] uint32_t fuzzy_prefix_lock_length() const noexcept { return _d.fuzzy_prefix_lock_length; }
+    // elementFilter annotation for sameElement
+    [[nodiscard]] const std::vector<uint32_t>& get_element_filter() const noexcept { return _d._element_filter; }
 
     // Get the flags of the current item.
     [[nodiscard]] bool hasNoRankFlag() const noexcept { return _d.noRankFlag; }

--- a/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
@@ -392,7 +392,10 @@ QueryBuilder::build_equiv_term(const QueryNodeResultFactory& factory, QueryStack
 std::unique_ptr<QueryNode>
 QueryBuilder::build_same_element_term(const QueryNodeResultFactory& factory, QueryStackIterator& queryRep)
 {
-    auto sen = std::make_unique<SameElementQueryNode>(factory.create(), queryRep.index_as_string(), queryRep.getArity());
+    auto sen = std::make_unique<SameElementQueryNode>(factory.create(),
+                                                      queryRep.index_as_string(),
+                                                      queryRep.getArity(),
+                                                      queryRep.get_element_filter());
     _same_element_view = queryRep.index_as_string();
     _expose_match_data_for_same_element = true;
     auto arity = queryRep.getArity();

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
@@ -14,11 +14,13 @@ using search::fef::MatchData;
 
 namespace search::streaming {
 
-SameElementQueryNode::SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index, uint32_t num_terms) noexcept
+SameElementQueryNode::SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index,
+                                           uint32_t num_terms, std::vector<uint32_t> element_filter) noexcept
     : QueryTerm(std::move(result_base), "", index, Type::WORD, Normalizing::NONE),
       _children(),
       _element_ids(),
-      _cached_evaluate_result()
+      _cached_evaluate_result(),
+      _element_filter(std::move(element_filter))
 {
     _children.reserve(num_terms);
 }
@@ -59,8 +61,15 @@ SameElementQueryNode::get_element_ids(std::vector<uint32_t>& element_ids)
             return;
         }
     }
-    _children.front()->get_element_ids(element_ids);
-    std::span<const std::unique_ptr<QueryNode>> others(_children.begin() + 1, _children.end());
+    std::span<const std::unique_ptr<QueryNode>> others;
+    if (!_element_filter.empty()) {
+        element_ids.insert(element_ids.end(), _element_filter.begin(), _element_filter.end());
+        others = std::span<const std::unique_ptr<QueryNode>>(_children.begin(), _children.end());
+
+    } else {
+        _children.front()->get_element_ids(element_ids);
+        others = std::span<const std::unique_ptr<QueryNode>>(_children.begin() + 1, _children.end());
+    }
     if (others.empty()) {
         return;
     }

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.h
@@ -15,8 +15,10 @@ class SameElementQueryNode : public QueryTerm
     QueryNodeList         _children;
     std::vector<uint32_t> _element_ids;
     std::optional<bool>   _cached_evaluate_result;
+    std::vector<uint32_t> _element_filter;
 public:
-    SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index, uint32_t num_terms) noexcept;
+    SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index,
+                         uint32_t num_terms, std::vector<uint32_t> element_filter) noexcept;
     ~SameElementQueryNode() override;
     bool evaluate() override;
     const HitList & evaluateHits(HitList & hl) override;

--- a/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
@@ -127,7 +127,7 @@ public:
         return *this;
     }
     bool is_expensive() const { return _expensive; }
-    std::vector<uint32_t> get_element_filter() const { return _element_filter; }
+    [[nodiscard]] const std::vector<uint32_t>& get_element_filter() const { return _element_filter; }
 private:
     bool _expensive;
     std::vector<uint32_t> _element_filter;

--- a/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
@@ -119,16 +119,18 @@ private:
 
 class SameElement : public QueryNodeMixin<SameElement, Intermediate>, public Term {
 public:
-    SameElement(std::string view, int32_t id, Weight weight)
-        : Term(std::move(view), id, weight), _expensive(false) {}
+    SameElement(std::string view, int32_t id, Weight weight, std::vector<uint32_t> element_filter = std::vector<uint32_t>())
+        : Term(std::move(view), id, weight), _expensive(false), _element_filter(std::move(element_filter)) {}
     virtual ~SameElement() = 0;
     SameElement &set_expensive(bool value) {
         _expensive = value;
         return *this;
     }
     bool is_expensive() const { return _expensive; }
+    std::vector<uint32_t> get_element_filter() const { return _element_filter; }
 private:
     bool _expensive;
+    std::vector<uint32_t> _element_filter;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
+++ b/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
@@ -144,6 +144,9 @@ private:
     void visit(SameElement &node) override {
         auto* item = _item_stack.back()->mutable_item_same_element();
         copyTermState(node, item->mutable_properties());
+        for (const uint32_t id : node.get_element_filter()) {
+            item->add_element_filter(id);
+        }
         visitNodes(node.getChildren());
     }
 

--- a/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
@@ -131,8 +131,8 @@ typename NodeTypes::Phrase *createPhrase(const std::string & view, int32_t id, W
     return new typename NodeTypes::Phrase(view, id, weight);
 }
 template <class NodeTypes>
-typename NodeTypes::SameElement *createSameElement(const std::string & view, int32_t id, Weight weight) {
-    return new typename NodeTypes::SameElement(view, id, weight);
+typename NodeTypes::SameElement *createSameElement(const std::string & view, int32_t id, Weight weight, std::vector<uint32_t> element_filter = std::vector<uint32_t>()) {
+    return new typename NodeTypes::SameElement(view, id, weight, std::move(element_filter));
 }
 template <class NodeTypes, typename... Args>
 typename NodeTypes::WeightedSetTerm *createWeightedSetTerm(Args&&... args) {
@@ -302,8 +302,8 @@ public:
         setWeightOverride(weight);
         return node;
     }
-    typename NodeTypes::SameElement &addSameElement(int child_count, const string & view, int32_t id, Weight weight) {
-        return addIntermediate(createSameElement<NodeTypes>(view, id, weight), child_count);
+    typename NodeTypes::SameElement &addSameElement(int child_count, const string & view, int32_t id, Weight weight, std::vector<uint32_t> element_filter = std::vector<uint32_t>()) {
+        return addIntermediate(createSameElement<NodeTypes>(view, id, weight, std::move(element_filter)), child_count);
     }
     typename NodeTypes::WeightedSetTerm &addWeightedSetTerm(int child_count, const string & view, int32_t id, Weight weight) {
         adjustWeight(weight);

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.h
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.h
@@ -57,8 +57,8 @@ struct SimplePhrase : Phrase {
 };
 
 struct SimpleSameElement : SameElement {
-    SimpleSameElement(std::string view, int32_t id, Weight weight)
-        : SameElement(std::move(view), id, weight) {}
+    SimpleSameElement(std::string view, int32_t id, Weight weight, std::vector<uint32_t> element_filter = std::vector<uint32_t>())
+        : SameElement(std::move(view), id, weight, std::move(element_filter)) {}
     ~SimpleSameElement() override;
 };
 struct SimpleWeightedSetTerm : WeightedSetTerm {

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -16,11 +16,13 @@ namespace search::queryeval {
 
 SameElementBlueprint::SameElementBlueprint(const FieldSpec &field,
                                            const std::vector<search::fef::TermFieldHandle>& descendants_index_handles,
-                                           bool expensive)
+                                           bool expensive,
+                                           std::vector<uint32_t> element_filter)
     : IntermediateBlueprint(),
       _field(field),
       _descendants_index_handles(descendants_index_handles),
-      _expensive(expensive)
+      _expensive(expensive),
+      _element_filter(std::move(element_filter))
 {
 }
 
@@ -117,7 +119,8 @@ SameElementBlueprint::create_same_element_search(MatchData& md, TermFieldMatchDa
     }
     // match data for subtree (subtree_md) must be owned by search iterator
     return std::make_unique<SameElementSearch>(tfmd, std::move(descendants_index_tfmd), std::move(sub_searches),
-                                               strict());
+                                               strict(),
+                                               _element_filter); // Copy element filter, do not move it
 }
 
 SearchIterator::UP

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -17,11 +17,13 @@ private:
     FieldSpec             _field;
     std::vector<search::fef::TermFieldHandle> _descendants_index_handles; // handles with early unpack
     bool                  _expensive;
+    std::vector<uint32_t> _element_filter;
     AnyFlow my_flow(InFlow in_flow) const override;
 public:
     SameElementBlueprint(const FieldSpec &field,
                          const std::vector<search::fef::TermFieldHandle>& descendants_index_handles,
-                         bool expensive);
+                         bool expensive,
+                         std::vector<uint32_t> element_filter = std::vector<uint32_t>());
     SameElementBlueprint(const SameElementBlueprint &) = delete;
     SameElementBlueprint &operator=(const SameElementBlueprint &) = delete;
     ~SameElementBlueprint() override;

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_search.h
@@ -27,6 +27,7 @@ private:
     std::vector<std::unique_ptr<SearchIterator>> _children;
     std::vector<uint32_t>                        _matchingElements;
     bool                                         _strict;
+    std::vector<uint32_t>                        _element_filter;
 
     void fetch_matching_elements(uint32_t docid, std::vector<uint32_t> &dst);
     bool check_docid_match(uint32_t docid);
@@ -37,7 +38,8 @@ public:
     SameElementSearch(fef::TermFieldMatchData &tfmd,
                       std::vector<fef::TermFieldMatchData*> descendants_index_tfmd,
                       std::vector<std::unique_ptr<SearchIterator>> children,
-                      bool strict);
+                      bool strict,
+                      std::vector<uint32_t> element_filter = std::vector<uint32_t>());
     ~SameElementSearch() override;
     void initRange(uint32_t begin_id, uint32_t end_id) override;
     void doSeek(uint32_t docid) override;


### PR DESCRIPTION
This allows you to check an array at specific indices. Todos:
- [ ] Decide on a name for the annotation.
- [ ] Allow number literals in sameElement. Currently have to be strings even though one is using a byte array, for example.
- [ ] Optimizations for specific types of arrays. (Replace SameElementBlueprint by blueprint directly checking the array?)