### PR TITLE
Demote MessageBus trace log level from `INFO` to `FINE`

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
@@ -349,7 +349,7 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
         @Override
         public void handleReply(Reply reply) {
             if (reply.getTrace().getLevel() > 0) {
-                log.log(Level.INFO, reply.getTrace().toString());
+                log.log(Level.FINE, () -> reply.getTrace().toString());
             }
             OperationContext context = (OperationContext) reply.getContext();
             long reqId = context.reqId;


### PR DESCRIPTION
@bjorncs please review

If `traceLevel` has been set > 0 for all client requests, this can light a bonfire under the log processing infrastructure.

This is the only log statement in the file, so if anyone truly wishes to stare at MessageBus traces, they can `vespa-logctl` their way to enlightenment.

