### PR TITLE
Add annotation for limiting sameElement to specific IDs 3/4: streaming search

### DIFF
--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -843,7 +843,7 @@ TEST(QueryBuilderTest, require_that_empty_intermediate_node_can_be_added) {
 }
 
 TEST(QueryBuilderTest, control_size_of_SimpleQueryStackDumpIterator) {
-    EXPECT_EQ(160u, sizeof(SimpleQueryStackDumpIterator));
+    EXPECT_EQ(184u, sizeof(SimpleQueryStackDumpIterator));
 }
 
 TEST(QueryBuilderTest, test_query_parsing_error) {

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -70,11 +70,14 @@ protected:
 
     SameElementQueryNodeTest();
     ~SameElementQueryNodeTest() override;
-    static bool evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv);
-    static std::vector<uint32_t> get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv);
+    static bool evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter = std::vector<uint32_t>());
+    static std::vector<uint32_t> get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter = std::vector<uint32_t>());
     std::vector<std::vector<uint32_t>> extract_element_ids(QueryTweak query_tweak,
-                                                           const std::vector<std::vector<uint32_t>>& elementsvv);
-    static std::unique_ptr<Query> make_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv);
+                                                           const std::vector<std::vector<uint32_t>>& elementsvv,
+                                                           std::vector<uint32_t> element_filter = std::vector<uint32_t>());
+    static std::unique_ptr<Query> make_query(QueryTweak query_tweak,
+                                             const std::vector<std::vector<uint32_t>>& elementsvv,
+                                             std::vector<uint32_t> element_filter = std::vector<uint32_t>());
 };
 
 SameElementQueryNodeTest::SameElementQueryNodeTest()
@@ -85,25 +88,25 @@ SameElementQueryNodeTest::SameElementQueryNodeTest()
 SameElementQueryNodeTest::~SameElementQueryNodeTest() = default;
 
 bool
-SameElementQueryNodeTest::evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::evaluate_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter)
 {
-    auto query = make_query(query_tweak, elementsvv);
+    auto query = make_query(query_tweak, elementsvv, std::move(element_filter));
     return query->getRoot().evaluate();
 }
 
 std::vector<uint32_t>
-SameElementQueryNodeTest::get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::get_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter)
 {
-    auto query = make_query(query_tweak, elementsvv);
+    auto query = make_query(query_tweak, elementsvv, std::move(element_filter));
     std::vector<uint32_t> result;
     query->getRoot().get_element_ids(result);
     return result;
 }
 
 std::vector<std::vector<uint32_t>>
-SameElementQueryNodeTest::extract_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::extract_element_ids(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv, std::vector<uint32_t> element_filter)
 {
-    auto query = make_query(query_tweak, elementsvv);
+    auto query = make_query(query_tweak, elementsvv, std::move(element_filter));
     auto md = MatchData::makeTestInstance(elementsvv.size(), 1);
     constexpr uint32_t docid = 2;
     IndexEnvironment index_env;
@@ -118,7 +121,9 @@ SameElementQueryNodeTest::extract_element_ids(QueryTweak query_tweak, const std:
 }
 
 std::unique_ptr<Query>
-SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<std::vector<uint32_t>>& elementsvv)
+SameElementQueryNodeTest::make_query(QueryTweak query_tweak,
+                                     const std::vector<std::vector<uint32_t>>& elementsvv,
+                                     std::vector<uint32_t> element_filter)
 {
     QueryBuilder<SimpleQueryNodeTypes> builder;
     auto num_terms = elementsvv.size();
@@ -135,7 +140,7 @@ SameElementQueryNodeTest::make_query(QueryTweak query_tweak, const std::vector<s
         default:
             break;
     }
-    builder.addSameElement(top_arity, "field", 0, Weight(0));
+    builder.addSameElement(top_arity, "field", 0, Weight(0), std::move(element_filter));
     for (uint32_t idx = 0; idx < elementsvv.size(); ++idx) {
         switch (query_tweak) {
             case QueryTweak::AND:
@@ -367,4 +372,60 @@ TEST_F(SameElementQueryNodeTest, rank_below_same_element)
               extract_element_ids(QueryTweak::RANK, elementsvv5));
     EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 4, 6,9 }, { 4, 9 } }),
               extract_element_ids(QueryTweak::RANK, elementsvv9));
