### PR TITLE
Use Text.format in ApplicationMojo

### DIFF
--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -88,7 +88,7 @@ public class ApplicationMojo extends AbstractMojo {
                 throw new IllegalArgumentException("compile version (" + compileVersion + ") cannot be higher than parent version (" + parentVersion + ")");
         }
 
-        String metaData = String.format(Locale.ROOT, """
+        String metaData = Text.format("""
                                         {
                                           "compileVersion": "%s",
                                           "buildTime": %d,


### PR DESCRIPTION
Replace String.format(Locale.ROOT, ...) with Text.format(...) to use the standard utility method for locale-independent string formatting.
