### PR TITLE
Use Text.format in container-disc

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
+++ b/container-disc/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
@@ -22,6 +22,7 @@ import com.yahoo.jdisc.service.ClientProvider;
 import com.yahoo.jdisc.service.ServerProvider;
 import com.yahoo.osgi.OsgiImpl;
 import com.yahoo.osgi.OsgiWrapper;
+import com.yahoo.text.Text;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 
@@ -127,7 +128,7 @@ public class HandlersConfigurerDi {
             if (qualifierIsUsed(bundleSpec, activeVersions)) {
                 versionsMessage += " Note that qualifier strings must be matched exactly. ";
             }
-            return String.format("%sInstalled application bundles: [%s]",
+            return Text.format("%sInstalled application bundles: [%s]",
                                  versionsMessage,
                                  activeBundles.stream()
                                          .map(BsnVersion::toReadableString)

--- a/container-disc/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/Container.java
@@ -17,6 +17,7 @@ import com.yahoo.container.di.componentgraph.core.Node;
 import com.yahoo.container.di.config.ApplicationBundlesConfig;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
 import com.yahoo.container.di.config.SubscriberFactory;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.yolean.UncheckedInterruptedException;
 import org.osgi.framework.Bundle;
@@ -123,12 +124,12 @@ public class Container {
             updateApplyOnRestart();
 
             if (log.isLoggable(FINE))
-                log.log(FINE, String.format("getConfigAndCreateGraph:\n" + "graph.configKeys = %s\n" + "graph.generation = %s\n" + "snapshot = %s\n",
+                log.log(FINE, Text.format("getConfigAndCreateGraph:\n" + "graph.configKeys = %s\n" + "graph.generation = %s\n" + "snapshot = %s\n",
                                             graph.configKeys(), graph.generation(), snapshot));
 
             if (snapshot instanceof BootstrapConfigs) {
                 if (getBootstrapGeneration() <= previousConfigGeneration) {
-                    throw new IllegalStateException(String.format(
+                    throw new IllegalStateException(Text.format(
                             "Got bootstrap configs out of sequence for old config generation %d.\n" + "Previous config generation is %d",
                             getBootstrapGeneration(), previousConfigGeneration));
                 }
@@ -163,7 +164,7 @@ public class Container {
     }
 
     private String configGenerationsString() {
-        return String.format("bootstrap generation = %d\n" + "components generation: %d\n" + "previous generation: %d",
+        return Text.format("bootstrap generation = %d\n" + "components generation: %d\n" + "previous generation: %d",
                              getBootstrapGeneration(), getComponentsGeneration(), previousConfigGeneration);
     }
 

--- a/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
@@ -111,7 +111,7 @@ public class ComponentGraph {
     public <T> T getInstance(Key<T> key) {
         // TODO: Combine exception handling with lookupGlobalComponent.
         Object ob = lookupGlobalComponent(key).map(Node::component)
-                .orElseThrow(() -> new IllegalStateException(Text.format("No global component with key '%s'  ", key)));
+                .orElseThrow(() -> new IllegalStateException(Text.format("No global component with key '%s'", key)));
         return (T) ob;
     }
 

--- a/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
@@ -15,6 +15,7 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.container.di.componentgraph.Provider;
 import com.yahoo.container.di.componentgraph.cycle.CycleFinder;
 import com.yahoo.container.di.componentgraph.cycle.Graph;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 
 import java.lang.annotation.Annotation;
@@ -110,7 +111,7 @@ public class ComponentGraph {
     public <T> T getInstance(Key<T> key) {
         // TODO: Combine exception handling with lookupGlobalComponent.
         Object ob = lookupGlobalComponent(key).map(Node::component)
-                .orElseThrow(() -> new IllegalStateException(String.format("No global component with key '%s'  ", key)));
+                .orElseThrow(() -> new IllegalStateException(Text.format("No global component with key '%s'  ", key)));
         return (T) ob;
     }
 
@@ -289,7 +290,7 @@ public class ComponentGraph {
         Key<?> key = getKey(clazz, bindingAnnotations.stream().findFirst());
 
         if (bindingAnnotations.size() > 1) {
-            throw new RuntimeException(String.format("More than one binding annotation used in class '%s'", node.instanceType()));
+            throw new RuntimeException(Text.format("More than one binding annotation used in class '%s'", node.instanceType()));
         }
 
         Collection<ComponentNode> injectedNodesOfCorrectType = matchingComponentNodes(node.componentsToInject, key);
@@ -300,12 +301,12 @@ public class ComponentGraph {
         } else {
             //TODO: !className for last parameter
             throw new RuntimeException(
-                    String.format("Multiple components of type '%s' injected into component '%s'", clazz.getName(), node.instanceType()));
+                    Text.format("Multiple components of type '%s' injected into component '%s'", clazz.getName(), node.instanceType()));
         }
     }
 
     private static String messageForNoGlobalComponent(Class<?> clazz, Node node) {
-        return String.format(" component of class %s to inject into component %s.", clazz.getName(), node.idAndType());
+        return Text.format(" component of class %s to inject into component %s.", clazz.getName(), node.idAndType());
     }
 
     private String messageForMultipleClassLoaders(Class<?> clazz) {

--- a/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentNode.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentNode.java
@@ -7,6 +7,7 @@ import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.ComponentId;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.container.di.componentgraph.Provider;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 
 import java.lang.annotation.Annotation;
@@ -296,7 +297,7 @@ public class ComponentNode extends Node {
         } else if (publicConstructors.length == 1) {
             return publicConstructors[0];
         } else {
-            log.warning(String.format("Multiple public constructors found in class %s, there should only be one. "
+            log.warning(Text.format("Multiple public constructors found in class %s, there should only be one. "
                     + "If more than one public constructor is needed, the primary one must be annotated with @Inject.", clazz.getName()));
             List<Pair<Constructor<?>, Integer>> withParameterCount = new ArrayList<>();
             for (Constructor<?> ctor : publicConstructors) {

--- a/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentRegistryNode.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentRegistryNode.java
@@ -6,6 +6,7 @@ import com.google.inject.util.Types;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.config.ConfigInstance;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 
 import java.util.List;
@@ -84,7 +85,7 @@ public class ComponentRegistryNode extends Node {
 
     @Override
     public String label() {
-        return String.format("{ComponentRegistry\\<%s\\>|%s}", componentClass.getSimpleName(), Node.packageName(componentClass));
+        return Text.format("{ComponentRegistry\\<%s\\>|%s}", componentClass.getSimpleName(), Node.packageName(componentClass));
     }
 
     private static ComponentId componentId(Class<?> componentClass) {

--- a/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/GuiceNode.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/componentgraph/core/GuiceNode.java
@@ -4,6 +4,7 @@ package com.yahoo.container.di.componentgraph.core;
 import com.google.inject.Key;
 import com.yahoo.component.ComponentId;
 import com.yahoo.config.ConfigInstance;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 
 import java.lang.annotation.Annotation;
@@ -67,7 +68,7 @@ public final class GuiceNode extends Node {
 
     @Override
     public String label() {
-        return String.format("{{%s|Guice}|%s}", instanceType().getSimpleName(), Node.packageName(instanceType()));
+        return Text.format("{{%s|Guice}|%s}", instanceType().getSimpleName(), Node.packageName(instanceType()));
     }
 
     private static ComponentId componentId(Object instance) {

--- a/container-disc/src/main/java/com/yahoo/container/handler/LogReader.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/LogReader.java
@@ -35,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
+import java.nio.charset.StandardCharsets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -64,7 +65,7 @@ class LogReader {
         double fromSeconds = from.getEpochSecond() + from.getNano() / 1e9;
         double toSeconds = to.getEpochSecond() + to.getNano() / 1e9;
         long linesWritten = 0;
-        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         for (List<Path> logs : getMatchingFiles(from, to)) {
             List<LogLineIterator> logLineIterators = new ArrayList<>();
             try {

--- a/container-disc/src/main/java/com/yahoo/container/handler/threadpool/ContainerThreadpoolImpl.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/threadpool/ContainerThreadpoolImpl.java
@@ -6,6 +6,7 @@ import com.yahoo.component.AbstractComponent;
 import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.container.protect.ProcessTerminator;
 import com.yahoo.jdisc.Metric;
+import com.yahoo.text.Text;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -76,7 +77,7 @@ public class ContainerThreadpoolImpl extends AbstractComponent implements AutoCl
         int minThreads = minThreads(config, cpus, hasRelThreads);
         int queueSize = queueSize(config, maxThreads, hasRelQueueSize);
 
-        log.config(String.format("Threadpool '%s': min=%d, max=%d, queue=%s", name, minThreads, maxThreads, queueSizeToString(queueSize)));
+        log.config(Text.format("Threadpool '%s': min=%d, max=%d, queue=%s", name, minThreads, maxThreads, queueSizeToString(queueSize)));
 
         ThreadPoolMetric threadPoolMetric = new ThreadPoolMetric(metric, name);
         WorkerCompletionTimingThreadPoolExecutor executor =
@@ -154,7 +155,7 @@ public class ContainerThreadpoolImpl extends AbstractComponent implements AutoCl
 
     /** Summary string of the config for exceptions. */
     private static String summarizeConfigToString(ContainerThreadpoolConfig c, int cpus) {
-        return String.format(
+        return Text.format(
                 "abs[min=%d,max=%d,queue=%d] rel[min=%.3f,max=%.3f,queue=%.3f] cpus=%d",
                 c.minThreads(), c.maxThreads(), c.queueSize(),
                 c.relativeMinThreads(), c.relativeMaxThreads(), c.relativeQueueSize(),

--- a/container-disc/src/main/java/com/yahoo/container/http/filter/FilterChainRepository.java
+++ b/container-disc/src/main/java/com/yahoo/container/http/filter/FilterChainRepository.java
@@ -22,6 +22,7 @@ import com.yahoo.jdisc.http.filter.SecurityResponseFilterChain;
 import com.yahoo.jdisc.http.filter.chain.RequestFilterChain;
 import com.yahoo.jdisc.http.filter.chain.ResponseFilterChain;
 import com.yahoo.processing.execution.chain.ChainRegistry;
+import com.yahoo.text.Text;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -144,7 +145,7 @@ public class FilterChainRepository extends AbstractComponent {
                 .collect(toSet());
         if (!requestFilters.isEmpty() && !responseFilters.isEmpty()) {
             throw new IllegalArgumentException(
-                    String.format(
+                    Text.format(
                             "Can't mix request and response filters in chain %s: request filters: %s, response filters: %s.",
                             chain.getId(), requestFilters, responseFilters));
         }

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -46,6 +46,7 @@ import com.yahoo.messagebus.jdisc.MbusServer;
 import com.yahoo.messagebus.network.rpc.SlobrokConfigSubscriber;
 import com.yahoo.net.HostName;
 import com.yahoo.security.tls.Capability;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.yolean.Exceptions;
 import com.yahoo.yolean.UncheckedInterruptedException;
@@ -407,7 +408,7 @@ public final class ConfiguredApplication implements Application {
                 }
             }
             if ( ! serversToClose.isEmpty()) {
-                log.info(String.format("Closing %d server instances", serversToClose.size()));
+                log.info(Text.format("Closing %d server instances", serversToClose.size()));
                 for (ServerProvider server : ordered(serversToClose, JettyHttpServer.class, MbusServer.class)) {
                     server.close();
                     startedServers.remove(server);
@@ -498,7 +499,7 @@ public final class ConfiguredApplication implements Application {
         configurer.shutdownConfigRetriever();
         try {
             reconfigurerThread.join();
-            log.info(String.format(
+            log.info(Text.format(
                     "Reconfiguration thread shutdown completed in %.3f seconds", (System.currentTimeMillis() - start) / 1000D));
         } catch (InterruptedException e) {
             String message = "Interrupted while waiting for reconfiguration shutdown";

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/DataplaneProxyService.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/DataplaneProxyService.java
@@ -7,6 +7,7 @@ import com.yahoo.cloud.config.DataplaneProxyConfig;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.jdisc.http.server.jetty.DataplaneProxyCredentials;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -59,7 +60,7 @@ public final class DataplaneProxyService extends AbstractComponent {
     public DataplaneProxyService() {
         this(Paths.get(PREFIX), new NginxProxyCommands(), 1, false, false);
     }
-    
+
     DataplaneProxyService(Path root, ProxyCommands proxyCommands, int reloadPeriodMinutes) {
         this(root, proxyCommands, reloadPeriodMinutes, false, false);
     }
@@ -128,8 +129,8 @@ public final class DataplaneProxyService extends AbstractComponent {
                                                    useAzureProxy,
                                                    isDevEnvironment));
                 if (configChanged) {
-                    logger.log(Level.INFO, "Configuring data plane proxy service. Token endpoints: [%s]"
-                            .formatted(String.join(", ", config.tokenEndpoints())));
+                    logger.log(Level.INFO, Text.format("Configuring data plane proxy service. Token endpoints: [%s]",
+                            String.join(", ", config.tokenEndpoints())));
                 }
                 if (configChanged && state == NginxState.RUNNING) {
                     changeState(NginxState.RELOAD_REQUIRED);
@@ -250,7 +251,7 @@ public final class DataplaneProxyService extends AbstractComponent {
             nginxTemplate = replace(nginxTemplate, "vespa_token_port", Integer.toString(vespaTokenPort));
             nginxTemplate = replace(nginxTemplate, "prefix", root.toString());
             String tokenmapping = tokenEndpoints.stream()
-                    .map("        %s vespatoken;"::formatted)
+                    .map(s -> Text.format("        %s vespatoken;", s))
                     .collect(Collectors.joining("\n"));
             nginxTemplate = replace(nginxTemplate, "vespa_token_endpoints", tokenmapping);
 
@@ -319,7 +320,7 @@ public final class DataplaneProxyService extends AbstractComponent {
                 ).start();
                 int exitCode = startCommand.waitFor();
                 if (exitCode != 0) {
-                    throw new RuntimeException("Non-zero exitcode from nginx: %d".formatted(exitCode));
+                    throw new RuntimeException(Text.format("Non-zero exitcode from nginx: %d", exitCode));
                 }
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException("Could not start nginx", e);
@@ -336,7 +337,7 @@ public final class DataplaneProxyService extends AbstractComponent {
                 ).start();
                 int exitCode = stopCommand.waitFor();
                 if (exitCode != 0) {
-                    throw new RuntimeException("Non-zero exitcode from nginx: %d".formatted(exitCode));
+                    throw new RuntimeException(Text.format("Non-zero exitcode from nginx: %d", exitCode));
                 }
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException("Could not start nginx", e);
@@ -354,7 +355,7 @@ public final class DataplaneProxyService extends AbstractComponent {
                 ).start();
                 int exitCode = reloadCommand.waitFor();
                 if (exitCode != 0) {
-                    throw new RuntimeException("Non-zero exitcode from nginx: %d".formatted(exitCode));
+                    throw new RuntimeException(Text.format("Non-zero exitcode from nginx: %d", exitCode));
                 }
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException("Could not start nginx", e);

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SecretsProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SecretsProvider.java
@@ -4,6 +4,7 @@ package com.yahoo.container.jdisc;
 import ai.vespa.secret.Secret;
 import ai.vespa.secret.Secrets;
 import com.yahoo.container.di.componentgraph.Provider;
+import com.yahoo.text.Text;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
@@ -35,7 +36,7 @@ public class SecretsProvider implements Provider<Secrets> {
             var value = System.getenv(envName);
             if (value == null || value.isEmpty()) {
                 throw new IllegalArgumentException(
-                        "Secret '%s' not found. Set environment variable '%s'".formatted(key, envName));
+                        Text.format("Secret '%s' not found. Set environment variable '%s'", key, envName));
             }
             return () -> value;
         }

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MicrometerMetricReporter.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MicrometerMetricReporter.java
@@ -4,6 +4,7 @@ import ai.vespa.metrics.set.MicrometerMetrics;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.jdisc.Metric;
+import com.yahoo.text.Text;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.FunctionCounter;
@@ -66,7 +67,7 @@ public class MicrometerMetricReporter extends AbstractComponent {
             try {
                 c.close();
             } catch (Exception e) {
-                log.warning(() -> "Failed to close instance of %s: %s".formatted(c.getClass().getName(), e));
+                log.warning(() -> Text.format("Failed to close instance of %s: %s", c.getClass().getName(), e));
             }
         }
     }
@@ -92,7 +93,7 @@ public class MicrometerMetricReporter extends AbstractComponent {
             for (var meter : getMeters()) {
                 var name = meter.getId().getName();
                 if (!ALLOWED_METERS.contains(name)) {
-                    log.fine(() -> "Ignoring meter with id '%s'".formatted(meter.getId()));
+                    log.fine(() -> Text.format("Ignoring meter with id '%s'", meter.getId()));
                     continue;
                 }
                 var dimensions = new HashMap<String, Object>();

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/state/PrometheusHelper.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/state/PrometheusHelper.java
@@ -2,10 +2,12 @@
 package com.yahoo.container.jdisc.state;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.yahoo.text.Text;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -47,8 +49,8 @@ public class PrometheusHelper {
     }
 
     private static byte[] getMetricLines(String metricName, String dimensions, Number value, long timestamp) {
-        return (String.format(HELP_LINE, metricName, metricName) +
-                String.format(METRIC_LINE, metricName, dimensions, value, timestamp)).getBytes();
+        return (Text.format(HELP_LINE, metricName, metricName) +
+                Text.format(METRIC_LINE, metricName, dimensions, value, timestamp)).getBytes(StandardCharsets.UTF_8);
     }
 
     private static String sanitize(String name) {

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/state/StateHandler.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/state/StateHandler.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.nio.charset.StandardCharsets;
 
 import static com.yahoo.container.jdisc.state.JsonUtil.sanitizeDouble;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -211,7 +212,7 @@ public class StateHandler extends AbstractRequestHandler implements CapabilityRe
     private byte[] buildHistogramsOutput() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         if (snapshotProvider != null) {
-            snapshotProvider.histogram(new PrintStream(baos));
+            snapshotProvider.histogram(new PrintStream(baos, false, StandardCharsets.UTF_8));
         }
         return baos.toByteArray();
     }
@@ -426,7 +427,7 @@ public class StateHandler extends AbstractRequestHandler implements CapabilityRe
     private static byte[] toPrettyString(JsonNode resources) throws JsonProcessingException {
         return jsonMapper.writerWithDefaultPrettyPrinter()
                 .writeValueAsString(resources)
-                .getBytes();
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     static class Tuple {

--- a/container-disc/src/main/java/com/yahoo/container/logging/ConnectionLogHandler.java
+++ b/container-disc/src/main/java/com/yahoo/container/logging/ConnectionLogHandler.java
@@ -2,6 +2,8 @@
 
 package com.yahoo.container.logging;
 
+import com.yahoo.text.Text;
+
 /**
  * @author mortent
  */
@@ -13,10 +15,10 @@ class ConnectionLogHandler {
         logFileHandler = new LogFileHandler<>(
                 LogFileHandler.Compression.ZSTD,
                 bufferSize,
-                useClusterIdInFileName ? String.format("logs/vespa/%s/ConnectionLog.%s.%s", logDirectoryName, clusterName, "%Y%m%d%H%M%S") :
-                                          String.format("logs/vespa/%s/ConnectionLog.%s", logDirectoryName, "%Y%m%d%H%M%S"),
+                useClusterIdInFileName ? Text.format("logs/vespa/%s/ConnectionLog.%s.%s", logDirectoryName, clusterName, "%Y%m%d%H%M%S") :
+                                          Text.format("logs/vespa/%s/ConnectionLog.%s", logDirectoryName, "%Y%m%d%H%M%S"),
                 "0 60 ...",
-                useClusterIdInFileName ? String.format("ConnectionLog.%s", clusterName) :
+                useClusterIdInFileName ? Text.format("ConnectionLog.%s", clusterName) :
                                           "ConnectionLog",
                 queueSize,
                 "connection-logger",

--- a/container-disc/src/main/java/com/yahoo/container/logging/VespaAccessLog.java
+++ b/container-disc/src/main/java/com/yahoo/container/logging/VespaAccessLog.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.Locale;
 
 /**
  * @author Bjorn Borud
@@ -26,7 +27,7 @@ public final class VespaAccessLog extends AbstractComponent implements RequestLo
     }
 
     private static SimpleDateFormat createDateFormat() {
-        SimpleDateFormat format = new SimpleDateFormat("[dd/MMM/yyyy:HH:mm:ss Z]");
+        SimpleDateFormat format = new SimpleDateFormat("[dd/MMM/yyyy:HH:mm:ss Z]", Locale.ROOT);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         return format;
     }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/base/JsonSecurityRequestFilterBase.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/base/JsonSecurityRequestFilterBase.java
@@ -13,6 +13,7 @@ import com.yahoo.jdisc.handler.ResponseDispatch;
 import com.yahoo.jdisc.handler.ResponseHandler;
 import com.yahoo.jdisc.http.filter.DiscFilterRequest;
 import com.yahoo.jdisc.http.filter.SecurityRequestFilter;
+import com.yahoo.text.Text;
 
 import java.io.UncheckedIOException;
 import java.util.Objects;
@@ -55,7 +56,7 @@ public abstract class JsonSecurityRequestFilterBase extends ChainedComponent imp
         error.response.headers().put("Cache-Control", "must-revalidate,no-cache,no-store");
         try (FastContentWriter writer = ResponseDispatch.newInstance(error.response).connectFastWriter(responseHandler)) {
             String jsonAsStr = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
-            log.log(Level.FINE, () -> String.format("Error response for '%s': statusCode=%d, json='%s'",
+            log.log(Level.FINE, () -> Text.format("Error response for '%s': statusCode=%d, json='%s'",
                     request, error.response.getStatus(), jsonAsStr));
             writer.write(jsonAsStr);
         } catch (JsonProcessingException e) {

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/misc/LocalhostFilter.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/misc/LocalhostFilter.java
@@ -5,6 +5,7 @@ import com.google.common.net.InetAddresses;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.http.filter.DiscFilterRequest;
 import com.yahoo.jdisc.http.filter.security.base.JsonSecurityRequestFilterBase;
+import com.yahoo.text.Text;
 
 import java.net.InetAddress;
 import java.util.Optional;
@@ -24,7 +25,7 @@ public class LocalhostFilter extends JsonSecurityRequestFilterBase {
         if (!remoteAddr.isLoopbackAddress() && !request.getRemoteAddr().equals(request.getLocalAddr())) {
             return Optional.of(new ErrorResponse(
                     Response.Status.UNAUTHORIZED,
-                    String.format("%s %s denied for %s: Unauthorized host", request.getMethod(),
+                    Text.format("%s %s denied for %s: Unauthorized host", request.getMethod(),
                                   request.getUri().getPath(), request.getRemoteAddr())));
         }
         return Optional.empty();

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -9,6 +9,7 @@ import com.yahoo.jdisc.http.SslProvider;
 import com.yahoo.jdisc.http.ssl.impl.DefaultConnectorSsl;
 import com.yahoo.security.tls.MixedMode;
 import com.yahoo.security.tls.TransportSecurityUtils;
+import com.yahoo.text.Text;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
@@ -123,7 +124,7 @@ public class ConnectorFactory {
     }
 
     private List<ConnectionFactory> connectionFactoriesForTlsMixedMode(Metric metric) {
-        log.warning(String.format("TLS mixed mode enabled for port %d - HTTP/2 and proxy-protocol are not supported",
+        log.warning(Text.format("TLS mixed mode enabled for port %d - HTTP/2 and proxy-protocol are not supported",
                 connectorConfig.listenPort()));
         HttpConnectionFactory httpFactory = newHttp1ConnectionFactory(metric);
         SslConnectionFactory sslFactory = newSslConnectionFactory(metric, httpFactory);
@@ -172,15 +173,14 @@ public class ConnectorFactory {
                     try {
                         return HttpCompliance.Violation.valueOf(name);
                     } catch (IllegalArgumentException e) {
-                        log.warning("Ignoring unknown violation '%s'".formatted(name));
+                        log.warning(Text.format("Ignoring unknown violation '%s'", name));
                         return null;
                     }
                 })
                 .filter(Objects::nonNull)
                 .toList();
         if (jettyViolationsAllowed.isEmpty()) return HttpCompliance.RFC7230;
-        log.info("Disabling HTTP compliance checks for port %d: %s"
-                .formatted(
+        log.info(Text.format("Disabling HTTP compliance checks for port %d: %s",
                         cfg.listenPort(),
                         jettyViolationsAllowed.stream().map(HttpCompliance.Violation::getName).toList()));
         return HttpCompliance.RFC7230.with(
@@ -261,7 +261,7 @@ public class ConnectorFactory {
     private record HttpComplianceViolationListener(Metric metric) implements ComplianceViolation.Listener {
         @Override
         public void onComplianceViolation(ComplianceViolation.Event e) {
-            log.fine(() -> "Compliance violation: mode=%s, violation=%s".formatted(e.mode().getName(), e.violation().getName()));
+            log.fine(() -> Text.format("Compliance violation: mode=%s, violation=%s", e.mode().getName(), e.violation().getName()));
             var ctx = metric.createContext(Map.of("mode", e.mode().getName(), "violation", e.violation().getName()));
             metric.add(ContainerMetrics.JETTY_HTTP_COMPLIANCE_VIOLATION.baseName(), 1L, ctx);
         }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorSpecificContextHandler.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorSpecificContextHandler.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.server.jetty;
 
+import com.yahoo.text.Text;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -19,10 +20,10 @@ class ConnectorSpecificContextHandler extends ContextHandler {
         this.connector = c;
         List<String> allowedServerNames = c.connectorConfig().serverName().allowed();
         if (allowedServerNames.isEmpty()) {
-            setVirtualHosts(List.of("@%s".formatted(c.getName())));
+            setVirtualHosts(List.of(Text.format("@%s", c.getName())));
         } else {
             var virtualHosts = allowedServerNames.stream()
-                    .map(name -> "%s@%s".formatted(name, c.getName()))
+                    .map(name -> Text.format("%s@%s", name, c.getName()))
                     .toList();
             setVirtualHosts(virtualHosts);
         }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/DataplaneProxyCredentials.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/DataplaneProxyCredentials.java
@@ -6,6 +6,7 @@ import com.yahoo.component.annotation.Inject;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.security.X509CertificateUtils;
 import com.yahoo.security.X509CertificateWithKey;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.defaults.Defaults;
 
 import java.io.IOException;
@@ -73,7 +74,7 @@ public class DataplaneProxyCredentials extends AbstractComponent {
             return Optional.of(x509Certificate);
         } catch (IOException e) {
             // Some exception occurred, assume credentials corrupted and requires a new pair.
-            log.log(Level.WARNING, "Failed to load credentials: %s".formatted(e.getMessage()));
+            log.log(Level.WARNING, Text.format("Failed to load credentials: %s", e.getMessage()));
             log.log(Level.FINE, e.toString(), e);
             return Optional.empty();
         }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/FormPostRequestHandler.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/FormPostRequestHandler.java
@@ -11,6 +11,7 @@ import com.yahoo.jdisc.handler.DelegatedRequestHandler;
 import com.yahoo.jdisc.handler.RequestHandler;
 import com.yahoo.jdisc.handler.ResponseHandler;
 import com.yahoo.jdisc.http.HttpRequest;
+import com.yahoo.text.Text;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
@@ -96,7 +97,7 @@ class FormPostRequestHandler extends AbstractRequestHandler implements ContentCh
             parameterMap = parseFormParameters(content);
         } catch (IllegalArgumentException e) {
             // Log for now until this is solved properly
-            log.log(Level.INFO, "Failed to parse form parameters: %s".formatted(e.getMessage()));
+            log.log(Level.INFO, Text.format("Failed to parse form parameters: %s", e.getMessage()));
             completionHandler.failed(new RequestException(BAD_REQUEST, "Failed to parse form parameters", e));
             return;
         }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JdiscDispatchingHandler.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JdiscDispatchingHandler.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Locale;
 
 import static com.yahoo.jdisc.http.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED;
 import static com.yahoo.jdisc.http.server.jetty.RequestUtils.SUPPORTED_METHODS;
@@ -81,7 +82,7 @@ class JdiscDispatchingHandler extends Handler.Abstract.NonBlocking {
         var accessLogEntry = new AccessLogEntry();
         jettyRequest.setAttribute(ATTRIBUTE_NAME_ACCESS_LOG_ENTRY, accessLogEntry);
 
-        if (!SUPPORTED_METHODS.contains(jettyRequest.getMethod().toUpperCase())) {
+        if (!SUPPORTED_METHODS.contains(jettyRequest.getMethod().toUpperCase(Locale.ROOT))) {
             Response.writeError(jettyRequest, jettyResponse, callback, HttpStatus.METHOD_NOT_ALLOWED_405);
             return;
         }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyConnectionLogger.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyConnectionLogger.java
@@ -8,6 +8,7 @@ import com.yahoo.io.HexDump;
 import com.yahoo.jdisc.http.ServerConfig;
 import com.yahoo.security.SubjectAlternativeName;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.text.Text;
 import org.eclipse.jetty.alpn.server.ALPNServerConnection;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http2.server.internal.HTTP2ServerConnection;
@@ -211,10 +212,10 @@ class JettyConnectionLogger extends EventsHandler implements Connection.Listener
             String listenerType, String methodName, String methodArgumentsFormat, List<Object> methodArguments, ListenerHandler handler) {
         if (!enabled) return;
         try {
-            log.log(Level.FINE, () -> String.format(listenerType + "." + methodName + "(" + methodArgumentsFormat + ")", methodArguments.toArray()));
+            log.log(Level.FINE, () -> Text.format(listenerType + "." + methodName + "(" + methodArgumentsFormat + ")", methodArguments.toArray()));
             handler.run();
         } catch (Exception e) {
-            log.log(Level.WARNING, String.format("Exception in %s.%s listener: %s", listenerType, methodName, e.getMessage()), e);
+            log.log(Level.WARNING, Text.format("Exception in %s.%s listener: %s", listenerType, methodName, e.getMessage()), e);
         }
     }
 

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyRequestContentReader.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyRequestContentReader.java
@@ -217,10 +217,10 @@ class JettyRequestContentReader {
             long written = bytesWritten.addAndGet(buf.remaining());
             if (contentLengthHeader != -1 && contentLengthHeader > maxContentSize) {
                 handler.failed(new RequestException(
-                        HttpStatus.PAYLOAD_TOO_LARGE_413, messageTemplate.formatted(contentLengthHeader, maxContentSize)));
+                        HttpStatus.PAYLOAD_TOO_LARGE_413, Text.format(messageTemplate, contentLengthHeader, maxContentSize)));
             } else if (written > maxContentSize) {
                 handler.failed(new RequestException(
-                        HttpStatus.PAYLOAD_TOO_LARGE_413, messageTemplate.formatted(written, maxContentSize)));
+                        HttpStatus.PAYLOAD_TOO_LARGE_413, Text.format(messageTemplate, written, maxContentSize)));
             } else {
                 delegate.write(buf, handler);
             }

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLog.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLog.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.ObjLongConsumer;
 import java.util.stream.Collectors;
+import java.util.Locale;
 
 /**
  * A {@link RequestLog} implementation that collects statistics like HTTP response types aggregated by category.
@@ -156,7 +157,7 @@ class MetricAggregatingRequestLog implements RequestLog {
         private static String requestType(Request req, List<String> monitoringHandlerPaths,
                                           List<String> searchHandlerPaths) {
             HttpRequest.RequestType requestType = (HttpRequest.RequestType)req.getAttribute(requestTypeAttribute);
-            if (requestType != null) return requestType.name().toLowerCase();
+            if (requestType != null) return requestType.name().toLowerCase(Locale.ROOT);
             // Deduce from path and method:
             String path = req.getHttpURI().getPath();
             if (path == null) return "none";

--- a/container-disc/src/main/java/com/yahoo/restapi/JacksonJsonResponse.java
+++ b/container-disc/src/main/java/com/yahoo/restapi/JacksonJsonResponse.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A JSON response using Jackson for serialization.
@@ -48,7 +49,7 @@ public class JacksonJsonResponse<T> extends HttpResponse {
         if (log.isLoggable(Level.FINE)) {
             String json = writer.writeValueAsString(entity);
             log.log(Level.FINE, "Writing the following JSON to response output stream:\n" + json);
-            outputStream.write(json.getBytes());
+            outputStream.write(json.getBytes(StandardCharsets.UTF_8));
         } else {
             writer.writeValue(outputStream, entity);
         }

--- a/container-disc/src/main/java/com/yahoo/restapi/RestApiImpl.java
+++ b/container-disc/src/main/java/com/yahoo/restapi/RestApiImpl.java
@@ -18,6 +18,7 @@ import com.yahoo.security.tls.Capability;
 import com.yahoo.security.tls.CapabilitySet;
 import com.yahoo.security.tls.ConnectionAuthContext;
 import com.yahoo.security.tls.TransportSecurityUtils;
+import com.yahoo.text.Text;
 
 import javax.net.ssl.SSLSession;
 import java.io.InputStream;
@@ -124,7 +125,7 @@ class RestApiImpl implements RestApi {
                         @Override public URI uri() { return uri; }
                     });
         }
-        throw new IllegalStateException(String.format("No ACL mapping configured for '%s' to '%s'", method, route.name));
+        throw new IllegalStateException(Text.format("No ACL mapping configured for '%s' to '%s'", method, route.name));
     }
 
     private HttpResponse dispatchToRoute(Route route, RequestContextImpl context) {

--- a/container-disc/src/test/java/com/yahoo/container/di/ContainerTestBase.java
+++ b/container-disc/src/test/java/com/yahoo/container/di/ContainerTestBase.java
@@ -6,6 +6,7 @@ import com.yahoo.container.core.config.BundleTestUtil;
 import com.yahoo.container.core.config.TestOsgi;
 import com.yahoo.container.di.ContainerTest.ComponentTakingConfig;
 import com.yahoo.container.di.componentgraph.core.ComponentGraph;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
@@ -69,7 +70,7 @@ public class ContainerTestBase {
         for (int i = 0; i < applicationBundles.size(); i++) {
             bundles.append("bundles[" + i + "] \"" + applicationBundles.get(i) + "\"\n");
         }
-        dirConfigSource.writeConfig("application-bundles", String.format("bundles[%s]\n%s", applicationBundles.size(), bundles));
+        dirConfigSource.writeConfig("application-bundles", Text.format("bundles[%s]\n%s", applicationBundles.size(), bundles));
     }
 
     protected void writeBootstrapConfigs(ComponentEntry... componentEntries) {
@@ -80,7 +81,7 @@ public class ContainerTestBase {
             components.append(componentEntries[i].asConfig(i));
             components.append('\n');
         }
-        dirConfigSource.writeConfig("components", String.format("components[%s]\n%s", componentEntries.length, components));
+        dirConfigSource.writeConfig("components", Text.format("components[%s]\n%s", componentEntries.length, components));
     }
 
     protected void writeBootstrapConfigs(String componentId, Class<?> classId) {

--- a/container-disc/src/test/java/com/yahoo/container/handler/AccessLogRequestHandlerTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/handler/AccessLogRequestHandlerTest.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.Executor;
 
+import java.nio.charset.StandardCharsets;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -24,14 +25,14 @@ public class AccessLogRequestHandlerTest {
         keeper.addUri("foo");
         HttpResponse response = handler.handle(null);
         response.render(out);
-        assertEquals("{\"entries\":[{\"url\":\"foo\"}]}", out.toString());
+        assertEquals("{\"entries\":[{\"url\":\"foo\"}]}", out.toString(StandardCharsets.UTF_8));
     }
 
     @Test
     void testEmpty() throws IOException {
         HttpResponse response = handler.handle(null);
         response.render(out);
-        assertEquals("{\"entries\":[]}", out.toString());
+        assertEquals("{\"entries\":[]}", out.toString(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -40,7 +41,7 @@ public class AccessLogRequestHandlerTest {
         keeper.addUri("foo");
         HttpResponse response = handler.handle(null);
         response.render(out);
-        assertEquals("{\"entries\":[{\"url\":\"foo\"},{\"url\":\"foo\"}]}", out.toString());
+        assertEquals("{\"entries\":[{\"url\":\"foo\"},{\"url\":\"foo\"}]}", out.toString(StandardCharsets.UTF_8));
     }
 
 }

--- a/container-disc/src/test/java/com/yahoo/container/handler/LogHandlerTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/handler/LogHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -54,9 +55,9 @@ public class LogHandlerTest {
         protected void writeLogs(OutputStream out, Instant from, Instant to, long maxLines, Optional<String> hostname)  {
             try {
                 if (to.isAfter(Instant.ofEpochMilli(1000))) {
-                    out.write("newer log".getBytes());
+                    out.write("newer log".getBytes(StandardCharsets.UTF_8));
                 } else {
-                    out.write("older log".getBytes());
+                    out.write("older log".getBytes(StandardCharsets.UTF_8));
                 }
             } catch (Exception e) {}
         }

--- a/container-disc/src/test/java/com/yahoo/container/handler/LogReaderTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/handler/LogReaderTest.java
@@ -115,13 +115,13 @@ public class LogReaderTest {
     private byte[] compress1(String input) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         OutputStream zip = new GZIPOutputStream(baos);
-        zip.write(input.getBytes());
+        zip.write(input.getBytes(UTF_8));
         zip.close();
         return baos.toByteArray();
     }
 
     private byte[] compress2(String input) {
-        byte[] data = input.getBytes();
+        byte[] data = input.getBytes(UTF_8);
         return new ZstdCompressor().compress(data, 0, data.length);
     }
 

--- a/container-disc/src/test/java/com/yahoo/container/handler/VipStatusHandlerTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/handler/VipStatusHandlerTestCase.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -98,7 +99,7 @@ public class VipStatusHandlerTestCase {
     void testFileFound() throws IOException {
         File statusFile = File.createTempFile("VipStatusHandlerTestCase", null);
         try {
-            FileWriter writer = new FileWriter(statusFile);
+            FileWriter writer = new FileWriter(statusFile, StandardCharsets.UTF_8);
             String OK = "OK\n";
             writer.write(OK);
             writer.close();

--- a/container-disc/src/test/java/com/yahoo/container/handler/metrics/MetricsV2HandlerTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/handler/metrics/MetricsV2HandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.io.InputStreamReader;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -139,7 +140,7 @@ public class MetricsV2HandlerTest {
         if (in == null) {
             throw new RuntimeException("File not found: " + filename);
         }
-        return new BufferedReader(new InputStreamReader(in)).lines().collect(Collectors.joining("\n"));
+        return new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8)).lines().collect(Collectors.joining("\n"));
     }
 
 }

--- a/container-disc/src/test/java/com/yahoo/container/logging/JSONLogTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/logging/JSONLogTestCase.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.nio.charset.StandardCharsets;
 
 import static com.yahoo.test.json.JsonTestHelper.assertJsonEquals;
 
@@ -298,7 +299,7 @@ public class JSONLogTestCase {
     private String formatEntry(RequestLogEntry entry) {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             new JSONFormatter().write(entry, outputStream);
-            return outputStream.toString();
+            return outputStream.toString(StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/container-disc/src/test/java/com/yahoo/container/logging/LogFileHandlerTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/logging/LogFileHandlerTestCase.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.Date;
 import java.util.function.BiFunction;
 import java.util.logging.Formatter;
@@ -108,7 +109,7 @@ public class LogFileHandlerTestCase {
         File root = newFolder(temporaryFolder, "testlogforsymlinkchecking");
         Formatter formatter = new Formatter() {
             public String format(LogRecord r) {
-                DateFormat df = new SimpleDateFormat("yyyy.MM.dd:HH:mm:ss.SSS");
+                DateFormat df = new SimpleDateFormat("yyyy.MM.dd:HH:mm:ss.SSS", Locale.ROOT);
                 String timeStamp = df.format(new Date(r.getMillis()));
                 return ("[" + timeStamp + "]" + " " + formatMessage(r));
             }
@@ -168,7 +169,7 @@ public class LogFileHandlerTestCase {
     void testcompression_gzip() throws InterruptedException, IOException {
         testcompression(
                 Compression.GZIP, "gz",
-                (compressedFile, __) -> uncheck(() -> new String(new GZIPInputStream(Files.newInputStream(compressedFile)).readAllBytes())));
+                (compressedFile, __) -> uncheck(() -> new String(new GZIPInputStream(Files.newInputStream(compressedFile)).readAllBytes(), StandardCharsets.UTF_8)));
     }
 
     @Test
@@ -181,7 +182,7 @@ public class LogFileHandlerTestCase {
                     byte[] uncompressedBytes = new byte[uncompressedSize];
                     byte[] compressedBytes = Files.readAllBytes(compressedFile);
                     zstdCompressor.decompress(compressedBytes, 0, compressedBytes.length, uncompressedBytes, 0, uncompressedBytes.length);
-                    return new String(uncompressedBytes);
+                    return new String(uncompressedBytes, StandardCharsets.UTF_8);
                 }));
     }
 
@@ -212,7 +213,7 @@ public class LogFileHandlerTestCase {
             Thread.sleep(1);
         }
         assertTrue(compressed.exists());
-        String uncompressedContent = decompressor.apply(compressed.toPath(), content.getBytes().length);
+        String uncompressedContent = decompressor.apply(compressed.toPath(), content.getBytes(StandardCharsets.UTF_8).length);
         assertEquals(uncompressedContent, content);
         h.shutdown();
     }

--- a/container-disc/src/test/java/com/yahoo/container/logging/test/LogFormatterTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/logging/test/LogFormatterTestCase.java
@@ -4,9 +4,7 @@ package com.yahoo.container.logging.test;
 import com.yahoo.container.logging.LogFormatter;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
 import java.time.Instant;
-import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/container-disc/src/test/java/com/yahoo/container/logging/test/LogFormatterTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/logging/test/LogFormatterTestCase.java
@@ -5,6 +5,8 @@ import com.yahoo.container.logging.LogFormatter;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -16,8 +18,8 @@ public class LogFormatterTestCase {
     @Test
     void testIt() {
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"));
-        @SuppressWarnings("deprecation")
-        long time = new Date(103, 7, 25, 13, 30, 35).getTime();
+        // Use Instant instead of deprecated Date constructor
+        long time = Instant.parse("2003-08-25T13:30:35Z").toEpochMilli();
         String result = LogFormatter.insertDate("test%Y%m%d%H%M%S%x", time);
         assertEquals("test20030825133035Aug", result);
         result = LogFormatter.insertDate("test%s%T", time);

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/filter/security/misc/LocalhostFilterTest.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/filter/security/misc/LocalhostFilterTest.java
@@ -5,6 +5,7 @@ import com.yahoo.container.jdisc.RequestHandlerTestDriver;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.http.filter.DiscFilterRequest;
 import com.yahoo.jdisc.http.filter.util.FilterTestUtils;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +33,7 @@ public class LocalhostFilterTest {
 
     private static DiscFilterRequest createRequest(String remoteAddr, String localAddr) {
         return FilterTestUtils.newRequestBuilder()
-                .withUri("http://%s:8080/".formatted(localAddr))
+                .withUri(Text.format("http://%s:8080/", localAddr))
                 .withRemoteAddress(remoteAddr, 12345)
                 .build();
     }

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/filter/security/rule/RuleBasedRequestFilterTest.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/filter/security/rule/RuleBasedRequestFilterTest.java
@@ -15,6 +15,7 @@ import com.yahoo.vespa.config.jdisc.http.filter.RuleBasedFilterConfig.Rule;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 
@@ -230,7 +231,7 @@ class RuleBasedRequestFilterTest {
         assertEquals(expectedCode, response.getStatus());
         ObjectNode expectedJson = Jackson.mapper().createObjectNode();
         expectedJson.put("message", expectedMessage).put("code", expectedCode);
-        JsonNode actualJson = Jackson.mapper().readTree(handler.readAll().getBytes());
+        JsonNode actualJson = Jackson.mapper().readTree(handler.readAll().getBytes(StandardCharsets.UTF_8));
         assertEquals(expectedJson, actualJson);
     }
 

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/FilterIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/FilterIT.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -665,7 +666,7 @@ public class FilterIT {
             final HttpResponse response = HttpResponse.newInstance(responseStatus);
             final ContentChannel channel = responseHandler.handleResponse(response);
             final CompletionHandler completionHandler = null;
-            channel.write(ByteBuffer.wrap(responseMessage.getBytes()), completionHandler);
+            channel.write(ByteBuffer.wrap(responseMessage.getBytes(StandardCharsets.UTF_8)), completionHandler);
             channel.close(null);
         }
     }

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
@@ -716,7 +716,7 @@ public class HttpServerIT {
         for (int i = 0; i < 1000; i++) {
             builder.append(i);
         }
-        byte[] content = builder.toString().getBytes();
+        byte[] content = builder.toString().getBytes(UTF_8);
         for (int i = 0; i < 100; i++) {
             driver.client().newPost("/status.html").setBinaryContent(content).execute()
                     .expectStatusCode(is(OK));
@@ -1122,7 +1122,7 @@ public class HttpServerIT {
         public ContentChannel handleRequest(Request request, ResponseHandler handler) {
             var ch = handler.handleResponse(new Response(OK));
             for (var value : request.headers().get(headerName)) {
-                ch.write(ByteBuffer.wrap((value + "\n").getBytes()), null);
+                ch.write(ByteBuffer.wrap((value + "\n").getBytes(java.nio.charset.StandardCharsets.UTF_8)), null);
             }
             ch.close(null);
             return null;

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLogTest.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLogTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.http.server.jetty.MetricAggregatingRequestLog.StatisticsEntry;
+import com.yahoo.text.Text;
 import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -142,7 +143,7 @@ public class MetricAggregatingRequestLogTest {
                         && entry.dimensions.statusCode == statusCode)
                 .mapToLong(entry -> entry.value)
                 .reduce(Long::sum)
-                .orElseThrow(() -> new AssertionError(String.format("Not matching entry in result (scheme=%s, method=%s, name=%s, type=%s)", scheme, method, name, requestType)));
+                .orElseThrow(() -> new AssertionError(Text.format("Not matching entry in result (scheme=%s, method=%s, name=%s, type=%s)", scheme, method, name, requestType)));
         assertThat(value, equalTo(expectedValue));
     }
 

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/ProxyProtocolIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/ProxyProtocolIT.java
@@ -8,6 +8,7 @@ import com.yahoo.container.logging.RequestLogEntry;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.jdisc.http.ServerConfig;
 import com.yahoo.security.SslContextBuilder;
+import com.yahoo.text.Text;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
@@ -175,7 +176,7 @@ class ProxyProtocolIT {
             } catch (ExecutionException e) {
                 // Retry when the server closes the connection before the TLS handshake is completed. This has been observed in CI.
                 // We have been unable to reproduce this locally. The cause is therefor currently unknown.
-                log.log(Level.WARNING, String.format("Attempt %d failed: %s", attempt, e.getMessage()), e);
+                log.log(Level.WARNING, Text.format("Attempt %d failed: %s", attempt, e.getMessage()), e);
                 Thread.sleep(10);
                 cause = e;
             } finally {


### PR DESCRIPTION
Systematically replace String.format() calls with com.yahoo.text.Text.format() across the container-disc module to ensure locale-independent formatting. Also adds explicit UTF-8 charset specifications and uses Locale.ROOT for case conversions to prevent locale-dependent behavior.

Changes:
- Replace String.format() with Text.format() (45 files)
- Replace .formatted() template strings with Text.format()
- Add explicit StandardCharsets.UTF_8 for getBytes() calls
- Use Locale.ROOT for toUpperCase/toLowerCase operations
- Use Locale.ROOT in SimpleDateFormat constructors
