### PR TITLE
Use explicit locale in predicate-search modules

### DIFF
--- a/predicate-search-core/src/main/java/com/yahoo/search/predicate/PredicateQueryParser.java
+++ b/predicate-search-core/src/main/java/com/yahoo/search/predicate/PredicateQueryParser.java
@@ -4,6 +4,7 @@ package com.yahoo.search.predicate;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -62,7 +63,7 @@ public class PredicateQueryParser {
         } catch (IOException e) {
             throw new AssertionError("This should never happen when parsing from a String", e);
         } catch (Exception e) {
-            throw new IllegalArgumentException(String.format("Parsing query from JSON failed: '%s'", json), e);
+            throw new IllegalArgumentException(Text.format("Parsing query from JSON failed: '%s'", json), e);
         }
     }
 
@@ -99,11 +100,11 @@ public class PredicateQueryParser {
         }
         if (key == null) {
             throw new IllegalArgumentException(
-                    String.format("Feature key is missing! (%s)", parser.currentLocation()));
+                    Text.format("Feature key is missing! (%s)", parser.currentLocation()));
         }
         if (value == null) {
             throw new IllegalArgumentException(
-                    String.format("Feature value is missing! (%s)", parser.currentLocation()));
+                    Text.format("Feature value is missing! (%s)", parser.currentLocation()));
         }
         featureHandler.accept(key, value, subqueryBitmap);
     }
