### PR TITLE
Enable SO_KEEPALIVE and SO_LINGER on JRT TCP connections

### DIFF
--- a/jrt/src/com/yahoo/jrt/Connection.java
+++ b/jrt/src/com/yahoo/jrt/Connection.java
@@ -397,6 +397,10 @@ class Connection extends Target {
         return ((socket != null) && (socket.channel() != null));
     }
 
+    SocketChannel socketChannel() {
+        return hasSocket() ? socket.channel() : null;
+    }
+
     public void closeSocket() {
         if (hasSocket()) {
             try {

--- a/jrt/src/com/yahoo/jrt/Connection.java
+++ b/jrt/src/com/yahoo/jrt/Connection.java
@@ -178,6 +178,8 @@ class Connection extends Target {
         try {
             socket.channel().configureBlocking(false);
             socket.channel().socket().setTcpNoDelay(tcpNoDelay);
+            socket.channel().socket().setKeepAlive(true);
+            socket.channel().socket().setSoLinger(true, 0);
             selectionKey = socket.channel().register(selector,
                     SelectionKey.OP_READ | SelectionKey.OP_WRITE,
                     this);

--- a/jrt/tests/com/yahoo/jrt/ConnectTest.java
+++ b/jrt/tests/com/yahoo/jrt/ConnectTest.java
@@ -1,12 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jrt;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ConnectTest {
 
     @org.junit.Test
-    public void testConnect() throws ListenFailedException {
+    public void testConnect() throws ListenFailedException, java.net.SocketException {
         Test.Orb server   = new Test.Orb(new Transport());
         Test.Orb client   = new Test.Orb(new Transport());
         Acceptor acceptor = server.listen(new Spec(0));
@@ -20,6 +21,12 @@ public class ConnectTest {
             try { Thread.sleep(100); } catch (InterruptedException e) {}
         }
         assertTrue(target.isConnected());
+
+        // Verify socket options set in Connection.init()
+        java.net.Socket sock = target.socketChannel().socket();
+        assertTrue("SO_KEEPALIVE should be enabled", sock.getKeepAlive());
+        assertEquals("SO_LINGER should be 0", 0, sock.getSoLinger());
+        assertTrue("TCP_NODELAY should be enabled", sock.getTcpNoDelay());
 
         target.close();
 


### PR DESCRIPTION
## Summary

- Enable `SO_KEEPALIVE` on JRT TCP connections for dead peer detection via OS-level keepalive probes
- Enable `SO_LINGER` with timeout 0 for immediate connection teardown (RST instead of TIME_WAIT) when closing stale connections

These options help detect and clean up stale TCP connections faster, particularly useful during rolling upgrades when config servers restart and existing connections may become half-open.

## Changes

Single file change in `jrt/src/com/yahoo/jrt/Connection.java`:
- `socket.channel().socket().setKeepAlive(true)` — enables TCP keepalive probes
- `socket.channel().socket().setSoLinger(true, 0)` — enables immediate teardown on close

## Background

This is part of a larger effort to address stale TCP connections blocking file distribution downloads (split from #35932 per reviewer feedback). The socket options are the smallest, most independent piece.