### PR TITLE
Move schema-language-server profile to parent and root pom

### DIFF
--- a/integration/schema-language-server/pom.xml
+++ b/integration/schema-language-server/pom.xml
@@ -12,17 +12,8 @@
     <artifactId>schema-language-server-parent</artifactId>
     <packaging>pom</packaging>
     <version>8-SNAPSHOT</version>
-    <profiles>
-        <!-- Build schema-language-server modules (language-server and lemminx-vespa).
-             Disabled by default as these are only needed for IDE plugin development/deployment.
-             Enable with -Pschema-language-server or activate in IntelliJ via
-             Maven tool window > Profiles > schema-language-server -->
-        <profile>
-            <id>schema-language-server</id>
-            <modules>
-                <module>language-server</module>
-                <module>lemminx-vespa</module>
-            </modules>
-        </profile>
-    </profiles>
+    <modules>
+        <module>language-server</module>
+        <module>lemminx-vespa</module>
+    </modules>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -603,6 +603,16 @@
                 <vespaCompilerArgs.xlint>-Xlint:all,-this-escape</vespaCompilerArgs.xlint>
             </properties>
         </profile>
+        <!-- Build schema-language-server modules (language-server and lemminx-vespa).
+             Disabled by default as these are only needed for IDE plugin development/deployment.
+             Enable with -Pschema-language-server or activate in IntelliJ via
+             Maven tool window > Profiles > schema-language-server -->
+        <profile>
+            <id>schema-language-server</id>
+            <properties>
+                <schema-language-server.skip>false</schema-language-server.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -1481,6 +1491,7 @@
         <test.hide>true</test.hide>
         <ffm.args/>
 
+        <schema-language-server.skip>true</schema-language-server.skip>
         <vespaClients.jdk.releaseVersion>11</vespaClients.jdk.releaseVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
         <module>zookeeper-command-line-client</module>
         <module>zookeeper-common</module>
         <module>zookeeper-server</module>
-        <module>integration/schema-language-server</module>
     </modules>
 
     <profiles>
@@ -133,6 +132,12 @@
             <activation><jdk>[25,26)</jdk></activation>
             <modules>
                 <module>datasketches-java25</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>schema-language-server</id>
+            <modules>
+                <module>integration/schema-language-server</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
## Summary
- Move schema-language-server profile and skip property from `schema-language-server-parent` to `parent/pom.xml`
- Move `integration/schema-language-server` module from default modules in root `pom.xml` into the `schema-language-server` profile
- The entire schema-language-server module tree is now excluded from the build by default, activated with `-Pschema-language-server`