### PR TITLE
Use base64 encoding_format for VoyageAI embeddings API

### DIFF
--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -29,7 +29,10 @@ import okhttp3.RequestBody;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -224,26 +227,26 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
     private List<Tensor> toTensors(String responseBody, TensorType targetType, String outputDtype, Context context) {
         try {
             Response response;
-            List<List<Number>> embeddings;
+            List<String> encodedEmbeddings;
             if (isContextualModel()) {
                 var contextualResponse = objectMapper.readValue(responseBody, ContextualResponse.class);
                 response = contextualResponse;
-                embeddings = contextualResponse.data.get(0).data.stream()
+                encodedEmbeddings = contextualResponse.data.get(0).data.stream()
                         .map(TextEmbeddingData::embedding)
                         .toList();
             } else {
                 var voyageResponse = objectMapper.readValue(responseBody, TextResponse.class);
                 response = voyageResponse;
-                embeddings = voyageResponse.data.stream()
+                encodedEmbeddings = voyageResponse.data.stream()
                         .map(TextEmbeddingData::embedding)
                         .toList();
             }
             runtime.sampleSequenceLength(response.usage().totalTokens(), context);
             String dimensionName = targetType.dimensions().get(0).name();
-            return embeddings.stream()
-                    .map(embedding -> switch (outputDtype) {
-                        case "float" -> createFloatTensor(embedding, dimensionName, targetType.valueType());
-                        case "int8", "binary" -> createInt8Tensor(embedding, dimensionName);
+            return encodedEmbeddings.stream()
+                    .map(encoded -> switch (outputDtype) {
+                        case "float" -> decodeBase64FloatTensor(encoded, dimensionName, targetType.valueType());
+                        case "int8", "binary" -> decodeBase64Int8Tensor(encoded, dimensionName);
                         default -> throw new IllegalArgumentException("Unsupported output_dtype: " + outputDtype);
                     })
                     .toList();
@@ -334,24 +337,20 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
         return remainingMs;
     }
 
-    private Tensor createFloatTensor(List<Number> embedding, String dimensionName, TensorType.Value valueType) {
-        TensorType type = new TensorType.Builder(valueType)
-                .indexed(dimensionName, embedding.size())
-                .build();
-        IndexedTensor.Builder builder = IndexedTensor.Builder.of(type);
-        for (int i = 0; i < embedding.size(); i++) {
-            builder.cell(embedding.get(i).floatValue(), i);
-        }
-        return builder.build();
+    private static Tensor decodeBase64FloatTensor(String base64, String dimensionName, TensorType.Value valueType) {
+        var buffer = ByteBuffer.wrap(Base64.getDecoder().decode(base64)).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+        var values = new float[buffer.remaining()];
+        buffer.get(values);
+        var type = new TensorType.Builder(valueType).indexed(dimensionName, values.length).build();
+        return IndexedTensor.Builder.of(type, values).build();
     }
 
-    private Tensor createInt8Tensor(List<Number> embedding, String dimensionName) {
-        TensorType type = new TensorType.Builder(TensorType.Value.INT8)
-                .indexed(dimensionName, embedding.size())
-                .build();
-        IndexedTensor.Builder builder = IndexedTensor.Builder.of(type);
-        for (int i = 0; i < embedding.size(); i++) {
-            builder.cell(embedding.get(i).byteValue(), i);
+    private static Tensor decodeBase64Int8Tensor(String base64, String dimensionName) {
+        var bytes = Base64.getDecoder().decode(base64);
+        var type = new TensorType.Builder(TensorType.Value.INT8).indexed(dimensionName, bytes.length).build();
+        var builder = IndexedTensor.Builder.of(type);
+        for (int i = 0; i < bytes.length; i++) {
+            builder.cell(bytes[i], i);
         }
         return builder.build();
     }
@@ -431,17 +430,18 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("input_type") String inputType,
             @JsonProperty("truncation") boolean truncation,
             @JsonProperty("output_dimension") @JsonInclude(JsonInclude.Include.NON_NULL) Integer outputDimension,
-            @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype) {
+            @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype,
+            @JsonProperty("encoding_format") String encodingFormat) {
 
         static TextRequest of(List<String> texts, String model, String inputType,
                               boolean truncation, Integer outputDimension, String outputDtype) {
-            return new TextRequest(texts, model, inputType, truncation, outputDimension, outputDtype);
+            return new TextRequest(texts, model, inputType, truncation, outputDimension, outputDtype, "base64");
         }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record TextEmbeddingData(
-            @JsonProperty("embedding") List<Number> embedding,
+            @JsonProperty("embedding") String embedding,
             @JsonProperty("index") int index) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -457,12 +457,13 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("model") String model,
             @JsonProperty("input_type") @JsonInclude(JsonInclude.Include.NON_NULL) String inputType,
             @JsonProperty("output_dimension") @JsonInclude(JsonInclude.Include.NON_NULL) Integer outputDimension,
-            @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype) {
+            @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype,
+            @JsonProperty("encoding_format") String encodingFormat) {
 
         static ContextualRequest of(List<String> texts, String model, String inputType,
                                     Integer outputDimension, String outputDtype) {
             return new ContextualRequest(List.of(texts), model, inputType,
-                                         outputDimension, outputDtype);
+                                         outputDimension, outputDtype, "base64");
         }
     }
 
@@ -483,12 +484,13 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("input_type") @JsonInclude(JsonInclude.Include.NON_NULL) String inputType,
             @JsonProperty("truncation") boolean truncation,
             @JsonProperty("output_dimension") @JsonInclude(JsonInclude.Include.NON_NULL) Integer outputDimension,
-            @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype) {
+            @JsonProperty("output_dtype") @JsonInclude(JsonInclude.Include.NON_NULL) String outputDtype,
+            @JsonProperty("encoding_format") String encodingFormat) {
 
         static MultimodalRequest of(String text, String model, String inputType,
                                     boolean truncation, Integer outputDimension, String outputDtype) {
             return new MultimodalRequest(List.of(MultimodalInput.of(text)), model, inputType,
-                                         truncation, outputDimension, outputDtype);
+                                         truncation, outputDimension, outputDtype, "base64");
         }
     }
 

--- a/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
@@ -6,6 +6,7 @@ import ai.vespa.secret.Secrets;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.InvocationContext;
 import com.yahoo.language.process.TimeoutException;
+import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.text.Text;
@@ -17,10 +18,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Duration;
-import java.util.Locale;
+import java.util.Base64;
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntFunction;
 
 import static com.yahoo.text.Lowercase.toUpperCase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -80,7 +82,9 @@ public class VoyageAIEmbedderTest {
         assertEquals("POST", request.getMethod());
         assertEquals("/v1/embeddings", request.getPath());
         assertTrue(request.getHeader("Authorization").startsWith("Bearer "));
-        assertTrue(request.getBody().readUtf8().contains("\"model\":\"voyage-3\""));
+        String body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"model\":\"voyage-3\""));
+        assertTrue(body.contains("\"encoding_format\":\"base64\""));
     }
 
     @Test
