### PR TITLE
Added logging of fetched config states in RestartOnDeployMaintainer

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/PendingRestarts.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/PendingRestarts.java
@@ -86,13 +86,17 @@ public class PendingRestarts {
         generationsForRestarts.forEach((g, hostnames) -> { if (generation >= g) ready.addAll(hostnames); });
         return ready;
     }
-
+    
     @Override
     public String toString() {
         return Text.format(
-                "generationsForRestarts=%s",
+                "generationsForRestarts={%s}",
                 generationsForRestarts().entrySet().stream()
-                        .map(entry -> Text.format("%d -> [%s]", entry.getKey(), String.join(", ", entry.getValue())))
+                        .sorted(Map.Entry.comparingByKey())
+                        .map(entry -> Text.format(
+                                "%d -> [%s]",
+                                entry.getKey(),
+                                entry.getValue().stream().sorted().collect(Collectors.joining(", "))))
                         .collect(Collectors.joining(", ")));
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/PendingRestarts.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/PendingRestarts.java
@@ -1,10 +1,13 @@
 package com.yahoo.vespa.config.server.application;
 
+import com.yahoo.text.Text;
+
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
@@ -82,5 +85,14 @@ public class PendingRestarts {
         LinkedHashSet<String> ready = new LinkedHashSet<>();
         generationsForRestarts.forEach((g, hostnames) -> { if (generation >= g) ready.addAll(hostnames); });
         return ready;
+    }
+
+    @Override
+    public String toString() {
+        return Text.format(
+                "generationsForRestarts=%s",
+                generationsForRestarts().entrySet().stream()
+                        .map(entry -> Text.format("%d -> [%s]", entry.getKey(), String.join(", ", entry.getValue())))
+                        .collect(Collectors.joining(", ")));
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
@@ -86,7 +86,7 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                                     log.log(
                                             Level.INFO,
                                             Text.format(
-                                                    "Failed to update pending restarts for %s: %s",
+                                                    "Failed to update pending restarts of %s: %s",
                                                     id.toFullString(), Exceptions.toMessageString(e)));
                                     failures.incrementAndGet();
                                 }
@@ -123,17 +123,16 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
             return restarts;
         }
 
-        log.fine(() -> Text.format(
-                "Pending restarts of %s: %s",
-                id.toFullString(),
-                restarts.toString()));
+        log.fine(() -> Text.format("Pending restarts of %s: %s", id.toFullString(), restarts.toString()));
 
         Map<String, List<ServiceConfigState>> configStates = serviceConfigStateFetcher.apply(restarts.hostnames());
 
         if (configStates.isEmpty()) {
-            log.fine(() -> Text.format("No services states of %s are fetched.", id.toFullString()));
+            log.fine(() -> Text.format("No service config states of %s are fetched.", id.toFullString()));
         } else {
-            log.fine(() -> configStatesToString(configStates));
+            log.fine(() -> Text.format(
+                    "Fetched service config states of %s for %s: %s",
+                    id.toFullString(), String.join(", ", restarts.hostnames()), configStatesToString(configStates)));
         }
 
         // Minimum observed config generation for all services without applyOnRestart across all pending restart nodes.
@@ -192,9 +191,10 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
 
         return restarts.withoutPreviousGenerations(readyGeneration);
     }
-    
+
     static String configStatesToString(Map<String, List<ServiceConfigState>> statesByHostname) {
         return statesByHostname.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> Text.format(
                         "%s -> [%s]",
                         entry.getKey(),

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
@@ -126,20 +126,20 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
         log.fine(() -> Text.format(
                 "Pending restarts of %s: %s",
                 id.toFullString(),
-                restarts.generationsForRestarts().entrySet().stream()
-                        .map(entry -> Text.format("%d -> [%s]", entry.getKey(), String.join(", ", entry.getValue())))
-                        .collect(Collectors.joining(", "))));
+                restarts.toString()));
 
-        Map<String, List<ServiceConfigState>> statesByHostname = serviceConfigStateFetcher.apply(restarts.hostnames());
+        Map<String, List<ServiceConfigState>> configStates = serviceConfigStateFetcher.apply(restarts.hostnames());
 
-        if (statesByHostname.isEmpty()) {
+        if (configStates.isEmpty()) {
             log.fine(() -> Text.format("No services states of %s are fetched.", id.toFullString()));
+        } else {
+            log.fine(() -> configStatesToString(configStates));
         }
 
         // Minimum observed config generation for all services without applyOnRestart across all pending restart nodes.
         // Services with applyOnRestart set to {@code true} are excluded because they are waiting for restart to apply a
         // new config and report a new config generation.
-        OptionalLong minObservedGeneration = statesByHostname.values().stream()
+        OptionalLong minObservedGeneration = configStates.values().stream()
                 .flatMap(List::stream)
                 .filter(state -> !state.applyOnRestart().orElse(false))
                 .mapToLong(ServiceConfigState::currentGeneration)
@@ -191,5 +191,21 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                 nodesToRestart.stream().sorted().collect(Collectors.joining(", "))));
 
         return restarts.withoutPreviousGenerations(readyGeneration);
