### PR TITLE
Make model-evaluation locale-independent

### DIFF
--- a/model-evaluation/src/main/java/ai/vespa/models/handler/ModelsEvaluationHandler.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/handler/ModelsEvaluationHandler.java
@@ -103,7 +103,7 @@ public class ModelsEvaluationHandler extends ThreadedHttpRequestHandler {
             }
         }
         Tensor result = evaluator.evaluate();
-        return switch (property(request, "format.tensors").orElse("short").toLowerCase()) {
+        return switch (property(request, "format.tensors").orElse("short").toLowerCase(java.util.Locale.ROOT)) {
             case "short"        -> new Response(200, JsonFormat.encode(result, true,  false));
             case "long"         -> new Response(200, JsonFormat.encode(result, false, false));
             case "short-value"  -> new Response(200, JsonFormat.encode(result, true,  true));
@@ -205,7 +205,7 @@ public class ModelsEvaluationHandler extends ThreadedHttpRequestHandler {
         }
 
         private static String[] splitPath(HttpRequest request) {
-            String path = request.getUri().getPath().toLowerCase();
+            String path = request.getUri().getPath().toLowerCase(java.util.Locale.ROOT);
             if (path.startsWith("/")) {
                 path = path.substring("/".length());
             }

--- a/model-evaluation/src/test/java/ai/vespa/models/handler/HandlerTester.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/handler/HandlerTester.java
@@ -130,7 +130,7 @@ class HandlerTester {
     private String getContents(HttpResponse response) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             response.render(stream);
-            return stream.toString();
+            return stream.toString(StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new Error(e);
         }


### PR DESCRIPTION
Use explicit Locale.ROOT for toLowerCase() operations and explicit UTF-8 charset for toString() to avoid platform-dependent behavior.
