### PR TITLE
Explicitly specify locale in application tests

### DIFF
--- a/application/src/test/java/com/yahoo/application/ApplicationTest.java
+++ b/application/src/test/java/com/yahoo/application/ApplicationTest.java
@@ -346,7 +346,7 @@ public class ApplicationTest {
             try (DefaultHttpClient client = new org.apache.http.impl.client.DefaultHttpClient()) {
                 HttpResponse response = client.execute(new HttpGet("http://localhost:" + httpPort));
                 assertEquals(200, response.getStatusLine().getStatusCode());
-                BufferedReader r = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+                BufferedReader r = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
                 String line;
                 StringBuilder sb = new StringBuilder();
                 while ((line = r.readLine()) != null) {

--- a/application/src/test/java/com/yahoo/application/container/handler/ResponseTestCase.java
+++ b/application/src/test/java/com/yahoo/application/container/handler/ResponseTestCase.java
@@ -3,6 +3,8 @@ package com.yahoo.application.container.handler;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -13,16 +15,16 @@ public class ResponseTestCase {
 
     @Test
     void requireThatCharsetParsingWorks() {
-        assertEquals("utf-8", Response.charset("text/foobar").toString().toLowerCase());
-        assertEquals("utf-8", Response.charset("adsf").toString().toLowerCase());
-        assertEquals("utf-8", Response.charset("").toString().toLowerCase());
-        assertEquals("utf-8", Response.charset(null).toString().toLowerCase());
+        assertEquals("utf-8", Response.charset("text/foobar").toString().toLowerCase(Locale.ROOT));
+        assertEquals("utf-8", Response.charset("adsf").toString().toLowerCase(Locale.ROOT));
+        assertEquals("utf-8", Response.charset("").toString().toLowerCase(Locale.ROOT));
+        assertEquals("utf-8", Response.charset(null).toString().toLowerCase(Locale.ROOT));
 
-        assertEquals("us-ascii", Response.charset("something; charset=US-ASCII").toString().toLowerCase());
-        assertEquals("iso-8859-1", Response.charset("something; charset=iso-8859-1").toString().toLowerCase());
+        assertEquals("us-ascii", Response.charset("something; charset=US-ASCII").toString().toLowerCase(Locale.ROOT));
+        assertEquals("iso-8859-1", Response.charset("something; charset=iso-8859-1").toString().toLowerCase(Locale.ROOT));
 
-        assertEquals("utf-8", Response.charset("something; charset=").toString().toLowerCase());
-        assertEquals("utf-8", Response.charset("something; charset=bananarama").toString().toLowerCase());
+        assertEquals("utf-8", Response.charset("something; charset=").toString().toLowerCase(Locale.ROOT));
+        assertEquals("utf-8", Response.charset("something; charset=bananarama").toString().toLowerCase(Locale.ROOT));
     }
 
     @Test

--- a/application/src/test/java/com/yahoo/application/container/handlers/MockHttpHandler.java
+++ b/application/src/test/java/com/yahoo/application/container/handlers/MockHttpHandler.java
@@ -8,6 +8,7 @@ import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executor;
 
 /**
@@ -24,7 +25,7 @@ public class MockHttpHandler extends ThreadedHttpRequestHandler {
         return new HttpResponse(200) {
             @Override
             public void render(OutputStream outputStream) throws IOException {
-                PrintStream out = new PrintStream(outputStream);
+                PrintStream out = new PrintStream(outputStream, true, StandardCharsets.UTF_8);
                 out.print("OK");
                 out.flush();
             }


### PR DESCRIPTION
Avoid locale-dependent behavior in test code by:
- Using StandardCharsets.UTF_8 when creating InputStreamReader and PrintStream
- Using Locale.ROOT for toLowerCase() operations to ensure consistent behavior across different system locales
