### PR TITLE
Prepare for hiding match data from ranking framework.

### DIFF
--- a/searchlib/src/apps/tests/memoryindexstress_test.cpp
+++ b/searchlib/src/apps/tests/memoryindexstress_test.cpp
@@ -430,7 +430,7 @@ verifyResult(const FakeResult &expect, Searchable &index, std::string fieldName,
     for (search->seek(1); !search->isAtEnd(); search->seek(search->getDocId() + 1)) {
         actual.doc(search->getDocId());
         search->unpack(search->getDocId());
-        EXPECT_EQ(search->getDocId(), tmd.getDocId());
+        EXPECT_TRUE(tmd.has_ranking_data(search->getDocId()));
         FieldPositionsIterator p = tmd.getIterator();
         actual.len(p.getFieldLength());
         for (; p.valid(); p.next()) {

--- a/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
+++ b/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
@@ -593,8 +593,9 @@ ShowPostingListSubApp::showPostingList()
             sb->unpack(docId);
             for (uint32_t field = 0; field < numFields; ++field) {
                 const TermFieldMatchData &md = *tfmda[field];
-                if (md.getDocId() != docId)
+                if (!md.has_ranking_data(docId)) {
                     continue;
+                }
                 std::cout << " field = " << fieldNames[field] << '\n';
                 FieldPositionsIterator fpi = md.getIterator();
                 uint32_t lastElement = static_cast<uint32_t>(-1);

--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -395,7 +395,7 @@ BitVectorTest::checkSearch(AttributePtr v,
         ++docFreq,
         assert(!checkStride || (docId % 5) == 2u);
         sb->unpack(docId);
-        EXPECT_EQ(md.getDocId(), docId);
+        EXPECT_TRUE(md.has_ranking_data(docId));
         if (v->getCollectionType() == CollectionType::SINGLE || !weights) {
             EXPECT_EQ(1, md.getWeight());
         } else if (v->getCollectionType() == CollectionType::ARRAY) {

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -840,7 +840,7 @@ EnumeratedSaveTest::testReload(AttributePtr v0,
     sb->seek(1u);
     EXPECT_EQ(7u, sb->getDocId());
     sb->unpack(7u);
-    EXPECT_EQ(md.getDocId(), 7u);
+    EXPECT_TRUE(md.has_ranking_data(7u));
     if (v->getCollectionType() == CollectionType::SINGLE || flagAttr) {
         EXPECT_EQ(md.getWeight(), 1);
     } else if (v->getCollectionType() == CollectionType::ARRAY) {

--- a/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
+++ b/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
@@ -62,7 +62,7 @@ bool is_hit_with_weight(Iterator& iter, TermFieldMatchData& match, DocId lid, in
         return false;
     }
     iter.unpack(lid);
-    EXPECT_EQ(lid, match.getDocId()) << (failed = true, "");
+    EXPECT_TRUE(match.has_ranking_data(lid)) << (failed = true, "");
     if (failed) {
         return false;
     }
@@ -80,7 +80,7 @@ bool is_strict_hit_with_weight(Iterator& iter, TermFieldMatchData& match,
         return false;
     }
     iter.unpack(expected_lid);
-    EXPECT_EQ(expected_lid, match.getDocId())  << (failed = true, "");
+    EXPECT_TRUE(match.has_ranking_data(expected_lid))  << (failed = true, "");
     if (failed) {
         return false;
     }
@@ -587,7 +587,7 @@ void test_search_cache(bool increase_child_lidspace, FilterConfig filter_config)
     EXPECT_FALSE(iter->seek(1));
     EXPECT_TRUE(iter->seek(3));
     iter->unpack(3);
-    EXPECT_EQ(3, match.getDocId());
+    EXPECT_TRUE(match.has_ranking_data(3));
     if (filter_config == FilterConfig::ExplicitlyEnabled) {
         EXPECT_EQ(1, match.getWeight());
     } else {

--- a/searchlib/src/tests/attribute/multi_term_or_filter_search/multi_term_or_filter_search_test.cpp
+++ b/searchlib/src/tests/attribute/multi_term_or_filter_search/multi_term_or_filter_search_test.cpp
@@ -77,7 +77,7 @@ public:
             if (iterator.seek(doc_id)) {
                 result.emplace_back(doc_id);
                 iterator.unpack(doc_id);
-                EXPECT_EQ(doc_id, _tfmd.getDocId());
+                EXPECT_TRUE(_tfmd.has_ranking_data(doc_id));
                 ++doc_id;
             } else {
                 doc_id = std::max(doc_id + 1, iterator.getDocId());

--- a/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
@@ -1052,12 +1052,12 @@ SearchContextTest::testSearchIteratorUnpacking(const AttributePtr & attr, Search
     // unpack and check weights
     search.unpack(1);
     EXPECT_EQ(search.getDocId(), 1u);
-    EXPECT_EQ(md.getDocId(), 1u);
+    EXPECT_TRUE(md.has_ranking_data(1u));
     EXPECT_EQ(md.getWeight(), weights[0]);
 
     search.unpack(2);
     EXPECT_EQ(search.getDocId(), 2u);
-    EXPECT_EQ(md.getDocId(), 2u);
+    EXPECT_TRUE(md.has_ranking_data(2u));
     if (withElementId && attr->hasMultiValue() && !attr->hasWeightedSetType()) {
         std::vector<uint32_t> elems;
         search.get_element_ids(2, elems);
@@ -1070,7 +1070,7 @@ SearchContextTest::testSearchIteratorUnpacking(const AttributePtr & attr, Search
 
     search.unpack(3);
     EXPECT_EQ(search.getDocId(), 3u);
-    EXPECT_EQ(md.getDocId(), 3u);
+    EXPECT_TRUE(md.has_ranking_data(3u));
     if (withElementId && attr->hasMultiValue() && !attr->hasWeightedSetType()) {
         std::vector<uint32_t> elems;
         search.get_element_ids(3, elems);
@@ -1084,7 +1084,7 @@ SearchContextTest::testSearchIteratorUnpacking(const AttributePtr & attr, Search
     if (extra) {
         search.unpack(4);
         EXPECT_EQ(search.getDocId(), 4u);
-        EXPECT_EQ(md.getDocId(), 4u);
+        EXPECT_TRUE(md.has_ranking_data(4u));
         EXPECT_EQ(md.getWeight(), 1);
     }
 }
@@ -1599,7 +1599,7 @@ SearchContextTest::test_weighted_prefix_search(const std::string& name, const Co
             itr->initRange(1, attr->getCommittedDocIdLimit());
             EXPECT_TRUE(itr->seek(1));
             itr->unpack(1);
-            EXPECT_EQ(1, md.getDocId());
+            EXPECT_TRUE(md.has_ranking_data(1));
             int32_t expected_weight = (preserve_weight || !common_word || !cfg.fastSearch()) ?
                                       (attr->hasWeightedSetType() ?
                                        (common_word ? (1000 + 300 + 200 + 10 + 3 + 2) : (1000 + 300 + 200)) :

--- a/searchlib/src/tests/common/location_iterator/location_iterator_test.cpp
+++ b/searchlib/src/tests/common/location_iterator/location_iterator_test.cpp
@@ -94,7 +94,7 @@ public:
             d = std::max(d, iterator->getDocId());
             _tfmd.setRawScore(0, 0.0);
             iterator->unpack(d);
-            EXPECT_EQ(_tfmd.getDocId(), d);
+            EXPECT_TRUE(_tfmd.has_ranking_data(d));
             EXPECT_NE(_tfmd.getRawScore(), 0.0);
             int32_t dx = geo.point.x - _positions[d].first;
             int32_t dy = geo.point.y - _positions[d].second;

--- a/searchlib/src/tests/features/prod_features_framework.cpp
+++ b/searchlib/src/tests/features/prod_features_framework.cpp
@@ -133,10 +133,10 @@ TEST_F(ProdFeaturesTest, test_framework)
     }
     { // check that data is cleared
         MatchDataBuilder mdb(queryEnv, *data);
-        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 0)->has_data(TermFieldMatchData::invalidId()));
-        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 1)->has_data(TermFieldMatchData::invalidId()));
-        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 2)->has_data(TermFieldMatchData::invalidId()));
-        EXPECT_TRUE(mdb.getTermFieldMatchData(1, 1)->has_data(TermFieldMatchData::invalidId()));
+        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 0)->has_invalid_docid());
+        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 1)->has_invalid_docid());
+        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 2)->has_invalid_docid());
+        EXPECT_TRUE(mdb.getTermFieldMatchData(1, 1)->has_invalid_docid());
 
         // test illegal things
         ASSERT_TRUE(!mdb.addOccurence("foo", 1, 10)); // invalid term/field combination

--- a/searchlib/src/tests/features/prod_features_framework.cpp
+++ b/searchlib/src/tests/features/prod_features_framework.cpp
@@ -133,10 +133,10 @@ TEST_F(ProdFeaturesTest, test_framework)
     }
     { // check that data is cleared
         MatchDataBuilder mdb(queryEnv, *data);
-        EXPECT_EQ(mdb.getTermFieldMatchData(0, 0)->getDocId(), TermFieldMatchData::invalidId());
-        EXPECT_EQ(mdb.getTermFieldMatchData(0, 1)->getDocId(), TermFieldMatchData::invalidId());
-        EXPECT_EQ(mdb.getTermFieldMatchData(0, 2)->getDocId(), TermFieldMatchData::invalidId());
-        EXPECT_EQ(mdb.getTermFieldMatchData(1, 1)->getDocId(), TermFieldMatchData::invalidId());
+        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 0)->has_data(TermFieldMatchData::invalidId()));
+        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 1)->has_data(TermFieldMatchData::invalidId()));
+        EXPECT_TRUE(mdb.getTermFieldMatchData(0, 2)->has_data(TermFieldMatchData::invalidId()));
+        EXPECT_TRUE(mdb.getTermFieldMatchData(1, 1)->has_data(TermFieldMatchData::invalidId()));
 
         // test illegal things
         ASSERT_TRUE(!mdb.addOccurence("foo", 1, 10)); // invalid term/field combination

