### PR TITLE
Use explicit locale in document processing code

### DIFF
--- a/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerAllMessageTypesTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerAllMessageTypesTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.docproc.jdisc;
 
 import com.yahoo.collections.Pair;
+import java.util.Locale;
 import com.yahoo.docproc.CallStack;
 import com.yahoo.docproc.DocumentProcessor;
 import com.yahoo.docproc.Processing;
@@ -158,7 +159,7 @@ public class DocumentProcessingHandlerAllMessageTypesTestCase extends DocumentPr
                     for (Field f : doc.getDataType().fieldSet()) {
                         FieldValue val = doc.getFieldValue(f);
                         if (val instanceof StringFieldValue sf) {
-                            doc.setFieldValue(f, new StringFieldValue(sf.getString().toUpperCase()));
+                            doc.setFieldValue(f, new StringFieldValue(sf.getString().toUpperCase(Locale.ROOT)));
                         }
                     }
                 }

--- a/docproc/src/test/java/com/yahoo/docproc/proxy/SchemaMappingAndAccessesTest.java
+++ b/docproc/src/test/java/com/yahoo/docproc/proxy/SchemaMappingAndAccessesTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.docproc.proxy;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -310,7 +311,7 @@ public class SchemaMappingAndAccessesTest {
         ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
         mapped.serialize(bos);
         doc.serialize(bos2);
-        assertEquals(bos.toString(), bos2.toString());
+        assertEquals(bos.toString(StandardCharsets.UTF_8), bos2.toString(StandardCharsets.UTF_8));
         assertEquals(mapped.toXml(), doc.toXml());
         assertEquals(mapped.getFieldCount(), doc.getFieldCount());
         assertTrue(mapped.getDocument()==doc);

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
@@ -24,6 +24,7 @@ import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
 import com.yahoo.language.provider.DefaultEmbedderProvider;
 import com.yahoo.language.provider.DefaultGeneratorProvider;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
@@ -117,20 +118,20 @@ public class IndexingProcessor extends DocumentProcessor {
                 String message = Exceptions.toMessageString(e);
                 return Progress.INVALID_INPUT.withReason(
                         op.getId() != null
-                        ? "Operation on '%s' contains invalid input: %s".formatted(op.getId().toString(), message)
-                        : "Operation contains invalid input: %s".formatted(message));
+                        ? Text.format("Operation on '%s' contains invalid input: %s", op.getId().toString(), message)
+                        : Text.format("Operation contains invalid input: %s", message));
             } catch (OverloadException e) {
                 String message = Exceptions.toMessageString(e);
                 return Progress.OVERLOAD.withReason(
                         op.getId() != null
-                        ? "Operation on '%s' rejected due to overload: %s".formatted(op.getId().toString(), message)
-                        : "Operation rejected due to overload: %s".formatted(message));
+                        ? Text.format("Operation on '%s' rejected due to overload: %s", op.getId().toString(), message)
+                        : Text.format("Operation rejected due to overload: %s", message));
             } catch (TimeoutException e) {
                 String message = Exceptions.toMessageString(e);
                 return Progress.TIMEOUT.withReason(
                         op.getId() != null
-                        ? "Operation on '%s' timed out: %s".formatted(op.getId().toString(), message)
-                        : "Operation timed out: %s".formatted(message));
+                        ? Text.format("Operation on '%s' timed out: %s", op.getId().toString(), message)
+                        : Text.format("Operation timed out: %s", message));
             }
         }
         proc.getDocumentOperations().clear();


### PR DESCRIPTION
- Use Locale.ROOT for case conversion to avoid locale-dependent behavior
- Specify UTF-8 charset explicitly when converting ByteArrayOutputStream
- Replace String.formatted() with Text.format() for consistent formatting
