### PR TITLE
Explicitly specify UTF-8 when writing services.xml

### DIFF
--- a/application/src/main/java/com/yahoo/application/Application.java
+++ b/application/src/main/java/com/yahoo/application/Application.java
@@ -42,6 +42,7 @@ import java.net.BindException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -369,7 +370,7 @@ public final class Application implements AutoCloseable {
         }
 
         private void generateXml() throws Exception {
-            try (PrintWriter xml = new PrintWriter(Files.newOutputStream(path.resolve("services.xml")))) {
+            try (PrintWriter xml = new PrintWriter(Files.newOutputStream(path.resolve("services.xml")), true, StandardCharsets.UTF_8)) {
                 xml.println("<?xml version=\"1.0\" encoding=\"utf-8\" ?>");
                 for (Map.Entry<String, Container> entry : containers.entrySet()) {
                     entry.getValue().build(xml, entry.getKey(), (networking == Networking.enable ? getRandomPort() : -1));


### PR DESCRIPTION
Use StandardCharsets.UTF_8 when creating PrintWriter for services.xml to ensure consistent encoding across platforms, matching the UTF-8 declaration in the XML header.
