### PR TITLE
Add friendly type name to ResultNode in grouping.

### DIFF
--- a/searchlib/src/vespa/searchlib/aggregation/hitlist.h
+++ b/searchlib/src/vespa/searchlib/aggregation/hitlist.h
@@ -21,6 +21,7 @@ private:
     int64_t onGetInteger(size_t index) const override { (void) index; return 0; }
     double onGetFloat(size_t index)    const override { (void) index; return 0.0; }
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override { (void) index; return buf; }
+    std::string_view friendly_type_name() const noexcept override { return "<hitlist>"; }
     size_t hash() const override { return 0; }
     void set(const ResultNode & rhs) override;
     void decode(const void * buf) override {

--- a/searchlib/src/vespa/searchlib/expression/attributeresult.h
+++ b/searchlib/src/vespa/searchlib/expression/attributeresult.h
@@ -32,6 +32,7 @@ private:
         return get_raw();
     }
     int64_t onGetEnum(size_t index) const override { (void) index; return (static_cast<int64_t>(_attribute->getEnum(_docId))); }
+    std::string_view friendly_type_name() const noexcept override { return "<attribute_result>"; }
     void set(const search::expression::ResultNode&) override { }
     size_t hash() const override { return _docId; }
 
@@ -47,6 +48,9 @@ public:
         : AttributeResult(attribute, docId)
     { }
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+private:
+    std::string_view friendly_type_name() const noexcept override { return "<long_attribute_result>"; }
 };
 
 class FloatAttributeResult : public AttributeResult {
@@ -57,6 +61,9 @@ public:
         : AttributeResult(attribute, docId)
     { }
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+private:
+    std::string_view friendly_type_name() const noexcept override { return "<double_attribute_result>"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
@@ -193,6 +193,9 @@ public:
 private:
     void set(const ResultNode&) override;
     size_t hash() const override { return 0; }
+
+    std::string_view friendly_type_name() const noexcept override { return "<field_value>"; }
+
     const FieldValue * _fv;
 };
 
@@ -312,6 +315,9 @@ private:
     String2ResultNode * clone() const override { return new String2ResultNode(_s); }
     void set(const ResultNode&) override;
     size_t hash() const override { return 0; }
+
+    std::string_view friendly_type_name() const noexcept override { return "<string_adapter>"; }
+
     std::string _s;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.h
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.h
@@ -24,6 +24,9 @@ public:
 private:
     void set(const ResultNode&) override;
     size_t hash() const override { return 0; }
+
+    std::string_view friendly_type_name() const noexcept override { return "<default>"; }
+
     static char null;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/enumresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/enumresultnode.h
@@ -16,6 +16,8 @@ public:
 private:
     int64_t onGetEnum(size_t index) const override { (void) index; return getValue(); }
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "string"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/floatbucketresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/floatbucketresultnode.h
@@ -47,6 +47,8 @@ public:
     }
     const FloatBucketResultNode& getNullBucket() const override { return getNull(); }
     static const FloatBucketResultNode & getNull() { return _nullResult; }
+
+    std::string_view friendly_type_name() const noexcept override { return "float_bucket"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/floatresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/floatresultnode.h
@@ -49,6 +49,9 @@ private:
     int64_t onGetInteger(size_t index) const override;
     double onGetFloat(size_t index)    const override;
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "double"; }
+
     double _value;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/integerbucketresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/integerbucketresultnode.h
@@ -12,6 +12,7 @@ private:
     int64_t _to;
     static IntegerBucketResultNode _nullResult;
 
+    std::string_view friendly_type_name() const noexcept override { return "integer_bucket"; }
     size_t onGetRawByteSize() const override { return sizeof(_from) + sizeof(_to); }
     void create(void * buf)  const override  { (void) buf; }
     void destroy(void * buf) const override  { (void) buf; }

--- a/searchlib/src/vespa/searchlib/expression/integerresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/integerresultnode.h
@@ -104,6 +104,8 @@ public:
     bool getBool() const { return getValue(); }
 private:
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "bool"; }
 };
 
 class Int8ResultNode : public IntegerResultNodeT<int8_t>
@@ -115,6 +117,8 @@ public:
     Int8ResultNode(int8_t v=0) : Base(v) { }
 private:
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "byte"; }
 };
 
 class Int16ResultNode : public IntegerResultNodeT<int16_t>
@@ -126,6 +130,8 @@ public:
     Int16ResultNode(int16_t v=0) : Base(v) { }
 private:
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "short"; }
 };
 
 class Int32ResultNode : public IntegerResultNodeT<int32_t>
@@ -137,6 +143,8 @@ public:
     Int32ResultNode(int32_t v=0) : Base(v) { }
 private:
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "int"; }
 };
 
 class Int64ResultNode : public IntegerResultNodeT<int64_t>
