### PR TITLE
Add `field[index]=value` syntactic sugar for sameElement with elementFilter

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -419,15 +419,21 @@ public class YqlParser implements Parser {
      * Expected input: EQ( INDEX ( field_name, number ), value )
      */
     private OperatorNode<ExpressionOperator> rewriteIndexedAccess(OperatorNode<ExpressionOperator> ast) {
-        if (ast.getOperator() != ExpressionOperator.EQ) return ast;
+        if (ast.getOperator() != ExpressionOperator.EQ) {
+            return ast;
+        }
+
         OperatorNode<ExpressionOperator> lhs = ast.getArgument(0);
         OperatorNode<ExpressionOperator> value = ast.getArgument(1);
+        if (lhs.getOperator() != ExpressionOperator.INDEX) {
+            return ast;
+        }
 
-        if (lhs.getOperator() != ExpressionOperator.INDEX) return ast;
         OperatorNode<ExpressionOperator> field = lhs.getArgument(0);
         OperatorNode<ExpressionOperator> index = lhs.getArgument(1);
-        if (index.getOperator() != ExpressionOperator.LITERAL)
+        if (index.getOperator() != ExpressionOperator.LITERAL) {
             throw newUnexpectedArgumentException(index, ExpressionOperator.LITERAL);
+        }
 
         // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
         value = toLiteralString(value);
@@ -444,8 +450,9 @@ public class YqlParser implements Parser {
 
     // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
     private static OperatorNode<ExpressionOperator> toLiteralString(OperatorNode<ExpressionOperator> ast) {
-        if (ast.getOperator() == ExpressionOperator.LITERAL && !(ast.getArgument(0) instanceof String))
+        if (ast.getOperator() == ExpressionOperator.LITERAL && !(ast.getArgument(0) instanceof String)) {
             return OperatorNode.create(ast.getLocation(), ExpressionOperator.LITERAL, ast.getArgument(0).toString());
+        }
         return ast;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -429,6 +429,8 @@ public class YqlParser implements Parser {
         if (index.getOperator() != ExpressionOperator.LITERAL)
             throw newUnexpectedArgumentException(index, ExpressionOperator.LITERAL);
 
+        // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
+        value = toLiteralString(value);
         int elementIndex = convertToIntForElementFilter(index.getArgument(0));
         OperatorNode<ExpressionOperator> sameElement = OperatorNode.create(
                 ast.getLocation(),
@@ -438,6 +440,13 @@ public class YqlParser implements Parser {
         sameElement.putAnnotation(ELEMENT_FILTER, List.of(elementIndex));
 
         return OperatorNode.create(ast.getLocation(), ExpressionOperator.CONTAINS, field, sameElement);
+    }
+
+    // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
+    private static OperatorNode<ExpressionOperator> toLiteralString(OperatorNode<ExpressionOperator> ast) {
+        if (ast.getOperator() == ExpressionOperator.LITERAL && !(ast.getArgument(0) instanceof String))
+            return OperatorNode.create(ast.getLocation(), ExpressionOperator.LITERAL, ast.getArgument(0).toString());
+        return ast;
     }
 
     private Item buildFunctionCallOrCompositeLeaf(OperatorNode<ExpressionOperator> ast, String currentField) {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -437,7 +437,7 @@ public class YqlParser implements Parser {
 
         // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
         value = toLiteralString(value);
-        int elementIndex = convertToIntForElementFilter(index.getArgument(0));
+        int elementIndex = convertToElementId(index.getArgument(0));
         OperatorNode<ExpressionOperator> sameElement = OperatorNode.create(
                 ast.getLocation(),
                 ExpressionOperator.CALL,
@@ -814,40 +814,40 @@ public class YqlParser implements Parser {
             List<Integer> filter = new ArrayList<>();
             if (elementFilterObj instanceof List<?> list) {
                 for (Object val : list) {
-                    filter.add(convertToIntForElementFilter(val));
+                    filter.add(convertToElementId(val));
                 }
             } else {
-                filter.add(convertToIntForElementFilter(elementFilterObj));
+                filter.add(convertToElementId(elementFilterObj));
             }
             sameElement.setElementFilter(filter);
         }
     }
 
     /** Element filter accepts Integer. Allows Long that is within Integer size. */
-    private int convertToIntForElementFilter(Object val) {
+    private int convertToElementId(Object val) {
         if (val == null) {
-            throw new IllegalArgumentException("elementFilter cannot contain null values");
+            throw new IllegalArgumentException("element id cannot be null");
         }
         if (val instanceof Integer intVal) {
             if (intVal < 0) {
-                throw new IllegalArgumentException("elementFilter values must be non-negative, got: " + val);
+                throw new IllegalArgumentException("element id must be non-negative, got: " + val);
             }
             return intVal;
         } else if (val instanceof Long longVal) {
             if (longVal > Integer.MAX_VALUE) {
                 throw new IllegalArgumentException(
-                        "elementFilter values must fit in int32 range, got: " + longVal);
+                        "element id must fit in int32 range, got: " + longVal);
             }
             if (longVal < 0) {
-                throw new IllegalArgumentException("elementFilter values must be non-negative, got: " + val);
+                throw new IllegalArgumentException("element id must be non-negative, got: " + val);
             }
             return longVal.intValue();
         } else if (val instanceof Double || val instanceof Float) {
             throw new IllegalArgumentException(
-                    "elementFilter values must be integers, not floating point numbers. Got: " + val);
+                    "element id must be integer, not floating point number. Got: " + val);
         } else {
             throw new IllegalArgumentException(
-                    "elementFilter values must be integers, got: " + val.getClass().getSimpleName());
+                    "element id must be integer, got: " + val.getClass().getSimpleName());
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -485,19 +485,19 @@ public class YqlParserTestCase {
     void testSameElementWithInvalidElementFilter() {
         // Test negative number
         assertParseFail("select * from sources * where myfield contains ({elementFilter:-1} sameElement(name contains 'John'))",
-                new IllegalArgumentException("elementFilter values must be non-negative, got: -1"));
+                new IllegalArgumentException("element id must be non-negative, got: -1"));
 
         // Test negative in array
         assertParseFail("select * from sources * where myfield contains ({elementFilter:[1,-2,3]} sameElement(name contains 'John'))",
-                new IllegalArgumentException("elementFilter values must be non-negative, got: -2"));
+                new IllegalArgumentException("element id must be non-negative, got: -2"));
 
         // Test floating point number
         assertParseFail("select * from sources * where myfield contains ({elementFilter:1.5} sameElement(name contains 'John'))",
-                new IllegalArgumentException("elementFilter values must be integers, not floating point numbers. Got: 1.5"));
+                new IllegalArgumentException("element id must be integer, not floating point number. Got: 1.5"));
 
         // Test floating point in array
         assertParseFail("select * from sources * where myfield contains ({elementFilter:[1,2.5,3]} sameElement(name contains 'John'))",
-                new IllegalArgumentException("elementFilter values must be integers, not floating point numbers. Got: 2.5"));
+                new IllegalArgumentException("element id must be integer, not floating point number. Got: 2.5"));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -503,10 +503,22 @@ public class YqlParserTestCase {
     @Test
     void testIndexedAccessRewritesToSameElement() {
         // ints[1] = 2 should rewrite to ints contains ({elementFilter:[1]}sameElement(2))
-        QueryTree qt = parse("select * from sources * where ints[1] = \"2\"");
+        QueryTree qt = parse("select * from sources * where strings[1] = \"foo\"");
         SameElementItem se = (SameElementItem) qt.getRoot();
+        assertEquals("strings", se.getFieldName());
+        assertEquals(List.of(1), se.getElementFilter());
+        assertEquals(1, se.getItemCount());
+
+        qt = parse("select * from sources * where ints[1] = 2");
+        se = (SameElementItem) qt.getRoot();
         assertEquals("ints", se.getFieldName());
         assertEquals(List.of(1), se.getElementFilter());
+        assertEquals(1, se.getItemCount());
+
+        qt = parse("select * from sources * where bools[0] = true");
+        se = (SameElementItem) qt.getRoot();
+        assertEquals("bools", se.getFieldName());
+        assertEquals(List.of(0), se.getElementFilter());
         assertEquals(1, se.getItemCount());
     }
 

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -501,6 +501,16 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testIndexedAccessRewritesToSameElement() {
+        // ints[1] = 2 should rewrite to ints contains ({elementFilter:[1]}sameElement(2))
+        QueryTree qt = parse("select * from sources * where ints[1] = \"2\"");
+        SameElementItem se = (SameElementItem) qt.getRoot();
+        assertEquals("ints", se.getFieldName());
+        assertEquals(List.of(1), se.getElementFilter());
+        assertEquals(1, se.getItemCount());
+    }
+
+    @Test
     void testPhrase() {
         assertParse("select foo from bar where baz contains phrase(\"a\", \"b\")",
                 "baz:\"a b\"");


### PR DESCRIPTION
- Rewrites `field[index]=value` to `field contains ({elementFilter:[index]}sameElement(value))`
- We stringify the value since sameElement only supports strings.

@havardpe please review
@boeker fyi