### PR TITLE
Always let AND/OR/ANDNOT iterators in filter searches be non-strict

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -194,7 +194,7 @@ assertWhiteList(const SimpleResult &exp, Blueprint::UP whiteListBlueprint, bool 
 
     SearchIterator::UP sb = whiteListBlueprint->createSearch(*md);
     SimpleResult act;
-    act.searchStrict(*sb, docIdLimit);
+    act.search(*sb, docIdLimit);
     EXPECT_EQ(exp, act);
 }
 
@@ -208,11 +208,7 @@ assertSearchResult(const SimpleResult &exp, const DocumentMetaStore &dms,
     TermFieldMatchData tfmd;
     SearchIterator::UP sb = sc->createIterator(&tfmd, strict);
     SimpleResult act;
-    if (strict) {
-        act.search(*sb);
-    } else {
-        act.search(*sb, docIdLimit);
-    }
+    act.search(*sb, docIdLimit);
     EXPECT_EQ(exp, act);
 }
 

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -954,7 +954,7 @@ TEST(QueryTest, requireThatWhiteListBlueprintCanBeUsed)
     SearchIterator::UP search = query.createSearch(*md);
     SimpleResult exp = SimpleResult().addHit(1).addHit(5).addHit(7).addHit(11);
     SimpleResult act;
-    act.search(*search);
+    act.search(*search, 42);
     EXPECT_EQ(exp, act);
 }
 

--- a/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
+++ b/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
@@ -48,7 +48,7 @@ struct Fixture : ImportedAttributeFixture {
     }
 
     SimpleResult search(SearchIterator& iter) {
-        return SimpleResult().searchStrict(iter, get_imported_attr()->getNumDocs());
+        return SimpleResult().search(iter, get_imported_attr()->getNumDocs());
     }
 };
 

--- a/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
@@ -1975,11 +1975,7 @@ public:
         TermFieldMatchData tfmd;
         auto itr = search_ctx->createIterator(&tfmd, strict);
         SimpleResult result;
-        if (strict) {
-            result.searchStrict(*itr, _attr.getNumDocs());
-        } else {
-            result.search(*itr, _attr.getNumDocs());
-        }
+        result.search(*itr, _attr.getNumDocs());
         return result;
     }
 };

--- a/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
+++ b/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
@@ -257,7 +257,7 @@ DiskIndexTest::search(const FieldIndex& field_index, const DictionaryLookupResul
 {
     TermFieldMatchDataArray mda;
     auto sb = field_index.create_iterator(lookup_result, handle, mda);
-    return SimpleResult().search(*sb);
+    return SimpleResult().search(*sb, 1000);
 }
 
 Blueprint::UP
@@ -382,8 +382,8 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
         EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s, 1000));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 1000));
     }
     { // bitvector due to no ranking needed
         b = create_blueprint(FieldSpec("f2", 0, 0, false), makeTerm("w2"));
@@ -397,24 +397,24 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
         EXPECT_TRUE(mda2[0]->isNotNeeded());
         s = (dynamic_cast<LeafBlueprint *>(b.get()))->createLeafSearch(mda2);
         EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s, 1000));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 1000));
     }
     { // fake bitvector (wrapping posocc iterator)
         b = create_blueprint(FieldSpec("f1", 0, 0, true), makeTerm("w1"));
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
         EXPECT_TRUE(dynamic_cast<BooleanMatchIteratorWrapper *>(s.get()) != nullptr);
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s, 1000));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 1000));
     }
     { // posting list iterator
         b = create_blueprint(FieldSpec("f1", 0, 0), makeTerm("w1"));
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
         ASSERT_TRUE((dynamic_cast<ZcRareWordPosOccIterator<true, false> *>(s.get()) != nullptr) || (dynamic_cast<ZcPosOccIterator<true, false> *>(s.get()) != nullptr));
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s, 1000));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 1000));
     }
     { // bitvector used due to filter threshold set.
         // The term 'w2' hits 17 docs in field 'f2' (bitvector for term exists).
@@ -423,8 +423,8 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
         EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s, 100));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 100));
     }
     { // bitvector used due to filter threshold overridden in the query.
         // The term 'w2' hits 17 docs in field 'f2' (bitvector for term exists).
@@ -434,8 +434,8 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
         EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != nullptr);
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*s, 100));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 100));
         _requestContext.get_create_blueprint_params().filter_threshold = std::nullopt;
     }
     { // fake bitvector (wrapping posocc iterator) used due to filter threshold set.
@@ -445,8 +445,8 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
         s = leaf_b.createLeafSearch(mda);
         EXPECT_TRUE((dynamic_cast<BooleanMatchIteratorWrapper *>(s.get()) != nullptr));
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*s, 100));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound), 100));
     }
 }
 