@@ -148,6 +156,8 @@ public:
     Int64ResultNode(int64_t v=0) : Base(v) { }
 private:
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "long"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
@@ -24,7 +24,7 @@ const BoolResultNode* as_bool_result(const ResultNode* result) {
 bool IsTruePredicateNode::check(const ResultNode* result) const {
     if (!result->inherits(BoolResultNode::classId)) {
         throw vespalib::IllegalArgumentException(
-            std::format("istrue() requires boolean input, got {}", result->friendly_type_name()));
+            std::format("istrue() requires input to be type bool, got {}", result->friendly_type_name()));
     }
 
     return as_bool_result(result)->getBool();

--- a/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/istrue_predicate_node.cpp
@@ -24,7 +24,7 @@ const BoolResultNode* as_bool_result(const ResultNode* result) {
 bool IsTruePredicateNode::check(const ResultNode* result) const {
     if (!result->inherits(BoolResultNode::classId)) {
         throw vespalib::IllegalArgumentException(
-            std::format("istrue() requires boolean input, got {}", result->getClass().name()));
+            std::format("istrue() requires boolean input, got {}", result->friendly_type_name()));
     }
 
     return as_bool_result(result)->getBool();

--- a/searchlib/src/vespa/searchlib/expression/nullresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/nullresultnode.h
@@ -28,6 +28,8 @@ private:
     void decode(const void * buf) override { (void) buf; }
     void encode(void * buf) const override { (void) buf; }
     void swap(void * buf) override { (void) buf; }
+
+    std::string_view friendly_type_name() const noexcept override { return "null"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/positiveinfinityresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/positiveinfinityresultnode.h
@@ -22,6 +22,8 @@ private:
     double onGetFloat(size_t index)    const override;
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
     size_t onGetRawByteSize() const override { return 0; }
+
+    std::string_view friendly_type_name() const noexcept override { return "infinity"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/rawbucketresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/rawbucketresultnode.h
@@ -36,6 +36,8 @@ public:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     const RawBucketResultNode& getNullBucket() const override { return getNull(); }
     static const RawBucketResultNode & getNull() { return _nullResult; }
+
+    std::string_view friendly_type_name() const noexcept override { return "raw_bucket"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/rawresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/rawresultnode.h
@@ -45,6 +45,9 @@ private:
     int64_t onGetInteger(size_t index) const override;
     double onGetFloat(size_t index)    const override;
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "string"; }
+
     V _value;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/resultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/resultnode.h
@@ -5,6 +5,8 @@
 #include "serializer.h"
 #include <vespa/vespalib/util/buffer.h>
 
+#include <string_view>
+
 namespace search::expression {
 
 class BucketResultNode;
@@ -44,6 +46,11 @@ public:
     int64_t getInteger(size_t index) const { return onGetInteger(index); }
     double    getFloat(size_t index) const { return onGetFloat(index); }
     ConstBufferRef getString(size_t index, BufferRef buf) const { return onGetString(index, buf); }
+
+    /**
+     * Friendly type name that can be displayed to user.
+     */
+    [[nodiscard]] virtual std::string_view friendly_type_name() const noexcept = 0;
 
 private:
     virtual int64_t onGetInteger(size_t index) const = 0;

--- a/searchlib/src/vespa/searchlib/expression/resultvector.h
+++ b/searchlib/src/vespa/searchlib/expression/resultvector.h
@@ -357,6 +357,8 @@ public:
     DECLARE_RESULTNODE(BoolResultNodeVector);
 
     const IntegerBucketResultNode& getNullBucket() const override { return IntegerBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<bool>"; }
 };
 
 class Int8ResultNodeVector : public NumericResultNodeVectorT<Int8ResultNode>
@@ -366,6 +368,8 @@ public:
     DECLARE_RESULTNODE(Int8ResultNodeVector);
 
     const IntegerBucketResultNode& getNullBucket() const override { return IntegerBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<byte>"; }
 };
 
 class Int16ResultNodeVector : public NumericResultNodeVectorT<Int16ResultNode>
@@ -375,6 +379,8 @@ public:
     DECLARE_RESULTNODE(Int16ResultNodeVector);
 
     const IntegerBucketResultNode& getNullBucket() const override { return IntegerBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<short>"; }
 };
 
 class Int32ResultNodeVector : public NumericResultNodeVectorT<Int32ResultNode>
@@ -384,6 +390,8 @@ public:
     DECLARE_RESULTNODE(Int32ResultNodeVector);
 
     const IntegerBucketResultNode& getNullBucket() const override { return IntegerBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<int>"; }
 };
 
 class Int64ResultNodeVector : public NumericResultNodeVectorT<Int64ResultNode>
@@ -393,6 +401,8 @@ public:
     DECLARE_RESULTNODE(Int64ResultNodeVector);
 
     const IntegerBucketResultNode& getNullBucket() const override { return IntegerBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<long>"; }
 };
 
 using IntegerResultNodeVector = Int64ResultNodeVector;
@@ -402,6 +412,8 @@ class EnumResultNodeVector : public NumericResultNodeVectorT<EnumResultNode>
 public:
     EnumResultNodeVector() = default;
     DECLARE_RESULTNODE(EnumResultNodeVector);
+
+    std::string_view friendly_type_name() const noexcept override { return "array<string>"; }
 };
 
 class FloatResultNodeVector : public NumericResultNodeVectorT<FloatResultNode>
@@ -411,6 +423,8 @@ public:
     DECLARE_RESULTNODE(FloatResultNodeVector);
 
     const FloatBucketResultNode& getNullBucket() const override { return FloatBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<double>"; }
 };
 
 class StringResultNodeVector : public ResultNodeVectorT<StringResultNode, cmpT<ResultNode>, vespalib::Identity>
@@ -420,6 +434,8 @@ public:
     DECLARE_RESULTNODE(StringResultNodeVector);
 
     const StringBucketResultNode& getNullBucket() const override { return StringBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<string>"; }
 };
 
 class RawResultNodeVector : public ResultNodeVectorT<RawResultNode, cmpT<ResultNode>, vespalib::Identity>
@@ -429,6 +445,8 @@ public:
     DECLARE_RESULTNODE(RawResultNodeVector);
 
     const RawBucketResultNode& getNullBucket() const override { return RawBucketResultNode::getNull(); }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<raw>"; }
 };
 
 class IntegerBucketResultNodeVector : public ResultNodeVectorT<IntegerBucketResultNode, contains<IntegerBucketResultNode, int64_t>, GetInteger >
@@ -436,6 +454,8 @@ class IntegerBucketResultNodeVector : public ResultNodeVectorT<IntegerBucketResu
 public:
     IntegerBucketResultNodeVector() = default;
     DECLARE_RESULTNODE(IntegerBucketResultNodeVector);
+
+    std::string_view friendly_type_name() const noexcept override { return "array<long_bucket>"; }
 };
 
 class FloatBucketResultNodeVector : public ResultNodeVectorT<FloatBucketResultNode, contains<FloatBucketResultNode, double>, GetFloat >
@@ -443,6 +463,8 @@ class FloatBucketResultNodeVector : public ResultNodeVectorT<FloatBucketResultNo
 public:
     FloatBucketResultNodeVector() = default;
     DECLARE_RESULTNODE(FloatBucketResultNodeVector);
+
+    std::string_view friendly_type_name() const noexcept override { return "array<double_bucket>"; }
 };
 
 class StringBucketResultNodeVector : public ResultNodeVectorT<StringBucketResultNode, contains<StringBucketResultNode, ResultNode::ConstBufferRef>, GetString >
@@ -450,6 +472,8 @@ class StringBucketResultNodeVector : public ResultNodeVectorT<StringBucketResult
 public:
     StringBucketResultNodeVector() = default;
     DECLARE_RESULTNODE(StringBucketResultNodeVector);
+
+    std::string_view friendly_type_name() const noexcept override { return "array<string_bucket>"; }
 };
 
 class RawBucketResultNodeVector : public ResultNodeVectorT<RawBucketResultNode, contains<RawBucketResultNode, ResultNode::ConstBufferRef>, GetString >
