### PR TITLE
yum repo

### DIFF
--- a/fbench/README
+++ b/fbench/README
@@ -13,7 +13,7 @@ https://github.com/vespa-engine/vespa.
 Installing on Vespa CentOS / RHEL 7:
   yum-config-manager --add-repo \
     https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-9/group_vespa-vespa-epel-9.repo
-  yum -y install epel-release centos-release-scl
+  yum -y install epel-release
   yum -y install vespa
 
 The above installation provides the follwing vespa-fbench executables:

--- a/fbench/README
+++ b/fbench/README
@@ -12,7 +12,7 @@ https://github.com/vespa-engine/vespa.
 
 Installing on Vespa CentOS / RHEL 7:
   yum-config-manager --add-repo \
-    https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo
+    https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-9/group_vespa-vespa-epel-9.repo
   yum -y install epel-release centos-release-scl
   yum -y install vespa
 


### PR DESCRIPTION
Updated the repository URL for Vespa installation on CentOS/RHEL 7 to point to EPEL 9.

Based on user feedback. @esolitos please take a look, not sure if we should clarify "CentOS / RHEL 7" (this is old) and if line 16 is needed