### PR TITLE
Refactor vespa-enforcer-extensions, use Text.format

### DIFF
--- a/vespa-enforcer-extensions/src/main/java/com/yahoo/vespa/maven/plugin/enforcer/AllowedDependencies.java
+++ b/vespa-enforcer-extensions/src/main/java/com/yahoo/vespa/maven/plugin/enforcer/AllowedDependencies.java
@@ -72,7 +72,7 @@ public class AllowedDependencies extends AbstractEnforcerRule implements Enforce
 
     public void execute() throws EnforcerRuleException {
         var dependencies = getDependenciesOfAllProjects();
-        getLog().info(String.format(Locale.ROOT, "Found %d unique dependencies ", dependencies.size()));
+        getLog().info(Text.format("Found %d unique dependencies ", dependencies.size()));
         var specFile = Paths.get(project.getBasedir() + File.separator + this.specFile).normalize();
         var spec = loadDependencySpec(specFile);
         var resolved = resolve(spec, dependencies);
@@ -82,7 +82,7 @@ public class AllowedDependencies extends AbstractEnforcerRule implements Enforce
                     .map(p -> p.isEmpty() || Boolean.parseBoolean(p))
                     .orElse(true);
             writeDependencySpec(specFile, resolved, guessProperty);
-            getLog().info(String.format(Locale.ROOT, "Updated spec file '%s'", specFile.toString()));
+            getLog().info(Text.format("Updated spec file '%s'", specFile.toString()));
         } else {
             warnOnDuplicateVersions(resolved);
             validateDependencies(resolved, session.getRequest().getPom().toPath(), project.getArtifactId());
@@ -237,17 +237,17 @@ public class AllowedDependencies extends AbstractEnforcerRule implements Enforce
         Set<Dependency> allDeps = new HashSet<>(resolved.matchedDeps());
         allDeps.addAll(resolved.unmatchedDeps());
         for (Dependency d : allDeps) {
-            String id = String.format(Locale.ROOT, "%s:%s", d.groupId(), d.artifactId());
+            String id = Text.format("%s:%s", d.groupId(), d.artifactId());
             versionsForDependency.computeIfAbsent(id, __ -> new TreeSet<>()).add(d.version());
         }
         versionsForDependency.forEach((dependency, versions) -> {
             if (versions.size() > 1) {
-                getLog().warn(String.format(Locale.ROOT, "'%s' has multiple versions %s", dependency, versions));
+                getLog().warn(Text.format("'%s' has multiple versions %s", dependency, versions));
             }
         });
     }
 
-    private static String projectIdOf(MavenProject project) { return String.format(Locale.ROOT, "%s:%s", project.getGroupId(), project.getArtifactId()); }
+    private static String projectIdOf(MavenProject project) { return Text.format("%s:%s", project.getGroupId(), project.getArtifactId()); }
 
     private record Rule(String groupId, String artifactId, String version, Optional<String> classifier){
         static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$\\{(.+?)}");
@@ -291,7 +291,7 @@ public class AllowedDependencies extends AbstractEnforcerRule implements Enforce
                 // Guess property name if properties are provided
                 var matchingProps = props.entrySet().stream()
                         .filter(e -> e.getValue().equals(version))
-                        .map(v -> String.format(Locale.ROOT, "${%s}", v.getKey()))
+                        .map(v -> Text.format("${%s}", v.getKey()))
                         .collect(Collectors.joining("|"));
                 if (!matchingProps.isEmpty()) versionStr = matchingProps;
             }


### PR DESCRIPTION
Replace String.format(Locale.ROOT, ...) with Text.format(...) for consistent locale handling across the codebase.