@@ -457,6 +481,8 @@ class RawBucketResultNodeVector : public ResultNodeVectorT<RawBucketResultNode, 
 public:
     RawBucketResultNodeVector() = default;
     DECLARE_RESULTNODE(RawBucketResultNodeVector);
+
+    std::string_view friendly_type_name() const noexcept override { return "array<raw_bucket>"; }
 };
 
 class GeneralResultNodeVector : public ResultNodeVector
@@ -482,6 +508,9 @@ private:
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override {
         return  index < _v.size() ? _v[index]->getString(buf) : ConstBufferRef(buf.data(), 0);
     }
+
+    std::string_view friendly_type_name() const noexcept override { return "array<object>"; }
+
     size_t hash() const override;
     size_t onSize() const override { return _v.size(); }
     std::vector<ResultNode::CP> _v;

--- a/searchlib/src/vespa/searchlib/expression/stringbucketresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/stringbucketresultnode.h
@@ -43,6 +43,8 @@ public:
     }
     const StringBucketResultNode& getNullBucket() const override { return getNull(); }
     static const StringBucketResultNode & getNull() { return _nullResult; }
+
+    std::string_view friendly_type_name() const noexcept override { return "string_bucket"; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/stringresultnode.h
+++ b/searchlib/src/vespa/searchlib/expression/stringresultnode.h
@@ -55,6 +55,9 @@ private:
     int64_t onGetInteger(size_t index) const override;
     double onGetFloat(size_t index)    const override;
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override;
+
+    std::string_view friendly_type_name() const noexcept override { return "string"; }
+
     std::string _value;
 };
 


### PR DESCRIPTION
- Runtime checks that the result type of an expression is valid, but has no way of displaying the type in a user-friendly manner. 
- This PR adds `friendly_type_name()`, which lets each `ResultNode` say what type they have as a string.
- In the `istrue` use case, manual testing shows that a field with `array<T>` will iterate over each element, such that only `T` will be part of the error message.

@arnej27959 please review