### PR TITLE
Use Text.format in clustercontroller-core

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.vdslib.state.ClusterState;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.content.StorDistributionConfig;
 
 import java.util.List;
@@ -320,19 +321,19 @@ public class ClusterStateBundle {
     @Override
     public String toString() {
         String feedBlockedStr = clusterFeedIsBlocked()
-                ? String.format(Locale.ROOT, ", feed blocked: '%s'", feedBlock.description)
+                ? Text.format(", feed blocked: '%s'", feedBlock.description)
                 : "";
         String distributionConfigStr = (distributionConfig != null)
-                ? String.format(Locale.ROOT, ", distribution config: %s", distributionConfig.highLevelDescription())
+                ? Text.format(", distribution config: %s", distributionConfig.highLevelDescription())
                 : "";
         if (derivedBucketSpaceStates.isEmpty()) {
-            return String.format(Locale.ROOT, "ClusterStateBundle('%s'%s%s%s)", baselineState,
+            return Text.format("ClusterStateBundle('%s'%s%s%s)", baselineState,
                     deferredActivation ? " (deferred activation)" : "",
                     feedBlockedStr, distributionConfigStr);
         }
         Map<String, AnnotatedClusterState> orderedStates = new TreeMap<>(derivedBucketSpaceStates);
-        return String.format(Locale.ROOT, "ClusterStateBundle('%s', %s%s%s%s)", baselineState, orderedStates.entrySet().stream()
-                .map(e -> String.format(Locale.ROOT, "%s '%s'", e.getKey(), e.getValue()))
+        return Text.format("ClusterStateBundle('%s', %s%s%s%s)", baselineState, orderedStates.entrySet().stream()
+                .map(e -> Text.format("%s '%s'", e.getKey(), e.getValue()))
                 .collect(Collectors.joining(", ")),
                 deferredActivation ? " (deferred activation)" : "",
                 feedBlockedStr, distributionConfigStr);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateHistoryEntry.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateHistoryEntry.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 
 import java.util.Locale;
@@ -98,7 +99,7 @@ public class ClusterStateHistoryEntry {
     // String representation only used for test expectation failures and debugging output.
     // Actual status page history entry rendering emits formatted date/time.
     public String toString() {
-        return String.format(Locale.ROOT, "state '%s' at time %d", getStateString(BASELINE), time);
+        return Text.format("state '%s' at time %d", getStateString(BASELINE), time);
     }
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeErrorStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeErrorStats.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.hostinfo.ResponseStats;
 
 import java.util.Arrays;
@@ -155,7 +156,7 @@ public class ContentNodeErrorStats {
 
     @Override
     public String toString() {
-        return String.format(Locale.ROOT, "{statsFromDistributors=[%s]}",
+        return Text.format("{statsFromDistributors=[%s]}",
                              Arrays.toString(statsFromDistributors.entrySet().toArray()));
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentNodeStats.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import java.util.Locale;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.hostinfo.StorageNode;
 
 import java.util.Arrays;
@@ -172,7 +173,7 @@ public class ContentNodeStats {
 
     @Override
     public String toString() {
-        return String.format(Locale.ROOT, "{index=%d, bucketSpaces=[%s]}",
+        return Text.format("{index=%d, bucketSpaces=[%s]}",
                 nodeIndex, Arrays.toString(bucketSpaces.entrySet().toArray()));
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.clustercontroller.core;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.subscription.ConfigInstanceSerializer;
 import com.yahoo.slime.Slime;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.distribution.Group;
 import com.yahoo.vdslib.distribution.GroupVisitor;
@@ -69,7 +70,7 @@ public class DistributionConfigBundle {
     public int searchableCopies() { return config.ready_copies(); }
 
     public String highLevelDescription() {
-        return String.format(Locale.ROOT, "%d nodes; %d groups; redundancy %d; searchable-copies %d", 
+        return Text.format("%d nodes; %d groups; redundancy %d; searchable-copies %d",
                 totalNodeCount(), totalLeafGroupCount(), redundancy(), searchableCopies());
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiff.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiff.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -59,7 +60,7 @@ public class DistributionDiff {
 
     private static void addIfDiffers(IntegerDiff diff, String name, List<String> diffs) {
         if (diff.differs()) {
-            diffs.add(String.format(Locale.ROOT, "%s: %d -> %d", name, diff.before, diff.after));
+            diffs.add(Text.format("%s: %d -> %d", name, diff.before, diff.after));
         }
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -66,7 +67,7 @@ public class DistributionDiffCalculator {
             // "invalid" is the fixed index string value of the root group. If the root group contains
             // any nodes at all, there will not be any nested groups by definition, as only leaf groups
             // may contain nodes.
-            String name = "invalid".equals(g.index()) ? "root group" : String.format(Locale.ROOT, "group %s", g.index());
+            String name = "invalid".equals(g.index()) ? "root group" : Text.format("group %s", g.index());
             groups.put(name, new GroupNodes(g.nodes().stream().map(n -> n.index()).collect(Collectors.toSet())));
         }
         return groups;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/EventDiffCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/EventDiffCalculator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
@@ -129,7 +130,7 @@ public class EventDiffCalculator {
                 // distributionConfigTo must be non-null
                 events.add(createClusterEvent(
                         "Cluster controller is now the authoritative source for distribution config. " +
-                        String.format(Locale.ROOT, "Active config: %s", params.distributionConfigTo.highLevelDescription()), params));
+                        Text.format("Active config: %s", params.distributionConfigTo.highLevelDescription()), params));
             } else if (params.distributionConfigTo == null) {
                 events.add(createClusterEvent(
                         "Cluster controller is no longer the authoritative source for distribution config", params));
@@ -137,7 +138,7 @@ public class EventDiffCalculator {
                 // Distribution config was present in both old and new; emit a human-readable diff.
                 String configDiff = DistributionDiffCalculator.computeDiff(params.distributionConfigFrom, params.distributionConfigTo).toString();
                 if (!configDiff.isEmpty()) {
-                    events.add(createClusterEvent(String.format(Locale.ROOT, "Distribution config changed: %s", configDiff), params));
+                    events.add(createClusterEvent(Text.format("Distribution config changed: %s", configDiff), params));
                 }
             }
         }
@@ -147,7 +148,7 @@ public class EventDiffCalculator {
         // TODO should we emit any events when description changes?
         if (feedBlockStateHasChanged(params)) {
             if (params.feedBlockTo != null) {
-                events.add(createClusterEvent(String.format(Locale.ROOT, "Cluster feed blocked due to resource exhaustion: %s",
+                events.add(createClusterEvent(Text.format("Cluster feed blocked due to resource exhaustion: %s",
                         params.feedBlockTo.getDescription()), params));
             } else {
                 events.add(createClusterEvent("Cluster feed no longer blocked", params));
@@ -221,11 +222,11 @@ public class EventDiffCalculator {
 
         for (var ex : setSubtraction(fromBlockSet, toBlockSet)) {
             var info = cluster.getNodeInfo(ex.node);
-            events.add(createNodeEvent(info, String.format(Locale.ROOT, "Removed resource exhaustion: %s", ex.toExhaustionRemovedDescription()), params));
+            events.add(createNodeEvent(info, Text.format("Removed resource exhaustion: %s", ex.toExhaustionRemovedDescription()), params));
         }
         for (var ex : setSubtraction(toBlockSet, fromBlockSet)) {
             var info = cluster.getNodeInfo(ex.node);
-            events.add(createNodeEvent(info, String.format(Locale.ROOT, "Added resource exhaustion: %s", ex.toExhaustionAddedDescription()), params));
+            events.add(createNodeEvent(info, Text.format("Added resource exhaustion: %s", ex.toExhaustionAddedDescription()), params));
         }
     }
 
@@ -247,10 +248,10 @@ public class EventDiffCalculator {
             } else if (isMayHaveMergesPendingDownEdge(prevReason, currReason)) {
                 events.add(createNodeEvent(info, "Node no longer has merges pending", params));
             } else if (isMaintenanceGracePeriodExceededDownEdge(prevReason, currReason, nodeFrom, nodeTo)) {
-                events.add(createNodeEvent(info, String.format(Locale.ROOT, "Exceeded implicit maintenance mode grace period of " +
+                events.add(createNodeEvent(info, Text.format("Exceeded implicit maintenance mode grace period of " +
                         "%d milliseconds. Marking node down.", params.maxMaintenanceGracePeriodTimeMs), params));
             }
-            events.add(createNodeEvent(info, String.format(Locale.ROOT, "Altered node state in cluster state from '%s' to '%s'",
+            events.add(createNodeEvent(info, Text.format("Altered node state in cluster state from '%s' to '%s'",
                     nodeFrom.toString(true), nodeTo.toString(true)), params));
         }
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.document.FixedBucketSpaces;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.state.ClusterState;
@@ -318,7 +319,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         var previouslyExhausted = calc.enumerateNodeResourceExhaustions(nodeInfo);
         var nowExhausted        = calc.resourceExhaustionsFromHostInfo(nodeInfo, newHostInfo);
         if (!previouslyExhausted.equals(nowExhausted)) {
-            context.log(logger, Level.FINE, () -> String.format(Locale.ROOT, "Triggering state recomputation due to change in cluster feed block: %s -> %s",
+            context.log(logger, Level.FINE, () -> Text.format("Triggering state recomputation due to change in cluster feed block: %s -> %s",
                                             previouslyExhausted, nowExhausted));
             stateChangeHandler.setStateChangedFlag();
         }
@@ -445,7 +446,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         Set<ConfiguredNode> nodes = new HashSet<>(cluster.clusterInfo().getConfiguredNodes().values());
         // TODO wouldn't it be better to always get bundle information from the state broadcaster?
         var currentBundle = stateVersionTracker.getVersionedClusterStateBundle();
-        context.log(logger, Level.FINE, () -> String.format(Locale.ROOT, "All distributors have ACKed cluster state version %d", currentBundle.getVersion()));
+        context.log(logger, Level.FINE, () -> Text.format("All distributors have ACKed cluster state version %d", currentBundle.getVersion()));
         stateChangeHandler.handleAllDistributorsInSync(currentBundle.getBaselineClusterState(), nodes, database, dbContext);
         convergedStates.add(currentBundle);
     }
@@ -701,13 +702,13 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         }
 
         final RemoteClusterControllerTask.Context taskContext = createRemoteTaskProcessingContext();
-        context.log(logger, Level.FINEST, () -> String.format(Locale.ROOT, "Processing remote task of type '%s'", task.getClass().getName()));
+        context.log(logger, Level.FINEST, () -> Text.format("Processing remote task of type '%s'", task.getClass().getName()));
         task.doRemoteFleetControllerTask(taskContext);
         if (taskMayBeCompletedImmediately(task)) {
-            context.log(logger, Level.FINEST, () -> String.format(Locale.ROOT, "Done processing remote task of type '%s'", task.getClass().getName()));
+            context.log(logger, Level.FINEST, () -> Text.format("Done processing remote task of type '%s'", task.getClass().getName()));
             task.notifyCompleted();
         } else {
-            context.log(logger, Level.FINEST, () -> String.format(Locale.ROOT, "Remote task of type '%s' queued until state recomputation", task.getClass().getName()));
+            context.log(logger, Level.FINEST, () -> Text.format("Remote task of type '%s' queued until state recomputation", task.getClass().getName()));
             tasksPendingStateRecompute.add(task);
         }
 
@@ -756,7 +757,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
     private static <E> String stringifyListWithLimits(List<E> list, int limit) {
         if (list.size() > limit) {
             var sub = list.subList(0, limit);
-            return String.format(Locale.ROOT, "%s (... and %d more)",
+            return Text.format("%s (... and %d more)",
                     sub.stream().map(E::toString).collect(Collectors.joining(", ")),
                     list.size() - limit);
         } else {
@@ -769,7 +770,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         if (nodes.isEmpty()) {
             return "";
         }
-        return String.format(Locale.ROOT, "the following nodes have not converged to at least version %d: %s",
+        return Text.format("the following nodes have not converged to at least version %d: %s",
                 taskConvergeVersion, stringifyListWithLimits(nodes, options.maxDivergentNodesPrintedInTaskErrorMessages()));
     }
 
@@ -787,13 +788,13 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
             VersionDependentTaskCompletion taskCompletion = taskCompletionQueue.peek();
             // TODO expose and use monotonic clock instead of system clock
             if (publishedVersion >= taskCompletion.getMinimumVersion()) {
-                context.log(logger, Level.FINE, () -> String.format(Locale.ROOT, "Deferred task of type '%s' has minimum version %d, published is %d; completing",
+                context.log(logger, Level.FINE, () -> Text.format("Deferred task of type '%s' has minimum version %d, published is %d; completing",
                                                     taskCompletion.getTask().getClass().getName(), taskCompletion.getMinimumVersion(), publishedVersion));
                 taskCompletion.getTask().notifyCompleted();
                 taskCompletionQueue.remove();
             } else if (taskCompletion.getDeadlineTimePointMs() <= now) {
                 var details = buildNodesNotYetConvergedMessage(taskCompletion.getMinimumVersion());
-                context.log(logger, Level.WARNING, () -> String.format(Locale.ROOT, "Deferred task of type '%s' has exceeded wait deadline; completing with failure (details: %s)",
+                context.log(logger, Level.WARNING, () -> Text.format("Deferred task of type '%s' has exceeded wait deadline; completing with failure (details: %s)",
                                                        taskCompletion.getTask().getClass().getName(), details));
                 taskCompletion.getTask().handleFailure(RemoteClusterControllerTask.Failure.of(
                         RemoteClusterControllerTask.FailureCondition.DEADLINE_EXCEEDED, details));
@@ -1030,7 +1031,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
                 database.loadWantedStates(databaseContext);
                 // TODO determine if we need any specialized handling here if feed block is set in the loaded bundle
 
-                context.log(logger, Level.INFO, () -> String.format(Locale.ROOT, "Loaded previous cluster state bundle from ZooKeeper: %s", previousBundle));
+                context.log(logger, Level.INFO, () -> Text.format("Loaded previous cluster state bundle from ZooKeeper: %s", previousBundle));
                 stateVersionTracker.setClusterStateBundleRetrievedFromZooKeeper(previousBundle);
 
                 eventLog.add(new ClusterEvent(ClusterEvent.Type.MASTER_ELECTION, "This node just became fleetcontroller master. Bumped version to "

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerContext.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerContext.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import java.util.Locale;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -23,7 +24,7 @@ public interface FleetControllerContext {
             var args = new Object[1 + rest.length];
             args[0] = first;
             System.arraycopy(rest, 0, args, 1, rest.length);
-            return String.format(Locale.ROOT, format, args);
+            return Text.format(format, args);
         });
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
@@ -54,7 +55,7 @@ public class MetricUpdater {
     private Duration stateVersionConvergenceGracePeriod = Duration.ofSeconds(30);
 
     public MetricUpdater(MetricReporter metricReporter, Timer timer, int controllerIndex, String clusterName) {
-        this.metricReporter = new ComponentMetricReporter(metricReporter, String.format(Locale.ROOT, "%s.", CLUSTER_CONTROLLER));
+        this.metricReporter = new ComponentMetricReporter(metricReporter, Text.format("%s.", CLUSTER_CONTROLLER));
         this.metricReporter.addDimension(CONTROLLER_INDEX, String.valueOf(controllerIndex));
         this.metricReporter.addDimension(CLUSTER, clusterName);
         this.metricReporter.addDimension(CLUSTER_ID, clusterName);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeInfo.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.collections.Pair;
 import com.yahoo.jrt.Target;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.distribution.Group;
 import com.yahoo.vdslib.state.ClusterState;
@@ -447,7 +448,7 @@ abstract public class NodeInfo implements Comparable<NodeInfo> {
                 && (wentDownAtClusterState == null || wentDownAtClusterState.getVersion() < stateBundle.getVersion())
                 && !stateBundle.getBaselineClusterState().getNodeState(node).getState().oneOf("dsm"))
             {
-                log.log(Level.FINE, () -> String.format(Locale.ROOT, "Clearing going down timestamp of node %s after " +
+                log.log(Level.FINE, () -> Text.format("Clearing going down timestamp of node %s after " +
                         "receiving ack of cluster state bundle %s", node, stateBundle));
                 wentDownWithStartTime = 0;
             }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core;
 
 import ai.vespa.metrics.StorageMetrics;
 import com.yahoo.lang.SettableOptional;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.distribution.Group;
 import com.yahoo.vdslib.state.ClusterState;
@@ -135,7 +136,7 @@ public class NodeStateChangeChecker {
             return Optional.empty();
         }
         if (metrics.docs.isEmpty() || metrics.docs.get().getLast() == null) {
-            log.log(Level.WARNING, String.format(Locale.ROOT, "Host info inconsistency: storage node %d reports entry count but not document count", nodeIndex));
+            log.log(Level.WARNING, Text.format("Host info inconsistency: storage node %d reports entry count but not document count", nodeIndex));
             return Optional.of(disallow("The storage node host info reports stored entry count, but not document count"));
         }
         long lastEntries = metrics.entries.get().getLast();
@@ -143,20 +144,20 @@ public class NodeStateChangeChecker {
         if (lastEntries != 0) {
             long buckets    = metrics.buckets.map(Metrics.Value::getLast).orElse(-1L);
             long tombstones = lastEntries - lastDocs; // docs are a subset of entries, so |docs| <= |entries|
-            return Optional.of(disallow(String.format(Locale.ROOT, "The storage node stores %d documents and %d tombstones across %d buckets", lastDocs, tombstones, buckets)));
+            return Optional.of(disallow(Text.format("The storage node stores %d documents and %d tombstones across %d buckets", lastDocs, tombstones, buckets)));
         }
         // At this point we believe we have zero entries. Cross-check with visible doc count; it should
         // always be present when an entry count of zero is present and transitively always be zero.
         if (lastDocs != 0) {
-            log.log(Level.WARNING, String.format(Locale.ROOT, "Host info inconsistency: storage node %d reports 0 entries, but %d documents", nodeIndex, lastDocs));
-            return Optional.of(disallow(String.format(Locale.ROOT, "The storage node reports 0 entries, but %d documents", lastDocs)));
+            log.log(Level.WARNING, Text.format("Host info inconsistency: storage node %d reports 0 entries, but %d documents", nodeIndex, lastDocs));
+            return Optional.of(disallow(Text.format("The storage node reports 0 entries, but %d documents", lastDocs)));
         }
         return Optional.of(allow());
     }
 
     private static Result checkLegacyZeroBucketsStoredOnContentNode(long lastBuckets) {
         if (lastBuckets != 0) {
-            return disallow(String.format(Locale.ROOT, "The storage node manages %d buckets", lastBuckets));
+            return disallow(Text.format("The storage node manages %d buckets", lastBuckets));
         }
         return allow();
     }
@@ -343,7 +344,7 @@ public class NodeStateChangeChecker {
             return Optional.of(allow());
         }
 
-        return Optional.of(disallow(String.format(Locale.ROOT, "At most %d groups can have wanted state: %s",
+        return Optional.of(disallow(Text.format("At most %d groups can have wanted state: %s",
                                                   maxNumberOfGroupsAllowedToBeDown,
                                                   sortSetIntoList(retiredAndNotUpGroups))));
     }
@@ -403,13 +404,13 @@ public class NodeStateChangeChecker {
             var storageNodeInfo = clusterInfo.getStorageNodeInfo(index);
             State storageNodeWantedState = storageNodeInfo.getUserWantedState().getState();
             if (storageNodeWantedState != UP) {
-                return disallow(String.format(Locale.ROOT, message, storageNodeInfo.type(), index, storageNodeWantedState));
+                return disallow(Text.format(message, storageNodeInfo.type(), index, storageNodeWantedState));
             }
 
             var distributorNodeInfo = clusterInfo.getDistributorNodeInfo(index);
             State distributorWantedState = distributorNodeInfo.getUserWantedState().getState();
             if (distributorWantedState != UP) {
-                return disallow(String.format(Locale.ROOT, message, distributorNodeInfo.type(), index, distributorWantedState));
+                return disallow(Text.format(message, distributorNodeInfo.type(), index, distributorWantedState));
             }
         }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.hostinfo.HostInfo;
 
 import java.util.Collection;
@@ -80,7 +81,7 @@ public class ResourceExhaustionCalculator {
 
     public static String decoratedMessage(ContentCluster cluster, String msg) {
         // Disambiguate content cluster and add a user-friendly documentation link to the error message
-        return String.format(Locale.ROOT, "in content cluster '%s': %s. See https://docs.vespa.ai/en/writing/feed-block.html", cluster.getName(), msg);
+        return Text.format("in content cluster '%s': %s. See https://docs.vespa.ai/en/writing/feed-block.html", cluster.getName(), msg);
     }
 
     public ClusterStateBundle.FeedBlock inferContentClusterFeedBlockOrNull(ContentCluster cluster) {
@@ -98,7 +99,7 @@ public class ResourceExhaustionCalculator {
                 .map(NodeResourceExhaustion::toExhaustionAddedDescription)
                 .collect(Collectors.joining(", "));
         if (exhaustions.size() > maxDescriptions) {
-            description += String.format(Locale.ROOT, " (... and %d more)", exhaustions.size() - maxDescriptions);
+            description += Text.format(" (... and %d more)", exhaustions.size() - maxDescriptions);
         }
         description = decoratedMessage(cluster, description);
         // FIXME we currently will trigger a cluster state recomputation even if the number of

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.jrt.ErrorCode;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
@@ -107,13 +108,13 @@ public class SystemStateBroadcaster {
                 if (reply.getReturnCode() != ErrorCode.NO_SUCH_METHOD) {
                     context.log(log,
                                 Level.FINE,
-                                () -> String.format(Locale.ROOT, "Activation NACK for node %s with version %d, message %s",
+                                () -> Text.format("Activation NACK for node %s with version %d, message %s",
                                                     info, version, reply.getReturnMessage()));
                     success = false;
                 } else {
                     context.log(log,
                                 Level.FINE,
-                                () -> String.format(Locale.ROOT, "Node %s did not understand state activation RPC; " +
+                                () -> Text.format("Node %s did not understand state activation RPC; " +
                                                     "implicitly treating state %d as activated on node",
                                                     info, version));
                 }
@@ -122,14 +123,14 @@ public class SystemStateBroadcaster {
                 // Avoid spamming the logs since this will happen on all resends until (presumably) the controller
                 // loses election status.
                 // TODO this should trigger a loss of current controller's leadership!
-                reportNodeError(nodeOk, info, String.format(Locale.ROOT, "Activation of version %d did not take effect, node %s " +
+                reportNodeError(nodeOk, info, Text.format("Activation of version %d did not take effect, node %s " +
                                 "reports it has an actual pending version of %d. Racing with another controller?",
                                 version, info, reply.getActualVersion()));
                 success = false;
             } else {
                 context.log(log,
                             Level.FINE,
-                            () -> String.format(Locale.ROOT, "Node %s reports successful activation of state version %d",
+                            () -> Text.format("Node %s reports successful activation of state version %d",
                                                 info, version));
             }
             info.setSystemStateVersionActivationAcked(version, success);
@@ -154,13 +155,13 @@ public class SystemStateBroadcaster {
                     if (info.getNewestSystemStateVersionSent() == version) {
                         boolean nodeOk = nodeReportsSelfAsAvailable(info);
                         reportNodeError(nodeOk, info,
-                                String.format(Locale.ROOT, "Got error response %d: %s from %s setdistributionstates request.",
+                                Text.format("Got error response %d: %s from %s setdistributionstates request.",
                                         req.getReply().getReturnCode(), req.getReply().getReturnMessage(), info));
                     }
                 }
             } else {
                 info.setClusterStateBundleVersionAcknowledged(version, true);
-                context.log(log, Level.FINE, () -> String.format(Locale.ROOT, "Node %s ACKed system state version %d.", info, version));
+                context.log(log, Level.FINE, () -> Text.format("Node %s ACKed system state version %d.", info, version));
                 lastErrorReported.remove(info.getNode());
             }
         }
@@ -238,7 +239,7 @@ public class SystemStateBroadcaster {
             if (clusterStateBundle.deferredActivation()) {
                 context.log(log,
                             Level.FINE,
-                            () -> String.format(Locale.ROOT, "All distributors have ACKed cluster state " +
+                            () -> Text.format("All distributors have ACKed cluster state " +
                                                 "version %d, sending activation", currentStateVersion));
             } else {
                 markCurrentClusterStateAsConverged(database, dbContext, fleetController);
@@ -259,7 +260,7 @@ public class SystemStateBroadcaster {
         } else {
             context.log(log,
                         Level.FINE,
-                        () -> String.format(Locale.ROOT, "distributors still need activation in state %d (last converged: %d)",
+                        () -> Text.format("distributors still need activation in state %d (last converged: %d)",
                                             currentStateVersion, lastClusterStateVersionConverged));
         }
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.database;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.State;
@@ -258,7 +259,7 @@ public class DatabaseHandler {
                 didWork |= performZooKeeperWrites();
             }
         } catch (CasWriteFailed e) {
-            fleetControllerContext.log(logger, Level.WARNING, String.format(Locale.ROOT, "CaS write to ZooKeeper failed, another controller " +
+            fleetControllerContext.log(logger, Level.WARNING, Text.format("CaS write to ZooKeeper failed, another controller " +
                                                                             "has likely taken over ownership: %s", e.getMessage()));
             // Clear DB and master election state. This shall trigger a full re-fetch of all
             // version and election-related metadata.

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/MasterDataGatherer.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.database;
 
+import com.yahoo.text.Text;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -125,7 +126,7 @@ public final class MasterDataGatherer {
                     } else {
                         // May happen when pending data watch error callbacks are triggered concurrently with
                         // internal voting state having already been cleared due to connectivity issues.
-                        log.log(Level.INFO, String.format(Locale.ROOT, "Fleetcontroller %d: ignoring removal of vote from node %d " +
+                        log.log(Level.INFO, Text.format("Fleetcontroller %d: ignoring removal of vote from node %d " +
                                 "since it was not present in existing vote mapping", nodeIndex, index));
                     }
                 } else {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.database;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.State;
@@ -206,7 +207,7 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (KeeperException.BadVersionException e) {
-            throw new CasWriteFailed(String.format(Locale.ROOT, "version mismatch in cluster state version znode (expected %d): %s",
+            throw new CasWriteFailed(Text.format("version mismatch in cluster state version znode (expected %d): %s",
                     lastKnownStateVersionZNodeVersion, e.getMessage()), e);
         } catch (Exception e) {
             maybeLogExceptionWarning(e, "Failed to store latest system state version used " + version);
@@ -351,14 +352,14 @@ public class ZooKeeperDatabase extends Database {
         try{
             context.log(log,
                         Level.FINE,
-                        () -> String.format(Locale.ROOT, "Storing published state bundle %s at '%s' with expected znode version %d",
+                        () -> Text.format("Storing published state bundle %s at '%s' with expected znode version %d",
                                             stateBundle, paths.publishedStateBundle(), lastKnownStateBundleZNodeVersion));
             var stat = session.setData(paths.publishedStateBundle(), encodedBundle, lastKnownStateBundleZNodeVersion);
             lastKnownStateBundleZNodeVersion = stat.getVersion();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (KeeperException.BadVersionException e) {
-            throw new CasWriteFailed(String.format(Locale.ROOT, "version mismatch in cluster state bundle znode (expected %d): %s",
+            throw new CasWriteFailed(Text.format("version mismatch in cluster state bundle znode (expected %d): %s",
                     lastKnownStateBundleZNodeVersion, e.getMessage()), e);
         } catch (Exception e) {
             maybeLogExceptionWarning(e, "Failed to store last published cluster state bundle in ZooKeeper");

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Request.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Request.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.restapiv2;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.RemoteClusterControllerTask;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.DeadlineExceededException;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.InternalFailure;
@@ -65,7 +66,7 @@ public abstract class Request<Result> extends RemoteClusterControllerTask {
 
     private static String failureStringWithPossibleMessage(String prefix, String message) {
         if (message != null && !message.isEmpty()) {
-            return String.format(Locale.ROOT, "%s: %s", prefix, message);
+            return Text.format("%s: %s", prefix, message);
         }
         return prefix;
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/RPCCommunicator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/RPCCommunicator.java
@@ -11,6 +11,7 @@ import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Target;
 import com.yahoo.jrt.Transport;
 import com.yahoo.jrt.Values;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.State;
@@ -114,7 +115,7 @@ public class RPCCommunicator implements Communicator {
     public void getNodeState(NodeInfo node, Waiter<GetNodeStateRequest> externalWaiter) {
         Target connection = getConnection(node);
         if ( ! connection.isValid()) {
-            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Connection to '%s' could not be created.", node.getRpcAddress()));
+            log.log(Level.FINE, () -> Text.format("Connection to '%s' could not be created.", node.getRpcAddress()));
         }
         NodeState currentState = node.getReportedState();
         Request req = new Request("getnodestate3");
@@ -141,7 +142,7 @@ public class RPCCommunicator implements Communicator {
 
         Target connection = getConnection(node);
         if ( ! connection.isValid()) {
-            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Connection to '%s' could not be created.", node.getRpcAddress()));
+            log.log(Level.FINE, () -> Text.format("Connection to '%s' could not be created.", node.getRpcAddress()));
             return;
         }
         Request req = new Request(SET_DISTRIBUTION_STATES_RPC_METHOD_NAME);
@@ -152,7 +153,7 @@ public class RPCCommunicator implements Communicator {
         v.add(new Int32Value(encodedBundle.getCompression().uncompressedSize()));
         v.add(new DataValue(encodedBundle.getCompression().data()));
 
-        log.log(Level.FINE, () -> String.format(Locale.ROOT, "Sending '%s' RPC to %s for state version %d",
+        log.log(Level.FINE, () -> Text.format("Sending '%s' RPC to %s for state version %d",
                 req.methodName(), node.getRpcAddress(), stateBundle.getVersion()));
         RPCSetClusterStateRequest stateRequest = new RPCSetClusterStateRequest(node, req, baselineState.getVersion());
         waiter.setRequest(stateRequest);
@@ -167,14 +168,14 @@ public class RPCCommunicator implements Communicator {
 
         Target connection = getConnection(node);
         if ( ! connection.isValid()) {
-            log.log(Level.FINE, () -> String.format(Locale.ROOT, "Connection to '%s' could not be created.", node.getRpcAddress()));
+            log.log(Level.FINE, () -> Text.format("Connection to '%s' could not be created.", node.getRpcAddress()));
             return;
         }
 
         var req = new Request(ACTIVATE_CLUSTER_STATE_VERSION_RPC_METHOD_NAME);
         req.parameters().add(new Int32Value(clusterStateVersion));
 
-        log.log(Level.FINE, () -> String.format(Locale.ROOT, "Sending '%s' RPC to %s for state version %d",
+        log.log(Level.FINE, () -> Text.format("Sending '%s' RPC to %s for state version %d",
                 req.methodName(), node.getRpcAddress(), clusterStateVersion));
         var activationRequest = new RPCActivateClusterStateVersionRequest(node, req, clusterStateVersion);
         waiter.setRequest(activationRequest);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFixture.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.state.ClusterState;
@@ -137,7 +138,7 @@ public class ClusterFixture {
 
     public ClusterFixture assignDummyRpcAddresses() {
         cluster.getNodeInfos().forEach(ni -> {
-            ni.setRpcAddress(String.format(Locale.ROOT, "tcp/%s.%d.local:0",
+            ni.setRpcAddress(Text.format("tcp/%s.%d.local:0",
                     ni.isStorage() ? "storage" : "distributor",
                     ni.getNodeIndex()));
         });

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DummyVdsNode.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DummyVdsNode.java
@@ -14,6 +14,7 @@ import com.yahoo.jrt.Transport;
 import com.yahoo.jrt.slobrok.api.BackOffPolicy;
 import com.yahoo.jrt.slobrok.api.Register;
 import com.yahoo.jrt.slobrok.api.SlobrokList;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
@@ -432,7 +433,7 @@ public class DummyVdsNode {
                     activatedClusterStateVersion = activateVersion;
                     timer.notifyAll();
                 } else {
-                    log.log(Level.FINE, () -> String.format(Locale.ROOT, "Dummy node %s: got a mismatching activation (request version %d, " +
+                    log.log(Level.FINE, () -> Text.format("Dummy node %s: got a mismatching activation (request version %d, " +
                             "actual %d), not marking version as active", this, activateVersion, actualVersion));
                 }
             }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Transport;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.NodeType;
@@ -177,7 +178,7 @@ public class MasterElectionTest extends FleetControllerTest {
             lastState = currentState;
             if (currentState.getVersion() <= last.getVersion()) {
                 throw new IllegalStateException(
-                        String.format(Locale.ROOT, "Cluster state version strict increase invariant broken! " +
+                        Text.format("Cluster state version strict increase invariant broken! " +
                                       "Old state was '%s', new state is '%s'", last, currentState));
             }
         }
@@ -410,7 +411,7 @@ public class MasterElectionTest extends FleetControllerTest {
         // at ACKing a previous one.
         this.nodes.stream().filter(DummyVdsNode::isDistributor).forEach(node -> {
             node.setNodeState(new NodeState(NodeType.DISTRIBUTOR, State.UP),
-                    String.format(Locale.ROOT, "{\"cluster-state-version\":%d}", ackVersion));
+                    Text.format("{\"cluster-state-version\":%d}", ackVersion));
         });
         waitForStateInAllSpaces("version:\\d+ distributor:10 storage:10");
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vespa.clustercontroller.core.matchers.HasMetricContext;
@@ -76,7 +77,7 @@ public class MetricReporterTest {
     }
 
     private static String metricName(String subName) {
-        return String.format(Locale.ROOT, "%s.%s", CLUSTER_CONTROLLER, subName);
+        return Text.format("%s.%s", CLUSTER_CONTROLLER, subName);
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.state.ClusterState;
@@ -56,7 +57,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     private static ClusterState defaultAllUpClusterState(int nodeCount) {
-        return clusterState(String.format("version:%d distributor:%d storage:%d",
+        return clusterState(Text.format("version:%d distributor:%d storage:%d",
                                           currentClusterStateVersion,
                                           nodeCount,
                                           nodeCount));
@@ -153,7 +154,7 @@ public class NodeStateChangeCheckerTest {
         // Nodes 0-3, storage node 0 being in maintenance with "Orchestrator" description.
         ContentCluster cluster = createCluster(4, maxNumberOfGroupsAllowedToBeDown);
         setStorageNodeWantedStateToOrchestratorMaintenance(cluster, 0);
-        ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+        ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                 "version:%d distributor:4 storage:4 .0.s:m",
                 currentClusterStateVersion));
 
@@ -181,7 +182,7 @@ public class NodeStateChangeCheckerTest {
 
         // Node in group 0 in maintenance, set storage node in group 1 to maintenance
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:4 .0.s:d storage:4 .0.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:4 .0.s:d storage:4 .0.s:m", currentClusterStateVersion));
             int nodeIndex = 1;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
             setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
@@ -189,7 +190,7 @@ public class NodeStateChangeCheckerTest {
 
         // Nodes in group 0 and 1 in maintenance, try to set storage node in group 2 to maintenance while storage node 2 is down, should fail
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:4 storage:4 .0.s:m .1.s:m .2.s:d", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:4 storage:4 .0.s:m .1.s:m .2.s:d", currentClusterStateVersion));
             int nodeIndex = 2;
             cluster.clusterInfo().getStorageNodeInfo(nodeIndex).setReportedState(new NodeState(STORAGE, DOWN), 0);
             Node node = new Node(STORAGE, nodeIndex);
@@ -201,7 +202,7 @@ public class NodeStateChangeCheckerTest {
 
         // Nodes in group 0 and 1 in maintenance, try to set storage node in group 2 to maintenance, should fail
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:4 storage:4 .0.s:m .1.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:4 storage:4 .0.s:m .1.s:m", currentClusterStateVersion));
             int nodeIndex = 2;
             Node node = new Node(STORAGE, nodeIndex);
             Result result = evaluateTransition(cluster, node, clusterState, UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -228,7 +229,7 @@ public class NodeStateChangeCheckerTest {
 
         // One node in group 0 in maintenance, try to set another storage node in group 0 to maintenance, should fail
         {
-            ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+            ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                     "version:%d distributor:4 storage:4 .0.s:m",
                     currentClusterStateVersion));
             int nodeIndex = 1;
@@ -238,7 +239,7 @@ public class NodeStateChangeCheckerTest {
 
         // One node in group 0 in maintenance, try to set a storage node in group 1 to maintenance, should also fail
         {
-            ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+            ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                     "version:%d distributor:4 storage:4 .0.s:m",
                     currentClusterStateVersion));
             int nodeIndex = 2;
@@ -265,7 +266,7 @@ public class NodeStateChangeCheckerTest {
 
         // 1 Node in group 0 in maintenance, try to set node 1 in group 0 to maintenance
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 .0.s:d storage:8 .0.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 .0.s:d storage:8 .0.s:m", currentClusterStateVersion));
             int nodeIndex = 1;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
             setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
@@ -273,7 +274,7 @@ public class NodeStateChangeCheckerTest {
 
         // 2 nodes in group 0 in maintenance, try to set storage node 2 in group 1 to maintenance
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m", currentClusterStateVersion));
             int nodeIndex = 2;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
             setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
@@ -281,14 +282,14 @@ public class NodeStateChangeCheckerTest {
 
         // 2 nodes in group 0 and 1 in group 1 in maintenance, try to set storage node 4 in group 2 to maintenance, should fail (different group)
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m", currentClusterStateVersion));
             int nodeIndex = 4;
             settingToMaintenanceIsNotAllowed(nodeIndex, cluster, clusterState, "At most 2 groups can have wanted state: [0, 1]");
         }
 
         // 2 nodes in group 0 and 1 in group 1 in maintenance, try to set storage node 3 in group 1 to maintenance
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m", currentClusterStateVersion));
             int nodeIndex = 3;
             settingToMaintenanceIsAllowed(nodeIndex, cluster, clusterState);
             setStorageNodeWantedStateToOrchestratorMaintenance(cluster, nodeIndex);
@@ -296,7 +297,7 @@ public class NodeStateChangeCheckerTest {
 
         // 2 nodes in group 0 and 2 nodes in group 1 in maintenance, try to set storage node 4 in group 2 to maintenance, should fail
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m .3.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .2.s:m .3.s:m", currentClusterStateVersion));
             int nodeIndex = 4;
             settingToMaintenanceIsNotAllowed(nodeIndex, cluster, clusterState, "At most 2 groups can have wanted state: [0, 1]");
         }
@@ -304,7 +305,7 @@ public class NodeStateChangeCheckerTest {
         // 2 nodes in group 0 in maintenance, storage node 3 in group 1 is in maintenance with another description
         // (set in maintenance by operator), try to set storage node 2 in group 1 to maintenance, should be allowed
         {
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .3.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m .3.s:m", currentClusterStateVersion));
             setStorageNodeWantedState(cluster, 3, MAINTENANCE, "Maintenance, set by operator");  // Set to another description
             setStorageNodeWantedState(cluster, 2, UP, ""); // Set back to UP, want to set this to maintenance again
             int nodeIndex = 2;
@@ -321,7 +322,7 @@ public class NodeStateChangeCheckerTest {
             setStorageNodeWantedState(cluster, 1, MAINTENANCE, "Orchestrator");
             setStorageNodeWantedState(cluster, 2, UP, ""); // Set up again
             setStorageNodeWantedState(cluster, 3, UP, ""); // Set up again
-            ClusterState clusterState = clusterState(String.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m", currentClusterStateVersion));
+            ClusterState clusterState = clusterState(Text.format("version:%d distributor:8 storage:8 .0.s:m .1.s:m", currentClusterStateVersion));
 
             // Set bucket in sync to 1 for node 2 in group 1
             var distributorHostInfo = createDistributorHostInfo(1, 2, 1);
@@ -342,7 +343,7 @@ public class NodeStateChangeCheckerTest {
         // Nodes 0-3, distributor 0 being down with "Orchestrator" description.
         ContentCluster cluster = createCluster(4, maxNumberOfGroupsAllowedToBeDown);
         setDistributorNodeWantedState(cluster, 0, DOWN, "Orchestrator");
-        ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+        ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                 "version:%d distributor:4 .0.s:d storage:4",
                 currentClusterStateVersion));
 
@@ -357,7 +358,7 @@ public class NodeStateChangeCheckerTest {
         // 2 groups: nodes 0-1 is group 0, 2-3 is group 1.
         ContentCluster cluster = createCluster(4, 2, maxNumberOfGroupsAllowedToBeDown);
         setDistributorNodeWantedState(cluster, 0, DOWN, "Orchestrator");
-        ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+        ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                 "version:%d distributor:4 .0.s:d storage:4",
                 currentClusterStateVersion));
 
@@ -386,7 +387,7 @@ public class NodeStateChangeCheckerTest {
         // 2 groups: nodes 0-1 is group 0, 2-3 is group 1.
         ContentCluster cluster = createCluster(4, 2, maxNumberOfGroupsAllowedToBeDown);
         setStorageNodeWantedState(cluster, 0, MAINTENANCE, "Orchestrator");
-        ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+        ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                 "version:%d distributor:4 storage:4 .0.s:m",
                 currentClusterStateVersion));
 
@@ -412,7 +413,7 @@ public class NodeStateChangeCheckerTest {
         // 2 groups: nodes 0-1 is group 0, 2-3 is group 1.
         ContentCluster cluster = createCluster(4, 2, maxNumberOfGroupsAllowedToBeDown);
         setStorageNodeWantedStateToOrchestratorMaintenance(cluster, 0);
-        ClusterState clusterStateWith0InMaintenance = clusterState(String.format(
+        ClusterState clusterStateWith0InMaintenance = clusterState(Text.format(
                 "version:%d distributor:4 storage:4 .0.s:m",
                 currentClusterStateVersion));
         // Pretend we got a reconfig or leadership change, causing our knowledge of the old world
@@ -443,7 +444,7 @@ public class NodeStateChangeCheckerTest {
         cluster.clusterInfo()
                .getStorageNodeInfo(3)
                .setReportedState(new NodeState(STORAGE, DOWN), 0);
-        ClusterState clusterStateWith3Down = clusterState(String.format(
+        ClusterState clusterStateWith3Down = clusterState(Text.format(
                 "version:%d distributor:4 storage:4 .3.s:d",
                 currentClusterStateVersion));
 
@@ -484,7 +485,7 @@ public class NodeStateChangeCheckerTest {
 
         markAllNodesAsReportingStateUp(cluster);
 
-        ClusterState stateWithNodeDown = clusterState(String.format(
+        ClusterState stateWithNodeDown = clusterState(Text.format(
                 "version:%d distributor:4 storage:4 .%d.s:d",
                 currentClusterStateVersion, storageNode.getIndex()));
 
@@ -717,7 +718,7 @@ public class NodeStateChangeCheckerTest {
         // in state Down should halt the upgrade. This must also take into account the generated
         // state, not just the reported state. In this case, all nodes are reported as being Up
         // but one node has a generated state of Down.
-        ClusterState stateWithNodeDown = clusterState(String.format(
+        ClusterState stateWithNodeDown = clusterState(Text.format(
                 "version:%d distributor:4 storage:4 .3.s:d",
                 currentClusterStateVersion));
 
@@ -867,7 +868,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     private ClusterState retiredClusterStateSuffix() {
-        return clusterState(String.format("version:%d distributor:4 storage:4 .%d.s:r",
+        return clusterState(Text.format("version:%d distributor:4 storage:4 .%d.s:r",
                                           currentClusterStateVersion,
                                           storageNode.getIndex()));
     }
@@ -880,7 +881,7 @@ public class NodeStateChangeCheckerTest {
             // accidentally use the wrong dimension.
             return Stream.of("default", "global")
                     .map(bucketSpace ->
-                        String.format(Locale.ROOT, """
+                        Text.format("""
                         {
                             "name":"vds.datastored.bucket_space.%s",
                             "values":{"last":%d},
@@ -892,7 +893,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     private static HostInfo createHostInfoWithMetrics(int clusterStateVersion, HostInfoMetrics hostInfoMetrics) {
-        return HostInfo.createHostInfo(String.format("""
+        return HostInfo.createHostInfo(Text.format("""
                         {
                           "metrics":
                           {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/ClusterEventWithDescription.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/ClusterEventWithDescription.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.ClusterEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -24,7 +25,7 @@ public class ClusterEventWithDescription extends BaseMatcher<ClusterEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "ClusterEvent with description '%s'", expected));
+        description.appendText(Text.format("ClusterEvent with description '%s'", expected));
     }
 
     @Override
@@ -33,7 +34,7 @@ public class ClusterEventWithDescription extends BaseMatcher<ClusterEvent> {
             return;
         }
         ClusterEvent other = (ClusterEvent)item;
-        description.appendText(String.format(Locale.ROOT, "got description '%s'", other.getDescription()));
+        description.appendText(Text.format("got description '%s'", other.getDescription()));
     }
 
     public static ClusterEventWithDescription clusterEventWithDescription(String description) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventForNode.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventForNode.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
@@ -22,13 +23,13 @@ public class EventForNode extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "NodeEvent for node %s", expected));
+        description.appendText(Text.format("NodeEvent for node %s", expected));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format(Locale.ROOT, "got node %s", other.getNode().getNode()));
+        description.appendText(Text.format("got node %s", other.getNode().getNode()));
     }
 
     public static EventForNode eventForNode(Node expected) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTimeIs.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTimeIs.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.Event;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -24,17 +25,16 @@ public class EventTimeIs extends BaseMatcher<Event> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "Event with time %d", expected));
+        description.appendText(Text.format("Event with time %d", expected));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         Event other = (Event)item;
-        description.appendText(String.format(Locale.ROOT, "event time is %d", other.getTimeMs()));
+        description.appendText(Text.format("event time is %d", other.getTimeMs()));
     }
 
     public static EventTimeIs eventTimeIs(long time) {
         return new EventTimeIs(time);
     }
 }
-

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTypeIs.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/EventTypeIs.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -24,13 +25,13 @@ public class EventTypeIs extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "NodeEvent with description '%s'", expected));
+        description.appendText(Text.format("NodeEvent with description '%s'", expected));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format(Locale.ROOT, "got description '%s'", other.getDescription()));
+        description.appendText(Text.format("got description '%s'", other.getDescription()));
     }
 
     public static EventTypeIs eventTypeIs(NodeEvent.Type type) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasMetricContext.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasMetricContext.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.utils.util.MetricReporter;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -29,12 +30,12 @@ public class HasMetricContext extends BaseMatcher<MetricReporter.Context> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "Context with dimensions %s", dimensions));
+        description.appendText(Text.format("Context with dimensions %s", dimensions));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
-        description.appendText(String.format(Locale.ROOT, "Context dimensions are %s", item.toString()));
+        description.appendText(Text.format("Context dimensions are %s", item.toString()));
     }
 
     public static class Dimension {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasStateReasonForNode.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/HasStateReasonForNode.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vespa.clustercontroller.core.NodeStateReason;
 import org.hamcrest.BaseMatcher;
@@ -28,7 +29,7 @@ public class HasStateReasonForNode extends BaseMatcher<Map<Node, NodeStateReason
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "has node state reason %s", expected.toString()));
+        description.appendText(Text.format("has node state reason %s", expected.toString()));
     }
 
     @Override
@@ -36,7 +37,7 @@ public class HasStateReasonForNode extends BaseMatcher<Map<Node, NodeStateReason
         @SuppressWarnings("unchecked")
         Map<Node, NodeStateReason> other = (Map<Node, NodeStateReason>)item;
         if (other.containsKey(node)) {
-            description.appendText(String.format(Locale.ROOT, "has reason %s", other.get(node).toString()));
+            description.appendText(Text.format("has reason %s", other.get(node).toString()));
         } else {
             description.appendText("has no entry for node");
         }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventForBucketSpace.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventForBucketSpace.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -25,13 +26,13 @@ public class NodeEventForBucketSpace extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "NodeEvent for bucket space '%s'", bucketSpace.orElse("null")));
+        description.appendText(Text.format("NodeEvent for bucket space '%s'", bucketSpace.orElse("null")));
     }
 
     @Override
     public void describeMismatch(Object item, Description description) {
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format(Locale.ROOT, "got bucket space '%s'", other.getBucketSpace().orElse("null")));
+        description.appendText(Text.format("got bucket space '%s'", other.getBucketSpace().orElse("null")));
     }
 
     public static NodeEventForBucketSpace nodeEventForBucketSpace(String bucketSpace) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventWithDescription.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/matchers/NodeEventWithDescription.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.matchers;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.NodeEvent;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -24,7 +25,7 @@ public class NodeEventWithDescription extends BaseMatcher<NodeEvent> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.format(Locale.ROOT, "NodeEvent with description '%s'", expected));
+        description.appendText(Text.format("NodeEvent with description '%s'", expected));
     }
 
     @Override
@@ -33,7 +34,7 @@ public class NodeEventWithDescription extends BaseMatcher<NodeEvent> {
             return;
         }
         NodeEvent other = (NodeEvent)item;
-        description.appendText(String.format(Locale.ROOT, "got description '%s'", other.getDescription()));
+        description.appendText(Text.format("got description '%s'", other.getDescription()));
     }
 
     public static NodeEventWithDescription nodeEventWithDescription(String description) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core.restapiv2;
 
 import com.yahoo.time.TimeBudget;
+import com.yahoo.text.Text;
 import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.MasterInterface;
@@ -133,7 +134,7 @@ public class SetNodeStateTest extends StateRestApiTest {
     private String musicClusterExpectedUserStateString(String groupName,
                                                        String generatedState, String unitState,
                                                        String userState, String userReason) {
-        return String.format(Locale.ROOT, """
+        return Text.format("""
                {
                  "attributes" : {
                    "hierarchical-group" : "%s"

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.rpc;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
 import com.yahoo.vespa.clustercontroller.core.ClusterStateBundleUtil;
 import com.yahoo.vespa.clustercontroller.core.DistributionBuilder;
@@ -46,7 +47,7 @@ public class SlimeClusterStateBundleCodecTest {
             allDownStates.append(" .").append(i).append(".s:d");
         }
         // Exact same state set string repeated twice; perfect compression fodder.
-        return ClusterStateBundleUtil.makeBundle(String.format(Locale.ROOT, "distributor:100%s storage:100%s",
+        return ClusterStateBundleUtil.makeBundle(Text.format("distributor:100%s storage:100%s",
                 allDownStates, allDownStates));
     }
 

--- a/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/requests/SetUnitStateRequest.java
+++ b/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/requests/SetUnitStateRequest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.utils.staterestapi.requests;
 
 import com.yahoo.time.TimeBudget;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.InvalidContentException;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.response.UnitState;
 
@@ -26,7 +27,7 @@ public interface SetUnitStateRequest extends UnitRequest {
             try {
                 return Condition.valueOf(value.toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException e) {
-                throw new InvalidContentException(String.format(Locale.ROOT, "Invalid value for condition: '%s', expected one of 'force', 'safe'", value));
+                throw new InvalidContentException(Text.format("Invalid value for condition: '%s', expected one of 'force', 'safe'", value));
             }
         }
     }
@@ -58,7 +59,7 @@ public interface SetUnitStateRequest extends UnitRequest {
             } else if (value.equalsIgnoreCase(NO_WAIT.name)) {
                 return NO_WAIT;
             }
-            throw new InvalidContentException(String.format(Locale.ROOT, "Invalid value for response-wait: '%s', expected one of '%s', '%s'",
+            throw new InvalidContentException(Text.format("Invalid value for response-wait: '%s', expected one of '%s', '%s'",
                     value, WAIT_UNTIL_CLUSTER_ACKED.name, NO_WAIT.name));
         }
     }

--- a/clustercontroller-utils/src/test/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/DummyStateApi.java
+++ b/clustercontroller-utils/src/test/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/DummyStateApi.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.utils.staterestapi;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.InvalidContentException;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.MissingUnitException;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.errors.OperationNotSupportedForUnitException;
@@ -201,7 +202,7 @@ public class DummyStateApi implements StateRestAPI {
         }
         n.state = newState.get("current").id();
         n.reason = newState.get("current").reason();
-        String reason = String.format("DummyStateAPI %s call", request.getResponseWait().getName());
+        String reason = Text.format("DummyStateAPI %s call", request.getResponseWait().getName());
         return new SetResponse(reason, true);
     }
 


### PR DESCRIPTION
Refactor string formatting calls across the clustercontroller-core module to use the Text.format utility method instead of String.format with explicit Locale.ROOT.