### PR TITLE
Standardize encoding in vespaclient-java module

### DIFF
--- a/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/UlimitProbe.java
+++ b/vespaclient-java/src/main/java/ai/vespa/vespasignificance/merge/UlimitProbe.java
@@ -4,6 +4,7 @@ package ai.vespa.vespasignificance.merge;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -27,7 +28,7 @@ public class UlimitProbe {
         Process p = null;
         try {
             p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
-            try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
                 String out = r.readLine();
                 // Example outputs: "10240" or "unlimited"
                 if (out == null) return -1L;

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
@@ -34,6 +34,7 @@ import com.yahoo.messagebus.SourceSessionParams;
 import com.yahoo.messagebus.StaticThrottlePolicy;
 import com.yahoo.messagebus.network.rpc.RPCNetworkParams;
 import com.yahoo.messagebus.routing.Route;
+import com.yahoo.text.Text;
 import com.yahoo.vespaxmlparser.FeedReader;
 import com.yahoo.vespaxmlparser.FeedOperation;
 import com.yahoo.vespaxmlparser.RemoveFeedOperation;
@@ -504,8 +505,8 @@ public class SimpleFeeder implements ReplyHandler {
 
     private synchronized void printReport(PrintStream out) {
         // Errors will stop feed so we just fake the num errors = 0
-        out.format("%10d, %12d, 0, %11d, %11d, %11d\n", System.currentTimeMillis() - startTime,
-                numReplies.get(), minLatency, maxLatency, sumLatency / Long.max(1, numReplies.get()));
+        out.print(Text.format("%10d, %12d, 0, %11d, %11d, %11d\n", System.currentTimeMillis() - startTime,
+                              numReplies.get(), minLatency, maxLatency, sumLatency / Long.max(1, numReplies.get())));
     }
 
     private static String formatErrors(Reply reply) {

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/filedistribution/status/FileDistributionStatusClient.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/filedistribution/status/FileDistributionStatusClient.java
@@ -1,8 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.filedistribution.status;
 
-import com.yahoo.json.Jackson;
 import ai.vespa.util.http.hc5.VespaHttpClientBuilder;
+import com.yahoo.json.Jackson;
+import com.yahoo.text.Text;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airlift.airline.Command;
 import io.airlift.airline.HelpOption;
@@ -118,7 +120,7 @@ public class FileDistributionStatusClient {
     }
 
     private URI createStatusApiUri() {
-        String path = String.format("/application/v2/tenant/%s/application/%s/environment/%s/region/%s/instance/%s/filedistributionstatus",
+        String path = Text.format("/application/v2/tenant/%s/application/%s/environment/%s/region/%s/instance/%s/filedistributionstatus",
                                     tenantName, applicationName, environment, region, instanceName);
         try {
             return new URIBuilder()

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliOptions.java
@@ -1,12 +1,14 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.security.tool;
 
+import com.yahoo.text.Text;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,12 +34,12 @@ class CliOptions {
 
     static void printTopLevelHelp(PrintStream out, List<Tool> tools) {
         var formatter = new HelpFormatter();
-        var writer    = new PrintWriter(out);
+        var writer    = new PrintWriter(out, false, StandardCharsets.UTF_8);
         formatter.printHelp(
                 writer,
                 formatter.getWidth(),
                 "vespa-security <tool> [TOOL OPTIONS]",
-                "Where <tool> is one of: %s".formatted(tools.stream().map(Tool::name).collect(Collectors.joining(", "))),
+                Text.format("Where <tool> is one of: %s", tools.stream().map(Tool::name).collect(Collectors.joining(", "))),
                 withHelpOption(List.of()),
                 formatter.getLeftPadding(),
                 formatter.getDescPadding(),
@@ -49,11 +51,11 @@ class CliOptions {
                                       ToolDescription toolDesc,
                                       Options optionsWithHelp) {
         var formatter = new HelpFormatter();
-        var writer    = new PrintWriter(out);
+        var writer    = new PrintWriter(out, false, StandardCharsets.UTF_8);
         formatter.printHelp(
                 writer,
                 formatter.getWidth(),
-                "vespa-security %s %s".formatted(toolName, toolDesc.helpArgSuffix()),
+                Text.format("vespa-security %s %s", toolName, toolDesc.helpArgSuffix()),
                 toolDesc.helpHeader(),
                 optionsWithHelp,
                 formatter.getLeftPadding(),

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliUtils.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.security.tool;
 
+import com.yahoo.text.Text;
 import org.apache.commons.cli.CommandLine;
 
 import java.io.IOException;
@@ -18,7 +19,7 @@ public class CliUtils {
     public static String optionOrThrow(CommandLine arguments, String option) {
         var value = arguments.getOptionValue(option);
         if (value == null) {
-            throw new IllegalArgumentException("Required argument '--%s' must be provided".formatted(option));
+            throw new IllegalArgumentException(Text.format("Required argument '--%s' must be provided", option));
         }
         return value;
     }
@@ -33,7 +34,7 @@ public class CliUtils {
         } else {
             var inputPath = Paths.get(pathOrDash);
             if (!Files.exists(inputPath)) {
-                throw new IllegalArgumentException("Input file '%s' does not exist".formatted(inputPath.toString()));
+                throw new IllegalArgumentException(Text.format("Input file '%s' does not exist", inputPath.toString()));
             }
             return Files.newInputStream(inputPath);
         }

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ConvertBaseTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ConvertBaseTool.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.security.tool.crypto;
 
 import com.yahoo.security.Base58;
 import com.yahoo.security.Base62;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.security.tool.CliUtils;
 import com.yahoo.vespa.security.tool.Tool;
 import com.yahoo.vespa.security.tool.ToolDescription;
@@ -53,10 +54,10 @@ public class ConvertBaseTool implements Tool {
     public ToolDescription description() {
         return new ToolDescription(
                 "--from <base N> --to <base M>",
-                ("Reads up to %d bytes of STDIN interpreted as a base N string (ignoring " +
-                 "whitespace) and writes to STDOUT as a base M string. Note that base 64 is " +
-                 "expected to be in (and is output as) the URL-safe alphabet (padding optional " +
-                 "for input, no padding for output).").formatted(MAX_IN_BYTES),
+                Text.format("Reads up to %d bytes of STDIN interpreted as a base N string (ignoring " +
+                            "whitespace) and writes to STDOUT as a base M string. Note that base 64 is " +
+                            "expected to be in (and is output as) the URL-safe alphabet (padding optional " +
+                            "for input, no padding for output).", MAX_IN_BYTES),
                 "Note: this is a BETA tool version; its interface may be changed at any time.",
                 OPTIONS);
     }
@@ -71,8 +72,8 @@ public class ConvertBaseTool implements Tool {
             // to risk melting someone's CPU by them piping something large into the process by accident.
             byte[] inBytes = invocation.stdIn().readAllBytes();
             if (inBytes.length > MAX_IN_BYTES) {
-                throw new IllegalArgumentException("Input size is too large (%d), max is %d"
-                                                   .formatted(inBytes.length, MAX_IN_BYTES));
+                throw new IllegalArgumentException(Text.format("Input size is too large (%d), max is %d",
+                                                                inBytes.length, MAX_IN_BYTES));
             }
             var inString = fromUtf8Bytes(inBytes).strip(); // We ignore whitespace to avoid trailing \n issues
             byte[] decoded = switch (fromBase) {
@@ -80,14 +81,14 @@ public class ConvertBaseTool implements Tool {
                 case 58 -> Base58.codec().decode(inString);
                 case 62 -> Base62.codec().decode(inString);
                 case 64 -> Base64.getUrlDecoder().decode(inString);
-                default -> throw new IllegalArgumentException("Unsupported from-base: %d".formatted(fromBase));
+                default -> throw new IllegalArgumentException(Text.format("Unsupported from-base: %d", fromBase));
             };
             String encoded = switch (toBase) {
                 case 16 -> hex(decoded);
                 case 58 -> Base58.codec().encode(decoded);
                 case 62 -> Base62.codec().encode(decoded);
                 case 64 -> Base64.getUrlEncoder().withoutPadding().encodeToString(decoded);
-                default -> throw new IllegalArgumentException("Unsupported to-base: %d".formatted(toBase));
+                default -> throw new IllegalArgumentException(Text.format("Unsupported to-base: %d", toBase));
             };
             invocation.stdOut().println(encoded);
         } catch (IOException e) {

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
@@ -5,6 +5,7 @@ import com.yahoo.security.SealedSharedKey;
 import com.yahoo.security.SecretSharedKey;
 import com.yahoo.security.SharedKeyGenerator;
 import com.yahoo.security.SharedKeyResealingSession;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.security.tool.CliUtils;
 import com.yahoo.vespa.security.tool.Tool;
 import com.yahoo.vespa.security.tool.ToolDescription;
@@ -14,6 +15,7 @@ import org.apache.commons.cli.Option;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
@@ -152,10 +154,10 @@ public class DecryptTool implements Tool {
         var session = SharedKeyResealingSession.newEphemeralSession();
         var req     = session.resealingRequestFor(sealedSharedKey);
 
-        invocation.stdOut().format("\nInteractive token resealing request:\n\n%s\n\n", req.toSerializedString());
-        invocation.stdOut().format("Paste response and hit return: ");
+        invocation.stdOut().print(Text.format("\nInteractive token resealing request:\n\n%s\n\n", req.toSerializedString()));
+        invocation.stdOut().print(Text.format("Paste response and hit return: "));
 
-        try (var reader = new BufferedReader(new InputStreamReader(invocation.stdIn()))) {
+        try (var reader = new BufferedReader(new InputStreamReader(invocation.stdIn(), StandardCharsets.UTF_8))) {
             var serializedRes = reader.readLine().strip();
             if (serializedRes.isEmpty()) {
                 throw new IllegalArgumentException("Empty response; aborting");

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/KeygenTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/KeygenTool.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.security.tool.crypto;
 
 import com.yahoo.security.KeyUtils;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.security.tool.CliUtils;
 import com.yahoo.vespa.security.tool.Tool;
 import com.yahoo.vespa.security.tool.ToolDescription;
@@ -73,9 +74,9 @@ public class KeygenTool implements Tool {
     private static void handleExistingFileIfAny(Path filePath, boolean allowOverwrite) throws IOException {
         if (Files.exists(filePath)) {
             if (!allowOverwrite) {
-                throw new IllegalArgumentException(("Output file '%s' already exists. No keys written. " +
-                                                    "If you want to overwrite existing files, specify --%s.")
-                                                   .formatted(filePath.toAbsolutePath().toString(), OVERWRITE_EXISTING_OPTION));
+                throw new IllegalArgumentException(Text.format("Output file '%s' already exists. No keys written. " +
+                                                                "If you want to overwrite existing files, specify --%s.",
+                                                                filePath.toAbsolutePath().toString(), OVERWRITE_EXISTING_OPTION));
             } else {
                 // Explicitly delete the file since Files.createFile() will fail if it already exists.
                 Files.delete(filePath);

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/TokenInfoTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/TokenInfoTool.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.security.tool.crypto;
 
 import com.yahoo.security.SealedSharedKey;
 import com.yahoo.text.StringUtilities;
+import com.yahoo.text.Text;
 import com.yahoo.vespa.security.tool.Tool;
 import com.yahoo.vespa.security.tool.ToolDescription;
 import com.yahoo.vespa.security.tool.ToolInvocation;
@@ -46,10 +47,10 @@ public class TokenInfoTool implements Tool {
         var token = SealedSharedKey.fromTokenString(leftoverArgs[0]);
         var stdOut = invocation.stdOut();
 
-        stdOut.format("Version:         %d\n", token.tokenVersion());
-        stdOut.format("Key ID:          %s (%s)\n", StringUtilities.escape(token.keyId().asString()), hex(token.keyId().asBytes()));
-        stdOut.format("HPKE enc:        %s\n", hex(token.enc()));
-        stdOut.format("HPKE ciphertext: %s\n", hex(token.ciphertext()));
+        stdOut.print(Text.format("Version:         %d\n", token.tokenVersion()));
+        stdOut.print(Text.format("Key ID:          %s (%s)\n", StringUtilities.escape(token.keyId().asString()), hex(token.keyId().asBytes())));
+        stdOut.print(Text.format("HPKE enc:        %s\n", hex(token.enc())));
+        stdOut.print(Text.format("HPKE ciphertext: %s\n", hex(token.ciphertext())));
 
         return 0;
     }

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
@@ -13,6 +13,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Scanner;
@@ -243,7 +244,7 @@ public class CommandLineOptions {
         // WARNING: CommandLine.getArgs may return a single empty string as the only element
         if (documentIds.isEmpty() ||
                 documentIds.size() == 1 && documentIds.get(0).isEmpty()) {
-            return new Scanner(stdIn);
+            return new Scanner(stdIn, StandardCharsets.UTF_8);
         } else {
             return documentIds.iterator();
         }

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
@@ -13,6 +13,7 @@ import com.yahoo.documentapi.messagebus.protocol.GetDocumentReply;
 import com.yahoo.messagebus.Message;
 import com.yahoo.messagebus.Reply;
 import com.yahoo.messagebus.Trace;
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespaclient.ClusterDef;
 import com.yahoo.vespaclient.ClusterList;
@@ -106,7 +107,7 @@ public class DocumentRetriever {
         }
         if (clusterDef == null) {
             String names = createClusterNamesString();
-            throw new DocumentRetrieverException(String.format(
+            throw new DocumentRetrieverException(Text.format(
                     "The Vespa cluster contains the content clusters %s, not %s. Please select a valid vespa cluster.",
                     names, clusterName));
         }
@@ -144,14 +145,14 @@ public class DocumentRetriever {
         if (reply.hasErrors()) {
             System.err.print("Request failed: ");
             for (int i = 0; i < reply.getNumErrors(); i++) {
-                System.err.printf("\n  %s", reply.getError(i));
+                System.err.print(Text.format("\n  %s", reply.getError(i)));
             }
             System.err.println();
             return;
         }
 
         if (!(reply instanceof GetDocumentReply)) {
-            System.err.printf("Unexpected reply %s: '%s'\n", reply.getType(), reply.toString());
+            System.err.print(Text.format("Unexpected reply %s: '%s'\n", reply.getType(), reply.toString()));
             return;
         }
 
@@ -164,7 +165,7 @@ public class DocumentRetriever {
         }
 
         if (params.showDocSize) {
-            System.out.printf("Document size: %d bytes.\n", document.getSerializedSize());
+            System.out.print(Text.format("Document size: %d bytes.\n", document.getSerializedSize()));
         }
         if (params.printIdsOnly) {
             System.out.println(document.getId());

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/Main.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespaget;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespaclient.ClusterList;
 
 import java.util.logging.Level;
@@ -27,9 +28,9 @@ public class Main {
                 documentRetriever.retrieveDocuments();
             }
         } catch (IllegalArgumentException e) {
-            System.err.printf("Failed to parse command line arguments: %s.\n", e.getMessage());
+            System.err.print(Text.format("Failed to parse command line arguments: %s.\n", e.getMessage()));
         } catch (DocumentRetrieverException e) {
-            System.err.printf("Failed to retrieve documents: %s\n", e.getMessage());
+            System.err.print(Text.format("Failed to retrieve documents: %s\n", e.getMessage()));
         }
     }
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/CommandLineOptions.java
@@ -3,17 +3,16 @@ package com.yahoo.vespasignificance;
 
 import ai.vespa.vespasignificance.export.ExportClientParameters;
 import ai.vespa.vespasignificance.merge.MergeClientParameters;
+import com.yahoo.text.Text;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
-
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 
 /**
  * This class is responsible for parsing the command line arguments and print the help page.
@@ -69,7 +68,7 @@ public class CommandLineOptions {
         StringBuilder header = new StringBuilder("Commands:\n");
         registeredCommands().entrySet().stream()
                 .sorted(Map.Entry.comparingByKey(byName))
-                .forEach(e -> header.append(String.format("  %-12s %s%n", e.getKey(), e.getValue())));
+                .forEach(e -> header.append(Text.format("  %-12s %s%n", e.getKey(), e.getValue())));
         header.append("\nOptions:");
 
         fmt.printHelp("vespa-significance <command> [options]", header.toString(), createGlobalOptions(), "", false);
@@ -318,4 +317,3 @@ public class CommandLineOptions {
         }
     }
 }
-

--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/Main.java
@@ -4,6 +4,7 @@ package com.yahoo.vespasignificance;
 
 import ai.vespa.vespasignificance.export.Export;
 import ai.vespa.vespasignificance.merge.MergeCommand;
+import com.yahoo.text.Text;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.ParseException;
@@ -72,7 +73,7 @@ public class Main {
             SignificanceModelGenerator significanceModelGenerator = createSignificanceModelGenerator(params);
             System.exit(significanceModelGenerator.run());
         } catch (ParseException e) {
-            System.err.printf("Error: %s.\n", e.getMessage());
+            System.err.print(Text.format("Error: %s.\n", e.getMessage()));
             CommandLineOptions.printGenerateHelp();
             System.exit(1);
         }
@@ -97,7 +98,7 @@ public class Main {
             Export export = new Export(clientParams);
             System.exit(export.run());
         } catch (ParseException e) {
-            System.err.printf("Error: %s.\n", e.getMessage());
+            System.err.print(Text.format("Error: %s.\n", e.getMessage()));
             CommandLineOptions.printExportHelp();
             System.exit(1);
         }
@@ -118,7 +119,7 @@ public class Main {
             MergeCommand merge = new MergeCommand(clientParams);
             System.exit(merge.run());
         } catch (ParseException e) {
-            System.err.printf("Error: %s.\n", e.getMessage());
+            System.err.print(Text.format("Error: %s.\n", e.getMessage()));
             CommandLineOptions.printMergeHelp();
             System.exit(1);
         }

--- a/vespaclient-java/src/main/java/com/yahoo/vespastat/BucketStatsPrinter.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespastat/BucketStatsPrinter.java
@@ -3,6 +3,7 @@ package com.yahoo.vespastat;
 
 import com.yahoo.document.BucketId;
 import com.yahoo.documentapi.messagebus.protocol.GetBucketListReply;
+import com.yahoo.text.Text;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -26,7 +27,7 @@ public class BucketStatsPrinter {
     public void retrieveAndPrintBucketStats(ClientParameters.SelectionType type, String id, boolean dumpData, String bucketSpace) throws BucketStatsException {
         BucketId bucketId = retriever.getBucketIdForType(type, id);
         if (type == ClientParameters.SelectionType.GROUP || type == ClientParameters.SelectionType.USER) {
-            out.printf("Generated 32-bit bucket id: %s\n", bucketId);
+            out.print(Text.format("Generated 32-bit bucket id: %s\n", bucketId));
         }
 
         List<GetBucketListReply.BucketInfo> bucketList = retriever.retrieveBucketList(bucketId, bucketSpace);
@@ -47,13 +48,13 @@ public class BucketStatsPrinter {
         } else {
             out.println("Bucket maps to the following actual files:");
             for (GetBucketListReply.BucketInfo bucketInfo : bucketList) {
-                out.printf("\t%s\n", bucketInfo);
+                out.print(Text.format("\t%s\n", bucketInfo));
             }
         }
     }
 
     private void printBucketStats(BucketId bucket, String stats) {
-        out.printf("\nDetails for %s:\n%s", bucket, stats);
+        out.print(Text.format("\nDetails for %s:\n%s", bucket, stats));
     }
 
 }

--- a/vespaclient-java/src/main/java/com/yahoo/vespastat/BucketStatsRetriever.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespastat/BucketStatsRetriever.java
@@ -17,6 +17,7 @@ import com.yahoo.documentapi.messagebus.protocol.GetBucketListReply;
 import com.yahoo.documentapi.messagebus.protocol.StatBucketMessage;
 import com.yahoo.documentapi.messagebus.protocol.StatBucketReply;
 import com.yahoo.messagebus.Reply;
+import com.yahoo.text.Text;
 
 import java.util.List;
 
@@ -64,7 +65,7 @@ public class BucketStatsRetriever {
                 return bucketIdFactory.getBucketId(new DocumentId(id));
             case BUCKET:
                 // The internal parser of BucketID is used since the Java Long.decode cannot handle unsigned longs.
-                return new BucketId(String.format("BucketId(%s)", id));
+                return new BucketId(Text.format("BucketId(%s)", id));
             case GID:
                 return convertGidToBucketId(id);
             case USER:
@@ -72,13 +73,13 @@ public class BucketStatsRetriever {
                 try {
                     BucketSet bucketList = selector.getBucketList(createDocumentSelection(type, id));
                     if (bucketList.size() != 1) {
-                        String message = String.format("Document selection must map to only one location. " +
+                        String message = Text.format("Document selection must map to only one location. " +
                                 "Specified selection matches %d locations.", bucketList.size());
                         throw new BucketStatsException(message);
                     }
                     return bucketList.iterator().next();
                 } catch (ParseException e) {
-                    throw new BucketStatsException(String.format("Invalid id: %s (%s).", id, e.getMessage()), e);
+                    throw new BucketStatsException(Text.format("Invalid id: %s (%s).", id, e.getMessage()), e);
                 }
             default:
                 throw new RuntimeException("Unreachable code");
@@ -109,7 +110,7 @@ public class BucketStatsRetriever {
             throw new BucketStatsException(makeErrorMessage(reply));
         }
         if (!type.isInstance(reply)) {
-            throw new BucketStatsException(String.format("Unexpected reply %s: '%s'", reply.getType(), reply.toString()));
+            throw new BucketStatsException(Text.format("Unexpected reply %s: '%s'", reply.getType(), reply.toString()));
         }
         return type.cast(reply);
     }
@@ -118,7 +119,7 @@ public class BucketStatsRetriever {
         StringBuilder b = new StringBuilder();
         b.append("Request failed: \n");
         for (int i = 0; i < reply.getNumErrors(); i++) {
-            b.append(String.format("\t %s\n", reply.getError(i)));
+            b.append(Text.format("\t %s\n", reply.getError(i)));
         }
         return b.toString();
     }
@@ -128,13 +129,13 @@ public class BucketStatsRetriever {
             case BUCKET:
                 return "true";
             case DOCUMENT:
-                return String.format("id=\"%s\"", id);
+                return Text.format("id=\"%s\"", id);
             case GID:
-                return String.format("id.gid=\"gid(%s)\"", id);
+                return Text.format("id.gid=\"gid(%s)\"", id);
             case USER:
-                return String.format("id.user=%s", id);
+                return Text.format("id.user=%s", id);
             case GROUP:
-                return String.format("id.group=\"%s\"", id);
+                return Text.format("id.group=\"%s\"", id);
             default:
                 throw new RuntimeException("Unreachable code");
         }

--- a/vespaclient-java/src/main/java/com/yahoo/vespastat/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespastat/Main.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespastat;
 
+import com.yahoo.text.Text;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -30,7 +32,7 @@ public class Main {
             BucketStatsPrinter printer = new BucketStatsPrinter(retriever, System.out);
             printer.retrieveAndPrintBucketStats(params.selectionType, params.id, params.dumpData, params.bucketSpace);
         } catch (IllegalArgumentException e) {
-            System.err.printf("Failed to parse command line arguments: %s.\n", e.getMessage());
+            System.err.print(Text.format("Failed to parse command line arguments: %s.\n", e.getMessage()));
         } catch (BucketStatsException e) {
             System.err.println(e.getMessage());
         }

--- a/vespaclient-java/src/main/java/com/yahoo/vespasummarybenchmark/VespaSummaryBenchmark.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasummarybenchmark/VespaSummaryBenchmark.java
@@ -28,6 +28,7 @@ import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,7 @@ public class VespaSummaryBenchmark {
         try {
             FileInputStream fstream = new FileInputStream(fileName);
             DataInputStream in = new DataInputStream(fstream);
-            BufferedReader br = new BufferedReader(new InputStreamReader(in));
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
             String strLine;
 
             List<String> docIds = new ArrayList<>();

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -14,6 +14,7 @@ import com.yahoo.documentapi.messagebus.MessageBusParams;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.log.LogSetup;
 import com.yahoo.messagebus.StaticThrottlePolicy;
+import com.yahoo.text.Text;
 import com.yahoo.vespaclient.ClusterDef;
 import com.yahoo.vespaclient.ClusterList;
 import org.apache.commons.cli.CommandLine;
@@ -353,7 +354,7 @@ public class VdsVisit {
                 .longOpt("bucketspace")
                 .hasArg(true)
                 .argName("space")
-                .desc(String.format("Bucket space to visit ('%s' or '%s'). If not specified, '%s' is used.",
+                .desc(Text.format("Bucket space to visit ('%s' or '%s'). If not specified, '%s' is used.",
                         FixedBucketSpaces.defaultSpace(), FixedBucketSpaces.globalSpace(), FixedBucketSpaces.defaultSpace()))
                 .build());
 
@@ -761,7 +762,7 @@ public class VdsVisit {
         } else {
             out.println("Visiting documents matching: " + params.getDocumentSelection());
         }
-        out.println(String.format("Visiting bucket space: %s", params.getBucketSpace()));
+        out.println(Text.format("Visiting bucket space: %s", params.getBucketSpace()));
         if (params.getFromTimestamp() != 0 && params.getToTimestamp() != 0) {
             out.println("Visiting in the inclusive timestamp range "
                                + params.getFromTimestamp() + " - " + params.getToTimestamp() + ".");
@@ -808,7 +809,7 @@ public class VdsVisit {
             out.println("Skip visiting super buckets with fatal errors.");
         }
         if (params.getSlices() > 1) {
-            out.format("Visiting slice %d out of %s slices\n", params.getSliceId(), params.getSlices());
+            out.print(Text.format("Visiting slice %d out of %s slices\n", params.getSliceId(), params.getSlices()));
         }
     }
 
@@ -839,8 +840,8 @@ public class VdsVisit {
                 visitorParameters.setResumeToken(new ProgressToken(progressFileContents));
 
                 if (params.isVerbose()) {
-                    System.err.format("Resuming visitor already %.1f %% finished.\n",
-                            visitorParameters.getResumeToken().percentFinished());
+                    System.err.print(Text.format("Resuming visitor already %.1f %% finished.\n",
+                                                 visitorParameters.getResumeToken().percentFinished()));
                 }
             } catch (NoSuchFileException e) {
                 // Ignore; file has not been created yet but will be shortly.

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisitHandler.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisitHandler.java
@@ -10,12 +10,14 @@ import java.io.IOException;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Date;
-import java.util.TimeZone;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -130,7 +132,7 @@ public abstract class VdsVisitHandler {
             }
             if (showProgress) {
                 synchronized (printLock) {
-                    DecimalFormat df = new DecimalFormat("#.#");
+                    DecimalFormat df = new DecimalFormat("#.#", DecimalFormatSymbols.getInstance(Locale.US));
                     String percentage = df.format(token.percentFinished());
                     if (!percentage.equals(lastPercentage)) {
                         if (lastLineIsProgress) {
@@ -153,7 +155,7 @@ public abstract class VdsVisitHandler {
         }
 
         private String getDateTime() {
-            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz");
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz", Locale.US);
             dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             Date date = new Date();
             return dateFormat.format(date);

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/ExportTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -85,7 +86,7 @@ class ExportTest {
 
         var baosOut = new ByteArrayOutputStream();
         var prevOut = System.out;
-        System.setOut(new PrintStream(baosOut));
+        System.setOut(new PrintStream(baosOut, false, StandardCharsets.UTF_8));
         try {
             int code = new Export(params, locator, wf, dumpFn, dcpf).run();
             assertEquals(0, code);

--- a/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/VespaIndexInspectClientTest.java
+++ b/vespaclient-java/src/test/java/ai/vespa/vespasignificance/export/VespaIndexInspectClientTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -28,7 +29,7 @@ class VespaIndexInspectClientTest {
         private boolean destroyed;
 
         FakeProcess(String stdout, int exitCode) {
-            this.out = new ByteArrayInputStream(stdout.getBytes());
+            this.out = new ByteArrayInputStream(stdout.getBytes(StandardCharsets.UTF_8));
             this.exitCode = exitCode;
         }
 

--- a/vespaclient-java/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespa/feed/perf/FeederParamsTest.java
@@ -12,6 +12,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,11 +35,11 @@ public class FeederParamsTest {
     public void requireThatAccessorsWork() {
         FeederParams params = new FeederParams();
 
-        PrintStream stdErr = new PrintStream(new ByteArrayOutputStream());
+        PrintStream stdErr = new PrintStream(new ByteArrayOutputStream(), false, StandardCharsets.UTF_8);
         params.setStdErr(stdErr);
         assertSame(stdErr, params.getStdErr());
 
-        PrintStream stdOut = new PrintStream(new ByteArrayOutputStream());
+        PrintStream stdOut = new PrintStream(new ByteArrayOutputStream(), false, StandardCharsets.UTF_8);
         params.setStdOut(stdOut);
         assertSame(stdOut, params.getStdOut());
 

--- a/vespaclient-java/src/test/java/com/yahoo/vespa/feed/perf/SimpleFeederTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespa/feed/perf/SimpleFeederTest.java
@@ -94,7 +94,7 @@ public class SimpleFeederTest {
                                {"update":"id:simple:simple::1","fields":{"my_str":{"assign":"bar"}}},
                                {"remove":"id:simple:simple::2"}
                              ]""",
-                     dump.toString());
+                     dump.toString(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -129,8 +129,8 @@ public class SimpleFeederTest {
                            {"id":"id:simple:simple::1","fields":{"my_str":"bar"}},
                            {"remove":"id:simple:simple::2"}
                          ]""",
-                     dump.toString());
-        assertFeed(dump.toString(),
+                     dump.toString(StandardCharsets.UTF_8));
+        assertFeed(dump.toString(StandardCharsets.UTF_8),
                 new MessageHandler() {
                     @Override
                     public void handleMessage(Message msg) {
@@ -326,9 +326,9 @@ public class SimpleFeederTest {
         TestDriver(FeederParams params, InputStream in, MessageHandler validator) throws IOException, ListenFailedException {
             server = new SimpleServer(CONFIG_DIR, validator);
             feeder = new SimpleFeeder(params.setConfigId("dir:" + CONFIG_DIR)
-                                            .setStdErr(new PrintStream(err))
+                                            .setStdErr(new PrintStream(err, false, StandardCharsets.UTF_8))
                                             .setInputStreams(List.of(in))
-                                            .setStdOut(new PrintStream(out)));
+                                            .setStdOut(new PrintStream(out, false, StandardCharsets.UTF_8)));
         }
 
         void run() throws Throwable {

--- a/vespaclient-java/src/test/java/com/yahoo/vespa/feed/perf/SimpleServer.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespa/feed/perf/SimpleServer.java
@@ -17,6 +17,7 @@ import com.yahoo.messagebus.network.rpc.RPCNetworkParams;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Simon Thoresen Hult
@@ -38,7 +39,7 @@ public class SimpleServer {
                               new MessageBusParams().addProtocol(new DocumentProtocol(documentMgr)));
         session = mbus.createDestinationSession(new DestinationSessionParams().setMessageHandler(msgHandler));
 
-        PrintWriter writer = new PrintWriter(new FileWriter(configDir + "/messagebus.cfg"));
+        PrintWriter writer = new PrintWriter(new FileWriter(configDir + "/messagebus.cfg", StandardCharsets.UTF_8));
         writer.println("routingtable[1]\n" +
                        "routingtable[0].protocol \"document\"\n" +
                        "routingtable[0].hop[0]\n" +
@@ -48,7 +49,7 @@ public class SimpleServer {
                        "routingtable[0].route[0].hop[0] \"" + session.getConnectionSpec() + "\"");
         writer.close();
 
-        writer = new PrintWriter(new FileWriter(configDir + "/slobroks.cfg"));
+        writer = new PrintWriter(new FileWriter(configDir + "/slobroks.cfg", StandardCharsets.UTF_8));
         writer.println(slobrok.configId().substring(4));
         writer.close();
     }

--- a/vespaclient-java/src/test/java/com/yahoo/vespa/security/tool/CryptoToolsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespa/security/tool/CryptoToolsTest.java
@@ -5,6 +5,7 @@ import com.yahoo.security.KeyId;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SealedSharedKey;
 import com.yahoo.security.SharedKeyGenerator;
+import com.yahoo.text.Text;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -13,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -132,9 +134,9 @@ public class CryptoToolsTest {
         verifyStderrEquals(List.of("keygen",
                                    "--private-out-file", absPathOf(privKeyFile),
                                    "--public-out-file",  absPathOf(pubKeyFile)),
-                ("Invalid command line arguments: Output file '%s' already exists. No keys written. " +
-                 "If you want to overwrite existing files, specify --overwrite-existing.\n")
-                .formatted(absPathOf(privKeyFile)));
+                Text.format("Invalid command line arguments: Output file '%s' already exists. No keys written. " +
+                 "If you want to overwrite existing files, specify --overwrite-existing.\n",
+                 absPathOf(privKeyFile)));
 
         Files.delete(privKeyFile);
         Files.writeString(pubKeyFile, TEST_PUB_KEY);
@@ -142,9 +144,9 @@ public class CryptoToolsTest {
         verifyStderrEquals(List.of("keygen",
                                    "--private-out-file", absPathOf(privKeyFile),
                                    "--public-out-file",  absPathOf(pubKeyFile)),
-                ("Invalid command line arguments: Output file '%s' already exists. No keys written. " +
-                 "If you want to overwrite existing files, specify --overwrite-existing.\n")
-                 .formatted(absPathOf(pubKeyFile)));
+                Text.format("Invalid command line arguments: Output file '%s' already exists. No keys written. " +
+                 "If you want to overwrite existing files, specify --overwrite-existing.\n",
+                 absPathOf(pubKeyFile)));
     }
 
     @Test
@@ -274,8 +276,8 @@ public class CryptoToolsTest {
                                    "--output-file",      "foo",
                                    "--private-key-file", absPathOf(privKeyFile),
                                    "--token",            TEST_TOKEN),
-                ("Invalid command line arguments: Private key file '%s' is insecurely " +
-                 "world-readable; refusing to read it\n").formatted(absPathOf(privKeyFile)));
+                Text.format("Invalid command line arguments: Private key file '%s' is insecurely " +
+                 "world-readable; refusing to read it\n", absPathOf(privKeyFile)));
     }
 
     @Test
@@ -606,15 +608,15 @@ public class CryptoToolsTest {
         var stdOutBytes = new ByteArrayOutputStream();
         var stdErrBytes = new ByteArrayOutputStream();
         var stdIn       = new ByteArrayInputStream(stdInBytes);
-        var stdOut      = new PrintStream(stdOutBytes);
-        var stdError    = new PrintStream(stdErrBytes);
+        var stdOut      = new PrintStream(stdOutBytes, false, StandardCharsets.UTF_8);
+        var stdError    = new PrintStream(stdErrBytes, false, StandardCharsets.UTF_8);
 
         int exitCode = new Main(stdIn, stdOut, stdError, consoleInput).execute(args.toArray(new String[0]), env);
 
         stdOut.flush();
         stdError.flush();
 
-        return new ProcessOutput(exitCode, stdOutBytes.toString(), stdErrBytes.toString());
+        return new ProcessOutput(exitCode, stdOutBytes.toString(StandardCharsets.UTF_8), stdErrBytes.toString(StandardCharsets.UTF_8));
     }
 
     private static String readTestResource(String fileName) throws IOException {

--- a/vespaclient-java/src/test/java/com/yahoo/vespafeeder/BenchmarkProgressPrinterTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespafeeder/BenchmarkProgressPrinterTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,7 +20,7 @@ public class BenchmarkProgressPrinterTest {
     void testSimple() {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ManualTimer timer = new ManualTimer();
-        BenchmarkProgressPrinter printer = new BenchmarkProgressPrinter(timer, new PrintStream(output));
+        BenchmarkProgressPrinter printer = new BenchmarkProgressPrinter(timer, new PrintStream(output, false, StandardCharsets.UTF_8));
         RouteMetricSet metrics = new RouteMetricSet("foobar", timer, printer);
 
         {
@@ -62,7 +63,7 @@ public class BenchmarkProgressPrinterTest {
 
         metrics.done();
 
-        String val = output.toString().split("\n")[1];
+        String val = output.toString(StandardCharsets.UTF_8).split("\n")[1];
 
         String correctPattern = "62000, \\d+, \\d+, \\d+, \\d+, \\d+$";
         assertTrue(val.matches(correctPattern), "Value '" + val + "' does not match pattern '" + correctPattern + "'");

--- a/vespaclient-java/src/test/java/com/yahoo/vespafeeder/ProgressPrinterTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespafeeder/ProgressPrinterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -20,7 +21,7 @@ public class ProgressPrinterTest {
     void testSimple() {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ManualTimer timer = new ManualTimer();
-        ProgressPrinter printer = new ProgressPrinter(timer, new PrintStream(output));
+        ProgressPrinter printer = new ProgressPrinter(timer, new PrintStream(output, false, StandardCharsets.UTF_8));
         RouteMetricSet metrics = new RouteMetricSet("foobar", printer);
 
         {
@@ -67,7 +68,7 @@ public class ProgressPrinterTest {
             metrics.addReply(reply);
         }
 
-        String val = output.toString().replaceAll("latency\\(min, max, avg\\): .*", "latency(min, max, avg): 0, 0, 0");
+        String val = output.toString(StandardCharsets.UTF_8).replaceAll("latency\\(min, max, avg\\): .*", "latency(min, max, avg): 0, 0, 0");
 
         String correct =
                 "\rSuccessfully sent 2 messages so far" +

--- a/vespaclient-java/src/test/java/com/yahoo/vespafeeder/VespaFeederTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespafeeder/VespaFeederTestCase.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -154,7 +155,7 @@ public class VespaFeederTestCase {
     private static class FeedFixture {
         DummySessionFactory sessionFactory = DummySessionFactory.createWithAutoReply();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(outputStream);
+        PrintStream printStream = new PrintStream(outputStream, false, StandardCharsets.UTF_8);
         DocumentTypeManager typeManager = new DocumentTypeManager();
         FeedFixture() {
             DocumentTypeManagerConfigurer.configure(typeManager, "file:src/test/files/documentmanager.cfg");
@@ -177,7 +178,7 @@ public class VespaFeederTestCase {
         assertFalse(update.getCreateIfNonExistent());
         assertEquals("id:test:news::foo", ((RemoveDocumentMessage) f.sessionFactory.messages.get(2)).getDocumentId().toString());
 
-        assertTrue(f.outputStream.toString().contains("Messages sent to vespa"));
+        assertTrue(f.outputStream.toString(StandardCharsets.UTF_8).contains("Messages sent to vespa"));
     }
 
     @Test
@@ -197,7 +198,7 @@ public class VespaFeederTestCase {
         assertFalse(update.getCreateIfNonExistent());
         assertEquals("id:test:news::foo", ((RemoveDocumentMessage) feedFixture.sessionFactory.messages.get(2)).getDocumentId().toString());
 
-        assertTrue(feedFixture.outputStream.toString().contains("Messages sent to vespa"));
+        assertTrue(feedFixture.outputStream.toString(StandardCharsets.UTF_8).contains("Messages sent to vespa"));
     }
 
     @Test

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -181,12 +182,12 @@ public class CommandLineOptionsTest {
     void testPrintHelp() {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         PrintStream oldOut = System.out;
-        System.setOut(new PrintStream(outContent));
+        System.setOut(new PrintStream(outContent, false, StandardCharsets.UTF_8));
         try {
             CommandLineOptions options = new CommandLineOptions(emptyStream);
             options.printHelp();
 
-            String output = outContent.toString();
+            String output = outContent.toString(StandardCharsets.UTF_8);
             assertTrue(output.contains("vespa-get <options> [documentid...]"));
             assertTrue(output.contains("Fetch a document from a Vespa Content cluster."));
         } finally {

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
@@ -13,6 +13,7 @@ import com.yahoo.documentapi.messagebus.protocol.GetDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.GetDocumentReply;
 import com.yahoo.messagebus.Error;
 import com.yahoo.messagebus.Reply;
+import com.yahoo.text.Text;
 import com.yahoo.vespaclient.ClusterDef;
 import com.yahoo.vespaclient.ClusterList;
 import org.junit.jupiter.api.AfterEach;
@@ -23,6 +24,7 @@ import org.mockito.ArgumentMatcher;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -62,8 +64,8 @@ public class DocumentRetrieverTest {
     public void setUpStreams() {
         oldOut = System.out;
         oldErr = System.err;
-        System.setOut(new PrintStream(outContent));
-        System.setErr(new PrintStream(errContent));
+        System.setOut(new PrintStream(outContent, false, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(errContent, false, StandardCharsets.UTF_8));
     }
 
     @BeforeEach
@@ -108,7 +110,7 @@ public class DocumentRetrieverTest {
     }
 
     private void assertContainsDocument(String documentId) {
-        assertTrue(outContent.toString().contains(String.format(
+        assertTrue(outContent.toString(StandardCharsets.UTF_8).contains(Text.format(
                 "{\"id\":\"%s\"", documentId)));
     }
 
@@ -266,7 +268,7 @@ public class DocumentRetrieverTest {
         DocumentRetriever documentRetriever = createDocumentRetriever(params);
         documentRetriever.retrieveDocuments();
 
-        assertTrue(errContent.toString().contains("Request failed"));
+        assertTrue(errContent.toString(StandardCharsets.UTF_8).contains("Request failed"));
     }
 
     @Test
@@ -282,7 +284,7 @@ public class DocumentRetrieverTest {
         DocumentRetriever documentRetriever = createDocumentRetriever(params);
         documentRetriever.retrieveDocuments();
 
-        assertTrue(outContent.toString().contains(String.format("Document size: %d bytes", document.getSerializedSize())));
+        assertTrue(outContent.toString(StandardCharsets.UTF_8).contains(Text.format("Document size: %d bytes", document.getSerializedSize())));
     }
 
     @Test
@@ -297,7 +299,7 @@ public class DocumentRetrieverTest {
         DocumentRetriever documentRetriever = createDocumentRetriever(params);
         documentRetriever.retrieveDocuments();
 
-        assertEquals(DOC_ID_1 + "\n", outContent.toString());
+        assertEquals(DOC_ID_1 + "\n", outContent.toString(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -313,7 +315,7 @@ public class DocumentRetrieverTest {
         documentRetriever.retrieveDocuments();
 
         verify(mockedSession, times(1)).syncSend(any());
-        assertEquals(outContent.toString(), "Document not found.\n");
+        assertEquals(outContent.toString(StandardCharsets.UTF_8), "Document not found.\n");
     }
 
     @Test
@@ -332,7 +334,7 @@ public class DocumentRetrieverTest {
         documentRetriever.retrieveDocuments();
 
         verify(mockedSession, times(1)).setTraceLevel(traceLevel);
-        assertTrue(outContent.toString().contains("<trace>"));
+        assertTrue(outContent.toString(StandardCharsets.UTF_8).contains("<trace>"));
     }
 
 }

--- a/vespaclient-java/src/test/java/com/yahoo/vespastat/BucketStatsPrinterTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespastat/BucketStatsPrinterTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,13 +38,13 @@ public class BucketStatsPrinterTest {
     }
 
     private String getOutputString() {
-        String content = out.toString();
+        String content = out.toString(StandardCharsets.UTF_8);
         out.reset();
         return content;
     }
 
     private String retreiveAndPrintBucketStats(ClientParameters.SelectionType type, String id, boolean dumpData) throws BucketStatsException {
-        BucketStatsPrinter printer = new BucketStatsPrinter(retriever, new PrintStream(out));
+        BucketStatsPrinter printer = new BucketStatsPrinter(retriever, new PrintStream(out, false, StandardCharsets.UTF_8));
         printer.retrieveAndPrintBucketStats(type, id, dumpData, bucketSpace);
         return getOutputString();
     }

--- a/vespaclient-java/src/test/java/com/yahoo/vespastat/CommandLineOptionsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespastat/CommandLineOptionsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -64,11 +65,11 @@ public class CommandLineOptionsTest {
     void testPrintHelp() {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         PrintStream oldOut = System.out;
-        System.setOut(new PrintStream(outContent));
+        System.setOut(new PrintStream(outContent, false, StandardCharsets.UTF_8));
         try {
             CommandLineOptions options = new CommandLineOptions();
             options.printHelp();
-            String output = outContent.toString();
+            String output = outContent.toString(StandardCharsets.UTF_8);
             assertTrue(output.contains("vespa-stat [options]"));
         } finally {
             System.setOut(oldOut);

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/StdOutVisitorHandlerTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/StdOutVisitorHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -50,10 +51,10 @@ public class StdOutVisitorHandlerTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         var params = createHandlerParams(jsonOutput, false, false);
         params.printIds = true;
-        StdOutVisitorHandler visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true));
+        StdOutVisitorHandler visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true, StandardCharsets.UTF_8));
         VisitorDataHandler dataHandler = visitorHandler.getDataHandler();
         dataHandler.onDone();
-        String output = out.toString();
+        String output = out.toString(StandardCharsets.UTF_8);
         assertEquals("", output.trim());
     }
 
@@ -62,11 +63,11 @@ public class StdOutVisitorHandlerTest {
     void printing_zero_documents_produces_empty_output(boolean jsonOutput) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         StdOutVisitorHandler visitorHandler =
-                new StdOutVisitorHandler(createHandlerParams(jsonOutput, false, false), new PrintStream(out, true));
+                new StdOutVisitorHandler(createHandlerParams(jsonOutput, false, false), new PrintStream(out, true, StandardCharsets.UTF_8));
         VisitorDataHandler dataHandler = visitorHandler.getDataHandler();
         dataHandler.onDone();
         String expectedOutput = jsonOutput ? "[]" : "";
-        String output = out.toString().trim();
+        String output = out.toString(StandardCharsets.UTF_8).trim();
         assertEquals(expectedOutput, output);
     }
 
@@ -78,7 +79,7 @@ public class StdOutVisitorHandlerTest {
         var putMsg = new PutDocumentMessage(new DocumentPut(doc));
 
         var out = new ByteArrayOutputStream();
-        var visitorHandler = new StdOutVisitorHandler(createHandlerParams(true, tensorShortForm, tensorDirectValues), new PrintStream(out, true));
+        var visitorHandler = new StdOutVisitorHandler(createHandlerParams(true, tensorShortForm, tensorDirectValues), new PrintStream(out, true, StandardCharsets.UTF_8));
         var dataHandler = visitorHandler.getDataHandler();
         var controlSession = mock(VisitorControlSession.class);
         var ackToken = mock(AckToken.class);
@@ -86,7 +87,7 @@ public class StdOutVisitorHandlerTest {
         dataHandler.onMessage(putMsg, ackToken);
         dataHandler.onDone();
 
-        String output = out.toString().trim();
+        String output = out.toString(StandardCharsets.UTF_8).trim();
         assertEquals(expectedOutput, output);
     }
 
@@ -127,7 +128,7 @@ public class StdOutVisitorHandlerTest {
                                               : StdOutVisitorHandler.OutputFormat.JSON;
 
         var out            = new ByteArrayOutputStream();
-        var visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true));
+        var visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true, StandardCharsets.UTF_8));
         var dataHandler    = visitorHandler.getDataHandler();
         var controlSession = mock(VisitorControlSession.class);
         dataHandler.setSession(controlSession);
@@ -137,7 +138,7 @@ public class StdOutVisitorHandlerTest {
         dataHandler.onMessage(createPutWithDocAndValue(docType, "id:baz:foo::3", "\r\ncool fox\r\n"), mock(AckToken.class));
         dataHandler.onDone();
 
-        String output = out.toString().trim();
+        String output = out.toString(StandardCharsets.UTF_8).trim();
         if (jsonLinesFormat) {
             // JSONL; no implicit start/end array chars or trailing commas after objects
             var expected = """
@@ -165,7 +166,7 @@ public class StdOutVisitorHandlerTest {
         params.nullRender = true;
 
         var out            = new ByteArrayOutputStream();
-        var visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true));
+        var visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true, StandardCharsets.UTF_8));
         var dataHandler    = visitorHandler.getDataHandler();
         var controlSession = mock(VisitorControlSession.class);
         dataHandler.setSession(controlSession);
@@ -175,7 +176,7 @@ public class StdOutVisitorHandlerTest {
         dataHandler.onMessage(createPutWithDocAndValue(docType, "id:baz:foo::3", "\r\ncool fox\r\n"), mock(AckToken.class));
         dataHandler.onDone();
 
-        String output = out.toString().trim();
+        String output = out.toString(StandardCharsets.UTF_8).trim();
         assertEquals("", output);
     }
 

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
@@ -177,7 +177,7 @@ public class VdsVisitTestCase {
         assertTrue(params.visitInconsistentBuckets());
         assertEquals("fnord", params.getVisitorLibrary());
         // TODO: FIXME? multiple library params doesn't work
-        assertArrayEquals("rargh".getBytes(), params.getLibraryParameters().get("asdf"));
+        assertArrayEquals("rargh".getBytes(StandardCharsets.UTF_8), params.getLibraryParameters().get("asdf"));
         //assertTrue(Arrays.equals("pie".getBytes(), params.getLibraryParameters().get("pinkie")));
         assertEquals(555, allParams.getProcessTime());
         assertEquals(2002, params.getMaxTotalHits());
@@ -190,7 +190,7 @@ public class VdsVisitTestCase {
         assertEquals(5, params.getSliceId());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(outputStream);
+        PrintStream printStream = new PrintStream(outputStream, false, StandardCharsets.UTF_8);
         VdsVisit.verbosePrintParameters(allParams, printStream);
         printStream.flush();
         String nl = System.getProperty("line.separator"); // the joys of running tests on windows


### PR DESCRIPTION
Replace String.format() with Text.format() for locale-independent formatting and add explicit UTF-8 charset to I/O operations. This ensures consistent behavior across different locales and follows the pattern established in config-model and config-application-package modules.