### PR TITLE
Standardize on Text.format in vespajlib

### DIFF
--- a/vespajlib/src/main/java/ai/vespa/json/Json.java
+++ b/vespajlib/src/main/java/ai/vespa/json/Json.java
@@ -6,6 +6,7 @@ import com.yahoo.slime.ObjectTraverser;
 import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.slime.Type;
+import com.yahoo.text.Text;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -54,13 +55,13 @@ public class Json implements Iterable<Json> {
     public Json f(String field) { return field(field); }
     public Json field(String field) {
         requireType(Type.OBJECT);
-        return new Json(inspector.field(field), path.isEmpty() ? field : String.format(Locale.ROOT, "%s.%s", path, field));
+        return new Json(inspector.field(field), path.isEmpty() ? field : Text.format("%s.%s", path, field));
     }
 
     public Json a(int index) { return entry(index); }
     public Json entry(int index) {
         requireType(ARRAY);
-        return new Json(inspector.entry(index), String.format(Locale.ROOT, "%s[%d]", path, index));
+        return new Json(inspector.entry(index), Text.format("%s[%d]", path, index));
     }
 
     public int length() { return inspector.children(); }
@@ -104,7 +105,7 @@ public class Json implements Iterable<Json> {
         try {
             return Instant.parse(asString());
         } catch (DateTimeParseException e) {
-            throw new InvalidJsonException(String.format(Locale.ROOT, "Expected JSON member '%s' to be a valid timestamp: %s", path, e.getMessage()));
+            throw new InvalidJsonException(Text.format("Expected JSON member '%s' to be a valid timestamp: %s", path, e.getMessage()));
         }
     }
     public Instant asInstant(Instant defaultValue) {
@@ -172,13 +173,13 @@ public class Json implements Iterable<Json> {
 
     private InvalidJsonException createInvalidTypeException(Type... expected) {
         var expectedTypesString = Arrays.stream(expected).map(this::toString).collect(joining("' or '", "'", "'"));
-        var pathString = path.isEmpty() ? "JSON" : String.format(Locale.ROOT, "JSON member '%s'", path);
+        var pathString = path.isEmpty() ? "JSON" : Text.format("JSON member '%s'", path);
         return new InvalidJsonException(
-                String.format(Locale.ROOT, "Expected %s to be a %s but got '%s'", pathString, expectedTypesString, toString(inspector.type())));
+                Text.format("Expected %s to be a %s but got '%s'", pathString, expectedTypesString, toString(inspector.type())));
     }
 
     private InvalidJsonException createMissingMemberException() {
-        return new InvalidJsonException(path.isEmpty() ? "Missing JSON" : String.format(Locale.ROOT, "Missing JSON member '%s'", path));
+        return new InvalidJsonException(path.isEmpty() ? "Missing JSON" : Text.format("Missing JSON member '%s'", path));
     }
 
     private String toString(Type type) {

--- a/vespajlib/src/main/java/ai/vespa/utils/BytesQuantity.java
+++ b/vespajlib/src/main/java/ai/vespa/utils/BytesQuantity.java
@@ -1,5 +1,6 @@
 package ai.vespa.utils;
 
+import com.yahoo.text.Text;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -63,7 +64,7 @@ public class BytesQuantity {
         var matcher = PATTERN.matcher(value);
         if (!matcher.matches())
             throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "Bytes quantity '%s' does not match pattern '%s'", value, PATTERN.pattern()));
+                    Text.format("Bytes quantity '%s' does not match pattern '%s'", value, PATTERN.pattern()));
         var digits = Long.parseLong(matcher.group("digits"));
         var unit = Unit.fromString(matcher.group("unit"));
         return BytesQuantity.of(digits, unit);

--- a/vespajlib/src/main/java/ai/vespa/validation/PathValidator.java
+++ b/vespajlib/src/main/java/ai/vespa/validation/PathValidator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.validation;
 
+import com.yahoo.text.Text;
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -19,7 +20,7 @@ public class PathValidator {
      */
     public static void validateChildOf(Path root, Path path) {
         if (!path.normalize().startsWith(root)) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid path %s", path));
+            throw new IllegalArgumentException(Text.format("Invalid path %s", path));
         }
     }
 

--- a/vespajlib/src/main/java/ai/vespa/validation/Validation.java
+++ b/vespajlib/src/main/java/ai/vespa/validation/Validation.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.validation;
 
+import com.yahoo.text.Text;
 import com.yahoo.yolean.Exceptions;
 
 import java.util.Objects;
@@ -74,7 +75,7 @@ public class Validation {
     public static void requireNonNulls(Object... objs) {
         for (int i = 0; i < objs.length; i++) {
             int effectivelyFinal = i;
-            Objects.requireNonNull(objs[i], () -> String.format(Locale.ROOT, "Argument at index %d is null", effectivelyFinal));
+            Objects.requireNonNull(objs[i], () -> Text.format("Argument at index %d is null", effectivelyFinal));
         }
     }
 

--- a/vespajlib/src/main/java/com/yahoo/net/AcceptHeaderMatcher.java
+++ b/vespajlib/src/main/java/com/yahoo/net/AcceptHeaderMatcher.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.net;
 
+import com.yahoo.text.Text;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -163,7 +164,7 @@ public class AcceptHeaderMatcher {
                     if (isTokenChar(ch)) {
                         yield lexToken();
                     }
-                    throw new IllegalArgumentException(String.format(Locale.ROOT, "failed to lex next token at index %d", tokStart));
+                    throw new IllegalArgumentException(Text.format("failed to lex next token at index %d", tokStart));
                 }
             };
         }
