### PR TITLE
Migrate to Text.format in indexinglanguage

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GenerateExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/GenerateExpression.java
@@ -9,6 +9,7 @@ import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.FieldGenerator;
+import com.yahoo.text.Text;
 
 import java.util.List;
 import java.util.Objects;
@@ -30,7 +31,7 @@ public class GenerateExpression extends Expression {
 
     /** The target type we are generating into. */
     private DataType targetType;
-    
+
     public GenerateExpression(Linguistics linguistics,
                               Components<FieldGenerator> generators,
                               String generatorId,
@@ -45,8 +46,7 @@ public class GenerateExpression extends Expression {
         if (!inputType.isAssignableTo(DataType.STRING)) {
             throw new VerificationException(
                     this,
-                    "Generate expression for field %s requires string input type, but got %s."
-                            .formatted(destination, inputType.getName())
+                    Text.format("Generate expression for field %s requires string input type, but got %s.", destination, inputType.getName())
             );
         }
 
@@ -80,19 +80,18 @@ public class GenerateExpression extends Expression {
         FieldValue inputValue = context.getCurrentValue();
         DataType inputType = inputValue.getDataType();
         FieldValue generatedValue;
-        
+
         if (inputType == DataType.STRING) {
             var promptString = ((StringFieldValue) inputValue).getString();
             generatedValue = generate(StringPrompt.from(promptString), context);
         } else {
             throw new IllegalArgumentException(
-                    ("Generate expression for field %s requires string input type, but got %s.")
-                            .formatted(destination, inputType.getName()));
+                    Text.format("Generate expression for field %s requires string input type, but got %s.", destination, inputType.getName()));
         }
-        
+
         context.setCurrentValue(generatedValue);
     }
-    
+
     private FieldValue generate(Prompt prompt, ExecutionContext context) {
         var generatorContext =  new FieldGenerator.Context(destination, targetType, context.getCache())
                 .setLanguage(context.resolveLanguage(linguistics))

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeExpression.java
@@ -5,6 +5,7 @@ import com.yahoo.document.DataType;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.Transformer;
+import com.yahoo.text.Text;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,7 +63,7 @@ public final class NormalizeExpression extends Expression {
             if (c >= ' ') {
                 buf.append(c);
             } else {
-                buf.append(String.format("U+%04X", (int)c));
+                buf.append(Text.format("U+%04X", (int)c));
             }
         }
         return buf.toString();

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.Locale;
 
 import static com.yahoo.language.LinguisticsCase.toLowerCase;
 
@@ -284,12 +285,13 @@ public class LinguisticsAnnotator {
         if (maxRatio >= 1 && (maxCharacters < 0 || maxCharacters == Integer.MAX_VALUE)) return false;
         var replacementCharCount = text.chars().filter(c -> c == 0xFFFD).count();
         if (replacementCharCount > maxCharacters && replacementCharCount > text.length() * maxRatio) {
-            var reason = ("Some text of length %d is classified as binary data as it contains %d Unicode replacement characters. " +
-                    "(max-replacement-character-ratio=%d%%, max-replacement-characters=%d)")
-                    .formatted(text.length(), replacementCharCount, (int)Math.round(maxRatio * 100) , maxCharacters);
-            var docIdString = (docId != null) ? "%s".formatted(docId.toString()) : "<unknown>";
+            var reason = String.format(Locale.ROOT,
+                    "Some text of length %d is classified as binary data as it contains %d Unicode replacement characters. " +
+                    "(max-replacement-character-ratio=%d%%, max-replacement-characters=%d)",
+                    text.length(), replacementCharCount, (int)Math.round(maxRatio * 100) , maxCharacters);
+            var docIdString = (docId != null) ? Text.format("%s", docId.toString()) : "<unknown>";
             if (isReindexingOperation) {
-                log.warning("Skipping tokenization of '%s' while reindexing: %s. ".formatted(docIdString, reason));
+                log.warning(Text.format("Skipping tokenization of \'%s\' while reindexing: %s. ", docIdString, reason));
                 return true;
             } else {
                 throw new InvalidInputException(reason);

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/EchoTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/EchoTestCase.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
 import static org.junit.Assert.assertEquals;
@@ -23,17 +24,17 @@ public class EchoTestCase {
     public void requireThatAccessorsWork() {
         assertSame(System.out, new EchoExpression().getOutputStream());
 
-        PrintStream out = new PrintStream(System.out);
+        PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8);
         assertSame(out, new EchoExpression(out).getOutputStream());
     }
 
     @Test
     public void requireThatHashCodeAndEqualsAreImplemented() {
-        PrintStream out = new PrintStream(System.out);
+        PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8);
         Expression exp = new EchoExpression(out);
         assertFalse(exp.equals(new Object()));
         assertFalse(exp.equals(new EchoExpression()));
-        assertFalse(exp.equals(new EchoExpression(new PrintStream(System.err))));
+        assertFalse(exp.equals(new EchoExpression(new PrintStream(System.err, true, StandardCharsets.UTF_8))));
         assertEquals(exp, new EchoExpression(out));
         assertEquals(exp.hashCode(), new EchoExpression(out).hashCode());
     }
@@ -44,9 +45,9 @@ public class EchoTestCase {
 
         ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter());
         ctx.setCurrentValue(new StringFieldValue("69"));
-        new EchoExpression(new PrintStream(out)).execute(ctx);
+        new EchoExpression(new PrintStream(out, true, StandardCharsets.UTF_8)).execute(ctx);
 
-        assertEquals("69" + System.getProperty("line.separator"), out.toString());
+        assertEquals("69" + System.getProperty("line.separator"), out.toString(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/linguistics/SimpleAnnotationsComparisonTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/linguistics/SimpleAnnotationsComparisonTestCase.java
@@ -15,6 +15,7 @@ import com.yahoo.language.process.Token;
 import com.yahoo.language.process.TokenType;
 import com.yahoo.language.process.Tokenizer;
 import com.yahoo.language.simple.SimpleToken;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.indexinglanguage.linguistics.LinguisticsAnnotator.TermOccurrences;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -310,7 +311,7 @@ public class SimpleAnnotationsComparisonTestCase {
 
         @Override
         public String toString() {
-            return String.format("Annotation(from=%d, length=%d, term='%s')", from, length, term);
+            return Text.format("Annotation(from=%d, length=%d, term='%s')", from, length, term);
         }
     }
 


### PR DESCRIPTION
Replace String.format() with Text.format() throughout the indexinglanguage module for locale-independent formatting and consistency with Vespa conventions. Also adds explicit UTF-8 charset to PrintStreams in test code.

Changes affect GenerateExpression, NormalizeExpression, LinguisticsAnnotator, and related test cases.