--- a/searchlib/src/tests/fef/fef_test.cpp
+++ b/searchlib/src/tests/fef/fef_test.cpp
@@ -47,7 +47,7 @@ TEST(FefTest, test_layout)
     {
         TermFieldMatchData tmd;
         EXPECT_EQ(IllegalFieldId, tmd.getFieldId());
-        EXPECT_EQ(TermFieldMatchData::invalidId(), tmd.getDocId());
+        EXPECT_TRUE(tmd.has_data(TermFieldMatchData::invalidId()));
     }
     MatchDataLayout mdl;
     EXPECT_EQ(mdl.allocTermField(0), 0u);
@@ -137,10 +137,10 @@ TEST(FefTest, term_field_match_data_filter_elements_normal)
     filter_elems(tfmd, docid3, {2, 3});
     EXPECT_EQ(elems({3}), get_elems(tfmd, docid3));
     EXPECT_EQ(1, tfmd.getNumOccs());
-    EXPECT_EQ(docid3, tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_ranking_data(docid3));
     filter_elems(tfmd, docid3, {1, 2});
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_EQ(TermFieldMatchData::invalidId(), tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_future_match_data)
@@ -150,7 +150,7 @@ TEST(FefTest, term_field_match_data_filter_elements_future_match_data)
     set_elems(tfmd, docid3, {1, 3});
     filter_elems(tfmd, docid2, {});
     EXPECT_EQ(elems({1, 3}), get_elems(tfmd, docid3));
-    EXPECT_EQ(docid3, tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_ranking_data(docid3));
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_past_match_data)
@@ -160,7 +160,7 @@ TEST(FefTest, term_field_match_data_filter_elements_past_match_data)
     set_elems(tfmd, docid3, {1, 3});
     filter_elems(tfmd, docid4, {1, 2, 3});
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_EQ(TermFieldMatchData::invalidId(), tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_empty_filter)
@@ -169,17 +169,17 @@ TEST(FefTest, term_field_match_data_filter_elements_empty_filter)
     set_elems(tfmd, docid3, {1, 3});
     filter_elems(tfmd, docid3, {});
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_EQ(TermFieldMatchData::invalidId(), tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_empty_match_data)
 {
     TermFieldMatchData tfmd;
     set_elems(tfmd, docid3, {});
-    EXPECT_EQ(docid3, tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_ranking_data(docid3));
     filter_elems(tfmd, docid3, {1, 2, 3}); // Clear empty (before and after filtering) match data
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_EQ(TermFieldMatchData::invalidId(), tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
 }
 
 TEST(FefTest, verify_size_of_essential_fef_classes) {

--- a/searchlib/src/tests/fef/fef_test.cpp
+++ b/searchlib/src/tests/fef/fef_test.cpp
@@ -47,7 +47,7 @@ TEST(FefTest, test_layout)
     {
         TermFieldMatchData tmd;
         EXPECT_EQ(IllegalFieldId, tmd.getFieldId());
-        EXPECT_TRUE(tmd.has_data(TermFieldMatchData::invalidId()));
+        EXPECT_TRUE(tmd.has_invalid_docid());
     }
     MatchDataLayout mdl;
     EXPECT_EQ(mdl.allocTermField(0), 0u);
@@ -140,7 +140,7 @@ TEST(FefTest, term_field_match_data_filter_elements_normal)
     EXPECT_TRUE(tfmd.has_ranking_data(docid3));
     filter_elems(tfmd, docid3, {1, 2});
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(tfmd.has_invalid_docid());
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_future_match_data)
@@ -160,7 +160,7 @@ TEST(FefTest, term_field_match_data_filter_elements_past_match_data)
     set_elems(tfmd, docid3, {1, 3});
     filter_elems(tfmd, docid4, {1, 2, 3});
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(tfmd.has_invalid_docid());
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_empty_filter)
@@ -169,7 +169,7 @@ TEST(FefTest, term_field_match_data_filter_elements_empty_filter)
     set_elems(tfmd, docid3, {1, 3});
     filter_elems(tfmd, docid3, {});
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(tfmd.has_invalid_docid());
 }
 
 TEST(FefTest, term_field_match_data_filter_elements_empty_match_data)
@@ -179,7 +179,7 @@ TEST(FefTest, term_field_match_data_filter_elements_empty_match_data)
     EXPECT_TRUE(tfmd.has_ranking_data(docid3));
     filter_elems(tfmd, docid3, {1, 2, 3}); // Clear empty (before and after filtering) match data
     EXPECT_EQ(elems({}), get_elems(tfmd, docid3));
