### PR TITLE
Support quoted field path map keys in Java document selection parser

### DIFF
--- a/document/src/main/javacc/SelectParser.jj
+++ b/document/src/main/javacc/SelectParser.jj
@@ -47,8 +47,8 @@ TOKEN :
 
 TOKEN :
 {
-    <LBRACE: "("> |
-    <RBRACE: ")"> |
+    <LPAREN: "("> |
+    <RPAREN: ")"> |
     <ADD: "+"> |
     <SUB: "-"> |
     <MUL: "*"> |
@@ -65,8 +65,9 @@ TOKEN :
     <GT: ">"> |
     <LT: "<"> |
     <DOLLAR: "$"> |
-    <STRING: ("\"" (~["\""] | "\\\"")* "\"") |
-             ("'" (~["'"] | "\\'")* "'")> |
+    <STRING: (<DQ_STRING> | <SQ_STRING>)>             |
+        <#DQ_STRING: ("\"" (~["\""] | "\\\"")* "\"")> |
+        <#SQ_STRING: ("'"  (~["'"]  | "\\'" )* "'")>  |
     <ID: "id"> |
     <ID_SCHEME: "scheme"> |
     <ID_TYPE: "type"> |
@@ -82,7 +83,17 @@ TOKEN :
     <AND: "and"> |
     <OR: "or"> |
     <NOT: "not"> |
-    <IDENTIFIER: ["a"-"z","A"-"Z", "_"] (["a"-"z","A"-"Z","0"-"9","_","-","@","$","[","]","{","}"])*>
+    <IDENTIFIER: ["a"-"z","A"-"Z", "_"] (["a"-"z","A"-"Z","0"-"9","_"])*> |
+      /* FIXME this is a syntactic hack to "flatten" fieldpath map and array lookups into a single token
+       * rather than match these structurally in the parser itself. This is due to the way fieldpaths
+       * are handled in the legacy AST (i.e. as strings, not structures), and this must be changed first
+       * before we can fix this.
+       * Backend field path expression parsing only supports double quoted strings, so make this a
+       * constraint here as well to fail early and fast.
+       */
+    <FP_MAP_LOOKUP:   "{" ((<DOLLAR>)? <IDENTIFIER> | <DIGITS> | <DQ_STRING>) "}"> |
+    <FP_ARRAY_LOOKUP: "[" ((<DOLLAR> <IDENTIFIER>)  | <DIGITS>) "]">               |
+        <#DIGITS: (["0"-"9"])+> // Not the same as <DECIMAL> which doesn't allow leading 0 (and thus not simply "0")
 }
 
 ExpressionNode expression() :
@@ -119,7 +130,7 @@ ExpressionNode negation() :
 
 NowNode now() : { }
 {
-    ( <NOW> <LBRACE> <RBRACE> )
+    ( <NOW> <LPAREN> <RPAREN> )
     { return new NowNode(); }
 }
 
@@ -159,14 +170,15 @@ VariableNode variable() :
 
 ExpressionNode attribute() :
 {
+    String fp;
     ExpressionNode value;
     AttributeNode.Item item;
     List items = new ArrayList();
 }
 {
-    ( value = value() ( <DOT> identifier()  { item = new AttributeNode.Item(token.image); }
-                        [ <LBRACE> <RBRACE> { item.setType(AttributeNode.Item.FUNCTION); } ]
-                                            { items.add(item); } )* )
+    ( value = value() ( <DOT> fp = verbatimFieldPath() { item = new AttributeNode.Item(fp); }
+                        [ <LPAREN> <RPAREN>            { item.setType(AttributeNode.Item.FUNCTION); } ]
+                                                       { items.add(item); } )* )
     {
         if ( ! items.isEmpty()) // A value followed by dotted access/method call
             return new AttributeNode(value, items);
@@ -188,7 +200,7 @@ ExpressionNode value() :
         ret = literal() |
         ret = variable() |
         ret = now() |
-        <LBRACE> ret = logic() <RBRACE> { ret = new EmbracedNode(ret); } ) |
+        <LPAREN> ret = logic() <RPAREN> { ret = new EmbracedNode(ret); } ) |
      ( ret = document() ) )
     { return ret; }
 }
@@ -221,7 +233,30 @@ void identifier() : { }
        <OR> |
        // <NOT> |  Causes a choice conflict, but it is not such a good name anyway ...
        <IDENTIFIER> )
