### PR TITLE
Equals array index in select language

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -67,7 +67,6 @@ import com.yahoo.search.yql.YqlParser;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.ObjectTraverser;
-import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.slime.Type;
 import java.nio.charset.StandardCharsets;

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -690,11 +690,11 @@ public class SelectParser implements Parser {
         }
 
         String field = params.field.asString();
-        return switch (value.type()) {
-            case BOOL -> new BoolItem(value.asBool(), field);
-            case LONG -> new IntItem(value.asLong(), field);
+        return switch (params.value.type()) {
+            case BOOL -> new BoolItem(params.value.asBool(), field);
+            case LONG -> new IntItem(params.value.asLong(), field);
             default -> throw new IllegalArgumentException("'value' in 'equals' should be a boolean or integer, but " +
-                    "was " + value.type());
+                    "was " + params.value.type());
         };
     }
 
@@ -745,7 +745,7 @@ public class SelectParser implements Parser {
                                                           "or string but was " + value.type());
         };
 
-        SameElementItem sameElement = new SameElementItem(params.field.toString());
+        SameElementItem sameElement = new SameElementItem(params.field.asString());
         sameElement.setElementFilter(List.of(elementIndex));
         sameElement.addItem(valueItem);
         return sameElement;

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -67,6 +67,7 @@ import com.yahoo.search.yql.YqlParser;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.ObjectTraverser;
+import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.slime.Type;
 import java.nio.charset.StandardCharsets;
@@ -673,88 +674,80 @@ public class SelectParser implements Parser {
         return hitLimit[0];
     }
 
