### PR TITLE
Batch node metrics requests. Remove previous snapshot before fetching new

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsRetriever.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsRetriever.java
@@ -21,11 +21,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,11 +47,14 @@ public final class ApplicationMetricsRetriever extends AbstractComponent impleme
     private static final int HTTP_CONNECT_TIMEOUT = 5000;
     private static final int HTTP_SOCKET_TIMEOUT = 30000;
     private static final Duration METRICS_TTL = Duration.ofSeconds(30);
+    static final int FETCH_BATCH_SIZE = 50;
 
     private final CloseableHttpAsyncClient httpClient = createHttpClient();
     private final List<NodeMetricsClient> clients;
     private final Thread pollThread;
     private final Set<ConsumerId> consumerSet;
+    private final Map<ConsumerId, Integer> pendingBatches = new HashMap<>();
+    private final Map<ConsumerId, Integer> activeReaders  = new HashMap<>();
     private long pollCount = 0;
     private volatile boolean stopped;
     private volatile Duration taskTimeout;
@@ -77,10 +80,10 @@ public final class ApplicationMetricsRetriever extends AbstractComponent impleme
                 }
                 for (ConsumerId consumer : consumers) {
                     int numFailed = fetchMetricsAsync(consumer);
-                    if (numFailed > 0 ) {
-                        log.log(Level.INFO, "Updated metrics for consumer '" + consumer +"' failed for " + numFailed + " services");
+                    if (numFailed > 0) {
+                        log.log(Level.INFO, "Updated metrics for consumer '" + consumer + "' failed for " + numFailed + " services");
                     } else {
-                        log.log(Level.FINE, "Updated metrics for consumer '" + consumer +"'.");
+                        log.log(Level.FINE, "Updated metrics for consumer '" + consumer + "'.");
                     }
                 }
                 Duration timeUntilNextPoll = Duration.ofMillis(1000);
@@ -131,12 +134,29 @@ public final class ApplicationMetricsRetriever extends AbstractComponent impleme
                 // Wakeup poll thread first time we see a new consumer
                 pollThread.notifyAll();
             }
+            activeReaders.merge(consumer, 1, Integer::sum);
+            long deadline = System.currentTimeMillis() + HTTP_CONNECT_TIMEOUT;
+            while (pendingBatches.getOrDefault(consumer, 0) > 0) {
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    log.log(Level.WARNING, "Timed out waiting for in-flight metrics batch for consumer '" + consumer + "'");
+                    break;
+                }
+                try { pollThread.wait(remaining); } catch (InterruptedException e) { break; }
+            }
         }
