### PR TITLE
Replace restart on deploy in onnx calculator with defer until restart in restart action

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ConfigChangeAction;
+import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.model.api.OnnxModelCost;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
@@ -18,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import static com.yahoo.config.model.api.ConfigChangeRestartAction.ConfigChange.DEFER_UNTIL_RESTART;
 import static com.yahoo.config.model.api.OnnxModelCost.ModelInfo;
 import static com.yahoo.vespa.model.application.validation.JvmHeapSizeValidator.gbLimit;
 import static com.yahoo.vespa.model.application.validation.JvmHeapSizeValidator.percentLimit;
@@ -96,9 +98,13 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
 
     private static void setRestartOnDeployAndAddRestartAction(List<ConfigChangeAction> actions, ApplicationContainerCluster cluster, String message) {
         log.log(INFO, message);
-        cluster.onnxModelCostCalculator().setRestartOnDeploy();
-        cluster.onnxModelCostCalculator().store();
-        actions.add(new VespaRestartAction(cluster.id(), message, cluster.getContainers().stream().map(AbstractService::getServiceInfo).toList()));
+        actions.add(new VespaRestartAction(
+                cluster.id(),
+                message,
+                cluster.getContainers().stream()
+                        .map(AbstractService::getServiceInfo)
+                        .toList(),
+                DEFER_UNTIL_RESTART));
     }
 
     private static boolean enoughMemoryToAvoidRestart(ApplicationContainerCluster clusterInCurrentModel,

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidatorTest.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.model.api.ApplicationClusterEndpoint;
 import com.yahoo.config.model.api.ConfigChangeAction;
+import com.yahoo.config.model.api.ConfigChangeRestartAction.ConfigChange;
 import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.OnnxModelCost;
 import com.yahoo.config.model.api.OnnxModelOptions;
@@ -54,6 +55,10 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
         assertEquals(1, result.size());
         assertTrue(result.get(0).validationId().isEmpty());
         assertEquals("Onnx model 'https://data.vespa-cloud.com/onnx_models/e5-base-v2/model.onnx' has changed (estimated cost), need to restart services in container cluster 'cluster1'", result.get(0).getMessage());
+        assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        var restartAction = (VespaRestartAction) result.get(0);
+        assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
     }
 
     @Test
@@ -72,6 +77,10 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
         List<ConfigChangeAction> result = validateModel(current, next);
         assertEquals(1, result.size());
         assertStartsWith("Onnx model 'https://data.vespa-cloud.com/onnx_models/e5-base-v2/model.onnx' has changed (model hash)", result);
+        assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        var restartAction = (VespaRestartAction) result.get(0);
+        assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
     }
 
     @Test
@@ -81,6 +90,10 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
         List<ConfigChangeAction> result = validateModel(current, next);
         assertEquals(1, result.size());
         assertStartsWith("Onnx model 'https://data.vespa-cloud.com/onnx_models/e5-base-v2/model.onnx' has changed (model option(s))", result);
+        assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        var restartAction = (VespaRestartAction) result.get(0);
+        assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
     }
 
     @Test
@@ -92,6 +105,10 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
         assertStartsWith("Onnx model set has changed from [https://data.vespa-cloud.com/onnx_models/e5-base-v2/model.onnx] " +
                                  "to [https://data.vespa-cloud.com/onnx_models/e5-small-v2/model.onnx",
                          result);
+        assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        var restartAction = (VespaRestartAction) result.get(0);
+        assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
     }
 
     private static List<ConfigChangeAction> validateModel(VespaModel current, VespaModel next) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Defer until restart in restart action is a recently implemented general mechanism to handle reconfiguration on restart, used by other validator. It makes sense to use it for onnx model change as well instead of restart on deploy stored in onnx model calculator. This might help resolve some of the issues we have with reconfiguration of onnx models.

FYI @hmusum @olaaun
Revert this if it start causing troubles in system and integration tests involving onnx models.
