### PR TITLE
Standardize locale handling in logserver

### DIFF
--- a/logserver/src/main/java/ai/vespa/logserver/protocol/ArchiveLogMessagesMethod.java
+++ b/logserver/src/main/java/ai/vespa/logserver/protocol/ArchiveLogMessagesMethod.java
@@ -9,6 +9,7 @@ import com.yahoo.jrt.Method;
 import com.yahoo.jrt.Request;
 import com.yahoo.logserver.LogDispatcher;
 import com.yahoo.security.tls.Capability;
+import com.yahoo.text.Text;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -73,7 +74,7 @@ public class ArchiveLogMessagesMethod {
                 int uncompressedSize = rpcRequest.parameters().get(1).asInt32();
                 byte[] logRequestPayload = rpcRequest.parameters().get(2).asData();
                 if (uncompressedSize != logRequestPayload.length) {
-                    rpcRequest.setError(ErrorCode.METHOD_FAILED, String.format("Invalid uncompressed size: got %d while data is of size %d ", uncompressedSize, logRequestPayload.length));
+                    rpcRequest.setError(ErrorCode.METHOD_FAILED, Text.format("Invalid uncompressed size: got %d while data is of size %d ", uncompressedSize, logRequestPayload.length));
                     rpcRequest.returnRequest();
                     return;
                 }

--- a/logserver/src/main/java/com/yahoo/logserver/filter/LogFilterManager.java
+++ b/logserver/src/main/java/com/yahoo/logserver/filter/LogFilterManager.java
@@ -4,6 +4,7 @@ package com.yahoo.logserver.filter;
 import com.yahoo.log.LogLevel;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -50,7 +51,7 @@ public class LogFilterManager {
             throw new NullPointerException("name cannot be null");
         }
 
-        String n = name.toLowerCase();
+        String n = name.toLowerCase(Locale.ROOT);
 
         if (n.startsWith("system.")) {
             throw new IllegalArgumentException("'system' namespace is reserved");

--- a/logserver/src/main/java/com/yahoo/logserver/handlers/archive/ArchiverHandler.java
+++ b/logserver/src/main/java/com/yahoo/logserver/handlers/archive/ArchiverHandler.java
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -72,8 +73,8 @@ public final class ArchiverHandler extends AbstractLogHandler {
      * Creates an ArchiverHandler
      */
     private ArchiverHandler() {
-        calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-        dateformat = new SimpleDateFormat("yyyy/MM/dd/HH");
+        calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"), Locale.US);
+        dateformat = new SimpleDateFormat("yyyy/MM/dd/HH", Locale.US);
         dateformat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         setLogFilter(null);

--- a/logserver/src/main/java/com/yahoo/logserver/handlers/archive/LogWriter.java
+++ b/logserver/src/main/java/com/yahoo/logserver/handlers/archive/LogWriter.java
@@ -5,8 +5,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
-
 import java.util.logging.Level;
 
 /**
@@ -69,7 +69,7 @@ public final class LogWriter {
                 log.log(Level.FINE, () -> "nextWriter, new file: " + name);
                 currentFile = f;
                 bytesWritten = 0;
-                return new FileWriter(f, true);
+                return new FileWriter(f, StandardCharsets.UTF_8, true);
             }
 
             // just skip over directories for now
@@ -83,7 +83,7 @@ public final class LogWriter {
                 log.fine("nextWriter, resuming " + name + ", length was " + f.length());
                 currentFile = f;
                 bytesWritten = f.length();
-                return new FileWriter(f, true);
+                return new FileWriter(f, StandardCharsets.UTF_8, true);
             } else {
 
                 log.fine("nextWriter, not resuming " + name

--- a/logserver/src/test/java/com/yahoo/logserver/handlers/archive/ArchiverHandlerTestCase.java
+++ b/logserver/src/test/java/com/yahoo/logserver/handlers/archive/ArchiverHandlerTestCase.java
@@ -8,6 +8,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.yahoo.text.Utf8;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -132,7 +134,7 @@ public class ArchiverHandlerTestCase {
             File f = new File(name);
             assertTrue(f.exists());
 
-            BufferedReader br = new BufferedReader(new FileReader(f));
+            BufferedReader br = new BufferedReader(Utf8.createReader(f));
             for (String line = br.readLine();
                  line != null;
                  line = br.readLine()) {
@@ -184,7 +186,7 @@ public class ArchiverHandlerTestCase {
             assertTrue(f.exists());
 
             // ensure there's the same log message in all files
-            BufferedReader br = new BufferedReader(new FileReader(f));
+            BufferedReader br = new BufferedReader(Utf8.createReader(f));
             for (String line = br.readLine();
                  line != null;
                  line = br.readLine()) {

--- a/logserver/src/test/java/com/yahoo/logserver/handlers/archive/FilesArchivedTestCase.java
+++ b/logserver/src/test/java/com/yahoo/logserver/handlers/archive/FilesArchivedTestCase.java
@@ -9,6 +9,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +29,7 @@ public class FilesArchivedTestCase {
     private void makeLogfile(String name, long hours) throws IOException {
         File f = new File(tmpDir, name);
         f.getParentFile().mkdirs();
-        new FileWriter(f).write("foo bar baz\n");
+        new FileWriter(f, StandardCharsets.UTF_8).write("foo bar baz\n");
         long now = System.currentTimeMillis();
         f.setLastModified(now - (hours * 3600 * 1000));
     }


### PR DESCRIPTION
Make logserver code locale-independent and charset-explicit to avoid platform-dependent behavior:
- Use Locale.ROOT/Locale.US for case conversions and date formatting
- Explicitly specify UTF-8 charset for file I/O operations
- Replace String.format with Text.format utility

This ensures consistent behavior across different system locales and prevents encoding issues with log file operations.
