### PR TITLE
Fix median=0 coverage bypass during group expansion

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
@@ -35,7 +35,7 @@ public class SearchGroupsImpl implements SearchGroups {
 
     public boolean isGroupCoverageSufficient(boolean currentIsGroupCoverageSufficient,
                                              long groupDocumentCount, long medianDocumentCount, long maxDocumentCount) {
-        if (medianDocumentCount <= 0) return true;
+        if (maxDocumentCount <= 0) return true;
         if (currentIsGroupCoverageSufficient) {
             if (availabilityPolicy.prioritizeAvailability()) {
                 // To take a group *out of* rotation, require that it has less active documents than the median.

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
@@ -181,6 +181,19 @@ public class SearchClusterCoverageTest {
     }
 
     @Test
+    void twenty_groups_of_which_eleven_were_just_added_with_no_docs() {
+        var tester = new SearchClusterTester(20, 3);
+
+        for (int i = 0; i < 9; i++)
+            tester.setDocsPerNode(1000, i);   // groups 9-19 left at 0 docs, nodes not working
+
+        tester.pingIterationCompleted();
+
+        for (int i = 0;  i < 9;  i++) assertTrue(tester.group(i).hasSufficientCoverage());
+        for (int i = 9;  i < 20; i++) assertFalse(tester.group(i).hasSufficientCoverage());
+    }
+
+    @Test
     void one_group_few_docs_unbalanced() {
         var tester = new SearchClusterTester(1, 2);
 


### PR DESCRIPTION
## Summary

- During autoscaling, when more than half of all groups have 0 docs (newly provisioned), the Guava median falls to 0 and the shortcut `if (medianDocumentCount <= 0) return true` marks all groups as sufficient — including empty ones
- This causes ~55% of queries to be routed to groups with no working nodes, returning HTTP 503 for several minutes until redistribution recovers
- Fix: use `maxDocumentCount` instead — the bootstrap shortcut now only fires when even the most-loaded group has no docs; empty new groups correctly fail the coverage check via the existing `hasSufficientCoverage()` logic

## Test plan

- [ ] Existing `SearchClusterCoverageTest` tests continue to pass
- [ ] New regression test `twenty_groups_of_which_eleven_were_just_added_with_no_docs` reproduces the 9+11 group expansion scenario and verifies only the 9 populated groups have sufficient coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)