### PR TITLE
feat: add DynamicBatcher for batching items across caller threads

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/concurrent/DynamicBatcher.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/DynamicBatcher.java
@@ -1,0 +1,219 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.concurrent;
+
+import com.yahoo.text.Text;
+import com.yahoo.yolean.Exceptions;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Groups items from multiple caller threads into batches, partitioned by a caller-supplied key.
+ * <p>
+ * Caller threads block in {@link #execute} until their batch is executed.
+ * One caller thread per batch acts as executor; the others wait for the result.
+ * No dedicated thread pool is used for dispatching batch operations.
+ * <p>
+ * A batch is dispatched when it reaches {@code maxBatchSize} or when
+ * {@code maxDelay} has elapsed since the first item was added (whichever comes first).
+ *
+ * @param <K> partition key type — represents additional context or fixed parameters that determine how items are
+ *            grouped; items with the same key are batched together
+ *            (must have proper {@link Object#equals} and {@link Object#hashCode})
+ * @param <I> input item type
+ * @param <O> output result type
+ * @author bjorncs
+ * @author havardpe
+ */
+public class DynamicBatcher<K, I, O> {
+
+    /** A batched operation that processes multiple inputs for a given key. */
+    @FunctionalInterface
+    public interface BatchOperation<K, I, O> {
+        /**
+         * @param key    the partition key
+         * @param inputs the list of inputs (at least one, at most {@code maxBatchSize})
+         * @return a list of outputs, one per input, in the same order
+         */
+        List<O> execute(K key, List<I> inputs);
+    }
+
+    private static class Batch<K, I, O> {
+        final Object monitor = new Object();
+        final K key;
+        final List<I> inputs;
+        final Instant deadline;
+        boolean isFilling = true;
+        boolean isDone = false;
+        List<O> results;
+        Exception failure;
+
+        Batch(K key, int maxBatchSize, I initialInput, Instant deadline) {
+            this.key = key;
+            this.deadline = deadline;
+            this.inputs = new ArrayList<>(maxBatchSize);
+            this.inputs.add(initialInput);
+        }
+    }
+
+    private final Object batchesLock = new Object();
+    private final BatchOperation<K, I, O> processBatch;
+    private final int maxBatchSize;
+    private final Duration maxDelay;
+    private final Timer timer;
+    private final Map<K, Batch<K, I, O>> batches = new HashMap<>();
+    private final Runnable onWaiting;
+
+    public DynamicBatcher(int maxBatchSize, Duration maxDelay, BatchOperation<K, I, O> operation) {
+        this(Timer.monotonic, maxBatchSize, maxDelay, operation, () -> {});
+    }
+
+    DynamicBatcher(Timer timer, int maxBatchSize, Duration maxDelay, BatchOperation<K, I, O> operation) {
+        this(timer, maxBatchSize, maxDelay, operation, () -> {});
+    }
+
+    DynamicBatcher(Timer timer, int maxBatchSize, Duration maxDelay, BatchOperation<K, I, O> operation, Runnable onWaiting) {
+        if (maxBatchSize < 1) throw new IllegalArgumentException("maxBatchSize must be >= 1, got " + maxBatchSize);
+        if (maxDelay.isNegative() || maxDelay.isZero()) throw new IllegalArgumentException("maxDelay must be positive, got " + maxDelay);
+        this.processBatch = Objects.requireNonNull(operation);
+        this.maxBatchSize = maxBatchSize;
+        this.maxDelay = maxDelay;
+        this.timer = Objects.requireNonNull(timer);
+        this.onWaiting = Objects.requireNonNull(onWaiting);
+    }
+
+    /**
+     * Submits an input for batched execution under the given key.
+     * Blocks until the batch containing this item is executed and the result is available.
+     *
+     * @param key   the partition key
+     * @param input the input item
+     * @return the output corresponding to this input
+     */
+    public O execute(K key, I input) {
+        if (maxBatchSize == 1) {
+            return processBatch.execute(key, List.of(input)).get(0);
+        }
+
+        enum Role {CREATOR, WAITER, EXECUTOR}
+        Batch<K, I, O> batch;
+        Role role = Role.CREATOR;
+        int index = 0;
+
+        // Determine batch, role and index
+        synchronized (batchesLock) {
+            var existing = batches.get(key);
+            if (existing == null) {
+                batch = startNewBatch(key, input);
+            } else {
+                synchronized (existing.monitor) {
+                    if (!existing.isFilling) {
+                        batch = startNewBatch(key, input);
+                    } else {
+                        batch = existing;
+                        index = existing.inputs.size();
+                        existing.inputs.add(input);
+                        if (existing.inputs.size() == maxBatchSize) {
+                            batches.remove(key);
+                            existing.isFilling = false;
+                            role = Role.EXECUTOR;
+                        } else {
+                            role = Role.WAITER;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Wait for timeout or completion
+        boolean removeBatch = false;
+        if (role == Role.CREATOR) {
+            synchronized (batch.monitor) {
+                onWaiting.run();
+                for (long deadlineMs = batch.deadline.toEpochMilli(), now = timer.instant().toEpochMilli();
+                     !batch.isDone && now < deadlineMs;
+                     now = timer.instant().toEpochMilli()) {
+                    try { batch.monitor.wait(deadlineMs - now); }
+                    catch (InterruptedException e) {}
+                }
+                if (!batch.isDone && batch.isFilling) {
+                    role = Role.EXECUTOR;
+                    batch.isFilling = false;
+                    removeBatch = true;
+                }
+            }
+        }
+
+        if (role == Role.EXECUTOR) {
+            if (removeBatch) {
+                synchronized (batchesLock) { batches.remove(batch.key, batch); }
+            }
+            return executeBatch(batch, index);
+        }
+        return awaitResult(batch, index);
+    }
+
+    /** Wakes up all waiting threads. For unit testing. */
+    void wakeup() {
+        List<Batch<K, I, O>> snapshot;
+        synchronized (batchesLock) {
+            snapshot = List.copyOf(batches.values());
+        }
+        for (var batch : snapshot) {
+            synchronized (batch.monitor) { batch.monitor.notifyAll(); }
+        }
+    }
+
+    private Batch<K, I, O> startNewBatch(K key, I input) {
+        var b = new Batch<K, I, O>(key, maxBatchSize, input, timer.instant().plus(maxDelay));
+        batches.put(key, b);
+        return b;
+    }
+
+    private O executeBatch(Batch<K, I, O> batch, int index) {
+        List<I> inputs;
+        synchronized (batch.monitor) {
+            inputs = List.copyOf(batch.inputs);
+        }
+        List<O> results;
+        try {
+            results = List.copyOf(processBatch.execute(batch.key, inputs));
+            if (results.size() != inputs.size())
+                throw new IllegalStateException(
+                        Text.format("BatchOperation returned %d results for %d inputs", results.size(), inputs.size()));
+        } catch (Exception e) {
+            completeBatch(batch, null, e);
+            throw e;
+        }
+        completeBatch(batch, results, null);
+        return results.get(index);
+    }
+
+    private void completeBatch(Batch<K, I, O> batch, List<O> results, Exception failure) {
+        synchronized (batch.monitor) {
+            batch.isDone = true;
+            if (failure == null) {
+                batch.results = results;
+            } else {
+                batch.failure = failure;
+            }
+            batch.monitor.notifyAll();
+        }
+    }
+
+    private O awaitResult(Batch<K, I, O> batch, int index) {
+        synchronized (batch.monitor) {
+            while (!batch.isDone) {
+                try { batch.monitor.wait(); }
+                catch (InterruptedException e) {}
+            }
+            if (batch.failure != null) throw Exceptions.throwUnchecked(batch.failure);
+            return batch.results.get(index);
+        }
+    }
+}

--- a/vespajlib/src/main/java/com/yahoo/concurrent/ManualTimer.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/ManualTimer.java
@@ -7,7 +7,7 @@ package com.yahoo.concurrent;
  */
 public class ManualTimer implements Timer {
 
-    private long millis = 0;
+    private volatile long millis = 0;
     public void set(long ms) { millis = ms; }
     public void advance(long ms) { millis += ms; }
 

--- a/vespajlib/src/test/java/com/yahoo/concurrent/DynamicBatcherTest.java
+++ b/vespajlib/src/test/java/com/yahoo/concurrent/DynamicBatcherTest.java
@@ -1,0 +1,342 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.concurrent;
+
+import com.yahoo.yolean.Exceptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author bjorncs
+ * @author havardpe
+ */
+@Timeout(30)
+class DynamicBatcherTest {
+
+    @Test
+    void batch_dispatched_when_full() throws Exception {
+        var invocations = new CopyOnWriteArrayList<List<String>>();
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 3, Duration.ofSeconds(10), (key, inputs) -> {
+                    invocations.add(List.copyOf(inputs));
+                    return inputs.stream().map(s -> s + "-out").toList();
+                });
+
+        var barrier = new CyclicBarrier(3);
+        var results = new String[3];
+        var threads = new Thread[3];
+        for (int i = 0; i < 3; i++) {
+            var idx = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    results[idx] = batcher.execute("k", "item-" + idx);
+                } catch (Exception e) { throw new RuntimeException(e); }
+            });
+            threads[i].setDaemon(true);
+            threads[i].start();
+        }
+        for (var t : threads) t.join();
+
+        assertEquals(1, invocations.size());
+        assertEquals(3, invocations.get(0).size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals("item-" + i + "-out", results[i]);
+        }
+    }
+
+    @Test
+    void timeout_triggers_partial_batch() throws Exception {
+        var timer = new ManualTimer();
+        var invocations = new CopyOnWriteArrayList<List<String>>();
+        var waiting = new CountDownLatch(1);
+        var batcher = new DynamicBatcher<String, String, String>(
+                timer, 100, Duration.ofMillis(50), (key, inputs) -> {
+                    invocations.add(List.copyOf(inputs));
+                    return inputs.stream().map(s -> s + "-out").toList();
+                }, waiting::countDown);
+
+        var resultRef = new AtomicReference<String>();
+        var thread = new Thread(() -> resultRef.set(batcher.execute("k", "solo")));
+        thread.setDaemon(true);
+        thread.start();
+
+        waiting.await();
+        timer.advance(50);
+        batcher.wakeup();
+        thread.join();
+
+        assertEquals(1, invocations.size());
+        assertEquals(List.of("solo"), invocations.get(0));
+        assertEquals("solo-out", resultRef.get());
+    }
+
+    @Test
+    void separate_keys_produce_separate_batches() throws Exception {
+        var invocations = new ConcurrentHashMap<String, List<String>>();
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 2, Duration.ofSeconds(10), (key, inputs) -> {
+                    invocations.put(key, List.copyOf(inputs));
+                    return inputs.stream().map(s -> key + ":" + s).toList();
+                });
+
+        var results = new ConcurrentHashMap<String, String>();
+        var barrier = new CyclicBarrier(4);
+        var threads = new ArrayList<Thread>();
+        for (var entry : List.of(Map.entry("a", "x1"), Map.entry("a", "x2"),
+                                 Map.entry("b", "y1"), Map.entry("b", "y2"))) {
+            var t = new Thread(() -> {
+                try {
+                    barrier.await();
+                    var r = batcher.execute(entry.getKey(), entry.getValue());
+                    results.put(entry.getValue(), r);
+                } catch (Exception e) { throw new RuntimeException(e); }
+            });
+            t.setDaemon(true);
+            t.start();
+            threads.add(t);
+        }
+        for (var t : threads) t.join();
+
+        assertEquals(2, invocations.size());
+        assertEquals(2, invocations.get("a").size());
+        assertEquals(2, invocations.get("b").size());
+        assertEquals("a:x1", results.get("x1"));
+        assertEquals("a:x2", results.get("x2"));
+        assertEquals("b:y1", results.get("y1"));
+        assertEquals("b:y2", results.get("y2"));
+    }
+
+    @Test
+    void operation_failure_propagated_to_all_callers() throws Exception {
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 3, Duration.ofSeconds(10),
+                (key, inputs) -> { throw new RuntimeException("batch-fail"); });
+
+        var barrier = new CyclicBarrier(3);
+        var errors = new ConcurrentHashMap<Integer, RuntimeException>();
+        var threads = new Thread[3];
+        for (int i = 0; i < 3; i++) {
+            var idx = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    batcher.execute("k", "item-" + idx);
+                } catch (RuntimeException e) {
+                    errors.put(idx, e);
+                } catch (Exception e) { throw new RuntimeException(e); }
+            });
+            threads[i].setDaemon(true);
+            threads[i].start();
+        }
+        for (var t : threads) t.join();
+
+        assertEquals(3, errors.size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals("batch-fail", errors.get(i).getMessage());
+        }
+    }
+
+    @Test
+    void checked_exception_thrown_as_is() throws Exception {
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 2, Duration.ofSeconds(10),
+                (key, inputs) -> { throw Exceptions.throwUnchecked(new IOException("io-fail")); });
+
+        var barrier = new CyclicBarrier(2);
+        var errors = new ConcurrentHashMap<Integer, Exception>();
+        var threads = new Thread[2];
+        for (int i = 0; i < 2; i++) {
+            var idx = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    batcher.execute("k", "item-" + idx);
+                } catch (Exception e) {
+                    errors.put(idx, e);
+                }
+            });
+            threads[i].setDaemon(true);
+            threads[i].start();
+        }
+        for (var t : threads) t.join();
+
+        assertEquals(2, errors.size());
+        for (var error : errors.values()) {
+            assertInstanceOf(IOException.class, error);
+            assertEquals("io-fail", error.getMessage());
+        }
+    }
+
+    @Test
+    void result_size_mismatch_throws() throws Exception {
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 2, Duration.ofSeconds(10),
+                (key, inputs) -> List.of("only-one"));
+
+        var barrier = new CyclicBarrier(2);
+        var errors = new ConcurrentHashMap<Integer, RuntimeException>();
+        var threads = new Thread[2];
+        for (int i = 0; i < 2; i++) {
+            var idx = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    batcher.execute("k", "item-" + idx);
+                } catch (RuntimeException e) {
+                    errors.put(idx, e);
+                } catch (Exception e) { throw new RuntimeException(e); }
+            });
+            threads[i].setDaemon(true);
+            threads[i].start();
+        }
+        for (var t : threads) t.join();
+
+        assertEquals(2, errors.size());
+        for (var error : errors.values()) {
+            assertInstanceOf(IllegalStateException.class, error);
+            assertEquals("BatchOperation returned 1 results for 2 inputs", error.getMessage());
+        }
+    }
+
+    @Test
+    void max_batch_size_one_executes_immediately() throws Exception {
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 1, Duration.ofSeconds(10),
+                (key, inputs) -> inputs.stream().map(s -> s + "!").toList());
+
+        assertEquals("hello!", batcher.execute("k", "hello"));
+        assertEquals("world!", batcher.execute("k", "world"));
+    }
+
+    @Test
+    void concurrent_stress_test() throws Exception {
+        var threadCount = 50;
+        var batchSize = 5;
+        var batcher = new DynamicBatcher<Integer, Integer, Integer>(
+                batchSize, Duration.ofMillis(5),
+                (key, inputs) -> inputs.stream().map(i -> i * 10 + key).toList());
+
+        var barrier = new CyclicBarrier(threadCount);
+        var results = new ConcurrentHashMap<String, Integer>();
+        var threads = new ArrayList<Thread>();
+
+        for (int i = 0; i < threadCount; i++) {
+            var key = i % 3;
+            var input = i;
+            var t = new Thread(() -> {
+                try {
+                    barrier.await();
+                    var result = batcher.execute(key, input);
+                    results.put(key + ":" + input, result);
+                } catch (Exception e) { throw new RuntimeException(e); }
+            });
+            t.setDaemon(true);
+            t.start();
+            threads.add(t);
+        }
+        for (var t : threads) t.join();
+
+        assertEquals(threadCount, results.size());
+        for (int i = 0; i < threadCount; i++) {
+            var key = i % 3;
+            assertEquals(i * 10 + key, results.get(key + ":" + i));
+        }
+    }
+
+    @Test
+    void partial_batch_with_multiple_items_on_timeout() throws Exception {
+        var timer = new ManualTimer();
+        var invocations = new CopyOnWriteArrayList<List<String>>();
+        var creatorWaiting = new CountDownLatch(1);
+        var batcher = new DynamicBatcher<String, String, String>(
+                timer, 100, Duration.ofMillis(50), (key, inputs) -> {
+                    invocations.add(List.copyOf(inputs));
+                    return inputs.stream().map(s -> s + "-out").toList();
+                }, creatorWaiting::countDown);
+
+        var results = new ConcurrentHashMap<String, String>();
+
+        // Start CREATOR thread
+        var t1 = new Thread(() -> results.put("item-0", batcher.execute("k", "item-0")));
+        t1.setDaemon(true);
+        t1.start();
+        creatorWaiting.await();
+
+        // Start WAITER thread and wait for it to join the batch and enter wait
+        var t2 = new Thread(() -> results.put("item-1", batcher.execute("k", "item-1")));
+        t2.setDaemon(true);
+        t2.start();
+        while (t2.getState() != Thread.State.WAITING) Thread.onSpinWait();
+
+        // Trigger timeout
+        timer.advance(50);
+        batcher.wakeup();
+        t1.join();
+        t2.join();
+
+        assertEquals(1, invocations.size());
+        assertEquals(2, invocations.get(0).size());
+        assertEquals("item-0-out", results.get("item-0"));
+        assertEquals("item-1-out", results.get("item-1"));
+    }
+
+    @Test
+    void sequential_batches_on_same_key() throws Exception {
+        var invocations = new CopyOnWriteArrayList<List<String>>();
+        var batcher = new DynamicBatcher<String, String, String>(
+                new ManualTimer(), 2, Duration.ofSeconds(10), (key, inputs) -> {
+                    invocations.add(List.copyOf(inputs));
+                    return inputs.stream().map(s -> s + "-out").toList();
+                });
+
+        for (int round = 0; round < 2; round++) {
+            var barrier = new CyclicBarrier(2);
+            var results = new String[2];
+            var threads = new Thread[2];
+            var r = round;
+            for (int i = 0; i < 2; i++) {
+                var idx = i;
+                threads[i] = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        results[idx] = batcher.execute("k", "r" + r + "-" + idx);
+                    } catch (Exception e) { throw new RuntimeException(e); }
+                });
+                threads[i].setDaemon(true);
+                threads[i].start();
+            }
+            for (var t : threads) t.join();
+
+            assertEquals(round + 1, invocations.size());
+            assertEquals(2, invocations.get(round).size());
+            for (int i = 0; i < 2; i++) {
+                assertEquals("r" + round + "-" + i + "-out", results[i]);
+            }
+        }
+    }
+
+    @Test
+    void constructor_validates_parameters() {
+        DynamicBatcher.BatchOperation<String, String, String> op = (k, i) -> i;
+        assertThrows(IllegalArgumentException.class, () -> new DynamicBatcher<>(0, Duration.ofSeconds(1), op));
+        assertThrows(IllegalArgumentException.class, () -> new DynamicBatcher<>(1, Duration.ZERO, op));
+        assertThrows(IllegalArgumentException.class, () -> new DynamicBatcher<>(1, Duration.ofMillis(-1), op));
+        assertThrows(NullPointerException.class, () -> new DynamicBatcher<>(1, Duration.ofSeconds(1), null));
+        assertThrows(NullPointerException.class, () -> new DynamicBatcher<>(1, null, op));
+    }
+}


### PR DESCRIPTION
Utility that groups items from multiple caller threads into batches partitioned by a caller-supplied key. One caller thread per batch acts as executor while others wait for the result. Batches are dispatched when reaching max size or max delay timeout.