-
+    /**
+     * Equals operator.
+     * <p>
+     * Short form: { "equals": [field, value] }
+     * Long form:  { "equals": { "field": field, "value": value } }
+     * <p>
+     * Optional argument: "index". Then it is turned into sameElement with array access.
+     */
     private Item buildEquals(String key, Inspector value) {
-        if (value.type() == OBJECT && value.field("index").valid()) {
-            return buildSameElementWithElementFilter(value);
-        }
-
-        Map<Integer, Inspector> children = equalsChildMap(value);
-        if ( children.size() != 2)
-            throw new IllegalArgumentException("The value of 'equals' should be an array containing a field name and " +
-                                               "a value, but was " + value);
-        if ( children.get(0).type() != STRING)
-            throw new IllegalArgumentException("The first array element under 'equals' should be a field name string " +
-                                               "but was " + children.get(0));
-        String field = children.get(0).asString();
-        return switch (children.get(1).type()) {
-            case BOOL -> new BoolItem(children.get(1).asBool(), field);
-            case LONG -> new IntItem(children.get(1).asLong(), field);
-            default ->
-                    throw new IllegalArgumentException("The second array element under 'equals' should be a boolean " +
-                                                       "or int value but was " + children.get(1));
-        };
-    }
-
-    /** Builds child map for equals operator from object or array. */
-    private Map<Integer, Inspector> equalsChildMap(Inspector value) {
-        if (value.type() == OBJECT) {
-            var params = extractEqualsFieldAndValue(value, false);
-            return Map.of(0, params.field, 1, params.value);
-        } else {
-            return childMap(value);
-        }
-    }
-
-    record EqualsParams(Inspector field, Inspector value, Optional<Inspector> index) {}
-
-    /** Extracts and validates 'field' and 'value' from an equals object. */
-    private EqualsParams extractEqualsFieldAndValue(Inspector value, boolean requireIndex) {
-        Inspector fieldInspector = value.field("field");
-        Inspector valueInspector = value.field("value");
-        Inspector indexInspector = value.field("index");
-
-        if (!fieldInspector.valid() || !valueInspector.valid() || (requireIndex && !indexInspector.valid())) {
-            throw new IllegalArgumentException(
-                    "Expected 'equals' object to contain 'field'" + (requireIndex ? ", 'index'" : "") +
-                            ", and 'value', but got " + value);
-        }
-
-        if (fieldInspector.type() != STRING) {
-            throw new IllegalArgumentException("'field' in 'equals' should be a string but was " + fieldInspector.type());
-        }
-
-        return new EqualsParams(fieldInspector, valueInspector, Optional.ofNullable(indexInspector));
-    }
-
-    /** Builds sameElement accessing a specific index in an array. */
-    private Item buildSameElementWithElementFilter(Inspector value) {
-        EqualsParams params = extractEqualsFieldAndValue(value, true);
-        Inspector indexInspector = params.index.orElseThrow();
-        Inspector valueInspector = params.value;
-
-        if (indexInspector.type() != LONG) {
-            throw new IllegalArgumentException("'index' in 'equals' should be an integer but was " +
-                                               indexInspector.type());
+        var params = extractEqualsParams(value);
+        params.validateTypes();
+        if (params.index.valid()) {
+            return buildSameElementWithElementFilter(params);
         }
 
         String field = params.field.asString();
-        Object indexObj = indexInspector.asLong();
-        int elementIndex = YqlParser.convertToElementId(indexObj);
+        return switch (value.type()) {
+            case BOOL -> new BoolItem(value.asBool(), field);
+            case LONG -> new IntItem(value.asLong(), field);
+            default -> throw new IllegalArgumentException("'value' in 'equals' should be a boolean or integer, but " +
+                    "was " + value.type());
+        };
+    }
 
-        // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
-        String stringValue = switch (valueInspector.type()) {
-            case BOOL -> String.valueOf(valueInspector.asBool());
-            case LONG -> String.valueOf(valueInspector.asLong());
-            case DOUBLE -> String.valueOf(valueInspector.asDouble());
-            case STRING -> valueInspector.asString();
+    /** Holds and validates equals operator parameters. */
+    record EqualsParams(Inspector field, Inspector value, Inspector index) {
+        void validateTypes() {
+            if (!field.valid()) {
+                throw new IllegalArgumentException("Expected 'field' in 'equals' but is missing.");
+            }
+
+            if (!value.valid()) {
+                throw new IllegalArgumentException("Expected 'value' in 'equals' but is missing.");
+            }
+
+            if (field.type() != STRING) {
+                throw new IllegalArgumentException("'field' in 'equals' should be a string but was " + field.type());
+            }
+
+            if (index.valid() && (index.type() != LONG)) {
+                throw new IllegalArgumentException("'index' in 'equals' should be an integer but was " + index.type());
+            }
+        }
+    }
+
+    /** Extracts equals operator parameters from object and array form. */
+    private EqualsParams extractEqualsParams(Inspector value) {
+        if (value.type() == OBJECT) {
+            return new EqualsParams(value.field("field"), value.field("value"), value.field("index"));
+        } else {
+            if (value.entries() != 2) {
+                throw new IllegalArgumentException("The value of 'equals' should be an array containing a field name" +
+                        " and a value, but was " + value);
+            }
+            return new EqualsParams(value.entry(0), value.entry(1), value.entry(2));
+        }
+    }
+
+    /** Builds sameElement accessing a specific index in an array. */
+    private Item buildSameElementWithElementFilter(EqualsParams params) {
+        int elementIndex = YqlParser.convertToElementId(params.index.asLong());
+        var value = params.value;
+        Item valueItem = switch (value.type()) {
+            case BOOL -> new BoolItem(value.asBool(), "");
+            case LONG -> new IntItem(value.asLong(), "");
+            case DOUBLE -> new IntItem(new Limit(value.asDouble(), true), new Limit(value.asDouble(), true), "");
+            case STRING -> new WordItem(value.asString(), "");
             default -> throw new IllegalArgumentException("'value' in 'equals' should be a boolean, integer, double, " +
-                                                          "or string but was " + valueInspector.type());
+                                                          "or string but was " + value.type());
         };
 
-        SameElementItem sameElement = new SameElementItem(field);
+        SameElementItem sameElement = new SameElementItem(params.field.toString());
         sameElement.setElementFilter(List.of(elementIndex));
-        sameElement.addItem(new WordItem(stringValue, ""));
+        sameElement.addItem(valueItem);
         return sameElement;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -63,6 +63,7 @@ import com.yahoo.search.query.parser.Parser;
 import com.yahoo.search.query.parser.ParserEnvironment;
 import com.yahoo.search.query.parser.ParserFactory;
 import com.yahoo.search.yql.VespaGroupingStep;
+import com.yahoo.search.yql.YqlParser;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.ObjectTraverser;
@@ -674,7 +675,11 @@ public class SelectParser implements Parser {
 
 
     private Item buildEquals(String key, Inspector value) {
-        Map<Integer, Inspector> children = childMap(value);
+        if (value.type() == OBJECT && value.field("index").valid()) {
+            return buildSameElementWithElementFilter(value);
+        }
+
+        Map<Integer, Inspector> children = equalsChildMap(value);
         if ( children.size() != 2)
             throw new IllegalArgumentException("The value of 'equals' should be an array containing a field name and " +
                                                "a value, but was " + value);
@@ -689,6 +694,68 @@ public class SelectParser implements Parser {
                     throw new IllegalArgumentException("The second array element under 'equals' should be a boolean " +
                                                        "or int value but was " + children.get(1));
         };
+    }
+
+    /** Builds child map for equals operator from object or array. */
+    private Map<Integer, Inspector> equalsChildMap(Inspector value) {
+        if (value.type() == OBJECT) {
+            var params = extractEqualsFieldAndValue(value, false);
+            return Map.of(0, params.field, 1, params.value);
+        } else {
+            return childMap(value);
+        }
+    }
+
+    record EqualsParams(Inspector field, Inspector value, Optional<Inspector> index) {}
+
+    /** Extracts and validates 'field' and 'value' from an equals object. */
+    private EqualsParams extractEqualsFieldAndValue(Inspector value, boolean requireIndex) {
+        Inspector fieldInspector = value.field("field");
+        Inspector valueInspector = value.field("value");
+        Inspector indexInspector = value.field("index");
+
+        if (!fieldInspector.valid() || !valueInspector.valid() || (requireIndex && !indexInspector.valid())) {
+            throw new IllegalArgumentException(
+                    "Expected 'equals' object to contain 'field'" + (requireIndex ? ", 'index'" : "") +
+                            ", and 'value', but got " + value);
+        }
+
+        if (fieldInspector.type() != STRING) {
+            throw new IllegalArgumentException("'field' in 'equals' should be a string but was " + fieldInspector.type());
+        }
+
+        return new EqualsParams(fieldInspector, valueInspector, Optional.ofNullable(indexInspector));
+    }
+
+    /** Builds sameElement accessing a specific index in an array. */
+    private Item buildSameElementWithElementFilter(Inspector value) {
+        EqualsParams params = extractEqualsFieldAndValue(value, true);
+        Inspector indexInspector = params.index.orElseThrow();
+        Inspector valueInspector = params.value;
+
+        if (indexInspector.type() != LONG) {
+            throw new IllegalArgumentException("'index' in 'equals' should be an integer but was " +
+                                               indexInspector.type());
+        }
+
+        String field = params.field.asString();
+        Object indexObj = indexInspector.asLong();
+        int elementIndex = YqlParser.convertToElementId(indexObj);
+
+        // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
+        String stringValue = switch (valueInspector.type()) {
+            case BOOL -> String.valueOf(valueInspector.asBool());
+            case LONG -> String.valueOf(valueInspector.asLong());
+            case DOUBLE -> String.valueOf(valueInspector.asDouble());
+            case STRING -> valueInspector.asString();
+            default -> throw new IllegalArgumentException("'value' in 'equals' should be a boolean, integer, double, " +
+                                                          "or string but was " + valueInspector.type());
+        };
+
+        SameElementItem sameElement = new SameElementItem(field);
+        sameElement.setElementFilter(List.of(elementIndex));
+        sameElement.addItem(new WordItem(stringValue, ""));
+        return sameElement;
     }
 
     private Item buildIn(String key, Inspector value) {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -824,7 +824,7 @@ public class YqlParser implements Parser {
     }
 
     /** Element filter accepts Integer. Allows Long that is within Integer size. */
-    private int convertToElementId(Object val) {
+    public static int convertToElementId(Object val) {
         if (val == null) {
             throw new IllegalArgumentException("element id cannot be null");
         }

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -23,6 +23,7 @@ import com.yahoo.prelude.query.Substring;
 import com.yahoo.prelude.query.SubstringItem;
 import com.yahoo.prelude.query.SuffixItem;
 import com.yahoo.prelude.query.WeakAndItem;
+import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.WordAlternativesItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.processing.IllegalInputException;
@@ -783,6 +784,44 @@ public class SelectTestCase {
     void testEquals() {
         assertParse("{\"equals\": [\"public\",true]}", "public:true");
         assertParse("{\"equals\": [\"public\",5]}", "public:5");
+        // Object syntax without index
+        assertParse("{\"equals\": {\"field\": \"public\", \"value\": true}}", "public:true");
+        assertParse("{\"equals\": {\"field\": \"public\", \"value\": 5}}", "public:5");
+    }
+
+    @Test
+    void testEqualsWithArrayIndex() {
+        // Boolean value
+        assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 2, \"value\": true }}",
+                    "my_arr:{true}");
+        var boolTree = parseWhere("{\"equals\": {\"field\": \"my_arr\", \"index\": 2, \"value\": true }}");
+        var boolSameElement = assertInstanceOf(SameElementItem.class, boolTree.getRoot());
+        assertEquals("my_arr", boolSameElement.getFieldName());
+        assertEquals(List.of(2), boolSameElement.getElementFilter());
+        assertEquals(1, boolSameElement.getItemCount());
+
+        // Integer value
+        assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": 42 }}",
+                    "my_arr:{42}");
+        var intTree = parseWhere("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": 42 }}");
+        var intSameElement = assertInstanceOf(SameElementItem.class, intTree.getRoot());
+        assertEquals(List.of(0), intSameElement.getElementFilter());
+
+        // String value
+        assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 1, \"value\": \"hello\" }}",
+                    "my_arr:{hello}");
+    }
+
+    @Test
+    void testEqualsWithArrayIndexErrors() {
+        assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 2 }}",
+                new IllegalArgumentException("Expected 'equals' object to contain 'field', 'index', and 'value', but got {\"field\":\"my_arr\",\"index\":2}"));
+        assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": -1, \"value\": true }}",
+                new IllegalArgumentException("element id must be non-negative, got: -1"));
+        assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 3000000000, \"value\": true }}",
+                new IllegalArgumentException("element id must fit in int32 range, got: 3000000000"));
+        assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 1.5, \"value\": true }}",
+                new IllegalArgumentException("element id must be integer, not floating point number. Got: 1.5"));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -818,7 +818,7 @@ public class SelectTestCase {
     @Test
     void testEqualsWithArrayIndexErrors() {
         assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 2 }}",
