### PR TITLE
Add iterators to ResultNodeVector

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -136,6 +136,7 @@ vespa_define_module(
     src/tests/expression/filter_predicate_node
     src/tests/expression/float_bucket_result_node
     src/tests/expression/interpolated_document_field_lookup_node
+    src/tests/expression/resultvector_iterator
     src/tests/features
     src/tests/features/beta
     src/tests/features/bm25

--- a/searchlib/src/tests/expression/resultvector_iterator/CMakeLists.txt
+++ b/searchlib/src/tests/expression/resultvector_iterator/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_test_executable(searchlib_resultvector_iterator_test_app
+    SOURCES
+    resultvector_iterator_test.cpp
+    DEPENDS
+    searchlib_test
+)

--- a/searchlib/src/tests/expression/resultvector_iterator/resultvector_iterator_test.cpp
+++ b/searchlib/src/tests/expression/resultvector_iterator/resultvector_iterator_test.cpp
@@ -1,0 +1,135 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchlib/expression/resultvector.h>
+#include <vespa/searchlib/expression/integerresultnode.h>
+#include <vespa/searchlib/expression/stringresultnode.h>
+#include <vespa/searchlib/expression/floatresultnode.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+#include <algorithm>
+
+using namespace search::expression;
+
+class ResultVectorIteratorTest : public ::testing::Test {
+protected:
+    static Int64ResultNodeVector create_int_vector(const std::vector<int64_t>& values) {
+        Int64ResultNodeVector vec;
+        for (const auto val : values) {
+            vec.push_back(Int64ResultNode(val));
+        }
+        return vec;
+    }
+
+    static StringResultNodeVector create_string_vector(const std::vector<std::string>& values) {
+        StringResultNodeVector vec;
+        for (const auto& val : values) {
+            vec.push_back(StringResultNode(val));
+        }
+        return vec;
+    }
+};
+
+TEST_F(ResultVectorIteratorTest, test_basic_iteration) {
+    auto vec = create_int_vector({1, 2, 3, 4, 5});
+
+    // Test range-based for loop with non-const iterator
+    std::vector<int64_t> collected;
+    for (auto& node : vec) {
+        collected.push_back(node.getInteger());
+    }
+
+    EXPECT_EQ(collected.size(), 5);
+    EXPECT_EQ(collected[0], 1);
+    EXPECT_EQ(collected[1], 2);
+    EXPECT_EQ(collected[2], 3);
+    EXPECT_EQ(collected[3], 4);
+    EXPECT_EQ(collected[4], 5);
+}
+
+TEST_F(ResultVectorIteratorTest, test_const_iteration) {
+    const auto vec = create_int_vector({10, 20, 30});
+
+    // Test range-based for loop with const iterator
+    std::vector<int64_t> collected;
+    for (const auto& node : vec) {
+        collected.push_back(node.getInteger());
+    }
+
+    EXPECT_EQ(collected.size(), 3);
+    EXPECT_EQ(collected[0], 10);
+    EXPECT_EQ(collected[1], 20);
+    EXPECT_EQ(collected[2], 30);
+}
+
+TEST_F(ResultVectorIteratorTest, test_empty_vector) {
+    Int64ResultNodeVector vec;
+
+    // Test that iteration over empty vector works
+    int count = 0;
+    for (const auto& node : vec) {
+        (void)node;
+        count++;
+    }
+
+    EXPECT_EQ(count, 0);
+}
+
+TEST_F(ResultVectorIteratorTest, test_string_vector_iteration) {
+    auto vec = create_string_vector({"hello", "world", "test"});
+
+    std::vector<std::string> collected;
+    for (const auto& node : vec) {
+        const auto& str_node = static_cast<const StringResultNode&>(node);
+        collected.push_back(str_node.get());
+    }
+
+    EXPECT_EQ(collected.size(), 3);
+    EXPECT_EQ(collected[0], "hello");
+    EXPECT_EQ(collected[1], "world");
+    EXPECT_EQ(collected[2], "test");
+}
+
+TEST_F(ResultVectorIteratorTest, test_iterator_equality) {
+    auto vec = create_int_vector({1, 2, 3});
+
+    const auto it1 = vec.begin();
+    const auto it2 = vec.begin();
+    const auto end = vec.end();
+
+    EXPECT_TRUE(it1 == it2);
+    EXPECT_FALSE(it1 != it2);
+    EXPECT_FALSE(it1 == end);
+    EXPECT_TRUE(it1 != end);
+}
+
+TEST_F(ResultVectorIteratorTest, test_polymorphic_iteration) {
+    auto vec = create_int_vector({1, 2, 3, 4, 5});
+    ResultNodeVector* poly_vec = &vec;
+
+    // Test that we can iterate through the polymorphic base class pointer
+    std::vector<int64_t> collected;
+    for (ResultNode& node : *poly_vec) {
+        collected.push_back(node.getInteger());
+    }
+
+    EXPECT_EQ(collected.size(), 5);
+    EXPECT_EQ(collected[0], 1);
+    EXPECT_EQ(collected[4], 5);
+}
+
+TEST_F(ResultVectorIteratorTest, test_modification_through_iterator) {
+    auto vec = create_int_vector({1, 2, 3});
+
+    // Modify values through non-const iterator
+    for (auto& node : vec) {
+        auto& int_node = static_cast<Int64ResultNode&>(node);
+        int_node.set(int_node.getInteger() * 2);
+    }
+
+    // Verify modification
+    EXPECT_EQ(vec.get(0).getInteger(), 2);
+    EXPECT_EQ(vec.get(1).getInteger(), 4);
+    EXPECT_EQ(vec.get(2).getInteger(), 6);
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/expression/resultvector_iterator/resultvector_iterator_test.cpp
+++ b/searchlib/src/tests/expression/resultvector_iterator/resultvector_iterator_test.cpp
@@ -93,12 +93,8 @@ TEST_F(ResultVectorIteratorTest, test_iterator_equality) {
     auto vec = create_int_vector({1, 2, 3});
 
     const auto it1 = vec.begin();
-    const auto it2 = vec.begin();
     const auto end = vec.end();
 
-    EXPECT_TRUE(it1 == it2);
-    EXPECT_FALSE(it1 != it2);
-    EXPECT_FALSE(it1 == end);
     EXPECT_TRUE(it1 != end);
 }
 
@@ -108,28 +104,13 @@ TEST_F(ResultVectorIteratorTest, test_polymorphic_iteration) {
 
     // Test that we can iterate through the polymorphic base class pointer
     std::vector<int64_t> collected;
-    for (ResultNode& node : *poly_vec) {
+    for (const ResultNode& node : *poly_vec) {
         collected.push_back(node.getInteger());
     }
 
     EXPECT_EQ(collected.size(), 5);
     EXPECT_EQ(collected[0], 1);
     EXPECT_EQ(collected[4], 5);
-}
-
-TEST_F(ResultVectorIteratorTest, test_modification_through_iterator) {
-    auto vec = create_int_vector({1, 2, 3});
-
-    // Modify values through non-const iterator
-    for (auto& node : vec) {
-        auto& int_node = static_cast<Int64ResultNode&>(node);
-        int_node.set(int_node.getInteger() * 2);
-    }
-
-    // Verify modification
-    EXPECT_EQ(vec.get(0).getInteger(), 2);
-    EXPECT_EQ(vec.get(1).getInteger(), 4);
-    EXPECT_EQ(vec.get(2).getInteger(), 6);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/expression/resultvector.h
+++ b/searchlib/src/vespa/searchlib/expression/resultvector.h
@@ -50,6 +50,49 @@ public:
     virtual void min(const ResultNode & b) { (void) b; }
     virtual void max(const ResultNode & b) { (void) b; }
     virtual void add(const ResultNode & b) { (void) b; }
+
+    // Iterator support for range-based for loops
+    class iterator {
+        ResultNodeVector* _vec;
+        size_t _index;
+    public:
+        iterator(ResultNodeVector* vec, size_t index) : _vec(vec), _index(index) {}
+
+        ResultNode& operator*() const { return _vec->get(_index); }
+        ResultNode* operator->() const { return &_vec->get(_index); }
+
+        iterator& operator++() { ++_index; return *this; }
+        iterator operator++(int) { auto tmp = *this; ++_index; return tmp; }
+
+        bool operator==(const iterator& other) const { return _vec == other._vec && _index == other._index; }
+        bool operator!=(const iterator& other) const { return !(*this == other); }
+    };
+
+    // Iterator support for range-based for loops
+    class const_iterator {
+        const ResultNodeVector* _vec;
+        size_t _index;
+    public:
+        const_iterator(const ResultNodeVector* vec, size_t index)
+            : _vec(vec), _index(index) {}
+
+        const ResultNode& operator*() const { return _vec->get(_index); }
+        const ResultNode* operator->() const { return &_vec->get(_index); }
+
+        const_iterator& operator++() { ++_index; return *this; }
+        const_iterator operator++(int) { auto tmp = *this; ++_index; return tmp; }
+
+        bool operator==(const const_iterator& other) const { return _vec == other._vec && _index == other._index; }
+        bool operator!=(const const_iterator& other) const { return !(*this == other); }
+    };
+
+    iterator begin() { return {this, 0}; }
+    iterator end() { return {this, size()}; }
+    [[nodiscard]] const_iterator begin() const { return {this, 0}; }
+    [[nodiscard]] const_iterator end() const { return {this, size()}; }
+    [[nodiscard]] const_iterator cbegin() const { return {this, 0}; }
+    [[nodiscard]] const_iterator cend() const { return {this, size()}; }
+
 private:
     virtual size_t onSize() const = 0;
     void set(const ResultNode & rhs) override { (void) rhs; }


### PR DESCRIPTION
Allows for range-based for loops using `ResultNodeVector` in grouping expressions and filters code.

```c++
const ResultNodeVector* some_vector;
for (const ResultNode& node : *some_vector) {
    ...
}
```

@arnej27959 please review