### PR TITLE
Fix stale config keys after failed construction

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/Container.java
@@ -120,7 +120,11 @@ public class Container {
     {
         ConfigSnapshot snapshot;
         while (true) {
-            snapshot = retriever.getConfigs(graph.configKeys(), leastGeneration, isInitializing);
+            // If the previous generation was invalidated (leastGeneration > graph.generation()),
+            // the old graph's config keys may reference components that no longer exist.
+            // Use empty keys to force a bootstrap-first config retrieval.
+            var configKeys = leastGeneration > graph.generation() ? Set.<ConfigKey<? extends ConfigInstance>>of() : graph.configKeys();
+            snapshot = retriever.getConfigs(configKeys, leastGeneration, isInitializing);
             updateApplyOnRestart();
 
             if (log.isLoggable(FINE))


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This was surfaced by a failed model component causing need for a manual restart of container nodes to bring them back up.
See [VESPANG-2765](https://vespaai.atlassian.net/browse/VESPANG-2765) for logs and additional details. 

I was able to reproduce the issue, and Claude helped me pinpoint the root cause, which should be fixed by this.

**Summary**

  - Fix infinite failure loop when a deployment removes a component and adds a broken one
  - After constructComponents() fails, currentGraph stays at the old generation. On retry, stale configKeys() from the old graph are passed to ConfigRetriever.getConfigs(), subscribing to keys for components that no longer exist.
 The config server rejects these, causing a permanent loop.                             
  - Fix: when leastGeneration > graph.generation() (previous generation was invalidated), pass empty component config keys to force bootstrap-first retrieval. After bootstrap configs arrive, createComponentGraph() produces a new graph with correct keys.

  **Test**
  - The added test failed (Red/Green TDD) before the fix was added. 
  - New test uses a BanningSubscriberFactory to simulate config server rejection of non-existent keys
  - All existing ContainerTest tests pass

Please review carefully, as this is not well-known territory for me.