### PR TITLE
remove useless ".num0" suffix

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -109,7 +109,7 @@ public class ClusterSearcher extends Searcher {
 
     private static ClusterParams makeClusterParams(String searchclusterName, DocumentdbInfoConfig documentDbConfig, SchemaInfo schemaInfo, QrSearchersConfig qrSearchersConfig)
     {
-        return new ClusterParams(searchclusterName + ".num" + 0, UUID.randomUUID().toString(),
+        return new ClusterParams(searchclusterName, UUID.randomUUID().toString(),
                                  null, documentDbConfig, schemaInfo, qrSearchersConfig);
     }
 


### PR DESCRIPTION
@hmusum please review

addresses https://github.com/vespa-engine/vespa/issues/35833

note: this will probably show up as changes in the "source" fields from streaming search, it used to say "search.num0" but will now say just "search" - just like indexed search already does.
