### PR TITLE
Remove zoneDnsSuffixes field from configserver config definition

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -45,8 +45,6 @@ cloud string default="default"
 environment string default="prod"
 region string default="default"
 system string default="default"
-# TODO: Unused, remove in Vespa 9 at the latest
-zoneDnsSuffixes[] string
 
 # RPC protocol
 maxgetconfigclients int default=1000000


### PR DESCRIPTION
Has not been used for a long time

