### PR TITLE
Add `istrue` filter predicate to grouping

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -3297,6 +3297,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.grouping.request.IsTruePredicate" : {
+    "superClass" : "com.yahoo.search.grouping.request.FilterExpression",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(com.yahoo.search.grouping.request.GroupingExpression)",
+      "public com.yahoo.search.grouping.request.GroupingExpression getExpression()",
+      "public java.lang.String toString()",
+      "public com.yahoo.search.grouping.request.FilterExpression copy()"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.grouping.request.LongBucket" : {
     "superClass" : "com.yahoo.search.grouping.request.BucketValue",
     "interfaces" : [ ],

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/IsTruePredicate.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/IsTruePredicate.java
@@ -1,0 +1,33 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.grouping.request;
+
+import com.yahoo.api.annotations.Beta;
+
+/**
+ * Represents a filter that evaluates to true when its expression evaluates to a boolean true value.
+ *
+ * @author johsol
+ */
+@Beta
+public class IsTruePredicate extends FilterExpression {
+
+    private final GroupingExpression expression;
+
+    public IsTruePredicate(GroupingExpression expression) {
+        this.expression = expression;
+    }
+
+    public GroupingExpression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("istrue(%s)", expression);
+    }
+
+    @Override
+    public FilterExpression copy() {
+        return new IsTruePredicate(expression.copy());
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/ExpressionConverter.java
@@ -30,6 +30,7 @@ import com.yahoo.search.grouping.request.GroupingOperation;
 import com.yahoo.search.grouping.request.HourOfDayFunction;
 import com.yahoo.search.grouping.request.InfiniteValue;
 import com.yahoo.search.grouping.request.InterpolatedLookup;
+import com.yahoo.search.grouping.request.IsTruePredicate;
 import com.yahoo.search.grouping.request.LongValue;
 import com.yahoo.search.grouping.request.MathACosFunction;
 import com.yahoo.search.grouping.request.MathACosHFunction;
@@ -129,6 +130,7 @@ import com.yahoo.searchlib.expression.IntegerBucketResultNode;
 import com.yahoo.searchlib.expression.IntegerBucketResultNodeVector;
 import com.yahoo.searchlib.expression.IntegerResultNode;
 import com.yahoo.searchlib.expression.InterpolatedLookupNode;
+import com.yahoo.searchlib.expression.IsTruePredicateNode;
 import com.yahoo.searchlib.expression.MD5BitFunctionNode;
 import com.yahoo.searchlib.expression.MathFunctionNode;
 import com.yahoo.searchlib.expression.MaxFunctionNode;
@@ -271,6 +273,8 @@ class ExpressionConverter {
             return new RegexPredicateNode(rp.getPattern(), toExpressionNode(rp.getExpression()));
         } else if (expression instanceof RangePredicate rp) {
             return new RangePredicateNode(rp.getLower(), rp.getUpper(), toExpressionNode(rp.getExpression()), rp.getLowerInclusive(), rp.getUpperInclusive());
+        } else if (expression instanceof IsTruePredicate rp) {
+            return new IsTruePredicateNode(toExpressionNode(rp.getExpression()));
         } else if (expression instanceof NotPredicate np) {
             return new NotPredicateNode(toFilterExpressionNode(np.getExpression()));
         } else if (expression instanceof OrPredicate op) {

--- a/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
+++ b/container-search/src/main/javacc/com/yahoo/search/grouping/request/parser/GroupingParser.jj
@@ -122,6 +122,7 @@ TOKEN :
     <GROUP: "group"> |
     <HINT: "hint"> |
     <HYPOT: "hypot"> |
+    <ISTRUE: "istrue"> |
     <KEEP: "keep"> |
     <LOG: "log"> |
     <LOG1P: "log1p"> |
@@ -979,7 +980,8 @@ FilterExpression filterPrimary(GroupingOperation grp) :
 {
     (( lbrace() f = filterExp(grp) rbrace() ) |
     ( f = regexPredicate(grp) )              |
-    ( f = rangePredicate(grp) ))
+    ( f = rangePredicate(grp) )              |
+    ( f = istruePredicate(grp) ))
     { return f; }
 }
 
@@ -1004,6 +1006,15 @@ RangePredicate rangePredicate(GroupingOperation grp) :
 {
     <RANGE> lbrace() lower = number() comma() upper = number() comma() exp = exp(grp) [ comma()  lowerInclusive = booleanValue() comma() upperInclusive = booleanValue() ] rbrace()
     { return new RangePredicate(lower, upper, exp, lowerInclusive.getValue(), upperInclusive.getValue()); }
+}
+
+IsTruePredicate istruePredicate(GroupingOperation grp) :
+{
+    GroupingExpression exp;
+}
+{
+    <ISTRUE> lbrace() exp = exp(grp) rbrace()
+    { return new IsTruePredicate(exp); }
 }
 
 FilterExpression orPredicate(GroupingOperation grp) :
@@ -1146,6 +1157,7 @@ String identifier() :
         <HINT> |
         <HYPOT> |
         <IDENTIFIER> |
+        <ISTRUE> |
         <KEEP> |
         <LOG> |
         <LOG1P> |

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
@@ -23,6 +23,7 @@ import com.yahoo.searchlib.expression.AttributeNode;
 import com.yahoo.searchlib.expression.ConstantNode;
 import com.yahoo.searchlib.expression.ExpressionNode;
 import com.yahoo.searchlib.expression.FilterExpressionNode;
+import com.yahoo.searchlib.expression.IsTruePredicateNode;
 import com.yahoo.searchlib.expression.NotPredicateNode;
 import com.yahoo.searchlib.expression.OrPredicateNode;
 import com.yahoo.searchlib.expression.RangePredicateNode;
@@ -852,6 +853,12 @@ public class RequestBuilderTestCase {
     }
 
     @Test
+    void require_that_istrue_filter_layout_is_correct() {
+        assertLayout("all(group(a) filter(istrue(a)) each(output(count())))",
+                "[[{ Attribute, filter = [IsTrue [Attribute]], result = [Count] }]]");
+    }
+
+    @Test
     void require_that_filter_predicate_layout_is_correct() {
         // Not[Regex]
         assertLayout("all(group(a) filter(not regex(\".*suffix$\", a)) each(output(count())))",
@@ -1171,6 +1178,9 @@ public class RequestBuilderTestCase {
                 var expression = rpn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
                 return String.format(Locale.US, "Range [%f, %f, %s, %s, %s]",
                                      lower, upper, expression, lowerInclusive, upperInclusive);
+            } else if (filterExp instanceof IsTruePredicateNode itn) {
+                var expression = itn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
+                return String.format("IsTrue [%s]", expression);
             } else if (filterExp instanceof NotPredicateNode npn) {
                 var simpleName = npn.getExpression().map(LayoutWriter::toSimpleName).orElse("");
                 return "Not [%s]".formatted(simpleName);

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -187,6 +187,7 @@ TOKEN :
     <GROUP: "group"> |
     <HINT: "hint"> |
     <HYPOT: "hypot"> |
+    <ISTRUE: "istrue"> |
     <KEEP: "keep"> |
     <LOG: "log"> |
     <LOG1P: "log1p"> |
@@ -1045,7 +1046,8 @@ FilterExpression filterPrimary(GroupingOperation grp) :
 (
     ( lbraceElm f = filterExp(grp) rbraceElm ) |
     ( f = regexPredicate(grp) )                |
-    ( f = rangePredicate(grp) )
+    ( f = rangePredicate(grp) )                |
+    ( f = istruePredicate(grp) )
 )
 {
     return f;
@@ -1085,6 +1087,16 @@ RangePredicate rangePredicate(GroupingOperation grp) :
     )
 {
     return new RangePredicate(lower, upper, exp, lowerInclusive.getValue(), upperInclusive.getValue());
+}
+;
+
+IsTruePredicate istruePredicate(GroupingOperation grp) :
+{
+    GroupingExpression exp;
+}
+    ( <ISTRUE> lbraceElm exp = expElm(grp) rbraceElm )
+{
+    return new IsTruePredicate(exp);
 }
 ;
 
@@ -1228,6 +1240,7 @@ String identifierStr :
         <HINT> |
         <HYPOT> |
         <IDENTIFIER> |
+        <ISTRUE> |
         <KEEP> |
         <LOG> |
         <LOG1P> |

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/semantictokens/VespaGroupingSemanticTokenConfig.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/yqlplus/semantictokens/VespaGroupingSemanticTokenConfig.java
@@ -49,6 +49,7 @@ import ai.vespa.schemals.parser.grouping.ast.INFIX_MOD;
 import ai.vespa.schemals.parser.grouping.ast.INFIX_MUL;
 import ai.vespa.schemals.parser.grouping.ast.INFIX_SUB;
 import ai.vespa.schemals.parser.grouping.ast.INTERPOLATEDLOOKUP;
+import ai.vespa.schemals.parser.grouping.ast.ISTRUE;
 import ai.vespa.schemals.parser.grouping.ast.LOG;
 import ai.vespa.schemals.parser.grouping.ast.LOG10;
 import ai.vespa.schemals.parser.grouping.ast.LOG1P;
@@ -114,6 +115,7 @@ import ai.vespa.schemals.parser.grouping.ast.ZCURVE;
 import ai.vespa.schemals.parser.grouping.ast.andFunction;
 import ai.vespa.schemals.parser.grouping.ast.andPredicate;
 import ai.vespa.schemals.parser.grouping.ast.identifierStr;
+import ai.vespa.schemals.parser.grouping.ast.istruePredicate;
 import ai.vespa.schemals.parser.grouping.ast.notPredicate;
 import ai.vespa.schemals.parser.grouping.ast.number;
 import ai.vespa.schemals.parser.grouping.ast.orFunction;
@@ -248,6 +250,7 @@ class VespaGroupingSemanticToken {
         put(new Pair<>(AND.class, andPredicate.class), logicalFilter);
         put(new Pair<>(OR.class, orPredicate.class), logicalFilter);
         put(new Pair<>(NOT.class, notPredicate.class), logicalFilter);
+        put(new Pair<>(ISTRUE.class, istruePredicate.class), logicalFilter);
 
         put(new Pair<>(AND.class, andFunction.class), simpleExpressions);
         put(new Pair<>(OR.class, orFunction.class), simpleExpressions);

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/IsTruePredicateNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/IsTruePredicateNode.java
@@ -1,0 +1,71 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchlib.expression;
+
+import com.yahoo.vespa.objects.Deserializer;
+import com.yahoo.vespa.objects.ObjectVisitor;
+import com.yahoo.vespa.objects.Serializer;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Protocol class for {@code IsTruePredicate}.
+ *
+ * @author johsol
+ */
+public class IsTruePredicateNode extends FilterExpressionNode {
+
+    public static final int classId = registerClass(0x4000 + 180, IsTruePredicateNode.class, IsTruePredicateNode::new);
+
+    private ExpressionNode expression;
+
+    public IsTruePredicateNode() {
+    }
+
+    public IsTruePredicateNode(ExpressionNode expression) {
+        this.expression = expression;
+    }
+
+    public Optional<ExpressionNode> getExpression() {
+        return Optional.ofNullable(expression);
+    }
+
+    @Override
+    protected int onGetClassId() {
+        return classId;
+    }
+
+    @Override
+    public IsTruePredicateNode clone() {
+        return new IsTruePredicateNode(expression != null ? expression.clone() : null);
+    }
+
+    @Override
+    protected void onSerialize(Serializer buf) {
+        serializeOptional(buf, expression);
+    }
+
+    @Override
+    protected void onDeserialize(Deserializer buf) {
+        expression = (ExpressionNode) deserializeOptional(buf);
+    }
+
+    @Override
+    public void visitMembers(ObjectVisitor visitor) {
+        super.visitMembers(visitor);
+        visitor.visit("expression", expression);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IsTruePredicateNode that = (IsTruePredicateNode) o;
+        return Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expression);
+    }
+}

--- a/searchlib/src/vespa/searchlib/aggregation/grouping.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/grouping.cpp
@@ -211,10 +211,6 @@ void
 Grouping::merge(Grouping & b)
 {
     _root.merge(_levels, _firstLevel, 0, b._root);
-    // If either grouping is invalid, the merged result should be invalid
-    if (!b._valid) {
-        _valid = false;
-    }
 }
 
 void

--- a/searchlib/src/vespa/searchlib/aggregation/grouping.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/grouping.cpp
@@ -211,6 +211,10 @@ void
 Grouping::merge(Grouping & b)
 {
     _root.merge(_levels, _firstLevel, 0, b._root);
+    // If either grouping is invalid, the merged result should be invalid
+    if (!b._valid) {
+        _valid = false;
+    }
 }
 
 void

--- a/searchlib/src/vespa/searchlib/common/identifiable.h
+++ b/searchlib/src/vespa/searchlib/common/identifiable.h
@@ -187,3 +187,4 @@
 #define CID_search_expression_RangePredicateNode            SEARCHLIB_CID(178)
 
 #define CID_search_aggregation_QuantileAggregationResult    SEARCHLIB_CID(179)
+#define CID_search_expression_IsTruePredicateNode           SEARCHLIB_CID(180)

--- a/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/expression/CMakeLists.txt
@@ -40,6 +40,7 @@ vespa_add_library(searchlib_expression OBJECT
     integerresultnode.cpp
     range_predicate_node.cpp
     regex_predicate_node.cpp
+    istrue_predicate_node.cpp
     not_predicate_node.cpp
     multi_arg_predicate_node.cpp
     or_predicate_node.cpp

--- a/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
@@ -1,8 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "istrue_predicate_node.h"
 #include "integerresultnode.h"
-#include "resultnode.h"
-#include "resultvector.h"
 
 #include <vespa/vespalib/util/exceptions.h>
 
@@ -17,10 +15,6 @@ IMPLEMENT_IDENTIFIABLE_NS2(search, expression, IsTruePredicateNode, FilterPredic
 
 namespace {
 
-bool is_bool_result(const ResultNode* result) {
-    return result->inherits(BoolResultNode::classId);
-}
-
 const BoolResultNode* as_bool_result(const ResultNode* result) {
     return static_cast<const BoolResultNode*>(result);
 }
@@ -28,23 +22,9 @@ const BoolResultNode* as_bool_result(const ResultNode* result) {
 }
 
 bool IsTruePredicateNode::check(const ResultNode* result) const {
-    if (result->inherits(ResultNodeVector::classId)) {
-        const auto* result_vector = static_cast<const ResultNodeVector *>(result);
-        for (const auto& node : *result_vector) {
-            if (!is_bool_result(&node)) {
-                throw vespalib::IllegalArgumentException(
-                    std::format("istrue() requires boolean input, got {}", node.getClass().name()));
-            }
-            if (as_bool_result(&node)->getBool()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    if (!is_bool_result(result)) {
+    if (!result->inherits(BoolResultNode::classId)) {
         throw vespalib::IllegalArgumentException(
-            std::format("istrue() requires boolean input, got %s", result->getClass().name()));
+            std::format("istrue() requires boolean input, got {}", result->getClass().name()));
     }
 
     return as_bool_result(result)->getBool();
@@ -78,7 +58,6 @@ IsTruePredicateNode::IsTruePredicateNode(ExpressionNode::UP input)
   : _expression(std::move(input))
 {
 }
-
 
 Serializer& IsTruePredicateNode::onSerialize(Serializer& os) const {
     return os << _expression;

--- a/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
@@ -1,0 +1,101 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "istrue_predicate_node.h"
+#include "integerresultnode.h"
+#include "resultnode.h"
+#include "resultvector.h"
+
+#include <vespa/vespalib/util/exceptions.h>
+
+#include <format>
+
+namespace search::expression {
+
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+IMPLEMENT_IDENTIFIABLE_NS2(search, expression, IsTruePredicateNode, FilterPredicateNode);
+
+namespace {
+
+bool is_bool_result(const ResultNode* result) {
+    return result->inherits(BoolResultNode::classId);
+}
+
+const BoolResultNode* as_bool_result(const ResultNode* result) {
+    return static_cast<const BoolResultNode*>(result);
+}
+
+}
+
+bool IsTruePredicateNode::check(const ResultNode* result) const {
+    if (result->inherits(ResultNodeVector::classId)) {
+        const auto* result_vector = static_cast<const ResultNodeVector *>(result);
+        for (const auto& node : *result_vector) {
+            if (!is_bool_result(&node)) {
+                throw vespalib::IllegalArgumentException(
+                    std::format("istrue() requires boolean input, got {}", node.getClass().name()));
+            }
+            if (as_bool_result(&node)->getBool()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (!is_bool_result(result)) {
+        throw vespalib::IllegalArgumentException(
+            std::format("istrue() requires boolean input, got %s", result->getClass().name()));
+    }
+
+    return as_bool_result(result)->getBool();
+}
+
+bool IsTruePredicateNode::allow(const document::Document& doc, HitRank rank) {
+    if (_expression.getRoot()) {
+        _expression.execute(doc, rank);
+        return check(_expression.getResult());
+    }
+    return false;
+}
+
+bool IsTruePredicateNode::allow(DocId docId, HitRank rank) {
+    if (_expression.getRoot()) {
+        _expression.execute(docId, rank);
+        return check(_expression.getResult());
+    }
+    return false;
+}
+
+IsTruePredicateNode::IsTruePredicateNode() noexcept = default;
+
+IsTruePredicateNode::~IsTruePredicateNode() = default;
+
+IsTruePredicateNode::IsTruePredicateNode(const IsTruePredicateNode&) = default;
+
+IsTruePredicateNode& IsTruePredicateNode::operator=(const IsTruePredicateNode&) = default;
+
+IsTruePredicateNode::IsTruePredicateNode(ExpressionNode::UP input)
+  : _expression(std::move(input))
+{
+}
+
+
+Serializer& IsTruePredicateNode::onSerialize(Serializer& os) const {
+    return os << _expression;
+}
+
+Deserializer& IsTruePredicateNode::onDeserialize(Deserializer& is) {
+    is >> _expression;
+    return is;
+}
+
+void IsTruePredicateNode::visitMembers(vespalib::ObjectVisitor& visitor) const {
+    visit(visitor, "expression", _expression);
+}
+
+void IsTruePredicateNode::selectMembers(const vespalib::ObjectPredicate& predicate,
+                                        vespalib::ObjectOperation& operation) {
+    _expression.select(predicate, operation);
+}
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.h
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "expressiontree.h"
+#include "filter_predicate_node.h"
+
+namespace search::expression {
+
+/**
+ * Implements istrue filter in grouping expressions.
+ *
+ * Checks if a boolean expression evaluates to true. The expression must
+ * evaluate to a BoolResultNode, otherwise grouping will fail with an error.
+ **/
+class IsTruePredicateNode : public FilterPredicateNode {
+    ExpressionTree _expression;
+
+    [[nodiscard]] bool check(const ResultNode* result) const;
+
+public:
+    IsTruePredicateNode() noexcept;
+    ~IsTruePredicateNode() override;
+    IsTruePredicateNode(const IsTruePredicateNode&);
+    IsTruePredicateNode& operator=(const IsTruePredicateNode&);
+
+    [[nodiscard]] IsTruePredicateNode* clone() const override { return new IsTruePredicateNode(*this); }
+
+    // for unit testing:
+    explicit IsTruePredicateNode(ExpressionNode::UP input);
+
+    DECLARE_IDENTIFIABLE_NS2(search, expression, IsTruePredicateNode);
+    DECLARE_NBO_SERIALIZE;
+    bool allow(DocId docId, HitRank rank) override;
+    bool allow(const document::Document&, HitRank) override;
+    void visitMembers(vespalib::ObjectVisitor& visitor) const override;
+    void selectMembers(const vespalib::ObjectPredicate& predicate,
+                       vespalib::ObjectOperation& operation) override;
+};
+
+} // namespace search::expression

--- a/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.h
+++ b/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.h
@@ -9,8 +9,9 @@ namespace search::expression {
 /**
  * Implements istrue filter in grouping expressions.
  *
- * Checks if a boolean expression evaluates to true. The expression must
- * evaluate to a BoolResultNode, otherwise grouping will fail with an error.
+ * Checks if a boolean expression evaluates to true. The expression is expected
+ * to evaluate to a BoolResultNode. If it is not a boolean, this predicate will
+ * throw.
  **/
 class IsTruePredicateNode : public FilterPredicateNode {
     ExpressionTree _expression;


### PR DESCRIPTION
- Syntax: `istrue ( EXPR )`
- The `EXPR` must evaluate to a boolean value. Otherwise, grouping will fail.
- Allocates identifiable id 180 for istrue.
- Wrapped `_filter.allow` in try catch.
- Adds grammar to the language server.

Errors surface like this:
- Query: `... | all(group(a) filter(istrue(n)) each(output(count())))`
- Result: `Grouping filter error: istrue() requires boolean input, got search::expression::Int64ResultNode`

Will make the error message print human-readable types soon.

@arnej27959 please review