@@ -336,7 +337,7 @@ public class AcceptHeaderMatcher {
             String type = token();
             expectAndAdvance(TokenType.FWD_SLASH);
             String subtype = token();
-            return new MediaType(type, subtype, String.format(Locale.ROOT, "%s/%s", type, subtype));
+            return new MediaType(type, subtype, Text.format("%s/%s", type, subtype));
         }
 
         /**
@@ -421,7 +422,7 @@ public class AcceptHeaderMatcher {
 
         private Token expectAndAdvance(TokenType expectedType) {
             if (mismatches(expectedType)) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "Expected token of type %s, got %s", expectedType, lexer.peek().type));
+                throw new IllegalArgumentException(Text.format("Expected token of type %s, got %s", expectedType, lexer.peek().type));
             }
             return advance();
         }

--- a/vespajlib/src/main/java/com/yahoo/text/Ascii.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Ascii.java
@@ -82,7 +82,7 @@ public class Ascii {
             default:
                 ByteBuffer buf = charset.encode(CharBuffer.wrap(Character.toChars(c)));
                 while (buf.hasRemaining()) {
-                    out.append(ESCAPE_CHAR).append(String.format(Locale.ROOT, "x%02X", buf.get()));
+                    out.append(ESCAPE_CHAR).append(Text.format("x%02X", buf.get()));
                 }
                 break;
             }

--- a/vespajlib/src/main/java/com/yahoo/vespa/VersionTagger.java
+++ b/vespajlib/src/main/java/com/yahoo/vespa/VersionTagger.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa;
 
+import com.yahoo.text.Text;
 import com.yahoo.text.Utf8;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -95,14 +96,14 @@ public class VersionTagger {
         System.err.println("generating: " + outFile);
 
         Map<String, String> vtagMap = readVtagMap(vtagmapPath);
-        writer.write(String.format(Locale.ROOT, "package %s;\n\n", packageName));
+        writer.write(Text.format("package %s;\n\n", packageName));
 
         if (format == Format.VTAG) {
             writer.write("import java.time.Instant;\n");
             writer.write("import com.yahoo.component.Version;\n");
         }
 
-        writer.write(String.format(Locale.ROOT, "\npublic class %s {\n", className));
+        writer.write(Text.format("\npublic class %s {\n", className));
         if (!vtagMap.containsKey(V_TAG_PKG)) {
             throw new RuntimeException("V_TAG_PKG not present in map file");
         }
@@ -110,9 +111,9 @@ public class VersionTagger {
             case SIMPLE:
                 String version = vtagMap.get(V_TAG_PKG);
                 String elements[] = version.split("\\.");
-                writer.write(String.format(Locale.ROOT, "    public static final int major = %s;\n", elements[0]));
-                writer.write(String.format(Locale.ROOT, "    public static final int minor = %s;\n", elements[1]));
-                writer.write(String.format(Locale.ROOT, "    public static final int micro = %s;\n", elements[2]));
+                writer.write(Text.format("    public static final int major = %s;\n", elements[0]));
+                writer.write(Text.format("    public static final int minor = %s;\n", elements[1]));
+                writer.write(Text.format("    public static final int micro = %s;\n", elements[2]));
                 break;
             case VTAG:
                 long commitDateSecs = 0;
@@ -120,7 +121,7 @@ public class VersionTagger {
                     var key = entry.getKey();
                     var value = entry.getValue();
                     try {
-                        writer.write(String.format(Locale.ROOT, "    public static final String %s = \"%s\";\n", key, value));
+                        writer.write(Text.format("    public static final String %s = \"%s\";\n", key, value));
                         if ("V_TAG_COMMIT_DATE".equals(key)) {
                             commitDateSecs = Long.parseLong(value);
                         }

--- a/vespajlib/src/test/java/com/yahoo/text/AsciiTest.java
+++ b/vespajlib/src/test/java/com/yahoo/text/AsciiTest.java
@@ -49,21 +49,21 @@ public class AsciiTest {
                 expected = "\\t";
                 break;
             default:
-                expected = String.format(Locale.ROOT, "\\x%02X", i);
+                expected = Text.format("\\x%02X", i);
                 break;
             }
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
         for (int i = 0x80; i < 0xC0; ++i) {
-            String expected = String.format(Locale.ROOT, "\\xC2\\x%02X", i);
+            String expected = Text.format("\\xC2\\x%02X", i);
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
         for (int i = 0xC0; i < 0x0100; ++i) {
-            String expected = String.format(Locale.ROOT, "\\xC3\\x%02X", i - 0x40);
+            String expected = Text.format("\\xC3\\x%02X", i - 0x40);
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
         for (int i = 0x0100; i < 0x0140; ++i) {
-            String expected = String.format(Locale.ROOT, "\\xC4\\x%02X", i - 0x80);
+            String expected = Text.format("\\xC4\\x%02X", i - 0x80);
             assertEncodeUtf8(expected, new StringBuilder().appendCodePoint(i).toString());
         }
     }
@@ -90,15 +90,15 @@ public class AsciiTest {
     @Test
     public void requireThatUtf8SequencesAreUnescaped() {
         for (int i = 0x80; i < 0xC0; ++i) {
-            String str = String.format(Locale.ROOT, "\\xC2\\x%02X", i);
+            String str = Text.format("\\xC2\\x%02X", i);
             assertDecodeUtf8(new StringBuilder().appendCodePoint(i).toString(), str);
         }
         for (int i = 0xC0; i < 0x0100; ++i) {
-            String str = String.format(Locale.ROOT, "\\xC3\\x%02X", i - 0x40);
+            String str = Text.format("\\xC3\\x%02X", i - 0x40);
             assertDecodeUtf8(new StringBuilder().appendCodePoint(i).toString(), str);
         }
         for (int i = 0x0100; i < 0x0140; ++i) {
-            String str = String.format(Locale.ROOT, "\\xC4\\x%02X", i - 0x80);
+            String str = Text.format("\\xC4\\x%02X", i - 0x80);
             assertDecodeUtf8(new StringBuilder().appendCodePoint(i).toString(), str);
         }
     }


### PR DESCRIPTION
Replace String.format(Locale.ROOT, ...) calls with Text.format(...) throughout the vespajlib module to ensure consistent locale-independent formatting. This provides a cleaner API and guarantees UTF-8 encoding across all formatted strings in core utility classes including JSON handling, validation, and network code.
