### PR TITLE
Make vdslib locale-independent

### DIFF
--- a/vdslib/src/main/java/com/yahoo/vdslib/state/NodeState.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/state/NodeState.java
@@ -146,7 +146,7 @@ public class NodeState implements Cloneable {
     public String toString(boolean compact) {
         StringBuilder sb = new StringBuilder();
         if (compact) {
-            sb.append(state.serialize().toUpperCase());
+            sb.append(state.serialize().toUpperCase(Locale.ROOT));
         } else {
             sb.append(state);
         }

--- a/vdslib/src/main/java/com/yahoo/vdslib/state/State.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/state/State.java
@@ -2,6 +2,7 @@
 package com.yahoo.vdslib.state;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  *
@@ -68,7 +69,7 @@ public enum State {
     @Override
     public String toString() {
         String id = name();
-        String lower = id.substring(1).toLowerCase();
+        String lower = id.substring(1).toLowerCase(Locale.ROOT);
         return id.charAt(0) + lower;
     }
 

--- a/vdslib/src/test/java/com/yahoo/vdslib/distribution/CrossPlatformTestFactory.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/distribution/CrossPlatformTestFactory.java
@@ -1,10 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vdslib.distribution;
 
+import com.yahoo.text.Utf8;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -28,7 +31,7 @@ public abstract class CrossPlatformTestFactory {
         if (!reference.exists()) {
             return;
         }
-        try (BufferedReader br = new BufferedReader(new FileReader(reference))) {
+        try (BufferedReader br = new BufferedReader(Utf8.createReader(reference))) {
             StringBuilder sb = new StringBuilder();
             while (true) {
                 String line = br.readLine();
@@ -43,7 +46,7 @@ public abstract class CrossPlatformTestFactory {
         String target = directory + "/" + name + ".java.results";
         String tmpName = target + ".tmp";
         File results = new File(tmpName);
-        try (FileWriter fw = new FileWriter(results)) {
+        try (FileWriter fw = new FileWriter(results, StandardCharsets.UTF_8)) {
             fw.write(serialize());
         }
         Files.move(Path.of(tmpName), Path.of(target),


### PR DESCRIPTION
Use Locale.ROOT for case conversion operations (toUpperCase/toLowerCase) and StandardCharsets.UTF_8 for file I/O to ensure consistent behavior across different system locales. This prevents locale-dependent bugs where string operations might produce unexpected results.