-        Map<Node, List<MetricsPacket>> metrics = new HashMap<>();
-        for (NodeMetricsClient client : clients) {
-            metrics.put(client.node, client.getMetrics(consumer));
+        try {
+            Map<Node, List<MetricsPacket>> metrics = new HashMap<>();
+            for (NodeMetricsClient client : clients) {
+                metrics.put(client.node, client.getMetrics(consumer));
+            }
+            return metrics;
+        } finally {
+            synchronized (pollThread) {
+                activeReaders.merge(consumer, -1, Integer::sum);
+                pollThread.notifyAll();
+            }
         }
-        return metrics;
     }
 
     void startPollAndWait() {
@@ -156,23 +176,39 @@ public final class ApplicationMetricsRetriever extends AbstractComponent impleme
     }
 
     private int fetchMetricsAsync(ConsumerId consumer) {
-        Map<Node, Future<?>> futures = new HashMap<>();
-        for (NodeMetricsClient client : clients) {
-            client.startSnapshotUpdate(consumer, METRICS_TTL).ifPresent(future -> futures.put(client.node, future));
-        }
         int numOk = 0;
-        int numTried = futures.size();
-        for (Map.Entry<Node, Future<?>> entry : futures.entrySet()) {
+        int numTried = 0;
+        for (int i = 0; i < clients.size(); i += FETCH_BATCH_SIZE) {
             if (stopped) break;
+            synchronized (pollThread) {
+                while (activeReaders.getOrDefault(consumer, 0) > 0)
+                    try { pollThread.wait(); } catch (InterruptedException e) { break; }
+                pendingBatches.merge(consumer, 1, Integer::sum);
+            }
             try {
-                entry.getValue().get(taskTimeout.toMillis(), TimeUnit.MILLISECONDS);
-                numOk++;
-            } catch (InterruptedException | ExecutionException | TimeoutException | CancellationException e) {
-                Throwable cause = e.getCause();
-                if (stopped || e instanceof ExecutionException && ((cause instanceof SocketException) || cause instanceof ConnectTimeoutException)) {
-                    log.log(Level.FINE, "Failed retrieving metrics for '" + entry.getKey() + "' : " + cause.getMessage());
-                } else {
-                    log.log(Level.WARNING, "Failed retrieving metrics for '" + entry.getKey() + "' : ", e);
+                List<NodeMetricsClient> batch = clients.subList(i, Math.min(i + FETCH_BATCH_SIZE, clients.size()));
+                HashMap<Node, Future<?>> futures = new HashMap<>();
+                for (NodeMetricsClient client : batch)
+                    client.startSnapshotUpdate(consumer, METRICS_TTL).ifPresent(f -> futures.put(client.node, f));
+                numTried += futures.size();
+                for (Map.Entry<Node, Future<?>> entry : futures.entrySet()) {
+                    if (stopped) break;
+                    try {
+                        entry.getValue().get(taskTimeout.toMillis(), TimeUnit.MILLISECONDS);
+                        numOk++;
+                    } catch (InterruptedException | ExecutionException | TimeoutException | CancellationException e) {
+                        Throwable cause = e.getCause();
+                        if (stopped || e instanceof ExecutionException && (cause instanceof SocketException || cause instanceof ConnectTimeoutException)) {
+                            log.log(Level.FINE, "Failed retrieving metrics for '" + entry.getKey() + "' : " + cause.getMessage());
+                        } else {
+                            log.log(Level.WARNING, "Failed retrieving metrics for '" + entry.getKey() + "' : ", e);
+                        }
+                    }
+                }
+            } finally {
+                synchronized (pollThread) {
+                    pendingBatches.merge(consumer, -1, Integer::sum);
+                    pollThread.notifyAll();
                 }
             }
         }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/NodeMetricsClient.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/NodeMetricsClient.java
@@ -63,6 +63,7 @@ public class NodeMetricsClient {
         var snapshot = snapshots.get(consumer);
         if ((snapshot != null) && snapshot.isValid(clock.instant(), ttl)) return Optional.empty();
 
+        snapshots.remove(consumer);
         return Optional.of(retrieveMetrics(consumer));
     }
 

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsRetrieverTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsRetrieverTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.http.application;
 
+import ai.vespa.metricsproxy.metric.model.MetricsPacket;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,6 +9,9 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 import static ai.vespa.metricsproxy.TestUtil.getFileContents;
 import static ai.vespa.metricsproxy.http.application.ApplicationMetricsRetriever.MAX_TIMEOUT;
@@ -143,6 +147,42 @@ public class ApplicationMetricsRetrieverTest {
         // Verify successful retrieving
         wireMockRule.removeStubMapping(delayedStub);
         verifyRetrievingMetricsFromSingleNode(config, node);
+    }
+
+    @Test
+    public void metrics_are_retrieved_in_batches() {
+        int numNodes = ApplicationMetricsRetriever.FETCH_BATCH_SIZE + 1;
+        String[] paths = IntStream.range(0, numNodes).mapToObj(i -> "/node" + i).toArray(String[]::new);
+        for (String path : paths)
+            wireMockRule.stubFor(get(urlPathEqualTo(path)).willReturn(aResponse().withBody(RESPONSE)));
+
+        MetricsNodesConfig config = nodesConfig(paths);
+        ApplicationMetricsRetriever retriever = new ApplicationMetricsRetriever(config);
+        retriever.getMetrics();
+        retriever.startPollAndWait();
+        Map<Node, List<MetricsPacket>> metricsByNode = retriever.getMetrics();
+        assertEquals(numNodes, metricsByNode.size());
+        for (int i = 0; i < numNodes; i++)
+            assertEquals(4, metricsByNode.get(new Node(config.node(i))).size());
+    }
+
+    @Test
+    public void get_metrics_waits_for_in_flight_batch_to_complete() throws Exception {
+        MetricsNodesConfig config = nodesConfig("/node0");
+        wireMockRule.stubFor(get(urlPathEqualTo("/node0"))
+                                     .willReturn(aResponse().withBody(RESPONSE).withFixedDelay(1000)));
+
+        ApplicationMetricsRetriever retriever = new ApplicationMetricsRetriever(config);
+        retriever.getMetrics();
+
+        Thread pollThread = new Thread(retriever::startPollAndWait);
+        pollThread.start();
+        Thread.sleep(200);
+
+        Map<Node, List<MetricsPacket>> metrics = retriever.getMetrics();
+        pollThread.join();
+        assertEquals("getMetrics should have waited for the batch and returned fresh data",
+                     4, metrics.get(new Node(config.node(0))).size());
     }
 
     @Test


### PR DESCRIPTION
Also adds some logic preventing from the currently retrieved batch to be empty during getMetrics

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
