### PR TITLE
Track consecutive RPC timeouts in file distribution and close stale connections

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/Connection.java
+++ b/config/src/main/java/com/yahoo/vespa/config/Connection.java
@@ -17,4 +17,6 @@ public interface Connection {
 
     String getAddress();
 
+    default void closeConnection() {}
+
 }

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnection.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnection.java
@@ -43,6 +43,15 @@ public class JRTConnection implements Connection {
         return address;
     }
 
+    @Override
+    public synchronized void closeConnection() {
+        if (target != null) {
+            logger.log(Level.INFO, "Closing connection to " + address);
+            target.close();
+            target = null;
+        }
+    }
+
     /**
      * This is synchronized to avoid multiple ConfigInstances creating new targets simultaneously, if
      * the existing target is null, invalid or has not yet been initialized.

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -62,11 +62,27 @@ public class FileDownloader implements AutoCloseable {
         this.timeout = timeout;
         // Needed to receive RPC receiveFile* calls from server after starting download of file reference
         new FileReceiver(supervisor, downloads, downloadDirectory);
-        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool,
-                                                                   downloads,
-                                                                   timeout,
-                                                                   backoffInitialTime,
-                                                                   downloadDirectory);
+        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
+                                                                    backoffInitialTime, downloadDirectory);
+        if (forceDownload)
+            log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
+    }
+
+    public FileDownloader(ConnectionPool connectionPool,
+                          Supervisor supervisor,
+                          File downloadDirectory,
+                          Duration timeout,
+                          Duration backoffInitialTime,
+                          int maxTimeoutsBeforeClose) {
+        this.connectionPool = connectionPool;
+        this.supervisor = supervisor;
+        this.downloadDirectory = downloadDirectory;
+        this.timeout = timeout;
+        // Needed to receive RPC receiveFile* calls from server after starting download of file reference
+        new FileReceiver(supervisor, downloads, downloadDirectory);
+        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
+                                                                    backoffInitialTime, downloadDirectory,
+                                                                    maxTimeoutsBeforeClose);
         if (forceDownload)
             log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
     }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.filedistribution;
 
 import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.config.FileReference;
+import com.yahoo.jrt.ErrorCode;
 import com.yahoo.jrt.Int32Value;
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.Spec;
@@ -39,6 +40,8 @@ public class FileReferenceDownloader {
     private static final Logger log = Logger.getLogger(FileReferenceDownloader.class.getName());
     private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(lz4, none, zstd);
 
+    private enum DownloadResult { SUCCESS, TIMEOUT, FAILURE }
+
     private final ExecutorService downloadExecutor =
             Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
                                          new DaemonThreadFactory("filereference downloader"));
@@ -49,17 +52,31 @@ public class FileReferenceDownloader {
     private final Optional<Duration> rpcTimeout; // Only used when overridden with env variable
     private final File downloadDirectory;
     private final AtomicBoolean shutDown = new AtomicBoolean(false);
+    private final int maxTimeoutsBeforeClose;
 
     FileReferenceDownloader(ConnectionPool connectionPool,
                             Downloads downloads,
                             Duration timeout,
                             Duration backoffInitialTime,
                             File downloadDirectory) {
+        this(connectionPool, downloads, timeout, backoffInitialTime, downloadDirectory,
+             Optional.ofNullable(System.getenv("VESPA_FILE_DOWNLOAD_MAX_TIMEOUTS_BEFORE_CLOSE"))
+                     .map(Integer::parseInt)
+                     .orElse(0));
+    }
+
+    FileReferenceDownloader(ConnectionPool connectionPool,
+                            Downloads downloads,
+                            Duration timeout,
+                            Duration backoffInitialTime,
+                            File downloadDirectory,
+                            int maxTimeoutsBeforeClose) {
         this.connectionPool = connectionPool;
         this.downloads = downloads;
         this.downloadTimeout = timeout;
         this.backoffInitialTime = backoffInitialTime;
         this.downloadDirectory = downloadDirectory;
+        this.maxTimeoutsBeforeClose = maxTimeoutsBeforeClose;
         // Undocumented on purpose, might change or be removed at any time
         var timeoutString = Optional.ofNullable(System.getenv("VESPA_FILE_DOWNLOAD_RPC_TIMEOUT"));
         this.rpcTimeout = timeoutString.map(t -> Duration.ofSeconds(Integer.parseInt(t)));
@@ -69,6 +86,7 @@ public class FileReferenceDownloader {
         Instant end = Instant.now().plus(downloadTimeout);
         FileReference fileReference = fileReferenceDownload.fileReference();
         int retryCount = 0;
+        int timeoutCount = 0;
         Connection connection = connectionPool.getCurrent();
         do {
             if (retryCount > 0)
@@ -81,8 +99,19 @@ public class FileReferenceDownloader {
             var timeout = rpcTimeout.orElse(Duration.between(Instant.now(), end));
             log.log(Level.FINE, "Wait until download of " + fileReference + " has started, retryCount " + retryCount +
                     ", timeout " + timeout + " (request from " + fileReferenceDownload.client() + ")");
-            if ( ! timeout.isNegative() && startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout))
-                return;
+            if ( ! timeout.isNegative()) {
+                var result = startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout);
+                if (result == DownloadResult.SUCCESS) return;
+                if (result == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                    timeoutCount++;
+                    if (timeoutCount >= maxTimeoutsBeforeClose) {
+                        log.log(Level.INFO, "RPC request for " + fileReference + " timed out " + timeoutCount +
+                                " times, closing connection to " + connection.getAddress());
+                        connection.closeConnection();
+                        timeoutCount = 0;
+                    }
+                }
+            }
 
             retryCount++;
             // There might not be one connection that works for all file references (each file reference might
@@ -131,10 +160,13 @@ public class FileReferenceDownloader {
 
                     log.log(Level.FINE, () -> "Will download " + fileReference + " with timeout " + downloadTimeout + " from " + spec.host());
                     downloads.add(fileReferenceDownload);
-                    var downloading = startDownloadRpc(fileReferenceDownload, 1, connection, downloadTimeout);
+                    var result = startDownloadRpc(fileReferenceDownload, 1, connection, downloadTimeout);
+                    if (result == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                        connection.closeConnection();
+                    }
                     // Need to explicitly remove from downloads if downloading has not started.
                     // If downloading *has* started FileReceiver will take care of that when download has completed or failed
-                    if ( ! downloading)
+                    if (result != DownloadResult.SUCCESS)
                         downloads.remove(fileReference);
                 });
         }
@@ -144,7 +176,7 @@ public class FileReferenceDownloader {
         downloads.remove(fileReference);
     }
 
-    private boolean startDownloadRpc(FileReferenceDownload fileReferenceDownload, int retryCount, Connection connection, Duration timeout) {
+    private DownloadResult startDownloadRpc(FileReferenceDownload fileReferenceDownload, int retryCount, Connection connection, Duration timeout) {
         Request request = createRequest(fileReferenceDownload);
         connection.invokeSync(request, timeout);
 
@@ -157,18 +189,18 @@ public class FileReferenceDownloader {
 
             if (errorCode == 0) {
                 log.log(Level.FINE, () -> "Found " + fileReference + " available at " + address);
-                return true;
+                return DownloadResult.SUCCESS;
             } else {
                 var error = FileApiErrorCodes.get(errorCode);
                 log.log(logLevel, "Downloading " + fileReference + " from " + address + " failed (" + error + ")");
-                return false;
+                return DownloadResult.FAILURE;
             }
         } else {
             log.log(logLevel, "Downloading " + fileReference + " from " + address +
                     " (client " + fileReferenceDownload.client() + ") failed:" +
                     " error code " + request.errorCode() + " (" + request.errorMessage() + ")." +
                     " (retry " + retryCount + ", rpc timeout " + timeout + ")");
-            return false;
+            return request.errorCode() == ErrorCode.TIMEOUT ? DownloadResult.TIMEOUT : DownloadResult.FAILURE;
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds timeout tracking to file distribution RPC downloads: when consecutive timeouts exceed a configurable threshold, the connection is closed via `Target.close()` so `JRTConnection.getTarget()` reconnects automatically
- Adds `closeConnection()` to the `Connection` interface (default no-op) with implementation in `JRTConnection`
- Controlled by `VESPA_FILE_DOWNLOAD_MAX_TIMEOUTS_BEFORE_CLOSE` env var (default `0` = disabled)

## Details
When a file distribution RPC request times out, the underlying TCP connection may be stale (e.g., broken by a load balancer or network partition). Previously, the downloader would keep retrying on the same dead connection until the overall download timeout expired.

Now, `FileReferenceDownloader` returns a `DownloadResult` enum (`SUCCESS`/`TIMEOUT`/`FAILURE`) from `startDownloadRpc`. In `waitUntilDownloadStarted`, consecutive timeouts are tracked per connection. When the count reaches `maxTimeoutsBeforeClose`, the connection is closed and the counter resets. The connection pool's `switchConnection` on each retry naturally picks up a fresh connection.

## Test plan
- [x] `testConnectionCloseOnTimeout` — threshold=1, verifies close called for each timeout
- [x] `testConnectionCloseAfterNTimeouts` — threshold=2 with 6 timeouts, verifies 3 closes
- [x] `testNoConnectionCloseOnTimeoutByDefault` — threshold=0, verifies no closes
- [x] All existing `FileDownloaderTest` tests pass unchanged