+}
+
+TEST_F(SameElementQueryNodeTest, element_filter_simple)
+{
+    std::vector<std::vector<uint32_t>> elementsvv({ { 5, 7, 10, 12 }, { 4, 7, 12, 14} });
+
+    std::vector<uint32_t> element_filter({ 5 });
+    EXPECT_FALSE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<uint32_t>{}), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { }, { } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+
+    std::vector<uint32_t> element_filter2({ 7 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<uint32_t>{ 7 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 7 }, { 7 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+}
+
+TEST_F(SameElementQueryNodeTest, element_filter_with_multiple_ids)
+{
+    std::vector<std::vector<uint32_t>> elementsvv({ { 5, 7, 10, 12 }, { 4, 7, 12, 14} });
+    std::vector<uint32_t> element_filter({ 4, 5, 6, 7, 9, 10, 12, 13 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<uint32_t>{ 7, 12 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 7, 12 }, { 7, 12 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+}
+
+TEST_F(SameElementQueryNodeTest, element_filter_for_indexing)
+{
+    std::vector<std::vector<uint32_t>> elementsvv({ { 4, 7, 12, 14} });
+
+    std::vector<uint32_t> element_filter({ 4 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<uint32_t>{ 4 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 4 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter));
+
+    std::vector<uint32_t> element_filter2({ 5 });
+    EXPECT_FALSE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<uint32_t>{ }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter2));
+
+    std::vector<uint32_t> element_filter3({ 3, 14 });
+    EXPECT_TRUE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter3));
+    EXPECT_EQ((std::vector<uint32_t>{ 14 }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter3));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { 14 } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter3));
+
+    std::vector<uint32_t> element_filter4({ 3, 13 });
+    EXPECT_FALSE(evaluate_query(QueryTweak::NORMAL, elementsvv, element_filter4));
+    EXPECT_EQ((std::vector<uint32_t>{ }), get_element_ids(QueryTweak::NORMAL, elementsvv, element_filter4));
+    EXPECT_EQ((std::vector<std::vector<uint32_t>>{ { } }),
+              extract_element_ids(QueryTweak::NORMAL, elementsvv, element_filter4));
 }

