### PR TITLE
Ensure locale-independent formatting in feed client

### DIFF
--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/MultiFeedException.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/MultiFeedException.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,7 +33,7 @@ public class MultiFeedException extends RuntimeException {
     }
 
     private static String toMessage(Collection<FeedException> exceptions) {
-        return String.format("%d feed operations failed", exceptions.size());
+        return String.format(Locale.ROOT, "%d feed operations failed", exceptions.size());
     }
 
 }

--- a/vespa-feed-client-api/src/test/java/ai/vespa/feed/client/examples/JsonStreamFeederExample.java
+++ b/vespa-feed-client-api/src/test/java/ai/vespa/feed/client/examples/JsonStreamFeederExample.java
@@ -8,6 +8,7 @@ import ai.vespa.feed.client.OperationParameters;
 import ai.vespa.feed.client.Result;
 
 import java.net.URI;
+import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -98,7 +99,7 @@ class JsonStreamFeederExample extends Thread implements AutoCloseable {
                         System.err.println(feedClient.stats());
                     }
                     if (throwable != null) {
-                        System.err.printf("Failure for '%s': %s", docId, throwable);
+                        System.err.printf(Locale.ROOT, "Failure for '%s': %s", docId, throwable);
                         throwable.printStackTrace();
                     }
                 });

--- a/vespa-feed-client-api/src/test/java/ai/vespa/feed/client/examples/SimpleExample.java
+++ b/vespa-feed-client-api/src/test/java/ai/vespa/feed/client/examples/SimpleExample.java
@@ -9,6 +9,7 @@ import ai.vespa.feed.client.Result;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 class SimpleExample {
@@ -25,7 +26,7 @@ class SimpleExample {
                 if (throwable != null) {
                     throwable.printStackTrace();
                 } else {
-                    System.out.printf("'%s' for document '%s': %s%n", result.type(), result.documentId(), result.resultMessage());
+                    System.out.printf(Locale.ROOT, "'%s' for document '%s': %s%n", result.type(), result.documentId(), result.resultMessage());
                 }
             }));
         }

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliArguments.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliArguments.java
@@ -17,8 +17,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -88,23 +90,23 @@ class CliArguments {
             if (args.hasOption(SPEED_TEST_OPTION)) {
                 if (   args.hasOption(FILE_OPTION) && (args.hasOption(STDIN_OPTION) || args.hasOption(TEST_PAYLOAD_SIZE_OPTION))
                     || args.hasOption(STDIN_OPTION) && args.hasOption(TEST_PAYLOAD_SIZE_OPTION)) {
-                    throw new CliArgumentsException(String.format("At most one of '%s', '%s' and '%s' may be specified", FILE_OPTION, STDIN_OPTION, TEST_PAYLOAD_SIZE_OPTION));
+                    throw new CliArgumentsException(String.format(Locale.ROOT, "At most one of '%s', '%s' and '%s' may be specified", FILE_OPTION, STDIN_OPTION, TEST_PAYLOAD_SIZE_OPTION));
                 }
             }
             else {
                 if (args.hasOption(FILE_OPTION) == args.hasOption(STDIN_OPTION)) {
-                    throw new CliArgumentsException(String.format("Exactly one of '%s' and '%s' must be specified", FILE_OPTION, STDIN_OPTION));
+                    throw new CliArgumentsException(String.format(Locale.ROOT, "Exactly one of '%s' and '%s' must be specified", FILE_OPTION, STDIN_OPTION));
                 }
                 if (args.hasOption(TEST_PAYLOAD_SIZE_OPTION)) {
-                    throw new CliArgumentsException(String.format("Option '%s' can only be specified together with '%s'", TEST_PAYLOAD_SIZE_OPTION, SPEED_TEST_OPTION));
+                    throw new CliArgumentsException(String.format(Locale.ROOT, "Option '%s' can only be specified together with '%s'", TEST_PAYLOAD_SIZE_OPTION, SPEED_TEST_OPTION));
                 }
             }
             if (args.hasOption(CERTIFICATE_OPTION) != args.hasOption(PRIVATE_KEY_OPTION)) {
                 throw new CliArgumentsException(
-                        String.format("Both '%s' and '%s' must be specified together", CERTIFICATE_OPTION, PRIVATE_KEY_OPTION));
+                        String.format(Locale.ROOT, "Both '%s' and '%s' must be specified together", CERTIFICATE_OPTION, PRIVATE_KEY_OPTION));
             }
         } else if (args.hasOption(HELP_OPTION) && args.hasOption(VERSION_OPTION)) {
-            throw new CliArgumentsException(String.format("Cannot specify both '%s' and '%s'", HELP_OPTION, VERSION_OPTION));
+            throw new CliArgumentsException(String.format(Locale.ROOT, "Cannot specify both '%s' and '%s'", HELP_OPTION, VERSION_OPTION));
         }
     }
 
