### PR TITLE
Add Storage API RPC protocol metadata propagation

### DIFF
--- a/storage/src/tests/storageapi/mbusprot/storageprotocoltest.cpp
+++ b/storage/src/tests/storageapi/mbusprot/storageprotocoltest.cpp
@@ -1,23 +1,23 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/storageapi/message/persistence.h>
+#include <vespa/document/base/testdocman.h>
+#include <vespa/document/fieldvalue/intfieldvalue.h>
+#include <vespa/document/test/make_bucket_space.h>
+#include <vespa/document/test/make_document_bucket.h>
+#include <vespa/document/update/assignvalueupdate.h>
+#include <vespa/document/update/documentupdate.h>
+#include <vespa/document/update/fieldpathupdates.h>
+#include <vespa/storageapi/mbusprot/storagecommand.h>
+#include <vespa/storageapi/mbusprot/storageprotocol.h>
+#include <vespa/storageapi/mbusprot/storagereply.h>
 #include <vespa/storageapi/message/bucket.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/storageapi/message/internal.h>
+#include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/storageapi/message/stat.h>
-#include <vespa/storageapi/mbusprot/storageprotocol.h>
-#include <vespa/storageapi/mbusprot/storagecommand.h>
-#include <vespa/storageapi/mbusprot/storagereply.h>
 #include <vespa/storageapi/message/visitor.h>
 #include <vespa/vdslib/state/clusterstate.h>
-#include <vespa/document/base/testdocman.h>
-#include <vespa/document/update/documentupdate.h>
-#include <vespa/document/update/assignvalueupdate.h>
-#include <vespa/document/update/fieldpathupdates.h>
-#include <vespa/document/fieldvalue/intfieldvalue.h>
-#include <vespa/document/test/make_document_bucket.h>
-#include <vespa/document/test/make_bucket_space.h>
 #include <vespa/vespalib/util/growablebytebuffer.h>
 #include <vespa/vespalib/util/size_literals.h>
 
