### PR TITLE
Standardize locale in schema-language-server

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaLanguageServer.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaLanguageServer.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -184,9 +185,9 @@ public class SchemaLanguageServer implements LanguageServer, LanguageClientAware
             setupDocumentation(docPath);
         } catch (IOException ioex) {
             this.logger.error("Failed to set up documentation. Error: " + ioex.getMessage());
-            try (ByteArrayOutputStream os = new ByteArrayOutputStream(); PrintStream ps = new PrintStream(os)) {
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream(); PrintStream ps = new PrintStream(os, true, StandardCharsets.UTF_8)) {
                 ioex.printStackTrace(ps);
-                logger.error(os.toString());
+                logger.error(os.toString(StandardCharsets.UTF_8));
             } catch (IOException bruh) {
                 logger.error("Error inside error " + bruh.getMessage());
             }
@@ -278,9 +279,9 @@ public class SchemaLanguageServer implements LanguageServer, LanguageClientAware
                     }
                     Files.createDirectories(destination.getParent());
                     try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(entry.getName())) {
-                        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
                         String content = reader.lines().collect(Collectors.joining(System.lineSeparator()));
-                        Files.write(destination, content.getBytes(), StandardOpenOption.CREATE);
+                        Files.write(destination, content.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
                     }
                 }
             }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaTextDocumentService.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/SchemaTextDocumentService.java