--- a/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
@@ -294,6 +294,7 @@ bool handle(const ItemSameElement& item, QueryStackIterator::Data& _d) {
     fillTermProperties(item.properties(), _d);
     _d.itemType = ParseItem::ItemType::ITEM_SAME_ELEMENT;
     _d.arity = item.children_size();
+    _d._element_filter = std::vector<uint32_t>(item.element_filter().cbegin(), item.element_filter().cend());
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/parsequery/parse.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace search::query {
 
@@ -55,6 +56,7 @@ public:
         uint32_t exploreAdditionalHits = 0;
         uint32_t fuzzy_max_edit_distance = 0;
         uint32_t fuzzy_prefix_lock_length = 0;
+        std::vector<uint32_t> _element_filter;
 
         void clear();
     };
@@ -90,6 +92,8 @@ public:
     // fuzzy match arguments (see also: has_prefix_match_semantics() for fuzzy prefix matching)
     [[nodiscard]] uint32_t fuzzy_max_edit_distance() const noexcept { return _d.fuzzy_max_edit_distance; }
     [[nodiscard]] uint32_t fuzzy_prefix_lock_length() const noexcept { return _d.fuzzy_prefix_lock_length; }
+    // elementFilter annotation for sameElement
+    [[nodiscard]] const std::vector<uint32_t>& get_element_filter() const noexcept { return _d._element_filter; }
 
     // Get the flags of the current item.
     [[nodiscard]] bool hasNoRankFlag() const noexcept { return _d.noRankFlag; }

--- a/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
@@ -392,7 +392,10 @@ QueryBuilder::build_equiv_term(const QueryNodeResultFactory& factory, QueryStack
 std::unique_ptr<QueryNode>
 QueryBuilder::build_same_element_term(const QueryNodeResultFactory& factory, QueryStackIterator& queryRep)
 {
-    auto sen = std::make_unique<SameElementQueryNode>(factory.create(), queryRep.index_as_string(), queryRep.getArity());
+    auto sen = std::make_unique<SameElementQueryNode>(factory.create(),
+                                                      queryRep.index_as_string(),
+                                                      queryRep.getArity(),
+                                                      queryRep.get_element_filter());
     _same_element_view = queryRep.index_as_string();
     _expose_match_data_for_same_element = true;
     auto arity = queryRep.getArity();

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
@@ -63,7 +63,7 @@ SameElementQueryNode::get_element_ids(std::vector<uint32_t>& element_ids)
     }
     std::span<const std::unique_ptr<QueryNode>> others;
     if (!_element_filter.empty()) {
-        element_ids.insert(element_ids.end(), _element_filter.begin(), _element_filter.end());
+        element_ids = _element_filter;
         others = std::span<const std::unique_ptr<QueryNode>>(_children.begin(), _children.end());
 
     } else {

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
@@ -65,7 +65,6 @@ SameElementQueryNode::get_element_ids(std::vector<uint32_t>& element_ids)
     if (!_element_filter.empty()) {
         element_ids = _element_filter;
         others = std::span<const std::unique_ptr<QueryNode>>(_children.begin(), _children.end());
-
     } else {
         _children.front()->get_element_ids(element_ids);
         others = std::span<const std::unique_ptr<QueryNode>>(_children.begin() + 1, _children.end());

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.cpp
@@ -14,11 +14,13 @@ using search::fef::MatchData;
 
 namespace search::streaming {
 
-SameElementQueryNode::SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index, uint32_t num_terms) noexcept
+SameElementQueryNode::SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index,
+                                           uint32_t num_terms, std::vector<uint32_t> element_filter) noexcept
     : QueryTerm(std::move(result_base), "", index, Type::WORD, Normalizing::NONE),
       _children(),
       _element_ids(),
-      _cached_evaluate_result()
+      _cached_evaluate_result(),
+      _element_filter(std::move(element_filter))
 {
     _children.reserve(num_terms);
 }
@@ -59,8 +61,15 @@ SameElementQueryNode::get_element_ids(std::vector<uint32_t>& element_ids)
             return;
         }
     }
-    _children.front()->get_element_ids(element_ids);
-    std::span<const std::unique_ptr<QueryNode>> others(_children.begin() + 1, _children.end());
+    std::span<const std::unique_ptr<QueryNode>> others;
+    if (!_element_filter.empty()) {
+        element_ids.insert(element_ids.end(), _element_filter.begin(), _element_filter.end());
+        others = std::span<const std::unique_ptr<QueryNode>>(_children.begin(), _children.end());
+
+    } else {
+        _children.front()->get_element_ids(element_ids);
+        others = std::span<const std::unique_ptr<QueryNode>>(_children.begin() + 1, _children.end());
+    }
     if (others.empty()) {
         return;
     }

--- a/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/same_element_query_node.h
@@ -15,8 +15,10 @@ class SameElementQueryNode : public QueryTerm
     QueryNodeList         _children;
     std::vector<uint32_t> _element_ids;
     std::optional<bool>   _cached_evaluate_result;
+    std::vector<uint32_t> _element_filter;
 public:
-    SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index, uint32_t num_terms) noexcept;
+    SameElementQueryNode(std::unique_ptr<QueryNodeResultBase> result_base, string index,
+                         uint32_t num_terms, std::vector<uint32_t> element_filter) noexcept;
     ~SameElementQueryNode() override;
     bool evaluate() override;
     const HitList & evaluateHits(HitList & hl) override;

--- a/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
+++ b/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
@@ -144,6 +144,9 @@ private:
     void visit(SameElement &node) override {
         auto* item = _item_stack.back()->mutable_item_same_element();
         copyTermState(node, item->mutable_properties());
+        for (const uint32_t id : node.get_element_filter()) {
+            item->add_element_filter(id);
+        }
         visitNodes(node.getChildren());
     }
 


### PR DESCRIPTION
Break up https://github.com/vespa-engine/vespa/pull/35836 into smaller pull requests.

Implement the element filter in streaming search.