### PR TITLE
Add minimum node count validator for first-time deployments

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -763,6 +763,7 @@
       "public static final enum com.yahoo.config.application.api.ValidationId pagedSettingRemoval",
       "public static final enum com.yahoo.config.application.api.ValidationId redundancyIncrease",
       "public static final enum com.yahoo.config.application.api.ValidationId redundancyOne",
+      "public static final enum com.yahoo.config.application.api.ValidationId minimumNodeCount",
       "public static final enum com.yahoo.config.application.api.ValidationId resourcesReduction",
       "public static final enum com.yahoo.config.application.api.ValidationId skipOldConfigModels",
       "public static final enum com.yahoo.config.application.api.ValidationId tensorTypeChange",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/ValidationId.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/ValidationId.java
@@ -27,6 +27,7 @@ public enum ValidationId {
     pagedSettingRemoval("paged-setting-removal", "Removing paged for an attribute. May cause content nodes to run out of memory"),
     redundancyIncrease("redundancy-increase", "Not in use"), // TODO: Remove on Vespa 9
     redundancyOne("redundancy-one", "Setting redundancy=1 requires a validation override on first deployment"),
+    minimumNodeCount("minimum-node-count", "Deploying clusters with fewer than 2 nodes in production requires a validation override on first deployment"),
     resourcesReduction("resources-reduction", "Large reductions in node resources (> 50% of the current max total resources)"),
     skipOldConfigModels("skip-old-config-models", "For internal use, skip building old config models"),
     tensorTypeChange("tensor-type-change", "NOT USED"), // TODO: Remove on Vespa 9

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -86,7 +86,7 @@ public class VespaModelFactory implements ModelFactory {
                 Clock.systemUTC(), Zone.defaultZone());
     }
 
