### PR TITLE
Update container-disc leakage spec [MERGEOK]

### DIFF
--- a/container-disc/leakage-spec.json
+++ b/container-disc/leakage-spec.json
@@ -39,14 +39,6 @@
   "com.yahoo.container.jdisc.ContentChannelOutputStream" : [
     "com.yahoo.io.WritableByteTransmitter"
   ],
-  "com.yahoo.container.jdisc.DataplaneProxyConfigurator" : [
-    "com.yahoo.cloud.config.DataplaneProxyConfig",
-    "com.yahoo.jdisc.http.server.jetty.DataplaneProxyCredentials"
-  ],
-  "com.yahoo.container.jdisc.DataplaneProxyService" : [
-    "com.yahoo.cloud.config.DataplaneProxyConfig",
-    "com.yahoo.jdisc.http.server.jetty.DataplaneProxyCredentials"
-  ],
   "com.yahoo.container.jdisc.DisableOsgiFramework" : [
     "com.yahoo.jdisc.application.OsgiFramework",
     "org.osgi.framework.Bundle",


### PR DESCRIPTION
Remove `DataplaneProxyConfigurator` and `DataplaneProxyService` entries from `container-disc/leakage-spec.json`. These classes were moved to `cloud-tenant` in #35995.