@@ -244,7 +246,7 @@ class CliArguments {
     private boolean has(String option) { return arguments.hasOption(option); }
 
     private static CliArgumentsException newInvalidValueException(String option, ParseException cause) {
-        return new CliArgumentsException(String.format("Invalid value for '%s': %s", option, cause.getMessage()), cause);
+        return new CliArgumentsException(String.format(Locale.ROOT, "Invalid value for '%s': %s", option, cause.getMessage()), cause);
     }
 
     private static Options createOptions() {
@@ -398,7 +400,7 @@ class CliArguments {
 
     void printHelp(OutputStream out) {
         HelpFormatter formatter = new HelpFormatter();
-        PrintWriter writer = new PrintWriter(out);
+        PrintWriter writer = new PrintWriter(out, true, StandardCharsets.UTF_8);
         formatter.printHelp(
                 writer,
                 formatter.getWidth(),

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -270,7 +271,7 @@ public class CliClient {
 
     private static void writeFloatField(JsonGenerator generator, String name, double value, int precision) throws IOException {
         generator.writeFieldName(name);
-        generator.writeNumber(String.format("%." + precision + "f", value));
+        generator.writeNumber(String.format(Locale.ROOT, "%." + precision + "f", value));
     }
 
     /** Creates an input stream that spits out random documents (id and data) for one minute. */
@@ -281,7 +282,7 @@ public class CliClient {
 
     static InputStream createDummyInputStream(int payloadSize, Random random, BooleanSupplier hasNext) {
         int idSize = 8;
-        String template = String.format("{ \"put\": \"id:test:test::%s\", \"fields\": { \"test\": \"%s\" } }\n",
+        String template = String.format(Locale.ROOT, "{ \"put\": \"id:test:test::%s\", \"fields\": { \"test\": \"%s\" } }\n",
                                         IntStream.range(0, idSize).mapToObj(__ -> "*").collect(joining()),
                                         IntStream.range(0, payloadSize).mapToObj(__ -> "#").collect(joining()));
         byte[] buffer = template.getBytes(StandardCharsets.UTF_8);

--- a/vespa-feed-client-cli/src/test/java/ai/vespa/feed/client/impl/CliArgumentsTest.java
+++ b/vespa-feed-client-cli/src/test/java/ai/vespa/feed/client/impl/CliArgumentsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -109,8 +110,8 @@ class CliArgumentsTest {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         args.printHelp(out);
-        String text = out.toString();
-        String expectedHelp = new String(Files.readAllBytes(Paths.get("src", "test", "resources", "help.txt")));
+        String text = out.toString(StandardCharsets.UTF_8);
+        String expectedHelp = new String(Files.readAllBytes(Paths.get("src", "test", "resources", "help.txt")), StandardCharsets.UTF_8);
         assertEquals(expectedHelp, text);
     }
 

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/HttpFeedClient.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/HttpFeedClient.java
@@ -22,6 +22,7 @@ import java.net.URLEncoder;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
@@ -136,10 +137,10 @@ class HttpFeedClient implements FeedClient {
                                while (thrown instanceof CompletionException)
                                    thrown = thrown.getCause();
                                var finalThrown = thrown;
-                               log.log(Level.FINE, () -> String.format("Request %s failed: %s", request, finalThrown));
+                               log.log(Level.FINE, () -> String.format(Locale.ROOT, "Request %s failed: %s", request, finalThrown));
                                promise.completeExceptionally(thrown);
                            } else {
-                               log.log(Level.FINE, () -> String.format("Request %s completed successfully: %s", request, result));
+                               log.log(Level.FINE, () -> String.format(Locale.ROOT, "Request %s completed successfully: %s", request, result));
                                promise.complete(result);
                            }
                        });

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/JettyCluster.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/JettyCluster.java
@@ -44,6 +44,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -90,7 +91,7 @@ class JettyCluster implements Cluster {
                 long reqTimeoutMillis = req.timeLeft().toMillis();
                 if (reqTimeoutMillis <= 0) {
                     log.log(Level.FINE, () ->
-                            String.format("Request %s (%s) timed out after '%s' ms",
+                            String.format(Locale.ROOT, "Request %s (%s) timed out after '%s' ms",
                                     req, System.identityHashCode(vessel), req.timeout()));
                     vessel.completeExceptionally(new TimeoutException("operation timed out after '" + req.timeout() + "'"));
                     return;
@@ -117,13 +118,13 @@ class JettyCluster implements Cluster {
                     jettyReq.body(new BytesRequestContent(APPLICATION_JSON.asString(), bytes));
                 }
                 log.log(Level.FINE, () ->
-                        String.format("Dispatching request %s (%s) with timeout %d ms",
+                        String.format(Locale.ROOT, "Dispatching request %s (%s) with timeout %d ms",
                                 req, System.identityHashCode(vessel), reqTimeoutMillis));
                 jettyReq.send(new BufferingResponseListener() {
                     @Override
                     public void onComplete(Result result) {
                         log.log(Level.FINER, () ->
-                                String.format("Completed request %s (%s): %s",
+                                String.format(Locale.ROOT, "Completed request %s (%s): %s",
                                         req, System.identityHashCode(vessel),
                                         result.isFailed()
                                                 ? result.getFailure().toString() : result.getResponse().getStatus()));
@@ -187,7 +188,7 @@ class JettyCluster implements Cluster {
         httpClient.setMaxRequestsQueuedPerDestination(Integer.MAX_VALUE);
         httpClient.setFollowRedirects(false);
         httpClient.setUserAgentField(
-                new HttpField(HttpHeader.USER_AGENT, String.format("vespa-feed-client/%s (Jetty:%s)", Vespa.VERSION, Jetty.VERSION)));
+                new HttpField(HttpHeader.USER_AGENT, String.format(Locale.ROOT, "vespa-feed-client/%s (Jetty:%s)", Vespa.VERSION, Jetty.VERSION)));
         // Stop client from trying different IP address when TLS handshake fails
         httpClient.setSocketAddressResolver(new Ipv4PreferringResolver(httpClient, Duration.ofSeconds(10)));
         httpClient.setHttpCookieStore(new HttpCookieStore.Empty());
@@ -254,7 +255,7 @@ class JettyCluster implements Cluster {
     }
 
     private static String endpointUri(URI uri) {
-        return String.format("%s://%s:%s", uri.getScheme(), uri.getHost(), portOf(uri));
+        return String.format(Locale.ROOT, "%s://%s:%s", uri.getScheme(), uri.getHost(), portOf(uri));
     }
 
     private static class JettyResponse implements HttpResponse {


### PR DESCRIPTION
Use Locale.ROOT for all String.format() calls and toUpperCase() operations to avoid locale-dependent behavior in error messages, logging, and HTTP operations. Also ensure UTF-8 encoding for PrintWriter and String operations.