--- a/searchlib/src/tests/queryeval/blueprint/leaf_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/leaf_blueprints_test.cpp
@@ -21,7 +21,7 @@ TEST(LeafBlueprintsTest, empty_blueprint)
     SearchIterator::UP search = empty.createSearch(*md);
 
     SimpleResult res;
-    res.search(*search);
+    res.search(*search, 100);
     SimpleResult expect; // empty
     EXPECT_EQ(res, expect);
 }
@@ -39,7 +39,7 @@ TEST(LeafBlueprintsTest, simple_blueprint)
     SearchIterator::UP search = simple.createSearch(*md);
 
     SimpleResult res;
-    res.search(*search);
+    res.search(*search, 100);
     SimpleResult expect;
     expect.addHit(3).addHit(5).addHit(7);
     EXPECT_EQ(res, expect);

--- a/searchlib/src/tests/queryeval/exact_nearest_neighbor/exact_nearest_neighbor_test.cpp
+++ b/searchlib/src/tests/queryeval/exact_nearest_neighbor/exact_nearest_neighbor_test.cpp
@@ -136,11 +136,7 @@ SimpleResult find_matches_impl(std::shared_ptr<QueryEvalStats> stats, Fixture &e
                                                        std::make_unique<DistanceCalculator>(attr, qtv),
                                                        dh, filter,
                                                        env._matching_phase != MatchingPhase::FIRST_PHASE);
-    if (strict) {
-        return SimpleResult().searchStrict(*search, attr.getNumDocs());
-    } else {
-        return SimpleResult().search(*search, attr.getNumDocs());
-    }
+    return SimpleResult().search(*search, attr.getNumDocs());
 }
 
 template <bool strict>

--- a/searchlib/src/tests/queryeval/monitoring_search_iterator/monitoring_search_iterator_test.cpp
+++ b/searchlib/src/tests/queryeval/monitoring_search_iterator/monitoring_search_iterator_test.cpp
@@ -47,7 +47,7 @@ struct SimpleFixture
              false),
         _res()
     {
-        _res.search(_itr);
+        _res.search(_itr, 10);
     }
     ~SimpleFixture();
 };
@@ -96,7 +96,7 @@ struct TreeFixture
         _itr.reset(new MonitoringSearchIterator("and",
                                                 SearchIterator::UP(AndSearch::create(std::move(children), true)),
                                                 false));
-        _res.search(*_itr);
+        _res.search(*_itr, 10);
     }
     ~TreeFixture();
 };

--- a/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
+++ b/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
@@ -416,7 +416,7 @@ struct HeapFixture
     HeapFixture() : spec(2, 2), result() {
         spec.leaf(LeafSpec("A", 1).doc(1, 1).doc(2, 2).doc(3, 3).doc(4, 4).doc(5, 5).doc(6, 6));
         SearchIterator::UP sb(spec.create());
-        result.search(*sb);
+        result.search(*sb, 10);
     }
     ~HeapFixture();
 };