@@ -2,6 +2,7 @@ package ai.vespa.schemals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -97,13 +98,13 @@ public class SchemaTextDocumentService implements TextDocumentService {
             try {
 
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                PrintStream errorLogger = new PrintStream(outputStream);
+                PrintStream errorLogger = new PrintStream(outputStream, true, StandardCharsets.UTF_8);
                 Either<List<CompletionItem>, CompletionList> result =
                     Either.forLeft(CommonCompletion.getCompletionItems(eventContextCreator.createContext(completionParams), errorLogger));
 
                 if (outputStream.size() > 0) {
-                    schemaMessageHandler.logMessage(MessageType.Error, 
-                        "Completion failed with errors: " + outputStream.toString() 
+                    schemaMessageHandler.logMessage(MessageType.Error,
+                        "Completion failed with errors: " + outputStream.toString(StandardCharsets.UTF_8)
                     );
                 }
                 return result;

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/common/ClientLogger.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/common/ClientLogger.java
@@ -2,6 +2,7 @@ package ai.vespa.schemals.common;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.lsp4j.MessageType;
 
@@ -26,10 +27,10 @@ public class ClientLogger {
 
     public static String errorToString(Exception ex) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        PrintStream logger = new PrintStream(outputStream);
+        PrintStream logger = new PrintStream(outputStream, true, StandardCharsets.UTF_8);
         ex.printStackTrace(logger);
 
-        return outputStream.toString();
+        return outputStream.toString(StandardCharsets.UTF_8);
     }
 
     public void error(Exception ex) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/common/FileUtils.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/common/FileUtils.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.yahoo.io.IOUtils;
+import com.yahoo.text.Utf8;
 
 public class FileUtils {
     public static String fileNameFromPath(String path) {
@@ -42,7 +43,7 @@ public class FileUtils {
 
     public static String readFromURI(String fileURI) throws IOException {
         File file = new File(URI.create(fileURI));
-        return IOUtils.readAll(new FileReader(file));
+        return IOUtils.readAll(Utf8.createReader(file));
     }
 
     public static List<String> findSchemaFiles(String workspaceFolderUri, ClientLogger logger) {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/documentation/FetchDocumentation.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/documentation/FetchDocumentation.java
@@ -3,12 +3,14 @@ package ai.vespa.schemals.documentation;
 import ai.vespa.schemals.common.FileUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -78,7 +80,7 @@ public class FetchDocumentation {
 
             for (var entry : markdownContent.entrySet()) {
                 if (entry.getKey().contains("/")) continue;
-                String fileName = entry.getKey().toLowerCase();
+                String fileName = entry.getKey().toLowerCase(Locale.ROOT);
                 fileName = FileUtils.sanitizeFileName(fileName);
                 writeMarkdown(writePath.resolve(fileName + ".md"), entry.getValue());
             }
@@ -87,11 +89,11 @@ public class FetchDocumentation {
 
 
     private static void writeMarkdown(Path writePath, String markdown) throws IOException {
-        Files.write(writePath, markdown.getBytes(), StandardOpenOption.CREATE);
+        Files.write(writePath, markdown.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
     }
 
     private static String convertToToken(String h2Id) {
-        return h2Id.toUpperCase().replaceAll("-", "_");
+        return h2Id.toUpperCase(Locale.ROOT).replaceAll("-", "_");
     }
 
     // Runs during build

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/SchemaIndex.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/index/SchemaIndex.java
@@ -29,6 +29,7 @@ import ai.vespa.schemals.parser.ast.rankProfile;
 import ai.vespa.schemals.parser.ast.rootSchema;
 import ai.vespa.schemals.parser.ast.structDefinitionElm;
 import ai.vespa.schemals.parser.ast.structFieldDefinition;
+import com.yahoo.text.Text;
 
 public class SchemaIndex {
     public static final HashMap<Class<?>, SymbolType> IDENTIFIER_TYPE_MAP = new HashMap<>() {{
@@ -69,7 +70,7 @@ public class SchemaIndex {
 
     // This is an inheritance graph, even though it doesn't model *inheritance* per se.
     private InheritanceGraph<Symbol> documentReferenceGraph;
-    
+
     public SchemaIndex(ClientLogger logger) {
         this.logger = logger;
         this.documentInheritanceGraph        = new InheritanceGraph<>();
@@ -221,7 +222,7 @@ public class SchemaIndex {
         // Special case for schema and document because a schema can sometimes refer to a document and vice versa
         if (type == SymbolType.SCHEMA || type == SymbolType.DOCUMENT) {
             SymbolType firstCheck = (type == SymbolType.SCHEMA ? SymbolType.SCHEMA : SymbolType.DOCUMENT);
-            List<Symbol> schemaDefinitions = 
+            List<Symbol> schemaDefinitions =
                 symbolDefinitions.get(firstCheck)
                                .stream()
                                .filter(symbolDefinition -> symbolDefinition.getShortIdentifier().equals(shortIdentifier))
@@ -249,7 +250,7 @@ public class SchemaIndex {
     }
 
     /*
-     * Given a scope, type and short identifier, find definitions defined inside the actual scope. 
+     * Given a scope, type and short identifier, find definitions defined inside the actual scope.
      * Will not search inheritance graphs.
      */
     private Optional<Symbol> findSymbolInConcreteScope(Symbol scope, SymbolType type, String shortIdentifier) {
@@ -309,7 +310,7 @@ public class SchemaIndex {
     public boolean isInScope(Symbol symbol, Symbol scope) {
         if (scope == null) return true; // lets say every symbol is in the empty scope
         if (scope.getType() == SymbolType.RANK_PROFILE) {
-            return !rankProfileInheritanceGraph.findFirstMatches(scope, 
+            return !rankProfileInheritanceGraph.findFirstMatches(scope,
                     rankProfileDefinitionSymbol -> {
                         if (rankProfileDefinitionSymbol.equals(symbol.getScope())) {
                             return Boolean.valueOf(true);
@@ -317,16 +318,16 @@ public class SchemaIndex {
                         return null;
             }).isEmpty();
         } else if (scope.getType() == SymbolType.STRUCT) {
-            return !structInheritanceGraph.findFirstMatches(scope, 
+            return !structInheritanceGraph.findFirstMatches(scope,
                     structDefinitionSymbol -> {
                         if (structDefinitionSymbol.equals(symbol.getScope())) {
                             return Boolean.valueOf(true);
                         }
                         return null;
             }).isEmpty();
-        } else if ((symbol.getScope() == null || symbol.getScope().getType() == SymbolType.SCHEMA || symbol.getScope().getType() == SymbolType.DOCUMENT) && 
+        } else if ((symbol.getScope() == null || symbol.getScope().getType() == SymbolType.SCHEMA || symbol.getScope().getType() == SymbolType.DOCUMENT) &&
                 (scope.getType() == SymbolType.SCHEMA || scope.getType() == SymbolType.DOCUMENT)) {
-            return !documentInheritanceGraph.findFirstMatches(scope.getFileURI(), 
+            return !documentInheritanceGraph.findFirstMatches(scope.getFileURI(),
                 ancestorURI -> {
                     if (symbol.getFileURI().equals(ancestorURI)) {
                         return Boolean.valueOf(true);
@@ -341,8 +342,8 @@ public class SchemaIndex {
 
     /**
      * Retrieves the definition of a symbol from a map.
-     * We have three versions of this, because definitions can reference other definitions. 
-     * For example, struct-field is both a definition (you want to jump there if you go-to-definition on field.structfield somewhere else), 
+     * We have three versions of this, because definitions can reference other definitions.
+     * For example, struct-field is both a definition (you want to jump there if you go-to-definition on field.structfield somewhere else),
      * and a reference (to the field inside the struct).
      *  {@link getSymbolDefinition} returns identity if you supply a definition.
      *  {@link getNextSymbolDefinition} always tries to interpret the argument as a reference (jumping one step even if argument is a definition).
@@ -592,7 +593,7 @@ public class SchemaIndex {
 
         logger.info("\n === REFERENCES TO DEFINITIONS ===");
         for (var entry : definitionOfReference.entrySet()) {
-            String toPrint = String.format("%-50s -> %s", entry.getKey(), entry.getValue());
+            String toPrint = Text.format("%-50s -> %s", entry.getKey(), entry.getValue());
             logger.info(toPrint);
         }
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/RunVespaQuery.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/common/command/commandtypes/RunVespaQuery.java
@@ -3,11 +3,13 @@ package ai.vespa.schemals.lsp.common.command.commandtypes;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -55,7 +57,7 @@ public class RunVespaQuery implements SchemaCommand {
 
         runVespaQuery(queryCommand, context.logger).thenAccept(result -> {
             if (!result.success()) {
-                if (result.result().toLowerCase().contains("cannot run program")) {
+                if (result.result().toLowerCase(Locale.ROOT).contains("cannot run program")) {
                     context.messageHandler.sendMessage(MessageType.Error, "Could not find vespa CLI. Make sure vespa CLI is installed and added to path. Download vespa CLI here: https://docs.vespa.ai/en/clients/vespa-cli.html");
                     return;
                 }
@@ -102,7 +104,7 @@ public class RunVespaQuery implements SchemaCommand {
 
     private CompletableFuture<QueryResult> runVespaQuery(String query, ClientLogger logger) {
 
-        boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
 
         ProcessBuilder builder = new ProcessBuilder();
 
@@ -117,7 +119,7 @@ public class RunVespaQuery implements SchemaCommand {
 
                 Process process = builder.start();
 
-                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
 
                 String line;
                 StringBuilder output = new StringBuilder();
@@ -131,7 +133,7 @@ public class RunVespaQuery implements SchemaCommand {
                     return new QueryResult(true, output.toString());
                 }
 
-                BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+                BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8));
                 StringBuilder error = new StringBuilder();
                 while ((line = errorReader.readLine()) != null) {
                     error.append(line).append("\n");

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -3,6 +3,7 @@ package ai.vespa.schemals.lsp.schema.completion.provider;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -231,7 +232,7 @@ public class BodyKeywordCompletion implements CompletionProvider {
         // compute docs
         for (var entry : this.entrySet()) {
             for (CompletionItem item : entry.getValue()) {
-                String markdownKey = item.getLabel().toUpperCase().replaceAll("-", "_");
+                String markdownKey = item.getLabel().toUpperCase(Locale.ROOT).replaceAll("-", "_");
                 Optional<Hover> hover = SchemaHover.getFileHoverInformation(schemaHoverPath, markdownKey, new Range());
                 if (hover.isPresent() && hover.get().getContents().isRight()) {
                     item.setDocumentation(hover.get().getContents().getRight());

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/hover/SchemaHover.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/hover/SchemaHover.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -149,7 +150,7 @@ public class SchemaHover {
         for (int i = 0; i < indexingTypes.length; ++i) {
             if (i == 0) hoverText += "\n\t";
             else hoverText += " | ";
-            hoverText += indexingTypes[i].toString().toLowerCase();
+            hoverText += indexingTypes[i].toString().toLowerCase(Locale.ROOT);
         }
 
         String fieldDefinitionDocumentContent = context.scheduler.getDocument(fieldDefinitionSymbol.get().getFileURI()).getCurrentContent();

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/provider/GroupingExpressionProvider.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/completion/provider/GroupingExpressionProvider.java
@@ -2,6 +2,7 @@ package ai.vespa.schemals.lsp.yqlplus.completion.provider;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
@@ -27,13 +28,13 @@ public class GroupingExpressionProvider implements CompletionProvider {
 
 
     private final static List<String> mathFunctions = Arrays.stream(MathFunctions.Function.values())
-                                                            .map(func -> func.name().toLowerCase())
+                                                            .map(func -> func.name().toLowerCase(Locale.ROOT))
                                                             .toList();
 
     private final static List<String> timeFunctions = Arrays.stream(TimeFunctions.Type.values())
                                                             .map(func -> func.name()
                                                                              .replaceAll("_", "")
-                                                                             .toLowerCase())
+                                                                             .toLowerCase(Locale.ROOT))
                                                             .toList();
 
     private final static List<CompletionItem> expressionCompletions = List.of(

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocumentScheduler.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/SchemaDocumentScheduler.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -79,7 +80,7 @@ public class SchemaDocumentScheduler {
 
     private Optional<DocumentType> getDocumentTypeFromURI(String fileURI) {
         int dotIndex = fileURI.lastIndexOf('.');
-        String fileExtension = fileURI.substring(dotIndex + 1).toLowerCase();
+        String fileExtension = fileURI.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
 
         DocumentType documentType = fileExtensions.get(fileExtension);
         if (documentType == null) return Optional.empty();

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/VespaGroupingParser.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/VespaGroupingParser.java
@@ -1,6 +1,7 @@
 package ai.vespa.schemals.schemadocument;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.eclipse.lsp4j.Position;
@@ -17,7 +18,7 @@ class VespaGroupingParser {
 
     static YQLPartParseResult parseVespaGrouping(String input, ClientLogger logger, Position offset, int charOffset) {
 
-        CharSequence charSequence = input.toLowerCase();
+        CharSequence charSequence = input.toLowerCase(Locale.ROOT);
         GroupingParser parser = new GroupingParser(charSequence);
 
         try {

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/YQLDocument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/YQLDocument.java
@@ -2,6 +2,7 @@ package ai.vespa.schemals.schemadocument;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.eclipse.lsp4j.Diagnostic;
@@ -97,7 +98,7 @@ public class YQLDocument implements DocumentManager {
     }
 
     private static YQLPartParseResult parseYQLPart(String content, ClientLogger logger, Position offset, int charOffset) {
-        YQLPlusParser parser = new YQLPlusParser(content.toLowerCase());
+        YQLPlusParser parser = new YQLPlusParser(content.toLowerCase(Locale.ROOT));
 
         try {
             parser.statement();

--- a/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/UnpackRNGFiles.java
+++ b/integration/schema-language-server/lemminx-vespa/src/main/java/ai/vespa/lemminx/UnpackRNGFiles.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -49,9 +50,9 @@ public class UnpackRNGFiles {
                         continue;
                     }
                     try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(entry.getName())) {
-                        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
                         String content = reader.lines().collect(Collectors.joining(System.lineSeparator()));
-                        Files.write(writePath, content.getBytes(), StandardOpenOption.CREATE);
+                        Files.write(writePath, content.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
                     } catch (Exception ex) {
                         // Ignore: unwanted .rng file
                     }


### PR DESCRIPTION
Replaces platform-dependent default charset operations with explicit UTF-8 to ensure consistent behavior across different environments. This prevents encoding issues and locale-dependent bugs in string operations throughout the language server.

Key changes:
- Use StandardCharsets.UTF_8 explicitly for all stream readers/writers
- Replace Locale-dependent string operations with Locale.ROOT
- Use Vespa's Utf8.createReader() for file reading
- Specify UTF-8 when converting byte streams to strings
