### PR TITLE
feat: extract language detection and cache results across clear()

### DIFF
--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContextTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionContextTestCase.java
@@ -4,6 +4,9 @@ package com.yahoo.vespa.indexinglanguage.expressions;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.language.Language;
+import com.yahoo.language.Linguistics;
+import com.yahoo.language.detect.Detection;
+import com.yahoo.language.detect.Detector;
 import com.yahoo.language.simple.SimpleLinguistics;
 import org.junit.Test;
 
@@ -11,6 +14,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Simon Thoresen Hult
@@ -115,6 +124,24 @@ public class ExecutionContextTestCase {
         assertEquals(Language.JAPANESE, ctx.resolveLanguage(new SimpleLinguistics()));
         ctx.clear();
         assertEquals(Language.UNKNOWN, ctx.getLanguage());
+    }
+
+    @Test
+    public void requireThatDetectedLanguageIsCachedAcrossClear() {
+        var detector = mock(Detector.class);
+        when(detector.detect(anyString(), isNull())).thenReturn(new Detection(Language.JAPANESE, "UTF-8", false));
+        var linguistics = mock(Linguistics.class);
+        when(linguistics.getDetector()).thenReturn(detector);
+
+        var ctx = new ExecutionContext();
+        ctx.setCurrentValue(new StringFieldValue("text"));
+        assertEquals(Language.JAPANESE, ctx.resolveLanguage(linguistics));
+
+        ctx.clear();
+        ctx.setCurrentValue(new StringFieldValue("text"));
+        assertEquals(Language.JAPANESE, ctx.resolveLanguage(linguistics));
+
+        verify(detector, times(1)).detect(anyString(), isNull());
     }
 
     @Test


### PR DESCRIPTION
Language detection is expensive and should be cached to save compute