### PR TITLE
optionally prefer Dockerfile.alma8 and Dockerfile.alma9

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -48,6 +48,15 @@ cp -a "${LOCAL_RPM_REPO}/." "${WORKDIR}/docker-image/rpms/"
 cd "${WORKDIR}/docker-image"
 SOURCE_GITREF=$(git rev-parse HEAD)
 
+select_dockerfile() {
+    wanted="Dockefile.${VESPA_BUILDOS_LABEL}"
+    if [ -f "${wanted}" ]; then
+        echo "${wanted}"
+    else
+        echo "Dockerfile"
+    fi
+}
+
 echo "--- Building Vespa preview container"
 GHCR_PREVIEW_TAG=ghcr.io/vespa-engine/vespa-preview-${ARCH}:${VESPA_VERSION}${VESPA_CONTAINER_IMAGE_VERSION_TAG_SUFFIX}
 echo "Building container with tag: ${GHCR_PREVIEW_TAG}"
@@ -57,7 +66,7 @@ docker build --progress plain \
              --build-arg VESPA_BASE_IMAGE="$VESPA_BASE_IMAGE" \
              --tag vespaengine/vespa \
              --tag "${GHCR_PREVIEW_TAG}" \
-             --file Dockerfile .
+             --file "$(select_dockerfile)" .
 
 declare -r GITREF="${GITREF_SYSTEM_TEST:-HEAD}"
 
@@ -90,4 +99,4 @@ docker build --progress=plain \
              --build-arg VESPA_BASE_IMAGE="${GHCR_PREVIEW_TAG}" \
              --target systemtest \
              --tag "$DOCKER_SYSTEMTEST_TAG" \
-             --file Dockerfile .
+             --file "$(select_dockerfile)" .


### PR DESCRIPTION
Add a select_dockerfile function to .buildkite/build-container.sh that picks an OS-specific Dockerfile when one is available. If a file named Dockerfile.${VESPA_BUILDOS_LABEL} exists in the build context (e.g. Dockerfile.alma8 or Dockerfile.alma9), it is used instead of the default Dockerfile. Both docker build invocations in the script now use this function, allowing OS-variant-specific image builds while keeping full backward compatibility with the existing default Dockerfile.
