### PR TITLE
Add explicit UTF-8 charset in configserver

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/SessionContentReadResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/SessionContentReadResponse.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -58,7 +59,7 @@ public class SessionContentReadResponse extends HttpResponse {
 
         InputStream resources = Objects.requireNonNull(classLoader.getResourceAsStream("mime.types"),
                                                        "Failed to load resource 'mime.types'");
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(resources))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(resources, StandardCharsets.UTF_8))) {
             while (reader.ready()) {
                 String line = reader.readLine();
                 if (line.isEmpty() || line.charAt(0) == '#') continue;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/version/VersionState.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/version/VersionState.java
@@ -15,6 +15,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -83,7 +85,7 @@ public class VersionState {
 
     public void storeVersion(String vespaVersion) {
         curator.set(versionPath, Utf8.toBytes(vespaVersion));
-        try (FileWriter writer = new FileWriter(versionFile)) {
+        try (var writer = Files.newBufferedWriter(versionFile.toPath(), StandardCharsets.UTF_8)) {
             writer.write(vespaVersion);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -99,7 +101,7 @@ public class VersionState {
                 // continue, use value in file
             }
         }
-        try (FileReader reader = new FileReader(versionFile)) {
+        try (var reader = Files.newBufferedReader(versionFile.toPath(), StandardCharsets.UTF_8)) {
             return Version.fromString(IOUtils.readAll(reader));
         } catch (Exception e) {
             return Version.emptyVersion;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationTest.java
@@ -121,7 +121,7 @@ public class ApplicationTest {
                                             ModelConfig.CONFIG_DEF_NAMESPACE,
                                             ModelConfig.CONFIG_DEF_SCHEMA))
                 .serialize(baos, CompressionType.UNCOMPRESSED);
-        assertTrue(baos.toString().startsWith("{\"vespaVersion\":\"1.0.0\",\"hosts\":[{\"name\":\"mytesthost\""));
+        assertTrue(baos.toString(StandardCharsets.UTF_8).startsWith("{\"vespaVersion\":\"1.0.0\",\"hosts\":[{\"name\":\"mytesthost\""));
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/configchange/ConfigChangeActionsSlimeConverterTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/configchange/ConfigChangeActionsSlimeConverterTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static com.yahoo.vespa.config.server.configchange.Utils.CHANGE_ID;
@@ -34,7 +35,7 @@ public class ConfigChangeActionsSlimeConverterTest {
         new ConfigChangeActionsSlimeConverter(actions).toSlime(root);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         new JsonFormat(false).encode(outputStream, slime);
-        return outputStream.toString();
+        return outputStream.toString(StandardCharsets.UTF_8);
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLoggerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLoggerTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertTrue;
@@ -36,7 +37,7 @@ public class DeployHandlerLoggerTest {
         logMessages(logger);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new JsonFormat(true).encode(baos, logger.slime());
-        assertTrue(Pattern.matches(expectedPattern, baos.toString()));
+        assertTrue(Pattern.matches(expectedPattern, baos.toString(StandardCharsets.UTF_8)));
     }
 
     @SuppressWarnings("deprecation")

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -159,7 +160,7 @@ public class FileServerTest {
         }
 
         fileServer.startFileServing(reference, file.get(), fileReceiver, Set.of(lz4));
-        assertEquals(new String(content.get()), "dummy-data");
+        assertEquals(new String(content.get(), StandardCharsets.UTF_8), "dummy-data");
     }
 
     private void writeFile(String dir) throws IOException {
@@ -214,7 +215,7 @@ public class FileServerTest {
         FileReference fileReference = new FileReference("12y");
         var file = fileServer.getFileDownloadIfNeeded(new FileReferenceDownload(fileReference, "test"));
         fileServer.startFileServing(fileReference, file.get(), new FileReceiver(content), Set.of(compressionType));
-        assertEquals(new String(content.get()), "dummy-data");
+        assertEquals(new String(content.get(), StandardCharsets.UTF_8), "dummy-data");
     }
 
     private static class MockFileDownloader extends FileDownloader {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/SecretStoreValidatorTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/SecretStoreValidatorTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -60,7 +61,7 @@ public class SecretStoreValidatorTest {
         var response = secretStoreValidator.validateSecretStore(app, SystemName.PublicCd, requestBody);
         var body = new ByteArrayOutputStream();
         response.render(body);
-        assertEquals("is ok", body.toString());
+        assertEquals("is ok", body.toString(StandardCharsets.UTF_8));
     }
 
     private Application mockApplication() {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -870,7 +870,7 @@ public class ApplicationHandlerTest {
         if (expectedBody != null) {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             response.render(out);
-            assertJsonEquals(out.toString(), expectedBody);
+            assertJsonEquals(out.toString(UTF_8), expectedBody);
         }
         assertEquals(statusCode, response.getStatus());
     }
@@ -919,14 +919,14 @@ public class ApplicationHandlerTest {
 
     private static void assertResponse(String expectedJson, int status, HttpResponse response) {
         assertResponse((responseBody) -> assertJsonEquals(new String(responseBody
-                                                                             .getBytes()), expectedJson), status, response);
+                                                                             .getBytes(UTF_8), UTF_8), expectedJson), status, response);
     }
 
     private static void assertResponse(Consumer<String> assertFunc, int status, HttpResponse response) {
         ByteArrayOutputStream responseBody = new ByteArrayOutputStream();
         try {
             response.render(responseBody);
-            assertFunc.accept(responseBody.toString());
+            assertFunc.accept(responseBody.toString(UTF_8));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
@@ -29,6 +29,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +140,7 @@ public class SessionCreateHandlerTest extends SessionHandlerTest {
     @Test
     public void require_internal_error_when_exception() throws IOException {
         File outFile = CompressedApplicationInputStreamTest.createTarFile(temporaryFolder.getRoot().toPath());
-        new FileWriter(outFile).write("rubbish");
+        Files.writeString(outFile.toPath(), "rubbish", StandardCharsets.UTF_8);
         HttpResponse response = createHandler().handle(post(outFile));
         assertHttpStatusCodeErrorCodeAndMessage(response, INTERNAL_SERVER_ERROR,
                                                 HttpErrorResponse.ErrorCode.INTERNAL_SERVER_ERROR,

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/monitoring/ZKMetricUpdaterTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/monitoring/ZKMetricUpdaterTest.java
@@ -77,7 +77,7 @@ public class ZKMetricUpdaterTest {
         serverThread = Executors.defaultThreadFactory().newThread(() -> {
             while (!Thread.interrupted()) {
                 try (Socket connection = serverSocket.accept()) {
-                    BufferedReader input = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                    BufferedReader input = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
                     String verb = input.readLine();
                     if ("mntr".equals(verb)) {
                         DataOutputStream output = new DataOutputStream(connection.getOutputStream());

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/security/MultiTenantRpcAuthorizerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/security/MultiTenantRpcAuthorizerTest.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.List;
@@ -272,7 +273,7 @@ public class MultiTenantRpcAuthorizerTest {
         request.setString("clientHostname", hostname);
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             new JsonFormat(false).encode(out, data);
-            return out.toString();
+            return out.toString(StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/EndpointCertificateMetadataStoreTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/EndpointCertificateMetadataStoreTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
@@ -58,7 +59,7 @@ public class EndpointCertificateMetadataStoreTest {
     public void reads_object_format() {
         curator.set(endpointCertificateMetadataPath,
                 "{\"keyName\": \"vespa.tlskeys.tenant1--app1-key\", \"certName\":\"vespa.tlskeys.tenant1--app1-cert\", \"version\": 0}"
-                        .getBytes());
+                        .getBytes(StandardCharsets.UTF_8));
 
         // Read from zk and verify cert and key are available
         var secrets = endpointCertificateMetadataStore.readEndpointCertificateMetadata(applicationId)
@@ -75,6 +76,6 @@ public class EndpointCertificateMetadataStoreTest {
         endpointCertificateMetadataStore.writeEndpointCertificateMetadata(applicationId, endpointCertificateMetadata);
 
         assertEquals("{\"keyName\":\"key-name\",\"certName\":\"cert-name\",\"version\":1,\"issuer\":\"digicert\"}",
-                new String(curator.getData(endpointCertificateMetadataPath).orElseThrow()));
+                new String(curator.getData(endpointCertificateMetadataPath).orElseThrow(), StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
Replace platform-dependent default charset usage with explicit StandardCharsets.UTF_8 in file I/O operations and string conversions. This includes:
- InputStreamReader/OutputStreamReader constructors
- FileReader/FileWriter replaced with Files.newBufferedReader/Writer
- ByteArrayOutputStream.toString() calls
- String constructor from byte arrays