--- a/searchlib/src/tests/queryeval/profiled_iterator/profiled_iterator_test.cpp
+++ b/searchlib/src/tests/queryeval/profiled_iterator/profiled_iterator_test.cpp
@@ -154,7 +154,7 @@ void print_counts(const std::map<std::string,size_t> &counts) {
 void verify_result(SearchIterator &search, const std::vector<uint32_t> &hits) {
     SimpleResult actual;
     SimpleResult expect(hits);
-    actual.searchStrict(search, num_docs);
+    actual.search(search, num_docs);
     EXPECT_EQ(actual, expect);
 }
 

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -232,18 +232,18 @@ TEST(QueryEvalTest, test_and) {
     EXPECT_TRUE(dynamic_cast<const AndSearch *>(and_ab.get()) != nullptr);
     EXPECT_EQ(4u, dynamic_cast<AndSearch &>(*and_ab).estimate());
     SimpleResult res;
-    res.search(*and_ab);
+    res.search(*and_ab, 1000);
     SimpleResult expect;
     expect.addHit(5).addHit(30);
     EXPECT_EQ(res, expect);
 
     SearchIterator::UP filter_ab = and_b->createFilterSearch(upper_bound);
     SimpleResult filter_res;
-    filter_res.search(*filter_ab);
+    filter_res.search(*filter_ab, 1000);
     EXPECT_EQ(res, expect);
     std::string dump = filter_ab->asString();
     expect_match(dump, "upper");
-    expect_match(dump, "AndSearchStrict.*NoUnpack.*SimpleSearch.*upper.*SimpleSearch.*upper");
+    expect_match(dump, "AndSearchNoStrict.*NoUnpack.*SimpleSearch.*upper.*SimpleSearch.*upper");
     and_b->basic_plan(false, 1000);
     and_b->fetchPostings(ExecuteInfo::FULL);
     filter_ab = and_b->createFilterSearch(lower_bound);
@@ -269,18 +269,18 @@ TEST(QueryEvalTest, test_or)
         SearchIterator::UP or_ab = or_b->createSearch(*md);
 
         SimpleResult res;
-        res.search(*or_ab);
+        res.search(*or_ab, 1000);
         SimpleResult expect;
         expect.addHit(5).addHit(10).addHit(17).addHit(30);
         EXPECT_EQ(res, expect);
 
         SearchIterator::UP filter_ab = or_b->createFilterSearch(upper_bound);
         SimpleResult filter_res;
-        filter_res.search(*filter_ab);
+        filter_res.search(*filter_ab, 1000);
         EXPECT_EQ(res, expect);
         std::string dump = filter_ab->asString();
         expect_match(dump, "upper");
-        expect_match(dump, "StrictHeapOrSearch.*NoUnpack.*SimpleSearch.*upper.*SimpleSearch.*upper");
+        expect_match(dump, "OrLikeSearch.false.*NoUnpack.*SimpleSearch.*upper.*SimpleSearch.*upper");
         or_b->basic_plan(false, 1000);
         or_b->fetchPostings(ExecuteInfo::FULL);
         filter_ab = or_b->createFilterSearch(lower_bound);
@@ -413,14 +413,14 @@ TEST(QueryEvalTest, test_andnot)
         SearchIterator::UP andnot_ab = andnot_b->createSearch(*md);
 
         SimpleResult res;
-        res.search(*andnot_ab);
+        res.search(*andnot_ab, 1000);
         SimpleResult expect;
         expect.addHit(10);
         EXPECT_EQ(res, expect);
 
         SearchIterator::UP filter_ab = andnot_b->createFilterSearch(upper_bound);
         SimpleResult filter_res;
-        filter_res.search(*filter_ab);
+        filter_res.search(*filter_ab, 1000);
         EXPECT_EQ(res, expect);
         std::string dump = filter_ab->asString();
         expect_match(dump, "upper");
@@ -447,7 +447,7 @@ TEST(QueryEvalTest, test_andnot)
         SearchIterator::UP andnot_ab = andnot_b->createSearch(*md);
 
         SimpleResult res;
-        res.search(*andnot_ab);
+        res.search(*andnot_ab, 1000);
         SimpleResult expect;
         expect.addHit(1).addHit(10);
 
@@ -474,7 +474,7 @@ TEST(QueryEvalTest, test_andnot)
         SearchIterator::UP and_cab = and_b->createSearch(*md);
 
         SimpleResult res;
-        res.search(*and_cab);
+        res.search(*and_cab, 1000);
         SimpleResult expect;
         expect.addHit(1).addHit(10);
 
@@ -501,7 +501,7 @@ TEST(QueryEvalTest, test_rank)
         SearchIterator::UP rank_ab = rank_b->createSearch(*md);
 
         SimpleResult res;
-        res.search(*rank_ab);
+        res.search(*rank_ab, 1000);
         SimpleResult expect;
         expect.addHit(5).addHit(10).addHit(16).addHit(30);
 

--- a/searchlib/src/tests/queryeval/sourceblender/sourceblender_test.cpp
+++ b/searchlib/src/tests/queryeval/sourceblender/sourceblender_test.cpp
@@ -125,7 +125,7 @@ TEST(SourceBlenderTest, test_full_sourceblender_search)
 
     SearchIterator::UP blend(SourceBlenderSearch::create(sel->createIterator(), abc, true));
     SimpleResult result;
-    result.search(*blend);
+    result.search(*blend, 100);
 
     SimpleResult expect_result;
     expect_result.addHit(2).addHit(3).addHit(11).addHit(21).addHit(34);

--- a/searchlib/src/tests/queryeval/weak_and/weak_and_test.cpp
+++ b/searchlib/src/tests/queryeval/weak_and/weak_and_test.cpp
@@ -45,7 +45,7 @@ struct MyWandSpec : public WandSpec
     SimpleResult search() {
         SearchIterator::UP search(create());
         SimpleResult hits;
-        hits.search(*search);
+        hits.search(*search, docid_limit);
         return hits;
     }
 };
@@ -67,7 +67,7 @@ struct SimpleWandFixture {
         spec.leaf(LeafSpec("foo").doc(1).doc(2).doc(3).doc(4).doc(5).doc(6));
         spec.leaf(LeafSpec("bar").doc(1).doc(3).doc(5));
         SearchIterator::UP search(spec.create());
-        hits.search(*search);
+        hits.search(*search, docid_limit);
     }
     ~SimpleWandFixture();
 };