@@ -112,7 +113,7 @@ public class PredicateQueryParser {
         JsonToken actual = parser.nextToken();
         if (Arrays.stream(expected).noneMatch(e -> e.equals(actual))) {
             throw new IllegalArgumentException(
-                    String.format("Expected a token in %s, got %s (%s).",
+                    Text.format("Expected a token in %s, got %s (%s).",
                             Arrays.toString(expected), actual, parser.currentTokenLocation()));
         }
     }

--- a/predicate-search-core/src/test/java/com/yahoo/search/predicate/PredicateQueryParserTest.java
+++ b/predicate-search-core/src/test/java/com/yahoo/search/predicate/PredicateQueryParserTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate;
 
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -30,8 +31,8 @@ public class PredicateQueryParserTest {
         List<String> result = new ArrayList<>();
         parser.parseJsonQuery(
                 json,
-                (k, v, s) -> result.add(String.format("%s:%s:%#x", k, v, s)),
-                (k, v, s) -> result.add(String.format("%s:%d:%#x", k, v, s)));
+                (k, v, s) -> result.add(Text.format("%s:%s:%#x", k, v, s)),
+                (k, v, s) -> result.add(Text.format("%s:%d:%#x", k, v, s)));
 
         assertEquals(result, List.of(
                 "k1:value1:0x1", "k2:value2:0x3",

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndex.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndex.java
@@ -23,6 +23,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -127,7 +128,7 @@ public class PredicateIndex {
     public static PredicateIndex fromInputStream(DataInputStream in) throws IOException {
         int version = in.readInt();
         if (version != SERIALIZATION_FORMAT_VERSION) {
-            throw new IllegalArgumentException(String.format(
+            throw new IllegalArgumentException(String.format(Locale.ROOT,
                     "Invalid serialization format version. Expected %d, was %d.", SERIALIZATION_FORMAT_VERSION, version));
         }
         Config config = Config.fromInputStream(in);

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndexBuilder.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndexBuilder.java
@@ -19,6 +19,7 @@ import com.yahoo.search.predicate.index.PredicateOptimizer;
 import com.yahoo.search.predicate.index.SimpleIndex;
 import com.yahoo.search.predicate.index.conjunction.ConjunctionIndexBuilder;
 import com.yahoo.search.predicate.index.conjunction.IndexableFeatureConjunction;
+import com.yahoo.text.Text;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -262,7 +263,7 @@ public class PredicateIndexBuilder {
         @Override
         public String toString() {
             return metrics.entrySet().stream()
-                    .map(e -> String.format("%50s: %s", e.getKey(), e.getValue()))
+                    .map(e -> Text.format("%50s: %s", e.getKey(), e.getValue()))
                     .collect(joining("\n"));
         }
     }

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/benchmarks/HitsVerificationBenchmark.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/benchmarks/HitsVerificationBenchmark.java
@@ -11,6 +11,7 @@ import com.yahoo.search.predicate.PredicateQuery;
 import com.yahoo.search.predicate.serialization.PredicateQuerySerializer;
 import com.yahoo.search.predicate.utils.VespaFeedParser;
 import com.yahoo.search.predicate.utils.VespaQueryParser;
+import com.yahoo.text.Text;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.airlift.airline.HelpOption;
@@ -24,6 +25,7 @@ import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -85,7 +87,7 @@ public class HitsVerificationBenchmark {
 
     private static int runQueries(
             PredicateIndex index, Stream<PredicateQuery> queries, String outputFile) throws IOException {
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile, false))) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile, StandardCharsets.UTF_8, false))) {
             AtomicInteger i = new AtomicInteger();
             PredicateIndex.Searcher searcher = index.searcher();
             return queries.map(searcher::search)
@@ -113,7 +115,7 @@ public class HitsVerificationBenchmark {
             writer.append(Integer.toString(i))
                     .append(": ")
                     .append(hits.stream()
-                            .map(hit -> String.format("(%d, 0x%x)", hit.getDocId(), hit.getSubquery()))
+                            .map(hit -> Text.format("(%d, 0x%x)", hit.getDocId(), hit.getSubquery()))
                             .collect(joining(", ", "[", "]")))
                     .append("\n\n");
             return hits.size();

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/index/Interval.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/index/Interval.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate.index;
 
+import com.yahoo.text.Text;
+
 /**
  * Utility class for interval related constants and methods.
  * An interval consists of a begin and end value indicating the start and end of the interval.
@@ -77,11 +79,11 @@ public class Interval {
 
     private static String toString(int begin, int end) {
         if (begin == 0) {
-            return String.format("[%d]**", end);
+            return Text.format("[%d]**", end);
         } else if (begin > end) {
-            return String.format("[%d, %d]*", begin, end);
+            return Text.format("[%d, %d]*", begin, end);
         }
-        return String.format("[%d, %d]", begin, end);
+        return Text.format("[%d, %d]", begin, end);
     }
 
 }

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/serialization/PredicateQuerySerializer.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/serialization/PredicateQuerySerializer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.yahoo.search.predicate.PredicateQuery;
 import com.yahoo.search.predicate.PredicateQueryParser;
 import com.yahoo.search.predicate.SubqueryBitmap;
+import com.yahoo.text.Utf8;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -94,7 +95,7 @@ public class PredicateQuerySerializer {
 
     public static List<PredicateQuery> parseQueriesFromFile(String queryFile, int maxQueryCount) throws IOException {
         PredicateQuerySerializer serializer = new PredicateQuerySerializer();
-        try (BufferedReader reader = new BufferedReader(new FileReader(queryFile), 8 * 1024)) {
+        try (BufferedReader reader = new BufferedReader(Utf8.createReader(queryFile), 8 * 1024)) {
             return reader.lines()
                     .limit(maxQueryCount)
                     .map(serializer::fromJSON)

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/utils/TargetingQueryFileConverter.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/utils/TargetingQueryFileConverter.java
@@ -4,6 +4,8 @@ package com.yahoo.search.predicate.utils;
 import com.google.common.net.UrlEscapers;
 import com.yahoo.search.predicate.PredicateQuery;
 import com.yahoo.search.predicate.serialization.PredicateQuerySerializer;
+import com.yahoo.text.Text;
+import com.yahoo.text.Utf8;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -11,6 +13,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,7 +69,7 @@ public class TargetingQueryFileConverter {
 
     private static void writeSubqueriesToFile(List<Query> queries, File output, OutputFormat outputFormat)
             throws IOException {
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(output))) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(output, StandardCharsets.UTF_8))) {
             if (outputFormat == OutputFormat.JSON) {
                 writeJSONOutput(writer, queries);
             } else {
@@ -165,14 +168,14 @@ public class TargetingQueryFileConverter {
                     } else {
                         // Note: Cannot use method reference as both method toString(int) and method toString() match.
                         String values = features.collect(joining(", ", "{", "}"));
-                        return String.format("\"0x%s\":%s", Long.toHexString(e.getKey()), values);
+                        return Text.format("\"0x%s\":%s", Long.toHexString(e.getKey()), values);
                     }
                 })
                 .collect(joining(", ", "{", "}"));
     }
 
     private static Subqueries parseRiseQueries(File riseQueryFile, int maxQueries) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new FileReader(riseQueryFile))) {
+        try (BufferedReader reader = new BufferedReader(Utf8.createReader(riseQueryFile))) {
             Subqueries parsedSubqueries = new Subqueries();
             AtomicInteger counter = new AtomicInteger(1);
             reader.lines()
@@ -263,9 +266,9 @@ public class TargetingQueryFileConverter {
 
         public String asYqlString() {
             if (strValue != null) {
-                return String.format("\"%s\":\"%s\"", key, strValue);
+                return Text.format("\"%s\":\"%s\"", key, strValue);
             } else {
-                return String.format("\"%s\":%dl", key, longValue);
+                return Text.format("\"%s\":%dl", key, longValue);
             }
         }
 

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/utils/VespaFeedParser.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/utils/VespaFeedParser.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.predicate.utils;
 
 import com.yahoo.document.predicate.Predicate;
+import com.yahoo.text.Utf8;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -19,7 +20,7 @@ import java.util.function.Consumer;
 public class VespaFeedParser {
 
     public static int parseDocuments(String feedFile, int maxDocuments, Consumer<Predicate> consumer) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new FileReader(feedFile), 8 * 1024)) {
+        try (BufferedReader reader = new BufferedReader(Utf8.createReader(feedFile), 8 * 1024)) {
             reader.mark(1);
             String line = reader.readLine();
             boolean xmlFeed = line.startsWith("<");

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/utils/VespaQueryParser.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/utils/VespaQueryParser.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.predicate.utils;
 
 import com.yahoo.search.predicate.PredicateQuery;
+import com.yahoo.text.Utf8;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -24,7 +25,7 @@ public class VespaQueryParser {
      * Parses a query formatted using the deprecated boolean query format (query properties).
      */
     public static List<PredicateQuery> parseQueries(String queryFile, int maxQueryCount) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new FileReader(queryFile), 8 * 1024)) {
+        try (BufferedReader reader = new BufferedReader(Utf8.createReader(queryFile), 8 * 1024)) {
             List<PredicateQuery> queries = reader.lines()
                     .limit(maxQueryCount)
                     .map(VespaQueryParser::parseQueryFromQueryProperties)

--- a/predicate-search/src/test/java/com/yahoo/search/predicate/utils/PrimitiveArraySorterTest.java
+++ b/predicate-search/src/test/java/com/yahoo/search/predicate/utils/PrimitiveArraySorterTest.java
@@ -3,6 +3,7 @@ package com.yahoo.search.predicate.utils;
 
 import org.junit.jupiter.api.Test;
 
+import com.yahoo.text.Text;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -56,7 +57,7 @@ public class PrimitiveArraySorterTest {
             short[] customSorted = Arrays.copyOf(original, original.length);
             PrimitiveArraySorter.sort(customSorted, Short::compare);
             Arrays.sort(javaSorted);
-            String errorMsg = String.format("%s != %s (before sorting: %s)", Arrays.toString(customSorted), Arrays.toString(javaSorted), Arrays.toString(original));
+            String errorMsg = Text.format("%s != %s (before sorting: %s)", Arrays.toString(customSorted), Arrays.toString(javaSorted), Arrays.toString(original));
             assertArrayEquals(customSorted, javaSorted, errorMsg);
         }
     }


### PR DESCRIPTION
Replace String.format() with Text.format() or locale-specific variants to avoid locale-dependent formatting issues. Use explicit UTF-8 encoding for all file I/O operations instead of relying on platform defaults.