-    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(tfmd.has_invalid_docid());
 }
 
 TEST(FefTest, verify_size_of_essential_fef_classes) {

--- a/searchlib/src/tests/fef/phrasesplitter/phrasesplitter_test.cpp
+++ b/searchlib/src/tests/fef/phrasesplitter/phrasesplitter_test.cpp
@@ -40,7 +40,7 @@ TEST(PhraseSplitterTest, test_copy_term_field_match_data)
 
     PhraseSplitter::copyTermFieldMatchData(dst, src, 2);
 
-    EXPECT_EQ(dst.getDocId(), 1u);
+    EXPECT_TRUE(dst.has_ranking_data(1));
     {
         TermFieldMatchData::PositionsIterator itr = dst.begin();
         EXPECT_EQ(itr->getPosition(), 7u);

--- a/searchlib/src/tests/fef/termfieldmodel/termfieldmodel_test.cpp
+++ b/searchlib/src/tests/fef/termfieldmodel/termfieldmodel_test.cpp
@@ -51,7 +51,7 @@ void testInvalidId() {
     const TermFieldMatchData empty;
     using search::queryeval::SearchIterator;
 
-    EXPECT_EQ(TermFieldMatchData::invalidId(), empty.getDocId());
+    EXPECT_TRUE(empty.has_data(TermFieldMatchData::invalidId()));
     EXPECT_TRUE(TermFieldMatchData::invalidId() < (SearchIterator::beginId() + 1 ) ||
                TermFieldMatchData::invalidId() > (search::endDocId - 1));
 }
@@ -124,7 +124,7 @@ void testGenerate(State &state) {
 
     // stale unpacked data
     state.f5->reset(5);
-    EXPECT_EQ(5u, state.f5->getDocId());
+    EXPECT_TRUE(state.f5->has_ranking_data(5u));
     {
         TermFieldMatchDataPosition pos;
         pos.setPosition(3);
@@ -135,7 +135,7 @@ void testGenerate(State &state) {
         EXPECT_EQ(10u, state.f5->getIterator().getFieldLength());
     }
     state.f5->reset(6);
-    EXPECT_EQ(6u, state.f5->getDocId());
+    EXPECT_TRUE(state.f5->has_ranking_data(6u));
     EXPECT_EQ(FieldPositionsIterator::UNKNOWN_LENGTH,
                state.f5->getIterator().getFieldLength());
     EXPECT_EQ(0u, state.f5->getIterator().size());
@@ -175,9 +175,9 @@ void testGenerate(State &state) {
 }
 
 void testAnalyze(State &state) {
-    EXPECT_EQ(10u, state.f3->getDocId());
-    EXPECT_NE(10u, state.f5->getDocId());
-    EXPECT_EQ(10u, state.f7->getDocId());
+    EXPECT_TRUE(state.f3->has_ranking_data(10u));
+    EXPECT_FALSE(state.f5->has_data(10u));
+    EXPECT_TRUE(state.f7->has_ranking_data(10u));
 
     FieldPositionsIterator it = state.f3->getIterator();
     EXPECT_EQ(20u, it.getFieldLength());
@@ -316,7 +316,7 @@ TEST(TermFieldModelTest, require_that_MatchData_soft_reset_retains_appropriate_s
     EXPECT_TRUE(old_term->isNotNeeded());
     EXPECT_EQ(old_term->getFieldId(), 7u);
     EXPECT_EQ(old_term->getWeight(), 21);
-    EXPECT_EQ(old_term->getDocId(), 42u);
+    EXPECT_TRUE(old_term->has_ranking_data(42u));
     md->soft_reset();
     auto *new_term = md->resolveTermField(7);
     EXPECT_EQ(new_term, old_term);
@@ -324,7 +324,7 @@ TEST(TermFieldModelTest, require_that_MatchData_soft_reset_retains_appropriate_s
     EXPECT_TRUE(new_term->isNotNeeded());
     EXPECT_EQ(new_term->getFieldId(), 7u);
     EXPECT_EQ(new_term->getWeight(), 21);
-    EXPECT_EQ(new_term->getDocId(), TermFieldMatchData::invalidId());
+    EXPECT_TRUE(new_term->has_data(TermFieldMatchData::invalidId()));
 }
 
 TEST(TermFieldModelTest, require_that_compareWithExactness_implements_a_strict_weak_ordering) {

--- a/searchlib/src/tests/fef/termfieldmodel/termfieldmodel_test.cpp
+++ b/searchlib/src/tests/fef/termfieldmodel/termfieldmodel_test.cpp
@@ -51,7 +51,7 @@ void testInvalidId() {
     const TermFieldMatchData empty;
     using search::queryeval::SearchIterator;
 
-    EXPECT_TRUE(empty.has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(empty.has_invalid_docid());
     EXPECT_TRUE(TermFieldMatchData::invalidId() < (SearchIterator::beginId() + 1 ) ||
                TermFieldMatchData::invalidId() > (search::endDocId - 1));
 }
@@ -324,7 +324,7 @@ TEST(TermFieldModelTest, require_that_MatchData_soft_reset_retains_appropriate_s
     EXPECT_TRUE(new_term->isNotNeeded());
     EXPECT_EQ(new_term->getFieldId(), 7u);
     EXPECT_EQ(new_term->getWeight(), 21);
-    EXPECT_TRUE(new_term->has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(new_term->has_invalid_docid());
 }
 
 TEST(TermFieldModelTest, require_that_compareWithExactness_implements_a_strict_weak_ordering) {

--- a/searchlib/src/tests/fef/termmatchdatamerger/termmatchdatamerger_test.cpp
+++ b/searchlib/src/tests/fef/termmatchdatamerger/termmatchdatamerger_test.cpp
@@ -33,7 +33,7 @@ TEST(TermMatchDataMergerTest, merge_empty_input)
     uint32_t docid = 5;
     in.reset(docid);
     merger.merge(docid);
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_TRUE(out.begin() == out.end());
 }
 
@@ -70,7 +70,7 @@ TEST(TermMatchDataMergerTest, merge_simple)
 
     merger.merge(docid);
 
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(8u, out.end() - out.begin());
 
     EXPECT_EQ( 5u, out.begin()[0].getPosition());
@@ -101,7 +101,7 @@ TEST(TermMatchDataMergerTest, merge_simple)
 
     merger.merge(docid);
 
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(3u, out.end() - out.begin());
 
     EXPECT_EQ( 5u, out.begin()[0].getPosition());
@@ -113,7 +113,7 @@ TEST(TermMatchDataMergerTest, merge_simple)
     docid = 15;
 
     merger.merge(docid);
-    EXPECT_NE(docid, out.getDocId());
+    EXPECT_FALSE(out.has_data(docid));
 }
 
 TEST(TermMatchDataMergerTest, merge_multiple_fields)
@@ -156,9 +156,9 @@ TEST(TermMatchDataMergerTest, merge_multiple_fields)
 
     merger.merge(docid);
 
-    EXPECT_EQ(docid, out1.getDocId());
-    EXPECT_EQ(docid, out2.getDocId());
-    EXPECT_NE(docid, out3.getDocId());
+    EXPECT_TRUE(out1.has_ranking_data(docid));
+    EXPECT_TRUE(out2.has_ranking_data(docid));
+    EXPECT_FALSE(out3.has_data(docid));
 
     EXPECT_EQ(2u, out1.end() - out1.begin());
     EXPECT_EQ(3u, out2.end() - out2.begin());
@@ -206,7 +206,7 @@ TEST(TermMatchDataMergerTest, merge_duplicates)
 
     merger.merge(docid);
 
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(5u, out.end() - out.begin());
 
     EXPECT_EQ( 3u, out.begin()[0].getPosition());
@@ -241,7 +241,7 @@ TEST(TermMatchDataMergerTest, merge_max_element_length)
     b.appendPosition(make_pos(2));
     merger.merge(docid);
 
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(1000u, out.getIterator().getFieldLength());
 }
 
@@ -279,7 +279,7 @@ TEST_F(TermMatchDataMergerTest2, merge_no_normal_features)
     b.appendPosition(make_pos(3));
 
     merger.merge(docid);
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(0u, out.size());
 }
 
@@ -299,7 +299,7 @@ TEST_F(TermMatchDataMergerTest2, merge_interleaved_features)
     b.setFieldLength(35);
 
     merger.merge(docid);
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(2u, out.getNumOccs());
     EXPECT_EQ(35u, out.getFieldLength());
 }
@@ -322,7 +322,7 @@ TEST_F(TermMatchDataMergerTest2, merge_interleaved_features_with_detected_duplic
     b.appendPosition(make_pos(5));
 
     merger.merge(docid);
-    EXPECT_EQ(docid, out.getDocId());
+    EXPECT_TRUE(out.has_ranking_data(docid));
     EXPECT_EQ(1u, out.end() - out.begin());
     EXPECT_EQ( 5u, out.begin()[0].getPosition());
     EXPECT_EQ(1.5, out.begin()[0].getMatchExactness());

--- a/searchlib/src/tests/memoryindex/field_index/field_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/field_index/field_index_test.cpp
@@ -672,7 +672,7 @@ struct FieldIndexInterleavedFeaturesTest : public FieldIndexTest<FieldIndex<true
         EXPECT_EQ(exp_field_positions, toString(match_data));
         EXPECT_EQ(exp_num_occs, match_data.term.getNumOccs());
         EXPECT_EQ(exp_field_length, match_data.term.getFieldLength());
-        EXPECT_EQ(10, match_data.term.getDocId());
+        EXPECT_TRUE(match_data.term.has_ranking_data(10));
         auto& ranked_itr = dynamic_cast<RankedSearchIteratorBase&>(*itr);
         EXPECT_TRUE(ranked_itr.getUnpacked());
         EXPECT_TRUE(!itr->seek(11));

--- a/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
@@ -249,7 +249,7 @@ verifyResult(const FakeResult &expect,
         exp_simple.addHit(search->getDocId());
         actual.doc(search->getDocId());
         search->unpack(search->getDocId());
-        EXPECT_EQ(search->getDocId(), tmd.getDocId());
+        EXPECT_TRUE(tmd.has_ranking_data(search->getDocId()));
         FieldPositionsIterator p = tmd.getIterator();
         actual.len(p.getFieldLength());
         for (; p.valid(); p.next()) {

--- a/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/equiv_query_node_test.cpp
@@ -178,7 +178,7 @@ TEST_F(EquivQueryNodeTest, test_equiv_evaluate_and_unpack)
     tfmd1->setNeedInterleavedFeatures(true);
     IndexEnvironment ie;
     eqn.unpack_match_data(2, td, *md, ie, ElementIds::select_all());
-    EXPECT_EQ(2, tfmd0->getDocId());
+    EXPECT_TRUE(tfmd0->has_ranking_data(2));
     EXPECT_EQ(3, tfmd0->getNumOccs());
     EXPECT_EQ(3, tfmd0->end() - tfmd0->begin());
     auto itr = tfmd0->begin();
@@ -188,7 +188,7 @@ TEST_F(EquivQueryNodeTest, test_equiv_evaluate_and_unpack)
     ++itr;
     assert_tfmd_pos("tmfd0[2]", *itr, elem1, pos3, weight1, field0_element1_len);
     EXPECT_EQ(field0_len, tfmd0->getFieldLength());
-    EXPECT_EQ(2, tfmd1->getDocId());
+    EXPECT_TRUE(tfmd1->has_ranking_data(2));
     EXPECT_EQ(1, tfmd1->getNumOccs());
     EXPECT_EQ(1, tfmd1->end() - tfmd1->begin());
     itr = tfmd1->begin();

--- a/searchlib/src/tests/query/streaming/nearest_neighbor_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/nearest_neighbor_query_node_test.cpp
@@ -94,16 +94,16 @@ TEST_F(NearestNeighborQueryNodeTest, unpack_match_data_for_nearest_neighbor_quer
     auto md = MatchData::makeTestInstance(handle + 1, handle + 1);
     auto tfmd = md->resolveTermField(handle);
     auto invalid_id = TermFieldMatchData::invalidId();
-    EXPECT_EQ(invalid_id, tfmd->getDocId());
+    EXPECT_TRUE(tfmd->has_data(invalid_id));
     IndexEnvironment ie;
     node->unpack_match_data(1, *md, ie, ElementIds::select_all());
-    EXPECT_EQ(invalid_id, tfmd->getDocId());
+    EXPECT_TRUE(tfmd->has_data(invalid_id));
     constexpr double distance = 1.5;
     node->set_distance(distance);
     node->unpack_match_data(2, *md, ie, ElementIds::select_all());
-    EXPECT_EQ(2, tfmd->getDocId());
+    EXPECT_TRUE(tfmd->has_ranking_data(2));
     EXPECT_EQ(distance * 2, tfmd->getRawScore());
     node->reset();
     node->unpack_match_data(3, *md, ie, ElementIds::select_all());
-    EXPECT_EQ(2, tfmd->getDocId());
+    EXPECT_TRUE(tfmd->has_ranking_data(2));
 }

--- a/searchlib/src/tests/query/streaming/nearest_neighbor_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/nearest_neighbor_query_node_test.cpp
@@ -93,11 +93,10 @@ TEST_F(NearestNeighborQueryNodeTest, unpack_match_data_for_nearest_neighbor_quer
     td.addField(field_id).setHandle(handle);
     auto md = MatchData::makeTestInstance(handle + 1, handle + 1);
     auto tfmd = md->resolveTermField(handle);
-    auto invalid_id = TermFieldMatchData::invalidId();
-    EXPECT_TRUE(tfmd->has_data(invalid_id));
+    EXPECT_TRUE(tfmd->has_invalid_docid());
     IndexEnvironment ie;
     node->unpack_match_data(1, *md, ie, ElementIds::select_all());
-    EXPECT_TRUE(tfmd->has_data(invalid_id));
+    EXPECT_TRUE(tfmd->has_invalid_docid());
     constexpr double distance = 1.5;
     node->set_distance(distance);
     node->unpack_match_data(2, *md, ie, ElementIds::select_all());

--- a/searchlib/src/tests/query/streaming/query_term_test.cpp
+++ b/searchlib/src/tests/query/streaming/query_term_test.cpp
@@ -149,12 +149,12 @@ QueryTermTest::test_unpack_match_data_for_term_node(bool interleaved_features, b
     ASSERT_NO_FATAL_FAILURE(build_query(filter));
     _tfmd->setNeedInterleavedFeatures(interleaved_features);
     auto invalid_id = TermFieldMatchData::invalidId();
-    EXPECT_EQ(invalid_id, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_data(invalid_id));
     _node->unpack_match_data(1, *_md, _index_env, ElementIds::select_all());
-    EXPECT_EQ(invalid_id, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_data(invalid_id));
     ASSERT_NO_FATAL_FAILURE(populate_term());
     _node->unpack_match_data(2, *_md, _index_env, ElementIds::select_all());
-    EXPECT_EQ(2, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_ranking_data(2));
     if (interleaved_features && !filter) {
         EXPECT_EQ(mock_num_occs, _tfmd->getNumOccs());
         EXPECT_EQ(mock_field_length, _tfmd->getFieldLength());
@@ -165,7 +165,7 @@ QueryTermTest::test_unpack_match_data_for_term_node(bool interleaved_features, b
     EXPECT_EQ(filter ? 0 : mock_num_occs, _tfmd->size());
     _node->reset();
     _node->unpack_match_data(3, *_md, _index_env, ElementIds::select_all());
-    EXPECT_EQ(2, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_ranking_data(2));
 }
 
 TEST_F(QueryTermTest, unpack_normal_match_data_for_term_node)
@@ -195,28 +195,28 @@ TEST_F(QueryTermTest, unpack_match_data_with_element_filter)
     ASSERT_NO_FATAL_FAILURE(populate_term());
     constexpr uint32_t docid = 2;
     _node->unpack_match_data(docid, *_md, _index_env, ElementIds::select_all());
-    EXPECT_EQ(docid, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_ranking_data(docid));
     EXPECT_EQ(mock_num_occs, _tfmd->getNumOccs());
     EXPECT_EQ(mock_field_length, _tfmd->getFieldLength());
     EXPECT_EQ(mock_num_occs, _tfmd->size());
     EXPECT_EQ(make_vec({0, 3, 7, 10}), extract_element_ids(docid));
     reset_tfmd();
     _node->unpack_match_data(docid, *_md, _index_env, ElementIds(make_vec({0, 2, 3, 8, 10, 12})));
-    EXPECT_EQ(docid, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_ranking_data(docid));
     EXPECT_EQ(3, _tfmd->getNumOccs());
     EXPECT_EQ(mock_field_length, _tfmd->getFieldLength());
     EXPECT_EQ(3, _tfmd->size());
     EXPECT_EQ(make_vec({0, 3, 10}), extract_element_ids(docid));
     reset_tfmd();
     _node->unpack_match_data(docid, *_md, _index_env, ElementIds(make_vec({3})));
-    EXPECT_EQ(docid, _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_ranking_data(docid));
     EXPECT_EQ(1, _tfmd->getNumOccs());
     EXPECT_EQ(mock_field_length, _tfmd->getFieldLength());
     EXPECT_EQ(1, _tfmd->size());
     EXPECT_EQ(make_vec({3}), extract_element_ids(docid));
     reset_tfmd();
     _node->unpack_match_data(docid, *_md, _index_env, ElementIds(make_vec({4})));
-    EXPECT_EQ(TermFieldMatchData::invalidId(), _tfmd->getDocId());
+    EXPECT_TRUE(_tfmd->has_data(TermFieldMatchData::invalidId()));
     EXPECT_EQ(0, _tfmd->getNumOccs());
     EXPECT_EQ(0, _tfmd->getFieldLength());
     EXPECT_EQ(0, _tfmd->size());

--- a/searchlib/src/tests/query/streaming/query_term_test.cpp
+++ b/searchlib/src/tests/query/streaming/query_term_test.cpp
@@ -148,10 +148,9 @@ QueryTermTest::test_unpack_match_data_for_term_node(bool interleaved_features, b
 {
     ASSERT_NO_FATAL_FAILURE(build_query(filter));
     _tfmd->setNeedInterleavedFeatures(interleaved_features);
-    auto invalid_id = TermFieldMatchData::invalidId();
-    EXPECT_TRUE(_tfmd->has_data(invalid_id));
+    EXPECT_TRUE(_tfmd->has_invalid_docid());
     _node->unpack_match_data(1, *_md, _index_env, ElementIds::select_all());
-    EXPECT_TRUE(_tfmd->has_data(invalid_id));
+    EXPECT_TRUE(_tfmd->has_invalid_docid());
     ASSERT_NO_FATAL_FAILURE(populate_term());
     _node->unpack_match_data(2, *_md, _index_env, ElementIds::select_all());
     EXPECT_TRUE(_tfmd->has_ranking_data(2));
@@ -216,7 +215,7 @@ TEST_F(QueryTermTest, unpack_match_data_with_element_filter)
     EXPECT_EQ(make_vec({3}), extract_element_ids(docid));
     reset_tfmd();
     _node->unpack_match_data(docid, *_md, _index_env, ElementIds(make_vec({4})));
-    EXPECT_TRUE(_tfmd->has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(_tfmd->has_invalid_docid());
     EXPECT_EQ(0, _tfmd->getNumOccs());
     EXPECT_EQ(0, _tfmd->getFieldLength());
     EXPECT_EQ(0, _tfmd->size());

--- a/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
+++ b/searchlib/src/tests/query/streaming/same_element_query_node_test.cpp
@@ -303,7 +303,7 @@ TEST_F(SameElementQueryNodeTest, test_same_element_evaluate)
     tfmd0->setNeedInterleavedFeatures(true);
     IndexEnvironment ie;
     sameElem->unpack_match_data(2, td, *md, ie, ElementIds::select_all());
-    EXPECT_EQ(2, tfmd0->getDocId());
+    EXPECT_TRUE(tfmd0->has_ranking_data(2));
     EXPECT_EQ(0, tfmd0->getNumOccs());
     EXPECT_EQ(0, tfmd0->end() - tfmd0->begin());
 }

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -790,9 +790,9 @@ TEST(StreamingQueryTest, test_in_term)
     IndexEnvironment ie;
     term.unpack_match_data(23, td, md, ie, ElementIds::select_all());
     auto tmd0 = md.resolveTermField(0);
-    EXPECT_NE(23, tmd0->getDocId());
+    EXPECT_FALSE(tmd0->has_data(23));
     auto tmd2 = md.resolveTermField(1);
-    EXPECT_EQ(23, tmd2->getDocId());
+    EXPECT_TRUE(tmd2->has_ranking_data(23));
 }
 
 TEST(StreamingQueryTest, dot_product_term)
@@ -822,9 +822,9 @@ TEST(StreamingQueryTest, dot_product_term)
     IndexEnvironment ie;
     term.unpack_match_data(23, td, md, ie, ElementIds::select_all());
     auto tmd0 = md.resolveTermField(0);
-    EXPECT_NE(23, tmd0->getDocId());
+    EXPECT_FALSE(tmd0->has_data(23));
     auto tmd1 = md.resolveTermField(1);
-    EXPECT_EQ(23, tmd1->getDocId());
+    EXPECT_TRUE(tmd1->has_ranking_data(23));
     EXPECT_EQ(-17 * 27 + 9 * 2, tmd1->getRawScore());
 }
 
@@ -869,13 +869,13 @@ check_wand_term(double limit, const std::string& label)
     IndexEnvironment ie;
     term.unpack_match_data(23, td, md, ie, ElementIds::select_all());
     auto tmd0 = md.resolveTermField(0);
-    EXPECT_NE(23, tmd0->getDocId());
+    EXPECT_FALSE(tmd0->has_data(23));
     auto tmd1 = md.resolveTermField(1);
     if (limit < exp_wand_score_field_12) {
-        EXPECT_EQ(23, tmd1->getDocId());
+        EXPECT_TRUE(tmd1->has_ranking_data(23));
         EXPECT_EQ(exp_wand_score_field_12, tmd1->getRawScore());
     } else {
-        EXPECT_NE(23, tmd1->getDocId());
+        EXPECT_FALSE(tmd1->has_data(23));
     }
 }
 
@@ -925,9 +925,9 @@ TEST(StreamingQueryTest, weighted_set_term)
     IndexEnvironment ie;
     term.unpack_match_data(23, td, md, ie, ElementIds::select_all());
     auto tmd0 = md.resolveTermField(0);
-    EXPECT_NE(23, tmd0->getDocId());
+    EXPECT_FALSE(tmd0->has_data(23));
     auto tmd1 = md.resolveTermField(1);
-    EXPECT_EQ(23, tmd1->getDocId());
+    EXPECT_TRUE(tmd1->has_ranking_data(23));
     using Weights = std::vector<int32_t>;
     Weights weights;
     for (auto& pos : *tmd1) {

--- a/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
+++ b/searchlib/src/tests/query/word_alternatives/word_alternatives_test.cpp
@@ -226,7 +226,7 @@ TEST(WordAlternativesTest, require_that_blueprints_can_be_built) {
     EXPECT_EQ(docid, 17);
     s->unpack(docid);
     EXPECT_EQ(tfmd.getFieldId(), 42);
-    EXPECT_EQ(tfmd.getDocId(), docid);
+    EXPECT_TRUE(tfmd.has_ranking_data(docid));
     EXPECT_EQ(tfmd.getNumOccs(), 1);
     EXPECT_EQ(tfmd.size(), 1);
     auto iter = tfmd.begin();
@@ -241,7 +241,7 @@ TEST(WordAlternativesTest, require_that_blueprints_can_be_built) {
     docid = s->getDocId();
     EXPECT_EQ(docid, 23);
     s->unpack(docid);
-    EXPECT_EQ(tfmd.getDocId(), docid);
+    EXPECT_TRUE(tfmd.has_ranking_data(docid));
     EXPECT_EQ(tfmd.getNumOccs(), 1);
     EXPECT_EQ(tfmd.size(), 1);
     iter = tfmd.begin();

--- a/searchlib/src/tests/queryeval/blueprint/leaf_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/leaf_blueprints_test.cpp
@@ -66,8 +66,7 @@ TEST(LeafBlueprintsTest, fake_blueprint)
         search->unpack(10u);
         TermFieldMatchData &data = *md->resolveTermField(handle);
         EXPECT_EQ(fieldId, data.getFieldId());
-        EXPECT_EQ(10u, data.getDocId());
-        EXPECT_EQ(10u, data.getDocId());
+        EXPECT_TRUE(data.has_ranking_data(10u));
         FieldPositionsIterator itr = data.getIterator();
         EXPECT_EQ(50u, itr.getFieldLength());
         EXPECT_EQ(2u, itr.size());
@@ -85,7 +84,7 @@ TEST(LeafBlueprintsTest, fake_blueprint)
         search->unpack(25u);
         TermFieldMatchData &data = *md->resolveTermField(handle);
         EXPECT_EQ(fieldId, data.getFieldId());
-        EXPECT_EQ(25u, data.getDocId());
+        EXPECT_TRUE(data.has_ranking_data(25u));
         FieldPositionsIterator itr = data.getIterator();
         EXPECT_EQ(10u, itr.getFieldLength());
         EXPECT_EQ(1u, itr.size());

--- a/searchlib/src/tests/queryeval/equiv/equiv_test.cpp
+++ b/searchlib/src/tests/queryeval/equiv/equiv_test.cpp
@@ -75,7 +75,7 @@ EquivTest::test_equiv(bool strict, bool unpack_normal_features, bool unpack_inte
         {
             TermFieldMatchData &data = *md->resolveTermField(1);
             EXPECT_EQ(1u, data.getFieldId());
-            EXPECT_EQ(5u, data.getDocId());
+            EXPECT_TRUE(data.has_ranking_data(5u));
             FieldPositionsIterator itr = data.getIterator();
             if (unpack_normal_features) {
                 EXPECT_EQ(1u, itr.size());
@@ -95,7 +95,7 @@ EquivTest::test_equiv(bool strict, bool unpack_normal_features, bool unpack_inte
         {
             TermFieldMatchData &data = *md->resolveTermField(2);
             EXPECT_EQ(2u, data.getFieldId());
-            EXPECT_EQ(5u, data.getDocId());
+            EXPECT_TRUE(data.has_ranking_data(5u));
             FieldPositionsIterator itr = data.getIterator();
             if (unpack_normal_features) {
                 EXPECT_EQ(2u, itr.size());
@@ -124,11 +124,11 @@ EquivTest::test_equiv(bool strict, bool unpack_normal_features, bool unpack_inte
     EXPECT_EQ(10u, search->getDocId());
     { // test doc 10 results
         search->unpack(10u);
-        EXPECT_EQ(5u, md->resolveTermField(1)->getDocId()); // no match
+        EXPECT_TRUE(md->resolveTermField(1)->has_ranking_data(5u)); // no match
         {
             TermFieldMatchData &data = *md->resolveTermField(2);
             EXPECT_EQ(2u, data.getFieldId());
-            EXPECT_EQ(10u, data.getDocId());
+            EXPECT_TRUE(data.has_ranking_data(10u));
             FieldPositionsIterator itr = data.getIterator();
             if (unpack_normal_features) {
                 EXPECT_EQ(1u, itr.size());

--- a/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
+++ b/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
@@ -82,7 +82,7 @@ TEST_F(FakeSearchableTest, require_that_term_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(1);
                 EXPECT_EQ(1u, data.getFieldId());
-                EXPECT_EQ(5u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(5u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(2u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -139,7 +139,7 @@ TEST_F(FakeSearchableTest, require_that_phrase_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(1);
                 EXPECT_EQ(1u, data.getFieldId());
-                EXPECT_EQ(5u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(5u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(1u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -193,7 +193,7 @@ TEST_F(FakeSearchableTest, require_that_weigheted_set_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(1);
                 EXPECT_EQ(1u, data.getFieldId());
-                EXPECT_EQ(3u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(3u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(2u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -216,7 +216,7 @@ TEST_F(FakeSearchableTest, require_that_weigheted_set_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(1);
                 EXPECT_EQ(1u, data.getFieldId());
-                EXPECT_EQ(9u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(9u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(1u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -267,7 +267,7 @@ TEST_F(FakeSearchableTest, require_that_multi_field_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(1);
                 EXPECT_EQ(1u, data.getFieldId());
-                EXPECT_EQ(5u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(5u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(1u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -278,7 +278,7 @@ TEST_F(FakeSearchableTest, require_that_multi_field_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(2);
                 EXPECT_EQ(2u, data.getFieldId());
-                EXPECT_EQ(5u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(5u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(1u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -299,12 +299,12 @@ TEST_F(FakeSearchableTest, require_that_multi_field_search_works) {
             {
                 TermFieldMatchData &data = *md->resolveTermField(1);
                 EXPECT_EQ(1u, data.getFieldId());
-                EXPECT_NE(10u, data.getDocId());
+                EXPECT_FALSE(data.has_data(10u));
             }
             {
                 TermFieldMatchData &data = *md->resolveTermField(2);
                 EXPECT_EQ(2u, data.getFieldId());
-                EXPECT_EQ(10u, data.getDocId());
+                EXPECT_TRUE(data.has_ranking_data(10u));
                 FieldPositionsIterator itr = data.getIterator();
                 EXPECT_EQ(1u, itr.size());
                 ASSERT_TRUE(itr.valid());
@@ -368,7 +368,7 @@ TEST_F(FakeSearchableTest, require_that_match_data_is_compressed_for_attributes)
     {
         TermFieldMatchData &data = *md->resolveTermField(1);
         EXPECT_EQ(1u, data.getFieldId());
-        EXPECT_EQ(5u, data.getDocId());
+        EXPECT_TRUE(data.has_ranking_data(5u));
         FieldPositionsIterator itr = data.getIterator();
         EXPECT_EQ(1u, itr.size());
         ASSERT_TRUE(itr.valid());
@@ -429,14 +429,14 @@ TEST_F(FakeSearchableTest, require_that_repeated_unpack_for_same_docid_is_ignore
 
     EXPECT_TRUE(search->seek(docid));
     auto& tfmd = *md->resolveTermField(handle);
-    EXPECT_EQ(TermFieldMatchData::invalidId(), tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
     EXPECT_EQ(0u, tfmd.size());
     search->unpack(docid);
-    EXPECT_EQ(docid, tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_ranking_data(docid));
     EXPECT_EQ(2u, tfmd.size());
     tfmd.reset(another_docid);
     search->unpack(docid);
-    EXPECT_EQ(another_docid, tfmd.getDocId());
+    EXPECT_TRUE(tfmd.has_ranking_data(another_docid));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
+++ b/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
@@ -429,7 +429,7 @@ TEST_F(FakeSearchableTest, require_that_repeated_unpack_for_same_docid_is_ignore
 
     EXPECT_TRUE(search->seek(docid));
     auto& tfmd = *md->resolveTermField(handle);
-    EXPECT_TRUE(tfmd.has_data(TermFieldMatchData::invalidId()));
+    EXPECT_TRUE(tfmd.has_invalid_docid());
     EXPECT_EQ(0u, tfmd.size());
     search->unpack(docid);
     EXPECT_TRUE(tfmd.has_ranking_data(docid));

--- a/searchlib/src/tests/queryeval/multibitvectoriterator/multibitvectoriterator_test.cpp
+++ b/searchlib/src/tests/queryeval/multibitvectoriterator/multibitvectoriterator_test.cpp
@@ -222,15 +222,15 @@ void
 verifySelectiveUnpack(SearchIterator & s, const TermFieldMatchData * tfmd)
 {
     s.seek(1);
-    EXPECT_EQ(0u, tfmd[0].getDocId());
-    EXPECT_EQ(0u, tfmd[1].getDocId());
-    EXPECT_EQ(0u, tfmd[2].getDocId());
-    EXPECT_EQ(0u, tfmd[3].getDocId());
+    EXPECT_TRUE(tfmd[0].has_ranking_data(0u));
+    EXPECT_TRUE(tfmd[1].has_ranking_data(0u));
+    EXPECT_TRUE(tfmd[2].has_ranking_data(0u));
+    EXPECT_TRUE(tfmd[3].has_ranking_data(0u));
     s.unpack(1);
-    EXPECT_EQ(0u, tfmd[0].getDocId());
-    EXPECT_EQ(1u, tfmd[1].getDocId());
-    EXPECT_EQ(1u, tfmd[2].getDocId());
-    EXPECT_EQ(0u, tfmd[3].getDocId());
+    EXPECT_TRUE(tfmd[0].has_ranking_data(0u));
+    EXPECT_TRUE(tfmd[1].has_ranking_data(1u));
+    EXPECT_TRUE(tfmd[2].has_ranking_data(1u));
+    EXPECT_TRUE(tfmd[3].has_ranking_data(0u));
 }
 
 template<typename T>
@@ -270,12 +270,12 @@ void verifyOrUnpack(SearchIterator & s, TermFieldMatchData tfmd[3]) {
     s.initFullRange();
     s.seek(1);
     for (size_t i = 0; i < 3; i++) {
-        EXPECT_EQ(0u, tfmd[i].getDocId());
+        EXPECT_TRUE(tfmd[i].has_ranking_data(0u));
     }
     s.unpack(1);
-    EXPECT_EQ(0u, tfmd[0].getDocId());
-    EXPECT_EQ(1u, tfmd[1].getDocId());
-    EXPECT_EQ(0u, tfmd[2].getDocId());
+    EXPECT_TRUE(tfmd[0].has_ranking_data(0u));
+    EXPECT_TRUE(tfmd[1].has_ranking_data(1u));
+    EXPECT_TRUE(tfmd[2].has_ranking_data(0u));
 }
 
 TEST_F(MultiBitVectorIteratorTest, test_unpack_of_Or)

--- a/searchlib/src/tests/queryeval/or_speed/or_speed_test.cpp
+++ b/searchlib/src/tests/queryeval/or_speed/or_speed_test.cpp
@@ -250,15 +250,15 @@ struct OrSetup {
                 match = true;
                 if (unpacked) {
                     if (!match_data[i]->isNotNeeded()) {
-                        EXPECT_EQ(match_data[i]->getDocId(), docid) << "unpack was needed";
+                        EXPECT_TRUE(match_data[i]->has_ranking_data(docid)) << "unpack was needed";
                     } else if (check_skipped_unpack) {
-                        EXPECT_NE(match_data[i]->getDocId(), docid) << "unpack was not needed";
+                        EXPECT_FALSE(match_data[i]->has_data(docid)) << "unpack was not needed";
                     }
                 } else {
-                    EXPECT_NE(match_data[i]->getDocId(), docid) << "document was not unpacked";
+                    EXPECT_FALSE(match_data[i]->has_data(docid)) << "document was not unpacked";
                 }
             } else {
-                EXPECT_NE(match_data[i]->getDocId(), docid) << "document was not a match";
+                EXPECT_FALSE(match_data[i]->has_data(docid)) << "document was not a match";
             }
         }
         EXPECT_TRUE(match);

--- a/searchlib/src/tests/queryeval/same_element/same_element_test.cpp
+++ b/searchlib/src/tests/queryeval/same_element/same_element_test.cpp
@@ -40,7 +40,7 @@ void verify_md_elements(MatchData& md, const std::string& label, uint32_t docid,
     for (uint32_t i = 0; i < exp.size(); ++i) {
         act.emplace_back();
         auto& tfmd = *md.resolveTermField(i);
-        if (tfmd.getDocId() == docid) {
+        if (tfmd.has_data(docid)) {
             ElementIdExtractor::get_element_ids(tfmd, docid, act.back().emplace());
         }
     }
@@ -203,12 +203,12 @@ TEST(SameElementTest, require_that_strict_iterator_seeks_to_next_hit_and_can_unp
     EXPECT_FALSE(search->seek(1));
     EXPECT_EQ(search->getDocId(), 7u);
     search->unpack(7);
-    EXPECT_EQ(tfmd->getDocId(), 7u);
+    EXPECT_TRUE(tfmd->has_ranking_data(7u));
     EXPECT_TRUE(search->seek(9));
     EXPECT_EQ(search->getDocId(), 9u);
-    EXPECT_EQ(tfmd->getDocId(), 7u);
+    EXPECT_TRUE(tfmd->has_ranking_data(7u));
     search->unpack(9);
-    EXPECT_EQ(tfmd->getDocId(), 9u);
+    EXPECT_TRUE(tfmd->has_ranking_data(9u));
     EXPECT_FALSE(search->seek(10));
     EXPECT_TRUE(search->isAtEnd());
 }

--- a/searchlib/src/tests/queryeval/simple_phrase/simple_phrase_test.cpp
+++ b/searchlib/src/tests/queryeval/simple_phrase/simple_phrase_test.cpp
@@ -227,7 +227,7 @@ TEST(SimplePhraseTest, requireThatPhrasesAreUnpacked) {
                 ASSERT_TRUE(search->seek(doc_match));
                 search->unpack(doc_match);
 
-                EXPECT_EQ(doc_match, test.tmd().getDocId());
+                EXPECT_TRUE(test.tmd().has_ranking_data(doc_match));
                 if (unpack_normal_features) {
                     EXPECT_EQ(2, std::distance(test.tmd().begin(), test.tmd().end()));
                     EXPECT_EQ(1u, test.tmd().begin()->getPosition());
@@ -245,7 +245,7 @@ TEST(SimplePhraseTest, requireThatPhrasesAreUnpacked) {
                 // Repeated unpack should not do anything
                 test.writable_term_field_match_data().reset(doc_no_match);
                 search->unpack(doc_match);
-                EXPECT_EQ(doc_no_match, test.tmd().getDocId());
+                EXPECT_TRUE(test.tmd().has_ranking_data(doc_no_match));
             }
         }
     }

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
@@ -258,7 +258,7 @@ template <typename PL>
 void
 AttributePostingListIteratorT<PL>::doUnpack(uint32_t docId)
 {
-    if (_matchData->getDocId() == docId) {
+    if (_matchData->has_ranking_data(docId)) {
         return;
     }
     _matchData->resetOnlyDocId(docId);

--- a/searchlib/src/vespa/searchlib/features/attributematchfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/attributematchfeature.cpp
@@ -107,7 +107,7 @@ AttributeMatchExecutor<T>::Computer::run(uint32_t docId)
         const ITermData * td = _queryTerms[i].termData();
         feature_t significance = _queryTerms[i].significance();
         const TermFieldMatchData *tfmd = _md->resolveTermField(_queryTerms[i].fieldHandle());
-        if (tfmd->getDocId() == docId) { // hit on this document
+        if (tfmd->has_ranking_data(docId)) { // hit on this document
             _matches++;
             _matchedTermWeight += td->getWeight().percent();
             _matchedTermSignificance += significance;

--- a/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
@@ -60,7 +60,7 @@ Bm25Executor::execute(uint32_t doc_id)
 {
     feature_t score = 0;
     for (const auto& term : _terms) {
-        if (term.tfmd->getDocId() == doc_id) {
+        if (term.tfmd->has_ranking_data(doc_id)) {
             auto raw_num_occs = term.tfmd->getNumOccs();
             if (raw_num_occs == 0) {
                 // Interleaved features are missing. Assume 1 occurrence and average field length.

--- a/searchlib/src/vespa/searchlib/features/closenessfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/closenessfeature.cpp
@@ -48,7 +48,7 @@ ConvertRawScoreToCloseness::execute(uint32_t docId)
     assert(_md);
     for (const auto& elem : _bundle.elements()) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(elem.handle);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             feature_t converted = tfmd->getRawScore();
             max_closeness = std::max(max_closeness, converted);
         } else if (elem.calc) {

--- a/searchlib/src/vespa/searchlib/features/distancefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/distancefeature.cpp
@@ -56,7 +56,7 @@ ConvertRawscoreToDistance::execute(uint32_t docId)
     assert(_md);
     for (const auto& elem : _bundle.elements()) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(elem.handle);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             feature_t invdist = tfmd->getRawScore();
             feature_t converted = elem.calc ? elem.calc->function().to_distance(invdist) : ((1.0 / invdist) - 1.0);
             min_distance = std::min(min_distance, converted);

--- a/searchlib/src/vespa/searchlib/features/element_completeness_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/element_completeness_feature.cpp
@@ -42,7 +42,7 @@ ElementCompletenessExecutor::execute(uint32_t docId)
     assert(_queue.empty());
     for (size_t i = 0; i < _terms.size(); ++i) {
         const fef::TermFieldMatchData *tfmd = _md->resolveTermField(_terms[i].termHandle);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             Item item(i, tfmd->begin(), tfmd->end());
             if (item.pos != item.end) {
                 _queue.push(item);

--- a/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
@@ -265,7 +265,7 @@ public:
         }
         for (size_t i = 0; i < _terms.handles.size(); ++i) {
             const fef::TermFieldMatchData *tfmd = _md->resolveTermField(_terms.handles[i]);
-            if (tfmd->getDocId() == docId) {
+            if (tfmd->has_ranking_data(docId)) {
                 _pos[i] = tfmd->begin();
                 _end[i] = tfmd->end();
                 if (_pos[i] != _end[i]) {

--- a/searchlib/src/vespa/searchlib/features/elementwise_bm25_executor.cpp
+++ b/searchlib/src/vespa/searchlib/features/elementwise_bm25_executor.cpp
@@ -73,7 +73,7 @@ ElementwiseBm25Executor::execute(uint32_t doc_id)
     uint32_t element_length = 0;
     uint32_t num_occs = 0;
     for (const auto& term : _terms) {
-        if (term.tfmd->getDocId() == doc_id) {
+        if (term.tfmd->has_ranking_data(doc_id)) {
             num_occs = 0;
             for (auto& pos : *term.tfmd) {
                 if (num_occs > 0 && element_id == pos.getElementId()) {

--- a/searchlib/src/vespa/searchlib/features/fieldinfofeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/fieldinfofeature.cpp
@@ -31,7 +31,7 @@ IndexFieldInfoExecutor::execute(uint32_t docId)
     outputs().set_number(1, _isFilter);
     outputs().set_number(2, 1.0f); // searched
     const fef::TermFieldMatchData *tfmd = _md->resolveTermField(_fieldHandle);
-    if (tfmd->getDocId() == docId) {
+    if (tfmd->has_ranking_data(docId)) {
         outputs().set_number(3, 1.0f); // hit
     } else {
         outputs().set_number(3, 0.0f); // no hit
@@ -80,7 +80,7 @@ AttrFieldInfoExecutor::execute(uint32_t docId)
     outputs().set_number(1, 0.0); // not filter
     outputs().set_number(2, 1.0f); // searched
     const fef::TermFieldMatchData *tfmd = _md->resolveTermField(_fieldHandle);
-    if (tfmd->getDocId() == docId) {
+    if (tfmd->has_ranking_data(docId)) {
         outputs().set_number(3, 1.0f); // hit
         outputs().set_number(4, fef::FieldPositionsIterator::UNKNOWN_LENGTH); // len
         outputs().set_number(5, 0.0f); // first

--- a/searchlib/src/vespa/searchlib/features/fieldlengthfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/fieldlengthfeature.cpp
@@ -35,7 +35,7 @@ FieldLengthExecutor::execute(uint32_t docId)
     bool validVal = false;
     for (auto handle : _fieldHandles) {
         const TermFieldMatchData &tfmd = *_md->resolveTermField(handle);
-        if (tfmd.getDocId() == docId) {
+        if (tfmd.has_ranking_data(docId)) {
             FieldPositionsIterator it = tfmd.getIterator();
             if (it.valid()) {
                 if (val < it.getFieldLength())

--- a/searchlib/src/vespa/searchlib/features/fieldmatch/computer.cpp
+++ b/searchlib/src/vespa/searchlib/features/fieldmatch/computer.cpp
@@ -71,7 +71,7 @@ Computer::reset(uint32_t docId)
     for (uint32_t i = 0; i < _queryTerms.size(); ++i) {
         const ITermData *td = _queryTerms[i].termData();
         const TermFieldMatchData *tfmd = _splitter.resolveTermField(_queryTerms[i].fieldHandle());
-        if (tfmd->getDocId() != docId) { // only term match data if we have a hit
+        if (!tfmd->has_ranking_data(docId)) { // only term match data if we have a hit
             tfmd = nullptr;
         } else {
             FieldPositionsIterator it = tfmd->getIterator();

--- a/searchlib/src/vespa/searchlib/features/fieldtermmatchfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/fieldtermmatchfeature.cpp
@@ -39,7 +39,7 @@ FieldTermMatchExecutor::execute(uint32_t docId)
     uint32_t occurrences = 0;
     double sumExactness = 0;
     int64_t weight = 0;
-    if (tfmd.getDocId() == docId) {
+    if (tfmd.has_ranking_data(docId)) {
         search::fef::FieldPositionsIterator it = tfmd.getIterator();
         if (it.valid()) {
             lastPosition = 0;

--- a/searchlib/src/vespa/searchlib/features/item_raw_score_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/item_raw_score_feature.cpp
@@ -15,7 +15,7 @@ ItemRawScoreExecutor::execute(uint32_t docId)
     feature_t output = 0.0;
     for (uint32_t i = 0; i < _handles.size(); ++i) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(_handles[i]);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             output += tfmd->getRawScore();
         }
     }
@@ -35,7 +35,7 @@ SimpleItemRawScoreExecutor::execute(uint32_t docId)
 {
     feature_t output = 0.0;
     const TermFieldMatchData *tfmd = _md->resolveTermField(_handle);
-    if (tfmd->getDocId() == docId) {
+    if (tfmd->has_ranking_data(docId)) {
         output = tfmd->getRawScore();
     }
     outputs().set_number(0, output);

--- a/searchlib/src/vespa/searchlib/features/jarowinklerdistancefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/jarowinklerdistancefeature.cpp
@@ -49,7 +49,7 @@ JaroWinklerDistanceExecutor::execute(uint32_t docId)
         const search::fef::TermFieldHandle &handle = _termFieldHandles[term];
         if (handle != search::fef::IllegalHandle) {
             const search::fef::TermFieldMatchData &tfmd = *_md->resolveTermField(handle);
-            if (tfmd.getDocId() == docId) {
+            if (tfmd.has_ranking_data(docId)) {
                 it = tfmd.getIterator();
             }
         }

--- a/searchlib/src/vespa/searchlib/features/matchcountfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/matchcountfeature.cpp
@@ -48,7 +48,7 @@ MatchCountExecutor::execute(uint32_t docId) {
     size_t output = 0;
     for (uint32_t i = 0; i < _handles.size(); ++i) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(_handles[i]);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             output++;
         }
     }

--- a/searchlib/src/vespa/searchlib/features/matchesfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/matchesfeature.cpp
@@ -53,7 +53,7 @@ MatchesExecutor::execute(uint32_t docId) {
     size_t output = 0;
     for (uint32_t i = 0; i < _handles.size(); ++i) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(_handles[i]);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             output = 1;
             break;
         }

--- a/searchlib/src/vespa/searchlib/features/native_dot_product_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/native_dot_product_feature.cpp
@@ -44,7 +44,7 @@ NativeDotProductExecutor::execute(uint32_t docId)
     feature_t output = 0.0;
     for (uint32_t i = 0; i < _pairs.size(); ++i) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(_pairs[i].first);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             output += (tfmd->getWeight() * (int32_t)_pairs[i].second.percent());
         }
     }

--- a/searchlib/src/vespa/searchlib/features/nativeattributematchfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/nativeattributematchfeature.cpp
@@ -65,7 +65,7 @@ NativeAttributeMatchExecutorMulti::execute(uint32_t docId)
     feature_t score = 0;
     for (size_t i = 0; i < _queryTermData.size(); ++i) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(_queryTermData[i].tfh);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             score += calculateScore(_queryTermData[i], *tfmd);
         }
     }
@@ -82,7 +82,7 @@ void
 NativeAttributeMatchExecutorSingle::execute(uint32_t docId)
 {
     const TermFieldMatchData &tfmd = *_md->resolveTermField(_queryTermData.tfh);
-    outputs().set_number(0, (tfmd.getDocId() == docId)
+    outputs().set_number(0, tfmd.has_ranking_data(docId)
                          ? calculateScore(_queryTermData, tfmd)
                          : 0);
 }

--- a/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.cpp
@@ -57,7 +57,7 @@ NativeFieldMatchExecutor::calculateScore(const MyQueryTerm &qt, uint32_t docId)
         TermFieldHandle tfh = qt.handles()[i].first;
         const TermFieldMatchData *tfmd = _md->resolveTermField(tfh);
         const NativeFieldMatchParam & param = _params.vector[tfmd->getFieldId()];
-        if (tfmd->getDocId() == docId) { // do we have a hit
+        if (tfmd->has_ranking_data(docId)) { // do we have a hit
             FieldPositionsIterator pos = tfmd->getIterator();
             if (pos.valid()) {
                 uint32_t fieldLength = getFieldLength(param, pos.getFieldLength());

--- a/searchlib/src/vespa/searchlib/features/proximityfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/proximityfeature.cpp
@@ -35,9 +35,7 @@ ProximityExecutor::execute(uint32_t docId)
         const fef::TermFieldMatchData &matchA = *_md->resolveTermField(_termA);
         const fef::TermFieldMatchData &matchB = *_md->resolveTermField(_termB);
 
-        if (matchA.getDocId() == docId &&
-            matchB.getDocId() == docId)
-        {
+        if (matchA.has_ranking_data(docId) && matchB.has_ranking_data(docId)) {
             if (findBest(matchA, matchB)) return;
         }
     }

--- a/searchlib/src/vespa/searchlib/features/querycompletenessfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/querycompletenessfeature.cpp
@@ -40,7 +40,7 @@ QueryCompletenessExecutor::execute(uint32_t docId)
     uint32_t hit = 0, miss = 0;
     for (const auto& handle : _fieldHandles) {
         const fef::TermFieldMatchData &tfmd = *_md->resolveTermField(handle);
-        if (tfmd.getDocId() == docId) {
+        if (tfmd.has_ranking_data(docId)) {
             search::fef::FieldPositionsIterator field = tfmd.getIterator();
             while (field.valid() && field.getPosition() < _config.fieldBegin) {
                 field.next();

--- a/searchlib/src/vespa/searchlib/features/raw_score_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/raw_score_feature.cpp
@@ -28,7 +28,7 @@ RawScoreExecutor::execute(uint32_t docId)
     feature_t output = 0.0;
     for (auto handle : _handles) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(handle);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             output += tfmd->getRawScore();
         }
     }

--- a/searchlib/src/vespa/searchlib/features/reverseproximityfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/reverseproximityfeature.cpp
@@ -42,7 +42,7 @@ ReverseProximityExecutor::execute(uint32_t docId)
     search::fef::FieldPositionsIterator itA, itB;
     const fef::TermFieldMatchData &matchA = *_md->resolveTermField(_termA);
     const fef::TermFieldMatchData &matchB = *_md->resolveTermField(_termB);
-    if (matchA.getDocId() == docId && matchB.getDocId() == docId) {
+    if (matchA.has_ranking_data(docId) && matchB.has_ranking_data(docId)) {
         itA = matchA.getIterator();
         itB = matchB.getIterator();
         if (itA.valid() && itB.valid()) {

--- a/searchlib/src/vespa/searchlib/features/subqueries_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/subqueries_feature.cpp
@@ -27,7 +27,7 @@ void SubqueriesExecutor::execute(uint32_t docId) {
     uint32_t msb = 0;
     for (uint32_t i = 0; i < _handles.size(); ++i) {
         const TermFieldMatchData *tfmd = _md->resolveTermField(_handles[i]);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             lsb |= static_cast<uint32_t>(tfmd->getSubqueries());
             msb |= tfmd->getSubqueries() >> 32;
         }

--- a/searchlib/src/vespa/searchlib/features/term_field_md_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/term_field_md_feature.cpp
@@ -40,7 +40,7 @@ TermFieldMdExecutor::execute(uint32_t docId)
         const TermFieldMatchData &tfmd = *_md->resolveTermField(_terms[i].first);
         int32_t termWeight = _terms[i].second.percent();
 
-        if (tfmd.getDocId() == docId) {
+        if (tfmd.has_ranking_data(docId)) {
             ++termsmatched;
             score += tfmd.getWeight();
             occs += (tfmd.end() - tfmd.begin());

--- a/searchlib/src/vespa/searchlib/features/termdistancecalculator.cpp
+++ b/searchlib/src/vespa/searchlib/features/termdistancecalculator.cpp
@@ -18,7 +18,7 @@ TermDistanceCalculator::run(const QueryTerm &termX, const QueryTerm &termY, Elem
 {
     const TermFieldMatchData *tmdX = match.resolveTermField(termX.fieldHandle());
     const TermFieldMatchData *tmdY = match.resolveTermField(termY.fieldHandle());
-    if (tmdX->getDocId() != docId || tmdY->getDocId() != docId) {
+    if (!tmdX->has_ranking_data(docId) || !tmdY->has_ranking_data(docId)) {
         return;
     }
     findBest(tmdX, tmdY, element_gap, termX.termData()->getPhraseLength(), r.forwardDist, r.forwardTermPos);

--- a/searchlib/src/vespa/searchlib/features/termeditdistancefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/termeditdistancefeature.cpp
@@ -98,7 +98,7 @@ TermEditDistanceExecutor::execute(uint32_t docId)
             search::fef::TermFieldHandle handle = _fieldHandles[query - 1];
             if (handle != search::fef::IllegalHandle) {
                 const fef::TermFieldMatchData &tfmd = *_md->resolveTermField(handle);
-                if (tfmd.getDocId() == docId) {
+                if (tfmd.has_ranking_data(docId)) {
                     it = tfmd.getIterator(); // this is now valid
                     while (it.valid() && it.getPosition() < fieldBegin) {
                         it.next(); // forward to window

--- a/searchlib/src/vespa/searchlib/features/text_similarity_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/text_similarity_feature.cpp
@@ -110,7 +110,7 @@ TextSimilarityExecutor::execute(uint32_t docId)
 {
     for (size_t i = 0; i < _handles.size(); ++i) {
         const fef::TermFieldMatchData *tfmd = _md->resolveTermField(_handles[i]);
-        if (tfmd->getDocId() == docId) {
+        if (tfmd->has_ranking_data(docId)) {
             Item item(i, tfmd->begin(), tfmd->end());
             if (item.pos != item.end) {
                 _queue.push(item);

--- a/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.h
+++ b/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.h
@@ -210,6 +210,8 @@ public:
     // Returns true if this instance has match data for docId.
     bool has_data(uint32_t docId) const noexcept { return docId == _docId; }
 
+    bool has_invalid_docid() const noexcept { return _docId == invalidId(); }
+
     /**
      * Obtain the weight of the first occurrence in this field, or 1
      * if no occurrences are present. This function is intended for

--- a/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.h
+++ b/searchlib/src/vespa/searchlib/fef/termfieldmatchdata.h
@@ -204,6 +204,12 @@ public:
         return _docId;
     }
 
+    // Returns true if this instance has match data for docId that is visible to the ranking framework.
+    bool has_ranking_data(uint32_t docId) const noexcept { return docId == _docId; }
+
+    // Returns true if this instance has match data for docId.
+    bool has_data(uint32_t docId) const noexcept { return docId == _docId; }
+
     /**
      * Obtain the weight of the first occurrence in this field, or 1
      * if no occurrences are present. This function is intended for

--- a/searchlib/src/vespa/searchlib/fef/termmatchdatamerger.cpp
+++ b/searchlib/src/vespa/searchlib/fef/termmatchdatamerger.cpp
@@ -50,7 +50,7 @@ TermMatchDataMerger::merge(uint32_t docid,
     uint16_t field_length = 0u;
     for (size_t i = 0; i < in.size(); ++i) {
         const TermFieldMatchData *md = in[i].matchData;
-        if (md->getDocId() == docid) {
+        if (md->has_data(docid)) {
             if (needs_normal_features) {
                 for (const TermFieldMatchDataPosition &iter : *md) {
                     double exactness = in[i].exactness * iter.getMatchExactness();

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.hpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.hpp
@@ -81,7 +81,7 @@ QueryTerm::unpack_match_data_helper(uint32_t docid, const fef::ITermData& td, fe
                     tmd = match_data.resolveTermField(tfd->getHandle());
                     tmd->setFieldId(field_id);
                     // reset field match data, but only once per docId
-                    if (tmd->getDocId() != docid) {
+                    if (!tmd->has_data(docid)) {
                         tmd->reset(docid);
                     }
                 }

--- a/searchlib/src/vespa/searchlib/queryeval/element_id_extractor.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/element_id_extractor.cpp
@@ -9,7 +9,7 @@ void
 ElementIdExtractor::get_element_ids(const fef::TermFieldMatchData& tfmd, uint32_t docid,
                                     std::vector<uint32_t>& element_ids)
 {
-    if (tfmd.getDocId() == docid) {
+    if (tfmd.has_data(docid)) {
         int32_t prevId(-1);
         for (auto element: tfmd) {
             uint32_t id(element.getElementId());
@@ -25,7 +25,7 @@ void
 ElementIdExtractor::and_element_ids_into(const fef::TermFieldMatchData& tfmd, uint32_t docid,
                                          std::vector<uint32_t>& element_ids)
 {
-    if (tfmd.getDocId() == docid) {
+    if (tfmd.has_data(docid)) {
         size_t toKeep(0);
         int32_t id(-1);
         auto it = tfmd.begin();

--- a/searchlib/src/vespa/searchlib/queryeval/nearsearch.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearsearch.cpp
@@ -206,7 +206,7 @@ public:
     bool setup(const TermFieldMatchDataArray &input, size_t num_positive_terms, uint32_t docid) {
         for (size_t i = num_positive_terms; i < input.size(); ++i) {
             const search::fef::TermFieldMatchData *term = input[i];
-            if (term->getDocId() == docid && term->begin() != term->end()) {
+            if (term->has_data(docid) && term->begin() != term->end()) {
                 _queue.push({term->begin(), term->end()});
             }
         }
@@ -307,7 +307,7 @@ NearSearch::Matcher::match(uint32_t docId, MatchResult& match_result)
     uint32_t num_positive_terms = inputs().size() - num_negative_terms();
     for (uint32_t i = 0; i < num_positive_terms; ++i) {
         const search::fef::TermFieldMatchData *term = inputs()[i];
-        if (term->getDocId() != docId || term->begin() == term->end()) {
+        if (!term->has_data(docId) || term->begin() == term->end()) {
             LOG(debug, "No occurrences found for term %d.", i);
             return;
         }
@@ -383,7 +383,7 @@ ONearSearch::Matcher::match_impl(uint32_t docId, MatchResult& match_result, Filt
     PositionsIteratorList pos;
     for (uint32_t i = 0; i < numTerms; ++i) {
         const search::fef::TermFieldMatchData *term = inputs()[i];
-        if (term->getDocId() != docId || term->begin() == term->end()) {
+        if (!term->has_data(docId) || term->begin() == term->end()) {
             LOG(debug, "No occurrences found for term %d.", i);
             return;
         }

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakeword.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakeword.cpp
@@ -427,8 +427,9 @@ FakeWord::validate(search::queryeval::SearchIterator *iterator,
             unsigned int positions = d->_positions;
             iterator->unpack(docId);
             for (size_t lfi = 0; lfi < matchData.size(); ++lfi) {
-                if (matchData[lfi]->getDocId() != docId)
+                if (!matchData[lfi]->has_data(docId)) {
                     continue;
+                }
                 if (unpack_interleaved_features) {
                     assert(d->_collapsedDocWordFeatures._field_len == matchData[lfi]->getFieldLength());
                     assert(d->_collapsedDocWordFeatures._num_occs == matchData[lfi]->getNumOccs());
@@ -493,8 +494,9 @@ FakeWord::validate(search::queryeval::SearchIterator *iterator,
             iterator->unpack(docId);
             unsigned int positions = d->_positions;
             for (size_t lfi = 0; lfi < matchData.size(); ++lfi) {
-                if (matchData[lfi]->getDocId() != docId)
+                if (!matchData[lfi]->has_data(docId)) {
                     continue;
+                }
                 if (unpack_interleaved_features) {
                     assert(d->_collapsedDocWordFeatures._field_len == matchData[lfi]->getFieldLength());
                     assert(d->_collapsedDocWordFeatures._num_occs == matchData[lfi]->getNumOccs());
@@ -647,8 +649,9 @@ FakeWord::validate(FieldReader &fieldReader,
             unsigned int positions = d->_positions;
             presidue = positions;
             for (size_t lfi = 0; lfi < matchData.size(); ++lfi) {
-                if (matchData[lfi]->getDocId() != docId)
+                if (!matchData[lfi]->has_data(docId)) {
                     continue;
+                }
                 TMDPI mdpe = matchData[lfi]->end();
                 TMDPI mdp = matchData[lfi]->begin();
                 while (mdp != mdpe) {


### PR DESCRIPTION
Add has_ranking_data and has_data member functions to TermFieldMatchData.

@vekterli : please review
@arnej27959 , @havardpe : FYI
