### PR TITLE
Integrate dynamic batching into embedder pipeline

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/EmbedderBatchingConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/EmbedderBatchingConfig.java
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.component;
+
+import com.yahoo.text.XML;
+import org.w3c.dom.Element;
+
+import java.time.Duration;
+
+/**
+ * Shared parsing of the {@code <batching>} element for embedder components.
+ *
+ * @author bjorncs
+ */
+record EmbedderBatchingConfig(int maxSize, Duration maxDelay) {
+
+    static EmbedderBatchingConfig parseBatchingElement(Element parent) {
+        var batchingElement = XML.getChild(parent, "batching");
+        if (batchingElement == null) return null;
+        var maxSize = XML.attribute("max-size", batchingElement)
+                .map(value -> {
+                    try {
+                        return Integer.parseUnsignedInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException(
+                                "Batching max-size should be a positive integer, provided: " + value, e);
+                    }
+                })
+                .orElseThrow(() -> new IllegalArgumentException("Missing required attribute 'max-size' on <batching>"));
+        var maxDelay = XML.attribute("max-delay", batchingElement)
+                .map(v -> Duration.ofMillis(new com.yahoo.vespa.model.utils.Duration(v).getMilliSeconds()))
+                .orElseThrow(() -> new IllegalArgumentException("Missing required attribute 'max-delay' on <batching>"));
+        return new EmbedderBatchingConfig(maxSize, maxDelay);
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/VoyageAIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/VoyageAIEmbedder.java
@@ -8,6 +8,7 @@ import org.w3c.dom.Element;
 
 import static com.yahoo.text.XML.getChildValue;
 import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
+import static com.yahoo.vespa.model.container.component.EmbedderBatchingConfig.parseBatchingElement;
 
 /**
  * Configuration builder for VoyageAI embedder component.
@@ -24,6 +25,7 @@ public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedder
     private final Boolean truncate;
     private final Integer dimensions;
     private final String quantization;
+    private final EmbedderBatchingConfig batching;
 
     @SuppressWarnings("unused")
     public VoyageAIEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
@@ -38,6 +40,7 @@ public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedder
         this.endpoint = getChildValue(xml, "endpoint").orElse(null);
         this.truncate = getChildValue(xml, "truncate").map(Boolean::parseBoolean).orElse(null);
         this.quantization = getChildValue(xml, "quantization").orElse("auto");
+        this.batching = parseBatchingElement(xml);
 
         validate();
     }
@@ -62,6 +65,10 @@ public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedder
         }
         if (truncate != null) {
             builder.truncate(truncate);
+        }
+        if (batching != null) {
+            builder.batching.maxSize(batching.maxSize());
+            builder.batching.maxDelayMillis(batching.maxDelay().toMillis());
         }
     }
 }

--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -161,23 +161,27 @@ VoyageAIEmbedder =
    element dimensions { "256" | "512" | "1024" | "1536" | "2048" } &
    element quantization { "auto" | "float" | "int8" | "binary" }? &
    element endpoint { xsd:string }? &
-   element truncate { xsd:boolean }?
+   element truncate { xsd:boolean }? &
+   EmbedderBatchingParams
 
 OnnxModelExecutionParams =
     element onnx-execution-mode { "parallel" | "sequential" }? &
     element onnx-interop-threads { xsd:integer }? &
     element onnx-intraop-threads { xsd:integer }? &
     element onnx-gpu-device { xsd:integer }? &
-    element batching {
-        attribute max-size { xsd:integer } &
-        attribute max-delay { xsd:string }?
-    }? &
+    EmbedderBatchingParams &
     element concurrency {
         attribute type { "absolute" | "relative" }? &
         xsd:double { minExclusive = "0.0" }
     }? &
     # Path to model config file, e.g. Triton model config
     element model-config-override { xsd:string }?
+
+EmbedderBatchingParams =
+    element batching {
+        attribute max-size { xsd:integer } &
+        attribute max-delay { xsd:string }
+    }?
 
 EmbedderPoolingStrategy = element pooling-strategy { "cls" | "mean" | "none" }?
 

--- a/config-model/src/test/cfg/application/voyageai-embedder/services.xml
+++ b/config-model/src/test/cfg/application/voyageai-embedder/services.xml
@@ -12,6 +12,7 @@
             <dimensions>1024</dimensions>
             <endpoint>https://api.voyageai.com/v1/embeddings</endpoint>
             <truncate>true</truncate>
+            <batching max-size="16" max-delay="200ms"/>
         </component>
 
         <!-- VoyageAI Embedder with minimal configuration -->

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
@@ -42,6 +42,8 @@ public class VoyageAIEmbedderTest {
         assertEquals(1024, config.dimensions());
         assertEquals("https://api.voyageai.com/v1/embeddings", config.endpoint());
         assertTrue(config.truncate());
+        assertEquals(16, config.batching().maxSize());
+        assertEquals(200, config.batching().maxDelayMillis());
     }
 
     @Test
@@ -61,6 +63,8 @@ public class VoyageAIEmbedderTest {
         assertEquals("https://api.voyageai.com/v1/embeddings", config.endpoint()); // Default endpoint
         assertEquals(3, config.maxRetries()); // Default retries
         assertTrue(config.truncate()); // Default truncate
+        assertEquals(0, config.batching().maxSize()); // Default batching
+        assertEquals(0, config.batching().maxDelayMillis()); // Default batching
     }
 
     @Test

--- a/configdefinitions/src/vespa/voyage-ai-embedder.def
+++ b/configdefinitions/src/vespa/voyage-ai-embedder.def
@@ -29,3 +29,7 @@ timeout int default=60000
 
 # Truncate inputs that exceed model's maximum token limit
 truncate bool default=true
+
+# Dynamic batching configuration
+batching.maxSize int default=0
+batching.maxDelayMillis long default=0

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
@@ -24,6 +24,7 @@ import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
 import com.yahoo.language.provider.DefaultEmbedderProvider;
 import com.yahoo.language.provider.DefaultGeneratorProvider;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
@@ -71,14 +72,16 @@ public class IndexingProcessor extends DocumentProcessor {
                              Linguistics linguistics,
                              ComponentRegistry<Chunker> chunkers,
                              ComponentRegistry<Embedder> embedders,
-                             ComponentRegistry<FieldGenerator> generators) {
+                             ComponentRegistry<FieldGenerator> generators,
+                             MetricReceiver metricReceiver) {
         this(documentTypeManager,
              new ScriptManager(documentTypeManager,
                                ilscriptsConfig,
                                linguistics,
                                toMap(chunkers, null), // No failing default since we add pure Java default components
                                toMap(embedders, DefaultEmbedderProvider.class),
-                               toMap(generators, DefaultGeneratorProvider.class)
+                               toMap(generators, DefaultGeneratorProvider.class),
+                               metricReceiver
                 )
         );
     }

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/ScriptManager.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/ScriptManager.java
@@ -8,6 +8,7 @@ import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.Chunker;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.vespa.indexinglanguage.ScriptParserContext;
 import com.yahoo.vespa.indexinglanguage.expressions.InputExpression;
@@ -36,9 +37,10 @@ class ScriptManager {
     ScriptManager(DocumentTypeManager documentTypeManager, IlscriptsConfig config, Linguistics linguistics,
                          Map<String, Chunker> chunkers,
                          Map<String, Embedder> embedders,
-                         Map<String, FieldGenerator> generators) {
+                         Map<String, FieldGenerator> generators,
+                         MetricReceiver metricReceiver) {
         this.documentTypeManager = documentTypeManager;
-        documentFieldScripts = createScriptsMap(documentTypeManager, config, linguistics, chunkers, embedders, generators);
+        documentFieldScripts = createScriptsMap(documentTypeManager, config, linguistics, chunkers, embedders, generators, metricReceiver);
     }
 
     private Map<String, DocumentScript> getScripts(DocumentType inputType) {
@@ -74,9 +76,11 @@ class ScriptManager {
                                                                               Linguistics linguistics,
                                                                               Map<String, Chunker> chunkers,
                                                                               Map<String, Embedder> embedders,
-                                                                              Map<String, FieldGenerator> generators) {
+                                                                              Map<String, FieldGenerator> generators,
+                                                                              MetricReceiver metricReceiver) {
         Map<String, Map<String, DocumentScript>> documentFieldScripts = new HashMap<>(config.ilscript().size());
-        ScriptParserContext parserContext = new ScriptParserContext(linguistics, chunkers, embedders, generators);
+        ScriptParserContext parserContext = new ScriptParserContext(linguistics, chunkers, embedders, generators)
+                .setMetricReceiver(metricReceiver);
         parserContext.getAnnotatorConfig().setMaxTermOccurrences(config.maxtermoccurrences());
         parserContext.getAnnotatorConfig().setMaxTokenizeLength(config.fieldmatchmaxlength());
         parserContext.getAnnotatorConfig().setMaxReplacementCharactersRatio(config.maxReplacementCharactersRatio());

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
@@ -20,6 +20,7 @@ import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
 import com.yahoo.language.process.InvocationContext;
 import com.yahoo.language.process.TimeoutException;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.Tensors;
@@ -338,8 +339,9 @@ public class IndexingProcessorTestCase {
         var scripts = new ScriptManager(documentTypes, new IlscriptsConfig(config), null,
                                         Chunker.throwsOnUse.asMap(),
                                         Map.of("test", new TestEmbedder()),
-                                        FieldGenerator.throwsOnUse.asMap());
-        
+                                        FieldGenerator.throwsOnUse.asMap(),
+                                        MetricReceiver.nullImplementation);
+
         assertNotNull(scripts.getScript(documentTypes.getDocumentType("test")));
 
         var tester = new IndexingProcessorTester(documentTypes, scripts);
@@ -382,7 +384,8 @@ public class IndexingProcessorTestCase {
         var scripts = new ScriptManager(documentTypes, new IlscriptsConfig(config), null,
                                         Chunker.throwsOnUse.asMap(),
                                         Map.of("test", embedder),
-                                        FieldGenerator.throwsOnUse.asMap());
+                                        FieldGenerator.throwsOnUse.asMap(),
+                                        MetricReceiver.nullImplementation);
 
         var processor = new IndexingProcessor(documentTypes, scripts);
         var input = new DocumentPut(testType, "id:ns:test::");
@@ -432,7 +435,8 @@ public class IndexingProcessorTestCase {
             null,
             Chunker.throwsOnUse.asMap(),
             Map.of("test", embedder),
-            FieldGenerator.throwsOnUse.asMap()
+            FieldGenerator.throwsOnUse.asMap(),
+            MetricReceiver.nullImplementation
         );
 
         var processor = new IndexingProcessor(documentTypes, scripts);
@@ -487,7 +491,8 @@ public class IndexingProcessorTestCase {
                 null,
                 Chunker.throwsOnUse.asMap(),
                 Map.of("test", embedder),
-                FieldGenerator.throwsOnUse.asMap()
+                FieldGenerator.throwsOnUse.asMap(),
+                MetricReceiver.nullImplementation
         );
 
         var processor = new IndexingProcessor(documentTypes, scripts);
@@ -529,7 +534,8 @@ public class IndexingProcessorTestCase {
             var scripts = new ScriptManager(documentTypes, new IlscriptsConfig(config), null,
                                             Chunker.throwsOnUse.asMap(),
                                             Map.of("test", new TestEmbedder()),
-                                            FieldGenerator.throwsOnUse.asMap());
+                                            FieldGenerator.throwsOnUse.asMap(),
+                                            MetricReceiver.nullImplementation);
 
             nestedTester = new IndexingProcessorTester(documentTypes, scripts);
             inputType = nestedTester.getDocumentType("test");

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTester.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTester.java
@@ -15,6 +15,7 @@ import com.yahoo.document.update.ClearValueUpdate;
 import com.yahoo.document.update.FieldUpdate;
 import com.yahoo.document.update.ValueUpdate;
 import com.yahoo.language.simple.SimpleLinguistics;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 
 import java.util.List;
@@ -80,7 +81,8 @@ public class IndexingProcessorTester {
                                      new SimpleLinguistics(),
                                      new ComponentRegistry<>(),
                                      new ComponentRegistry<>(),
-                                     new ComponentRegistry<>());
+                                     new ComponentRegistry<>(),
+                                     MetricReceiver.nullImplementation);
     }
 
     private static IndexingProcessor newProcessor(DocumentTypeManager documentTypes, ScriptManager scripts) {

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
@@ -6,6 +6,7 @@ import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.language.process.Chunker;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import org.junit.Test;
 
@@ -32,7 +33,8 @@ public class ScriptManagerTestCase {
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(config), null,
                                                     Chunker.throwsOnUse.asMap(),
                                                     Embedder.throwsOnUse.asMap(),
-                                                    FieldGenerator.throwsOnUse.asMap());
+                                                    FieldGenerator.throwsOnUse.asMap(),
+                                                    MetricReceiver.nullImplementation);
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle")));
         assertNull(scriptMgr.getScript(new DocumentType("unknown")));
     }
@@ -49,7 +51,8 @@ public class ScriptManagerTestCase {
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(config), null,
                                                     Chunker.throwsOnUse.asMap(),
                                                     Embedder.throwsOnUse.asMap(),
-                                                    FieldGenerator.throwsOnUse.asMap());
+                                                    FieldGenerator.throwsOnUse.asMap(),
+                                                    MetricReceiver.nullImplementation);
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newssummary")));
         assertNull(scriptMgr.getScript(new DocumentType("unknown")));
     }
@@ -60,7 +63,8 @@ public class ScriptManagerTestCase {
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(new IlscriptsConfig.Builder()), null,
                                                     Chunker.throwsOnUse.asMap(),
                                                     Embedder.throwsOnUse.asMap(),
-                                                    FieldGenerator.throwsOnUse.asMap());
+                                                    FieldGenerator.throwsOnUse.asMap(),
+                                                    MetricReceiver.nullImplementation);
         assertNull(scriptMgr.getScript(new DocumentType("unknown")));
     }
 
@@ -70,7 +74,8 @@ public class ScriptManagerTestCase {
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(new IlscriptsConfig.Builder()), null,
                                                     Chunker.throwsOnUse.asMap(),
                                                     Embedder.throwsOnUse.asMap(),
-                                                    FieldGenerator.throwsOnUse.asMap());
+                                                    FieldGenerator.throwsOnUse.asMap(),
+                                                    MetricReceiver.nullImplementation);
         for (Iterator<DocumentType> it = typeMgr.documentTypeIterator(); it.hasNext(); ) {
             assertNull(scriptMgr.getScript(it.next()));
         }
@@ -90,7 +95,8 @@ public class ScriptManagerTestCase {
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(config), null,
                                                     Chunker.throwsOnUse.asMap(),
                                                     Embedder.throwsOnUse.asMap(),
-                                                    FieldGenerator.throwsOnUse.asMap());
+                                                    FieldGenerator.throwsOnUse.asMap(),
+                                                    MetricReceiver.nullImplementation);
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "title"));
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "weight"));
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "uri"));

--- a/indexinglanguage/pom.xml
+++ b/indexinglanguage/pom.xml
@@ -61,7 +61,25 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-disc</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>metrics</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>linguistics-components</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>jdisc_core</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ScriptParser.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ScriptParser.java
@@ -49,6 +49,7 @@ public final class ScriptParser {
         parser.setChunkers(context.getChunkers());
         parser.setEmbedders(context.getEmbedders());
         parser.setGenerators(context.getGenerators());
+        parser.setMetricReceiver(context.getMetricReceiver());
 
         try {
             return method.call(parser);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ScriptParserContext.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ScriptParserContext.java
@@ -5,6 +5,7 @@ import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.Chunker;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.indexinglanguage.linguistics.AnnotatorConfig;
 import com.yahoo.vespa.indexinglanguage.parser.CharStream;
 
@@ -21,6 +22,7 @@ public class ScriptParserContext {
     private final Map<String, Chunker> chunkers;
     private final Map<String, Embedder> embedders;
     private final Map<String, FieldGenerator> generators;
+    private MetricReceiver metricReceiver = MetricReceiver.nullImplementation;
     private String defaultFieldName = null;
     private CharStream inputStream = null;
 
@@ -62,6 +64,13 @@ public class ScriptParserContext {
 
     public Map<String, FieldGenerator> getGenerators() {
         return Collections.unmodifiableMap(generators);
+    }
+
+    public MetricReceiver getMetricReceiver() { return metricReceiver; }
+
+    public ScriptParserContext setMetricReceiver(MetricReceiver metricReceiver) {
+        this.metricReceiver = metricReceiver;
+        return this;
     }
 
     public String getDefaultFieldName() {

--- a/indexinglanguage/src/main/javacc/IndexingParser.jj
+++ b/indexinglanguage/src/main/javacc/IndexingParser.jj
@@ -112,6 +112,7 @@ import com.yahoo.language.process.Chunker;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
 import com.yahoo.language.Linguistics;
+import com.yahoo.metrics.simple.MetricReceiver;
 
 /**
  * @author Simon Thoresen Hult
@@ -123,6 +124,7 @@ public class IndexingParser {
     private Components<Chunker> chunkers;
     private Components<Embedder> embedders;
     private Components<FieldGenerator> generators;
+    private MetricReceiver metricReceiver = MetricReceiver.nullImplementation;
     private AnnotatorConfig globalAnnotatorConfig = new AnnotatorConfig();
 
     public IndexingParser(String str) {
@@ -151,6 +153,11 @@ public class IndexingParser {
 
     public IndexingParser setGenerators(Map<String, FieldGenerator> generators) {
         this.generators = new Components.Map<FieldGenerator>(generators, FieldGenerator.FailingFieldGenerator.factory());
+        return this;
+    }
+
+    public IndexingParser setMetricReceiver(MetricReceiver metricReceiver) {
+        this.metricReceiver = metricReceiver;
         return this;
     }
 
@@ -517,7 +524,7 @@ Expression embedExp() :
 }
 {
     <EMBED> [ LOOKAHEAD(2) embedderId = identifier() ] arguments = arguments()
-    { return new EmbedExpression(linguistics, embedders, embedderId, arguments); }
+    { return new EmbedExpression(linguistics, embedders, embedderId, arguments, metricReceiver); }
 }
 
 Expression generateExp() :

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTestCase.java
@@ -680,4 +680,14 @@ public class EmbeddingScriptTestCase {
                      sparseTensor.getTensor().get());
     }
 
+    @Test
+    public void testBatchingConfigFromEmbedder() {
+        var mockEmbedder = new EmbeddingScriptTester.MockBatchingEmbedder("myDocument.myTensor");
+        var tester = new EmbeddingScriptTester(Map.of("emb1", mockEmbedder));
+
+        tester.testStatement("input myText | embed emb1 | attribute 'myTensor'", "input text", "[105, 110, 112, 117]");
+        assertEquals(0, mockEmbedder.singleCallCount);
+        assertEquals(1, mockEmbedder.batchCallCount);
+    }
+
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/EmbeddingScriptTestCase.java
@@ -10,6 +10,7 @@ import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.document.datatypes.TensorFieldValue;
 import com.yahoo.language.process.Embedder;
+import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.indexinglanguage.expressions.ExecutionContext;
@@ -688,6 +689,30 @@ public class EmbeddingScriptTestCase {
         tester.testStatement("input myText | embed emb1 | attribute 'myTensor'", "input text", "[105, 110, 112, 117]");
         assertEquals(0, mockEmbedder.singleCallCount);
         assertEquals(1, mockEmbedder.batchCallCount);
+    }
+
+    @Test
+    public void testBatchMetricsEmitted() {
+        var metricReceiver = new MetricReceiver.MockReceiver();
+        var mockEmbedder = new EmbeddingScriptTester.MockBatchingEmbedder("myDocument.myTensor");
+        var tester = new EmbeddingScriptTester(Map.of("emb1", mockEmbedder), metricReceiver);
+
+        tester.testStatement("input myText | embed emb1 | attribute 'myTensor'", "input text", "[105, 110, 112, 117]");
+
+        var snapshot = metricReceiver.getSnapshot();
+        var metrics = snapshot.getValuesByMetricName();
+
+        var batchSizeEntries = metrics.get("embedder.batch.size");
+        assertEquals(1, batchSizeEntries.size());
+        assertEquals(1.0, batchSizeEntries.get(0).getValue().getLast(), 0.001);
+
+        var batchCountEntries = metrics.get("embedder.batch.count");
+        assertEquals(1, batchCountEntries.size());
+        assertEquals(1, batchCountEntries.get(0).getValue().getCount());
+
+        var queueTimeEntries = metrics.get("embedder.batch.queue_time");
+        assertEquals(1, queueTimeEntries.size());
+        assertTrue(queueTimeEntries.get(0).getValue().getLast() >= 0);
     }
 
 }

--- a/integration/schema-language-server/language-server/pom.xml
+++ b/integration/schema-language-server/language-server/pom.xml
@@ -68,6 +68,11 @@
       <artifactId>indexinglanguage</artifactId>
       <version>8-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-disc</artifactId>
+      <version>8-SNAPSHOT</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
@@ -28,6 +28,7 @@ INJECT IndexingParser:
     import com.yahoo.language.process.Embedder;
     import com.yahoo.language.process.FieldGenerator;
     import com.yahoo.language.Linguistics;
+    import com.yahoo.metrics.simple.MetricReceiver;
 {
 /**
  * @author Simon Thoresen Hult
@@ -478,7 +479,7 @@ Expression embedExp() :
       <EMBED> [ SCAN((identifierStr)+) => (embedderId = identifierStr()) ] arguments = arguments()
     )
     {
-        return new EmbedExpression(linguistics, embedders, embedderId, arguments);
+        return new EmbedExpression(linguistics, embedders, embedderId, arguments, MetricReceiver.nullImplementation);
     }
 ;
 

--- a/linguistics/abi-spec.json
+++ b/linguistics/abi-spec.json
@@ -397,6 +397,28 @@
       "public static final com.yahoo.language.process.Chunker throwsOnUse"
     ]
   },
+  "com.yahoo.language.process.Embedder$Batching" : {
+    "superClass" : "java.lang.Record",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "final",
+      "record"
+    ],
+    "methods" : [
+      "public void <init>(int, java.time.Duration)",
+      "public boolean isEnabled()",
+      "public static com.yahoo.language.process.Embedder$Batching of(int, java.time.Duration)",
+      "public final java.lang.String toString()",
+      "public final int hashCode()",
+      "public final boolean equals(java.lang.Object)",
+      "public int maxSize()",
+      "public java.time.Duration maxDelay()"
+    ],
+    "fields" : [
+      "public static final com.yahoo.language.process.Embedder$Batching DISABLED"
+    ]
+  },
   "com.yahoo.language.process.Embedder$Context" : {
     "superClass" : "com.yahoo.language.process.InvocationContext",
     "interfaces" : [ ],
@@ -463,7 +485,8 @@
       "public abstract java.util.List embed(java.lang.String, com.yahoo.language.process.Embedder$Context)",
       "public java.lang.String decode(java.util.List, com.yahoo.language.process.Embedder$Context)",
       "public abstract com.yahoo.tensor.Tensor embed(java.lang.String, com.yahoo.language.process.Embedder$Context, com.yahoo.tensor.TensorType)",
-      "public java.util.List embed(java.util.List, com.yahoo.language.process.Embedder$Context, com.yahoo.tensor.TensorType)"
+      "public java.util.List embed(java.util.List, com.yahoo.language.process.Embedder$Context, com.yahoo.tensor.TensorType)",
+      "public com.yahoo.language.process.Embedder$Batching batchingConfig()"
     ],
     "fields" : [
       "public static final java.lang.String defaultEmbedderId",

--- a/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
+++ b/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
@@ -214,7 +214,11 @@ public enum ContainerMetrics implements VespaMetrics {
     EMBEDDER_LATENCY("embedder.latency", Unit.MILLISECOND, "Time spent creating an embedding"),
     EMBEDDER_SEQUENCE_LENGTH("embedder.sequence_length", Unit.ITEM, "Number of tokens in the input sequence"),
     EMBEDDER_REQUEST_COUNT("embedder.request.count", Unit.REQUEST, "Number of embedder API requests"),
-    EMBEDDER_REQUEST_FAILURE_COUNT("embedder.request.failure.count", Unit.REQUEST, "Number of failed embedder API requests");
+    EMBEDDER_REQUEST_FAILURE_COUNT("embedder.request.failure.count", Unit.REQUEST, "Number of failed embedder API requests"),
+
+    EMBEDDER_BATCH_SIZE("embedder.batch.size", Unit.ITEM, "Number of items in each dispatched batch"),
+    EMBEDDER_BATCH_QUEUE_TIME("embedder.batch.queue_time", Unit.MILLISECOND, "Time spent waiting in queue before batch dispatch"),
+    EMBEDDER_BATCH_COUNT("embedder.batch.count", Unit.OPERATION, "Number of batch dispatches");
 
     private final String name;
     private final Unit unit;

--- a/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
@@ -179,6 +179,9 @@ public class Vespa9VespaMetricSet {
         addMetric(metrics, ContainerMetrics.EMBEDDER_SEQUENCE_LENGTH, EnumSet.of(max, sum, count));
         addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_COUNT, EnumSet.of(count));
         addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_FAILURE_COUNT, EnumSet.of(count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_BATCH_SIZE, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_BATCH_QUEUE_TIME, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_BATCH_COUNT, EnumSet.of(count));
 
         return metrics;
     }

--- a/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
@@ -243,6 +243,9 @@ public class VespaMetricSet {
         addMetric(metrics, ContainerMetrics.EMBEDDER_SEQUENCE_LENGTH, EnumSet.of(max, sum, count));
         addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_COUNT, EnumSet.of(count));
         addMetric(metrics, ContainerMetrics.EMBEDDER_REQUEST_FAILURE_COUNT, EnumSet.of(count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_BATCH_SIZE, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_BATCH_QUEUE_TIME, EnumSet.of(max, sum, count));
+        addMetric(metrics, ContainerMetrics.EMBEDDER_BATCH_COUNT, EnumSet.of(count));
 
         // Deprecated metrics. TODO: Remove on Vespa 9.
         addMetric(metrics, ContainerMetrics.SERVER_REJECTED_REQUESTS, EnumSet.of(rate, count));


### PR DESCRIPTION
## Summary

- Add `Embedder.Batching` record and `Embedder.batchingConfig()` to the `Embedder` interface for declarative batching configuration
- Implement `DynamicBatcher` integration in `EmbedExpression` with per-key batching, grouping concurrent embed calls into batches
- Extract shared `EmbedderBatchingConfig` for XML `<batching>` element parsing in config-model
- Add `<batching>` support to `VoyageAIEmbedder` (config-model + config definition) and batch embedding via `embed(List<String>, ...)` override
- Emit `embedder.batch.size`, `embedder.batch.queue_time`, and `embedder.batch.count` metrics with embedder/language/destination dimensions