### PR TITLE
Use Text.format in bundle-plugin

### DIFF
--- a/bundle-plugin-test/integration-test/src/test/java/com/yahoo/container/plugin/BundleTest.java
+++ b/bundle-plugin-test/integration-test/src/test/java/com/yahoo/container/plugin/BundleTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.plugin;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.VespaVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,7 +115,7 @@ public class BundleTest {
 
         var expected = List.of("ai.vespa.lib.public_api", "com.yahoo.lib.public_api", "com.yahoo.test");
         assertEquals(expected.size(), publicApi.size());
-        expected.forEach(pkg -> assertTrue(publicApi.contains(pkg), "Public api did not contain %s".formatted(pkg)));
+        expected.forEach(pkg -> assertTrue(publicApi.contains(pkg), Text.format("Public api did not contain %s", pkg)));
     }
 
     @Test
@@ -125,7 +126,7 @@ public class BundleTest {
 
         var expected = List.of("ai.vespa.internal", "ai.vespa.lib.non_public", "com.yahoo.lib.non_public", "com.yahoo.non_public");
         assertEquals(expected.size(), nonPublicApi.size());
-        expected.forEach(pkg -> assertTrue(nonPublicApi.contains(pkg), "Non-public api did not contain %s".formatted(pkg)));
+        expected.forEach(pkg -> assertTrue(nonPublicApi.contains(pkg), Text.format("Non-public api did not contain %s", pkg)));
    }
 
     @Test

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/bundle/AnalyzeBundle.java
@@ -40,7 +40,7 @@ public class AnalyzeBundle {
         try {
             return parseExports(manifest);
         } catch (Exception e) {
-            throw new RuntimeException(String.format(Locale.ROOT, "Invalid manifest in bundle '%s'", jarFile.getPath()), e);
+            throw new RuntimeException(Text.format("Invalid manifest in bundle '%s'", jarFile.getPath()), e);
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/ExportPackageAnnotation.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/ExportPackageAnnotation.java
@@ -29,12 +29,12 @@ public class ExportPackageAnnotation {
         requireNonNegative(micro, "micro");
         if (! QUALIFIER_PATTERN.matcher(qualifier).matches()) {
             throw new IllegalArgumentException(
-                    exportPackageError(String.format(Locale.ROOT, "qualifier must follow the format (alpha|digit|'_'|'-')* but was '%s'.", qualifier)));
+                    exportPackageError(Text.format("qualifier must follow the format (alpha|digit|'_'|'-')* but was '%s'.", qualifier)));
         }
     }
 
     public String osgiVersion() {
-        return String.format(Locale.ROOT, "%d.%d.%d", major, minor, micro) + (qualifier.isEmpty() ? "" : "." + qualifier);
+        return Text.format("%d.%d.%d", major, minor, micro) + (qualifier.isEmpty() ? "" : "." + qualifier);
     }
 
     private static String exportPackageError(String msg) {
@@ -43,7 +43,7 @@ public class ExportPackageAnnotation {
 
     private static void requireNonNegative(int i, String fieldName) {
         if (i < 0) {
-            throw new IllegalArgumentException(exportPackageError(String.format(Locale.ROOT, "%s must be non-negative but was %d.", fieldName, i)));
+            throw new IllegalArgumentException(exportPackageError(Text.format("%s must be non-negative but was %d.", fieldName, i)));
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AbstractGenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AbstractGenerateOsgiManifestMojo.java
@@ -211,7 +211,7 @@ abstract class AbstractGenerateOsgiManifestMojo extends AbstractMojo {
             return Analyze.analyzeClass(jarFile.getInputStream(entry), JdkVersionCheck.DISABLED, version);
         } catch (Exception e) {
             throw new MojoExecutionException(
-                    String.format(Locale.ROOT, "While analyzing the class '%s' in jar file '%s'", entry.getName(), jarFile.getName()), e);
+                    Text.format("While analyzing the class '%s' in jar file '%s'", entry.getName(), jarFile.getName()), e);
         }
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AssembleFatJarMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/AssembleFatJarMojo.java
@@ -132,7 +132,7 @@ public class AssembleFatJarMojo extends AbstractMojo {
     }
 
     private static String filename(Artifact a) {
-        return a.getGroupId().equals("com.yahoo.vespa") ? String.format(Locale.ROOT, "%s-jar-with-dependencies.jar", a.getArtifactId()) : a.getFile().getName();
+        return a.getGroupId().equals("com.yahoo.vespa") ? Text.format("%s-jar-with-dependencies.jar", a.getArtifactId()) : a.getFile().getName();
     }
 
     private File outputFile() {
@@ -152,7 +152,7 @@ public class AssembleFatJarMojo extends AbstractMojo {
             var project = session.getAllProjects().stream()
                     .filter(p -> p.getGroupId().equals(installedDepsProject[0]) && p.getArtifactId().equals(installedDepsProject[1]))
                     .findAny().orElseThrow(() -> new IllegalStateException(
-                            String.format(Locale.ROOT, "Cannot find %s. Build from project root with 'mvn install -pl :%s'", projectDefiningInstalledDependencies, this.project.getArtifactId())));
+                            Text.format("Cannot find %s. Build from project root with 'mvn install -pl :%s'", projectDefiningInstalledDependencies, this.project.getArtifactId())));
             var req = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
             req.setProject(project);
             var root = dependencyGraphBuilder.buildDependencyGraph(req, null);

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -130,7 +130,7 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
                 logProvidedArtifactsIncluded(artifactsToInclude, providedArtifactsFromManifest(wantedProvidedArtifact.get().getFile()));
             } else if (! suppressWarningMissingImportPackages && jdisc_core.isEmpty()) {
                 // TODO: Remove jdisc_core clause above and instead add suppressWarning to necessary vespa modules.
-                warnOrThrow(String.format(Locale.ROOT, "This project does not have '%s' as provided dependency, so the generated 'Import-Package' " +
+                warnOrThrow(Text.format("This project does not have '%s' as provided dependency, so the generated 'Import-Package' " +
                         "OSGi header may be missing important packages.", wantedProvidedDependency()));
             }
 
@@ -199,7 +199,7 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
 
     private void logNonPublicApiUsage(List<String> nonPublicApiUsed) {
         if (suppressWarningPublicApi || effectiveBundleType() != BundleType.USER || nonPublicApiUsed.isEmpty()) return;
-        warnOrThrow(String.format(Locale.ROOT, "This project uses packages that are not part of Vespa's public api: %s", nonPublicApiUsed));
+        warnOrThrow(Text.format("This project uses packages that are not part of Vespa's public api: %s", nonPublicApiUsed));
     }
 
     private static String publicApi(PackageTally tally) {
@@ -299,7 +299,7 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
         List<Artifact> unsupportedArtifacts = nonJarArtifacts.stream().filter(a -> ! a.getType().equals("pom"))
                 .toList();
 
-        unsupportedArtifacts.forEach(artifact -> warnOrThrow(String.format(Locale.ROOT, "Unsupported artifact '%s': Type '%s' is not supported. Please file a feature request.",
+        unsupportedArtifacts.forEach(artifact -> warnOrThrow(Text.format("Unsupported artifact '%s': Type '%s' is not supported. Please file a feature request.",
                                                                            artifact.getId(), artifact.getType())));
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/osgi/ImportPackages.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/osgi/ImportPackages.java
@@ -34,7 +34,7 @@ public class ImportPackages {
                     Arrays.stream(version.get().split("\\.")).map(Integer::parseInt).limit(3).forEach(this.versionNumber::add);
                 } catch (NumberFormatException e) {
                     throw new IllegalArgumentException(
-                            String.format(Locale.ROOT, "Invalid version number '%s' for package '%s'.", version.get(), packageName), e);
+                            Text.format("Invalid version number '%s' for package '%s'.", version.get(), packageName), e);
                 }
             }
         }
@@ -62,7 +62,7 @@ public class ImportPackages {
             } else {
                 int upperLimit = isGuavaPackage() ? INFINITE_VERSION // guava increases major version for each release
                         : versionNumber.get(0) + 1;
-                return Optional.of(String.format(Locale.ROOT, "[%s,%d)", version(), upperLimit));
+                return Optional.of(Text.format("[%s,%d)", version(), upperLimit));
             }
         }
 


### PR DESCRIPTION
Refactor string formatting across bundle-plugin to use the Vespa Text.format utility instead of String.format with explicit Locale.ROOT. This provides consistent formatting behavior while simplifying the code.
