### PR TITLE
Preallocate neighbor link meta vector based on max level links

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -413,6 +413,7 @@ HnswIndex<type>::search_layer_helper(Stats &stats, const BoundDistanceFunction &
               neighbor_subspace(neighbor_subspace_in) {}
     };
     std::vector<NeighborLinkMeta> neighbor_link_metas;
+    neighbor_link_metas.reserve(max_links_for_level(level));
 
     while (!candidates.empty()) {
         auto cand = candidates.top();


### PR DESCRIPTION
@arnej27959 please review

Based on microbenchmarks, this shaves off a dozen or so microseconds per query "for free", so might as well always do it.
