### PR TITLE
Ensure UTF-8 in config application package

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/application/ConfigDefinitionDir.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/ConfigDefinitionDir.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A @{link ConfigDefinitionDir} contains a set of config definitions. New definitions may be added,
@@ -41,7 +42,7 @@ public class ConfigDefinitionDir {
                         " (got " + outFile.getAbsolutePath() + ")");
             }
             OutputStream out = new FileOutputStream(outFile);
-            out.write(def.contents.getBytes());
+            out.write(def.contents.getBytes(StandardCharsets.UTF_8));
             out.close();
         }
     }

--- a/config-application-package/src/main/java/com/yahoo/config/application/XmlPreProcessor.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/XmlPreProcessor.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Tags;
+import com.yahoo.text.Utf8;
 import com.yahoo.text.XML;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
@@ -51,7 +52,7 @@ public class XmlPreProcessor {
                            RegionName region,
                            CloudName cloud,
                            Tags tags) throws IOException {
-        this(applicationDir, new FileReader(xmlInput), instance, environment, region, cloud, tags);
+        this(applicationDir, Utf8.createReader(xmlInput), instance, environment, region, cloud, tags);
     }
 
     public XmlPreProcessor(File applicationDir,

--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationFile.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationFile.java
@@ -83,9 +83,8 @@ public class FilesApplicationFile extends ApplicationFile {
 
     @Override
     public Reader createReader() throws FileNotFoundException {
-        return new FileReader(file);
+        return Utf8.createReader(file);
     }
-
     @Override
     public InputStream createInputStream() throws FileNotFoundException {
         return new FileInputStream(file);

--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
@@ -21,6 +21,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.io.IOUtils;
 import com.yahoo.io.reader.NamedReader;
 import com.yahoo.path.Path;
+import com.yahoo.text.Utf8;
 import com.yahoo.vespa.config.ConfigDefinition;
 import com.yahoo.vespa.config.ConfigDefinitionBuilder;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
@@ -145,7 +146,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
                             readers.addAll(getFiles(relativePath.append(file.getName()), namePrefix + "/" + file.getName(), suffix, recurse));
                     } else {
                         if (suffix == null || file.getName().endsWith(suffix))
-                            readers.add(new NamedReader(file.getName(), new FileReader(file)));
+                            readers.add(new NamedReader(file.getName(), Utf8.createReader(file)));
                     }
                 }
             }
