### PR TITLE
Use explicit locale and charset in config-proxy tests

### DIFF
--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ConfigProxyRpcServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ConfigProxyRpcServerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -229,7 +230,7 @@ public class ConfigProxyRpcServerTest {
         client.invoke(req);
         assertFalse(req.isError(), req.errorMessage());
         assertEquals(1, req.returnValues().size());
-        assertEquals("Cannot update sources when in '" + Mode.ModeName.MEMORYCACHE.name().toLowerCase() + "' mode", req.returnValues().get(0).asString());
+        assertEquals("Cannot update sources when in '" + Mode.ModeName.MEMORYCACHE.name().toLowerCase(Locale.ROOT) + "' mode", req.returnValues().get(0).asString());
 
         // TODO source connections needs to have deterministic order to work
         /*req = new Request("listSourceConnections");

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/UrlDownloaderTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/UrlDownloaderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -23,7 +24,7 @@ public class UrlDownloaderTest {
 
         assertFalse(downloader.alreadyDownloaded(temporaryFolder));
 
-        Files.write(temporaryFolder.toPath().resolve("foo"), "bar".getBytes());
+        Files.write(temporaryFolder.toPath().resolve("foo"), "bar".getBytes(StandardCharsets.UTF_8));
         assertTrue(downloader.alreadyDownloaded(temporaryFolder));
     }
 }


### PR DESCRIPTION
Specify Locale.ROOT for toLowerCase() and StandardCharsets.UTF_8 for getBytes() to avoid platform-dependent behavior in tests.
