### PR TITLE
ignore gcc_s since there is apparently cleverness to be had

### DIFF
--- a/tsan-suppressions.txt
+++ b/tsan-suppressions.txt
@@ -52,3 +52,6 @@ race:re2::DFA::DFA
 # (acquire-load in double-checked locking etc).
 race:ASN1_STRING_cmp
 race:ASN1_STRING_set
+
+# libgcc_s (unwinder / EH frame registration). Often triggers TSAN reports via lock-free FDE registry.
+module:libgcc_s.so.1


### PR DESCRIPTION
@vekterli please review

Should quiet the new TSAN warnings caused by parallell LLVM compilation.
Hopefully gcc is thread safe :-)