### PR TITLE
Fix TSan suppressions file syntax

### DIFF
--- a/tsan-suppressions.txt
+++ b/tsan-suppressions.txt
@@ -1,3 +1,8 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#
+# Suppressions file for ThreadSanitizer false positives.
+#
+
 # There is an explicit (and documented) mutex order inversion in the MergeThrottler component
 # that cannot cause a deadlock in practice due to separately maintained invariants for when the
 # mutexes can be locked. Of course, TSan is not able to infer this by itself, so silence this
@@ -54,4 +59,4 @@ race:ASN1_STRING_cmp
 race:ASN1_STRING_set
 
 # libgcc_s (unwinder / EH frame registration). Often triggers TSAN reports via lock-free FDE registry.
-module:libgcc_s.so.1
+called_from_lib:libgcc_s.so


### PR DESCRIPTION
@havardpe or @arnej27959 please review

Replace `module` with `called_from_lib` and remove file versioning suffix since suppression strings are implicitly surrounded by glob patterns (unless explicitly anchored).

Also add missing license header.

