### PR TITLE
Fix stale TCP connections blocking file distribution downloads

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/Connection.java
+++ b/config/src/main/java/com/yahoo/vespa/config/Connection.java
@@ -17,4 +17,6 @@ public interface Connection {
 
     String getAddress();
 
+    default void closeConnection() {}
+
 }

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnection.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnection.java
@@ -43,6 +43,21 @@ public class JRTConnection implements Connection {
         return address;
     }
 
+    public synchronized void closeTarget() {
+        if (target != null) {
+            logger.log(Level.INFO, "Force-closing connection to " + address +
+                       " (target valid=" + target.isValid() + ")");
+            target.closeSocket();  // Synchronously close TCP socket before async cleanup
+            target.close();
+            target = null;
+        }
+    }
+
+    @Override
+    public void closeConnection() {
+        closeTarget();
+    }
+
     /**
      * This is synchronized to avoid multiple ConfigInstances creating new targets simultaneously, if
      * the existing target is null, invalid or has not yet been initialized.

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -62,11 +62,27 @@ public class FileDownloader implements AutoCloseable {
         this.timeout = timeout;
         // Needed to receive RPC receiveFile* calls from server after starting download of file reference
         new FileReceiver(supervisor, downloads, downloadDirectory);
-        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool,
-                                                                   downloads,
-                                                                   timeout,
-                                                                   backoffInitialTime,
-                                                                   downloadDirectory);
+        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
+                                                                    backoffInitialTime, downloadDirectory);
+        if (forceDownload)
+            log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
+    }
+
+    public FileDownloader(ConnectionPool connectionPool,
+                          Supervisor supervisor,
+                          File downloadDirectory,
+                          Duration timeout,
+                          Duration backoffInitialTime,
+                          int maxTimeoutsBeforeClose) {
+        this.connectionPool = connectionPool;
+        this.supervisor = supervisor;
+        this.downloadDirectory = downloadDirectory;
+        this.timeout = timeout;
+        // Needed to receive RPC receiveFile* calls from server after starting download of file reference
+        new FileReceiver(supervisor, downloads, downloadDirectory);
+        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
+                                                                    backoffInitialTime, downloadDirectory,
+                                                                    maxTimeoutsBeforeClose);
         if (forceDownload)
             log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
     }

--- a/jrt/src/com/yahoo/jrt/Target.java
+++ b/jrt/src/com/yahoo/jrt/Target.java
@@ -162,6 +162,12 @@ public abstract class Target {
     public abstract boolean removeWatcher(TargetWatcher watcher);
 
     /**
+     * Synchronously close the underlying TCP socket. This is a no-op by default;
+     * subclasses backed by a real socket connection should override this.
+     */
+    public void closeSocket() {}
+
+    /**
      * Close this target. Note that the close operation is
      * asynchronous. If you need to wait for the target to become
      * invalid, use the {@link Transport#sync Transport.sync} method.

--- a/jrt/tests/com/yahoo/jrt/ConnectionTest.java
+++ b/jrt/tests/com/yahoo/jrt/ConnectionTest.java
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.jrt;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class ConnectionTest {
+
+    @org.junit.Test
+    public void closeSocketIsVisibleAcrossThreads() throws Exception {
+        Test.Orb server = new Test.Orb(new Transport());
+        Test.Orb client = new Test.Orb(new Transport());
+        Acceptor acceptor = server.listen(new Spec(0));
+        Target target = client.connect(new Spec("localhost", acceptor.port()));
+
+        // Wait for connection to be established
+        for (int i = 0; i < 100 && !target.isValid(); i++) {
+            Thread.sleep(10);
+        }
+        assertTrue(target.isValid());
+
+        // Close the socket from a different thread
+        CountDownLatch done = new CountDownLatch(1);
+        boolean[] closed = {false};
+        new Thread(() -> {
+            target.closeSocket();
+            closed[0] = true;
+            done.countDown();
+        }).start();
+
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertTrue(closed[0]);
+
+        target.close();
+        acceptor.shutdown().join();
+        client.transport().shutdown().join();
+        server.transport().shutdown().join();
+    }
+
+}


### PR DESCRIPTION
## Problem

When the config-proxy's RPC connection to a config server becomes stale (half-open TCP socket ), file distribution downloads hang indefinitely. The download executor retries on the same dead socket because `getTarget()` still sees it as "valid". This blocks all file reference downloads on the affected node for ~16 minutes until the configproxy's internal JRT reconnect timer fires.

## Root cause

1. **No mechanism to force-close a stale connection.** `FileReferenceDownloader` had no way to detect repeated timeouts and proactively tear down a dead connection.

2. **Cross-thread socket visibility.** The `socket` field in `jrt/Connection.java` is written by the Connector thread and read by the file downloader thread. Without `volatile`, `closeSocket()` could silently no-op due to JMM visibility — confirmed in production where `ss -tnp` showed the same local port and growing Send-Q after force-close attempts.

## Fix

### Timeout-based force-close (`filedistribution/`)

- Replace boolean return from `startDownloadRpc()` with `DownloadResult` enum (`SUCCESS`, `TIMEOUT`, `FAILURE`), distinguishing `ErrorCode.TIMEOUT` from other errors.
- Track consecutive RPC timeouts; after reaching the threshold, call `connection.closeConnection()` to synchronously close the TCP socket. The next retry establishes a fresh connection.

### Cross-thread socket visibility (`jrt/`)

- Add `volatile SocketChannel channelForClose` to `Connection.java` — written on socket creation, read in `closeSocket()`. This avoids adding volatile overhead to the hot I/O path (where `socket` is read on every packet).
- Add `closeSocket()` as a public no-op on `Target` (since `Connection` is package-private), overridden in `Connection`.

### TCP socket options (`jrt/`)

- Enable `SO_KEEPALIVE` (OS-level dead-peer detection) and `SO_LINGER(0)` (immediate RST on close) on JRT connections, matching C++ FNET behavior.

### Connection close API (`config/`)

- Add `closeConnection()` default method to `Connection` interface, implemented in `JRTConnection` to call `target.closeSocket()` (synchronous) then `target.close()` (async cleanup).

## How to activate

The feature is **off by default**. Two environment variables control it:

```bash
# Required: set an aggressive RPC timeout so retries happen within the download budget.
# By default rpc_timeout == download_timeout, so no retries are attempted.
VESPA_FILE_DOWNLOAD_RPC_TIMEOUT=5

# Force-close connection after N consecutive RPC timeouts (0 = disabled).
VESPA_FILE_DOWNLOAD_MAX_TIMEOUTS_BEFORE_CLOSE=2
```

With these settings: 5s timeout → close after 2 timeouts → fresh connection on 3rd attempt → recovery in ~15s instead of ~16min.

## Files changed

| File | Change |
|------|--------|
| `jrt/.../Target.java` | `closeSocket()` no-op on base class |
| `jrt/.../Connection.java` | `volatile channelForClose`, `closeSocket()` override, `SO_KEEPALIVE`, `SO_LINGER(0)` |
| `config/.../Connection.java` | `closeConnection()` default method |
| `config/.../JRTConnection.java` | `closeTarget()` — sync socket close + async cleanup |
| `filedistribution/.../FileReferenceDownloader.java` | `DownloadResult` enum, timeout counting, force-close logic |
| `filedistribution/.../FileDownloader.java` | Constructor overload for `maxTimeoutsBeforeClose` |
| `filedistribution/.../FileDownloaderTest.java` | 3 new tests + `TimeoutResponseHandler` mock |
| `jrt/.../ConnectionTest.java` | Cross-thread `closeSocket()` visibility test |

## Test plan

- [x] Unit tests for timeout-based close (threshold=1, threshold=2, disabled-by-default)
- [x] JRT test for cross-thread `closeSocket()` visibility
- [x] Observed working in production on Vespa 8.639.59 — stale socket closed, new connection established, downloads resumed immediately