@@ -358,11 +362,12 @@ public class VoyageAIEmbedderTest {
         assertEquals(1024, result.size());
         assertEquals(TensorType.Value.FLOAT, result.type().valueType());
 
-        // Verify request contains output_dtype=float and output_dimension=1024
+        // Verify request contains output_dtype=float, output_dimension=1024, encoding_format=base64
         RecordedRequest request = mockServer.takeRequest();
         String body = request.getBody().readUtf8();
         assertTrue(body.contains("\"output_dtype\":\"float\""));
         assertTrue(body.contains("\"output_dimension\":1024"));
+        assertTrue(body.contains("\"encoding_format\":\"base64\""));
     }
 
     @Test
@@ -582,6 +587,48 @@ public class VoyageAIEmbedderTest {
         assertEquals(Duration.ofMillis(200), batching.maxDelay());
     }
 
+    @Test
+    public void testBase64FloatRoundTrip() {
+        float[] expected = {1.0f, -0.5f, 0.0f, Float.MAX_VALUE};
+        var buffer = ByteBuffer.allocate(expected.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (float v : expected) buffer.putFloat(v);
+        var base64 = Base64.getEncoder().encodeToString(buffer.array());
+
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createBase64Response(1, base64)));
+
+        embedder = createEmbedder(4, "float");
+        var targetType = TensorType.fromSpec("tensor<float>(x[4])");
+        var context = new Embedder.Context("test-embedder");
+        var result = (IndexedTensor) embedder.embed("test", context, targetType);
+
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], result.getFloat(i), 0.0f, "Mismatch at index " + i);
+        }
+    }
+
+    @Test
+    public void testBase64Int8RoundTrip() {
+        byte[] expected = {0, 1, -1, 127, -128, 42};
+        var base64 = Base64.getEncoder().encodeToString(expected);
+
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createBase64Response(1, base64)));
+
+        embedder = createEmbedder(6, "int8");
+        var targetType = TensorType.fromSpec("tensor<int8>(x[6])");
+        var context = new Embedder.Context("test-embedder");
+        var result = (IndexedTensor) embedder.embed("test", context, targetType);
+
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], (byte) result.getFloat(i), "Mismatch at index " + i);
+        }
+    }
+
     // ===== Helper Methods =====
 
     private VoyageAIEmbedder createEmbedder() {
@@ -609,36 +656,55 @@ public class VoyageAIEmbedderTest {
         };
     }
 
