### PR TITLE
Replace bundle-plugin:assemble-fat-jar with maven-shade-plugin in schema-language-server

### DIFF
--- a/integration/schema-language-server/language-server/pom.xml
+++ b/integration/schema-language-server/language-server/pom.xml
@@ -138,17 +138,42 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.yahoo.vespa</groupId>
-        <artifactId>bundle-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
             <phase>package</phase>
-            <goals><goal>assemble-fat-jar</goal></goals>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>ai.vespa.schemals.SchemaLSLauncher</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/DEPENDENCIES</exclude>
+                    <exclude>META-INF/LICENSE*</exclude>
+                    <exclude>META-INF/NOTICE*</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>about.html</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>license/*</exclude>
+                    <exclude>**/package-info.class</exclude>
+                    <exclude>**/module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <mainClass>ai.vespa.schemals.SchemaLSLauncher</mainClass>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.congocc</groupId>   

--- a/integration/schema-language-server/lemminx-vespa/pom.xml
+++ b/integration/schema-language-server/lemminx-vespa/pom.xml
@@ -105,12 +105,35 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.yahoo.vespa</groupId>
-        <artifactId>bundle-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
             <phase>package</phase>
-            <goals><goal>assemble-fat-jar</goal></goals>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/DEPENDENCIES</exclude>
+                    <exclude>META-INF/LICENSE*</exclude>
+                    <exclude>META-INF/NOTICE*</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>about.html</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>license/*</exclude>
+                    <exclude>**/package-info.class</exclude>
+                    <exclude>**/module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary
- Replace `bundle-plugin:assemble-fat-jar` with `maven-shade-plugin` in `language-server` and `lemminx-vespa` modules
- Fixes build failure when building from `integration/schema-language-server/` subdirectory, caused by `bundle-plugin` resolving `vespa-3party-jars` via the reactor session which is absent in the subdirectory reactor
- These modules are standalone tools not deployed in Vespa's container, so all dependencies should be embedded