### PR TITLE
Refactor config-model to use Text.format

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/DocumentReferenceResolver.java
+++ b/config-model/src/main/java/com/yahoo/schema/DocumentReferenceResolver.java
@@ -5,6 +5,7 @@ import com.yahoo.document.Field;
 import com.yahoo.documentmodel.NewDocumentReferenceDataType;
 import com.yahoo.schema.document.SDDocumentType;
 import com.yahoo.schema.document.SDField;
+import com.yahoo.text.Text;
 
 import java.util.Collection;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class DocumentReferenceResolver {
         Schema schema = schemaMapping.get(targetDocumentName);
         if (schema == null) {
             throw new IllegalArgumentException(
-                    String.format(java.util.Locale.ROOT, "Invalid document reference '%s': " +
+                    Text.format("Invalid document reference '%s': " +
                                   "Could not find document type '%s'", field.getName(), targetDocumentName));
         }
         return new DocumentReference(field, schema);

--- a/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
@@ -21,6 +21,7 @@ import com.yahoo.searchlib.rankingexpression.parser.ParseException;
 import com.yahoo.searchlib.rankingexpression.rule.ReferenceNode;
 import com.yahoo.searchlib.rankingexpression.rule.SerializationContext;
 import com.yahoo.tensor.evaluation.TypeContext;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
 import static com.yahoo.searchlib.rankingexpression.Reference.wrapInRankingExpression;
 
@@ -531,10 +532,10 @@ public class RawRankProfile {
                 properties.add(new Pair<>("vespa.matching.filter_threshold", String.valueOf(filterThreshold.getAsDouble())));
             }
             for (var fieldAndThreshold : explicitFieldRankFilterThresholds.entrySet()) {
-                properties.add(new Pair<>(String.format(java.util.Locale.ROOT, "vespa.matching.filter_threshold.%s", fieldAndThreshold.getKey()), String.valueOf(fieldAndThreshold.getValue())));
+                properties.add(new Pair<>(Text.format("vespa.matching.filter_threshold.%s", fieldAndThreshold.getKey()), String.valueOf(fieldAndThreshold.getValue())));
             }
             for (var fieldAndElementGap : activeElementGapsPerField.entrySet()) {
-                properties.add(new Pair<>(String.format(java.util.Locale.ROOT, "vespa.matching.element_gap.%s", fieldAndElementGap.getKey()), fieldAndElementGap.getValue().toString()));
+                properties.add(new Pair<>(Text.format("vespa.matching.element_gap.%s", fieldAndElementGap.getKey()), fieldAndElementGap.getValue().toString()));
             }
             if (matchPhaseSettings != null) {
                 properties.add(new Pair<>("vespa.matchphase.degradation.attribute", matchPhaseSettings.getAttribute()));

--- a/config-model/src/main/java/com/yahoo/schema/processing/ValidateNoFieldRankFilterOverlap.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/ValidateNoFieldRankFilterOverlap.java
@@ -4,6 +4,7 @@ package com.yahoo.schema.processing;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.schema.RankProfileRegistry;
 import com.yahoo.schema.Schema;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 
 /**
@@ -42,7 +43,7 @@ public class ValidateNoFieldRankFilterOverlap extends Processor {
                 boolean hasExplicitFilterThreshold = rp.explicitFieldRankFilterThresholds().containsKey(field.getName());
                 if (isFilter && hasExplicitFilterThreshold) {
                     throw newProcessException(schema.getName(), field.getName(),
-                            String.format(java.util.Locale.ROOT, ("rank profile '%s' declares field as `rank %s { filter-threshold:... }`, but field " +
+                            Text.format(("rank profile '%s' declares field as `rank %s { filter-threshold:... }`, but field " +
                              "is also declared as `rank: filter`. These declarations are mutually exclusive."), rp.name(), field.getName()));
                 }
             }

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -26,6 +26,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.QuotaExceededException;
 import com.yahoo.config.provision.TransientException;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.VespaVersion;
 import com.yahoo.vespa.model.application.validation.Validation;
 import com.yahoo.vespa.model.application.validation.Validator;
@@ -132,7 +133,7 @@ public class VespaModelFactory implements ModelFactory {
                 VespaModel currentModel = (VespaModel) currentActiveModel.get();
                 var currentMeta = currentModel.applicationPackage().getMetaData();
                 var nextMeta = nextModel.applicationPackage().getMetaData();
-                log.log(Level.INFO, String.format(java.util.Locale.ROOT, "Model [%s/%s] -> [%s/%s] triggers reindexing: %s",
+                log.log(Level.INFO, Text.format("Model [%s/%s] -> [%s/%s] triggers reindexing: %s",
                                                   currentModel.version().toString(), currentMeta.toString(),
                                                   nextModel.version().toString(), nextMeta.toString(),
                                                   action));

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/AbstractBundleValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/AbstractBundleValidator.java
@@ -6,6 +6,7 @@ import com.yahoo.config.application.api.ComponentInfo;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.path.Path;
+import com.yahoo.text.Text;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import org.w3c.dom.Document;
@@ -57,7 +58,7 @@ public abstract class AbstractBundleValidator implements Validator {
             Path path = Path.fromString(info.getPathRelativeToAppDir());
             try {
                 context.deployState().getDeployLogger()
-                        .log(Level.FINE, String.format(java.util.Locale.ROOT, "Validating bundle at '%s'", path));
+                        .log(Level.FINE, Text.format("Validating bundle at '%s'", path));
                 JarFile jarFile = new JarFile(app.getFileReference(path));
                 validateJarFile(JarContext.of(context), jarFile);
             } catch (IOException e) {
@@ -97,7 +98,7 @@ public abstract class AbstractBundleValidator implements Validator {
     }
 
     protected final void log(DeployState state, Level level, String fmt, Object... args) {
-        state.getDeployLogger().logApplicationPackage(level, String.format(java.util.Locale.ROOT, fmt, args));
+        state.getDeployLogger().logApplicationPackage(level, Text.format(fmt, args));
     }
 
     private static final Pattern POM_FILE_LOCATION = Pattern.compile("META-INF/maven/.+?/.+?/pom.xml");
@@ -111,12 +112,12 @@ public abstract class AbstractBundleValidator implements Validator {
                         return XML.getDocumentBuilder(false)
                                 .parse(new InputSource(new StringReader(text)));
                     } catch (SAXException e) {
-                        String message = String.format(java.util.Locale.ROOT, "Unable to parse pom.xml from %s", filename(jar));
+                        String message = Text.format("Unable to parse pom.xml from %s", filename(jar));
                         logger.log(Level.SEVERE, message);
                         context.accept(message, e);
                     } catch (IOException e) {
                         logger.log(Level.INFO,
-                                String.format(java.util.Locale.ROOT, "Unable to read '%s' from '%s'", f.getName(), jar.getName()));
+                                Text.format("Unable to read '%s' from '%s'", f.getName(), jar.getName()));
                     }
                     return null;
                 });

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/AccessControlFilterExcludeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/AccessControlFilterExcludeValidator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.container.http.AccessControl;
 import com.yahoo.vespa.model.container.http.Http;
@@ -35,7 +36,7 @@ public class AccessControlFilterExcludeValidator implements Validator {
 
     private void verifyNoExclusions(String clusterId, AccessControl accessControl, Context context) {
         if (!accessControl.excludedBindings().isEmpty()) {
-            String message = String.format(java.util.Locale.ROOT, "Application cluster %s excludes paths from access control, this is not allowed and should be removed.", clusterId);
+            String message = Text.format("Application cluster %s excludes paths from access control, this is not allowed and should be removed.", clusterId);
             if (Set.of(DEFAULT, YAHOO).contains(context.deployState().zone().cloud().name())) {
                 context.deployState().getDeployLogger().log(Level.WARNING, message);
             } else {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudClientsValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudClientsValidator.java
@@ -1,6 +1,7 @@
 package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.text.Text;
 import org.bouncycastle.asn1.x509.TBSCertificate;
 
 import java.security.cert.CertificateEncodingException;
@@ -49,6 +50,6 @@ public class CloudClientsValidator implements Validator {
     }
 
     private static String errorMessage(String clusterName, String clientId, String message) {
-        return String.format(java.util.Locale.ROOT, "Client **%s** defined for cluster **%s** contains an invalid certificate: %s", clientId, clusterName, message);
+        return Text.format("Client **%s** defined for cluster **%s** contains an invalid certificate: %s", clientId, clusterName, message);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidator.java
@@ -6,6 +6,7 @@ import com.yahoo.io.IOUtils;
 import com.yahoo.io.reader.NamedReader;
 import com.yahoo.path.Path;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 
 import java.security.cert.X509Certificate;
@@ -51,7 +52,7 @@ public class CloudDataPlaneFilterValidator implements Validator {
                     .map(p -> ApplicationPackage.SECURITY_DIR.append(p).getRelative())
                     .sorted()
                     .toList();
-            context.illegal(String.format(java.util.Locale.ROOT, "Duplicate certificate(s) detected in files: %s. Certificate subject of duplicates: %s", filesWithDuplicates.toString(),
+            context.illegal(Text.format("Duplicate certificate(s) detected in files: %s. Certificate subject of duplicates: %s", filesWithDuplicates.toString(),
                                                duplicates.stream().map(cert -> cert.getSubjectX500Principal().getName()).toList().toString()));
         }
     }
@@ -60,7 +61,7 @@ public class CloudDataPlaneFilterValidator implements Validator {
         try {
             return X509CertificateUtils.certificateListFromPem(IOUtils.readAll(reader));
         } catch (Exception e) {
-            log.warning(String.format(java.util.Locale.ROOT, "Exception reading certificate list from application package. File: %s, exception message: %s", reader.getName(), e.getMessage()));
+            log.warning(Text.format("Exception reading certificate list from application package. File: %s, exception message: %s", reader.getName(), e.getMessage()));
             context.illegal("Error reading certificates from application package", e);
             return List.of();
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudHttpConnectorValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudHttpConnectorValidator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
@@ -24,7 +25,7 @@ public class CloudHttpConnectorValidator implements Validator {
             if (http == null) return;
             var illegalConnectors = http.getHttpServer().stream().flatMap(s -> s.getConnectorFactories().stream()
                     .filter(c -> !isAllowedConnector(c)))
-                    .map(cf -> String.format(java.util.Locale.ROOT, "%s@%d", cf.getName(), cf.getListenPort()))
+                    .map(cf -> Text.format("%s@%d", cf.getName(), cf.getListenPort()))
                     .toList();
             if (illegalConnectors.isEmpty()) return;
             context.illegal(

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudUserFilterValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/CloudUserFilterValidator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.container.http.HttpFilterChain;
 
@@ -27,7 +28,7 @@ public class CloudUserFilterValidator implements Validator {
             if (cluster.getHttp() == null) continue;
             for (var chain : cluster.getHttp().getFilterChains().allChains().allComponents()) {
                 if (chain.type() == HttpFilterChain.Type.USER) {
-                    var msg = String.format(java.util.Locale.ROOT, "Found filter chain violation - chain '%s' in cluster '%s'", cluster.name(), chain.id());
+                    var msg = Text.format("Found filter chain violation - chain '%s' in cluster '%s'", cluster.name(), chain.id());
                     context.deployState().getDeployLogger().log(Level.WARNING, msg);
                     violations.add(new Violation(cluster.name(), chain.id()));
                 }
@@ -35,9 +36,9 @@ public class CloudUserFilterValidator implements Validator {
         }
         if (violations.isEmpty()) return;
         var violationsStr = violations.stream()
-                .map(v -> String.format(java.util.Locale.ROOT, "chain '%s' in cluster '%s'", v.chain(), v.cluster()))
+                .map(v -> Text.format("chain '%s' in cluster '%s'", v.chain(), v.cluster()))
                 .collect(Collectors.joining(", ", "[", "]"));
-        var msg = String.format(java.util.Locale.ROOT, "HTTP filter chains are currently not supported in Vespa Cloud (%s)", violationsStr);
+        var msg = Text.format("HTTP filter chains are currently not supported in Vespa Cloud (%s)", violationsStr);
         context.illegal(msg);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ComplexFieldsWithStructFieldAttributesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ComplexFieldsWithStructFieldAttributesValidator.java
@@ -7,6 +7,7 @@ import com.yahoo.schema.derived.SchemaInfo;
 import com.yahoo.schema.document.ComplexAttributeFieldUtils;
 import com.yahoo.schema.document.GeoPos;
 import com.yahoo.schema.document.ImmutableSDField;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.search.SearchCluster;
 
@@ -51,7 +52,7 @@ public class ComplexFieldsWithStructFieldAttributesValidator implements Validato
     }
 
     private static String getErrorMessage(String clusterName, Schema schema, String unsupportedFields) {
-        return String.format(java.util.Locale.ROOT, "For cluster '%s', search '%s': The following complex fields do not support using struct field attributes: %s. " +
+        return Text.format("For cluster '%s', search '%s': The following complex fields do not support using struct field attributes: %s. " +
                              "Only supported for the following complex field types: array or map of struct with primitive types, map of primitive types. " +
                              "The supported primitive types are: byte, int, long, float, double and string",
                              clusterName, schema.getName(), unsupportedFields);

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ComplexFieldsWithStructFieldIndexesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ComplexFieldsWithStructFieldIndexesValidator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.derived.SchemaInfo;
 import com.yahoo.schema.document.ImmutableSDField;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ public class ComplexFieldsWithStructFieldIndexesValidator implements Validator {
             // TODO (Vespa 9 or before): Change back to an exception when no applications are using it wrong.
             context.deployState().getDeployLogger().logApplicationPackage(
                     Level.WARNING,
-                    String.format(java.util.Locale.ROOT, "For cluster '%s', schema '%s': The following complex fields have struct fields with 'indexing: index' which is not supported and has no effect: %s. " +
+                    Text.format("For cluster '%s', schema '%s': The following complex fields have struct fields with 'indexing: index' which is not supported and has no effect: %s. " +
                                   "Remove setting or change to 'indexing: attribute' if needed for matching.",
                                   clusterName, schema.getName(), unsupportedFields));
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/EmbedExpressionValidator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.indexinglanguage.ExpressionVisitor;
 import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
@@ -40,7 +41,7 @@ public class EmbedExpressionValidator implements Validator {
                                         ee.requestedEmbedderId().ifPresent(id -> {
                                             var fieldName = field.getName();
                                             var schemaName = schema.fullSchema().getName();
-                                            log.log(Level.FINE, () -> String.format(java.util.Locale.ROOT, "Found embedder '%s' for field '%s' in schema '%s'", id, fieldName, schemaName));
+                                            log.log(Level.FINE, () -> Text.format("Found embedder '%s' for field '%s' in schema '%s'", id, fieldName, schemaName));
                                             fieldToEmbedderId.put(new SchemaAndField(schemaName, fieldName), id);
                                         });
                                     }
@@ -57,7 +58,7 @@ public class EmbedExpressionValidator implements Validator {
                 containerCluster.getAllComponents()
                         .forEach(component -> {
                             var id = component.getComponentId().getName();
-                            log.log(Level.FINE, () -> String.format(java.util.Locale.ROOT, "Found component id '%s'", id));
+                            log.log(Level.FINE, () -> Text.format("Found component id '%s'", id));
                             allComponentIds.add(id);
                         }));
 
@@ -65,7 +66,7 @@ public class EmbedExpressionValidator implements Validator {
         fieldToEmbedderId.forEach((field, requestedEmbedderId) -> {
             if (!allComponentIds.contains(requestedEmbedderId)) {
                 context.illegal(
-                        String.format(java.util.Locale.ROOT, "The 'embed' expression for field '%s' in schema '%s' refers to an embedder with id '%s'. " + "No component with that id is configured.", field.fieldName(), field.schemaName(), requestedEmbedderId));
+                        Text.format("The 'embed' expression for field '%s' in schema '%s' refers to an embedder with id '%s'. " + "No component with that id is configured.", field.fieldName(), field.schemaName(), requestedEmbedderId));
             }
         });
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/EndpointCertificateSecretsValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/EndpointCertificateSecretsValidator.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.provision.CertificateNotReadyException;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 
 public class EndpointCertificateSecretsValidator implements Validator {
@@ -10,7 +11,7 @@ public class EndpointCertificateSecretsValidator implements Validator {
     @Override
     public void validate(Context context) {
         if (context.deployState().endpointCertificateSecrets().isPresent() && context.deployState().endpointCertificateSecrets().get().isMissing()) {
-            throw new CertificateNotReadyException(String.format(java.util.Locale.ROOT, "TLS enabled, but could not yet retrieve certificate version %s for application %s", context.deployState().endpointCertificateSecrets().get().version(), context.deployState().getProperties().applicationId().serializedForm()));
+            throw new CertificateNotReadyException(Text.format("TLS enabled, but could not yet retrieve certificate version %s for application %s", context.deployState().endpointCertificateSecrets().get().version(), context.deployState().getProperties().applicationId().serializedForm()));
         }
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/HnswValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/HnswValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.schema.derived.SchemaInfo;
 import com.yahoo.schema.document.ImmutableSDField;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.content.ContentSearchCluster;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
@@ -44,7 +45,7 @@ public class HnswValidator implements Validator {
                                      .toList();
         if (fields.isEmpty()) return;
 
-        var message = String.format(java.util.Locale.ROOT, ("Cluster '%s' has searchable copies > 1 and fields with hnsw index:" +
+        var message = Text.format(("Cluster '%s' has searchable copies > 1 and fields with hnsw index:" +
                 " %s." +
                 " This will use a lot of resources, consider using searchable-copies=1%s"), cluster.getClusterName(),
                            String.join(", ", fields),
@@ -65,7 +66,7 @@ public class HnswValidator implements Validator {
                            .toList();
         if (fields.isEmpty()) return Optional.empty();
 
-        return Optional.of(String.format(java.util.Locale.ROOT, "fields %s in schema %s", String.join(", ", fields), schema.name()));
+        return Optional.of(Text.format("fields %s in schema %s", String.join(", ", fields), schema.name()));
     }
 
     private static Set<ContentCluster> clustersWithMoreThanOneSearchableCopy(Context context) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/InfrastructureDeploymentValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/InfrastructureDeploymentValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.provision.TenantName;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 
 import java.util.logging.Logger;
@@ -22,7 +23,7 @@ public class InfrastructureDeploymentValidator implements Validator {
         if (TenantName.from("hosted-vespa").equals(context.model().applicationPackage().getApplicationId().tenant())) return;
         ConfigModelContext.ApplicationType applicationType = context.model().getAdmin().getApplicationType();
         if (applicationType != ConfigModelContext.ApplicationType.DEFAULT) {
-            log.warning(String.format(java.util.Locale.ROOT, "Tenant %s is not allowed to use application type %s", context.model().applicationPackage().getApplicationId().toFullString(), applicationType));
+            log.warning(Text.format("Tenant %s is not allowed to use application type %s", context.model().applicationPackage().getApplicationId().toFullString(), applicationType));
             context.illegal("Tenant is not allowed to override application type");
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/RankSetupValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/RankSetupValidator.java
@@ -11,6 +11,7 @@ import com.yahoo.log.LogMessage;
 import com.yahoo.schema.DistributableResource;
 import com.yahoo.system.ProcessExecuter;
 import com.yahoo.text.StringUtilities;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.search.AttributesConfig;
 import com.yahoo.vespa.config.search.ImportedFieldsConfig;
 import com.yahoo.vespa.config.search.IndexschemaConfig;
@@ -85,13 +86,13 @@ public class RankSetupValidator implements Validator {
     private boolean validate(Context context, String configId, SearchCluster searchCluster, String schema, File tempDir, boolean isStreaming) {
         Instant start = Instant.now();
         try {
-            log.log(Level.FINE, () -> String.format(java.util.Locale.ROOT, "Validating schema '%s' for cluster %s with config id %s", schema, searchCluster, configId));
+            log.log(Level.FINE, () -> Text.format("Validating schema '%s' for cluster %s with config id %s", schema, searchCluster, configId));
             boolean ret = execValidate(context, configId, searchCluster, schema, isStreaming);
             if (!ret) {
                 // Give up, don't log same error msg repeatedly
                 deleteTempDir(tempDir);
             }
-            log.log(Level.FINE, () -> String.format(java.util.Locale.ROOT, "Validation took %s ms", Duration.between(start, Instant.now()).toMillis()));
+            log.log(Level.FINE, () -> Text.format("Validation took %s ms", Duration.between(start, Instant.now()).toMillis()));
             return ret;
         } catch (IllegalArgumentException e) {
             deleteTempDir(tempDir);
@@ -142,8 +143,8 @@ public class RankSetupValidator implements Validator {
         for (DistributableResource model : resources) {
             String modelPath = getFileRepositoryPath(model.getFilePath().getName(), model.getFileReference());
             int index = config.size() / 2;
-            config.add(String.format(java.util.Locale.ROOT, "file[%d].ref \"%s\"", index, model.getFileReference()));
-            config.add(String.format(java.util.Locale.ROOT, "file[%d].path \"%s\"", index, modelPath));
+            config.add(Text.format("file[%d].ref \"%s\"", index, model.getFileReference()));
+            config.add(Text.format("file[%d].path \"%s\"", index, modelPath));
             log.log(Level.FINE, index + ": " + model.getPathType() + " -> " + model.getName() + " -> " + modelPath + " -> " + model.getFileReference());
         }
     }
@@ -171,7 +172,7 @@ public class RankSetupValidator implements Validator {
     }
 
     private boolean execValidate(Context context, String configId, SearchCluster sc, String sdName, boolean isStreaming) {
-        String command = String.format(java.util.Locale.ROOT, (isStreaming ? "%s %s -S" : "%s %s"), binaryName, configId);
+        String command = Text.format((isStreaming ? "%s %s -S" : "%s %s"), binaryName, configId);
         try {
             Pair<Integer, String> ret = new ProcessExecuter(true).exec(command);
             Integer exitCode = ret.getFirst();

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/StreamingValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/StreamingValidator.java
@@ -12,6 +12,7 @@ import com.yahoo.schema.derived.SchemaInfo;
 import com.yahoo.schema.document.Attribute;
 import com.yahoo.schema.document.ImmutableSDField;
 import com.yahoo.schema.document.MatchType;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.search.SearchCluster;
 
@@ -89,7 +90,7 @@ public class StreamingValidator implements Validator {
         for (Attribute attribute : derived.getAttributeFields().attributes()) {
             DataType dataType = attribute.getDataType();
             if (dataType instanceof NewDocumentReferenceDataType) {
-                String errorMessage = String.format(java.util.Locale.ROOT, "For search cluster '%s', streaming schema '%s': Attribute '%s' has type '%s'. " +
+                String errorMessage = Text.format("For search cluster '%s', streaming schema '%s': Attribute '%s' has type '%s'. " +
                                                     "Document references and imported fields are not allowed in streaming search.",
                                                     cluster, derived.getSchema().getName(), attribute.getName(), dataType.getName());
                 context.illegal(errorMessage);

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/TenantSecretValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/TenantSecretValidator.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.model.api.TenantVault;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.xml.CloudSecrets;
 
@@ -36,7 +37,7 @@ public class TenantSecretValidator implements Validator {
                         // Vault exists, check that the secret exists in the vault
                         var vaultSecrets = existingVaults.get(secretConfig.vault());
                         if (! hasSecret(secretConfig.name(), vaultSecrets)) {
-                            context.illegal(String.format(java.util.Locale.ROOT, "Secret '%s' is not defined in vault '%s'", secretConfig.name(), secretConfig.vault()));
+                            context.illegal(Text.format("Secret '%s' is not defined in vault '%s'", secretConfig.name(), secretConfig.vault()));
                         }
                     }
                 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UriBindingsValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UriBindingsValidator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.BindingPattern;
@@ -84,7 +85,7 @@ class UriBindingsValidator implements Validator {
     }
 
     private static String createErrorMessage(BindingPattern binding, String message) {
-        return String.format(java.util.Locale.ROOT, "For binding '%s': %s", binding.originalPatternString(), message);
+        return Text.format("For binding '%s': %s", binding.originalPatternString(), message);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/CertificateRemovalChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/CertificateRemovalChangeValidator.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.application.api.ValidationId;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.http.Client;
 
@@ -48,7 +49,7 @@ public class CertificateRemovalChangeValidator implements ChangeValidator {
                 .flatMap(Collection::stream)
                 .toList();
 
-        logger.log(Level.FINE, String.format(java.util.Locale.ROOT, "Certificates for cluster %s: Current: [%s], Next: [%s]", clusterId,
+        logger.log(Level.FINE, Text.format("Certificates for cluster %s: Current: [%s], Next: [%s]", clusterId,
                            currentCertificates.stream().map(cert -> cert.getSubjectX500Principal().getName()).collect(Collectors.joining(", ")),
                            nextCertificates.stream().map(cert -> cert.getSubjectX500Principal().getName()).collect(Collectors.joining(", "))));
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ConfigValueChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ConfigValueChangeValidator.java
@@ -7,6 +7,7 @@ import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.Service;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -114,7 +115,7 @@ public class ConfigValueChangeValidator implements ChangeValidator {
                                                                                    DeployLogger logger) {
 
         if (!hasConfigFieldsFlaggedWithRestart(configClass, service.getClass())) {
-            logger.logApplicationPackage(Level.FINE, String.format(java.util.Locale.ROOT, "%s is listed in the annotation for %s, " +
+            logger.logApplicationPackage(Level.FINE, Text.format("%s is listed in the annotation for %s, " +
                             "but does not have any restart flags in its config definition.",
                     configClass.getSimpleName(), service.getClass().getSimpleName()));
             return Optional.empty();

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ContainerRestartValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ContainerRestartValidator.java
@@ -5,6 +5,7 @@ import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.container.QrConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.ApplicationContainer;
@@ -55,7 +56,7 @@ public class ContainerRestartValidator implements ChangeValidator {
     }
 
     private static String createMessage(Container container) {
-        return String.format(java.util.Locale.ROOT, "Container '%s' is configured to always restart on deploy.", container.getConfigId());
+        return Text.format("Container '%s' is configured to always restart on deploy.", container.getConfigId());
     }
 
     private static boolean shouldContainerRestartOnDeploy(Container container, VespaModel nextModel) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -40,7 +41,7 @@ public class DataplaneProxyChangeValidator implements ChangeValidator {
                 var message = hasProxy
                         ? "Token endpoint was enabled for cluster '%s', services require restart"
                         : "Token endpoint was disabled for cluster '%s', services require restart";
-                var action = createRestartAction(currentCluster, String.format(java.util.Locale.ROOT, message, clusterId), DEFER_UNTIL_RESTART);
+                var action = createRestartAction(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
                 context.require(action);
             }
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneTokenRemovalValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneTokenRemovalValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.provision.DataplaneToken;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.http.Client;
 
@@ -51,7 +52,7 @@ public class DataplaneTokenRemovalValidator implements ChangeValidator {
                                         .map(DataplaneToken::tokenId)
                                         .toList();
 
-        logger.log(Level.FINE, String.format(java.util.Locale.ROOT, "Tokens for cluster %s: Current: [%s], Next: [%s]", clusterId,
+        logger.log(Level.FINE, Text.format("Tokens for cluster %s: Current: [%s], Next: [%s]", clusterId,
                            currentTokenIds.stream().collect(Collectors.joining(", ")),
                            nextTokenIds.stream().collect(Collectors.joining(", "))));
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.documentmodel.NewDocumentType;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
@@ -35,7 +36,7 @@ public class GlobalDocumentChangeValidator implements ChangeValidator {
                 boolean nextIsGlobal = nextCluster.isGloballyDistributed(nextDocumentType);
                 boolean hosted = context.deployState().isHosted();
                 if (currentIsGlobal != nextIsGlobal) {
-                    String reason = String.format(java.util.Locale.ROOT, "Document type %s in cluster %s changed global from %s to %s", documentTypeName, clusterName, currentIsGlobal, nextIsGlobal);
+                    String reason = Text.format("Document type %s in cluster %s changed global from %s to %s", documentTypeName, clusterName, currentIsGlobal, nextIsGlobal);
                     if ( ! context.deployState().validationOverrides().allows(ValidationId.globalDocumentChange, context.deployState().now())) {
                         if (! hosted)
                             reason = reason + "To handle this change, first stop services on all content nodes. Then, deploy with validation override. Finally, start services on all content nodes";

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -33,7 +34,7 @@ public class RestartOnDeployForLocalLLMValidator implements ChangeValidator {
 
         // Only restart services if we use a local LLM in both the next and previous generation
         for (var clusterId : intersect(previousClustersWithLocalLLM, nextClustersWithLocalLLM)) {
-            String message = String.format(java.util.Locale.ROOT, "Need to restart services in %s due to use of local LLM", clusterId);
+            String message = Text.format("Need to restart services in %s due to use of local LLM", clusterId);
             context.require(new VespaRestartAction(
                     clusterId,
                     message,

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.api.OnnxModelCost;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.Host;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -50,7 +51,7 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
             if (enoughMemoryToAvoidRestart(clusterInCurrentModel, cluster, context.deployState().getDeployLogger()))
                 continue;
 
-            log.log(FINE, String.format(java.util.Locale.ROOT, "Validating %s, current Onnx models:%s, next Onnx models:%s", cluster, currentModels, nextModels));
+            log.log(FINE, Text.format("Validating %s, current Onnx models:%s, next Onnx models:%s", cluster, currentModels, nextModels));
             validateModelChanges(cluster, currentModels, nextModels).forEach(context::require);
             validateSetOfModels(cluster, currentModels, nextModels).forEach(context::require);
         }
@@ -64,7 +65,7 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
             if (! currentModels.containsKey(nextModelInfo.modelId())) continue;
 
             modelChanged(nextModelInfo, currentModels.get(nextModelInfo.modelId())).ifPresent(change -> {
-                String message = String.format(java.util.Locale.ROOT, "Onnx model '%s' has changed (%s), need to restart services in %s", nextModelInfo.modelId(), change, cluster);
+                String message = Text.format("Onnx model '%s' has changed (%s), need to restart services in %s", nextModelInfo.modelId(), change, cluster);
                 setRestartOnDeployAndAddRestartAction(actions, cluster, message);
             });
         }
@@ -77,16 +78,16 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
         List<ConfigChangeAction> actions = new ArrayList<>();
         Set<String> currentModelIds = currentModels.keySet();
         Set<String> nextModelIds = nextModels.keySet();
-        log.log(FINE, String.format(java.util.Locale.ROOT, "Checking if Onnx model set has changed (%s) -> (%s)", currentModelIds, nextModelIds));
+        log.log(FINE, Text.format("Checking if Onnx model set has changed (%s) -> (%s)", currentModelIds, nextModelIds));
         if (! currentModelIds.equals(nextModelIds)) {
-            String message = String.format(java.util.Locale.ROOT, "Onnx model set has changed from %s to %s, need to restart services in %s", currentModelIds, nextModelIds, cluster);
+            String message = Text.format("Onnx model set has changed from %s to %s, need to restart services in %s", currentModelIds, nextModelIds, cluster);
             setRestartOnDeployAndAddRestartAction(actions, cluster, message);
         }
         return actions;
     }
 
     private Optional<String> modelChanged(OnnxModelCost.ModelInfo a, OnnxModelCost.ModelInfo b) {
-        log.log(FINE, String.format(java.util.Locale.ROOT, "Checking if model has changed (%s) -> (%s)", a, b));
+        log.log(FINE, Text.format("Checking if model has changed (%s) -> (%s)", a, b));
         if (a.estimatedCost() != b.estimatedCost()) return Optional.of("estimated cost");
         if (a.hash() != b.hash()) return Optional.of("model hash");
         if (! a.onnxModelOptions().equals(b.onnxModelOptions())) return Optional.of("model option(s)");
@@ -116,18 +117,18 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
         var availableMemoryPercentage = cluster.heapSizePercentageOfAvailable();
         int memoryPercentage = (int) (availableMemory / totalMemory * availableMemoryPercentage);
 
-        var prefix = String.format(java.util.Locale.ROOT, "Validating Onnx models memory usage for %s", cluster);
+        var prefix = Text.format("Validating Onnx models memory usage for %s", cluster);
         if (memoryPercentage < percentLimit) {
-            deployLogger.log(INFO, String.format(java.util.Locale.ROOT, "%s, percentage of available memory too low (%d < %d) to avoid restart, consider a flavor with more memory to avoid this", prefix, memoryPercentage, percentLimit));
+            deployLogger.log(INFO, Text.format("%s, percentage of available memory too low (%d < %d) to avoid restart, consider a flavor with more memory to avoid this", prefix, memoryPercentage, percentLimit));
             return false;
         }
 
         if (availableMemory < gbLimit) {
-            deployLogger.log(INFO, String.format(java.util.Locale.ROOT, "%s, available memory too low (%.2f Gb < %.2f Gb) to avoid restart, consider a flavor with more memory to avoid this", prefix, availableMemory, gbLimit));
+            deployLogger.log(INFO, Text.format("%s, available memory too low (%.2f Gb < %.2f Gb) to avoid restart, consider a flavor with more memory to avoid this", prefix, availableMemory, gbLimit));
             return false;
         }
 
-        log.log(FINE, String.format(java.util.Locale.ROOT, "%s, enough available memory (%.2f Gb) to avoid restart (models use %.2f Gb)", prefix, availableMemory, memoryUsedByModels));
+        log.log(FINE, Text.format("%s, enough available memory (%.2f Gb) to avoid restart (models use %.2f Gb)", prefix, availableMemory, memoryUsedByModels));
         return true;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForSidecarValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForSidecarValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.SidecarSpec;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -55,7 +56,7 @@ public class RestartOnDeployForSidecarValidator implements ChangeValidator {
             var changedSidecars = nextSidecars.stream().filter(nextSidecar -> previousSidecars.stream().anyMatch(
                     sidecar -> sidecar.matchesByIdOrName(nextSidecar) && !sidecar.equals(nextSidecar))).toList();
 
-            var messageBuilder = new StringBuilder(String.format(java.util.Locale.ROOT, "Need to restart services in %s due to", clusterId));
+            var messageBuilder = new StringBuilder(Text.format("Need to restart services in %s due to", clusterId));
 
             if (!removedSidecars.isEmpty()) {
                 messageBuilder.append(" removed sidecars: ").append(joinSidecarNames(removedSidecars));
@@ -78,7 +79,7 @@ public class RestartOnDeployForSidecarValidator implements ChangeValidator {
                             changedSidecar)).findFirst().orElseThrow(); // Should never throw.
 
                     var sidecarDiff = diffSidecarSpecs(matchingPreviousSidecar, changedSidecar);
-                    return String.format(java.util.Locale.ROOT, "'%s' (%s)", changedSidecar.name(), sidecarDiff);
+                    return Text.format("'%s' (%s)", changedSidecar.name(), sidecarDiff);
                 }).collect(Collectors.joining(", "));
 
                 messageBuilder.append(" changed sidecars: ").append(changedSidecarsMessage);
@@ -95,7 +96,7 @@ public class RestartOnDeployForSidecarValidator implements ChangeValidator {
     }
 
     private String joinSidecarNames(List<SidecarSpec> sidecars) {
-        return sidecars.stream().map(sidecar -> String.format(java.util.Locale.ROOT, "'%s'", sidecar.name())).collect(Collectors.joining(", "));
+        return sidecars.stream().map(sidecar -> Text.format("'%s'", sidecar.name())).collect(Collectors.joining(", "));
     }
 
     private String diffSidecarSpecs(SidecarSpec from, SidecarSpec to) {
@@ -104,43 +105,43 @@ public class RestartOnDeployForSidecarValidator implements ChangeValidator {
         var toResources = to.resources();
 
         if (from.id() != to.id()) {
-            changes.add(String.format(java.util.Locale.ROOT, "id: %s -> %s", from.id(), to.id()));
+            changes.add(Text.format("id: %s -> %s", from.id(), to.id()));
         }
 
         if (!from.name().equals(to.name())) {
-            changes.add(String.format(java.util.Locale.ROOT, "name: %s -> %s", from.name(), to.name()));
+            changes.add(Text.format("name: %s -> %s", from.name(), to.name()));
         }
 
         if (!from.image().equals(to.image())) {
-            changes.add(String.format(java.util.Locale.ROOT, "image: %s -> %s", from.image(), to.image()));
+            changes.add(Text.format("image: %s -> %s", from.image(), to.image()));
         }
 
         if (fromResources.maxCpu() != toResources.maxCpu()) {
-            changes.add(String.format(java.util.Locale.ROOT, "maxCpu: %s -> %s", fromResources.maxCpu(), toResources.maxCpu()));
+            changes.add(Text.format("maxCpu: %s -> %s", fromResources.maxCpu(), toResources.maxCpu()));
         }
 
         if (fromResources.minCpu() != toResources.minCpu()) {
-            changes.add(String.format(java.util.Locale.ROOT, "minCpu: %s -> %s", fromResources.minCpu(), toResources.minCpu()));
+            changes.add(Text.format("minCpu: %s -> %s", fromResources.minCpu(), toResources.minCpu()));
         }
 
         if (fromResources.memoryGiB() != toResources.memoryGiB()) {
-            changes.add(String.format(java.util.Locale.ROOT, "memoryGiB: %s -> %s", fromResources.memoryGiB(), toResources.memoryGiB()));
+            changes.add(Text.format("memoryGiB: %s -> %s", fromResources.memoryGiB(), toResources.memoryGiB()));
         }
 
         if (fromResources.hasGpu() != toResources.hasGpu()) {
-            changes.add(String.format(java.util.Locale.ROOT, "hasGpu: %s -> %s", fromResources.hasGpu(), toResources.hasGpu()));
+            changes.add(Text.format("hasGpu: %s -> %s", fromResources.hasGpu(), toResources.hasGpu()));
         }
 
         if (!from.volumeMounts().equals(to.volumeMounts())) {
-            changes.add(String.format(java.util.Locale.ROOT, "volumeMounts: %s -> %s", from.volumeMounts(), to.volumeMounts()));
+            changes.add(Text.format("volumeMounts: %s -> %s", from.volumeMounts(), to.volumeMounts()));
         }
 
         if (!from.envs().equals(to.envs())) {
-            changes.add(String.format(java.util.Locale.ROOT, "envs: %s -> %s", from.envs(), to.envs()));
+            changes.add(Text.format("envs: %s -> %s", from.envs(), to.envs()));
         }
 
         if (!from.command().equals(to.command())) {
-            changes.add(String.format(java.util.Locale.ROOT, "command: %s -> %s", from.command(), to.command()));
+            changes.add(Text.format("command: %s -> %s", from.command(), to.command()));
         }
 
         // Skipping livenessProbe diff since it doesn't affect sidecar functionality from sidecar client perspective.

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -42,7 +43,7 @@ public class RestartOnDeployForTritonOnnxRuntimeValidator implements ChangeValid
                 var message = hasTritonRuntime
                         ? "Triton ONNX runtime was enabled for cluster '%s', services require restart"
                         : "Triton ONNX runtime was disabled for cluster '%s', services require restart";
-                var action = createRestartAction(currentCluster, String.format(java.util.Locale.ROOT, message, clusterId), DEFER_UNTIL_RESTART);
+                var action = createRestartAction(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
                 context.require(action);
             }
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/StartupCommandChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/StartupCommandChangeValidator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.Service;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 
@@ -39,7 +40,7 @@ public class StartupCommandChangeValidator implements ChangeValidator {
 
         if (Objects.equals(currentCommand, nextCommand)) return Optional.empty();
 
-        String message = String.format(java.util.Locale.ROOT, "Startup command for '%s' has changed.\nNew command: %s\nCurrent command: %s",
+        String message = Text.format("Startup command for '%s' has changed.\nNew command: %s\nCurrent command: %s",
                                        currentService.getServiceName(), nextCommand, currentCommand);
         return Optional.of(new VespaRestartAction(ClusterSpec.Id.from(currentService.getConfigId()),
                                                   message,

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/AttributeChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/AttributeChangeValidator.java
@@ -11,6 +11,7 @@ import com.yahoo.schema.document.Attribute;
 import com.yahoo.schema.document.Case;
 import com.yahoo.schema.document.Dictionary;
 import com.yahoo.schema.document.HnswIndexParams;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.application.validation.Validation;
 import com.yahoo.vespa.model.application.validation.change.VespaConfigChangeAction;
 import com.yahoo.vespa.model.application.validation.change.VespaRestartAction;
@@ -144,7 +145,7 @@ public class AttributeChangeValidator {
         T currentValue = settingValueProvider.apply(current);
         T nextValue = settingValueProvider.apply(next);
         if ( ! Objects.equals(currentValue, nextValue)) {
-            String message = String.format(java.util.Locale.ROOT, "change property '%s' from '%s' to '%s'", setting, currentValue, nextValue);
+            String message = Text.format("change property '%s' from '%s' to '%s'", setting, currentValue, nextValue);
             if (hasHnswIndex(current) && hasHnswIndex(next))
                 context.invalid(ValidationId.hnswSettingsChange,
                                     message + ". This requires the hnsw index to be rebuilt during initialization, which may take a long time");
@@ -160,7 +161,7 @@ public class AttributeChangeValidator {
         T currentValue = settingValueProvider.apply(currentAttr.hnswIndexParams().get());
         T nextValue = settingValueProvider.apply(nextAttr.hnswIndexParams().get());
         if (!Objects.equals(currentValue, nextValue)) {
-            String message = String.format(java.util.Locale.ROOT, "change hnsw index property '%s' from '%s' to '%s'", setting, currentValue, nextValue);
+            String message = Text.format("change hnsw index property '%s' from '%s' to '%s'", setting, currentValue, nextValue);
             if (setting.equals("max-links-per-node"))
                 context.invalid(ValidationId.hnswSettingsChange,
                                     message + ". This requires the hnsw index to be rebuilt during initialization, which may take a long time");

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
@@ -6,6 +6,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AnyConfigProducer;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.text.Text;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.BertEmbedder;
@@ -54,7 +55,7 @@ public class DomComponentBuilder extends VespaDomBuilder.DomConfigProducerBuilde
                 case "bert-embedder" -> new BertEmbedder((ApplicationContainerCluster)ancestor, spec, state);
                 case "splade-embedder" -> new SpladeEmbedder((ApplicationContainerCluster)ancestor, spec, state);
                 case "voyage-ai-embedder" -> new VoyageAIEmbedder((ApplicationContainerCluster)ancestor, spec, state);
-                default -> throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Unknown component type '%s'", type));
+                default -> throw new IllegalArgumentException(Text.format("Unknown component type '%s'", type));
             };
         } else {
             var bundleSpec = BundleInstantiationSpecificationBuilder.build(spec).nestInNamespace(namespace);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -29,6 +29,7 @@ import com.yahoo.container.jdisc.messagebus.MbusServerProvider;
 import com.yahoo.document.restapi.DocumentOperationExecutorConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.search.config.QrStartConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
 import com.yahoo.vespa.config.search.core.OnnxModelsConfig;
 import com.yahoo.vespa.config.search.core.RankingConstantsConfig;
@@ -240,7 +241,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
             double availableMemoryGb = Math.max(0, totalMemoryMinusOverhead - onnxModelCostGb);
             int memoryPercentageOfAvailable = (int) (heapSizePercentageOfAvailable * availableMemoryGb / totalMemoryMinusOverhead);
             int memoryPercentageOfTotal = (int) (heapSizePercentageOfAvailable * availableMemoryGb / totalMemoryGb);
-            logger.log(FINE, () -> String.format(java.util.Locale.ROOT, ("%s: memoryPercentageOfAvailable=%d, memoryPercentageOfTotal=%d, " +
+            logger.log(FINE, () -> Text.format(("%s: memoryPercentageOfAvailable=%d, memoryPercentageOfTotal=%d, " +
                                     "availableMemoryGb=%f, totalMemoryGb=%f, heapSizePercentageOfAvailable=%d, onnxModelCostGb=%f"), id(), memoryPercentageOfAvailable, memoryPercentageOfTotal,
                                availableMemoryGb, totalMemoryGb, heapSizePercentageOfAvailable, onnxModelCostGb));
             return Optional.of(JvmMemoryPercentage.of(memoryPercentageOfAvailable, memoryPercentageOfTotal,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/IdentityProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/IdentityProvider.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.core.identity.IdentityConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
 
 import java.net.URI;
@@ -57,7 +58,7 @@ public class IdentityProvider extends SimpleComponent implements IdentityConfig.
 
     // TODO Move to Oath configmodel amender
     private String getConfigserverIdentityName() {
-        return String.format(java.util.Locale.ROOT, "%s.provider_%s_%s",
+        return Text.format("%s.provider_%s_%s",
                              configServerDomain(),
                              zone.environment().value(),
                              zone.region().value());

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
@@ -5,6 +5,7 @@ import com.yahoo.container.core.AccessLogConfig;
 import com.yahoo.container.logging.JSONAccessLog;
 import com.yahoo.container.logging.VespaAccessLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 
@@ -45,7 +46,7 @@ public final class AccessLogComponent extends SimpleComponent implements AccessL
         // In hosted Vespa we do not use the clusterName when setting up application ContainerCluster logging
         this(logType,
                 compressionType,
-             String.format(java.util.Locale.ROOT, "logs/vespa/access/%s.%s",
+             Text.format("logs/vespa/access/%s.%s",
                            capitalize(logTypeAndClusterName(logType, clusterName)),
                            "%Y%m%d%H%M%S"),
                 null,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Model.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Model.java
@@ -8,6 +8,7 @@ import com.yahoo.config.model.api.OnnxModelOptions;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.path.Path;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.xml.ModelIdResolver;
 import org.w3c.dom.Element;
@@ -78,7 +79,7 @@ class Model {
                     if (ds.isHosted() && modelId != null) {
                         return fromParams(ds, onnxModel.name(), modelId + "-vocab", null, null, null, requiredTags);
                     }
-                    throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "'%s' must be specified", paramName));
+                    throw new IllegalArgumentException(Text.format("'%s' must be specified", paramName));
                 });
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -13,6 +13,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.container.core.VipStatusConfig;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.net.HostName;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.configserver.option.ConfigOptions;
@@ -64,7 +65,7 @@ public class ConfigserverCluster extends TreeConfigProducer
         int[] zookeeperIds = getConfigServerZookeeperIds();
 
         if (configServers.length != zookeeperIds.length) {
-            throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Number of provided config server hosts (%d) must be the " +
+            throw new IllegalArgumentException(Text.format("Number of provided config server hosts (%d) must be the " +
                     "same as number of provided config server zookeeper ids (%d)",
                     configServers.length, zookeeperIds.length));
         }
@@ -74,7 +75,7 @@ public class ConfigserverCluster extends TreeConfigProducer
         // however, we cannot change this id for an existing server
         for (int i = 0; i < configServers.length; i++) {
             if (zookeeperIds[i] < 0) {
-                throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Zookeeper ids cannot be negative, was %d for %s",
+                throw new IllegalArgumentException(Text.format("Zookeeper ids cannot be negative, was %d for %s",
                         zookeeperIds[i], configServers[i].hostName));
             }
             if (configServers[i].hostName.equals(myhostname)) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/Client.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/Client.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.container.http;
 
 import com.yahoo.config.provision.DataplaneToken;
+import com.yahoo.text.Text;
 
 import java.security.cert.X509Certificate;
 import java.util.Collection;
@@ -76,7 +77,7 @@ public class Client {
             return switch (v) {
                 case "read" -> READ;
                 case "write" -> WRITE;
-                default -> throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Invalid permission '%s'. Valid values are 'read' and 'write'.", v));
+                default -> throw new IllegalArgumentException(Text.format("Invalid permission '%s'. Valid values are 'read' and 'write'.", v));
             };
         }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
@@ -5,6 +5,7 @@ import ai.vespa.utils.BytesQuantity;
 import com.yahoo.config.model.api.EndpointCertificateSecrets;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.security.tls.TlsContext;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
 
 import java.time.Duration;
@@ -49,14 +50,14 @@ public class HostedSslConnectorFactory extends ConnectorFactory {
                 .map(prefix -> {
                     var parts = prefix.split(":");
                     if (parts.length != 3) {
-                        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected string of format 'prefix:sample-rate:max-entity-size', got '%s'", prefix));
+                        throw new IllegalArgumentException(Text.format("Expected string of format 'prefix:sample-rate:max-entity-size', got '%s'", prefix));
                     }
                     var pathPrefix = parts[0];
                     if (pathPrefix.isBlank())
                         throw new IllegalArgumentException("Path prefix must not be blank");
                     var sampleRate = Double.parseDouble(parts[1]);
                     if (sampleRate < 0 || sampleRate > 1)
-                        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Sample rate must be in range [0, 1], got '%s'", sampleRate));
+                        throw new IllegalArgumentException(Text.format("Sample rate must be in range [0, 1], got '%s'", sampleRate));
                     var maxEntitySize = BytesQuantity.fromString(parts[2]);
                     return new EntityLoggingEntry(pathPrefix, sampleRate, maxEntitySize);
                 })

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/HttpBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/HttpBuilder.java
@@ -7,6 +7,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AnyConfigProducer;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.AthenzDomain;
+import com.yahoo.text.Text;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
@@ -127,7 +128,7 @@ public class HttpBuilder extends VespaDomBuilder.DomConfigProducerBuilderBase<Ht
         if (explicitDomain != null) {
             if (tenantDomain != null && !explicitDomain.equals(tenantDomain)) {
                 throw new IllegalArgumentException(
-                        String.format(java.util.Locale.ROOT, "Domain in access-control ('%s') does not match tenant domain ('%s')", explicitDomain.value(), tenantDomain.value()));
+                        Text.format("Domain in access-control ('%s') does not match tenant domain ('%s')", explicitDomain.value(), tenantDomain.value()));
             }
             deployState.getDeployLogger()
                     .logApplicationPackage(Level.WARNING,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/CloudTokenDataPlaneFilter.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/CloudTokenDataPlaneFilter.java
@@ -8,6 +8,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.DataplaneToken;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.jdisc.http.filter.security.cloud.config.CloudTokenDataPlaneFilterConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.http.Client;
 import com.yahoo.vespa.model.container.http.Filter;
@@ -24,7 +25,7 @@ class CloudTokenDataPlaneFilter extends Filter implements CloudTokenDataPlaneFil
         super(model());
         this.clients = List.copyOf(cluster.getClients());
         // Token domain must be identical to the domain used for generating the tokens
-        this.tokenContext = String.format(java.util.Locale.ROOT, "Vespa Cloud tenant data plane:%s", state.getProperties().applicationId().tenant().value());
+        this.tokenContext = Text.format("Vespa Cloud tenant data plane:%s", state.getProperties().applicationId().tenant().value());
     }
 
     private static ChainedComponentModel model() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -51,6 +51,7 @@ import com.yahoo.schema.derived.FileDistributedOnnxModels;
 import com.yahoo.schema.derived.RankProfileList;
 import com.yahoo.search.rendering.RendererRegistry;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.text.Text;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.AbstractService;
@@ -248,7 +249,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
         addParameterStoreValidationHandler(cluster, deployState);
     }
-    
+
     private boolean shouldUseTriton(ApplicationContainerCluster cluster, DeployState deployState) {
         var isPublicCloud = deployState.zone().system().isPublicCloudLike();
         var hasOnnxModels =  !cluster.onnxModelCostCalculator().models().isEmpty();
@@ -258,7 +259,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private List<SidecarSpec> getSidecars(ApplicationContainerCluster cluster, DeployState deployState, NodesSpecification nodesSpecification) {
         var sidecars = new ArrayList<SidecarSpec>();
-        
+
         if (shouldUseTriton(cluster, deployState)) {
             var hasGpu = !nodesSpecification.minResources().nodeResources().gpuResources().isZero();
 
@@ -411,7 +412,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                             context.getDeployState().getProperties().athenzDnsSuffix(),
                             context.getDeployState().zone(),
                             AthenzDomain.from(HOSTED_VESPA_TENANT_PARENT_DOMAIN + context.properties().applicationId().tenant().value()),
-                            AthenzService.from(String.format(java.util.Locale.ROOT, "%s-%s", context.properties().applicationId().application().value(), appContext)));
+                            AthenzService.from(Text.format("%s-%s", context.properties().applicationId().application().value(), appContext)));
     }
 
     private void addDeploymentSpecConfig(ApplicationContainerCluster cluster, ConfigModelContext context, DeployLogger deployLogger) {
@@ -610,7 +611,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private Optional<Client> getClient(Element clientElement, DeployState state) {
         String clientId = XML.attribute("id", clientElement).orElseThrow();
         if (clientId.startsWith("_"))
-            throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Invalid client id '%s', id cannot start with '_'", clientId));
+            throw new IllegalArgumentException(Text.format("Invalid client id '%s', id cannot start with '_'", clientId));
         var permissions = XML.attribute("permissions", clientElement)
                 .map(Client.Permission::fromCommaSeparatedString).orElse(Set.of());
 
@@ -618,7 +619,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                 .flatMap(certElem -> {
                     var file = app.getFile(Path.fromString(certElem.getAttribute("file")));
                     if (!file.exists()) {
-                        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Certificate file '%s' for client '%s' does not exist", file.getPath().getRelative(), clientId));
+                        throw new IllegalArgumentException(Text.format("Certificate file '%s' for client '%s' does not exist", file.getPath().getRelative(), clientId));
                     }
                     return getCertificates(file).stream();
                 })
@@ -635,7 +636,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                     var token = knownTokens.get(tokenId);
                     if (token == null)
                         deployLogger.logApplicationPackage(
-                                WARNING, String.format(java.util.Locale.ROOT, "Token '%s' for client '%s' does not exist", tokenId, clientId));
+                                WARNING, Text.format("Token '%s' for client '%s' does not exist", tokenId, clientId));
                     return token;
                 })
                 .filter(token -> {
@@ -643,14 +644,14 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                     boolean empty = token.versions().isEmpty();
                     if (empty)
                         deployLogger.logApplicationPackage(
-                                WARNING, String.format(java.util.Locale.ROOT, "Token '%s' for client '%s' has no active versions", token.tokenId(), clientId));
+                                WARNING, Text.format("Token '%s' for client '%s' has no active versions", token.tokenId(), clientId));
                     return !empty;
                 })
                 .toList();
 
         // Don't include 'client' that refers to token without versions
         if (referencedTokens.isEmpty()) {
-            deployLogger.log(Level.INFO, String.format(java.util.Locale.ROOT, "Skipping client '%s' as it does not refer to any activate tokens", clientId));
+            deployLogger.log(Level.INFO, Text.format("Skipping client '%s' as it does not refer to any activate tokens", clientId));
             return Optional.empty();
         }
 
@@ -667,10 +668,10 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             try {
                 x509Certificates = X509CertificateUtils.certificateListFromPem(certPem);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "File %s contains an invalid certificate", file.getPath().getRelative()), e);
+                throw new IllegalArgumentException(Text.format("File %s contains an invalid certificate", file.getPath().getRelative()), e);
             }
             if (x509Certificates.isEmpty()) {
-                throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "File %s does not contain any certificates.", file.getPath().getRelative()));
+                throw new IllegalArgumentException(Text.format("File %s does not contain any certificates.", file.getPath().getRelative()));
             }
             return x509Certificates;
         } catch (IOException e) {
@@ -956,8 +957,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
                     if (inferenceMemoryBytes > containerMemoryBytes) {
                         throw new IllegalArgumentException(
-                                String.format(
-                                        Locale.US,
+                                Text.format(
                                         "Inference memory cannot exceed available node memory (%.2f GiB), got: %s",
                                         nodeMemoryGiB, inferenceMemoryString
                                 ));
@@ -1474,7 +1474,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         String idAttr = element.getAttribute("id");
 
         if (idAttr.equals(xmlRendererId) || idAttr.equals(jsonRendererId)) {
-            throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Renderer id %s is reserved for internal use", idAttr));
+            throw new IllegalArgumentException(Text.format("Renderer id %s is reserved for internal use", idAttr));
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ModelIdResolver.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ModelIdResolver.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.container.xml;
 import com.yahoo.config.ModelReference;
 import com.yahoo.config.UrlReference;
 import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.text.Text;
 import com.yahoo.text.XML;
 import org.w3c.dom.Element;
 
@@ -162,7 +163,7 @@ public class ModelIdResolver {
         var providedModel = providedModels.get(modelId);
         if ( ! providedModel.tags().containsAll(requiredTags)) {
             throw new IllegalArgumentException(
-                    String.format(java.util.Locale.ROOT, "Model '%s' on '%s' has tags %s but are missing required tags %s", modelId, valueName, providedModel.tags(), requiredTags));
+                    Text.format("Model '%s' on '%s' has tags %s but are missing required tags %s", modelId, valueName, providedModel.tags(), requiredTags));
         }
         return providedModel.uri().toString();
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentNode.java
@@ -7,6 +7,7 @@ import com.yahoo.vespa.config.content.core.StorCommunicationmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.vespa.config.content.core.StorStatusConfig;
 import com.yahoo.config.model.producer.TreeConfigProducer;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
@@ -42,7 +43,7 @@ public abstract class ContentNode extends AbstractService
         // Only [0, UINT16_MAX - 1] is a valid range. UINT16_MAX is a special content layer-internal
         // sentinel value that must never be used by actual nodes.
         if (distributionKey < 0 || distributionKey >= 65535) {
-            throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Distribution key %d is outside valid range [0, 65534]", distributionKey));
+            throw new IllegalArgumentException(Text.format("Distribution key %d is outside valid range [0, 65534]", distributionKey));
         }
 
         initialize();

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ReservedDocumentTypeNameValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ReservedDocumentTypeNameValidator.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.content;
 
 import com.yahoo.documentmodel.NewDocumentType;
+import com.yahoo.text.Text;
 
 import java.util.List;
 import java.util.Map;
@@ -27,11 +28,11 @@ public class ReservedDocumentTypeNameValidator {
     }
 
     private static String asQuotedListString(List<String> list) {
-        return list.stream().map(s -> String.format(java.util.Locale.ROOT, "'%s'", s)).collect(Collectors.joining(", "));
+        return list.stream().map(s -> Text.format("'%s'", s)).collect(Collectors.joining(", "));
     }
 
     private static String makeReservedNameMessage(List<String> conflictingNames) {
-        return String.format(java.util.Locale.ROOT, "The following document types conflict with reserved keyword names: %s. Reserved keywords are %s",
+        return Text.format("The following document types conflict with reserved keyword names: %s. Reserved keywords are %s",
                 asQuotedListString(conflictingNames), asQuotedListString(ORDERED_RESERVED_NAMES));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/ml/OnnxModelInfo.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/ml/OnnxModelInfo.java
@@ -11,6 +11,7 @@ import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.io.IOUtils;
 import com.yahoo.path.Path;
 import com.yahoo.tensor.TensorType;
+import com.yahoo.text.Text;
 import onnx.Onnx;
 
 import java.io.ByteArrayOutputStream;
@@ -209,14 +210,14 @@ public class OnnxModelInfo {
         int skippedInput = 0;
         for (Onnx.ValueInfoProto valueInfo : model.getGraph().getInputList()) {
             if (initializerNames.contains(valueInfo.getName())) {
-                log.fine(() -> String.format(java.util.Locale.ROOT, "For '%s': skipping name '%s' as it's an initializer", path.getName(), valueInfo.getName()));
+                log.fine(() -> Text.format("For '%s': skipping name '%s' as it's an initializer", path.getName(), valueInfo.getName()));
                 ++skippedInput;
                 continue;
             }
             onnxTypeToJson(g, valueInfo);
         }
         if (skippedInput > 0)
-            log.info(String.format(java.util.Locale.ROOT, "For '%s': skipped %d inputs that were also listed in initializers", path.getName(), skippedInput));
+            log.info(Text.format("For '%s': skipped %d inputs that were also listed in initializers", path.getName(), skippedInput));
         g.writeEndArray();
 
         g.writeArrayFieldStart("outputs");

--- a/config-model/src/main/java/com/yahoo/vespa/model/utils/internal/ReflectionUtil.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/utils/internal/ReflectionUtil.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.utils.internal;
 import com.google.common.reflect.TypeToken;
 import com.yahoo.config.ChangesRequiringRestart;
 import com.yahoo.config.ConfigInstance;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.model.ConfigProducer;
 
@@ -72,7 +73,7 @@ public final class ReflectionUtil {
     public static ChangesRequiringRestart getChangesRequiringRestart(ConfigInstance from, ConfigInstance to) {
         Class<?> clazz = from.getClass();
         if (!clazz.equals(to.getClass())) {
-            throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "%s != %s", clazz, to.getClass()));
+            throw new IllegalArgumentException(Text.format("%s != %s", clazz, to.getClass()));
         }
         try {
             Method m = clazz.getDeclaredMethod("getChangesRequiringRestart", clazz);

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -24,6 +24,7 @@ import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.search.config.QrStartConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import com.yahoo.vespa.config.content.core.StorCommunicationmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorStatusConfig;
@@ -2254,7 +2255,7 @@ public class ModelProvisioningTest {
         {
             VespaModelTester tester = new VespaModelTester();
             tester.addHosts(6);
-            VespaModel model = tester.createModel(String.format(java.util.Locale.ROOT, servicesXml, "node", ""), true, deployStateWithClusterEndpoints("qrs").properties(new TestProperties()));
+            VespaModel model = tester.createModel(Text.format(servicesXml, "node", ""), true, deployStateWithClusterEndpoints("qrs").properties(new TestProperties()));
 
             var fleetControllerConfigBuilder = new FleetcontrollerConfig.Builder();
             model.getConfig(fleetControllerConfigBuilder, "admin/standalone/cluster-controllers/0/components/clustercontroller-content-configurer");
@@ -2264,7 +2265,7 @@ public class ModelProvisioningTest {
         {
             VespaModelTester tester = new VespaModelTester();
             tester.addHosts(6);
-            VespaModel model = tester.createModel(String.format(java.util.Locale.ROOT, servicesXml, "group", ""), true, deployStateWithClusterEndpoints("qrs").properties(new TestProperties()));
+            VespaModel model = tester.createModel(Text.format(servicesXml, "group", ""), true, deployStateWithClusterEndpoints("qrs").properties(new TestProperties()));
 
             var fleetControllerConfigBuilder = new FleetcontrollerConfig.Builder();
             model.getConfig(fleetControllerConfigBuilder, "admin/standalone/cluster-controllers/0/components/clustercontroller-content-configurer");
@@ -2275,7 +2276,7 @@ public class ModelProvisioningTest {
             VespaModelTester tester = new VespaModelTester();
             tester.addHosts(6);
             assertThrows(IllegalArgumentException.class, () ->
-            tester.createModel(String.format(java.util.Locale.ROOT, servicesXml, "node",
+            tester.createModel(Text.format(servicesXml, "node",
                                                      """
                                                      <tuning>
                                                        <cluster-controller>
@@ -2543,7 +2544,7 @@ public class ModelProvisioningTest {
     }
 
     private static String multipleContentClusters(int count1, int count2) {
-        return String.format(java.util.Locale.ROOT, """
+        return Text.format("""
                 <?xml version="1.0" encoding="utf-8" ?>
                 <services>
                   <content version='1.0' id='foo'>

--- a/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/parser/SchemaParserTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.schema.parser;
 
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.io.IOUtils;
+import com.yahoo.text.Text;
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 
 import java.io.File;
@@ -218,7 +219,7 @@ public class SchemaParserTestCase {
     }
 
     private void assertRankProfileWithOutOfRangeThrows(String rpContent) {
-        var input = String.format(java.util.Locale.ROOT, "schema foo { rank-profile rp { %s } }", rpContent);
+        var input = Text.format("schema foo { rank-profile rp { %s } }", rpContent);
         var e = assertThrows(IllegalArgumentException.class, () -> parseString(input));
         assertTrue(e.getMessage().contains("must be in range [0, 1]"));
     }

--- a/config-model/src/test/java/com/yahoo/schema/processing/FieldSetSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/FieldSetSettingsTestCase.java
@@ -6,6 +6,7 @@ import com.yahoo.schema.ApplicationBuilder;
 import com.yahoo.schema.derived.TestableDeployLogger;
 import com.yahoo.schema.document.MatchType;
 import com.yahoo.schema.parser.ParseException;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -162,7 +163,7 @@ public class FieldSetSettingsTestCase {
     }
 
     private static String schemaWithMatchSettings(String fieldSet, String fieldNameWithWordMatching, String fieldNameWithExactMatching) {
-        return String.format(java.util.Locale.ROOT, """
+        return Text.format("""
                   schema index_variants {
                     document index_variants {
                       field %s type string {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudClientsValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudClientsValidatorTest.java
@@ -2,6 +2,7 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.test.utils.DeployLoggerStub;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,6 @@ class CloudClientsValidatorTest {
     private static X509Certificate readTestCertificate(String filename) {
         return X509CertificateUtils.fromPem(new String(uncheck(
                 () -> CloudClientsValidatorTest.class.getResourceAsStream(
-                        String.format(java.util.Locale.ROOT, "/cloud-clients-validator/%s", filename)).readAllBytes()), java.nio.charset.StandardCharsets.UTF_8));
+                        Text.format("/cloud-clients-validator/%s", filename)).readAllBytes()), java.nio.charset.StandardCharsets.UTF_8));
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidatorTest.java
@@ -19,6 +19,7 @@ import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SignatureAlgorithm;
 import com.yahoo.security.X509CertificateBuilder;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class CloudDataPlaneFilterValidatorTest {
     void validator_accepts_distinct_client_certificates() throws IOException, SAXException {
         String certFile1 = "security/foo.pem";
         String certFile2 = "security/bar.pem";
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                         <services version='1.0'>
                           <container version='1.0'>
                             <clients>
@@ -79,7 +80,7 @@ public class CloudDataPlaneFilterValidatorTest {
         String certFile1 = "security/a.pem";
         String certFile2 = "security/b.pem";
         X509Certificate certificate = createCertificate("a");
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                 <services version='1.0'>
                   <container version='1.0'>
                     <clients>
@@ -101,14 +102,14 @@ public class CloudDataPlaneFilterValidatorTest {
 
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
         ValidationTester.expect(new CloudDataPlaneFilterValidator(), model, deployState,
-                                String.format(java.util.Locale.ROOT, "Duplicate certificate(s) detected in files: [%s, %s]. Certificate subject of duplicates: [%s]", certFile1, certFile2, certificate.getSubjectX500Principal().getName()));
+                                Text.format("Duplicate certificate(s) detected in files: [%s, %s]. Certificate subject of duplicates: [%s]", certFile1, certFile2, certificate.getSubjectX500Principal().getName()));
     }
 
     @Test
     void validator_rejects_duplicate_client_certificates_same_file() throws IOException, SAXException {
         String certFile1 = "security/a.pem";
         X509Certificate certificate = createCertificate("a");
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                 <services version='1.0'>
                   <container version='1.0'>
                     <clients>
@@ -125,7 +126,7 @@ public class CloudDataPlaneFilterValidatorTest {
 
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
         ValidationTester.expect(new CloudDataPlaneFilterValidator(), model, deployState,
-                                String.format(java.util.Locale.ROOT, "Duplicate certificate(s) detected in files: [%s]. Certificate subject of duplicates: [%s]", certFile1, certificate.getSubjectX500Principal().getName()));
+                                Text.format("Duplicate certificate(s) detected in files: [%s]. Certificate subject of duplicates: [%s]", certFile1, certificate.getSubjectX500Principal().getName()));
     }
 
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudHttpConnectorValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudHttpConnectorValidatorTest.java
@@ -8,6 +8,7 @@ import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
 
@@ -86,7 +87,7 @@ class CloudHttpConnectorValidatorTest {
     }
 
     private static void runValidatorOnApp(boolean hosted, String appTypeAttribute, String serverXml) throws Exception {
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                         <services version='1.0'%s>
                           <container version='1.0'>
                             <http>

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudUserFilterValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudUserFilterValidatorTest.java
@@ -9,6 +9,7 @@ import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
@@ -44,7 +45,7 @@ class CloudUserFilterValidatorTest {
     }
 
     private static void runValidatorOnApp(boolean isHosted, String applicationTypeAttribute) throws IOException, SAXException {
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                         <services version='1.0'%s>
                           <container version='1.0'>
                             <http>

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ContainerInCloudValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ContainerInCloudValidatorTest.java
@@ -8,6 +8,7 @@ import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
@@ -39,7 +40,7 @@ public class ContainerInCloudValidatorTest {
     }
 
     private static void runValidatorOnApp(boolean isHosted, String container) throws IOException, SAXException {
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                         <services version='1.0'>
                           %s
                         </services>

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UrlConfigValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UrlConfigValidatorTest.java
@@ -14,6 +14,7 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.embedding.BertBaseEmbedderConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import com.yahoo.vespa.config.buildergen.ConfigDefinition;
 import com.yahoo.vespa.model.VespaModel;
@@ -54,7 +55,7 @@ public class UrlConfigValidatorTest {
     }
 
     private static String containerXml(boolean isExclusive) {
-        return String.format(java.util.Locale.ROOT, """
+        return Text.format("""
                            <container version='1.0' id='default'>
                                <component id='transformer' class='ai.vespa.embedding.BertBaseEmbedder' bundle='model-integration'>
                                    <config name='embedding.bert-base-embedder'>
@@ -71,7 +72,7 @@ public class UrlConfigValidatorTest {
 
     private static void runValidatorOnApp(boolean isExclusive, SystemName systemName) throws IOException, SAXException {
         String container = containerXml(isExclusive);
-        String servicesXml = String.format(java.util.Locale.ROOT, """
+        String servicesXml = Text.format("""
                         <services version='1.0'>
                           %s
                         </services>

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidatorTest.java
@@ -5,6 +5,7 @@ import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestDeployState;
 import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
@@ -47,7 +48,7 @@ public class RestartOnDeployForLocalLLMValidatorTest {
     }
 
     private static VespaModel createModel(String component) {
-        var xml = String.format(java.util.Locale.ROOT, """
+        var xml = Text.format("""
                 <services version='1.0'>
                   <container id='cluster1' version='1.0'>
                     <http>
@@ -66,7 +67,7 @@ public class RestartOnDeployForLocalLLMValidatorTest {
     }
 
     private static String withComponent(String componentClass) {
-        return String.format(java.util.Locale.ROOT, "<component id='llm' class='%s' />", componentClass);
+        return Text.format("<component id='llm' class='%s' />", componentClass);
     }
 
     private static DeployState.Builder deployStateBuilder() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidatorTest.java
@@ -12,6 +12,7 @@ import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.provision.NodeResources;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
@@ -161,7 +162,7 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
     }
 
     private static VespaModel hostedModel(DeployState.Builder builder, String executionMode, String modelId) {
-        var servicesXml  = String.format(java.util.Locale.ROOT, """
+        var servicesXml  = Text.format("""
                           <services version='1.0'>
                             <container id='cluster1' version='1.0'>
                               <component id="hf-embedder" type="hugging-face-embedder">
@@ -197,7 +198,7 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
     }
 
     private static VespaModel nonHostedModel(DeployState.Builder builder, String executionMode, String modelId) {
-        var xml = String.format(java.util.Locale.ROOT, """
+        var xml = Text.format("""
                                        <services version='1.0'>
                                          <container id='cluster1' version='1.0'>
                                            <http>

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/component/ModelTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/component/ModelTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.container.component;
 
 import com.yahoo.config.UrlReference;
 import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.text.Text;
 import com.yahoo.text.XML;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,7 @@ public class ModelTest {
     @Test
     void valid_url(){
         var dummyUrl = "https://vespa.ai/some-model.onxx";
-        var xml = String.format(java.util.Locale.ROOT, """
+        var xml = Text.format("""
                 <component id="bert-embedder" type="hugging-face-embedder">
                   <transformer-model url="%s" />
                   <tokenizer-model url="%s"/>
@@ -56,7 +57,7 @@ public class ModelTest {
     @Test
     void authenticated_url(){
         var dummyUrl = "https://vespa.ai/some-model.onxx";
-        var xml = String.format(java.util.Locale.ROOT, """
+        var xml = Text.format("""
                 <component id="bert-embedder" type="hugging-face-embedder">
                   <transformer-model url="%s" secret-ref="myTransformerSecret" />
                   <tokenizer-model url="%s" secret-ref="myTokenizerSecret"/>

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/CloudDataPlaneFilterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/CloudDataPlaneFilterTest.java
@@ -20,6 +20,7 @@ import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SignatureAlgorithm;
 import com.yahoo.security.X509CertificateBuilder;
 import com.yahoo.security.X509CertificateUtils;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.ApplicationContainer;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
@@ -67,7 +68,7 @@ public class CloudDataPlaneFilterTest extends ContainerModelBuilderTestBase {
     public void it_generates_correct_config() throws IOException {
         Path certFile = securityFolder.resolve("foo.pem");
         Element clusterElem = DomBuilderTest.parse(
-                String.format(java.util.Locale.ROOT, """
+                Text.format("""
                         <container version='1.0'>
                           <clients>
                             <client id="foo" permissions="read,write">
@@ -124,7 +125,7 @@ public class CloudDataPlaneFilterTest extends ContainerModelBuilderTestBase {
     public void it_rejects_files_without_certificates() throws IOException {
         Path certFile = securityFolder.resolve("foo.pem");
         Element clusterElem = DomBuilderTest.parse(
-                String.format(java.util.Locale.ROOT, """
+                Text.format("""
                         <container version='1.0'>
                           <clients>
                             <client id="foo" permissions="read,write">

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/CloudTokenDataPlaneFilterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/CloudTokenDataPlaneFilterTest.java
@@ -16,6 +16,7 @@ import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.jdisc.http.filter.security.cloud.config.CloudTokenDataPlaneFilterConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.container.ApplicationContainer;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
@@ -79,7 +80,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void generates_correct_config_for_tokens() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var clusterElem = DomBuilderTest.parse(String.format(java.util.Locale.ROOT, servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
+        var clusterElem = DomBuilderTest.parse(Text.format(servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
         createCertificate(certFile);
         buildModel(Set.of(tokenEndpoint, mtlsEndpoint), defaultTokens, clusterElem);
 
@@ -96,7 +97,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void configures_dataplane_proxy_when_token_defined() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var clusterElem = DomBuilderTest.parse(String.format(java.util.Locale.ROOT, servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
+        var clusterElem = DomBuilderTest.parse(Text.format(servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
         createCertificate(certFile);
         buildModel(Set.of(tokenEndpoint, mtlsEndpoint), defaultTokens, clusterElem);
 
@@ -109,7 +110,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void configures_dataplane_proxy_when_token_defined_but_missing() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var clusterElem = DomBuilderTest.parse(String.format(java.util.Locale.ROOT, servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
+        var clusterElem = DomBuilderTest.parse(Text.format(servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
         createCertificate(certFile);
         buildModel(Set.of(tokenEndpoint, mtlsEndpoint), List.of(), clusterElem);
 
@@ -123,7 +124,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void does_notconfigure_dataplane_proxy_when_token_endpoints_not_defined() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var clusterElem = DomBuilderTest.parse(String.format(java.util.Locale.ROOT, servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
+        var clusterElem = DomBuilderTest.parse(Text.format(servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
         createCertificate(certFile);
         buildModel(Set.of(mtlsEndpoint), List.of(), clusterElem);
 
@@ -133,7 +134,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void configuresCorrectConnectors() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var clusterElem = DomBuilderTest.parse(String.format(java.util.Locale.ROOT, servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
+        var clusterElem = DomBuilderTest.parse(Text.format(servicesXmlTemplate, applicationFolder.toPath().relativize(certFile).toString()));
         createCertificate(certFile);
         buildModel(Set.of(tokenEndpoint, mtlsEndpoint), defaultTokens, clusterElem);
 
@@ -148,7 +149,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void fails_on_unknown_permission() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var servicesXml = String.format(java.util.Locale.ROOT, """
+        var servicesXml = Text.format("""
                 <container version='1.0'>
                   <clients>
                     <client id="foo" permissions="read,unknown-permission">
@@ -166,7 +167,7 @@ public class CloudTokenDataPlaneFilterTest extends ContainerModelBuilderTestBase
     @Test
     void fails_on_duplicate_clients() throws IOException {
         var certFile = securityFolder.resolve("foo.pem");
-        var servicesXml = String.format(java.util.Locale.ROOT, """
+        var servicesXml = Text.format("""
                     <container version="1.0">
                         <clients>
                             <client id="mtls" permissions="read,write">

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -40,6 +40,7 @@ import com.yahoo.container.usability.BindingsOverviewHandler;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.prelude.cluster.QrMonitorConfig;
 import com.yahoo.search.config.QrStartConfig;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ApplicationContainer;
@@ -324,7 +325,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                                <nodes count='2' />
                              </container>
                              """;
-        String deploymentXml = String.format(java.util.Locale.ROOT, """
+        String deploymentXml = Text.format("""
                                <deployment version='1.0'>
                                  <prod>
                                    <region>eu</region>
@@ -752,7 +753,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     }
 
     void createModelWithTesterNodes(String testerNodesXml) {
-        String containerXml = String.format(java.util.Locale.ROOT, "<container id='default' version='1.0'>%s</container>", testerNodesXml);
+        String containerXml = Text.format("<container id='default' version='1.0'>%s</container>", testerNodesXml);
         VespaModelTester tester = new VespaModelTester();
         tester.setApplicationId("t", "a", "i-t");
         tester.addHosts(3);
@@ -814,7 +815,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         return DomBuilderTest.parse(
                 "<container id='default' version='1.0'>",
                 "  <search>",
-                String.format(java.util.Locale.ROOT, "    <renderer id='%s'/>", rendererId),
+                Text.format("    <renderer id='%s'/>", rendererId),
                 "  </search>",
                 "</container>");
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.container.xml;
 import com.yahoo.component.ComponentId;
 import ai.vespa.embedding.config.VoyageAiEmbedderConfig;
 import com.yahoo.path.Path;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.Component;
@@ -110,7 +111,7 @@ public class VoyageAIEmbedderTest {
         };
 
         for (int i = 0; i < quantizations.length; i++) {
-            String xml = String.format(java.util.Locale.ROOT, """
+            String xml = Text.format("""
                     <?xml version="1.0" encoding="utf-8" ?>
                     <services version="1.0">
                         <container id="container" version="1.0">

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -46,6 +46,7 @@ import com.yahoo.vespa.model.routing.Routing;
 import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 import com.yahoo.vespa.model.utils.ResourceUtils;
+import com.yahoo.text.Text;
 import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
 
@@ -1047,7 +1048,7 @@ public class ContentClusterTest extends ContentBaseTest {
                                                        Optional<Flavor> flavor, StringBuffer deployWarningsBuffer) throws Exception {
         DeployLogger logger = (level, message) -> {
             if (level == Level.WARNING) { // only care about warnings
-                deployWarningsBuffer.append(String.format(java.util.Locale.ROOT, "%s\n", message));
+                deployWarningsBuffer.append(Text.format("%s\n", message));
             }
         };
         DeployState.Builder deployStateBuilder = new DeployState.Builder()
@@ -1547,7 +1548,7 @@ public class ContentClusterTest extends ContentBaseTest {
         // sentinel value that must never be used by actual nodes.
         for (int distKey : List.of(-1, 65535, 65536, 100000)) {
             assertThrows(IllegalArgumentException.class, () ->
-                    parse(String.format(java.util.Locale.ROOT, """
+                    parse(Text.format("""
                             <content version="1.0" id="storage">
                               <documents/>
                               <redundancy>1</redundancy>
@@ -1574,7 +1575,7 @@ public class ContentClusterTest extends ContentBaseTest {
                "  <redundancy>1</redundancy>" +
                "  <documents/>" +
                "  <group>" +
-               String.format(java.util.Locale.ROOT, "    <node distribution-key=\"%d\" hostalias=\"mockhost\"/>", key) +
+               Text.format("    <node distribution-key=\"%d\" hostalias=\"mockhost\"/>", key) +
                "  </group>" +
                "</content>";
     }
@@ -1751,7 +1752,7 @@ public class ContentClusterTest extends ContentBaseTest {
     }
 
     private String servicesWithGroups(int groupCount, double minGroupUpRatio) {
-        String services = String.format(java.util.Locale.ROOT, "<?xml version='1.0' encoding='UTF-8' ?>" +
+        String services = Text.format("<?xml version='1.0' encoding='UTF-8' ?>" +
                 "<services version='1.0'>" +
                 "  <container id='default' version='1.0' />" +
                 "  <content id='storage' version='1.0'>" +
@@ -1770,7 +1771,7 @@ public class ContentClusterTest extends ContentBaseTest {
         };
         services += distribution;
         for (int i = 0; i < groupCount; i++) {
-            services += String.format(java.util.Locale.ROOT, "    <group name='g-%d' distribution-key='%d'>" +
+            services += Text.format("    <group name='g-%d' distribution-key='%d'>" +
                                               "      <node hostalias='mockhost' distribution-key='%d'/>" +
                                               "    </group>",
                                       i, i, i);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.config.content.core.StorCommunicationmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorDistributormanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.config.model.test.MockRoot;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
 import com.yahoo.vespa.model.content.utils.ContentClusterUtils;
 import com.yahoo.vespa.model.content.utils.DocType;
@@ -355,7 +356,7 @@ public class DistributorTest {
     }
 
     private String createServices(String maxDocumentSize) {
-        return String.format(java.util.Locale.ROOT, """
+        return Text.format("""
                       <content id="foo">
                         <redundancy>1</redundancy>
                         <documents/>

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -21,6 +21,7 @@ import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.ProvisionLogger;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 
@@ -86,7 +87,7 @@ public class VespaModelTester {
             // Let host names sort in the opposite order of the order the hosts are added
             // This allows us to test index vs. name order selection when subsets of hosts are selected from a cluster
             // (for e.g cluster controllers and slobrok nodes)
-            String hostname = String.format(java.util.Locale.ROOT, "%s-%03d",
+            String hostname = Text.format("%s-%03d",
                                             "node" + "-" + Math.round(resources.vcpu()) +
                                                      "-" + Math.round(resources.memoryGiB()) +
                                                      "-" + Math.round(resources.diskGb()),


### PR DESCRIPTION
Replace all instances of String.format(java.util.Locale.ROOT, ...) with Text.format(...) across the config-model module.
