### PR TITLE
Use Text.format in abi-check-plugin

### DIFF
--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
@@ -37,7 +37,7 @@ public class PublicSignatureCollector extends ClassVisitor {
 
   private static String describeMethod(String name, int access, String returnType,
       List<String> argumentTypes) {
-    return String.format(Locale.ROOT, "%s %s %s(%s)", describeAccess(access, Util.methodFlags), returnType, name,
+    return Text.format("%s %s %s(%s)", describeAccess(access, Util.methodFlags), returnType, name,
         String.join(", ", argumentTypes));
   }
 
@@ -46,7 +46,7 @@ public class PublicSignatureCollector extends ClassVisitor {
   }
 
   private static String describeField(String name, int access, String type) {
-    return String.format(Locale.ROOT, "%s %s %s", describeAccess(access, Util.fieldFlags), type, name);
+    return Text.format("%s %s %s", describeAccess(access, Util.fieldFlags), type, name);
   }
 
   private static String internalNameToClassName(String superName) {

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/Util.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/Util.java
@@ -64,7 +64,7 @@ public class Util {
       access &= ~flag.bit;
     }
     if (access != 0) {
-      throw new IllegalArgumentException(String.format(Locale.ROOT, "Unexpected access bits: 0x%x", access));
+      throw new IllegalArgumentException(Text.format("Unexpected access bits: 0x%x", access));
     }
     return result;
   }

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/mojo/AbiCheck.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/mojo/AbiCheck.java
@@ -111,27 +111,27 @@ public class AbiCheck extends AbstractMojo {
     }
     if (!SetMatcher.compare(expected.interfaces, actual.interfaces,
         item -> true,
-        item -> log.error(String.format(Locale.ROOT, "Class %s: Missing interface %s", className, item)),
-        item -> log.error(String.format(Locale.ROOT, "Class %s: Extra interface %s", className, item)))) {
+        item -> log.error(Text.format("Class %s: Missing interface %s", className, item)),
+        item -> log.error(Text.format("Class %s: Extra interface %s", className, item)))) {
       match = false;
     }
     if (!SetMatcher
         .compare(new HashSet<>(expected.attributes), new HashSet<>(actual.attributes),
             item -> true,
-            item -> log.error(String.format(Locale.ROOT, "Class %s: Missing attribute %s", className, item)),
-            item -> log.error(String.format(Locale.ROOT, "Class %s: Extra attribute %s", className, item)))) {
+            item -> log.error(Text.format("Class %s: Missing attribute %s", className, item)),
+            item -> log.error(Text.format("Class %s: Extra attribute %s", className, item)))) {
       match = false;
     }
     if (!SetMatcher.compare(expected.methods, actual.methods,
         item -> true,
-        item -> log.error(String.format(Locale.ROOT, "Class %s: Missing method %s", className, item)),
-        item -> log.error(String.format(Locale.ROOT, "Class %s: Extra method %s", className, item)))) {
+        item -> log.error(Text.format("Class %s: Missing method %s", className, item)),
+        item -> log.error(Text.format("Class %s: Extra method %s", className, item)))) {
       match = false;
     }
     if (!SetMatcher.compare(expected.fields, actual.fields,
         item -> true,
-        item -> log.error(String.format(Locale.ROOT, "Class %s: Missing field %s", className, item)),
-        item -> log.error(String.format(Locale.ROOT, "Class %s: Extra field %s", className, item)))) {
+        item -> log.error(Text.format("Class %s: Missing field %s", className, item)),
+        item -> log.error(Text.format("Class %s: Extra field %s", className, item)))) {
       match = false;
     }
     return match;
@@ -179,8 +179,8 @@ public class AbiCheck extends AbstractMojo {
       Map<String, JavaClassSignature> actual, Log log) {
     return SetMatcher.compare(expected.keySet(), actual.keySet(),
         item -> matchingClasses(item, expected.get(item), actual.get(item), log),
-        item -> log.error(String.format(Locale.ROOT, "Missing class: %s", item)),
-        item -> log.error(String.format(Locale.ROOT, "Extra class: %s", item)));
+        item -> log.error(Text.format("Missing class: %s", item)),
+        item -> log.error(Text.format("Extra class: %s", item)));
   }
 
   // CLOVER:OFF


### PR DESCRIPTION
Replaces all String.format(Locale.ROOT, ...) calls with Text.format(...) in the abi-check-plugin module for cleaner locale-independent formatting. Affects signature collector classes and ABI checking logic.
