### PR TITLE
Use explicit locale in file distribution modules

### DIFF
--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
@@ -11,6 +11,7 @@ import com.yahoo.jrt.Transport;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -159,7 +160,7 @@ class FileAcquirerImpl implements FileAcquirer {
             }
         } while ( timer.isTimeLeft() );
 
-        throw new TimeoutException("Timed out waiting for " + fileReference + " after " + timeout + " " + timeUnit.name().toLowerCase());
+        throw new TimeoutException("Timed out waiting for " + fileReference + " after " + timeout + " " + timeUnit.name().toLowerCase(Locale.ROOT));
     }
 
 }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/RpcTester.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/RpcTester.java
@@ -13,15 +13,16 @@ import com.yahoo.jrt.StringValue;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Target;
 import com.yahoo.jrt.Transport;
+import com.yahoo.text.Text;
 
-import java.time.Duration;
-import java.util.logging.Level;
 import net.jpountz.xxhash.XXHash64;
 import net.jpountz.xxhash.XXHashFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class RpcTester {
@@ -42,7 +43,7 @@ public class RpcTester {
         //String fileReference = args[0];
         String fileReference = "59f93f445438c9db7ccbf1629f583c2aa004a68b";
         String filename = "com.yahoo.vespatest.ExtraHitSearcher-1.0.0-deploy.jar";
-        File file = new File(String.format("/tmp/%s/%s", fileReference, filename));
+        File file = new File(Text.format("/tmp/%s/%s", fileReference, filename));
         byte[] blob = null;
 
         try {

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileReceiverTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileReceiverTest.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import static com.yahoo.vespa.filedistribution.FileReferenceData.CompressionType;
@@ -55,10 +56,10 @@ public class FileReceiverTest {
     @Test
     public void receiveCompressedParts() throws IOException{
         File dirWithFiles = temporaryFolder.newFolder("files");
-        FileWriter writerA = new FileWriter(new File(dirWithFiles, "a"));
+        FileWriter writerA = new FileWriter(new File(dirWithFiles, "a"), StandardCharsets.UTF_8);
         writerA.write("1");
         writerA.close();
-        FileWriter writerB = new FileWriter(new File(dirWithFiles, "b"));
+        FileWriter writerB = new FileWriter(new File(dirWithFiles, "b"), StandardCharsets.UTF_8);
         writerB.write("2");
         writerB.close();
 


### PR DESCRIPTION
- Use Locale.ROOT for toLowerCase() to avoid locale-dependent behavior
- Replace String.format with Text.format for consistency
- Specify StandardCharsets.UTF_8 explicitly in FileWriter constructors
