### PR TITLE
Use Text.format in configserver module

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
@@ -24,6 +24,7 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -183,7 +184,7 @@ public class ConfigConvergenceChecker extends AbstractComponent {
                                 log.log(
                                         FINE,
                                         error,
-                                        () -> String.format("Failed to retrieve service config generation for '%s': %s", service, error.getMessage()));
+                                        () -> Text.format("Failed to retrieve service config generation for '%s': %s", service, error.getMessage()));
                                 temporaryResult.put(service, -1L);
                             }
                             return null;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
@@ -22,6 +22,7 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -103,7 +104,7 @@ public class ConfigStateChecker extends AbstractComponent {
                                 log.log(
                                         FINE,
                                         error,
-                                        () -> String.format(
+                                        () -> Text.format(
                                                 "Failed to retrieve service config state for '%s': %s",
                                                 service, error.getMessage()));
                                 temporaryResult.put(service, new ServiceConfigState(-1L, Optional.empty()));

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/DefaultClusterReindexingStatusClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/DefaultClusterReindexingStatusClient.java
@@ -17,6 +17,7 @@ import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.Timeout;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.net.URI;
@@ -75,7 +76,7 @@ public class DefaultClusterReindexingStatusClient implements ClusterReindexingSt
     @Override public void close() { uncheck(() -> httpClient.close()); }
 
     private CompletableFuture<Map<String, ClusterReindexing>> getReindexingStatus(ServiceInfo service) {
-        URI uri = URI.create(String.format("http://%s:%d/reindexing/v1/status", service.getHostName(), getStatePort(service)));
+        URI uri = URI.create(Text.format("http://%s:%d/reindexing/v1/status", service.getHostName(), getStatePort(service)));
         CompletableFuture<SimpleHttpResponse> responsePromise = new CompletableFuture<>();
         httpClient.execute(SimpleRequestBuilder.get(uri).build(), new FutureCallback<>() {
             @Override public void completed(SimpleHttpResponse result) { responsePromise.complete(result); }
@@ -86,7 +87,7 @@ public class DefaultClusterReindexingStatusClient implements ClusterReindexingSt
             if (response != null) {
                 return uncheck(() -> toClusterReindexing(response));
             } else {
-                throw throwUnchecked(new IOException(String.format("For '%s': %s", uri, error.getMessage()), error));
+                throw throwUnchecked(new IOException(Text.format("For '%s': %s", uri, error.getMessage()), error));
             }
         }, executor);
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -31,6 +31,7 @@ import com.yahoo.vespa.flags.ListFlag;
 import com.yahoo.vespa.flags.PermanentFlags;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import com.yahoo.text.Text;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -374,7 +375,7 @@ public class TenantApplications implements RequestHandler, HostValidator {
         try {
             return applicationMapper.getForVersion(appId, vespaVersion, clock.instant());
         } catch (VersionDoesNotExistException ex) {
-            throw new NotFoundException(String.format("%sNo such application (id %s): %s", TenantRepository.logPre(tenant), appId, ex.getMessage()));
+            throw new NotFoundException(Text.format("%sNo such application (id %s): %s", TenantRepository.logPre(tenant), appId, ex.getMessage()));
         }
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -30,6 +30,7 @@ import com.yahoo.vespa.config.server.session.SessionRepository;
 import com.yahoo.vespa.config.server.tenant.Tenant;
 import com.yahoo.yolean.Exceptions;
 import com.yahoo.yolean.concurrent.Memoized;
+import com.yahoo.text.Text;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -181,9 +182,9 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
         long configGeneration = session.getSessionId();
         applicationRepository.modifyPendingRestarts(applicationId, pendingRestarts -> pendingRestarts.withRestarts(configGeneration, nodesToRestart));
         String hostnames = nodesToRestart.stream().sorted().collect(joining(", "));
-        deployLogger.log(Level.INFO, String.format("Scheduled service restart of %d nodes: %s",
+        deployLogger.log(Level.INFO, Text.format("Scheduled service restart of %d nodes: %s",
                                                    nodesToRestart.size(), hostnames));
-        log.info(String.format("%sWill schedule service restart of %d nodes after convergence on generation %d (unless restartOnDeploy enabled): %s",
+        log.info(Text.format("%sWill schedule service restart of %d nodes after convergence on generation %d (unless restartOnDeploy enabled): %s",
                                session.logPre(), nodesToRestart.size(), configGeneration, hostnames));
         configChangeActions = configChangeActions == null ? null : configChangeActions.withRestartActions(new RestartActions());
     }
@@ -200,7 +201,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
 
             return reindexing;
         });
-        deployLogger.log(Level.INFO, String.format("Scheduled reindexing of %d document types across %d clusters: %s",
+        deployLogger.log(Level.INFO, Text.format("Scheduled reindexing of %d document types across %d clusters: %s",
                                                    entries.size(),
                                                    entries.stream().map(Reindexing::clusterId).distinct().count(),
                                                    entries.stream().collect(groupingBy(Reindexing::clusterId)).entrySet().stream()
@@ -224,8 +225,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                         "Cannot apply deferred reconfiguration: no model available for session " + session.getSessionId()));
         model.markClustersForDeferredReconfiguration(clustersWithDeferredReconfiguration);
         clustersWithDeferredReconfiguration.forEach(clusterName ->
-            deployLogger.log(Level.INFO, "Deferring reconfiguration of cluster '%s' until restart is completed"
-                    .formatted(clusterName)));
+            deployLogger.log(Level.INFO, Text.format("Deferring reconfiguration of cluster '%s' until restart is completed", clusterName)));
     }
 
     /**

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/SecretStoreValidator.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/SecretStoreValidator.java
@@ -15,6 +15,7 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.net.URI;
@@ -64,7 +65,7 @@ public class SecretStoreValidator {
             return new ProxyResponse(httpClient.execute(postRequest));
         } catch (IOException e) {
             return HttpErrorResponse.internalServerError(
-                    String.format("Failed to post request to %s: %s", uri, Exceptions.toMessageString(e))
+                    Text.format("Failed to post request to %s: %s", uri, Exceptions.toMessageString(e))
             );
         }
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v1/RoutingStatusApiHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v1/RoutingStatusApiHandler.java
@@ -16,6 +16,8 @@ import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.transaction.CuratorOperations;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.yolean.Exceptions;
+import com.yahoo.yolean.Exceptions;
+import com.yahoo.text.Text;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -112,7 +114,7 @@ public class RoutingStatusApiHandler extends RestApiRequestHandler<RoutingStatus
         DeploymentRoutingStatus deploymentRoutingStatus = deploymentStatus(upstreamName);
         // If the entire zone is out, we always return OUT regardless of the actual routing status
         if (zoneStatus() == RoutingStatus.out) {
-            String reason = String.format("Rotation is OUT because the zone is OUT (actual deployment status is %s)",
+            String reason = Text.format("Rotation is OUT because the zone is OUT (actual deployment status is %s)",
                                           deploymentRoutingStatus.status().name().toUpperCase(Locale.ENGLISH));
             deploymentRoutingStatus = new DeploymentRoutingStatus(RoutingStatus.out, "operator", reason,
                                                                   clock.instant());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/PendingRestartsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/PendingRestartsMaintainer.java
@@ -101,7 +101,7 @@ public class PendingRestartsMaintainer extends ConfigServerMaintainer {
         long lowestGeneration = convergence.currentGeneration;
         Set<String> nodesToRestart = restarts.restartsReadyAt(lowestGeneration);
         if (nodesToRestart.isEmpty()) {
-            log.info(String.format("Cannot yet restart nodes of %s, as some services are still on generation %d:\n\t%s",
+            log.info(Text.format("Cannot yet restart nodes of %s, as some services are still on generation %d:\n\t%s",
                     id.toFullString(),
                     lowestGeneration,
                     convergence.services().stream()
@@ -112,7 +112,7 @@ public class PendingRestartsMaintainer extends ConfigServerMaintainer {
         }
 
         restarter.accept(id, nodesToRestart);
-        log.info(String.format("Scheduled restart of %d nodes after observing generation %d: %s",
+        log.info(Text.format("Scheduled restart of %d nodes after observing generation %d: %s",
                 nodesToRestart.size(), lowestGeneration, nodesToRestart.stream().sorted().collect(Collectors.joining(", "))));
 
         return restarts.withoutPreviousGenerations(lowestGeneration);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
@@ -18,6 +18,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
+import com.yahoo.text.Text;
 
 import java.io.IOException;
 import java.net.URI;
@@ -91,7 +92,7 @@ public class ClusterDeploymentMetricsRetriever {
         }
 
         log.log(Level.FINE, () ->
-                String.format("Metric retrieval for %d nodes took %d milliseconds", hosts.size(), System.currentTimeMillis() - startTime)
+                Text.format("Metric retrieval for %d nodes took %d milliseconds", hosts.size(), System.currentTimeMillis() - startTime)
         );
 
         return clusterMetricsMap;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterSearchNodeMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterSearchNodeMetricsRetriever.java
@@ -56,7 +56,7 @@ public class ClusterSearchNodeMetricsRetriever {
         }
 
         log.log(Level.FINE, () ->
-                String.format("Proton metric retrieval for %d nodes took %d milliseconds", hosts.size(), System.currentTimeMillis() - startTime)
+                Text.format("Proton metric retrieval for %d nodes took %d milliseconds", hosts.size(), System.currentTimeMillis() - startTime)
         );*/
 
         return clusterMetricsMap;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -33,6 +33,7 @@ import com.yahoo.vespa.config.server.tenant.EndpointCertificateRetriever;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.text.Text;
 
 import java.util.Comparator;
 import java.util.List;
@@ -98,7 +99,7 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                                             ApplicationId applicationId,
                                             Optional<DockerImage> wantedDockerImageRepository,
                                             Version wantedNodeVespaVersion) {
-        log.log(Level.FINE, () -> String.format("Loading model version %s for session %s application %s",
+        log.log(Level.FINE, () -> Text.format("Loading model version %s for session %s application %s",
                                                 modelFactory.version(), applicationGeneration, applicationId));
         ModelContext.Properties modelContextProperties = createModelContextProperties(applicationId, modelFactory.version(), applicationPackage);
         Provisioned provisioned = new Provisioned();

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/security/GlobalConfigAuthorizationPolicy.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/security/GlobalConfigAuthorizationPolicy.java
@@ -5,6 +5,8 @@ import com.yahoo.cloud.config.LbServicesConfig;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.config.ConfigKey;
+import com.yahoo.vespa.config.ConfigKey;
+import com.yahoo.text.Text;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -32,7 +34,7 @@ enum GlobalConfigAuthorizationPolicy {
     static void verifyAccessAllowed(ConfigKey<?> configKey, NodeType nodeType) {
         GlobalConfigAuthorizationPolicy policy = findPolicyFromConfigKey(configKey);
         if (!policy.allowedToAccess.contains(nodeType)) {
-            String message = String.format(
+            String message = Text.format(
                     "Node with type '%s' is not allowed to access global config [%s]",
                     nodeType, configKey);
             throw new AuthorizationException(message);
@@ -43,7 +45,7 @@ enum GlobalConfigAuthorizationPolicy {
         return Arrays.stream(values())
                 .filter(policy -> policy.namespace.equals(configKey.getNamespace()) && policy.name.equals(configKey.getName()))
                 .findAny()
-                .orElseThrow(() -> new AuthorizationException(String.format("No policy defined for global config [%s]", configKey)));
+                .orElseThrow(() -> new AuthorizationException(Text.format("No policy defined for global config [%s]", configKey)));
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/version/VersionState.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/version/VersionState.java
@@ -9,6 +9,7 @@ import com.yahoo.path.Path;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.defaults.Defaults;
+import com.yahoo.text.Text;
 
 import java.io.File;
 import java.io.FileReader;
@@ -115,7 +116,7 @@ public class VersionState {
 
     @Override
     public String toString() {
-        return String.format("Current version:%s, stored version:%s", currentVersion(), storedVersion());
+        return Text.format("Current version:%s, stored version:%s", currentVersion(), storedVersion());
     }
 
     private void verifyVersionIntervalForUpgrade(Version storedVersion) {


### PR DESCRIPTION
Replace String.format() with Text.format() across the configserver module to avoid locale-dependent formatting issues. String.format() uses the default locale for number and date formatting, which can cause inconsistent behavior across different environments. Text.format() provides locale-independent formatting suitable for internal strings, log messages, and error messages.

Changes span 14 files including authorization, deployment, metrics, and HTTP handling code.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
