### PR TITLE
SelectParser text() operator

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/yql/TextInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/TextInputTestCase.java
@@ -17,11 +17,6 @@ import com.yahoo.search.query.parser.Parsable;
 import com.yahoo.search.query.parser.ParserEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -30,9 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for the text() function and shared behavior between text() and userInput().
- * Parameterized tests verify that grammar overrides and allowEmpty work identically
- * for both functions via the shared buildTextInput helper.
+ * Tests for the text() function in YQL.
  */
 public class TextInputTestCase {
 
@@ -43,174 +36,119 @@ public class TextInputTestCase {
         parser = new YqlParser(new ParserEnvironment());
     }
 
-    // --- Shared behavior: parameterized over text() and userInput() ---
-
-    static Stream<Arguments> textFunctions() {
-        return Stream.of(
-                //          label,        field,     yqlTemplate (use %s for annotation prefix and %s for input)
-                Arguments.of("text",      "title",   "select foo from bar where title contains (%s text(\"%s\"))"),
-                Arguments.of("userInput", "default", "select foo from bar where %s userInput(\"%s\")")
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: grammar:raw produces ExactStringItem")
-    @MethodSource("textFunctions")
-    void grammarRawProducesExactStringItem(String label, String field, String yqlTemplate) {
-        String yql = String.format(yqlTemplate, "{grammar:\"raw\"}", "a b");
-        Item root = parse(yql).getRoot();
+    @Test
+    void grammarRawProducesExactStringItem() {
+        Item root = parse("select foo from bar where title contains ({grammar:\"raw\"} text(\"a b\"))").getRoot();
         assertInstanceOf(ExactStringItem.class, root);
         WordItem word = (WordItem) root;
-        assertEquals(field, word.getIndexName());
+        assertEquals("title", word.getIndexName());
         assertEquals("a b", word.getWord());
     }
 
-    @ParameterizedTest(name = "{0}: grammar:all produces AndItem")
-    @MethodSource("textFunctions")
-    void grammarAllProducesAnd(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{grammar:\"all\"}", "a b")).getRoot();
-        assertCompositeOfWords(root, AndItem.class, field, 2);
+    @Test
+    void grammarAllProducesAnd() {
+        Item root = parse("select foo from bar where title contains ({grammar:\"all\"} text(\"a b\"))").getRoot();
+        assertCompositeOfWords(root, AndItem.class, "title", 2);
     }
 
-    @ParameterizedTest(name = "{0}: grammar:any produces OrItem")
-    @MethodSource("textFunctions")
-    void grammarAnyProducesOr(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{grammar:\"any\"}", "a b")).getRoot();
-        assertCompositeOfWords(root, OrItem.class, field, 2);
+    @Test
+    void grammarAnyProducesOr() {
+        Item root = parse("select foo from bar where title contains ({grammar:\"any\"} text(\"a b\"))").getRoot();
+        assertCompositeOfWords(root, OrItem.class, "title", 2);
     }
 
-    @ParameterizedTest(name = "{0}: grammar:weakAnd produces WeakAndItem")
-    @MethodSource("textFunctions")
-    void grammarWeakAndProducesWeakAnd(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{grammar:\"weakAnd\"}", "a b")).getRoot();
-        assertCompositeOfWords(root, WeakAndItem.class, field, 2);
+    @Test
+    void grammarWeakAndProducesWeakAnd() {
+        Item root = parse("select foo from bar where title contains ({grammar:\"weakAnd\"} text(\"a b\"))").getRoot();
+        assertCompositeOfWords(root, WeakAndItem.class, "title", 2);
     }
 
-    static Stream<Arguments> textFunctionsForAllowEmpty() {
-        return Stream.of(
-                Arguments.of("text",      "select foo from bar where title contains ([{allowEmpty:true}] text(@q))"),
-                Arguments.of("userInput", "select foo from bar where [{allowEmpty:true}] userInput(@q)")
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: allowEmpty with empty input returns NullItem")
-    @MethodSource("textFunctionsForAllowEmpty")
-    void allowEmptyReturnsNullItem(String label, String yql) {
-        Item root = parse(yql, "q", "").getRoot();
+    @Test
+    void allowEmptyReturnsNullItem() {
+        Item root = parse("select foo from bar where title contains ([{allowEmpty:true}] text(@q))", "q", "").getRoot();
         assertInstanceOf(NullItem.class, root);
     }
 
-    @ParameterizedTest(name = "{0}: targetHits sets N on WeakAndItem")
-    @MethodSource("textFunctions")
-    void targetHitsSetsWeakAndN(String label, String field, String yqlTemplate) {
-        String yql = String.format(yqlTemplate, "{targetHits:50}", "a b");
-        Item root = parse(yql).getRoot();
+    @Test
+    void targetHitsSetsWeakAndN() {
+        Item root = parse("select foo from bar where title contains ({targetHits:50} text(\"a b\"))").getRoot();
         assertInstanceOf(WeakAndItem.class, root);
         WeakAndItem weakAnd = (WeakAndItem) root;
         assertEquals(50, weakAnd.getTargetHits());
         assertEquals(2, weakAnd.getItemCount());
     }
 
-    static Stream<Arguments> textFunctionsForLanguage() {
-        return Stream.of(
-                Arguments.of("text",      "select foo from bar where title contains ({language:\"ja\"} text(\"\u30ab\u30bf\u30ab\u30ca\"))"),
-                Arguments.of("userInput", "select foo from bar where {language:\"ja\"} userInput(\"\u30ab\u30bf\u30ab\u30ca\")")
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: language annotation sets language on result")
-    @MethodSource("textFunctionsForLanguage")
-    void languageAnnotationSetsLanguage(String label, String yql) {
-        Item root = parse(yql).getRoot();
+    @Test
+    void languageAnnotationSetsLanguage() {
+        Item root = parse("select foo from bar where title contains ({language:\"ja\"} text(\"\u30ab\u30bf\u30ab\u30ca\"))").getRoot();
         assertEquals(Language.JAPANESE, root.getLanguage());
     }
 
-    @ParameterizedTest(name = "{0}: grammar.composite:and produces AndItem")
-    @MethodSource("textFunctions")
-    void grammarCompositeAndProducesAnd(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{grammar.composite:\"and\"}", "a b")).getRoot();
-        assertCompositeOfWords(root, AndItem.class, field, 2);
+    @Test
+    void grammarCompositeAndProducesAnd() {
+        Item root = parse("select foo from bar where title contains ({grammar.composite:\"and\"} text(\"a b\"))").getRoot();
+        assertCompositeOfWords(root, AndItem.class, "title", 2);
     }
 
-    @ParameterizedTest(name = "{0}: grammar.composite:or produces OrItem")
-    @MethodSource("textFunctions")
-    void grammarCompositeOrProducesOr(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{grammar.composite:\"or\"}", "a b")).getRoot();
-        assertCompositeOfWords(root, OrItem.class, field, 2);
+    @Test
+    void grammarCompositeOrProducesOr() {
+        Item root = parse("select foo from bar where title contains ({grammar.composite:\"or\"} text(\"a b\"))").getRoot();
+        assertCompositeOfWords(root, OrItem.class, "title", 2);
     }
 
-    @ParameterizedTest(name = "{0}: stem:false disables stemming on children")
-    @MethodSource("textFunctions")
-    void stemFalseDisablesStemming(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{stem:false}", "a")).getRoot();
+    @Test
+    void stemFalseDisablesStemming() {
+        Item root = parse("select foo from bar where title contains ({stem:false} text(\"a\"))").getRoot();
         WordItem word = getFirstWord(root);
         assertTrue(word.isStemmed(), "stem:false should mark word as pre-stemmed (isStemmed=true)");
     }
 
-    @ParameterizedTest(name = "{0}: ranked:false sets ranked=false on children")
-    @MethodSource("textFunctions")
-    void rankedFalseSetsUnranked(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{ranked:false}", "a")).getRoot();
+    @Test
+    void rankedFalseSetsUnranked() {
+        Item root = parse("select foo from bar where title contains ({ranked:false} text(\"a\"))").getRoot();
         WordItem word = getFirstWord(root);
         assertFalse(word.isRanked(), "ranked:false should set isRanked=false");
     }
 
-    @ParameterizedTest(name = "{0}: filter:true sets filter=true on children")
-    @MethodSource("textFunctions")
-    void filterTrueSetsFilter(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{filter:true}", "a")).getRoot();
+    @Test
+    void filterTrueSetsFilter() {
+        Item root = parse("select foo from bar where title contains ({filter:true} text(\"a\"))").getRoot();
         WordItem word = getFirstWord(root);
         assertTrue(word.isFilter(), "filter:true should set isFilter=true");
     }
 
-    @ParameterizedTest(name = "{0}: normalizeCase:false disables case normalization")
-    @MethodSource("textFunctions")
-    void normalizeCaseFalseDisablesNormalization(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{normalizeCase:false}", "a")).getRoot();
+    @Test
+    void normalizeCaseFalseDisablesNormalization() {
+        Item root = parse("select foo from bar where title contains ({normalizeCase:false} text(\"a\"))").getRoot();
         WordItem word = getFirstWord(root);
         assertTrue(word.isLowercased(), "normalizeCase:false should mark word as pre-lowercased (isLowercased=true)");
     }
 
-    @ParameterizedTest(name = "{0}: accentDrop:false disables accent dropping")
-    @MethodSource("textFunctions")
-    void accentDropFalseDisablesAccentDrop(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{accentDrop:false}", "a")).getRoot();
+    @Test
+    void accentDropFalseDisablesAccentDrop() {
+        Item root = parse("select foo from bar where title contains ({accentDrop:false} text(\"a\"))").getRoot();
         WordItem word = getFirstWord(root);
         assertFalse(word.isNormalizable(), "accentDrop:false should set isNormalizable=false");
     }
 
-    @ParameterizedTest(name = "{0}: usePositionData:false disables position data")
-    @MethodSource("textFunctions")
-    void usePositionDataFalseDisablesPositionData(String label, String field, String yqlTemplate) {
-        Item root = parse(String.format(yqlTemplate, "{usePositionData:false}", "a")).getRoot();
+    @Test
+    void usePositionDataFalseDisablesPositionData() {
+        Item root = parse("select foo from bar where title contains ({usePositionData:false} text(\"a\"))").getRoot();
         WordItem word = getFirstWord(root);
         assertFalse(word.usePositionData(), "usePositionData:false should set usePositionData=false");
     }
 
-    static Stream<Arguments> textFunctionsForNear() {
-        return Stream.of(
-                // text() already defaults to linguistics tokenization, just override composite to near
-                Arguments.of("text",
-                        "select foo from bar where title contains ({grammar.composite:\"near\",distance:3} text(\"a b\"))"),
-                // userInput() needs explicit tokenization override for near to work with linguistics
-                Arguments.of("userInput",
-                        "select foo from bar where {grammar.syntax:\"none\",grammar.tokenization:\"linguistics\",grammar.composite:\"near\",distance:3} userInput(\"a b\")")
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: distance annotation sets distance on NearItem")
-    @MethodSource("textFunctionsForNear")
-    void distanceSetsNearDistance(String label, String yql) {
-        Item root = parse(yql).getRoot();
+    @Test
+    void distanceSetsNearDistance() {
+        Item root = parse("select foo from bar where title contains ({grammar.composite:\"near\",distance:3} text(\"a b\"))").getRoot();
         assertInstanceOf(NearItem.class, root);
         NearItem near = (NearItem) root;
         assertEquals(3, near.getDistance());
         assertEquals(2, near.getItemCount());
     }
 
-    // --- text()-specific tests ---
-
     @Test
-    void testTextDefaultsToLinguisticsMode() {
+    void textDefaultsToLinguisticsMode() {
         Item root = parse("select foo from bar where title contains text(\"yoni jo dima\")").getRoot();
         assertInstanceOf(WeakAndItem.class, root);
         assertEquals("WEAKAND title:yoni title:jo title:dima", root.toString());
@@ -224,31 +162,25 @@ public class TextInputTestCase {
     }
 
     @Test
-    void testTextIgnoresDefaultIndexAndUsesContainsField() {
+    void textIgnoresDefaultIndexAndUsesContainsField() {
         Item root = parse("select foo from bar where title contains ({defaultIndex:\"other\"}text(\"a b\"))").getRoot();
         assertInstanceOf(WeakAndItem.class, root);
         assertEquals("WEAKAND title:a title:b", root.toString());
     }
 
     @Test
-    void testTextWithPropertyReference() {
+    void textWithPropertyReference() {
         Item root = parse("select foo from bar where title contains text(@q)", "q", "hello world").getRoot();
         assertInstanceOf(WeakAndItem.class, root);
         assertEquals("WEAKAND title:hello title:world", root.toString());
     }
 
     @Test
-    void testTextOutsideContainsFails() {
+    void textOutsideContainsFails() {
         assertThrows(IllegalArgumentException.class,
                 () -> parse("select foo from bar where text(\"a b\")"));
     }
 
-    // --- Helpers ---
-
-    /**
-     * Asserts that root is a CompositeItem of the expected type, containing the
-     * expected number of WordItems all indexed against the expected field.
-     */
     private static void assertCompositeOfWords(Item root, Class<? extends CompositeItem> expectedType,
                                                String expectedField, int expectedChildren) {
         assertInstanceOf(expectedType, root);
@@ -260,7 +192,6 @@ public class TextInputTestCase {
         }
     }
 
-    /** Extracts the first WordItem from the root, whether it's a composite or a single word. */
     private static WordItem getFirstWord(Item root) {
         if (root instanceof CompositeItem composite) {
             assertInstanceOf(WordItem.class, composite.getItem(0));

--- a/container-search/src/test/java/com/yahoo/select/SelectTextInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTextInputTestCase.java
@@ -1,0 +1,315 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.select;
+
+import com.yahoo.language.Language;
+import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.ExactStringItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.NearItem;
+import com.yahoo.prelude.query.NullItem;
+import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.PhraseSegmentItem;
+import com.yahoo.prelude.query.WeakAndItem;
+import com.yahoo.prelude.query.WordItem;
+import com.yahoo.processing.IllegalInputException;
+import com.yahoo.search.Query;
+import com.yahoo.search.query.QueryTree;
+import com.yahoo.search.query.Select;
+import com.yahoo.search.query.SelectParser;
+import com.yahoo.search.query.parser.Parsable;
+import com.yahoo.search.query.parser.ParserEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the text() operator in SelectParser (JSON query API).
+ */
+public class SelectTextInputTestCase {
+
+    private SelectParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = new SelectParser(new ParserEnvironment());
+    }
+
+    private QueryTree parseWhere(String where) {
+        Select select = new Select(where, "", new Query());
+        return parser.parse(new Parsable().setSelect(select));
+    }
+
+    private QueryTree parseWhereWithLanguage(String where, Language language) {
+        Select select = new Select(where, "", new Query());
+        return parser.parse(new Parsable().setSelect(select).setExplicitLanguage(Optional.of(language)));
+    }
+
+    private Item getRootItem(String where) {
+        return parseWhere(where).getRoot();
+    }
+
+    private void assertParseFail(String where, Throwable expectedCause) {
+        try {
+            parseWhere(where).toString();
+            fail("Parse succeeded: " + where);
+        } catch (Throwable outer) {
+            assertEquals(IllegalInputException.class, outer.getClass());
+            assertEquals("Illegal JSON query", outer.getMessage());
+            Throwable cause = outer.getCause();
+            assertNotNull(cause);
+            assertEquals(expectedCause.getClass(), cause.getClass());
+            assertEquals(expectedCause.getMessage(), cause.getMessage());
+        }
+    }
+
+    private static void assertAllChildWordsHaveField(Item root, String expectedField) {
+        if (root instanceof CompositeItem composite) {
+            for (int i = 0; i < composite.getItemCount(); i++)
+                assertAllChildWordsHaveField(composite.getItem(i), expectedField);
+        }
+        if (root instanceof WordItem word)
+            assertEquals(expectedField, word.getIndexName());
+    }
+
+    private static void assertAllChildWordsHaveLanguage(Item root, Language expected) {
+        if (root instanceof CompositeItem composite) {
+            for (int i = 0; i < composite.getItemCount(); i++)
+                assertAllChildWordsHaveLanguage(composite.getItem(i), expected);
+        }
+        assertEquals(expected, root.getLanguage());
+    }
+
+    private static WordItem getFirstWord(Item root) {
+        if (root instanceof CompositeItem composite) {
+            assertFalse(composite.getItemCount() == 0);
+            return getFirstWord(composite.getItem(0));
+        }
+        assertInstanceOf(WordItem.class, root);
+        return (WordItem) root;
+    }
+
+    @Test
+    void containsTextStringParses() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": \"a b\" } ] }");
+        assertNotNull(root);
+    }
+
+    @Test
+    void textObjectQueryShapeWorks() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\" } } ] }");
+        assertNotNull(root);
+        assertInstanceOf(WeakAndItem.class, root);
+        assertEquals(2, ((WeakAndItem) root).getItemCount());
+    }
+
+    @Test
+    void textObjectQueryWithAttributes() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar\": \"raw\" } } } ] }");
+        assertInstanceOf(ExactStringItem.class, root);
+    }
+
+    @Test
+    void textDefaultsToLinguistics() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": \"a b\" } ] }");
+        assertInstanceOf(WeakAndItem.class, root);
+    }
+
+    @Test
+    void defaultIndexPropagation() {
+        Item root = getRootItem("{ \"contains\": [ \"title\", { \"text\": \"x y\" } ] }");
+        assertAllChildWordsHaveField(root, "title");
+    }
+
+    @Test
+    void allowEmptyTrueReturnsNullItem() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"\", \"attributes\": { \"allowEmpty\": true } } } ] }");
+        assertInstanceOf(NullItem.class, root);
+    }
+
+    @Test
+    void allowEmptyFalseEmptyThrows() {
+        assertParseFail("{ \"contains\": [ \"f\", { \"text\": \"\" } ] }",
+                new IllegalArgumentException("text() requires a non-empty input string. Use allowEmpty annotation to allow empty input."));
+    }
+
+    @Test
+    void grammarRawYieldsExactStringItem() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar\": \"raw\" } } } ] }");
+        assertInstanceOf(ExactStringItem.class, root);
+        assertEquals("a b", ((ExactStringItem) root).getWord());
+    }
+
+    @Test
+    void grammarSegmentMultiTokenYieldsPhraseSegmentItem() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"hello world\", \"attributes\": { \"grammar\": \"segment\" } } } ] }");
+        assertInstanceOf(PhraseSegmentItem.class, root);
+        assertTrue(((PhraseSegmentItem) root).getItemCount() >= 1);
+    }
+
+    @Test
+    void grammarSegmentNonSegmentableFallsBackToWordItem() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"!!!@\", \"attributes\": { \"grammar\": \"segment\" } } } ] }");
+        assertTrue(root instanceof PhraseSegmentItem || root instanceof WordItem);
+        if (root instanceof PhraseSegmentItem p)
+            assertEquals(1, p.getItemCount());
+    }
+
+    @Test
+    void grammarCompositeAndProducesAndItem() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar.composite\": \"and\" } } } ] }");
+        assertInstanceOf(AndItem.class, root);
+    }
+
+    @Test
+    void grammarCompositeOrProducesOrItem() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar.composite\": \"or\" } } } ] }");
+        assertInstanceOf(OrItem.class, root);
+    }
+
+    @Test
+    void grammarCompositeWeakAndTargetHits() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar.composite\": \"weakAnd\", \"targetHits\": 50 } } } ] }");
+        assertInstanceOf(WeakAndItem.class, root);
+        assertEquals(50, ((WeakAndItem) root).getTargetHits());
+    }
+
+    @Test
+    void grammarCompositeWeakAndTotalTargetHits() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar.composite\": \"weakAnd\", \"totalTargetHits\": 100 } } } ] }");
+        assertInstanceOf(WeakAndItem.class, root);
+        assertEquals(100, ((WeakAndItem) root).getTotalTargetHits());
+    }
+
+    @Test
+    void grammarCompositeNearDistance() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar.composite\": \"near\", \"distance\": 5 } } } ] }");
+        assertInstanceOf(NearItem.class, root);
+        assertEquals(5, ((NearItem) root).getDistance());
+    }
+
+    @Test
+    void grammarCompositeONearDistance() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a b\", \"attributes\": { \"grammar.composite\": \"oNear\", \"distance\": 7 } } } ] }");
+        assertInstanceOf(NearItem.class, root);
+        assertEquals(7, ((NearItem) root).getDistance());
+    }
+
+    @Test
+    void explicitLanguageAnnotationSetsFrench() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"hello\", \"attributes\": { \"language\": \"fr\" } } } ] }");
+        assertEquals(Language.FRENCH, root.getLanguage());
+    }
+
+    @Test
+    void queryLevelExplicitLanguageUsed() {
+        String where = "{ \"contains\": [ \"f\", { \"text\": \"hello\" } ] }";
+        QueryTree tree = parseWhereWithLanguage(where, Language.JAPANESE);
+        Item root = tree.getRoot();
+        assertEquals(Language.JAPANESE, root.getLanguage());
+    }
+
+    @Test
+    void localAnnotationOverridesQueryLevel() {
+        String where = "{ \"contains\": [ \"f\", { \"text\": { \"query\": \"hello\", \"attributes\": { \"language\": \"en\" } } } ] }";
+        QueryTree tree = parseWhereWithLanguage(where, Language.JAPANESE);
+        Item root = tree.getRoot();
+        assertEquals(Language.ENGLISH, root.getLanguage());
+    }
+
+    @Test
+    void grammarSegmentLanguageRecursive() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"hello world\", \"attributes\": { \"grammar\": \"segment\", \"language\": \"ja\" } } } ] }");
+        assertAllChildWordsHaveLanguage(root, Language.JAPANESE);
+    }
+
+    @Test
+    void stemPropagates() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"stem\": false } } } ] }");
+        assertTrue(getFirstWord(root).isStemmed());
+    }
+
+    @Test
+    void rankedPropagates() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"ranked\": false } } } ] }");
+        assertFalse(getFirstWord(root).isRanked());
+    }
+
+    @Test
+    void filterPropagates() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"filter\": true } } } ] }");
+        assertTrue(getFirstWord(root).isFilter());
+    }
+
+    @Test
+    void normalizeCasePropagates() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"normalizeCase\": false } } } ] }");
+        assertTrue(getFirstWord(root).isLowercased());
+    }
+
+    @Test
+    void accentDropPropagates() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"accentDrop\": false } } } ] }");
+        assertFalse(getFirstWord(root).isNormalizable());
+    }
+
+    @Test
+    void usePositionDataPropagates() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"usePositionData\": false } } } ] }");
+        assertFalse(getFirstWord(root).usePositionData());
+    }
+
+    @Test
+    void segmentChildrenGetAnnotations() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"hello world\", \"attributes\": { \"grammar\": \"segment\", \"stem\": false } } } ] }");
+        assertInstanceOf(PhraseSegmentItem.class, root);
+        WordItem first = getFirstWord(root);
+        assertTrue(first.isStemmed(), "stem:false should propagate to segment children");
+    }
+
+    @Test
+    void rawAnnotationsDocumented() {
+        Item root = getRootItem("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"grammar\": \"raw\", \"stem\": false } } } ] }");
+        assertInstanceOf(ExactStringItem.class, root);
+        assertFalse(((ExactStringItem) root).isStemmed(), "grammar:raw does NOT propagate stem (and other annotations) by design");
+    }
+
+    @Test
+    void textArrayThrows() {
+        assertParseFail("{ \"contains\": [ \"f\", { \"text\": [ \"a b\" ] } ] }",
+                new IllegalArgumentException("text() does not support array arguments; use a string or an object with a 'query' field."));
+    }
+
+    @Test
+    void textChildrenThrows() {
+        assertParseFail("{ \"contains\": [ \"f\", { \"text\": { \"children\": [ \"a b\" ] } } ] }",
+                new IllegalArgumentException("text() does not support 'children'; use a 'query' string field instead."));
+    }
+
+    @Test
+    void textObjectWithoutQueryThrows() {
+        assertParseFail("{ \"contains\": [ \"f\", { \"text\": { } } ] }",
+                new IllegalArgumentException("text() object form requires a 'query' string field."));
+    }
+
+    @Test
+    void textQueryNonStringThrows() {
+        assertParseFail("{ \"contains\": [ \"f\", { \"text\": { \"query\": 42 } } ] }",
+                new IllegalArgumentException("text().query must be a string, got LONG"));
+    }
+
+    @Test
+    void unknownGrammarThrows() {
+        assertParseFail("{ \"contains\": [ \"f\", { \"text\": { \"query\": \"a\", \"attributes\": { \"grammar\": \"invalid\" } } } ] }",
+                new IllegalArgumentException("No query type 'invalid'"));
+    }
+
+    @Test
+    void textOutsideContainsFails() {
+        assertParseFail("{ \"text\": \"hello\" }",
+                new IllegalArgumentException("Expected and, and_not, call, contains, equals, in, matches, not, or or range, got text."));
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/vespa-engine/vespa/pull/35829

Something like this now works:
```http
POST /search/
{
  "select": {
    "where": {
      "contains": [
        "synonyms_test",
        {
          "text": "wi fi"
        }
      ]
    }
  }
}
```

Or, with annotations:
```http
POST /search/
{
  "select": {
    "where": {
      "contains": [
        "synonyms_test",
        {
          "text": {
            "query": "wi fi",
            "attributes": {
              "language": "en"
            }
          }
        }
      ]
    }
  }
}
```

Like the YQL variant, it supports all the annotations that `userInput()` supports. The main difference is that SelectParser didn't support `userInput` before. Not sure it needs to, given there's so much overlap.

Note that annotations go into the `query` attribute, instead of the usual `children` array. I think it's more intuitive this way, so I went ahead, given that it's completely new functionality.

Unit tests are added in a separate file because `SelectTestCase` is already large, and we have many new tests.

Also as a follow-up to https://github.com/vespa-engine/vespa/pull/35829 the tests from the YQL variant of `text()` are simplified, so they only look at the new operator. There are already quite a few tests that cover `userInput()` anyway.