### PR TITLE
Change default rollout strategy to 'simultaneous'

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
@@ -220,7 +220,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
     /** Returns the revision change strategy of this, which is {@link DeploymentSpec.RevisionChange#whenFailing} by default */
     public DeploymentSpec.RevisionChange revisionChange() { return revisionChange; }
 
-    /** Returns the upgrade rollout strategy of this, which is {@link DeploymentSpec.UpgradeRollout#separate} by default */
+    /** Returns the upgrade rollout strategy of this, which is {@link DeploymentSpec.UpgradeRollout#simultaneous} by default */
     public DeploymentSpec.UpgradeRollout upgradeRollout() { return upgradeRollout; }
 
     /** Minimum cumulative, enqueued risk required for a new revision to roll out to this instance. 0 by default. */

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -737,7 +737,7 @@ public final class DeploymentSpec {
         separate,
         /** Leading: Application changes are allowed to start and catch up to the platform upgrade. */
         leading,
-        // /** Simultaneous: Application changes deploy independently of platform upgrades. */
+        /** Simultaneous: Application changes deploy independently of platform upgrades. */
         simultaneous
     }
 

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -203,7 +203,7 @@ public class DeploymentSpecXmlReader {
         DeploymentSpec.UpgradePolicy upgradePolicy = getWithFallback(instanceElement, parentTag, upgradeTag, "policy", this::readUpgradePolicy, UpgradePolicy.defaultPolicy);
         DeploymentSpec.RevisionTarget revisionTarget = getWithFallback(instanceElement, parentTag, upgradeTag, "revision-target", this::readRevisionTarget, RevisionTarget.latest);
         DeploymentSpec.RevisionChange revisionChange = getWithFallback(instanceElement, parentTag, upgradeTag, "revision-change", this::readRevisionChange, RevisionChange.whenFailing);
-        DeploymentSpec.UpgradeRollout upgradeRollout = getWithFallback(instanceElement, parentTag, upgradeTag, "rollout", this::readUpgradeRollout, UpgradeRollout.separate);
+        DeploymentSpec.UpgradeRollout upgradeRollout = getWithFallback(instanceElement, parentTag, upgradeTag, "rollout", this::readUpgradeRollout, UpgradeRollout.simultaneous);
         int minRisk = getWithFallback(instanceElement, parentTag, upgradeTag, "min-risk", Integer::parseInt, 0);
         int maxRisk = getWithFallback(instanceElement, parentTag, upgradeTag, "max-risk", Integer::parseInt, 0);
         int maxIdleHours = getWithFallback(instanceElement, parentTag, upgradeTag, "max-idle-hours", Integer::parseInt, 8);

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -142,7 +142,7 @@ public class DeploymentSpecTest {
         assertEquals(DeploymentSpec.UpgradePolicy.defaultPolicy, spec.requireInstance("default").upgradePolicy());
         assertEquals(DeploymentSpec.RevisionTarget.latest, spec.requireInstance("default").revisionTarget());
         assertEquals(DeploymentSpec.RevisionChange.whenFailing, spec.requireInstance("default").revisionChange());
-        assertEquals(DeploymentSpec.UpgradeRollout.separate, spec.requireInstance("default").upgradeRollout());
+        assertEquals(DeploymentSpec.UpgradeRollout.simultaneous, spec.requireInstance("default").upgradeRollout());
         assertEquals(0, spec.requireInstance("default").minRisk());
         assertEquals(0, spec.requireInstance("default").maxRisk());
         assertEquals(8, spec.requireInstance("default").maxIdleHours());
@@ -425,16 +425,16 @@ public class DeploymentSpecTest {
                 "   <instance id='default'>" +
                 "      <upgrade rollout='leading' />" +
                 "   </instance>" +
-                "   <instance id='aggressive'>" +
-                "      <upgrade rollout='simultaneous' />" +
+                "   <instance id='conservative'>" +
+                "      <upgrade rollout='separate' />" +
                 "   </instance>" +
                 "   <instance id='custom'/>" +
                 "</deployment>"
         );
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         assertEquals("leading", spec.requireInstance("default").upgradeRollout().toString());
-        assertEquals("separate", spec.requireInstance("custom").upgradeRollout().toString());
-        assertEquals("simultaneous", spec.requireInstance("aggressive").upgradeRollout().toString());
+        assertEquals("separate", spec.requireInstance("conservative").upgradeRollout().toString());
+        assertEquals("simultaneous", spec.requireInstance("custom").upgradeRollout().toString());
     }
 
     @Test

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecWithoutInstanceTest.java
@@ -121,7 +121,7 @@ public class DeploymentSpecWithoutInstanceTest {
         assertFalse(spec.requireInstance("default").concerns(prod, Optional.of(RegionName.from("no-such-region"))));
 
         assertEquals(DeploymentSpec.UpgradePolicy.defaultPolicy, spec.requireInstance("default").upgradePolicy());
-        assertEquals(DeploymentSpec.UpgradeRollout.separate, spec.requireInstance("default").upgradeRollout());
+        assertEquals(DeploymentSpec.UpgradeRollout.simultaneous, spec.requireInstance("default").upgradeRollout());
     }
 
     @Test


### PR DESCRIPTION
Advantages:
- Faster deployments when there is an upgrade Disadvantages:
- Higher system entropy

The entropy problem has proven to be quite theoretical, so we should downweight it, and therefore change the default.
