### PR TITLE
Set phrase match length to phrase size 

### DIFF
--- a/searchlib/src/vespa/searchlib/fef/termfieldmatchdataposition.h
+++ b/searchlib/src/vespa/searchlib/fef/termfieldmatchdataposition.h
@@ -84,7 +84,7 @@ public:
     int32_t getElementWeight() const { return _elementWeight; }
     uint32_t getElementLen() const { return _elementLen; }
     float getMatchExactness() const { return _matchExactness; }
-    uint32_t getMatchLength() const { return _matchExactness; }
+    uint32_t getMatchLength() const { return _matchLength; }
 
     void setElementWeight(int32_t elementWeight) {
         _elementWeight = elementWeight;

--- a/searchlib/src/vespa/searchlib/queryeval/simple_phrase_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/simple_phrase_search.cpp
@@ -22,6 +22,7 @@ class PhraseMatcher {
     vector<TermFieldMatchData::PositionsIterator> &_iterators;
     uint32_t _element_id;
     uint32_t _position;
+    const uint32_t _phraseLength; // currently all children of phrase must be 1-word terms
 
     TermFieldMatchData::PositionsIterator &iterator(uint32_t word_index) {
         return _iterators[word_index];
@@ -84,7 +85,8 @@ public:
           _eval_order(eval_order),
           _iterators(iterators),
           _element_id(0),
-          _position(0)
+          _position(0),
+          _phraseLength(tmds.size())
     {
         for (size_t i = 0; i < _tmds.size(); ++i) {
             _iterators[i] = _tmds[i]->begin();
@@ -122,7 +124,9 @@ public:
             while (iterator(_eval_order[0]) != end(_eval_order[0])) {
                 if (match()) {
                     if (needs_normal_features) {
-                        tmd.appendPosition(*iterator(0));
+                        fef::TermFieldMatchDataPosition pos = *iterator(0);
+                        pos.setMatchLength(_phraseLength);
+                        tmd.appendPosition(pos);
                     }
                     ++num_occs;
                 }


### PR DESCRIPTION
When recording a phrase match in SimplePhraseSearch, set the match length to the number of words in the phrase (phraseLength) instead of inheriting the match length from the first matched term.

Also fix a bug in TermFieldMatchDataPosition::getMatchLength(), which was incorrectly returning _matchExactness (a float) instead of _matchLength.