-}  
+}
+
+/*
+ * FIXME this is a horrible leftover of post-parsed fieldpath processing that
+ * exposes what would normally be structural AST nodes as the raw string
+ * representation of the subexpression that spans the fieldpath. I.e. we mangle
+ * logically distinct expression pieces together as one identifier.
+ */
+String verbatimFieldPath() :
+{
+    String fp;
+}
+{
+    // We optimize for the common case where there's only a single token whose
+    // image can be returned verbatim, i.e. the String += operator realloc is fine
+    // when this is not the case.
+    ( identifier()                              { fp  = token.image; }
+      ( ( <FP_MAP_LOOKUP> | <FP_ARRAY_LOOKUP> ) { fp += token.image; }
+      )*
+    )
+    { return fp; }
+}
+
+
 
 IdNode id() :
 {

--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -148,6 +148,9 @@ public class DocumentSelectorTestCase {
         assertParse("music.expire > now() - 300");
         assertParse("now or now_search");
         assertParse("(music.expire / 1000) > (now() - 300)");
+        assertParse("music.foo{bananas} == 1");
+        assertParse("music.foo{\"bananas with bandanas\"} == 1");
+        assertParse("music.foo[0]{0}[1]{1}{bananas}.yes.with{\"oh so much\"}{$exciting}[$potassium]");
     }
 
     @Test
@@ -413,6 +416,7 @@ public class DocumentSelectorTestCase {
         MapFieldValue<StringFieldValue, Array> amval =
                 new MapFieldValue<>((MapDataType)documents.get(1).getDocument().getField("structarrmap").getDataType());
         amval.put(new StringFieldValue("foo"), aval);
+        amval.put(new StringFieldValue("key that needs escaping"), aval);
 
         Array<Struct> abval = new Array<>(documents.get(1).getDocument().getField("structarray").getDataType());
         {
@@ -741,6 +745,10 @@ public class DocumentSelectorTestCase {
         assertEquals(Result.FALSE, evaluate("test.mymap == 4", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.mymap = 3", documents.get(1))); // Fallback to ==
         assertEquals(Result.FALSE, evaluate("test.mymap = 4", documents.get(1))); // Fallback to ==
+        assertEquals(Result.FALSE, evaluate("test.structarrmap{\"key that needs escaping\"}", documents.get(0)));
+        assertEquals(Result.TRUE, evaluate("test.structarrmap{\"key that needs escaping\"}", documents.get(1)));
+        assertEquals(Result.FALSE, evaluate("test.structarrmap == \"key that needs escaping\"", documents.get(0)));
+        assertEquals(Result.TRUE, evaluate("test.structarrmap == \"key that needs escaping\"", documents.get(1)));
 
         assertEquals(Result.TRUE, evaluate("test.structarrmap{$x}[$y].key == 15 AND test.structarrmap{$x}[$y].value == \"structval1\"", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.structarrmap.value[$y].key == 15 AND test.structarrmap.value[$y].value == \"structval1\"", documents.get(1)));
@@ -750,8 +758,10 @@ public class DocumentSelectorTestCase {
 
         assertEquals(Result.TRUE, evaluate("test.stringweightedset", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.stringweightedset{val1}", documents.get(1)));
+        assertEquals(Result.TRUE, evaluate("test.stringweightedset{\"val1\"}", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.stringweightedset{val1} == 1", documents.get(1)));
         assertEquals(Result.FALSE, evaluate("test.stringweightedset{val1} == 2", documents.get(1)));
+        assertEquals(Result.FALSE, evaluate("test.stringweightedset{\"val1\"} == 2", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.stringweightedset == \"val1\"", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.stringweightedset = \"val*\"", documents.get(1)));
         assertEquals(Result.TRUE, evaluate("test.stringweightedset =~ \"val[0-9]\"", documents.get(1)));

--- a/document/src/tests/documentselectparsertest.cpp
+++ b/document/src/tests/documentselectparsertest.cpp
@@ -230,6 +230,7 @@ DocumentSelectParserTest::createDocs()
 
         MapFieldValue amval(_doc.back()->getField("structarrmap").getDataType());
         amval.put(StringFieldValue("foo"), aval);
+        amval.put(StringFieldValue("a key needing escaping"), aval);
 
         ArrayFieldValue abval(_doc.back()->getField("structarray").getDataType());
         {
@@ -951,6 +952,9 @@ TEST_F(DocumentSelectParserTest, operators_8)
     PARSE("testdoctype1.mymap == 4", *_doc[1], False);
     PARSE("testdoctype1.mymap = 3", *_doc[1], True); // Fallback to ==
     PARSE("testdoctype1.mymap = 4", *_doc[1], False); // Fallback to ==
+
+    PARSE("testdoctype1.structarrmap{\"a key needing escaping\"}", *_doc[1], True);
+    PARSE("testdoctype1.structarrmap{\"a key needing escaping\"}", *_doc[0], False);
 
     PARSE("testdoctype1.structarrmap{$x}[$y].key == 15 AND testdoctype1.structarrmap{$x}[$y].value == \"structval1\"", *_doc[1], True);
     PARSE("testdoctype1.structarrmap.value[$y].key == 15 AND testdoctype1.structarrmap.value[$y].value == \"structval1\"", *_doc[1], True);


### PR DESCRIPTION
@arnej27959 please review
@bratseth FYI

The JavaCC document selection parser previously slurped up field paths implicitly as part of a very liberal identifier lexing regex pattern, but without supporting quoting of string map keys. This commit breaks field path lexing out of the identifier and into dedicated map/array lookup tokens.

Ideally these should not be treated as tokens (but rather parser _rules_), but this is a workaround due to how field paths are treated as "opaque" strings and not AST nodes.

This is a very similar workaround to that used by the C++ document selection lexer+parser for treating field path expressions as verbatim string expressions, while at the same time performing sufficient structural validation to catch obviously broken syntax. Note that the C++ parser already supports quoted map keys.

In addition:
 * Remove multiple special characters that were previously allowed as part of identifiers, such as `@`, `-` etc. These were _likely_ added to support particular un-qoted key strings. Now matches the C++ lexer.
 * Rename `[LR]BRACE` to `[LR]PAREN` since they are indeed parentheses and not braces.