@@ -921,7 +921,7 @@ TEST_P(StorageProtocolTest, track_memory_footprint_for_some_messages) {
     EXPECT_EQ(sizeof(UpdateReply),       doc_reply_baseline + 120);
     EXPECT_EQ(sizeof(RemoveReply),       doc_reply_baseline + 112);
     EXPECT_EQ(sizeof(GetReply),          doc_reply_baseline + 136 + sizeof(std::string));
-    EXPECT_EQ(sizeof(StorageCommand),    msg_baseline   + 16);
+    EXPECT_EQ(sizeof(StorageCommand),    msg_baseline + 16);
     EXPECT_EQ(sizeof(BucketCommand),     sizeof(StorageCommand) + 24);
     EXPECT_EQ(sizeof(BucketInfoCommand), sizeof(BucketCommand));
     EXPECT_EQ(sizeof(TestAndSetCommand), sizeof(BucketInfoCommand) + sizeof(std::string) + sizeof(uint64_t));

--- a/storage/src/tests/storageserver/rpc/CMakeLists.txt
+++ b/storage/src/tests/storageserver/rpc/CMakeLists.txt
@@ -11,6 +11,7 @@ vespa_add_executable(storage_storageserver_rpc_gtest_runner_app TEST
     storage_teststorageserver
     vespa_storage
     GTest::gtest
+    GTest::gmock
 )
 
 vespa_add_test(

--- a/storage/src/vespa/storage/storageserver/rpc/metadata_propagator.h
+++ b/storage/src/vespa/storage/storageserver/rpc/metadata_propagator.h
@@ -1,0 +1,50 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace storage::api {
+class MetadataExtractor;
+class MetadataInjector;
+class StorageCommand;
+}
+
+namespace storage::rpc {
+
+/**
+ * Used to propagate StorageCommand-level metadata to and from RPC-level metadata.
+ *
+ * All methods must be fully thread safe.
+ */
+class MetadataPropagator {
+public:
+    virtual ~MetadataPropagator() = default;
+
+    /**
+     * Called at the time of serializing a StorageCommand to the underlying wire protocol.
+     * Allows for injecting any metadata key/value pairs the StorageCommand wants to propagate
+     * to the receiver, but that aren't part of the per-message schema itself.
+     *
+     * A propagator (if present) on the receiver side will have on_command_received()
+     * invoked with the newly materialized StorageCommand instance alongside an extractor
+     * that can read the values set by the sender.
+     *
+     * The transport carrier shall guarantee that the metadata injected will not be
+     * compressed during transport.
+     *
+     * The lifetime of the injector is only valid for the duration of the call.
+     */
+    virtual void on_send_command(const api::StorageCommand& cmd, api::MetadataInjector& injector) const = 0;
+
+    /**
+     * Invoked when a StorageCommand arrives at a storage server, with an extractor that
+     * can resolve key/value metadata sent for that command.
+     *
+     * This method is always invoked by the RPC layer right after it has been decoded
+     * but _before_ it is passed to any message handlers.
+     *
+     * The lifetime of the extractor is only valid for the duration of the call.
+     */
+    virtual void on_receive_command(api::StorageCommand& cmd, const api::MetadataExtractor& extractor) const = 0;
+};
+
+}

--- a/storage/src/vespa/storage/storageserver/rpc/metadata_propagator.h
+++ b/storage/src/vespa/storage/storageserver/rpc/metadata_propagator.h
@@ -13,7 +13,8 @@ namespace storage::rpc {
 /**
  * Used to propagate StorageCommand-level metadata to and from RPC-level metadata.
  *
- * All methods must be fully thread safe.
+ * Methods may be called concurrently, so any internal propagator state access must
+ * be thread safe.
  */
 class MetadataPropagator {
 public:

--- a/storage/src/vespa/storage/storageserver/rpc/protobuf/rpc_envelope.proto
+++ b/storage/src/vespa/storage/storageserver/rpc/protobuf/rpc_envelope.proto
@@ -8,6 +8,7 @@ package storage.protobuf;
 message RequestHeader {
     uint64 time_remaining_ms = 1;
     uint32 trace_level = 2;
+    map<string, string> header_kvs = 3;
 }
 
 message ResponseHeader {

--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
@@ -25,7 +25,6 @@ namespace storage::rpc {
 namespace {
 
 class RpcTargetImpl : public RpcTarget {
-private:
     FRT_Target* _target;
     std::string _spec;
 
@@ -45,7 +44,6 @@ public:
 }
 
 class SharedRpcResources::RpcTargetFactoryImpl : public RpcTargetFactory {
-private:
     FRT_Supervisor& _orb;
 
 public:
@@ -57,7 +55,7 @@ public:
         if (raw_target) {
             return std::make_unique<RpcTargetImpl>(raw_target, connection_spec);
         }
-        return std::unique_ptr<RpcTarget>();
+        return {};
     }
 };
 

--- a/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
+++ b/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
@@ -30,13 +30,15 @@ namespace rpc {
 
 class CachingRpcTargetResolver;
 class MessageCodecProvider;
+class MetadataPropagator;
 class SharedRpcResources;
 
 class StorageApiRpcService : public FRT_Invokable, public FRT_IRequestWait {
 public:
     struct Params {
+        std::shared_ptr<MetadataPropagator>      metadata_propagator;
         vespalib::compression::CompressionConfig compression_config;
-        size_t num_rpc_targets_per_node;
+        size_t                                   num_rpc_targets_per_node;
 
         Params();
         ~Params();

--- a/storage/src/vespa/storageapi/messageapi/metadata_extractor.h
+++ b/storage/src/vespa/storageapi/messageapi/metadata_extractor.h
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <optional>
+
+namespace storage::api {
+
+/**
+ * Abstraction for getting metadata values without needing to know anything
+ * about how the metadata is being transported.
+ *
+ * TODO dedupe with MessageBus once the dust settles
+ */
+class MetadataExtractor {
+public:
+    virtual ~MetadataExtractor() = default;
+
+    /**
+     * Retrieves a metadata value for a particular key, returning an empty optional
+     * if there is no mapped value for the key.
+     *
+     * @param key metadata-specific key. Should be unique for its purpose.
+     * @return the metadata value the key resolves to, or an empty optional if no value existed.
+     */
+    [[nodiscard]] virtual std::optional<std::string> extract_value(std::string_view key) const = 0;
+};
+
+}

--- a/storage/src/vespa/storageapi/messageapi/metadata_injector.h
+++ b/storage/src/vespa/storageapi/messageapi/metadata_injector.h
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string_view>
+
+namespace storage::api {
+
+/**
+ * Abstraction for setting metadata values without needing to know anything
+ * about how the metadata is being transported.
+ *
+ * TODO dedupe with MessageBus once the dust settles
+ */
+class MetadataInjector {
+public:
+    virtual ~MetadataInjector() = default;
+
+    /**
+     * Set a particular key/value mapping to be propagated as metadata.
+     *
+     * Prefer limiting both keys and values to only contain ASCII characters to
+     * maximize interoperability with other carrier protocols.
+     *
+     * It is unspecified whether multiple injection calls with the same key will
+     * reflect the first or last value set, so callers should not depend on this.
+     *
+     * @param key   Metadata key. Should be unique for its purpose.
+     * @param value Metadata value.
+     */
+    virtual void inject_key_value(std::string_view key, std::string_view value) = 0;
+};
+
+}


### PR DESCRIPTION
@havardpe please review. Plenty of future room for consolidating with MessageBus stuff (and a similar metadata propagator interface is likely to be added there as well).

Metadata is propagated over the wire via a new string -> string protobuf map field in the dedicated, existing message header RPC payload.

A `MetadataPropagator` interface has been added with distinct send/receive callback methods that will be invoked by the storage RPC layer when a `StorageCommand` is serialized and deserialized to/from the wire.

The send callback gets a `MetadataInjector` argument that can be used for setting arbitrary key/values associated with the command. This will transparently update the Protobuf header KV map.

The receive callback gets a `MetadataExtractor` argument that can be used for resolving keys to values. This will read directly from the underlying Protobuf header KV map.
