### PR TITLE
Fix locale-dependent string operations in tests

### DIFF
--- a/bundle-plugin-test/integration-test/src/test/java/com/yahoo/container/plugin/BundleTest.java
+++ b/bundle-plugin-test/integration-test/src/test/java/com/yahoo/container/plugin/BundleTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -114,7 +115,7 @@ public class BundleTest {
 
         var expected = List.of("ai.vespa.lib.public_api", "com.yahoo.lib.public_api", "com.yahoo.test");
         assertEquals(expected.size(), publicApi.size());
-        expected.forEach(pkg -> assertTrue(publicApi.contains(pkg), "Public api did not contain %s".formatted(pkg)));
+        expected.forEach(pkg -> assertTrue(publicApi.contains(pkg), String.format(Locale.ENGLISH, "Public api did not contain %s", pkg)));
     }
 
     @Test
@@ -125,7 +126,7 @@ public class BundleTest {
 
         var expected = List.of("ai.vespa.internal", "ai.vespa.lib.non_public", "com.yahoo.lib.non_public", "com.yahoo.non_public");
         assertEquals(expected.size(), nonPublicApi.size());
-        expected.forEach(pkg -> assertTrue(nonPublicApi.contains(pkg), "Non-public api did not contain %s".formatted(pkg)));
+        expected.forEach(pkg -> assertTrue(nonPublicApi.contains(pkg), String.format(Locale.ENGLISH, "Non-public api did not contain %s", pkg)));
    }
 
     @Test

--- a/documentgen-test/src/test/java/com/yahoo/vespa/config/DocumentGenPluginTest.java
+++ b/documentgen-test/src/test/java/com/yahoo/vespa/config/DocumentGenPluginTest.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -784,7 +785,7 @@ public class DocumentGenPluginTest {
     }
 
     private String className(String s) {
-        return s.substring(0, 1).toUpperCase()+s.substring(1);
+        return s.substring(0, 1).toUpperCase(Locale.ROOT)+s.substring(1);
     }
 
     private Music getMusicBasic() {


### PR DESCRIPTION
Replace locale-sensitive String.formatted() calls with explicit Locale.ENGLISH in BundleTest.java assertion messages, and specify Locale.ROOT for toUpperCase() operation in DocumentGenPluginTest.java to ensure consistent behavior across different system locales.
