### PR TITLE
Use Text.format in ZooKeeper server

### DIFF
--- a/zookeeper-server/zookeeper-server/src/main/java/org/apache/zookeeper/server/VespaNettyServerCnxnFactory.java
+++ b/zookeeper-server/zookeeper-server/src/main/java/org/apache/zookeeper/server/VespaNettyServerCnxnFactory.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package org.apache.zookeeper.server;
 
+import com.yahoo.text.Text;
 import com.yahoo.vespa.zookeeper.Configurator;
 
 import java.io.IOException;
@@ -27,12 +28,12 @@ public class VespaNettyServerCnxnFactory extends NettyServerCnxnFactory {
         super();
         this.isSecure = Configurator.VespaNettyServerCnxnFactory_isSecure;
         boolean portUnificationEnabled = Boolean.getBoolean(NettyServerCnxnFactory.PORT_UNIFICATION_KEY);
-        log.info(String.format(Locale.ROOT, "For %h: isSecure=%b, portUnification=%b", this, isSecure, portUnificationEnabled));
+        log.info(Text.format("For %h: isSecure=%b, portUnification=%b", this, isSecure, portUnificationEnabled));
     }
 
     @Override
     public void configure(InetSocketAddress addr, int maxClientCnxns, int backlog, boolean secure) throws IOException {
-        log.info(String.format(Locale.ROOT, "For %h: configured() invoked with parameter 'secure'=%b, overridden to %b", this, secure, isSecure));
+        log.info(Text.format("For %h: configured() invoked with parameter 'secure'=%b, overridden to %b", this, secure, isSecure));
         super.configure(addr, maxClientCnxns, backlog, isSecure);
     }
 }


### PR DESCRIPTION
Use Vespa's Text.format utility instead of String.format(Locale.ROOT, ...) for locale-safe string formatting in VespaNettyServerCnxnFactory logging.
