### PR TITLE
Use Text.format and locale in config-model-api

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/TimeWindow.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/TimeWindow.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.application.api;
 
+import com.yahoo.text.Text;
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Instant;
@@ -78,7 +79,7 @@ public class TimeWindow {
         return "time window for hour(s) " +
                hours.toString() +
                " on " + days.stream().map(DayOfWeek::name)
-                            .map(String::toLowerCase)
+                            .map(s -> s.toLowerCase(java.util.Locale.ROOT))
                             .toList() +
                " in time zone " + zone + " and " + dateRange.toString();
     }
@@ -119,7 +120,7 @@ public class TimeWindow {
         int start = hourFrom(startInclusive);
         int end = hourFrom(endInclusive);
         if (end < start) {
-            throw new IllegalArgumentException(String.format("Invalid hour range '%s-%s'", startInclusive,
+            throw new IllegalArgumentException(Text.format("Invalid hour range '%s-%s'", startInclusive,
                                                              endInclusive));
         }
         return IntStream.rangeClosed(start, end).boxed()
@@ -131,7 +132,7 @@ public class TimeWindow {
         DayOfWeek start = dayFrom(startInclusive);
         DayOfWeek end = dayFrom(endInclusive);
         if (end.getValue() < start.getValue()) {
-            throw new IllegalArgumentException(String.format("Invalid day range '%s-%s'", startInclusive,
+            throw new IllegalArgumentException(Text.format("Invalid day range '%s-%s'", startInclusive,
                                                              endInclusive));
         }
         return IntStream.rangeClosed(start.getValue(), end.getValue()).boxed()
@@ -142,7 +143,7 @@ public class TimeWindow {
     /** Parse day of week from string */
     private static DayOfWeek dayFrom(String day) {
         return Arrays.stream(DayOfWeek.values())
-                     .filter(dayOfWeek -> day.length() >= 3 && dayOfWeek.name().toLowerCase().startsWith(day))
+                     .filter(dayOfWeek -> day.length() >= 3 && dayOfWeek.name().toLowerCase(java.util.Locale.ROOT).startsWith(day))
                      .findFirst()
                      .orElseThrow(() -> new IllegalArgumentException("Invalid day '" + day + "'"));
     }

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -895,7 +895,7 @@ public class DeploymentSpecXmlReader {
     private static Duration toDuration(String durationSpec, String sourceDescription) {
         try {
             if (durationSpec == null || durationSpec.isBlank()) return Duration.ZERO;
-            durationSpec = durationSpec.trim().toLowerCase();
+            durationSpec = durationSpec.trim().toLowerCase(java.util.Locale.ROOT);
             var magnitude = toMagnitude(durationSpec);
             return switch (durationSpec.substring(durationSpec.length() - 1)) {
                 case "m" -> Duration.ofMinutes(magnitude);

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ContainerEndpoint.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ContainerEndpoint.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.api;
 
+import com.yahoo.text.Text;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalInt;
@@ -86,6 +87,6 @@ public class ContainerEndpoint {
 
     @Override
     public String toString() {
-        return String.format("container endpoint %s -> %s [scope=%s, weight=%s, routingMethod=%s, authMethod=%s]", clusterId, names, scope, weight, routingMethod, authMethod);
+        return Text.format("container endpoint %s -> %s [scope=%s, weight=%s, routingMethod=%s, authMethod=%s]", clusterId, names, scope, weight, routingMethod, authMethod);
     }
 }

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/Model.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/Model.java
@@ -94,8 +94,9 @@ public interface Model {
     default void markClustersForDeferredReconfiguration(Set<String> clusterNames) {
         if (!clusterNames.isEmpty()) {
             Logger.getLogger(Model.class.getName()).log(Level.INFO,
-                    "Deferred reconfiguration requested for clusters %s, but not supported for model of version %s"
-                            .formatted(clusterNames, version()));
+                    String.format(java.util.Locale.ROOT,
+                            "Deferred reconfiguration requested for clusters %s, but not supported for model of version %s",
+                            clusterNames, version()));
         }
     }
 }

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -18,6 +18,7 @@ import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provision.zone.AuthMethod;
 import com.yahoo.test.ManualClock;
+import com.yahoo.text.Text;
 import org.junit.Test;
 
 import java.io.StringReader;
@@ -1452,10 +1453,10 @@ public class DeploymentSpecTest {
                              </endpoints>
                            </instance>
                          </deployment>""";
-        assertInvalid(String.format(xmlForm, "id='foo' region='us-east'", "<region>us-east</region>"), "Instance-level endpoint 'foo': invalid 'region' attribute");
-        assertInvalid(String.format(xmlForm, "id='foo'", "<instance>us-east</instance>"), "Instance-level endpoint 'foo': invalid element 'instance'");
-        assertInvalid(String.format(xmlForm, "type='zone'", "<instance>us-east</instance>"), "Instance-level endpoint: invalid element 'instance'");
-        assertInvalid(String.format(xmlForm, "type='private'", "<instance>us-east</instance>"), "Instance-level endpoint: invalid element 'instance'");
+        assertInvalid(Text.format(xmlForm, "id='foo' region='us-east'", "<region>us-east</region>"), "Instance-level endpoint 'foo': invalid 'region' attribute");
+        assertInvalid(Text.format(xmlForm, "id='foo'", "<instance>us-east</instance>"), "Instance-level endpoint 'foo': invalid element 'instance'");
+        assertInvalid(Text.format(xmlForm, "type='zone'", "<instance>us-east</instance>"), "Instance-level endpoint: invalid element 'instance'");
+        assertInvalid(Text.format(xmlForm, "type='private'", "<instance>us-east</instance>"), "Instance-level endpoint: invalid element 'instance'");
     }
 
     @Test
@@ -1481,16 +1482,16 @@ public class DeploymentSpecTest {
                            </endpoints>
                          </deployment>
                          """;
-        assertInvalid(String.format(xmlForm, "", "weight='1'", "", "main", ""), "'region' attribute must be declared on either <endpoint> or <instance> tag");
-        assertInvalid(String.format(xmlForm, "region='us-west-1'", "weight='1'", "region='us-west-1'", "main", ""), "'region' attribute must be declared on either <endpoint> or <instance> tag");
-        assertInvalid(String.format(xmlForm, "region='us-west-1'", "", "", "main", ""), "Missing required attribute 'weight' in 'instance");
-        assertInvalid(String.format(xmlForm, "region='us-west-1'", "weight='1'", "", "", ""), "Application-level endpoint 'foo': empty 'instance' element");
-        assertInvalid(String.format(xmlForm, "region='invalid'", "weight='1'", "", "main", ""), "Application-level endpoint 'foo': targets undeclared region 'invalid' in instance 'main'");
-        assertInvalid(String.format(xmlForm, "region='us-west-1'", "weight='foo'", "", "main", ""), "Application-level endpoint 'foo': invalid weight value 'foo'");
-        assertInvalid(String.format(xmlForm, "region='us-west-1'", "weight='1'", "", "main", "<region>us-east-3</region>"), "Application-level endpoint 'foo': invalid element 'region'");
-        assertInvalid(String.format(xmlForm, "region='us-west-1'", "weight='0'", "", "main", ""), "Application-level endpoint 'foo': sum of all weights must be positive, got 0");
-        assertInvalid(String.format(xmlForm, "type='zone'", "weight='1'", "", "main", ""), "Endpoints at application level cannot be of type 'zone'");
-        assertInvalid(String.format(xmlForm, "type='private'", "weight='1'", "", "main", ""), "Endpoints at application level cannot be of type 'private'");
+        assertInvalid(Text.format(xmlForm, "", "weight='1'", "", "main", ""), "'region' attribute must be declared on either <endpoint> or <instance> tag");
+        assertInvalid(Text.format(xmlForm, "region='us-west-1'", "weight='1'", "region='us-west-1'", "main", ""), "'region' attribute must be declared on either <endpoint> or <instance> tag");
+        assertInvalid(Text.format(xmlForm, "region='us-west-1'", "", "", "main", ""), "Missing required attribute 'weight' in 'instance");
+        assertInvalid(Text.format(xmlForm, "region='us-west-1'", "weight='1'", "", "", ""), "Application-level endpoint 'foo': empty 'instance' element");
+        assertInvalid(Text.format(xmlForm, "region='invalid'", "weight='1'", "", "main", ""), "Application-level endpoint 'foo': targets undeclared region 'invalid' in instance 'main'");
+        assertInvalid(Text.format(xmlForm, "region='us-west-1'", "weight='foo'", "", "main", ""), "Application-level endpoint 'foo': invalid weight value 'foo'");
+        assertInvalid(Text.format(xmlForm, "region='us-west-1'", "weight='1'", "", "main", "<region>us-east-3</region>"), "Application-level endpoint 'foo': invalid element 'region'");
+        assertInvalid(Text.format(xmlForm, "region='us-west-1'", "weight='0'", "", "main", ""), "Application-level endpoint 'foo': sum of all weights must be positive, got 0");
+        assertInvalid(Text.format(xmlForm, "type='zone'", "weight='1'", "", "main", ""), "Endpoints at application level cannot be of type 'zone'");
+        assertInvalid(Text.format(xmlForm, "type='private'", "weight='1'", "", "main", ""), "Endpoints at application level cannot be of type 'private'");
     }
 
     @Test

--- a/config-model-api/src/test/java/com/yahoo/config/model/api/ModelContextTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/model/api/ModelContextTest.java
@@ -3,6 +3,7 @@ package com.yahoo.config.model.api;
 
 import org.junit.Test;
 
+import com.yahoo.text.Text;
 import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertNotNull;
@@ -17,7 +18,7 @@ public class ModelContextTest {
     public void verify_all_feature_flag_methods_have_annotation() {
         for (Method method : ModelContext.FeatureFlags.class.getDeclaredMethods()) {
             assertNotNull(
-                    String.format(
+                    Text.format(
                             "Method '%s' is not annotated with '%s'",
                             method.getName(), ModelContext.ModelFeatureFlag.class.getSimpleName()),
                     method.getDeclaredAnnotation(ModelContext.ModelFeatureFlag.class));
@@ -28,7 +29,7 @@ public class ModelContextTest {
     public void verify_all_feature_flag_methods_have_default_implementation() {
         for (Method method : ModelContext.FeatureFlags.class.getDeclaredMethods()) {
             assertTrue(
-                    String.format("Method '%s' has no default implementation", method.getName()),
+                    Text.format("Method '%s' has no default implementation", method.getName()),
                     method.isDefault());
         }
     }


### PR DESCRIPTION
Standardize string formatting across config-model-api by using Text.format instead of String.format/formatted(). Also make all toLowerCase() calls explicit by specifying Locale.ROOT to avoid locale-dependent behavior in string comparisons and formatting.