-    private static String createSuccessResponse(int dimensions, IntFunction<String> valueGenerator) {
-        return createBatchSuccessResponse(1, dimensions, valueGenerator);
+    private static String encodeFloatsToBase64(int dimensions, int batchOffset) {
+        var buffer = ByteBuffer.allocate(dimensions * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (int i = 0; i < dimensions; i++) {
+            buffer.putFloat((float) Math.sin((i + batchOffset) * 0.1));
+        }
+        return Base64.getEncoder().encodeToString(buffer.array());
     }
 
-    private static String createBatchSuccessResponse(int batchSize, int dimensions, IntFunction<String> valueGenerator) {
-        var dataEntries = new StringBuilder();
-        for (int b = 0; b < batchSize; b++) {
-            if (b > 0) dataEntries.append(",");
-            var embedding = new StringBuilder("[");
-            for (int i = 0; i < dimensions; i++) {
-                if (i > 0) embedding.append(",");
-                // Vary values by batch index to verify correct ordering
-                embedding.append(valueGenerator.apply(i + b * 1000));
-            }
-            embedding.append("]");
-            dataEntries.append(Text.format("{\"object\": \"embedding\", \"embedding\": %s, \"index\": %d}", embedding, b));
+    private static String encodeBytesToBase64(int dimensions) {
+        var bytes = new byte[dimensions];
+        for (int i = 0; i < dimensions; i++) {
+            bytes[i] = (byte) (i % 128);
         }
-        return Text.format("""
-                {
-                  "object": "list",
-                  "data": [%s],
-                  "model": "voyage-3",
-                  "usage": {"total_tokens": %d}
-                }
-                """, dataEntries, batchSize * 10);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     private static String createSuccessResponse(int dimensions) { return createFloatSuccessResponse(dimensions); }
-    private static String createFloatSuccessResponse(int dimensions) { return createSuccessResponse(dimensions, i -> Text.format("%.6f", Math.sin(i * 0.1))); }
-    private static String createFloatBatchSuccessResponse(int batchSize, int dimensions) { return createBatchSuccessResponse(batchSize, dimensions, i -> Text.format("%.6f", Math.sin(i * 0.1))); }
-    private static String createInt8SuccessResponse(int dimensions) { return createSuccessResponse(dimensions, i -> String.valueOf(i % 128)); }
+
+    private static String createFloatSuccessResponse(int dimensions) {
+        return createBase64Response(1, encodeFloatsToBase64(dimensions, 0));
+    }
+
+    private static String createFloatBatchSuccessResponse(int batchSize, int dimensions) {
+        var dataEntries = new StringBuilder();
+        for (int b = 0; b < batchSize; b++) {
+            if (b > 0) dataEntries.append(",");
+            dataEntries.append(Text.format("{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":%d}",
+                    encodeFloatsToBase64(dimensions, b * 1000), b));
+        }
+        return Text.format("""
+                {"object":"list","data":[%s],"model":"voyage-3","usage":{"total_tokens":%d}}
+                """, dataEntries, batchSize * 10);
+    }
+
+    private static String createInt8SuccessResponse(int dimensions) {
+        return createBase64Response(1, encodeBytesToBase64(dimensions));
+    }
+
     private static String createBinarySuccessResponse(int dimensions) { return createInt8SuccessResponse(dimensions); }
+
+    private static String createBase64Response(int batchSize, String... base64Embeddings) {
+        var dataEntries = new StringBuilder();
+        for (int b = 0; b < base64Embeddings.length; b++) {
+            if (b > 0) dataEntries.append(",");
+            dataEntries.append(Text.format("{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":%d}",
+                    base64Embeddings[b], b));
+        }
+        return Text.format("""
+                {"object":"list","data":[%s],"model":"voyage-3","usage":{"total_tokens":%d}}
+                """, dataEntries, batchSize * 10);
+    }
 }


### PR DESCRIPTION
## Summary
- Request base64 `encoding_format` from VoyageAI API instead of JSON arrays of numbers
- Decode base64 responses into tensors directly, avoiding intermediate `List<Number>` boxing
- Combine decode + tensor creation into single `decodeBase64FloatTensor` / `decodeBase64Int8Tensor` methods
- Add round-trip tests verifying base64 float and int8 encoding/decoding