### PR TITLE
refactor(ci): enforce required env variables in build scripts

### DIFF
--- a/.buildkite/bootstrap-cmake.sh
+++ b/.buildkite/bootstrap-cmake.sh
@@ -5,14 +5,19 @@
 # Configures the CMake build environment based on provided arguments and environment variables.
 
 set -o errexit
-set -o nounset
 set -o pipefail
+
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+if [[ ! -d "${SOURCE_DIR}" ]]; then
+    echo "Error: SOURCE_DIR '${SOURCE_DIR}' is not a directory." >&2
+    exit 1
+fi
+
+set -o nounset
 
 if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
-
-: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
 
 echo "--- 🔧 Configuring CMake build"
 # shellcheck disable=1091

--- a/.buildkite/bootstrap-cmake.sh
+++ b/.buildkite/bootstrap-cmake.sh
@@ -12,6 +12,8 @@ if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
 
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+
 echo "--- 🔧 Configuring CMake build"
 # shellcheck disable=1091
 source /etc/profile.d/enable-gcc-toolset.sh

--- a/.buildkite/bootstrap.sh
+++ b/.buildkite/bootstrap.sh
@@ -12,6 +12,9 @@ if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
 
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+: "${VESPA_CPP_TEST_JARS:?Environment variable VESPA_CPP_TEST_JARS must be set (path for C++ test JARs)}"
+
 echo "--- 🔧 Running Vespa bootstrap"
 cd "$SOURCE_DIR"
 ./bootstrap.sh full

--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -9,6 +9,8 @@ set -o pipefail
 set -o xtrace
 
 
+: "${VESPA_BUILDOS_LABEL:?Environment variable VESPA_BUILDOS_LABEL must be set (build OS label)}"
+
 if ! docker ps &> /dev/null; then
     echo "No working docker command found."
     exit 1

--- a/.buildkite/cpp-test.sh
+++ b/.buildkite/cpp-test.sh
@@ -11,7 +11,8 @@ set -o pipefail
 if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
-
+: "${NUM_CPU_LIMIT:?Environment variable NUM_CPU_LIMIT must be set (CPU limit)}"
+: "${LOG_DIR:?Environment variable LOG_DIR must be set (log directory)}"
 echo "--- 🧪 Running C++ tests"
 PATH=/opt/vespa-deps/bin:$PATH
 

--- a/.buildkite/cpp.sh
+++ b/.buildkite/cpp.sh
@@ -14,6 +14,9 @@ fi
 
 mydir=${0%/*}
 shlim=${mydir}/show-limits.sh
+
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+: "${NUM_CPP_THREADS:?Environment variable NUM_CPP_THREADS must be set (number of C++ threads)}"
 if [ -x "${shlim}" ]; then
     "${shlim}" || echo "failed: ${shlim}"
 fi

--- a/.buildkite/go.sh
+++ b/.buildkite/go.sh
@@ -11,7 +11,8 @@ set -o pipefail
 if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
-
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+: "${WORKDIR:?Environment variable WORKDIR must be set (working directory)}"
 echo "--- 🐹 Building Go components"
 cd "$SOURCE_DIR"
 

--- a/.buildkite/install.sh
+++ b/.buildkite/install.sh
@@ -11,7 +11,8 @@ set -o pipefail
 if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
-
+: "${NUM_CPU_LIMIT:?Environment variable NUM_CPU_LIMIT must be set (CPU limit)}"
+: "${WORKDIR:?Environment variable WORKDIR must be set (working directory)}"
 echo "--- 📦 Installing Vespa components"
 echo "Running make install with $NUM_CPU_LIMIT parallel jobs..."
 make -j "$NUM_CPU_LIMIT" install DESTDIR="$WORKDIR/vespa-install"

--- a/.buildkite/java.sh
+++ b/.buildkite/java.sh
@@ -14,6 +14,10 @@ fi
 
 mydir=${0%/*}
 shlim=${mydir}/show-limits.sh
+
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+: "${VESPA_MAVEN_TARGET:?Environment variable VESPA_MAVEN_TARGET must be set (Maven target)}"
+: "${NUM_MVN_THREADS:?Environment variable NUM_MVN_THREADS must be set (Maven threads)}"
 if [ -x "${shlim}" ]; then
     "${shlim}" || echo "failed: ${shlim}"
 fi

--- a/.buildkite/quick-start-guide.sh
+++ b/.buildkite/quick-start-guide.sh
@@ -12,6 +12,8 @@ if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
 
+: "${SOURCE_DIR:?Environment variable SOURCE_DIR must be set (path to source code)}"
+
 if [[ $VESPA_USE_SANITIZER != null ]]; then
     echo "Skipping quick start guide test for sanitizer builds."
     exit 0

--- a/.buildkite/upload-test-results.sh
+++ b/.buildkite/upload-test-results.sh
@@ -8,6 +8,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+: "${WORKDIR:?Environment variable WORKDIR must be set (working directory for test results)}"
+: "${LOG_DIR:?Environment variable LOG_DIR must be set (directory containing C++ test results)}"
+
 if [[ -n "${DEBUG:-}" ]]; then
     set -o xtrace
 fi
@@ -26,14 +29,10 @@ else
     CPP_TEST_TOKEN=$UNIT_TEST_CPP_ARM64_TOKEN
 fi
 
-if [[ -z $JAVA_TEST_TOKEN ]]; then
-    echo "Missing JAVA_TEST_TOKEN. Exiting."
-    exit 1
-fi
-if [[ -z $CPP_TEST_TOKEN ]]; then
-    echo "Missing CPP_TEST_TOKEN. Exiting."
-    exit 1
-fi
+{ set +o xtrace; } 2>/dev/null
+: "${JAVA_TEST_TOKEN:?Environment variable JAVA_TEST_TOKEN must be set (token for uploading Java test results)}"
+: "${CPP_TEST_TOKEN:?Environment variable CPP_TEST_TOKEN must be set (token for uploading C++ test results)}"
+[[ -n "${DEBUG:-}" ]] && set -o xtrace
 
 upload_result() {
     curl \


### PR DESCRIPTION
## What

- Uniform validation of mandatory env variables through shell expansion in builds scripts.

## Why

- Improved reliability and uniform early failure detection.