### PR TITLE
Remove redundant duplicate package-info files

### DIFF
--- a/container-messagebus/src/main/java/com/yahoo/messagebus/network/package-info.java
+++ b/container-messagebus/src/main/java/com/yahoo/messagebus/network/package-info.java
@@ -1,5 +1,0 @@
-// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage
-package com.yahoo.messagebus.network;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-messagebus/src/main/java/com/yahoo/messagebus/network/rpc/package-info.java
+++ b/container-messagebus/src/main/java/com/yahoo/messagebus/network/rpc/package-info.java
@@ -1,5 +1,0 @@
-// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage
-package com.yahoo.messagebus.network.rpc;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-messagebus/src/main/java/com/yahoo/messagebus/package-info.java
+++ b/container-messagebus/src/main/java/com/yahoo/messagebus/package-info.java
@@ -1,7 +1,0 @@
-// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage
-@PublicApi
-package com.yahoo.messagebus;
-
-import com.yahoo.api.annotations.PublicApi;
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-messagebus/src/main/java/com/yahoo/messagebus/routing/package-info.java
+++ b/container-messagebus/src/main/java/com/yahoo/messagebus/routing/package-info.java
@@ -1,5 +1,0 @@
-// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-@ExportPackage
-package com.yahoo.messagebus.routing;
-
-import com.yahoo.osgi.annotation.ExportPackage;


### PR DESCRIPTION
Remove 4 redundant `package-info.java` files from `container-messagebus` for packages where it has no classes. The `messagebus` module already has identical `@ExportPackage` declarations for these packages:

- `com.yahoo.messagebus`
- `com.yahoo.messagebus.routing`
- `com.yahoo.messagebus.network`
- `com.yahoo.messagebus.network.rpc`

The duplicates were artifacts from merging the `jdisc_messagebus_service` module (an OSGi bundle) into `container-messagebus` (a plain JAR) in 2021. Follow-up to #35998.