### PR TITLE
Use Text.format and locale-independent operations

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/FlagDefinition.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FlagDefinition.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
+import com.yahoo.text.Text;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
@@ -61,7 +62,7 @@ public class FlagDefinition {
     private static void validate(List<String> owners, Instant createdAt, Instant expiresAt, List<Dimension> dimensions) {
         if (expiresAt.isBefore(createdAt)) {
             throw new IllegalArgumentException(
-                    String.format(
+                    Text.format(
                             "Flag cannot expire before its creation date (createdAt='%s', expiresAt='%s')",
                             createdAt, expiresAt));
         }

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/CustomerRpmService.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/CustomerRpmService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.text.Text;
 
 import java.util.List;
 import java.util.Objects;
@@ -150,8 +151,7 @@ public class CustomerRpmService {
 
     @Override
     public String toString() {
-        return "{ unit: %s, package: %s, memory: %s MiB, cpu: %s, repositories: %s, disabled: %s }"
-                .formatted(
+        return Text.format("{ unit: %s, package: %s, memory: %s MiB, cpu: %s, repositories: %s, disabled: %s }",
                         unitName(), packageName(), memoryLimitMib(),
                         cpuLimitCores().map(Object::toString).orElse("unlimited"),
                         String.join(", ", repositories()),

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/Sidecar.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/Sidecar.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.text.Text;
 
 import java.util.List;
 import java.util.Map;
@@ -26,21 +27,21 @@ public record Sidecar(
         @JsonProperty("command") List<String> command) {
     private static final int MIN_ID = 0;
     private static final int MAX_ID = 99;
-    
+
     @JsonCreator
     public Sidecar {
         if (id < MIN_ID || id > MAX_ID) {
-            throw new IllegalArgumentException("Sidecar id must be between 0 and 99, actual: %s".formatted(id));
+            throw new IllegalArgumentException(Text.format("Sidecar id must be between 0 and 99, actual: %s", id));
         }
-        
+
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Sidecar name must be specified");
         }
-        
+
         if (image == null || image.isBlank()) {
             throw new IllegalArgumentException("Sidecar image must be specified");
         }
-        
+
         resources = resources == null ? SidecarResources.DEFAULT : resources;
         volumeMounts = volumeMounts == null ? List.of() : volumeMounts;
         envs = envs == null ? Map.of() : envs;

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/SidecarResources.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/SidecarResources.java
@@ -5,15 +5,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.text.Text;
 
 import java.util.HashSet;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public record SidecarResources(
-        @JsonProperty("maxCpu") double maxCpu, 
-        @JsonProperty("minCpu") double minCpu, 
-        @JsonProperty("memoryGiB") double memoryGiB, 
+        @JsonProperty("maxCpu") double maxCpu,
+        @JsonProperty("minCpu") double minCpu,
+        @JsonProperty("memoryGiB") double memoryGiB,
         @JsonProperty("gpu") String gpu) {
     // 0.0 means unlimited, gpu = null means no GPU
     public static SidecarResources DEFAULT = new SidecarResources(0.0, 0.0, 0.0, null);
@@ -21,20 +22,20 @@ public record SidecarResources(
     @JsonCreator
     public SidecarResources {
         if (maxCpu < 0) {
-            throw new IllegalArgumentException("maxCpu must be non-negative, actual %s".formatted(maxCpu));
+            throw new IllegalArgumentException(Text.format("maxCpu must be non-negative, actual %s", maxCpu));
         }
 
         if (minCpu < 0) {
-            throw new IllegalArgumentException("minCpu must be non-negative, actual %s".formatted(minCpu));
+            throw new IllegalArgumentException(Text.format("minCpu must be non-negative, actual %s", minCpu));
         }
 
         if (maxCpu != 0 && minCpu != 0 && maxCpu < minCpu) {
             throw new IllegalArgumentException(
-                    "Non-zero maxCpu must be greater than or equal to non-zero minCpu, actual %s and %s".formatted(maxCpu, minCpu));
+                    Text.format("Non-zero maxCpu must be greater than or equal to non-zero minCpu, actual %s and %s", maxCpu, minCpu));
         }
 
         if (memoryGiB < 0) {
-            throw new IllegalArgumentException("memoryGiB must be non-negative, actual %s".formatted(memoryGiB));
+            throw new IllegalArgumentException(Text.format("memoryGiB must be non-negative, actual %s", memoryGiB));
         }
 
         if (gpu != null && !gpu.equals("all")) {
@@ -46,23 +47,23 @@ public record SidecarResources(
 
                     if (trimmed.isEmpty()) {
                         throw new IllegalArgumentException(
-                                "GPU device indexes can't be empty, actual: %s".formatted(gpu));
+                                Text.format("GPU device indexes can't be empty, actual: %s", gpu));
                     }
 
                     int index = Integer.parseInt(trimmed);
 
                     if (index < 0) {
                         throw new IllegalArgumentException(
-                                "GPU device indexes must be non-negative, actual: %s".formatted(gpu));
+                                Text.format("GPU device indexes must be non-negative, actual: %s", gpu));
                     }
 
                     if (!indexes.add(index)) {
-                        throw new IllegalArgumentException("GPU device indexes contain duplicates: %s".formatted(gpu));
+                        throw new IllegalArgumentException(Text.format("GPU device indexes contain duplicates: %s", gpu));
                     }
                 }
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(
-                        "GPU must be null, \"all\", or comma-separated list of device indexes, actual: %s".formatted(
+                        Text.format("GPU must be null, \"all\", or comma-separated list of device indexes, actual: %s",
                                 gpu));
             }
         }

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/Sidecars.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/Sidecars.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.text.Text;
 
 import java.util.HashSet;
 import java.util.List;
@@ -22,7 +23,7 @@ public record Sidecars(@JsonProperty("sidecars") List<Sidecar> sidecars) {
         var ids = sidecars.stream().map(Sidecar::id).toList();
         var uniqueIds = new HashSet<>(ids);
         if (ids.size() != uniqueIds.size()) {
-            throw new IllegalArgumentException("Sidecar IDs must be unique, actual: %s".formatted(
+            throw new IllegalArgumentException(Text.format("Sidecar IDs must be unique, actual: %s",
                     ids.stream().map(String::valueOf).collect(Collectors.joining(", "))));
         }
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/Condition.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/Condition.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.json.wire.WireCondition;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -19,7 +20,7 @@ public interface Condition extends Predicate<FetchVector> {
         BLACKLIST,
         RELATIONAL;
 
-        public String toWire() { return name().toLowerCase(); }
+        public String toWire() { return name().toLowerCase(Locale.ROOT); }
 
         public static Type fromWire(String typeString) {
             for (Type type : values()) {

--- a/flags/src/test/java/com/yahoo/vespa/flags/PermanentFlagsTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/PermanentFlagsTest.java
@@ -7,6 +7,7 @@ import com.yahoo.vespa.flags.json.FlagData;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static com.yahoo.vespa.flags.FlagsTest.testGeneric;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,7 +38,7 @@ class PermanentFlagsTest {
     }
 
     private static FlagData wantedDockerTagFlagData(String value) {
-        return FlagData.deserialize("""
+        return FlagData.deserialize(String.format(Locale.ROOT, """
                 {
                     "id": "wanted-docker-tag",
                     "rules": [
@@ -46,7 +47,7 @@ class PermanentFlagsTest {
                         }
                     ]
                 }
-                """.formatted(value));
+                """, value));
     }
 
 }

--- a/flags/src/test/java/com/yahoo/vespa/flags/json/SerializationTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/json/SerializationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -168,7 +169,7 @@ public class SerializationTest {
         try (var cleanup = Flags.clearFlagsForTesting()) {
             String id = "id1";
             UnboundFlag<Double, ?, ?> doubleFlag = Flags.defineDoubleFlag(id, 1.2, List.of(), "1970-01-01", "2100-01-01", "description", "modification effect");
-            String json = """
+            String json = String.format(Locale.ROOT, """
                           {
                               "id": "%s",
                               "rules": [
@@ -177,7 +178,7 @@ public class SerializationTest {
                                   }
                               ]
                           }
-                          """.formatted(id, jsonValue);
+                          """, id, jsonValue);
             FlagData data = FlagData.deserialize(json);
             FlagSource flagSource = new SimpleFlagSource(data);
             return doubleFlag.bindTo(flagSource).boxedValue();


### PR DESCRIPTION
- Replace String.format() and .formatted() with Text.format() throughout flags module
- Add Locale.ROOT to toLowerCase() and String.format() calls for locale independence
- Add necessary imports for com.yahoo.text.Text and java.util.Locale

This ensures consistent string formatting and locale-independent string operations.