### PR TITLE
Locale-independent operations in container-search

### DIFF
--- a/container-search/src/main/java/ai/vespa/search/llm/LLMSearcher.java
+++ b/container-search/src/main/java/ai/vespa/search/llm/LLMSearcher.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.search.llm;
+import java.nio.charset.StandardCharsets;
 
 import ai.vespa.llm.InferenceParameters;
 import ai.vespa.llm.LanguageModel;
@@ -78,7 +79,7 @@ public class LLMSearcher extends Searcher {
         } else if (config.promptTemplate().isPresent()) {
             Path path = config.promptTemplate().get();
             try {
-                return new String(Files.readAllBytes(path));
+                return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new IllegalArgumentException("Could not read prompt template file: " + path, e);
             }

--- a/container-search/src/main/java/com/yahoo/prelude/Freshness.java
+++ b/container-search/src/main/java/com/yahoo/prelude/Freshness.java
@@ -2,6 +2,8 @@
 package com.yahoo.prelude;
 
 import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static com.yahoo.text.Lowercase.toLowerCase;
 
@@ -51,7 +53,7 @@ public class Freshness {
 
     /** Calculates the current time since epoch in seconds */
     public long getSystemTimeInSecondsSinceEpoch() {
-        long msSinceEpochNow = Calendar.getInstance().getTimeInMillis();
+        long msSinceEpochNow = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT).getTimeInMillis();
         return (msSinceEpochNow/1000);
     }
 

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
@@ -20,6 +20,7 @@ import com.yahoo.search.result.Hit;
 import com.yahoo.searchlib.aggregation.Grouping;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -236,7 +237,7 @@ public abstract class VespaBackend {
         if ((query.getTrace().getLevel()<level) || !query.getTrace().getQuery()) return;
 
         StringBuilder s = new StringBuilder();
-        s.append(sourceName).append(" ").append(phase.name().toLowerCase()).append(" to dispatch: ")
+        s.append(sourceName).append(" ").append(phase.name().toLowerCase(Locale.ROOT)).append(" to dispatch: ")
                 .append("query=[")
                 .append(query.getModel().getQueryTree().getRoot().toString())
                 .append("]");

--- a/container-search/src/main/java/com/yahoo/prelude/query/BoolItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/BoolItem.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.query;
+import java.util.Locale;
 
 import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
 import com.yahoo.processing.IllegalInputException;
@@ -61,7 +62,7 @@ public class BoolItem extends TermItem {
     }
 
     private boolean toBoolean(String stringValue) {
-        return switch (stringValue.toLowerCase()) {
+        return switch (stringValue.toLowerCase(Locale.ROOT)) {
             case "true" -> true;
             case "false" -> false;
             default -> throw new IllegalInputException("Expected 'true' or 'false', got '" + stringValue + "'");

--- a/container-search/src/main/java/com/yahoo/prelude/query/QueryCanonicalizer.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/QueryCanonicalizer.java
@@ -4,6 +4,7 @@ package com.yahoo.prelude.query;
 import com.yahoo.search.Query;
 import com.yahoo.search.query.QueryTree;
 import com.yahoo.search.query.properties.DefaultProperties;
+import com.yahoo.text.Text;
 
 import java.util.ListIterator;
 import java.util.Objects;
@@ -41,7 +42,7 @@ public class QueryCanonicalizer {
 
     /**
      * Canonicalizes this query
-     * 
+     *
      * @return null if the query is valid, an error message if it is invalid
      */
     private static String canonicalize(QueryTree query, Integer maxQueryItems) {
@@ -50,13 +51,13 @@ public class QueryCanonicalizer {
         if (query.isEmpty() && ! result.isError()) result = CanonicalizationResult.error("No query");
         int itemCount = query.treeSize();
         if (itemCount > maxQueryItems)
-            result = CanonicalizationResult.error(String.format("Query tree exceeds allowed item count. Configured limit: %d - Item count: %d", maxQueryItems, itemCount));
+            result = CanonicalizationResult.error(Text.format("Query tree exceeds allowed item count. Configured limit: %d - Item count: %d", maxQueryItems, itemCount));
         return result.error().orElse(null); // preserve old API, unfortunately
     }
 
     /**
      * Canonicalize this query
-     * 
+     *
      * @param item the item to canonicalize
      * @param parentIterator iterator for the parent of this item, never null
      * @return result of canonicalization
@@ -72,7 +73,7 @@ public class QueryCanonicalizer {
 
         return canonicalizeThis(item, parentIterator);
     }
-    
+
     private static CanonicalizationResult canonicalizeThis(Item item, ListIterator<Item> parentIterator) {
         if (item instanceof NullItem) parentIterator.remove();
         if ( ! (item instanceof CompositeItem composite)) return CanonicalizationResult.success();
@@ -102,7 +103,7 @@ public class QueryCanonicalizer {
                 collapseLevels(composite, i);
         }
     }
-    
+
     /** Collapse the next item of this iterator into the given parent, if appropriate */
     private static void collapseLevels(CompositeItem composite, ListIterator<Item> i) {
         if ( ! i.hasNext()) return;
@@ -126,9 +127,9 @@ public class QueryCanonicalizer {
             toIterator.add(i.next());
     }
 
-    /** 
+    /**
      * Handle FALSE items in the immediate children of this
-     * 
+     *
      * @return true if this composite was replaced by FALSE
      */
     private static boolean collapseFalse(CompositeItem composite, ListIterator<Item> parentIterator) {
@@ -157,7 +158,7 @@ public class QueryCanonicalizer {
             return false;
         }
     }
-    
+
     private static boolean containsFalse(CompositeItem composite) {
         for (ListIterator<Item> i = composite.getItemIterator(); i.hasNext(); )
             if (i.next() instanceof FalseItem) return true;
@@ -169,7 +170,7 @@ public class QueryCanonicalizer {
             if (iterator.next() instanceof FalseItem)
                 iterator.remove();
     }
-    
+
     private static void removeDuplicates(EquivItem composite) {
         int origSize = composite.getItemCount();
         for (int i = origSize - 1; i >= 1; --i) {
@@ -208,12 +209,12 @@ public class QueryCanonicalizer {
         private CanonicalizationResult(Optional<String> error) {
             this.error = error;
         }
-        
+
         /** Returns the error of this query, or empty if it is a valid query */
         public Optional<String> error() {
             return error;
         }
-    
+
         public static CanonicalizationResult error(String error) {
             return new CanonicalizationResult(Optional.of(error));
         }
@@ -221,7 +222,7 @@ public class QueryCanonicalizer {
         public static CanonicalizationResult success() {
             return new CanonicalizationResult(Optional.empty());
         }
-        
+
         public boolean isError() { return error.isPresent(); }
 
     }

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/ValidatePredicateSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/ValidatePredicateSearcher.java
@@ -14,6 +14,7 @@ import com.yahoo.search.Searcher;
 import com.yahoo.search.querytransform.BooleanSearcher;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
+import com.yahoo.text.Text;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,13 +68,13 @@ public class ValidatePredicateSearcher extends Searcher {
         private void visit(PredicateQueryItem item) {
             Index index = getIndexFromUnionOfDocumentTypes(item.getIndexName());
             if (!index.isPredicate()) {
-                errorMessages.add(ErrorMessage.createIllegalQuery(String.format("Index '%s' is not a predicate attribute.", index.getName())));
+                errorMessages.add(ErrorMessage.createIllegalQuery(Text.format("Index '%s' is not a predicate attribute.", index.getName())));
             }
             for (PredicateQueryItem.RangeEntry entry : item.getRangeFeatures()) {
                 long value = entry.getValue();
                 if (value < index.getPredicateLowerBound() || value > index.getPredicateUpperBound()) {
                     errorMessages.add(
-                            ErrorMessage.createIllegalQuery(String.format("%s=%d outside configured predicate bounds.", entry.getKey(), value)));
+                            ErrorMessage.createIllegalQuery(Text.format("%s=%d outside configured predicate bounds.", entry.getKey(), value)));
                 }
             }
         }
@@ -83,7 +84,7 @@ public class ValidatePredicateSearcher extends Searcher {
             Index index = getIndexFromUnionOfDocumentTypes(indexName);
             if (index.isPredicate()) {
                 errorMessages.add(
-                        ErrorMessage.createIllegalQuery(String.format("Index '%s' is predicate attribute and can only be used in conjunction with a predicate query operator.", indexName)));
+                        ErrorMessage.createIllegalQuery(Text.format("Index '%s' is predicate attribute and can only be used in conjunction with a predicate query operator.", indexName)));
             }
         }
 

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/benchmark/RuleBaseBenchmark.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/benchmark/RuleBaseBenchmark.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.semantics.benchmark;
+import java.nio.charset.StandardCharsets;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -14,6 +15,7 @@ import com.yahoo.search.Query;
 import com.yahoo.prelude.semantics.RuleBase;
 import com.yahoo.prelude.semantics.RuleImporter;
 import com.yahoo.prelude.semantics.parser.ParseException;
+import com.yahoo.text.Utf8;
 
 public class RuleBaseBenchmark {
 
@@ -30,7 +32,7 @@ public class RuleBaseBenchmark {
         }
         RuleBase ruleBase = new RuleImporter(new SimpleLinguistics()).importFile(ruleBaseFile, fsaFile);
         ArrayList<String> queries = new ArrayList<>();
-        BufferedReader reader = new BufferedReader(new FileReader(queryFile));
+        BufferedReader reader = new BufferedReader(Utf8.createReader(queryFile));
         String line;
         while((line=reader.readLine())!=null){
             queries.add(line);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/GroupingResultAggregator.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/GroupingResultAggregator.java
@@ -6,6 +6,7 @@ import com.yahoo.prelude.fastsearch.GroupingListHit;
 import com.yahoo.search.Query;
 import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.searchlib.aggregation.Hit;
+import com.yahoo.text.Text;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,7 +33,7 @@ class GroupingResultAggregator {
         if (documentDatabase == null) documentDatabase = result.getDocumentDatBase();
         if (query == null) query = result.getQuery();
         log.log(Level.FINE, () ->
-                String.format("Merging hit #%d having %d groupings",
+                Text.format("Merging hit #%d having %d groupings",
                         groupingHitsMerged, result.getGroupingList().size()));
         for (Grouping grouping : result.getGroupingList()) {
             groupings.merge(grouping.getId(), grouping, (existingGrouping, newGrouping) -> {
@@ -45,7 +46,7 @@ class GroupingResultAggregator {
     Optional<GroupingListHit> toAggregatedHit() {
         if (groupingHitsMerged == 0) return Optional.empty();
         log.log(Level.FINE, () ->
-                String.format("Creating aggregated hit containing %d groupings from %d hits with docsums '%s' and %s",
+                Text.format("Creating aggregated hit containing %d groupings from %d hits with docsums '%s' and %s",
                         groupings.size(), groupingHitsMerged, documentDatabase.getDocsumDefinitionSet(), query));
         GroupingListHit groupingHit = new GroupingListHit(List.copyOf(groupings.values()), documentDatabase, query);
         groupingHit.setQuery(query);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/CompressService.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/CompressService.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch.rpc;
+import java.util.Locale;
 
 import com.yahoo.compress.CompressionType;
 import com.yahoo.compress.Compressor;
@@ -19,7 +20,7 @@ public class CompressService implements CompressPayload {
 
     @Override
     public Compressor.Compression compress(Query query, byte[] payload) {
-        CompressionType compression = CompressionType.valueOf(query.properties().getString(dispatchCompression, "LZ4").toUpperCase());
+        CompressionType compression = CompressionType.valueOf(query.properties().getString(dispatchCompression, "LZ4").toUpperCase(Locale.ROOT));
         return compressor.compress(compression, payload);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/NotPredicate.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.grouping.request;
 
 import com.yahoo.api.annotations.Beta;
+import com.yahoo.text.Text;
 
 import java.util.Objects;
 
@@ -26,7 +27,7 @@ public class NotPredicate extends FilterExpression {
 
     @Override
     public String toString() {
-        return "(not %s".formatted(expression) + ")";
+        return Text.format("(not %s)", expression);
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/RegexPredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/RegexPredicate.java
@@ -2,9 +2,11 @@
 package com.yahoo.search.grouping.request;
 
 import com.yahoo.api.annotations.Beta;
+import com.yahoo.text.Text;
 
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
+
 
 /**
  * Represents a filter expression that matches a value from the evaluated expression against a regex.
@@ -28,7 +30,7 @@ public class RegexPredicate extends FilterExpression {
         try {
             Pattern.compile(pattern);
         } catch (PatternSyntaxException e) {
-            throw new IllegalArgumentException("Invalid regex pattern: %s (%s)".formatted(pattern, e.getMessage()), e);
+            throw new IllegalArgumentException(Text.format("Invalid regex pattern: %s (%s)", pattern, e.getMessage()), e);
         }
     }
 
@@ -47,6 +49,6 @@ public class RegexPredicate extends FilterExpression {
     public String getPattern() { return pattern; }
     public GroupingExpression getExpression() { return expression; }
 
-    @Override public String toString() { return "regex(\"%s\", %s)".formatted(pattern, expression); }
+    @Override public String toString() { return Text.format("regex(\"%s\", %s)", pattern, expression); }
     @Override public FilterExpression copy() { return new RegexPredicate(pattern, expression.copy()); }
 }

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
@@ -166,6 +166,7 @@ import com.yahoo.searchlib.expression.UcaFunctionNode;
 import com.yahoo.searchlib.expression.XorBitFunctionNode;
 import com.yahoo.searchlib.expression.XorFunctionNode;
 import com.yahoo.searchlib.expression.ZCurveFunctionNode;
+import com.yahoo.text.Text;
 
 /**
  * This is a helper class for {@link RequestBuilder} that offloads the code to convert {@link GroupingExpression} type
@@ -281,7 +282,7 @@ class ExpressionConverter {
             return new AndPredicateNode(args);
         } else {
             throw new IllegalInputException(
-                    "Can not convert '%s' to a filter expression.".formatted(expression.getClass().getSimpleName()));
+                    Text.format("Can not convert \'%s\' to a filter expression.", expression.getClass().getSimpleName()));
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/RequestBuilder.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/RequestBuilder.java
@@ -18,14 +18,15 @@ import com.yahoo.searchlib.aggregation.HitsAggregationResult;
 import com.yahoo.searchlib.expression.ExpressionNode;
 import com.yahoo.searchlib.expression.FilterExpressionNode;
 import com.yahoo.searchlib.expression.RangeBucketPreDefFunctionNode;
+import com.yahoo.text.Text;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalLong;
-import java.util.Deque;
 import java.util.TimeZone;
 
 /**
@@ -434,7 +435,7 @@ class RequestBuilder {
             }
         }
         if (totalGroupsAndSummaries > globalMaxGroups)
-            throw new IllegalInputException(String.format(
+            throw new IllegalInputException(Text.format(
                     "The theoretical total number of groups and summaries in grouping query exceeds " +
                             "'grouping.globalMaxGroups' ( %d > %d ). " +
                             "Either restrict group/summary counts with max() or disable 'grouping.globalMaxGroups'. " +

--- a/container-search/src/main/java/com/yahoo/search/logging/AbstractThreadedLogger.java
+++ b/container-search/src/main/java/com/yahoo/search/logging/AbstractThreadedLogger.java
@@ -3,6 +3,7 @@
 package com.yahoo.search.logging;
 
 import com.yahoo.component.AbstractComponent;
+import com.yahoo.text.Text;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -74,7 +75,7 @@ abstract class AbstractThreadedLogger extends AbstractComponent implements Logge
             try {
                 super.run();
             } catch (Exception e) {
-                log.log(Level.SEVERE, String.format("Error while sending logger entry: %s", e), e);
+                log.log(Level.SEVERE, Text.format("Error while sending logger entry: %s", e), e);
             }
         }
 

--- a/container-search/src/main/java/com/yahoo/search/logging/LocalDiskLogger.java
+++ b/container-search/src/main/java/com/yahoo/search/logging/LocalDiskLogger.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 package com.yahoo.search.logging;
+import java.nio.charset.StandardCharsets;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -16,7 +17,7 @@ public class LocalDiskLogger extends AbstractThreadedLogger {
     @Override
     public boolean transport(LoggerEntry entry) {
         String json = entry.serialize();
-        try (FileWriter fw = new FileWriter(logFilePath, true)) {
+        try (FileWriter fw = new FileWriter(logFilePath, StandardCharsets.UTF_8, true)) {
             fw.write(json);
             fw.write(System.getProperty("line.separator"));
             return true;

--- a/container-search/src/main/java/com/yahoo/search/mcp/McpSearchSpecProvider.java
+++ b/container-search/src/main/java/com/yahoo/search/mcp/McpSearchSpecProvider.java
@@ -18,6 +18,7 @@ import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.ExecutionFactory;
 import com.yahoo.tensor.Tensor;
+import com.yahoo.text.Text;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
 

--- a/container-search/src/main/java/com/yahoo/search/pagetemplates/config/PageTemplateXMLReader.java
+++ b/container-search/src/main/java/com/yahoo/search/pagetemplates/config/PageTemplateXMLReader.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.pagetemplates.config;
+import java.nio.charset.StandardCharsets;
 
 import com.yahoo.component.ComponentId;
 import com.yahoo.io.reader.NamedReader;
@@ -15,6 +16,7 @@ import com.yahoo.search.pagetemplates.model.Renderer;
 import com.yahoo.search.pagetemplates.model.Section;
 import com.yahoo.search.pagetemplates.model.Source;
 import com.yahoo.search.query.Sorting;
+import com.yahoo.text.Utf8;
 import com.yahoo.text.XML;
 import org.w3c.dom.Element;
 
@@ -58,7 +60,7 @@ public class PageTemplateXMLReader {
 
             for (File file : sortFiles(dir)) {
                 if ( ! file.getName().endsWith(".xml")) continue;
-                pageReaders.add(new NamedReader(file.getName(), new FileReader(file)));
+                pageReaders.add(new NamedReader(file.getName(), Utf8.createReader(file)));
             }
 
             return read(pageReaders, true);
@@ -82,7 +84,7 @@ public class PageTemplateXMLReader {
         NamedReader pageReader = null;
         try {
             File file = new File(fileName);
-            pageReader = new NamedReader(fileName,new FileReader(file));
+            pageReader = new NamedReader(fileName,Utf8.createReader(file));
             String firstName = file.getName().substring(0, file.getName().length() - 4);
             return read(List.of(pageReader), true).getComponent(firstName);
         }

--- a/container-search/src/main/java/com/yahoo/search/query/Sorting.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Sorting.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query;
+import java.util.Locale;
 
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.ULocale;
@@ -149,7 +150,7 @@ public class Sorting implements Cloneable {
     private static MissingPolicy decodeMissingPolicy(Tokenizer tokenizer) {
         var policyName = tokenizer.token();
         try {
-            return MissingPolicy.valueOf(policyName.toUpperCase());
+            return MissingPolicy.valueOf(policyName.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             throw new IllegalInputException("Unknown missing policy '" + policyName +"' at " + tokenizer.spec());
         }

--- a/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileXMLReader.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileXMLReader.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.profile.config;
+import java.nio.charset.StandardCharsets;
 
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
@@ -11,6 +12,7 @@ import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.FieldType;
 import com.yahoo.search.query.profile.types.QueryProfileType;
 import com.yahoo.search.query.profile.types.QueryProfileTypeRegistry;
+import com.yahoo.text.Utf8;
 import com.yahoo.text.XML;
 import org.w3c.dom.Element;
 
@@ -44,13 +46,13 @@ public class QueryProfileXMLReader {
 
             for (File file : sortFiles(dir)) {
                 if ( ! file.getName().endsWith(".xml")) continue;
-                queryProfileReaders.add(new NamedReader(file.getName(), new FileReader(file)));
+                queryProfileReaders.add(new NamedReader(file.getName(), Utf8.createReader(file)));
             }
             File typeDir = new File(dir,"types");
             if (typeDir.isDirectory()) {
                 for (File file : sortFiles(typeDir)) {
                     if ( ! file.getName().endsWith(".xml")) continue;
-                    queryProfileTypeReaders.add(new NamedReader(file.getName(), new FileReader(file)));
+                    queryProfileTypeReaders.add(new NamedReader(file.getName(), Utf8.createReader(file)));
                 }
             }
 

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.properties;
+import java.util.Locale;
 
 import com.yahoo.language.process.Embedder;
 import com.yahoo.processing.IllegalInputException;
@@ -64,7 +65,7 @@ public class QueryProperties extends Properties {
 
     private static void addDualCasedRM(Map<CompoundName, GetterSetter> map, String last, GetterSetter accessor) {
         map.put(CompoundName.fromComponents(Ranking.RANKING, Matching.MATCHING, last), accessor);
-        map.put(CompoundName.fromComponents(Ranking.RANKING, Matching.MATCHING, last.toLowerCase()), accessor);
+        map.put(CompoundName.fromComponents(Ranking.RANKING, Matching.MATCHING, last.toLowerCase(Locale.ROOT)), accessor);
     }
 
     private static final Map<CompoundName, GetterSetter> propertyAccessors = createPropertySetterMap();

--- a/container-search/src/main/java/com/yahoo/search/rendering/SyncDefaultRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/SyncDefaultRenderer.java
@@ -1,4 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 package com.yahoo.search.rendering;
 
 import com.yahoo.concurrent.CopyOnWriteHashMap;
@@ -20,6 +21,7 @@ import com.yahoo.search.result.Hit;
 import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.result.Relevance;
 import com.yahoo.search.result.StructuredData;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8String;
 import com.yahoo.text.XML;
 import com.yahoo.text.XMLWriter;
@@ -151,10 +153,10 @@ public final class SyncDefaultRenderer extends Renderer {
             final long summaryFetchTime = now - result.getElapsedTime().firstFill();
             final double querySeconds = ((double) queryTime) * milli;
             final double summarySeconds = ((double) summaryFetchTime) * milli;
-            writer.attribute(QUERY_TIME, String.format(threeDecimals, querySeconds));
-            writer.attribute(SUMMARY_FETCH_TIME, String.format(threeDecimals, summarySeconds));
+            writer.attribute(QUERY_TIME, Text.format(threeDecimals, querySeconds));
+            writer.attribute(SUMMARY_FETCH_TIME, Text.format(threeDecimals, summarySeconds));
         }
-        writer.attribute(SEARCH_TIME, String.format(threeDecimals, searchSeconds));
+        writer.attribute(SEARCH_TIME, Text.format(threeDecimals, searchSeconds));
     }
 
     protected static void renderCoverageAttributes(Coverage coverage, XMLWriter writer) throws IOException {

--- a/container-search/src/main/java/com/yahoo/search/rendering/XmlRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/XmlRenderer.java
@@ -24,6 +24,7 @@ import com.yahoo.search.result.Hit;
 import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.result.Relevance;
 import com.yahoo.search.result.StructuredData;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8String;
 import com.yahoo.text.XML;
 import com.yahoo.text.XMLWriter;
@@ -141,10 +142,10 @@ public final class XmlRenderer extends AsynchronousSectionedRenderer<Result> {
             final long summaryFetchTime = result.getElapsedTime().weightedFillTime();
             final double querySeconds = ((double) queryTime) * milli;
             final double summarySeconds = ((double) summaryFetchTime) * milli;
-            writer.attribute(QUERY_TIME, String.format(threeDecimals, querySeconds));
-            writer.attribute(SUMMARY_FETCH_TIME, String.format(threeDecimals, summarySeconds));
+            writer.attribute(QUERY_TIME, Text.format(threeDecimals, querySeconds));
+            writer.attribute(SUMMARY_FETCH_TIME, Text.format(threeDecimals, summarySeconds));
         }
-        writer.attribute(SEARCH_TIME, String.format(threeDecimals, searchSeconds));
+        writer.attribute(SEARCH_TIME, Text.format(threeDecimals, searchSeconds));
     }
 
     protected static void renderCoverageAttributes(Coverage coverage, XMLWriter writer) throws IOException {

--- a/container-search/src/main/java/com/yahoo/search/result/FeatureData.java
+++ b/container-search/src/main/java/com/yahoo/search/result/FeatureData.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.result;
+import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -110,7 +111,7 @@ public class FeatureData implements Inspectable, JsonProducer, DataSource {
              JsonGenerator generator = jsonFactory.createGenerator(out)) {
             asDataSource(tensorOptions).emit(new NonFiniteToNullDataSink(new JsonGeneratorDataSink(generator)));
             generator.flush();
-            return out.toString();
+            return out.toString(StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.significance;
+import java.util.Locale;
 
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.component.chain.dependencies.Before;
@@ -81,12 +82,13 @@ public class SignificanceSearcher extends Searcher {
             var result = new Result(query);
             result.hits().addError(
                     ErrorMessage.createIllegalQuery(
-                            ("Inconsistent 'significance' configuration for the rank profile '%s' in the schemas %s. " +
+                            String.format(Locale.ROOT,
+                                    "Inconsistent 'significance' configuration for the rank profile '%s' in the schemas %s. " +
                                     "Use 'restrict' to limit the query to a subset of schemas " +
                                     "(https://docs.vespa.ai/en/basics/schemas.html#multiple-schemas). " +
                                     "Specify same 'significance' configuration for all selected schemas " +
-                                    "(https://docs.vespa.ai/en/reference/schemas/schemas.html#significance).")
-                                    .formatted(rankProfileName, perSchemaSetup.keySet())));
+                                    "(https://docs.vespa.ai/en/reference/schemas/schemas.html#significance).",
+                                    rankProfileName, perSchemaSetup.keySet())));
             return result;
         }
 
@@ -101,8 +103,8 @@ public class SignificanceSearcher extends Searcher {
         try {
             var defaultModel = getSignificanceModelFromQueryLanguage(query);
             var defaultLanguage = query.getModel().getParsingLanguage();
-            log.log(Level.FINE, () -> "Got default model for language %s: %s"
-                    .formatted(defaultLanguage, defaultModel.getId()));
+            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Got default model for language %s: %s",
+                    defaultLanguage, defaultModel.getId()));
 
             setIDF(query.getModel().getQueryTree().getRoot(), defaultLanguage, defaultModel);
 
@@ -173,7 +175,7 @@ public class SignificanceSearcher extends Searcher {
                 return;
 
             var word = wi.getWord();
-            var documentFrequency = model.documentFrequency(word.toLowerCase());
+            var documentFrequency = model.documentFrequency(word.toLowerCase(Locale.ROOT));
             long N                = documentFrequency.corpusSize();
             long nq_i             = documentFrequency.frequency();
             log.log(Level.FINE, () -> "Setting document frequency for " + word + " to {frequency: " + nq_i + ", count: " + N + "}");
@@ -184,7 +186,7 @@ public class SignificanceSearcher extends Searcher {
             long best_freq = Long.MAX_VALUE;
             long best_count = 0;
             for (var alternative : wai.getAlternatives()) {
-                var documentFrequency = model.documentFrequency(alternative.word.toLowerCase());
+                var documentFrequency = model.documentFrequency(alternative.word.toLowerCase(Locale.ROOT));
                 long N                = documentFrequency.corpusSize();
                 long nq_i             = documentFrequency.frequency();
                 if (nq_i < best_freq) {

--- a/container-search/src/main/java/com/yahoo/search/yql/ProgramCompileException.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/ProgramCompileException.java
@@ -2,6 +2,8 @@
 package com.yahoo.search.yql;
 
 import com.yahoo.processing.IllegalInputException;
+import com.yahoo.text.Text;
+
 
 class ProgramCompileException extends IllegalInputException {
 
@@ -10,7 +12,7 @@ class ProgramCompileException extends IllegalInputException {
     }
 
     public ProgramCompileException(Location sourceLocation, String message, Object... args) {
-        super(String.format("%s %s", sourceLocation != null ? sourceLocation : "", args == null ? message : String.format(message, args)));
+        super(Text.format("%s %s", sourceLocation != null ? sourceLocation : "", args == null ? message : Text.format(message, args)));
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
@@ -30,6 +30,7 @@ import com.yahoo.search.result.FeatureData;
 import com.yahoo.search.result.Relevance;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.searchlib.aggregation.Grouping;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
 import com.yahoo.vdslib.VisitorStatistics;
@@ -140,7 +141,7 @@ public class StreamingBackend extends VespaBackend {
     @Override
     public Result doSearch2(String schema, Query query) {
         if (query.getTimeLeft() <= 0)
-            return new Result(query, ErrorMessage.createTimeout(String.format("No time left for searching (timeout=%d)", query.getTimeout())));
+            return new Result(query, ErrorMessage.createTimeout(Text.format("No time left for searching (timeout=%d)", query.getTimeout())));
 
         initializeMissingQueryFields(query);
         if (documentSelectionQueryParameterCount(query) != 1) {
@@ -179,7 +180,7 @@ public class StreamingBackend extends VespaBackend {
             double elapsedMillis = durationInMillisFromNanoTime(timeStartedNanos);
             if ((effectiveTraceLevel > 0) && timeoutBadEnoughToBeReported(query, elapsedMillis)) {
                 tracingOptions.getTraceExporter().maybeExport(() -> new TraceDescription(visitor.getTrace(),
-                                                                                         String.format("Trace of %s which timed out after %.3g seconds",
+                                                                                         Text.format("Trace of %s which timed out after %.3g seconds",
                                                                                                        query, elapsedMillis / 1000.0)));
             }
             return new Result(query, ErrorMessage.createTimeout(e.getMessage()));

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/LoggingTraceExporter.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/tracing/LoggingTraceExporter.java
@@ -1,8 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors.tracing;
 
+import com.yahoo.text.Text;
 import java.util.logging.Level;
-
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
@@ -17,7 +17,7 @@ public class LoggingTraceExporter implements TraceExporter {
     public void maybeExport(Supplier<TraceDescription> traceDescriptionSupplier) {
         var traceDescription = traceDescriptionSupplier.get();
         if (traceDescription.getTrace() != null) {
-            log.log(Level.WARNING, String.format("%s: %s", traceDescription.getDescription(),
+            log.log(Level.WARNING, Text.format("%s: %s", traceDescription.getDescription(),
                     traceDescription.getTrace().toString()));
         }
     }

--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -25,6 +25,7 @@ PARSER_BEGIN(GroupingParser)
 package com.yahoo.search.grouping.request.parser;
 
 import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.LinkedList;
 import com.yahoo.javacc.UnicodeUtilities;
@@ -1094,7 +1095,7 @@ BooleanValue booleanValue() :
 void byteValue(RawBuffer buffer) : { }
 {
     ( ( <INTEGER> { buffer.put(Byte.parseByte(token.image)); } ) |
-      ( <STRING> { buffer.put(token.image.getBytes()); } )
+      ( <STRING> { buffer.put(token.image.getBytes(StandardCharsets.UTF_8)); } )
     )
 }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/TopKEstimatorTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/TopKEstimatorTest.java
@@ -2,7 +2,6 @@
 package com.yahoo.search.dispatch;
 
 import org.junit.jupiter.api.Test;
-
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -151,7 +150,7 @@ public class TopKEstimatorTest {
         double [] P = {1.0, 0.9999, 0.99999, 0.999999, 0.9999999, 0.99999999, 0.999999999, 0.9999999999};
         int n = numPartitions;
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("Prob/Hits:"));
+        sb.append(String.format(Locale.ROOT, "Prob/Hits:"));
         for (double p : P) {
             sb.append(String.format(Locale.ENGLISH, " %1.10f", p));
         }

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/RawBufferTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/RawBufferTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.search.grouping.request;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class RawBufferTestCase {
 
     @Test
     void requireThatToStringWorks() {
-        assertToString(List.of("a".getBytes()[0], "b".getBytes()[0]), "{97,98}");
+        assertToString(List.of("a".getBytes(StandardCharsets.UTF_8)[0], "b".getBytes(StandardCharsets.UTF_8)[0]), "{97,98}");
         assertToString(List.of((byte) 2, (byte) 6), "{2,6}");
     }
 

--- a/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserBenchmarkTest.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/request/parser/GroupingParserBenchmarkTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -38,9 +39,9 @@ public class GroupingParserBenchmarkTest {
             }
         }
         long micros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - now);
-        System.out.format("%d \u03bcs (avg %.2f)\n", micros, (double) micros / (NUM_RUNS * inputs.size()));
+        System.out.format(Locale.ROOT, "%d \u03bcs (avg %.2f)\n", micros, (double) micros / (NUM_RUNS * inputs.size()));
         for (Map.Entry<String, Long> entry : PREV_RESULTS.entrySet()) {
-            System.out.format("%-20s : %4.2f\n", entry.getKey(), (double) micros / entry.getValue());
+            System.out.format(Locale.ROOT, "%-20s : %4.2f\n", entry.getKey(), (double) micros / entry.getValue());
         }
         System.out.println("\nignore " + ignore);
     }

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
@@ -1162,24 +1162,24 @@ public class RequestBuilderTestCase {
         private static String toSimpleName(FilterExpressionNode filterExp) {
             if (filterExp instanceof RegexPredicateNode rpn) {
                 var simpleName = rpn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
-                return "Regex [%s]".formatted(simpleName);
+                return String.format(Locale.ROOT, "Regex [%s]", simpleName);
             } else if (filterExp instanceof RangePredicateNode rpn) {
                 var lower = rpn.getLower().doubleValue();
                 var upper = rpn.getUpper().doubleValue();
                 var lowerInclusive = rpn.getLowerInclusive() ? "true" : "false";
                 var upperInclusive = rpn.getUpperInclusive() ? "true" : "false";
                 var expression = rpn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
-                return String.format(Locale.US, "Range [%f, %f, %s, %s, %s]",
+                return String.format(Locale.ROOT, "Range [%f, %f, %s, %s, %s]",
                                      lower, upper, expression, lowerInclusive, upperInclusive);
             } else if (filterExp instanceof NotPredicateNode npn) {
                 var simpleName = npn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
-                return "Not [%s]".formatted(simpleName);
+                return String.format(Locale.ROOT, "Not [%s]", simpleName);
             } else if (filterExp instanceof OrPredicateNode opn) {
                 var simpleName = opn.getArgs().stream().map(LayoutWriter::toSimpleName).collect(Collectors.joining(", "));
-                return "Or [%s]".formatted(simpleName);
+                return String.format(Locale.ROOT, "Or [%s]", simpleName);
             } else if (filterExp instanceof AndPredicateNode apn) {
                 var simpleName = apn.getArgs().stream().map(LayoutWriter::toSimpleName).collect(Collectors.joining(", "));
-                return "And [%s]".formatted(simpleName);
+                return String.format(Locale.ROOT, "And [%s]", simpleName);
             }
             return filterExp.getClass().getSimpleName();
         }

--- a/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTester.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTester.java
@@ -11,6 +11,7 @@ import com.yahoo.jdisc.test.MockMetric;
 import com.yahoo.net.HostName;
 import com.yahoo.search.Result;
 import com.yahoo.search.searchchain.config.test.SearchChainConfigurerTestCase;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
@@ -159,7 +160,7 @@ public class SearchHandlerTester implements AutoCloseable {
             if (metric.metrics().containsKey(key)) return;
             uncheckInterrupted(() -> Thread.sleep(1));
         }
-        fail(String.format("Could not find metric with key '%s' in '%s'", key, metric));
+        fail(Text.format("Could not find metric with key '%s' in '%s'", key, metric));
     }
 
     private void assertOkResult(RequestHandlerTestDriver.MockResponseHandler response, String expected) {

--- a/container-search/src/test/java/com/yahoo/search/logging/LocalDiskLoggerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/logging/LocalDiskLoggerTest.java
@@ -3,12 +3,14 @@
 package com.yahoo.search.logging;
 
 import com.yahoo.io.IOUtils;
+import com.yahoo.text.Utf8;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Base64;
 
@@ -29,13 +31,13 @@ public class LocalDiskLoggerTest {
         LocalDiskLogger logger = new LocalDiskLogger(builder.build());
 
         logger.newEntry()
-                .blob("my entry blob content".getBytes())
+                .blob("my entry blob content".getBytes(StandardCharsets.UTF_8))
                 .track("my-track")
                 .send();
         logger.deconstruct();
 
-        String test = IOUtils.readAll(new FileReader(logFile));
-        assertTrue(test.contains(Base64.getEncoder().encodeToString("my entry blob content".getBytes())));
+        String test = IOUtils.readAll(Utf8.createReader(logFile));
+        assertTrue(test.contains(Base64.getEncoder().encodeToString("my entry blob content".getBytes(StandardCharsets.UTF_8))));
         assertTrue(test.contains("my-track"));
     }
 

--- a/container-search/src/test/java/com/yahoo/search/logging/SpoolerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/logging/SpoolerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.test.ManualClock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -200,7 +201,7 @@ public class SpoolerTest {
 
     private boolean sendEntry(Logger logger, String x) {
         return logger.newEntry()
-                     .blob(x.getBytes())
+                     .blob(x.getBytes(StandardCharsets.UTF_8))
                      .send();
     }
 
@@ -219,7 +220,7 @@ public class SpoolerTest {
 
     private void assertContent(Path file, String expectedContent) throws IOException {
         String content = Files.readString(file);
-        assertTrue(content.contains(Base64.getEncoder().encodeToString(expectedContent.getBytes())));
+        assertTrue(content.contains(Base64.getEncoder().encodeToString(expectedContent.getBytes(StandardCharsets.UTF_8))));
     }
 
     private static Spooler createSpooler(Path spoolDir, int maxEntriesPerFile) {

--- a/container-search/src/test/java/com/yahoo/search/rendering/EventRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/EventRendererTestCase.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -291,7 +292,7 @@ public class EventRendererTestCase {
         @Override
         public synchronized void write(byte[] b, int off, int len) {
             super.write(b, off, len);
-            System.out.print(new String(b, off, len));
+            System.out.print(new String(b, off, len, StandardCharsets.UTF_8));
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/searchchain/config/test/SearchChainConfigurerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchchain/config/test/SearchChainConfigurerTestCase.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -288,7 +289,7 @@ public class SearchChainConfigurerTestCase {
 
     public static void printFile(File f, String content) throws IOException {
         OutputStream out = new FileOutputStream(f);
-        out.write(content.getBytes());
+        out.write(content.getBytes(StandardCharsets.UTF_8));
         out.close();
 
     }

--- a/container-search/src/test/java/com/yahoo/search/searchers/ValidateFuzzySearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/ValidateFuzzySearcherTestCase.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,7 +43,7 @@ public class ValidateFuzzySearcherTestCase {
         indexes = new ArrayList<>();
         for (Attribute.Datatype.Enum attr: Attribute.Datatype.Enum.values()) {
             for (Attribute.Collectiontype.Enum ctype: Attribute.Collectiontype.Enum.values()) {
-                String attributeName = attr.name().toLowerCase() + "_" + ctype.name().toLowerCase();
+                String attributeName = attr.name().toLowerCase(Locale.ROOT) + "_" + ctype.name().toLowerCase(Locale.ROOT);
                 attributes.add(attributeName);
 
                 Index index = new Index(attributeName);
@@ -57,8 +58,8 @@ public class ValidateFuzzySearcherTestCase {
     }
 
     private String makeQuery(String attribute, String query, int maxEditDistance, int prefixLength, boolean prefixMatch) {
-        return "select * from sources * where %s contains ({maxEditDistance:%d,prefixLength:%d,prefix:%b}fuzzy(\"%s\"))"
-                .formatted(attribute, maxEditDistance, prefixLength, prefixMatch, query);
+        return String.format(Locale.ROOT, "select * from sources * where %s contains ({maxEditDistance:%d,prefixLength:%d,prefix:%b}fuzzy(\"%s\"))",
+                attribute, maxEditDistance, prefixLength, prefixMatch, query);
     }
 
     private String makeQuery(String attribute, String query) {

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/ListMergerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/ListMergerTestCase.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors;
 
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -16,9 +17,9 @@ public class ListMergerTestCase {
     private void initializeLists(List<String> list1, List<String> list2, int entryCount, int padding) {
         for (int i = 0; i < entryCount; i++) {
             if ((i % 2) == 0) {
-                list1.add("String " + String.format("%0" + padding + "d", (i+1)));
+                list1.add("String " + Text.format("%0" + padding + "d", (i+1)));
             } else {
-                list2.add("String " + String.format("%0" + padding + "d", (i+1)));
+                list2.add("String " + Text.format("%0" + padding + "d", (i+1)));
             }
         }
     }
@@ -26,7 +27,7 @@ public class ListMergerTestCase {
     private void verifyList(List<String> list, int entryCount, int padding) {
         assertEquals(entryCount, list.size());
         for (int i = 0; i < entryCount; i++) {
-            assertEquals("String " + String.format("%0" + padding + "d", (i+1)), list.get(i));
+            assertEquals("String " + Text.format("%0" + padding + "d", (i+1)), list.get(i));
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingVisitorTest.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingVisitorTest.java
@@ -228,19 +228,19 @@ public class StreamingVisitorTest {
         assertEquals(AllFields.NAME, params.getFieldSet());
 
         // Verify library parameters
-        //System.err.println("query="+new String(params.getLibraryParameters().get("query")));
+        //System.err.println("query="+new String(params.getLibraryParameters().get("query"), StandardCharsets.UTF_8));
         assertNotNull(params.getLibraryParameters().get("query")); // TODO: Check contents
-        //System.err.println("query="+new String(params.getLibraryParameters().get("querystackcount")));
+        //System.err.println("query="+new String(params.getLibraryParameters().get("querystackcount"), StandardCharsets.UTF_8));
         assertNotNull(params.getLibraryParameters().get("querystackcount")); // TODO: Check contents
-        assertEquals(searchCluster, new String(params.getLibraryParameters().get("searchcluster")));
-        assertEquals(schema, new String(params.getLibraryParameters().get("schema")));
-        assertEquals(Objects.requireNonNullElse(qa.summary, "default"), new String(params.getLibraryParameters().get("summaryclass")));
-        assertEquals(Integer.toString(qa.offset+qa.hits), new String(params.getLibraryParameters().get("summarycount")));
-        assertEquals(Objects.requireNonNullElse(qa.profile, "default"), new String(params.getLibraryParameters().get("rankprofile")));
-        //System.err.println("queryflags="+new String(params.getLibraryParameters().get("queryflags")));
+        assertEquals(searchCluster, new String(params.getLibraryParameters().get("searchcluster"), StandardCharsets.UTF_8));
+        assertEquals(schema, new String(params.getLibraryParameters().get("schema"), StandardCharsets.UTF_8));
+        assertEquals(Objects.requireNonNullElse(qa.summary, "default"), new String(params.getLibraryParameters().get("summaryclass"), StandardCharsets.UTF_8));
+        assertEquals(Integer.toString(qa.offset+qa.hits), new String(params.getLibraryParameters().get("summarycount"), StandardCharsets.UTF_8));
+        assertEquals(Objects.requireNonNullElse(qa.profile, "default"), new String(params.getLibraryParameters().get("rankprofile"), StandardCharsets.UTF_8));
+        //System.err.println("queryflags="+new String(params.getLibraryParameters().get("queryflags"), StandardCharsets.UTF_8));
         assertNotNull(params.getLibraryParameters().get("queryflags")); // TODO: Check contents
         if (qa.location != null) {
-            assertEquals(qa.location, new String(params.getLibraryParameters().get("location")));
+            assertEquals(qa.location, new String(params.getLibraryParameters().get("location"), StandardCharsets.UTF_8));
         } else {
             assertNull(params.getLibraryParameters().get("location"));
         }
@@ -251,13 +251,13 @@ public class StreamingVisitorTest {
             assertNull(params.getLibraryParameters().get("rankproperties"));
         }
         if (qa.defineGrouping) {
-            //System.err.println("aggregation="+new String(params.getLibraryParameters().get("aggregation")));
+            //System.err.println("aggregation="+new String(params.getLibraryParameters().get("aggregation"), StandardCharsets.UTF_8));
             assertNotNull(params.getLibraryParameters().get("aggregation")); // TODO: Check contents
         } else {
             assertNull(params.getLibraryParameters().get("aggregation"));
         }
         if (qa.sortSpec != null) {
-            assertEquals(qa.sortSpec, new String(params.getLibraryParameters().get("sort")));
+            assertEquals(qa.sortSpec, new String(params.getLibraryParameters().get("sort"), StandardCharsets.UTF_8));
         } else {
             assertNull(params.getLibraryParameters().get("sort"));
         }


### PR DESCRIPTION
Use explicit Locale.ROOT for case conversions (toLowerCase/toUpperCase), explicit StandardCharsets.UTF_8 for string/byte encoding operations, and Text.format/String.format(Locale.ROOT) for formatting.
