### PR TITLE
Fix bundle-plugin losing @PublicApi when merging duplicate packages

### DIFF
--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageInfo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/PackageInfo.java
@@ -11,11 +11,15 @@ import java.util.Optional;
 record PackageInfo(String name, Optional<ExportPackageAnnotation> exportPackage, boolean isPublicApi) {
 
     /**
-     * Returns this if it has an ExportPackage annotation, otherwise returns the other.
-     * Used to combine objects, where this should take precedence over the other.
+     * Returns a PackageInfo with an ExportPackage annotation if either this or other has one.
+     * If both have ExportPackage, this takes precedence, but isPublicApi is OR-ed from both.
      */
     PackageInfo hasExportPackageOrElse(PackageInfo other) {
-        return exportPackage().isPresent() ? this : other;
+        if (exportPackage().isPresent()) {
+            boolean mergedPublicApi = isPublicApi || other.isPublicApi;
+            return mergedPublicApi == isPublicApi ? this : new PackageInfo(name, exportPackage, true);
+        }
+        return other;
     }
 
 }

--- a/bundle-plugin/src/test/java/com/yahoo/container/plugin/classanalysis/PackageInfoTest.java
+++ b/bundle-plugin/src/test/java/com/yahoo/container/plugin/classanalysis/PackageInfoTest.java
@@ -1,0 +1,80 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.container.plugin.classanalysis;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author gjoranv
+ */
+public class PackageInfoTest {
+
+    private static final ExportPackageAnnotation EXPORT = new ExportPackageAnnotation(0, 0, 0, "");
+
+    private static PackageInfo exportOnly(String name) {
+        return new PackageInfo(name, Optional.of(EXPORT), false);
+    }
+
+    private static PackageInfo exportAndPublic(String name) {
+        return new PackageInfo(name, Optional.of(EXPORT), true);
+    }
+
+    private static PackageInfo noExport(String name) {
+        return new PackageInfo(name, Optional.empty(), false);
+    }
+
+    @Test
+    void public_api_is_preserved_when_other_has_it() {
+        var result = exportOnly("p").hasExportPackageOrElse(exportAndPublic("p"));
+        assertTrue(result.isPublicApi());
+        assertTrue(result.exportPackage().isPresent());
+    }
+
+    @Test
+    void public_api_is_preserved_when_this_has_it() {
+        var result = exportAndPublic("p").hasExportPackageOrElse(exportOnly("p"));
+        assertTrue(result.isPublicApi());
+        assertTrue(result.exportPackage().isPresent());
+    }
+
+    @Test
+    void public_api_is_preserved_when_both_have_it() {
+        var result = exportAndPublic("p").hasExportPackageOrElse(exportAndPublic("p"));
+        assertTrue(result.isPublicApi());
+    }
+
+    @Test
+    void not_public_when_neither_has_it() {
+        var result = exportOnly("p").hasExportPackageOrElse(exportOnly("p"));
+        assertFalse(result.isPublicApi());
+    }
+
+    @Test
+    void this_export_annotation_takes_precedence() {
+        var thisExport = new ExportPackageAnnotation(1, 2, 3, "qualifier");
+        var thisInfo = new PackageInfo("p", Optional.of(thisExport), false);
+        var result = thisInfo.hasExportPackageOrElse(exportAndPublic("p"));
+        assertEquals(thisExport, result.exportPackage().get());
+        assertTrue(result.isPublicApi());
+    }
+
+    @Test
+    void returns_other_when_this_has_no_export() {
+        var result = noExport("p").hasExportPackageOrElse(exportAndPublic("p"));
+        assertTrue(result.isPublicApi());
+        assertTrue(result.exportPackage().isPresent());
+    }
+
+    @Test
+    void returns_other_when_this_has_no_export_and_other_is_not_public() {
+        var result = noExport("p").hasExportPackageOrElse(exportOnly("p"));
+        assertFalse(result.isPublicApi());
+        assertTrue(result.exportPackage().isPresent());
+    }
+
+}

--- a/container-messagebus/src/main/java/com/yahoo/messagebus/package-info.java
+++ b/container-messagebus/src/main/java/com/yahoo/messagebus/package-info.java
@@ -1,5 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 @ExportPackage
+@PublicApi
 package com.yahoo.messagebus;
 
+import com.yahoo.api.annotations.PublicApi;
 import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
## Summary

When two JARs both declare `@ExportPackage` for the same package, `PackageInfo.hasExportPackageOrElse()` would pick whichever entry was processed first, silently dropping `@PublicApi` from the other. This caused `com.yahoo.messagebus` to be misclassified as non-public API in the `container-disc` manifest.

- Fix the merge logic to OR the `isPublicApi` flags when both entries have `@ExportPackage`
- Add unit tests for all merge scenarios
- Add missing `@PublicApi` to `container-messagebus`'s duplicate `package-info.java` for `com.yahoo.messagebus`

Fixes [VESPANG-2634](https://vespaai.atlassian.net/browse/VESPANG-2634). 

## TODO
Cleaning up duplicate `package-info` files will be done in a later PR.