### PR TITLE
Add missing includes to header files

### DIFF
--- a/document/src/vespa/document/update/documentupdateflags.h
+++ b/document/src/vespa/document/update/documentupdateflags.h
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <cstdint>
+
 namespace document {
 
 /**
@@ -37,4 +39,3 @@ public:
 };
 
 }
-

--- a/eval/src/vespa/eval/eval/hamming_distance.h
+++ b/eval/src/vespa/eval/eval/hamming_distance.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <bit>
+#include <cstdint>
 
 namespace vespalib::eval {
 

--- a/fnet/src/vespa/fnet/iserveradapter.h
+++ b/fnet/src/vespa/fnet/iserveradapter.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "channel.h"
+
 /**
  * This class must be extended by the server application. It is needed
  * to let the application define the target packet handler for

--- a/messagebus/src/vespa/messagebus/network/rpcsend_private.h
+++ b/messagebus/src/vespa/messagebus/network/rpcsend_private.h
@@ -3,6 +3,7 @@
 
 #include <vespa/messagebus/trace.h>
 #include <vespa/messagebus/routing/routingnode.h>
+#include <vespa/fnet/frt/rpcrequest.h>
 
 namespace mbus::network::internal {
 /**

--- a/searchcore/src/vespa/searchcore/bmcluster/avg_sampler.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/avg_sampler.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace search::bmcluster {
 

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_range.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_range.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace search::bmcluster {
 
 /*

--- a/searchcore/src/vespa/searchcore/bmcluster/bucket_selector.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/bucket_selector.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace search::bmcluster {
 
 /*

--- a/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_usage_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_usage_listener.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "attribute_usage_stats.h"
+
 namespace proton {
 
 /*

--- a/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdbhandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdbhandler.cpp
@@ -88,4 +88,3 @@ BucketDBHandler::handleDeleteBucket(const BucketId &bucketId)
 }
 
 }
-

--- a/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdbhandler.h
+++ b/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdbhandler.h
@@ -6,6 +6,8 @@
 #include "ibucketdbhandlerinitializer.h"
 #include "bucket_create_notifier.h"
 
+#include <vespa/searchcore/proton/documentmetastore/i_document_meta_store.h>
+
 namespace proton::bucketdb {
 
 class BucketDBOwner;

--- a/searchcore/src/vespa/searchcore/proton/bucketdb/ibucketdbhandlerinitializer.h
+++ b/searchcore/src/vespa/searchcore/proton/bucketdb/ibucketdbhandlerinitializer.h
@@ -2,10 +2,13 @@
 
 #pragma once
 
+#include <vespa/searchcore/proton/documentmetastore/i_document_meta_store.h>
+#include <vespa/searchlib/common/serialnum.h>
+
 namespace proton::bucketdb {
 
 /**
- * The IBucketDBHandlerInitiaizer class handles initialization of a 
+ * The IBucketDBHandlerInitiaizer class handles initialization of a
  * BucketDBHandler.
  */
 class IBucketDBHandlerInitializer

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/document_meta_store_versions.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/document_meta_store_versions.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace proton::documentmetastore {
 
 constexpr uint32_t NO_DOCUMENT_SIZE_TRACKING_VERSION = 0u;

--- a/searchcore/src/vespa/searchcore/proton/server/i_proton_configurer_owner.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_proton_configurer_owner.h
@@ -3,10 +3,13 @@
 #pragma once
 
 #include <vespa/searchcore/proton/common/doctypename.h>
+#include <vespa/searchcore/proton/server/bootstrapconfig.h>
+#include <vespa/searchcore/proton/server/documentdbconfig.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/document/bucket/bucketspace.h>
 #include <memory>
 #include <string>
+
 
 namespace proton {
 

--- a/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <vespa/document/bucket/bucketid.h>
+#include <vespa/document/bucket/bucketidlist.h>
 #include <vespa/searchcore/proton/documentmetastore/i_document_meta_store.h>
 #include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
@@ -184,4 +186,3 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
 };
 
 }
-

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_store.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_store.h
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <vespa/document/fieldvalue/document.h>
 #include <vespa/vespalib/stllike/cache_stats.h>
 #include <vespa/searchlib/docstore/idocumentstore.h>
 

--- a/searchcore/src/vespa/searchcore/proton/test/mock_summary_adapter.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_summary_adapter.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vespa/searchcore/proton/server/isummaryadapter.h>
+#include <vespa/document/fieldvalue/document.h>
 
 namespace proton::test {
 

--- a/searchlib/src/tests/attribute/benchmark/attributeupdater.h
+++ b/searchlib/src/tests/attribute/benchmark/attributeupdater.h
@@ -5,6 +5,9 @@
 #include <vespa/vespalib/util/hdr_abort.h>
 #include <vespa/searchlib/util/randomgenerator.h>
 #include <vespa/searchlib/attribute/attribute.h>
+#include <vespa/searchlib/attribute/attributeguard.h>
+#include <iostream>
+#include <thread>
 
 #define VALIDATOR_STR(str) #str
 #define VALIDATOR_ASSERT(rc) reportAssert(rc, __FILE__, __LINE__, VALIDATOR_STR(rc))

--- a/searchlib/src/tests/queryeval/blueprint/mysearch.h
+++ b/searchlib/src/tests/queryeval/blueprint/mysearch.h
@@ -1,4 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/multisearch.h>
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>

--- a/searchlib/src/vespa/searchcommon/attribute/persistent_predicate_params.h
+++ b/searchlib/src/vespa/searchcommon/attribute/persistent_predicate_params.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <limits>
+#include <cstdint>
 
 namespace search::attribute {
 

--- a/searchlib/src/vespa/searchlib/attribute/posting_list_traverser.h
+++ b/searchlib/src/vespa/searchlib/attribute/posting_list_traverser.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <vespa/vespalib/datastore/entryref.h>
+
 namespace search::attribute {
 
 /*

--- a/searchlib/src/vespa/searchlib/bitcompression/raw_features_collector.h
+++ b/searchlib/src/vespa/searchlib/bitcompression/raw_features_collector.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "compression.h"
+#include <vespa/searchlib/index/docidandfeatures.h>
 #include <cassert>
 #include <limits>
 

--- a/searchlib/src/vespa/searchlib/common/i_flush_token.h
+++ b/searchlib/src/vespa/searchlib/common/i_flush_token.h
@@ -1,5 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#pragma once
+
 namespace search {
 
 /*

--- a/searchlib/src/vespa/searchlib/docstore/ibucketizer.h
+++ b/searchlib/src/vespa/searchlib/docstore/ibucketizer.h
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/util/generationhandler.h>
 #include <vespa/vespalib/util/buffer.h>
 #include <vespa/document/bucket/bucketid.h>
+#include <memory>
 
 namespace search {
 

--- a/searchlib/src/vespa/searchlib/engine/monitorapi.h
+++ b/searchlib/src/vespa/searchlib/engine/monitorapi.h
@@ -4,6 +4,7 @@
 
 #include "monitorrequest.h"
 #include "monitorreply.h"
+#include <memory>
 
 namespace search::engine {
 
@@ -61,4 +62,3 @@ public:
 };
 
 }
-

--- a/searchlib/src/vespa/searchlib/expression/bitfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/bitfunctionnode.h
@@ -3,6 +3,7 @@
 
 #include "multiargfunctionnode.h"
 #include "integerresultnode.h"
+#include "numericfunctionnode.h"
 
 namespace search {
 namespace expression {
@@ -21,4 +22,3 @@ private:
 
 }
 }
-

--- a/searchlib/src/vespa/searchlib/expression/getdocidnamespacespecificfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/getdocidnamespacespecificfunctionnode.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include "documentaccessornode.h"
+#include "resultnode.h"
+#include "stringresultnode.h"
 
 namespace search {
 namespace expression {

--- a/searchlib/src/vespa/searchlib/expression/getymumchecksumfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/getymumchecksumfunctionnode.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "documentaccessornode.h"
+#include "integerresultnode.h"
 
 namespace search {
 namespace expression {
@@ -23,4 +24,3 @@ private:
 
 }
 }
-

--- a/searchlib/src/vespa/searchlib/features/tensor_from_attribute_executor.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_attribute_executor.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/searchlib/fef/featureexecutor.h>
 #include <vespa/searchcommon/attribute/iattributevector.h>
 #include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/value.h>

--- a/searchlib/src/vespa/searchlib/index/bitvectorkeys.h
+++ b/searchlib/src/vespa/searchlib/index/bitvectorkeys.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace search::index {
 
 struct BitVectorWordSingleKey {

--- a/searchlib/src/vespa/searchlib/predicate/predicate_interval_posting_list.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_interval_posting_list.h
@@ -4,6 +4,7 @@
 
 #include "predicate_posting_list.h"
 #include "predicate_interval_store.h"
+#include "predicate_interval.h"
 
 namespace search::predicate {
 

--- a/searchlib/src/vespa/searchlib/query/tree/rectangle.h
+++ b/searchlib/src/vespa/searchlib/query/tree/rectangle.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace search::query {
 
 struct Rectangle {

--- a/searchlib/src/vespa/searchlib/util/posting_priority_queue.h
+++ b/searchlib/src/vespa/searchlib/util/posting_priority_queue.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vector>
+#include <cstdint>
 
 namespace search {
 

--- a/searchlib/src/vespa/searchlib/util/posting_priority_queue_merger.h
+++ b/searchlib/src/vespa/searchlib/util/posting_priority_queue_merger.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "posting_priority_queue.h"
+#include <vespa/searchlib/common/i_flush_token.h>
 
 namespace search {
 

--- a/searchlib/src/vespa/searchlib/util/random_normal.h
+++ b/searchlib/src/vespa/searchlib/util/random_normal.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/searchlib/common/feature.h>
 #include <vespa/vespalib/util/rand48.h>
 #include <cmath>
 
@@ -64,4 +65,3 @@ public:
 };
 
 } // search
-

--- a/searchsummary/src/vespa/juniper/charutil.h
+++ b/searchsummary/src/vespa/juniper/charutil.h
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <cstddef>
+
 namespace juniper {
 
 template <typename T> int strncmp(const T* s1, const T* s2, size_t n) {

--- a/storage/src/tests/persistence/filestorage/forwardingmessagesender.h
+++ b/storage/src/tests/persistence/filestorage/forwardingmessagesender.h
@@ -3,6 +3,7 @@
 
 #include <vespa/storage/common/messagesender.h>
 #include <vespa/storage/common/storagelink.h>
+#include <vespa/storageapi/mbusprot/storagecommand.h>
 
 namespace storage {
 

--- a/storage/src/vespa/storage/common/dummy_mbus_messages.h
+++ b/storage/src/vespa/storage/common/dummy_mbus_messages.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vespa/messagebus/message.h>
+#include <vespa/messagebus/reply.h>
 
 /**
  * Dummy-implementation of mbus::Message and mbus::Reply to be used when interacting with

--- a/storage/src/vespa/storage/common/visitorfactory.h
+++ b/storage/src/vespa/storage/common/visitorfactory.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <vespa/vdslib/container/parameters.h>
+#include <map>
 
 namespace storage {
 
@@ -36,4 +37,3 @@ public:
 };
 
 } // storage
-

--- a/storage/src/vespa/storage/distributor/distributor_interface.h
+++ b/storage/src/vespa/storage/distributor/distributor_interface.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "distributormessagesender.h"
+#include <vespa/vdslib/distribution/distribution.h>
 
 namespace storage { class DistributorConfiguration; }
 

--- a/storage/src/vespa/storage/distributor/potential_data_loss_report.h
+++ b/storage/src/vespa/storage/distributor/potential_data_loss_report.h
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace storage::distributor {

--- a/storage/src/vespa/storageframework/generic/status/statusreportermap.h
+++ b/storage/src/vespa/storageframework/generic/status/statusreportermap.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <string_view>
 #include <vector>
 
 namespace storage::framework {

--- a/vespalib/src/vespa/vespalib/btree/noaggrcalc.h
+++ b/vespalib/src/vespa/vespalib/btree/noaggrcalc.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "noaggregated.h"
+#include <cstdint>
 
 namespace vespalib::btree {
 

--- a/vespalib/src/vespa/vespalib/datastore/entry_comparator_wrapper.h
+++ b/vespalib/src/vespa/vespalib/datastore/entry_comparator_wrapper.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "entry_comparator.h"
+#include "atomic_entry_ref.h"
 
 namespace vespalib::datastore {
 

--- a/vespalib/src/vespa/vespalib/datastore/i_compactable.h
+++ b/vespalib/src/vespa/vespalib/datastore/i_compactable.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "entryref.h"
+
 namespace vespalib::datastore {
 
 /**

--- a/vespalib/src/vespa/vespalib/datastore/i_unique_store_dictionary.h
+++ b/vespalib/src/vespa/vespalib/datastore/i_unique_store_dictionary.h
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/util/generationhandler.h>
 #include <vespa/vespalib/util/memoryusage.h>
 #include <functional>
+#include <memory>
 #include <span>
 
 namespace vespalib::datastore {

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_remapper.h
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_remapper.h
@@ -2,9 +2,11 @@
 
 #pragma once
 
+#include "atomic_entry_ref.h"
 #include "entryref.h"
 #include "entry_ref_filter.h"
 #include <vector>
+#include <span>
 #include <vespa/vespalib/stllike/allocator.h>
 
 namespace vespalib::datastore {

--- a/vespalib/src/vespa/vespalib/hwaccelerated/float4.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/float4.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <concepts>
 

--- a/vespalib/src/vespa/vespalib/util/arraysize.h
+++ b/vespalib/src/vespa/vespalib/util/arraysize.h
@@ -2,10 +2,11 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace vespalib {
 
 template <typename T, size_t N>
 constexpr size_t arraysize(const T (&)[N]) { return N; }
 
 }  // namespace vespalib
-

--- a/vespalib/src/vespa/vespalib/util/fiddle.h
+++ b/vespalib/src/vespa/vespalib/util/fiddle.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 
 namespace vespalib::bits {
 
@@ -79,4 +80,3 @@ uint32_t split_range(uint32_t min, uint32_t max,
 //-----------------------------------------------------------------------------
 
 }
-

--- a/vespalib/src/vespa/vespalib/util/polymorphicarray.h
+++ b/vespalib/src/vespa/vespalib/util/polymorphicarray.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "polymorphicarraybase.h"
+#include <unistd.h>
+#include <memory>
 
 namespace vespalib {
 

--- a/vespalib/src/vespa/vespalib/util/polymorphicarraybase.h
+++ b/vespalib/src/vespa/vespalib/util/polymorphicarraybase.h
@@ -2,6 +2,8 @@
 //
 #pragma once
 
+#include <cstddef>
+
 namespace vespalib {
 
 class IArrayBase {

--- a/vespamalloc/src/vespamalloc/malloc/stat.h
+++ b/vespamalloc/src/vespamalloc/malloc/stat.h
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <cstddef>
+
 namespace vespamalloc {
 
 class NoStat


### PR DESCRIPTION
Fix missing includes across 52 header files in document, eval, fnet, messagebus, searchcore, searchlib, searchsummary, storage, and vespalib modules. This ensures headers can be compiled independently without relying on transitive includes from other files.

Changes include:
- Add <cstdint> and <cstddef> for standard integer type definitions
- Add <memory> for std::unique_ptr
- Add necessary class and function declarations (e.g., channel.h, rpcrequest.h)
- Add module-specific includes (e.g., attribute_usage_stats.h, i_document_meta_store.h)
