### PR TITLE
Vespa CLI: Simplify when there's an application package error

### DIFF
--- a/client/go/internal/cli/cmd/deploy_test.go
+++ b/client/go/internal/cli/cmd/deploy_test.go
@@ -105,10 +105,11 @@ func TestDeployCloudFastWait(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	httpClient.NextResponseString(200, `ok`)
-	httpClient.NextResponseString(200, `{"active": false, "status": "unsuccesful"}`)
-	httpClient.NextResponseString(200, `{"active": false, "status": "unsuccesful"}`)
+	httpClient.NextResponseString(200, `{"active": false, "status": "deploymentFailed",
+		"log": {"deployReal": [{"at": 1631707708431, "type": "warning", "message": "Deployment failed: File in application package with unknown extension: schemas/doc.sd~"}]},
+		"steps": {"deployReal": {"status": "failed"}}}`)
 	require.NotNil(t, cli.Run("deploy", pkgDir))
-	assert.Equal(t, stderr.String(), "Error: deployment failed: run 0 ended with unsuccessful status: unsuccesful\n")
+	assert.Equal(t, "Deployment failed: File in application package with unknown extension: schemas/doc.sd~\n", stderr.String())
 	assert.True(t, httpClient.Consumed())
 
 	// Deployment which is running does not return error
@@ -137,7 +138,7 @@ func TestDeployCloudUnauthorized(t *testing.T) {
 	assert.Nil(t, cli.Run("auth", "cert", pkgDir))
 	httpClient.NextResponseString(403, "bugger off")
 	require.NotNil(t, cli.Run("deploy", pkgDir))
-	assert.Equal(t, `Error: deployment failed: unauthorized (status 403)
+	assert.Equal(t, `Deployment failed: unauthorized (status 403)
 bugger off
 Hint: You do not have access to the tenant t1
 Hint: You may need to create the tenant at https://console.vespa-cloud.com/tenant

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -394,7 +394,11 @@ func (c *CLI) bindWaitFlag(cmd *cobra.Command, defaultSecs int, value *int) {
 }
 
 func (c *CLI) printErr(err error, hints ...string) {
-	fmt.Fprintln(c.Stderr, color.RedString("Error:"), err)
+	if msg, ok := strings.CutPrefix(err.Error(), "deployment failed: "); ok {
+		fmt.Fprintln(c.Stderr, color.RedString("Deployment failed:"), msg)
+	} else {
+		fmt.Fprintln(c.Stderr, color.RedString("Error:"), err)
+	}
 	for _, hint := range hints {
 		fmt.Fprintln(c.Stderr, color.CyanString("Hint:"), hint)
 	}

--- a/client/go/internal/cli/cmd/status_test.go
+++ b/client/go/internal/cli/cmd/status_test.go
@@ -187,9 +187,8 @@ Hint: --wait 120 will make this command wait for completion up to 2 minutes
 		Body:   []byte(`{"active": false, "status": "failure"}`),
 	}
 	client.NextResponse(run)
-	client.NextResponse(run)
 	assert.NotNil(t, cli.Run("status", "deployment", "42", "-w", "10"))
-	assert.Equal(t, "Waiting up to 10s for deployment to converge...\nWarning: deployment failed: run 42 ended with unsuccessful status: failure\n", stderr.String())
+	assert.Equal(t, "Warning: deployment failed: run 42 ended with unsuccessful status: failure\n", stderr.String())
 }
 
 func isLocalTarget(args []string) bool {

--- a/client/go/internal/cli/cmd/status_test.go
+++ b/client/go/internal/cli/cmd/status_test.go
@@ -187,8 +187,9 @@ Hint: --wait 120 will make this command wait for completion up to 2 minutes
 		Body:   []byte(`{"active": false, "status": "failure"}`),
 	}
 	client.NextResponse(run)
+	client.NextResponse(run)
 	assert.NotNil(t, cli.Run("status", "deployment", "42", "-w", "10"))
-	assert.Equal(t, "Warning: deployment failed: run 42 ended with unsuccessful status: failure\n", stderr.String())
+	assert.Equal(t, "Waiting up to 10s for deployment to converge...\nWarning: deployment failed: run 42 ended with unsuccessful status: failure\n", stderr.String())
 }
 
 func isLocalTarget(args []string) bool {

--- a/client/go/internal/cli/cmd/status_test.go
+++ b/client/go/internal/cli/cmd/status_test.go
@@ -187,7 +187,6 @@ Hint: --wait 120 will make this command wait for completion up to 2 minutes
 		Body:   []byte(`{"active": false, "status": "failure"}`),
 	}
 	client.NextResponse(run)
-	client.NextResponse(run)
 	assert.NotNil(t, cli.Run("status", "deployment", "42", "-w", "10"))
 	assert.Equal(t, "Waiting up to 10s for deployment to converge...\nWarning: deployment failed: run 42 ended with unsuccessful status: failure\n", stderr.String())
 }

