### PR TITLE
Fix schema language server build failure due to MetricReceiver dependency

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
@@ -56,6 +56,17 @@ public class EmbedExpression extends Expression  {
     private String destination;
 
     public EmbedExpression(Linguistics linguistics, Components<Embedder> embedders, String embedderId,
+                           List<String> arguments) {
+        this.linguistics = linguistics;
+        this.requestedEmbedderId = embedderId;
+        embedder = new Components.Selected<>("embedder", embedders, embedderId, true, arguments);
+        this.batcher = null;
+        this.batchSize = null;
+        this.batchQueueTime = null;
+        this.batchCount = null;
+    }
+
+    public EmbedExpression(Linguistics linguistics, Components<Embedder> embedders, String embedderId,
                            List<String> arguments, MetricReceiver metricReceiver) {
         this.linguistics = linguistics;
         this.requestedEmbedderId = embedderId;
@@ -288,6 +299,7 @@ public class EmbedExpression extends Expression  {
     }
 
     private void emitBatchMetrics(BatchKey key, List<EmbedInput> inputs) {
+        if (batchSize == null) return;
         var point = new Point(Map.of("embedder", embedder.id(),
                                       "language", key.language().languageCode(),
                                       "destination", key.destination()));

--- a/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
@@ -28,7 +28,6 @@ INJECT IndexingParser:
     import com.yahoo.language.process.Embedder;
     import com.yahoo.language.process.FieldGenerator;
     import com.yahoo.language.Linguistics;
-    import com.yahoo.metrics.simple.MetricReceiver;
 {
 /**
  * @author Simon Thoresen Hult
@@ -479,7 +478,7 @@ Expression embedExp() :
       <EMBED> [ SCAN((identifierStr)+) => (embedderId = identifierStr()) ] arguments = arguments()
     )
     {
-        return new EmbedExpression(linguistics, embedders, embedderId, arguments, MetricReceiver.nullImplementation);
+        return new EmbedExpression(linguistics, embedders, embedderId, arguments);
     }
 ;
 


### PR DESCRIPTION
## Summary

- Add secondary `EmbedExpression` constructor without `MetricReceiver` for contexts where metrics are unavailable (schema language server)
- Add null guard in `emitBatchMetrics` as safety net
- Remove `MetricReceiver` import from `IndexingParser.ccc`

FYI @esolitos 