### PR TITLE
Add applyOnRestart on ApplicationMetadataConfig with feature flag

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1359,7 +1359,8 @@
       "public java.lang.Object sidecarsForTest()",
       "public boolean useTriton()",
       "public int searchCoreMaxOutstandingMoveOps()",
-      "public double docprocHandlerThreadpool()"
+      "public double docprocHandlerThreadpool()",
+      "public boolean applyOnRestartForApplicationMetadataConfig()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -116,6 +116,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"bjorncs"}) default boolean useTriton() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int searchCoreMaxOutstandingMoveOps() { return 100; }
         @ModelFeatureFlag(owners = {"johsol"}) default double docprocHandlerThreadpool() { return 1.0; }
+        @ModelFeatureFlag(owners = {"glebashnik"}) default boolean applyOnRestartForApplicationMetadataConfig() { return false; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -208,6 +208,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean useTriton;
         private final int searchCoreMaxOutstandingMoveOps;
         private final double docprocHandlerThreadpool;
+        private final boolean applyOnRestartForApplicationMetadataConfig;
         private final IntFlag heapSizePercentageFlag;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
@@ -254,6 +255,7 @@ public class ModelContextImpl implements ModelContext {
             this.useTriton = Flags.USE_TRITON.bindTo(source).with(appId).with(version).value();
             this.searchCoreMaxOutstandingMoveOps = Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS.bindTo(source).with(appId).with(version).value();
             this.docprocHandlerThreadpool = Flags.DOCPROC_HANDLER_THREADPOOL.bindTo(source).with(appId).with(version).value();
+            this.applyOnRestartForApplicationMetadataConfig = Flags.APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG.bindTo(source).with(appId).with(version).value();
         }
 
         @Override public boolean useNonPublicEndpointForTest() { return useNonPublicEndpointForTest; }
@@ -301,6 +303,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean useTriton() { return useTriton; }
         @Override public int searchCoreMaxOutstandingMoveOps() { return searchCoreMaxOutstandingMoveOps; }
         @Override public double docprocHandlerThreadpool() { return docprocHandlerThreadpool; }
+        @Override public boolean applyOnRestartForApplicationMetadataConfig() { return applyOnRestartForApplicationMetadataConfig; }
     }
 
     public static class Properties implements ModelContext.Properties {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -402,7 +402,7 @@ public class Flags {
     public static final UnboundBooleanFlag APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG = defineFeatureFlag(
             "apply-on-restart-for-application-metadata-config", false,
             List.of("glebashnik"), "2026-02-13", "2026-08-13",
-            "Whether to set applyOnRestart flag on ApplicationMetadataConfig and ComponentsConfig. " + 
+            "Whether to set applyOnRestart flag on ApplicationMetadataConfig. " + 
                     "This might fix deferring config changes until container restart.",
             "Takes effect at redeployment",
             INSTANCE_ID

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -399,6 +399,15 @@ public class Flags {
             INSTANCE_ID
     );
 
+    public static final UnboundBooleanFlag APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG = defineFeatureFlag(
+            "apply-on-restart-for-application-metadata-config", false,
+            List.of("glebashnik"), "2026-02-13", "2026-08-13",
+            "Whether to set applyOnRestart flag on ApplicationMetadataConfig and ComponentsConfig. " + 
+                    "This might fix deferring config changes until container restart.",
+            "Takes effect at redeployment",
+            INSTANCE_ID
+    );
+
     public static final UnboundDoubleFlag HOST_MEMORY_SERVICES_MIXING_FACTOR = defineDoubleFlag(
             "host-memory-services-mixing-factor", 0.0,
             List.of("boeker"), "2026-01-16", "2026-04-16",


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Same as https://github.com/vespa-engine/vespa/pull/35637 but this time with a feature flag for testing.
Intends to fix deferring applying config on restart.
