### PR TITLE
Use explicit locale for string operations in cloud module

### DIFF
--- a/cloud/hosted-api/src/main/java/ai/vespa/hosted/api/TestDescriptor.java
+++ b/cloud/hosted-api/src/main/java/ai/vespa/hosted/api/TestDescriptor.java
@@ -9,6 +9,7 @@ import com.yahoo.slime.SlimeStream;
 import com.yahoo.slime.SlimeUtils;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -87,7 +88,7 @@ public class TestDescriptor {
         addJsonArrayForTests(tests, JSON_FIELD_STAGING_SETUP_TESTS, TestCategory.stagingsetuptest);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         uncheck(() -> new JsonFormat(/*compact*/false).encode(out, slime));
-        return out.toString();
+        return out.toString(StandardCharsets.UTF_8);
     }
 
     private void addJsonArrayForTests(Cursor testsRoot, String fieldName, TestCategory category) {

--- a/cloud/hosted-api/src/test/java/ai/vespa/hosted/api/MultiPartStreamerTest.java
+++ b/cloud/hosted-api/src/test/java/ai/vespa/hosted/api/MultiPartStreamerTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +24,7 @@ class MultiPartStreamerTest {
         MultiPartStreamer streamer = new MultiPartStreamer("My boundary");
 
         assertEquals("--My boundary--",
-                     new String(streamer.data().readAllBytes()));
+                     new String(streamer.data().readAllBytes(), StandardCharsets.UTF_8));
 
         streamer.addData("data", "uss/enterprise", "lore")
                 .addJson("json", "{\"xml\":false}")
@@ -50,14 +52,15 @@ class MultiPartStreamerTest {
                           Content-Type: application/octet-stream\r
                           \r
                           Hi\r
-                          --My boundary--""".formatted(file.getFileName());
+                          --My boundary--""";
+        expected = String.format(Locale.ROOT, expected, file.getFileName());
 
         assertEquals(expected,
-                     new String(streamer.data().readAllBytes()));
+                     new String(streamer.data().readAllBytes(), StandardCharsets.UTF_8));
 
         // Verify that all data is read again for a new builder.
         assertEquals(expected,
-                     new String(streamer.data().readAllBytes()));
+                     new String(streamer.data().readAllBytes(), StandardCharsets.UTF_8));
 
         assertEquals(List.of("multipart/form-data; boundary=My boundary; charset=utf-8"),
                      streamer.streamTo(HttpRequest.newBuilder(), Method.POST)

--- a/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/DisabledInInstances.java
+++ b/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/DisabledInInstances.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -37,7 +38,7 @@ class DisabledInInstancesCondition implements ExecutionCondition {
 
         List<String> disablingInstances = List.of(annotation.get().value());
         String thisInstance = TestRuntime.get().application().instance();
-        String reason = "Disabled in: %s. Current instance: %s.".formatted(disablingInstances.isEmpty() ? "no instances" : "instances " + String.join(", ", disablingInstances), thisInstance);
+        String reason = String.format(Locale.ROOT, "Disabled in: %s. Current instance: %s.", disablingInstances.isEmpty() ? "no instances" : "instances " + String.join(", ", disablingInstances), thisInstance);
         return disablingInstances.contains(thisInstance) ? ConditionEvaluationResult.disabled(reason) : ConditionEvaluationResult.enabled(reason);
     }
 

--- a/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/DisabledInRegions.java
+++ b/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/DisabledInRegions.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -38,7 +39,7 @@ class DisabledInRegionsCondition implements ExecutionCondition {
 
         List<String> disablingRegions = List.of(annotation.get().value());
         String thisRegion = TestRuntime.get().application().instance();
-        String reason = "Disabled in: %s. Current region: %s.".formatted(disablingRegions.isEmpty() ? "no regions" : "regions " + String.join(", ", disablingRegions), thisRegion);
+        String reason = String.format(Locale.ROOT, "Disabled in: %s. Current region: %s.", disablingRegions.isEmpty() ? "no regions" : "regions " + String.join(", ", disablingRegions), thisRegion);
         return disablingRegions.contains(thisRegion) ? ConditionEvaluationResult.disabled(reason) : ConditionEvaluationResult.enabled(reason);
     }
 

--- a/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/EnabledInInstances.java
+++ b/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/EnabledInInstances.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -37,7 +38,7 @@ class EnabledInInstancesCondition implements ExecutionCondition {
 
         List<String> enablingInstances = List.of(annotation.get().value());
         String thisInstance = TestRuntime.get().application().instance();
-        String reason = "Enabled in: %s. Current instance: %s.".formatted(enablingInstances.isEmpty() ? "no instances" : "instances " + String.join(", ", enablingInstances), thisInstance);
+        String reason = String.format(Locale.ROOT, "Enabled in: %s. Current instance: %s.", enablingInstances.isEmpty() ? "no instances" : "instances " + String.join(", ", enablingInstances), thisInstance);
         return enablingInstances.contains(thisInstance) ? ConditionEvaluationResult.enabled(reason) : ConditionEvaluationResult.disabled(reason);
     }
 

--- a/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/EnabledInRegions.java
+++ b/cloud/tenant-cd-api/src/main/java/ai/vespa/hosted/cd/EnabledInRegions.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -37,7 +38,7 @@ class EnabledInRegionsCondition implements ExecutionCondition {
 
         List<String> enablingRegions = List.of(annotation.get().value());
         String thisRegion = TestRuntime.get().zone().region();
-        String reason = "Enabled in: %s. Current region: %s.".formatted(enablingRegions.isEmpty() ? "no regions" : "regions " + String.join(", ", enablingRegions), thisRegion);
+        String reason = String.format(Locale.ROOT, "Enabled in: %s. Current region: %s.", enablingRegions.isEmpty() ? "no regions" : "regions " + String.join(", ", enablingRegions), thisRegion);
         return enablingRegions.contains(thisRegion) ? ConditionEvaluationResult.enabled(reason) : ConditionEvaluationResult.disabled(reason);
     }
 

--- a/cloud/tenant-cd-commons/src/main/java/ai/vespa/hosted/cd/commons/DefaultEndpointAuthenticator.java
+++ b/cloud/tenant-cd-commons/src/main/java/ai/vespa/hosted/cd/commons/DefaultEndpointAuthenticator.java
@@ -11,6 +11,7 @@ import com.yahoo.security.X509CertificateUtils;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
@@ -60,13 +61,13 @@ public class DefaultEndpointAuthenticator implements EndpointAuthenticator {
                     privateKeyFile = Properties.dataPlaneKeyFile().get();
             }
             if (certificateFile != null && privateKeyFile != null) {
-                X509Certificate certificate = X509CertificateUtils.fromPem(new String(Files.readAllBytes(certificateFile)));
+                X509Certificate certificate = X509CertificateUtils.fromPem(new String(Files.readAllBytes(certificateFile), StandardCharsets.UTF_8));
                 if (   Instant.now().isBefore(certificate.getNotBefore().toInstant())
                     || Instant.now().isAfter(certificate.getNotAfter().toInstant()))
                     throw new IllegalStateException("Certificate at '" + certificateFile + "' is valid between " +
                                                     certificate.getNotBefore() + " and " + certificate.getNotAfter() + " — not now.");
 
-                PrivateKey privateKey = KeyUtils.fromPemEncodedPrivateKey(new String(Files.readAllBytes(privateKeyFile)));
+                PrivateKey privateKey = KeyUtils.fromPemEncodedPrivateKey(new String(Files.readAllBytes(privateKeyFile), StandardCharsets.UTF_8));
                 return new SslContextBuilder().withKeyStore(privateKey, certificate).build();
             }
             if ( ! hasLocalTestConfig)

--- a/cloud/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/DeployMojo.java
+++ b/cloud/vespa-maven-plugin/src/main/java/ai/vespa/hosted/plugin/DeployMojo.java
@@ -14,6 +14,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 /**
  * Deploys a Vespa application package to the hosted Vespa API.
@@ -70,7 +71,7 @@ public class DeployMojo extends AbstractVespaDeploymentMojo {
         }
     }
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT).withZone(ZoneOffset.UTC);
     private static final String padding = "\n" + " ".repeat(23);
 
     private void print(DeploymentLog.Entry entry) {


### PR DESCRIPTION
Replace platform-dependent string operations with explicit locale-independent alternatives to avoid bugs when running on systems with different defaults:
- Use StandardCharsets.UTF_8 for byte array to string conversions
- Replace String.formatted() with String.format(Locale.ROOT, ...)
- Use Locale.ROOT for DateTimeFormatter patterns
