### PR TITLE
Fix typo in select_dockerfile function

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -47,7 +47,7 @@ cd "${WORKDIR}/docker-image"
 SOURCE_GITREF=$(git rev-parse HEAD)
 
 select_dockerfile() {
-    wanted="Dockefile.${VESPA_BUILDOS_LABEL}"
+    wanted="Dockerfile.${VESPA_BUILDOS_LABEL}"
     if [ -f "${wanted}" ]; then
         echo "${wanted}"
     else


### PR DESCRIPTION
Corrected "Dockefile" to "Dockerfile" in the wanted variable assignment. This typo would prevent the function from finding the correct Dockerfile for the specified build OS.