-    private VespaModelFactory(Version version, ConfigModelRegistry configModelRegistry, Clock clock, Zone zone) {
+    protected VespaModelFactory(Version version, ConfigModelRegistry configModelRegistry, Clock clock, Zone zone) {
         this.version = version;
         if (configModelRegistry == null) {
             this.configModelRegistry = new NullConfigModelRegistry();

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -27,6 +27,7 @@ import com.yahoo.vespa.model.application.validation.change.RestartOnDeployForTri
 import com.yahoo.vespa.model.application.validation.change.StartupCommandChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.StreamingSearchClusterChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.VespaRestartAction;
+import com.yahoo.vespa.model.application.validation.first.MinimumNodeCountValidator;
 import com.yahoo.vespa.model.application.validation.first.RedundancyValidator;
 import com.yahoo.yolean.Exceptions;
 
@@ -124,6 +125,7 @@ public class Validation {
 
     private static void validateFirstTimeDeployment(Execution execution) {
         new RedundancyValidator().validate((Context) execution);
+        new MinimumNodeCountValidator().validate((Context) execution);
     }
 
     private static void validateChanges(Execution execution) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -125,7 +125,7 @@ public class Validation {
 
     private static void validateFirstTimeDeployment(Execution execution) {
         new RedundancyValidator().validate((Context) execution);
-        new MinimumNodeCountValidator().validate((Context) execution);
+        new MinimumNodeCountValidator().validate(execution);
     }
 
     private static void validateChanges(Execution execution) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -125,7 +125,7 @@ public class Validation {
 
     private static void validateFirstTimeDeployment(Execution execution) {
         new RedundancyValidator().validate((Context) execution);
-        new MinimumNodeCountValidator().validate(execution);
+        new MinimumNodeCountValidator().validate((Context) execution);
     }
 
     private static void validateChanges(Execution execution) {
@@ -142,6 +142,7 @@ public class Validation {
         new NodeResourceChangeValidator().validate(execution);
         new CertificateRemovalChangeValidator().validate(execution);
         new RedundancyValidator().validate(execution);
+        new MinimumNodeCountValidator().validate(execution);
         new RestartOnDeployForOnnxModelChangesValidator().validate(execution);
         new RestartOnDeployForLocalLLMValidator().validate(execution);
         new RestartOnDeployForTritonOnnxRuntimeValidator().validate(execution);

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidator.java
@@ -1,0 +1,65 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation.first;
+
+import com.yahoo.config.application.api.ValidationId;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.application.validation.Validation.Context;
+import com.yahoo.vespa.model.application.validation.Validator;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.content.cluster.ContentCluster;
+
+import java.util.stream.Stream;
+
+/**
+ * Validates that applications in prod zones have at least 2 nodes in each cluster (without a validation override).
+ *
+ * @author hmusum
+ */
+public class MinimumNodeCountValidator implements Validator {
+
+    private static final int MINIMUM_NODE_COUNT = 2;
+
+    /** Validate on first deployment. */
+    @Override
+    public void validate(Context context) {
+        if ( ! shouldValidate(context.deployState())) return;
+
+        clustersWithTooFewNodes(context.model()).forEach(clusterName ->
+            invalidNodeCount(clusterName, context));
+    }
+
+    private boolean shouldValidate(DeployState deployState) {
+        return deployState.isHosted() && deployState.zone().environment().isProduction();
+    }
+
+    private Stream<String> clustersWithTooFewNodes(VespaModel model) {
+        Stream<String> contentClusters = model.getContentClusters().values().stream()
+                .filter(this::hasTooFewNodes)
+                .map(cluster -> "content cluster '" + cluster.id().value() + "'");
+
+        Stream<String> containerClusters = model.getContainerClusters().values().stream()
+                .filter(this::hasTooFewNodes)
+                .map(cluster -> "container cluster '" + cluster.id().value() + "'");
+
+        return Stream.concat(contentClusters, containerClusters);
+    }
+
+    private boolean hasTooFewNodes(ContentCluster cluster) {
+        if (cluster == null) return false;
+        return cluster.getRootGroup().countNodes(false) < MINIMUM_NODE_COUNT;
+    }
+
+    private boolean hasTooFewNodes(ApplicationContainerCluster cluster) {
+        if (cluster == null) return false;
+        return cluster.getContainers().size() < MINIMUM_NODE_COUNT;
+    }
+
+    private void invalidNodeCount(String clusterName, Context context) {
+        context.invalid(ValidationId.minimumNodeCount,
+                        clusterName + " has less than " + MINIMUM_NODE_COUNT + " nodes, " +
+                        "which may cause service disruption during node failures or upgrades. " +
+                        "This requires an override on first deployment in a production zone");
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidator.java
@@ -4,19 +4,19 @@ package com.yahoo.vespa.model.application.validation.first;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.application.validation.Validation.Context;
 import com.yahoo.vespa.model.application.validation.Validator;
+import com.yahoo.vespa.model.application.validation.change.ChangeValidator;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
-
-import java.util.stream.Stream;
 
 /**
  * Validates that applications in prod zones have at least 2 nodes in each cluster (without a validation override).
  *
  * @author hmusum
  */
-public class MinimumNodeCountValidator implements Validator {
+public class MinimumNodeCountValidator implements Validator, ChangeValidator {
 
     private static final int MINIMUM_NODE_COUNT = 2;
 
@@ -25,24 +25,35 @@ public class MinimumNodeCountValidator implements Validator {
     public void validate(Context context) {
         if ( ! shouldValidate(context.deployState())) return;
 
-        clustersWithTooFewNodes(context.model()).forEach(clusterName ->
-            invalidNodeCount(clusterName, context));
+        validateContentClusters(context.model(), null, context);
+        validateContainerClusters(context.model(), null, context);
+    }
+
+    /** Validate on change. */
+    @Override
+    public void validate(ChangeContext context) {
+        if ( ! shouldValidate(context.deployState())) return;
+
+        validateContentClusters(context.model(), context.previousModel(), context);
+        validateContainerClusters(context.model(), context.previousModel(), context);
     }
 
     private boolean shouldValidate(DeployState deployState) {
         return deployState.isHosted() && deployState.zone().environment().isProduction();
     }
 
-    private Stream<String> clustersWithTooFewNodes(VespaModel model) {
-        Stream<String> contentClusters = model.getContentClusters().values().stream()
+    private void validateContentClusters(VespaModel model, VespaModel previousModel, Context context) {
+        model.getContentClusters().values().stream()
                 .filter(this::hasTooFewNodes)
-                .map(cluster -> "content cluster '" + cluster.id().value() + "'");
+                .filter(cluster -> previousModel == null || ! hasTooFewNodes(previousModel.getContentClusters().get(cluster.id().value())))
+                .forEach(cluster -> invalidNodeCount("content cluster '" + cluster.id().value() + "'", context));
+    }
 
-        Stream<String> containerClusters = model.getContainerClusters().values().stream()
+    private void validateContainerClusters(VespaModel model, VespaModel previousModel, Context context) {
+        model.getContainerClusters().values().stream()
                 .filter(this::hasTooFewNodes)
-                .map(cluster -> "container cluster '" + cluster.id().value() + "'");
-
-        return Stream.concat(contentClusters, containerClusters);
+                .filter(cluster -> previousModel == null || ! hasTooFewNodes(previousModel.getContainerClusters().get(cluster.id().value())))
+                .forEach(cluster -> invalidNodeCount("container cluster '" + cluster.id().value() + "'", context));
     }
 
     private boolean hasTooFewNodes(ContentCluster cluster) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
@@ -57,7 +57,7 @@ public class ContentTypeRemovalValidatorTest {
                "    <documents>" +
                "      <document type='" + documentType + "' mode='index'/>" +
                "    </documents>" +
-               "    <nodes count='1'/>" +
+               "    <nodes count='2'/>" +
                "   </content>" +
                "</services>";
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidatorTest.java
@@ -52,7 +52,7 @@ public class GlobalDocumentChangeValidatorTest {
                 "      <document type='music' mode='index' global='" +
                 isGlobal + "'/>" +
                 "    </documents>" +
-                "    <nodes count='1'/>" +
+                "    <nodes count='2'/>" +
                 "   </content>" +
                 "</services>";
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidatorTest.java
@@ -11,6 +11,7 @@ import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -35,9 +36,9 @@ public class MinimumNodeCountValidatorTest {
         catch (Exception expected) {
             String message = Exceptions.toMessageString(expected);
             // Verify that minimum-node-count validation is triggered for both content and indexing clusters
-            assert message.contains("minimum-node-count") : "Expected 'minimum-node-count' in: " + message;
-            assert message.contains("content cluster 'contentClusterId'") : "Expected content cluster in: " + message;
-            assert message.contains("contentClusterId.indexing") : "Expected indexing cluster in: " + message;
+            assertTrue(message.contains("minimum-node-count"), "Expected 'minimum-node-count' in: " + message);
+            assertTrue(message.contains("content cluster 'contentClusterId'"), "Expected content cluster in: " + message);
+            assertTrue(message.contains("contentClusterId.indexing"), "Expected indexing cluster in: " + message);
         }
     }
 
@@ -49,8 +50,8 @@ public class MinimumNodeCountValidatorTest {
         }
         catch (Exception expected) {
             String message = Exceptions.toMessageString(expected);
-            assert message.contains("Deploying clusters with fewer than 2 nodes in production requires a validation override on first deployment");
-            assert message.contains("container cluster 'default'");
+            assertTrue(message.contains("Deploying clusters with fewer than 2 nodes in production requires a validation override on first deployment"));
+            assertTrue(message.contains("container cluster 'default'"));
         }
     }
 
@@ -88,8 +89,8 @@ public class MinimumNodeCountValidatorTest {
         }
         catch (Exception expected) {
             String message = Exceptions.toMessageString(expected);
-            assert message.contains("minimum-node-count") : "Expected 'minimum-node-count' in: " + message;
-            assert message.contains("content cluster 'contentClusterId'") : "Expected content cluster in: " + message;
+            assertTrue(message.contains("minimum-node-count"), "Expected 'minimum-node-count' in: " + message);
+            assertTrue(message.contains("content cluster 'contentClusterId'"), "Expected content cluster in: " + message);
         }
     }
 
@@ -116,8 +117,8 @@ public class MinimumNodeCountValidatorTest {
         }
         catch (Exception expected) {
             String message = Exceptions.toMessageString(expected);
-            assert message.contains("minimum-node-count") : "Expected 'minimum-node-count' in: " + message;
-            assert message.contains("container cluster 'default'") : "Expected container cluster in: " + message;
+            assertTrue(message.contains("minimum-node-count"), "Expected 'minimum-node-count' in: " + message);
+            assertTrue(message.contains("container cluster 'default'"), "Expected container cluster in: " + message);
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/MinimumNodeCountValidatorTest.java
@@ -1,0 +1,117 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation.first;
+
+import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.vespa.model.application.validation.ValidationTester;
+import com.yahoo.yolean.Exceptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author hmusum
+ */
+public class MinimumNodeCountValidatorTest {
+
+    private static final Zone zone = new Zone(SystemName.main, Environment.prod, RegionName.from("us-east"));
+
+    private final ValidationTester tester = new ValidationTester(7, false,
+                                                                 new TestProperties().setFirstTimeDeployment(true)
+                                                                                     .setHostedVespa(true),
+                                                                 zone);
+
+    @Test
+    void testMinimumNodeCountValidationForContentCluster() {
+        try {
+            // Content cluster with 1 node will trigger both minimum-node-count and redundancy-one validators
+            tester.deploy(null, getContentClusterServices(1, 1), zone, null, "contentClusterId.indexing");
+            fail("Expected exception due to too few nodes");
+        }
+        catch (Exception expected) {
+            String message = Exceptions.toMessageString(expected);
+            // Verify that minimum-node-count validation is triggered for both content and indexing clusters
+            assert message.contains("minimum-node-count") : "Expected 'minimum-node-count' in: " + message;
+            assert message.contains("content cluster 'contentClusterId'") : "Expected content cluster in: " + message;
+            assert message.contains("contentClusterId.indexing") : "Expected indexing cluster in: " + message;
+        }
+    }
+
+    @Test
+    void testMinimumNodeCountValidationForContainerCluster() {
+        try {
+            tester.deploy(null, getContainerClusterServices(1), zone, null);
+            fail("Expected exception due to too few nodes");
+        }
+        catch (Exception expected) {
+            String message = Exceptions.toMessageString(expected);
+            assert message.contains("Deploying clusters with fewer than 2 nodes in production requires a validation override on first deployment");
+            assert message.contains("container cluster 'default'");
+        }
+    }
+
+    @Test
+    void testOverridingMinimumNodeCountValidation() {
+        assertDoesNotThrow(() -> {
+            // Need both overrides since content cluster with 1 node triggers both validators
+            tester.deploy(null, getContentClusterServices(1, 1), zone, bothOverrides, "contentClusterId.indexing");
+        });
+        assertDoesNotThrow(() -> {
+            tester.deploy(null, getContainerClusterServices(1), zone, minimumNodeCountOverride);
+        });
+    }
+
+    @Test
+    void testMinimumNodeCountValidationPasses() {
+        // Should not throw exception when we have 2 or more nodes
+        assertDoesNotThrow(() -> {
+            tester.deploy(null, getContentClusterServices(2, 2), zone, null, "contentClusterId.indexing");
+        });
+        assertDoesNotThrow(() -> {
+            tester.deploy(null, getContainerClusterServices(2), zone, null);
+        });
+    }
+
+    private static String getContentClusterServices(int nodeCount, int redundancy) {
+        return "<services version='1.0'>" +
+               "  <content id='contentClusterId' version='1.0'>" +
+               "    <redundancy>" + redundancy + "</redundancy>" +
+               "    <engine>" +
+               "    <proton/>" +
+               "    </engine>" +
+               "    <documents>" +
+               "      <document type='music' mode='index'/>" +
+               "    </documents>" +
+               "    <nodes count='" + nodeCount + "'/>" +
+               "   </content>" +
+               "</services>";
+    }
+
+    private static String getContainerClusterServices(int nodeCount) {
+        return "<services version='1.0'>" +
+               "  <container id='default' version='1.0'>" +
+               "    <nodes count='" + nodeCount + "'/>" +
+               "   </container>" +
+               "</services>";
+    }
+
+    private static final String minimumNodeCountOverride =
+            """
+                    <validation-overrides>
+                        <allow until='2000-01-03'>minimum-node-count</allow>
+                    </validation-overrides>
+                    """;
+
+    private static final String bothOverrides =
+            """
+                    <validation-overrides>
+                        <allow until='2000-01-03'>minimum-node-count</allow>
+                        <allow until='2000-01-03'>redundancy-one</allow>
+                    </validation-overrides>
+                    """;
+
+}

--- a/configserver/src/test/apps/hosted-routing-app/validation-overrides.xml
+++ b/configserver/src/test/apps/hosted-routing-app/validation-overrides.xml
@@ -1,0 +1,3 @@
+<validation-overrides>
+    <allow until='2026-02-01'>minimum-node-count</allow>
+</validation-overrides>

--- a/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/validation-overrides.xml
+++ b/configserver/src/test/apps/hosted-with-duplicated-hosts-in-hosts-xml/validation-overrides.xml
@@ -1,0 +1,3 @@
+<validation-overrides>
+    <allow until='2026-02-01'>minimum-node-count</allow>
+</validation-overrides>

--- a/configserver/src/test/apps/hosted/validation-overrides.xml
+++ b/configserver/src/test/apps/hosted/validation-overrides.xml
@@ -1,0 +1,3 @@
+<validation-overrides>
+    <allow until='2026-02-01'>minimum-node-count</allow>
+</validation-overrides>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -18,6 +18,7 @@ import com.yahoo.container.handler.VipStatus;
 import com.yahoo.container.jdisc.state.StateMonitor;
 import com.yahoo.docproc.jdisc.metric.NullMetric;
 import com.yahoo.path.Path;
+import com.yahoo.test.ManualClock;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.config.server.deploy.DeployTester;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
@@ -57,6 +58,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ConfigServerBootstrapTest {
 
+    private final ManualClock clock = new ManualClock("2026-02-01T00:00:00");
+
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -64,7 +67,7 @@ public class ConfigServerBootstrapTest {
     public void testBootstrap() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
         InMemoryProvisioner provisioner = new InMemoryProvisioner(9, false);
-        DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory())
+        DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory(clock))
                                                                        .configserverConfig(configserverConfig)
                                                                        .hostProvisioner(provisioner).build();
         tester.deployApp("src/test/apps/hosted/");
@@ -103,7 +106,7 @@ public class ConfigServerBootstrapTest {
     public void testBootstrapWithVipStatusFile() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
         InMemoryProvisioner provisioner = new InMemoryProvisioner(9, false);
-        DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory())
+        DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory(clock))
                 .configserverConfig(configserverConfig).hostProvisioner(provisioner).build();
         tester.deployApp("src/test/apps/hosted/");
 
@@ -123,7 +126,7 @@ public class ConfigServerBootstrapTest {
     @Test
     public void testBootstrapWhenRedeploymentFails() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
-        DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory())
+        DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory(clock))
                 .configserverConfig(configserverConfig).build();
         tester.deployApp("src/test/apps/hosted/");
 
@@ -156,7 +159,7 @@ public class ConfigServerBootstrapTest {
         List<Host> hosts = createHosts(vespaVersion);
         Curator curator = new MockCurator();
         DeployTester tester = new DeployTester.Builder(temporaryFolder)
-                .modelFactory(DeployTester.createModelFactory(Version.fromString(vespaVersion)))
+                .modelFactory(DeployTester.createModelFactory(Version.fromString(vespaVersion), clock))
                 .hostProvisioner(new InMemoryProvisioner(new Hosts(hosts), true, false))
                 .configserverConfig(configserverConfig)
                 .zone(new Zone(Environment.dev, RegionName.defaultName()))
@@ -186,7 +189,7 @@ public class ConfigServerBootstrapTest {
         String oldVespaVersion = "8.100.1";
         Curator curator = new MockCurator();
         DeployTester tester = new DeployTester.Builder(temporaryFolder)
-                .modelFactory(DeployTester.createModelFactory(Version.fromString(oldVespaVersion)))
+                .modelFactory(DeployTester.createModelFactory(Version.fromString(oldVespaVersion), clock))
                 .configserverConfig(configserverConfig)
                 .curator(curator)
                 .build();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/model/TestModelFactory.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/model/TestModelFactory.java
@@ -7,7 +7,10 @@ import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.ModelCreateResult;
 import com.yahoo.config.model.api.ValidationParameters;
 import com.yahoo.component.Version;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModelFactory;
+
+import java.time.Clock;
 
 /**
  * @author Ulf Lilleengen
@@ -22,7 +25,11 @@ public class TestModelFactory extends VespaModelFactory {
     }
 
     public TestModelFactory(ConfigModelRegistry registry, Version vespaVersion) {
-        super(registry);
+        this(registry, vespaVersion, Clock.systemUTC());
+    }
+
+    public TestModelFactory(ConfigModelRegistry registry, Version vespaVersion, Clock clock) {
+        super(vespaVersion, registry, clock, Zone.defaultZone());
         this.vespaVersion = vespaVersion;
     }
 


### PR DESCRIPTION
Add a new validator that checks if clusters have at least 2 nodes in production environments during first-time deployment.

The validator:
- Checks both content clusters and container clusters
- Only runs on first-time deployments in production zones
- Can be overridden using the 'minimum-node-count' validation override

Needs some changes in internal repo as well
