### PR TITLE
add offset to BitSpan

### DIFF
--- a/vespalib/src/vespa/vespalib/util/bit_span.h
+++ b/vespalib/src/vespa/vespalib/util/bit_span.h
@@ -9,10 +9,12 @@ namespace vespalib {
 /**
  * A lightweight read-only view over bit-packed bool data.
  * Bits are stored LSB-first: bool[i] is bit (i%8) of byte[i/8].
+ * An optional bit offset allows the span to start at any bit position.
  */
 class BitSpan {
-    const char* _data;
-    uint32_t    _count;
+    const uint8_t* _data;
+    uint32_t       _offset;
+    uint32_t       _count;
 public:
     class Sentinel {
         const uint32_t _end;
@@ -21,22 +23,23 @@ public:
         bool valid(uint32_t pos) const noexcept { return pos < _end; }
     };
     class Iterator {
-        const char* _data;
-        uint32_t    _pos;
+        const uint8_t* _data;
+        uint32_t       _pos;
     public:
-        Iterator(const char* data, uint32_t pos) noexcept : _data(data), _pos(pos) {}
+        Iterator(const uint8_t* data, uint32_t pos) noexcept : _data(data), _pos(pos) {}
         bool operator*() const noexcept { return (_data[_pos / 8] >> (_pos % 8)) & 1; }
         Iterator& operator++() noexcept { ++_pos; return *this; }
         bool operator!=(Sentinel s) const noexcept { return s.valid(_pos); }
     };
 
-    BitSpan() noexcept : _data(nullptr), _count(0) {}
-    BitSpan(const char* data, uint32_t count) noexcept : _data(data), _count(count) {}
-    bool operator[](uint32_t i) const noexcept { return (_data[i / 8] >> (i % 8)) & 1; }
+    BitSpan() noexcept : _data(nullptr), _offset(0), _count(0) {}
+    BitSpan(const void* data, uint32_t count) noexcept : _data(static_cast<const uint8_t*>(data)), _offset(0), _count(count) {}
+    BitSpan(const void* data, uint32_t offset, uint32_t count) noexcept : _data(static_cast<const uint8_t*>(data)), _offset(offset), _count(count) {}
+    bool operator[](uint32_t i) const noexcept { return (_data[(_offset + i) / 8] >> ((_offset + i) % 8)) & 1; }
     uint32_t size() const noexcept { return _count; }
     bool empty() const noexcept { return _count == 0; }
-    Iterator begin() const noexcept { return Iterator(_data, 0); }
-    Sentinel end() const noexcept { return Sentinel(_count); }
+    Iterator begin() const noexcept { return Iterator(_data, _offset); }
+    Sentinel end() const noexcept { return Sentinel(_offset + _count); }
 };
 
 }


### PR DESCRIPTION
& use uint8_t* for bits and void* as parameter
& clean up unit tests

@toregge please review
enables storing bits with less byte alignment (for things like extendable attributes)
also enables future support for things like subspan, first, last, etc.
