### PR TITLE
Add feature flag to ignore connectivity checks at startup

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1359,6 +1359,7 @@
       "public int maxDocumentOperationRequestSizeMib()",
       "public java.lang.Object sidecarsForTest()",
       "public boolean useTriton()",
+      "public boolean ignoreConnectivityChecksAtStartup()",
       "public int searchCoreMaxOutstandingMoveOps()",
       "public double docprocHandlerThreadpool()",
       "public boolean applyOnRestartForApplicationMetadataConfig()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -114,6 +114,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"glebashnik"}) default int maxDocumentOperationRequestSizeMib() { return 2048; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default Object sidecarsForTest() { return null; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default boolean useTriton() { return false; }
+        @ModelFeatureFlag(owners = {"arnej"}) default boolean ignoreConnectivityChecksAtStartup() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int searchCoreMaxOutstandingMoveOps() { return 100; }
         @ModelFeatureFlag(owners = {"johsol"}) default double docprocHandlerThreadpool() { return 1.0; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default boolean applyOnRestartForApplicationMetadataConfig() { return false; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -79,6 +79,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private final Map<ClusterSpec.Type, String> mallocImpl = new HashMap<>();
     private final Map<String, Integer> searchNodeInitializerThreads = new HashMap<>();
     private boolean useTriton = false;
+    private boolean ignoreConnectivityChecksAtStartup = false;
     private double searchNodeReservedDiskSpaceFactor = 0.0;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
@@ -136,6 +137,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
         return clusterType.map(c -> mallocImpl.get(c)).orElse(null);
     }
     @Override public boolean useTriton() { return useTriton; }
+    @Override public boolean ignoreConnectivityChecksAtStartup() { return ignoreConnectivityChecksAtStartup; }
     @Override public double searchNodeReservedDiskSpaceFactor() { return searchNodeReservedDiskSpaceFactor; }
 
     public TestProperties maxUnCommittedMemory(int maxUnCommittedMemory) {
@@ -344,6 +346,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setUseTriton(boolean value) {
         this.useTriton = value;
+        return this;
+    }
+
+    public TestProperties setIgnoreConnectivityChecksAtStartup(boolean value) {
+        this.ignoreConnectivityChecksAtStartup = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -275,7 +275,7 @@ public class Admin extends TreeConfigProducer<AnyConfigProducer> implements Seri
 
     private void addConfigSentinel(DeployState deployState, HostResource host)
     {
-        ConfigSentinel configSentinel = new ConfigSentinel(host.getHost(), deployState.getProperties().applicationId(), deployState.zone());
+        ConfigSentinel configSentinel = new ConfigSentinel(host.getHost(), deployState);
         addAndInitializeService(deployState, host, configSentinel);
         host.getHost().setConfigSentinel(configSentinel);
     }

--- a/configd/src/apps/sentinel/connectivity.cpp
+++ b/configd/src/apps/sentinel/connectivity.cpp
@@ -140,6 +140,7 @@ void Connectivity::configure(const SentinelConfig::Connectivity& config, const M
     _config = config;
     LOG(config, "connectivity.maxBadCount = %d", _config.maxBadCount);
     LOG(config, "connectivity.minOkPercent = %d", _config.minOkPercent);
+    LOG(config, "connectivity.ignore = %s", _config.ignore ? "true" : "false");
     _checkSpecs = specsFrom(model);
 }
 
@@ -202,6 +203,10 @@ bool Connectivity::Accumulator::enoughOk(const SentinelConfig::Connectivity& con
         LOG(warning, "Only %zu of %zu nodes are up and OK, %.1f%% (min is %d%%)", _numOk, _numHandled, pct,
             config.minOkPercent);
         enough = false;
+    }
+    if (config.ignore && !enough) {
+        LOG(warning, "Connectivity checks ignored, proceeding with service startup anyway");
+        enough = true;
     }
     if (_numOk == _numHandled) {
         LOG(info, "All connectivity checks OK, proceeding with service startup");

--- a/configdefinitions/src/vespa/sentinel.def
+++ b/configdefinitions/src/vespa/sentinel.def
@@ -28,6 +28,9 @@ connectivity.minOkPercent int default=50
 ## Absolute number of nodes with confirmed network connectivity problems, maximum
 connectivity.maxBadCount int default=1
 
+## Ignore connectivity check results at startup (start services regardless)
+connectivity.ignore bool default=false
+
 ## The command to run. This will be run by sh -c, and the following
 ## environment variables are defined: $ROOT, $VESPA_SERVICE_NAME,
 ## $VESPA_CONFIG_ID

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -207,6 +207,7 @@ public class ModelContextImpl implements ModelContext {
         private final int maxDocumentOperationRequestSizeMib;
         private final Sidecars sidecarsForTest;
         private final boolean useTriton;
+        private final boolean ignoreConnectivityChecksAtStartup;
         private final int searchCoreMaxOutstandingMoveOps;
         private final double docprocHandlerThreadpool;
         private final boolean applyOnRestartForApplicationMetadataConfig;
@@ -256,6 +257,7 @@ public class ModelContextImpl implements ModelContext {
             this.maxDocumentOperationRequestSizeMib = Flags.MAX_DOCUMENT_OPERATION_REQUEST_SIZE_MIB.bindTo(source).with(appId).with(version).value();
             this.sidecarsForTest = Flags.SIDECARS_FOR_TEST.bindTo(source).with(appId).with(version).value();
             this.useTriton = Flags.USE_TRITON.bindTo(source).with(appId).with(version).value();
+            this.ignoreConnectivityChecksAtStartup = PermanentFlags.IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP.bindTo(source).with(appId).value();
             this.searchCoreMaxOutstandingMoveOps = Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS.bindTo(source).with(appId).with(version).value();
             this.docprocHandlerThreadpool = Flags.DOCPROC_HANDLER_THREADPOOL.bindTo(source).with(appId).with(version).value();
             this.applyOnRestartForApplicationMetadataConfig = Flags.APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG.bindTo(source).with(appId).with(version).value();
@@ -306,6 +308,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public int maxDocumentOperationRequestSizeMib() { return maxDocumentOperationRequestSizeMib; }
         @Override public Object sidecarsForTest() { return sidecarsForTest; }
         @Override public boolean useTriton() { return useTriton; }
+        @Override public boolean ignoreConnectivityChecksAtStartup() { return ignoreConnectivityChecksAtStartup; }
         @Override public int searchCoreMaxOutstandingMoveOps() { return searchCoreMaxOutstandingMoveOps; }
         @Override public double docprocHandlerThreadpool() { return docprocHandlerThreadpool; }
         @Override public boolean applyOnRestartForApplicationMetadataConfig() { return applyOnRestartForApplicationMetadataConfig; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -683,6 +683,14 @@ public class PermanentFlags {
             "Takes effect on next maintainer run",
             CLUSTER_ID, APPLICATION, TENANT_ID, ZONE_ID);
 
+    public static final UnboundBooleanFlag IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP = defineFeatureFlag(
+            "ignore-connectivity-checks-at-startup", false,
+            "Ignore connectivity checks in config-sentinel at startup. " +
+                    "Normally the sentinel checks that a sufficient fraction of cluster nodes can reach each other before starting services. " +
+                    "When this flag is set, services are started immediately regardless of connectivity check results.",
+            "Takes effect on next host restart",
+            TENANT_ID, APPLICATION, INSTANCE_ID);
+
     public static final UnboundListFlag<String> ALLOW_FLAVORS = defineListFlag(
             "allow-flavors", List.of(), String.class,
             "Flavors that that we will allow provisioning (flavors with lifecycle 'active' are allowed by default)" +


### PR DESCRIPTION
Introduces a permanent boolean feature flag
`ignore-connectivity-checks-at-startup` that allows bypassing the config-sentinel connectivity checks during node startup.

Normally the sentinel verifies that a sufficient fraction of cluster nodes can reach each other before starting services (controlled by `connectivity.minOkPercent` and `connectivity.maxBadCount`). When this flag is set for a tenant/application/instance, services are started immediately regardless of connectivity check results.
