### PR TITLE
Support fixed mbus throttle window size via env var

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/InstrumentedThrottlePolicy.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/InstrumentedThrottlePolicy.java
@@ -23,9 +23,18 @@ class InstrumentedThrottlePolicy extends DynamicThrottlePolicy {
     private final AtomicInteger previousMaxPending = new AtomicInteger(Integer.MIN_VALUE);
     private final Metric metric;
 
+    private static final String WINDOW_SIZE_ENV = "VESPA_MBUS_THROTTLE_WINDOW_SIZE";
+
     @Inject
     InstrumentedThrottlePolicy(Metric metric) {
         setResizeRate(2); // Increase the window size update rate by lowering resize rate...  ¯\_(ツ)_/¯
+        var windowSize = System.getenv(WINDOW_SIZE_ENV);
+        if (windowSize != null) {
+            int size = Integer.parseInt(windowSize);
+            setMinWindowSize(size);
+            setMaxWindowSize(size);
+            log.info("Fixed throttle window size set to %d from env var '%s'".formatted(size, WINDOW_SIZE_ENV));
+        }
         this.metric = metric;
     }
 


### PR DESCRIPTION
## Summary

- Add support for `VESPA_MBUS_THROTTLE_WINDOW_SIZE` environment variable in `InstrumentedThrottlePolicy`
- When set, pins both min and max window size to the given value, effectively making the policy behave like a static throttle policy
- When unset, behavior is unchanged (dynamic throttling with current defaults)