### PR TITLE
Adjust latency metrics to reflect engine execution time

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -223,7 +223,7 @@ public class StatisticsSearcher extends Searcher {
 
         incrQueryCount(metricContext);
         logQuery(query);
-        long startMs = query.getStartTime();
+        long startMs = executionStartTime(query);
         qps(metricContext);
         metric.set(QUERY_TIMEOUT_METRIC, query.getTimeout(), metricContext);
         Result result;
@@ -235,14 +235,16 @@ public class StatisticsSearcher extends Searcher {
             throw e;
         }
 
-        long endMs = System.currentTimeMillis();
-        long latencyMs = endMs - startMs;
-        if (latencyMs >= 0) {
-            addLatency(latencyMs, metricContext);
-        } else {
-            getLogger().log(Level.WARNING,
-                            "Apparently negative latency measure, start: " + startMs
-                            + ", end: " + endMs + ", for query: " + query + ". Could be caused by NTP adjustments.");
+        if (startMs > 0) {
+            long endMs = System.currentTimeMillis();
+            long latencyMs = endMs - startMs;
+            if (latencyMs >= 0) {
+                addLatency(latencyMs, metricContext);
+            } else {
+                getLogger().log(Level.WARNING,
+                                "Apparently negative latency measure, start: " + startMs
+                                + ", end: " + endMs + ", for query: " + query + ". Could be caused by NTP adjustments.");
+            }
         }
         if (result.hits().getError() != null) {
             incrErrorCount(result, metricContext);
@@ -405,6 +407,11 @@ public class StatisticsSearcher extends Searcher {
 
     private void addItemCountMetric(Query query, Metric.Context context) {
         metric.set(QUERY_ITEM_COUNT, query.getModel().getQueryTree().treeSize(), context);
+    }
+
+    private static long executionStartTime(Query query) {
+        var startTime = query.getHttpRequest().context().get("search.handlerStartTime");
+        return startTime != null ? (long) startTime : 0;
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.yahoo.container.protect.Error.BACKEND_COMMUNICATION_ERROR;
@@ -224,9 +223,7 @@ public class StatisticsSearcher extends Searcher {
 
         incrQueryCount(metricContext);
         logQuery(query);
-        // Timestamp when request was initially processed by Jetty
-        long startMs = Optional.ofNullable(query.getHttpRequest())
-                .map(r -> r.creationTime(TimeUnit.MILLISECONDS)).orElseGet(System::currentTimeMillis);
+        long startMs = query.getStartTime();
         qps(metricContext);
         metric.set(QUERY_TIMEOUT_METRIC, query.getTimeout(), metricContext);
         Result result;

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A search query containing all the information required to produce a Result.
@@ -362,7 +363,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
                       Map<String, Embedder> embedders,
                       ZoneInfo zoneInfo,
                       SchemaInfo schemaInfo) {
-        startTime = System.currentTimeMillis();
+        startTime = httpRequest.creationTime(TimeUnit.MILLISECONDS);
         if (queryProfile != null) {
             // Move all request parameters to the query profile
             Properties queryProfileProperties = new QueryProfileProperties(queryProfile, embedders, zoneInfo);

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A search query containing all the information required to produce a Result.
@@ -363,7 +362,7 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
                       Map<String, Embedder> embedders,
                       ZoneInfo zoneInfo,
                       SchemaInfo schemaInfo) {
-        startTime = httpRequest.creationTime(TimeUnit.MILLISECONDS);
+        startTime = System.currentTimeMillis();
         if (queryProfile != null) {
             // Move all request parameters to the query profile
             Properties queryProfileProperties = new QueryProfileProperties(queryProfile, embedders, zoneInfo);

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -80,7 +80,6 @@ public class SearchHandler extends LoggingRequestHandler {
 
     private static final CompoundName DETAILED_TIMING_LOGGING = CompoundName.from("trace.timingDetails");
     private static final CompoundName FORCE_TIMESTAMPS = CompoundName.from("trace.timestamps");
-
     /** Event name for number of connections to the search subsystem */
     private static final String SEARCH_CONNECTIONS = ContainerMetrics.SEARCH_CONNECTIONS.baseName();
     static final String RENDER_LATENCY_METRIC = ContainerMetrics.JDISC_RENDER_LATENCY.baseName();
@@ -227,6 +226,7 @@ public class SearchHandler extends LoggingRequestHandler {
     }
 
     private HttpSearchResponse handleBody(HttpRequest request) {
+        long executionStart = System.currentTimeMillis();
         Map<String, String> requestMap = requestMapFromRequest(request);
 
         // Get query profile
@@ -240,6 +240,7 @@ public class SearchHandler extends LoggingRequestHandler {
                                          .setZoneInfo(zoneInfo)
                                          .setSchemaInfo(executionFactory.schemaInfo())
                                          .build();
+        query.getHttpRequest().context().put("search.handlerStartTime", executionStart);
 
         // If format not explicitly set, use Accept header to determine response format
         if (!requestMap.containsKey("format") && !requestMap.containsKey("presentation.format")) {

--- a/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
+++ b/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
@@ -86,7 +86,7 @@ public enum ContainerMetrics implements VespaMetrics {
     SERVER_BYTES_SENT("serverBytesSent", Unit.BYTE, "The number of bytes sent from the server"),
 
     HANDLED_REQUESTS("handled.requests", Unit.OPERATION, "The number of requests handled per metrics snapshot"),
-    HANDLED_LATENCY("handled.latency", Unit.MILLISECOND, "The time used for requests during this metrics snapshot"),
+    HANDLED_LATENCY("handled.latency", Unit.MILLISECOND, "The time used for handling requests, excluding HTTP layer and rendering"),
     
     HTTPAPI_LATENCY("httpapi_latency", Unit.MILLISECOND, "Duration for requests to the HTTP document APIs"),
     HTTPAPI_PENDING("httpapi_pending", Unit.OPERATION, "Document operations pending execution"),
@@ -131,7 +131,7 @@ public enum ContainerMetrics implements VespaMetrics {
     FEED_HTTP_REQUESTS("feed.http-requests", Unit.OPERATION, "Feed HTTP requests"),
     QUERIES("queries", Unit.OPERATION, "Query volume"),
     QUERY_CONTAINER_LATENCY("query_container_latency", Unit.MILLISECOND, "The query execution time consumed in the container"),
-    QUERY_LATENCY("query_latency", Unit.MILLISECOND, "The overall query latency as seen by the container"),
+    QUERY_LATENCY("query_latency", Unit.MILLISECOND, "The overall query latency as observed by the container cluster, excluding HTTP layer and rendering"),
     QUERY_TIMEOUT("query_timeout", Unit.MILLISECOND, "The amount of time allowed for query execution, from the client"),
     FAILED_QUERIES("failed_queries", Unit.OPERATION, "The number of failed queries"),
     DEGRADED_QUERIES("degraded_queries", Unit.OPERATION, "The number of degraded queries, e.g. due to some content nodes not responding in time"),

--- a/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
@@ -172,6 +172,8 @@ public class Vespa9VespaMetricSet {
 
         addMetric(metrics, ContainerMetrics.JDISC_APPLICATION_FAILED_COMPONENT_GRAPHS.rate());
 
+        addMetric(metrics, ContainerMetrics.JDISC_RENDER_LATENCY, EnumSet.of(max, count, sum));
+
         addMetric(metrics, ContainerMetrics.FEED_LATENCY, EnumSet.of(sum, count, max));
 
         // Embedders


### PR DESCRIPTION
## Summary

Latency metrics previously started timing from the Jetty request timestamp, which includes HTTP parsing, filter chain execution, and POST payload transmission. This inflates what should be pure engine metrics.

- `query_latency` / `query_container_latency`: start timing from Query construction instead of Jetty request timestamp
- `handled.latency`: start timing from handler thread entry instead of `Request.creationTime`; remove `handler` and `endpoint` dimensions
- Per-request HTTP server metrics: remove `serverName` and `protocol` dimensions
- `jdisc.render.latency`: add to Vespa9VespaMetricSet