### PR TITLE
Use Text.format in logstash plugin

### DIFF
--- a/integration/logstash-plugins/logstash-output-vespa/src/main/java/org/logstashplugins/VespaFeed.java
+++ b/integration/logstash-plugins/logstash-output-vespa/src/main/java/org/logstashplugins/VespaFeed.java
@@ -400,7 +400,7 @@ public class VespaFeed implements Output {
                 }
             } catch (JsonProcessingException | RuntimeException e) {
                 // RuntimeException shouldn't really happen here, we use it in tests
-                String errorMessage = String.format("Error processing event to generate async feed request: %s", e.getMessage());
+                String errorMessage = Text.format("Error processing event to generate async feed request: %s", e.getMessage());
                 logger.error(errorMessage);
                 writeToDlq(event, errorMessage);
             }
@@ -421,7 +421,7 @@ public class VespaFeed implements Output {
                     try {
                         promise.get(); // This will throw the exception
                     } catch (Exception ex) {
-                        String errorMessage = String.format("Error while waiting for async operation to complete: %s", ex.getMessage());
+                        String errorMessage = Text.format("Error while waiting for async operation to complete: %s", ex.getMessage());
                         logger.error(errorMessage);
                         writeToDlq(event, errorMessage);
                     }
@@ -467,7 +467,7 @@ public class VespaFeed implements Output {
         if (feedConfig.isDynamicOperation()) {
             operation = getDynamicField(event, feedConfig.getOperation());
             if (!operation.equals("put") && !operation.equals("update") && !operation.equals("remove")) {
-                String errorMessage = String.format("Invalid operation (must be put, update or remove): {}", operation);
+                String errorMessage = Text.format("Invalid operation (must be put, update or remove): {}", operation);
                 logger.error(errorMessage);
                 writeToDlq(event, errorMessage);
                 return null;


### PR DESCRIPTION
Replace String.format with Text.format for error messages to ensure consistent formatting regardless of system locale settings.