+    }
+    
+    static String configStatesToString(Map<String, List<ServiceConfigState>> statesByHostname) {
+        return statesByHostname.entrySet().stream()
+                .map(entry -> Text.format(
+                        "%s -> [%s]",
+                        entry.getKey(),
+                        entry.getValue().stream()
+                                .map(state -> Text.format(
+                                        "{currentGeneration=%d, applyOnRestart=%s}",
+                                        state.currentGeneration(),
+                                        state.applyOnRestart()
+                                                .map(Object::toString)
+                                                .orElse("empty")))
+                                .collect(Collectors.joining(", "))))
+                .collect(Collectors.joining(", "));
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/PendingRestartsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/PendingRestartsTest.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.config.server.application;
 
 import org.junit.Test;
 
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,5 +40,21 @@ public class PendingRestartsTest {
         // Generation 2 should be unchanged (above threshold)
         assertTrue("Generation 2 should exist", generations.containsKey(2L));
         assertEquals("Generation 2 should be unchanged", Set.of("host2", "host4"), generations.get(2L));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("generationsForRestarts=", PendingRestarts.empty().toString());
+
+        Map<Long, Set<String>> generations = new LinkedHashMap<>();
+        Set<String> hosts1 = new LinkedHashSet<>();
+        hosts1.add("host1");
+        hosts1.add("host2");
+        generations.put(10L, hosts1);
+        generations.put(20L, Set.of("host3"));
+
+        PendingRestarts restarts = new PendingRestarts(generations);
+
+        assertEquals("generationsForRestarts=10 -> [host1, host2], 20 -> [host3]", restarts.toString());
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/PendingRestartsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/PendingRestartsTest.java
@@ -3,8 +3,6 @@ package com.yahoo.vespa.config.server.application;
 
 import org.junit.Test;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,17 +42,12 @@ public class PendingRestartsTest {
 
     @Test
     public void testToString() {
-        assertEquals("generationsForRestarts=", PendingRestarts.empty().toString());
+        assertEquals("generationsForRestarts={}", PendingRestarts.empty().toString());
 
-        Map<Long, Set<String>> generations = new LinkedHashMap<>();
-        Set<String> hosts1 = new LinkedHashSet<>();
-        hosts1.add("host1");
-        hosts1.add("host2");
-        generations.put(10L, hosts1);
-        generations.put(20L, Set.of("host3"));
+        PendingRestarts restarts = new PendingRestarts(Map.of(
+                10L, Set.of("host1", "host2"),
+                20L, Set.of("host3")));
 
-        PendingRestarts restarts = new PendingRestarts(generations);
-
-        assertEquals("generationsForRestarts=10 -> [host1, host2], 20 -> [host3]", restarts.toString());
+        assertEquals("generationsForRestarts={10 -> [host1, host2], 20 -> [host3]}", restarts.toString());
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
@@ -6,12 +6,14 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.config.server.application.PendingRestarts;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.configStatesToString;
 import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.triggerPendingRestarts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -160,5 +162,22 @@ class RestartOnDeployMaintainerTest {
                                         .withRestarts(3, List.of("c")),
                                 log)
                         .generationsForRestarts());
+    }
+
+    @Test
+    void test_statesByHostnameToString() {
+        assertEquals("", configStatesToString(Map.of()));
+
+        Map<String, List<ServiceConfigState>> states = new LinkedHashMap<>();
+        states.put("host1", List.of(
+                new ServiceConfigState(10, Optional.of(true)),
+                new ServiceConfigState(11, Optional.of(false))));
+        states.put("host2", List.of(
+                new ServiceConfigState(20, Optional.empty()),
+                new ServiceConfigState(21, Optional.of(true))));
+
+        assertEquals(
+                "host1 -> [{currentGeneration=10, applyOnRestart=true}, {currentGeneration=11, applyOnRestart=false}], host2 -> [{currentGeneration=20, applyOnRestart=empty}, {currentGeneration=21, applyOnRestart=true}]",
+                configStatesToString(states));
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.config.server.application.PendingRestarts;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -168,16 +167,18 @@ class RestartOnDeployMaintainerTest {
     void test_statesByHostnameToString() {
         assertEquals("", configStatesToString(Map.of()));
 
-        Map<String, List<ServiceConfigState>> states = new LinkedHashMap<>();
-        states.put("host1", List.of(
-                new ServiceConfigState(10, Optional.of(true)),
-                new ServiceConfigState(11, Optional.of(false))));
-        states.put("host2", List.of(
-                new ServiceConfigState(20, Optional.empty()),
-                new ServiceConfigState(21, Optional.of(true))));
-
         assertEquals(
-                "host1 -> [{currentGeneration=10, applyOnRestart=true}, {currentGeneration=11, applyOnRestart=false}], host2 -> [{currentGeneration=20, applyOnRestart=empty}, {currentGeneration=21, applyOnRestart=true}]",
-                configStatesToString(states));
+                "host1 -> [{currentGeneration=10, applyOnRestart=true}, {currentGeneration=11, applyOnRestart=false}],"
+                        + " host2 -> [{currentGeneration=20, applyOnRestart=empty}, {currentGeneration=21,"
+                        + " applyOnRestart=true}]",
+                configStatesToString(Map.of(
+                        "host1",
+                                List.of(
+                                        new ServiceConfigState(10, Optional.of(true)),
+                                        new ServiceConfigState(11, Optional.of(false))),
+                        "host2",
+                                List.of(
+                                        new ServiceConfigState(20, Optional.empty()),
+                                        new ServiceConfigState(21, Optional.of(true))))));
     }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

- Added even more logging to RestartOnDeployMaintainer
- Minor renaming