-                new IllegalArgumentException("Expected 'equals' object to contain 'field', 'index', and 'value', but got {\"field\":\"my_arr\",\"index\":2}"));
+                new IllegalArgumentException("Expected 'value' in 'equals' but is missing."));
         assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": -1, \"value\": true }}",
                 new IllegalArgumentException("element id must be non-negative, got: -1"));
         assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 3000000000, \"value\": true }}",

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -825,7 +825,7 @@ public class SelectTestCase {
         assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 3000000000, \"value\": true }}",
                 new IllegalArgumentException("element id must fit in int32 range, got: 3000000000"));
         assertParseFail("{\"equals\": {\"field\": \"my_arr\", \"index\": 1.5, \"value\": true }}",
-                new IllegalArgumentException("element id must be integer, not floating point number. Got: 1.5"));
+                new IllegalArgumentException("'index' in 'equals' should be an integer but was DOUBLE"));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -784,7 +784,6 @@ public class SelectTestCase {
     void testEquals() {
         assertParse("{\"equals\": [\"public\",true]}", "public:true");
         assertParse("{\"equals\": [\"public\",5]}", "public:5");
-        // Object syntax without index
         assertParse("{\"equals\": {\"field\": \"public\", \"value\": true}}", "public:true");
         assertParse("{\"equals\": {\"field\": \"public\", \"value\": 5}}", "public:5");
     }

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -810,6 +810,10 @@ public class SelectTestCase {
         // String value
         assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 1, \"value\": \"hello\" }}",
                     "my_arr:{hello}");
+
+        // Double value
+        assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": 3.14 }}",
+                    "my_arr:{3.14}");
     }
 
     @Test


### PR DESCRIPTION
Adds support for `field[2]=30` style selection in select language.

- Equals operator now supports array argument `[field, value]`, and object argument `{ "field": "field_name", "value": value }`.
- Added optional `"index": some_integer` to the object version.
- If index is present, this would mean sameElement with element filter instead of equals (like in YQL).

The following:

```json
{ "equals": { "field": "my_int_arr", "index": 2, "value": 30 } }
```

would match every document whose value at index 2 in `my_int_arr` is 30.

@havardpe please review