### PR TITLE
Refactor vespalog to use Text.format

### DIFF
--- a/vespalog/src/main/java/com/yahoo/log/LogMessage.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogMessage.java
@@ -3,6 +3,7 @@ package com.yahoo.log;
 
 import com.yahoo.log.event.Event;
 import com.yahoo.log.event.MalformedEventException;
+import com.yahoo.text.Text;
 
 import java.time.Instant;
 import java.util.Locale;
@@ -112,10 +113,10 @@ public class LogMessage
                 return Instant.ofEpochSecond(Long.parseLong(timeStr));
             }
             long seconds = Long.parseLong(timeStr.substring(0, decimalSeparator));
-            long nanoseconds = Long.parseLong(String.format(Locale.ROOT, "%1$-9s", timeStr.substring(decimalSeparator + 1)).replace(' ', '0')); // right pad with zeros
+            long nanoseconds = Long.parseLong(Text.format("%1$-9s", timeStr.substring(decimalSeparator + 1)).replace(' ', '0')); // right pad with zeros
             return Instant.ofEpochSecond(seconds, nanoseconds);
         } catch (NumberFormatException e) {
-            throw new InvalidLogFormatException(String.format(Locale.ROOT, "Failed to parse timestamp: %s. Timestamp string: '%s'", e.getMessage(), timeStr), e);
+            throw new InvalidLogFormatException(Text.format("Failed to parse timestamp: %s. Timestamp string: '%s'", e.getMessage(), timeStr), e);
         }
     }
 

--- a/vespalog/src/main/java/com/yahoo/log/VespaFormat.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaFormat.java
@@ -2,6 +2,7 @@
 package com.yahoo.log;
 
 import com.yahoo.log.impl.LogUtils;
+import com.yahoo.text.Text;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -91,7 +92,7 @@ class VespaFormat {
 
 
     public static String formatTime(Instant instant) {
-        return String.format(Locale.ROOT, "%d.%06d", instant.getEpochSecond(), instant.getNano() / 1000);
+        return Text.format("%d.%06d", instant.getEpochSecond(), instant.getNano() / 1000);
     }
 
     static String formatThreadProcess(long processId, long threadId) {


### PR DESCRIPTION
Replace String.format(Locale.ROOT, ...) calls with Text.format(...) in LogMessage and VespaFormat classes to ensure consistent locale-independent formatting across the vespalog module.