@@ -175,7 +176,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
         try {
             File hostsFile = applicationFile(HOSTS);
             if (!hostsFile.exists()) return null;
-            return new FileReader(hostsFile);
+            return Utf8.createReader(hostsFile);
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
@@ -238,7 +239,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
         Set<NamedReader> ret = new LinkedHashSet<>();
         try {
             for (File f : getSchemaFiles()) {
-                ret.add(new NamedReader(f.getName(), new FileReader(f)));
+                ret.add(new NamedReader(f.getName(), Utf8.createReader(f)));
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Couldn't get schema contents.", e);
@@ -254,7 +255,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
      */
     private Reader retrieveConfigDefReaderFromThis(File defPath) {
         try {
-            return new NamedReader(defPath.getPath(), new FileReader(defPath));
+            return new NamedReader(defPath.getPath(), Utf8.createReader(defPath));
         } catch (IOException e) {
             throw new IllegalArgumentException("Could not read config definition file '" + defPath + "'", e);
         }
@@ -335,8 +336,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
     @Override
     public Reader getServices() {
         try {
-            return new FileReader(applicationFile(SERVICES).getPath());
-        } catch (Exception e) {
+            return Utf8.createReader(applicationFile(SERVICES).getPath());        } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
     }
@@ -403,7 +403,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
         if ( ! metaFile.exists()) {
             return defaultMetaData;
         }
-        try (FileReader reader = new FileReader(metaFile)) {
+        try (Reader reader = Utf8.createReader(metaFile)) {
             return ApplicationMetaData.fromJsonString(IOUtils.readAll(reader));
         } catch (Exception e) {
             // Not a big deal, return default

--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/SchemaValidators.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/SchemaValidators.java
@@ -3,6 +3,7 @@ package com.yahoo.config.model.application.provider;
 
 import com.yahoo.component.Version;
 import com.yahoo.io.IOUtils;
+import com.yahoo.text.Text;
 import org.osgi.framework.Bundle;
 import org.xml.sax.SAXException;
 import java.io.File;
@@ -16,6 +17,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import static java.nio.file.Files.createTempDirectory;
@@ -123,7 +126,7 @@ public class SchemaValidators {
                     schemasFound = true;
                     copySchemas(schemaPath, tmpDir);
                 } else {
-                    log.log(Level.FINE, () -> String.format("Saving schemas for model bundle %s:%s", bundle.getSymbolicName(), bundle.getVersion()));
+                    log.log(Level.FINE, () -> Text.format("Saving schemas for model bundle %s:%s", bundle.getSymbolicName(), bundle.getVersion()));
                     for (Enumeration<URL> entries = bundle.findEntries("schema", "*.rnc", true); entries.hasMoreElements(); ) {
                         URL url = entries.nextElement();
                         writeContentsToFile(tmpDir, url.getFile(), url.openStream());
@@ -154,7 +157,7 @@ public class SchemaValidators {
     }
 
     private static void writeContentsToFile(File outDir, String outFile, InputStream inputStream) throws IOException {
-        String contents = IOUtils.readAll(new InputStreamReader(inputStream));
+        String contents = IOUtils.readAll(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
 
         // Validate and sanitize the output path
         File out = new File(outDir, outFile).getCanonicalFile();

--- a/config-application-package/src/test/java/com/yahoo/config/application/OverrideProcessorTest.java
+++ b/config-application-package/src/test/java/com/yahoo/config/application/OverrideProcessorTest.java
@@ -410,8 +410,8 @@ public class OverrideProcessorTest {
                         </container>
                         "</services>""";
 
-        assertOverride(input, "aws", expected.formatted("AwsSearcher"));
-        assertOverride(input, "gcp", expected.formatted("GcpSearcher"));
+        assertOverride(input, "aws", com.yahoo.text.Text.format(expected, "AwsSearcher"));
+        assertOverride(input, "gcp", com.yahoo.text.Text.format(expected, "GcpSearcher"));
     }
 
     private void assertOverride(Environment environment, RegionName region, String expected) throws TransformerException {

--- a/config-application-package/src/test/java/com/yahoo/config/model/application/provider/FilesApplicationPackageTest.java
+++ b/config-application-package/src/test/java/com/yahoo/config/model/application/provider/FilesApplicationPackageTest.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.io.IOUtils;
+import com.yahoo.text.Utf8;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -96,7 +97,7 @@ public class FilesApplicationPackageTest {
         assertTrue(app.getDeployment().isPresent());
         assertFalse(app.getDeploymentSpec().isEmpty());
         assertFalse(app.getMajorVersion().isPresent());
-        assertEquals(IOUtils.readAll(app.getDeployment().get()), IOUtils.readAll(new FileReader(deployment)));
+        assertEquals(IOUtils.readAll(app.getDeployment().get()), IOUtils.readAll(Utf8.createReader(deployment)));
     }
 
     @Test
@@ -108,7 +109,7 @@ public class FilesApplicationPackageTest {
         assertTrue(app.getDeployment().isPresent());
         assertTrue(app.getMajorVersion().isPresent());
         assertEquals(6, (int)app.getMajorVersion().get());
-        assertEquals(IOUtils.readAll(app.getDeployment().get()), IOUtils.readAll(new FileReader(deployment)));
+        assertEquals(IOUtils.readAll(app.getDeployment().get()), IOUtils.readAll(Utf8.createReader(deployment)));
     }
 
     @Test


### PR DESCRIPTION
Replace FileReader with Utf8.createReader() to avoid platform-dependent default charset issues. Use explicit StandardCharsets.UTF_8 when reading and writing file contents. Replace String.format() with Text.format() for consistency with Vespa text utilities.