--- a/client/go/internal/cli/cmd/waiter.go
+++ b/client/go/internal/cli/cmd/waiter.go
@@ -115,7 +115,7 @@ func (w *Waiter) Deployment(target vespa.Target, wantedID int64) (int64, error) 
 	if err == nil {
 		return id, err
 	}
-	if errors.Is(err, vespa.ErrDeployment) {
+	if errors.Is(err, vespa.ErrDeployment) && w.Timeout == 0 {
 		return id, err
 	}
 	timeout := w.Timeout

--- a/client/go/internal/cli/cmd/waiter.go
+++ b/client/go/internal/cli/cmd/waiter.go
@@ -115,9 +115,6 @@ func (w *Waiter) Deployment(target vespa.Target, wantedID int64) (int64, error) 
 	if err == nil {
 		return id, err
 	}
-	if errors.Is(err, vespa.ErrDeployment) && w.Timeout == 0 {
-		return id, err
-	}
 	timeout := w.Timeout
 	if timeout > 0 {
 		w.cli.printInfo("Waiting up to ", color.CyanString(timeout.String()), " for deployment to converge...")
@@ -125,6 +122,9 @@ func (w *Waiter) Deployment(target vespa.Target, wantedID int64) (int64, error) 
 		// If --wait is not explicitly given, we always wait a few seconds in Cloud to catch fast failures, e.g.
 		// invalid application package
 		timeout = 3 * time.Second
+	}
+	if errors.Is(err, vespa.ErrDeployment) {
+		return id, err
 	}
 	return target.AwaitDeployment(wantedID, timeout)
 }

--- a/client/go/internal/cli/cmd/waiter.go
+++ b/client/go/internal/cli/cmd/waiter.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -112,6 +113,9 @@ func (w *Waiter) Deployment(target vespa.Target, wantedID int64) (int64, error) 
 	// Send probe request to determine if we need to wait at all
 	id, err := target.AwaitDeployment(wantedID, 0)
 	if err == nil {
+		return id, err
+	}
+	if errors.Is(err, vespa.ErrDeployment) {
 		return id, err
 	}
 	timeout := w.Timeout


### PR DESCRIPTION
From
```
[19:39:29] warning Deployment failed: File in application package with unknown extension: schemas/doc.sd~, please delete or move file to another directory.
Error: deployment run 1 not yet complete after waiting up to 10m0s: aborting wait: deployment failed: run 1 ended with unsuccessful status: deploymentFailed
```
To
```
[12:38:45] info    Using CA signed certificate version 1
Waiting up to 10m0s for deployment to converge...
[12:38:45] info    Deploying platform version 8.646.22 and application dev build 9 for dev-aws-euw1-az1 of sebastian ...
[12:38:45] info    Using CA signed certificate version 1
Deployment failed: File in application package with unknown extension: schemas/doc.sd~, please delete or move file to another directory.
```

With a red "Deployment failed:"