@@ -84,7 +84,7 @@ struct AdvancedWandFixture {
         spec.leaf(LeafSpec("4").doc(4).doc(14).doc(114));
         spec.leaf(LeafSpec("5").doc(5).doc(15).doc(115));
         SearchIterator::UP search(spec.create());
-        hits.search(*search);
+        hits.search(*search, docid_limit);
     }
     ~AdvancedWandFixture();
 };
@@ -146,7 +146,7 @@ TEST(WeakAndTest, require_that_initial_docid_for_subsearches_are_taken_into_acco
     wand::MatchParams match_params(scores, wand::StopWordStrategy::none(), wand::DEFAULT_PARALLEL_WAND_SCORES_ADJUST_FREQUENCY, docid_limit);
     auto search = std::make_unique<TrackedSearch>("WAND", history, WeakAndSearch::create(terms, match_params, 2, true, false));
     SimpleResult hits;
-    hits.search(*search);
+    hits.search(*search, docid_limit);
     EXPECT_EQ(SimpleResult().addHit(10), hits);
     EXPECT_EQ(History().seek("WAND", 1).step("WAND", 10).unpack("WAND", 10).unpack("bar", 10)
               .seek("WAND", 11).seek("bar", 11).step("bar", search::endDocId).step("WAND", search::endDocId),

--- a/searchlib/src/tests/queryeval/weak_and/weak_and_test_expensive.cpp
+++ b/searchlib/src/tests/queryeval/weak_and/weak_and_test_expensive.cpp
@@ -45,7 +45,7 @@ TEST(WeakAndExpensiveTest, require_that_mod_search_works) {
     Stats stats;
     auto search = std::make_unique<ModSearch>(stats, 3, 8, 3, nullptr);
     SimpleResult hits;
-    hits.search(*search);
+    hits.search(*search, 100);
     EXPECT_EQ(SimpleResult().addHit(3).addHit(6), hits);
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -439,11 +439,11 @@ protected:
 public:
     SearchIteratorUP createSearch(fef::MatchData &md) const { return tag_with_id(createSearchImpl(md)); }
     SearchIteratorUP createFilterSearch(FilterConstraint constraint) const { return tag_with_id(createFilterSearchImpl(constraint)); }
-    static SearchIteratorUP create_and_filter(std::span<const UP> children, bool strict, FilterConstraint constraint);
-    static SearchIteratorUP create_or_filter(std::span<const UP> children, bool strict, FilterConstraint constraint);
-    static SearchIteratorUP create_atmost_and_filter(std::span<const UP> children, bool strict, FilterConstraint constraint);
-    static SearchIteratorUP create_atmost_or_filter(std::span<const UP> children, bool strict, FilterConstraint constraint);
-    static SearchIteratorUP create_andnot_filter(std::span<const UP> children, bool strict, FilterConstraint constraint);
+    static SearchIteratorUP create_and_filter(std::span<const UP> children, FilterConstraint constraint);
+    static SearchIteratorUP create_or_filter(std::span<const UP> children, FilterConstraint constraint);
+    static SearchIteratorUP create_atmost_and_filter(std::span<const UP> children, FilterConstraint constraint);
+    static SearchIteratorUP create_atmost_or_filter(std::span<const UP> children, FilterConstraint constraint);
+    static SearchIteratorUP create_andnot_filter(std::span<const UP> children, FilterConstraint constraint);
     static SearchIteratorUP create_first_child_filter(std::span<const UP> children, FilterConstraint constraint);
     static SearchIteratorUP create_default_filter(FilterConstraint constraint);
 

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.cpp
@@ -82,7 +82,7 @@ DotProductBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray
 SearchIterator::UP
 DotProductBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_or_filter(_terms, strict(), constraint);
+    return create_or_filter(_terms, constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.cpp
@@ -122,7 +122,7 @@ SearchIterator::UP EquivBlueprint::createLeafSearch(const fef::TermFieldMatchDat
 SearchIterator::UP
 EquivBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_or_filter(_terms, strict(), constraint);
+    return create_or_filter(_terms, constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
@@ -210,7 +210,7 @@ AndNotBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
     if (_elementwise) {
         return create_first_child_filter(get_children(), constraint);
     }
-    return create_andnot_filter(get_children(), strict(), constraint);
+    return create_andnot_filter(get_children(), constraint);
 }
 
 std::shared_ptr<GlobalFilter>
@@ -321,7 +321,7 @@ AndBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 SearchIterator::UP
 AndBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_and_filter(get_children(), strict(), constraint);
+    return create_and_filter(get_children(), constraint);
 }
 
 std::shared_ptr<GlobalFilter>
@@ -438,7 +438,7 @@ OrBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 SearchIterator::UP
 OrBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_or_filter(get_children(), strict(), constraint);
+    return create_or_filter(get_children(), constraint);
 }
 
 AnyFlow
@@ -575,7 +575,7 @@ WeakAndBlueprint::createIntermediateSearch(MultiSearch::Children sub_searches,
 SearchIterator::UP
 WeakAndBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_atmost_or_filter(get_children(), strict(), constraint);
+    return create_atmost_or_filter(get_children(), constraint);
 }
 
 void
@@ -671,7 +671,7 @@ NearBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     size_t positive_count = sat_sub(get_children().size(), _num_negative_terms);
     if (positive_count > 0) {
-        return create_atmost_and_filter(std::span(get_children().data(), positive_count), strict(), constraint);
+        return create_atmost_and_filter(std::span(get_children().data(), positive_count), constraint);
     }
     return std::make_unique<EmptySearch>();
 }
@@ -745,7 +745,7 @@ ONearBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
     size_t positive_count = sat_sub(get_children().size(), _num_negative_terms);
     if (positive_count > 0) {
-        return create_atmost_and_filter(std::span(get_children().data(), positive_count), strict(), constraint);
+        return create_atmost_and_filter(std::span(get_children().data(), positive_count), constraint);
     }
     return std::make_unique<EmptySearch>();
 }
@@ -907,7 +907,7 @@ SourceBlenderBlueprint::createIntermediateSearch(MultiSearch::Children sub_searc
 SearchIterator::UP
 SourceBlenderBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_atmost_or_filter(get_children(), strict(), constraint);
+    return create_atmost_or_filter(get_children(), constraint);
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -126,7 +126,7 @@ SameElementBlueprint::create_same_element_search(MatchData& md, TermFieldMatchDa
 SearchIterator::UP
 SameElementBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_atmost_and_filter(get_children(), strict(), constraint);
+    return create_atmost_and_filter(get_children(), constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.cpp
@@ -96,7 +96,7 @@ SimplePhraseBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &tfmd
 SearchIterator::UP
 SimplePhraseBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_atmost_and_filter(_terms, strict(), constraint);
+    return create_atmost_and_filter(_terms, constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/simpleresult.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/simpleresult.cpp
@@ -21,43 +21,18 @@ SimpleResult::clear()
 }
 
 SimpleResult &
-SimpleResult::search(SearchIterator &sb)
-{
-    clear();
-    // assume strict toplevel search object located at start
-    sb.initFullRange();
-    for (sb.seek(1); !sb.isAtEnd(); sb.seek(sb.getDocId() + 1)) {
-        sb.unpack(sb.getDocId());
-        _hits.push_back(sb.getDocId());
-    }
-    return *this;
-}
-
-SimpleResult &
-SimpleResult::searchStrict(SearchIterator &sb, uint32_t docIdLimit)
-{
-    clear();
-    // assume strict toplevel search object located at start
-    sb.initRange(1, docIdLimit);
-    for (sb.seek(1); !sb.isAtEnd(); sb.seek(sb.getDocId() + 1)) {
-        sb.unpack(sb.getDocId());
-        _hits.push_back(sb.getDocId());
-    }
-    return *this;
-}
-
-SimpleResult &
 SimpleResult::search(SearchIterator &sb, uint32_t docIdLimit)
 {
     clear();
-    // assume non-strict toplevel search object
-    sb.initRange(1, docIdLimit);
-    for (uint32_t docId = 1; !sb.isAtEnd(docId); ++docId) {
-        if (sb.seek(docId)) {
-            assert(docId == sb.getDocId());
-            sb.unpack(docId);
-            _hits.push_back(docId);
+    uint32_t docid = 1;
+    sb.initRange(docid, docIdLimit);
+    while (!sb.isAtEnd(docid)) {
+        if (sb.seek(docid)) {
+            assert(sb.getDocId() == docid);
+            sb.unpack(docid);
+            _hits.push_back(docid);
         }
+        docid = std::max(docid + 1, sb.getDocId());
     }
     return *this;
 }

--- a/searchlib/src/vespa/searchlib/queryeval/simpleresult.h
+++ b/searchlib/src/vespa/searchlib/queryeval/simpleresult.h
@@ -59,17 +59,7 @@ public:
     /**
      * Fill this result with all the hits returned by the given search
      * object. Old hits will be removed from this result before doing
-     * the search. Assumes strict toplevel search object located at start
-     *
-     * @param sb search object
-     **/
-    SimpleResult &search(SearchIterator &sb);
-    SimpleResult &searchStrict(SearchIterator &sb, uint32_t docIdLimit);
-
-    /**
-     * Fill this result with all the hits returned by the given search
-     * object. Old hits will be removed from this result before doing
-     * the search. Assumes non-strict toplevel search object.
+     * the search.
      *
      * @param sb search object
      * @param docIdLimit the end of the docId range for this search iterator

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.cpp
@@ -99,7 +99,7 @@ ParallelWeakAndBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
 std::unique_ptr<SearchIterator>
 ParallelWeakAndBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_atmost_or_filter(_terms, strict(), constraint);
+    return create_atmost_or_filter(_terms, constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
@@ -138,7 +138,7 @@ WeightedSetTermBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &t
 SearchIterator::UP
 WeightedSetTermBlueprint::createFilterSearchImpl(FilterConstraint constraint) const
 {
-    return create_or_filter(_terms, strict(), constraint);
+    return create_or_filter(_terms, constraint);
 }
 
 std::unique_ptr<MatchingElementsSearch>


### PR DESCRIPTION
This is to avoid the eagerness of the initRange function of strict iterators that will look for the first hit.

This is ok for filter searches as we are using the termwise API and not the seek API, but it requires that we will never add a parent iterator to any of these that expect strictness. We must also not expect strictness from the root filter search.

Also consolidated search functions on SimpleResult to not require strictness.

@arnej27959 @toregge please review
@bratseth FYI