### PR TITLE
Cache detected language in indexing expression evaluation

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContext.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContext.java
@@ -111,6 +111,7 @@ public class ExecutionContext {
 
     public Language resolveLanguage(Linguistics linguistics) {
         if (assignedLanguage != Language.UNKNOWN) return assignedLanguage;
+        if (detectedLanguage != Language.UNKNOWN) return detectedLanguage;
         if (linguistics == null) return Language.ENGLISH;
 
         Detection detection = linguistics.getDetector().detect(String.valueOf(currentValue), null);
@@ -134,17 +135,14 @@ public class ExecutionContext {
      * Clears all state in this pertaining to the current indexing statement
      * Does not clear the cache.
      * Note that assignLanguage is not cleared; an indexing statement doing
-     * set_language should affect following statements.
+     * set_language should affect the following statements.
      */
     public ExecutionContext clear() {
         // We do not really want to clear variables here, but because
         // indexing statements are re-ordered letting them survive
         // will be even more confusing than clearing them.
         variables.clear();
-        // We should probably clear detectedLanguage, but
-        // it looks like the statements that use it will reset it
-        // using resolveLanguage anyway.
-        // TODO: detectedLanguage = Language.UNKNOWN;
+        detectedLanguage = Language.UNKNOWN;
         currentValue = null;
         // note: must not reset per-document or global values (like isReindexingOperation, deadline)
         return this;

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContextTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContextTestCase.java
@@ -92,8 +92,29 @@ public class ExecutionContextTestCase {
         ExecutionContext ctx = new ExecutionContext();
         ctx.setCurrentValue(new StringFieldValue("\u3072\u3089\u304c\u306a"));
         assertEquals(Language.JAPANESE, ctx.resolveLanguage(new SimpleLinguistics()));
+        // Detected language is cached; clear() resets it for the next statement
+        ctx.clear();
         ctx.setCurrentValue(new StringFieldValue("\ud55c\uae00\uacfc"));
         assertEquals(Language.KOREAN, ctx.resolveLanguage(new SimpleLinguistics()));
+    }
+
+    @Test
+    public void requireThatDetectedLanguageIsCached() {
+        ExecutionContext ctx = new ExecutionContext();
+        ctx.setCurrentValue(new StringFieldValue("\u3072\u3089\u304c\u306a"));
+        assertEquals(Language.JAPANESE, ctx.resolveLanguage(new SimpleLinguistics()));
+        // Second call within same statement returns cached result
+        ctx.setCurrentValue(new StringFieldValue("\ud55c\uae00\uacfc"));
+        assertEquals(Language.JAPANESE, ctx.resolveLanguage(new SimpleLinguistics()));
+    }
+
+    @Test
+    public void requireThatClearResetsDetectedLanguage() {
+        ExecutionContext ctx = new ExecutionContext();
+        ctx.setCurrentValue(new StringFieldValue("\u3072\u3089\u304c\u306a"));
+        assertEquals(Language.JAPANESE, ctx.resolveLanguage(new SimpleLinguistics()));
+        ctx.clear();
+        assertEquals(Language.UNKNOWN, ctx.getLanguage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `ExecutionContext.resolveLanguage()` wrote to `detectedLanguage` but never checked it before running detection, causing expensive OpenNLP language detection to run for every expression that needs language (tokenize, normalize, embed) instead of once per statement
- Add cache check for `detectedLanguage` before invoking the language detector
- Clear `detectedLanguage` in `clear()` so each statement gets fresh detection appropriate for its input field, while multiple expressions within the same statement share the cached result