### PR TITLE
Respect tokenizer.json padding settings in HuggingFaceEmbedder

### DIFF
--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import static com.yahoo.language.huggingface.ModelInfo.PaddingStrategy.DO_NOT_PAD;
 import static com.yahoo.language.huggingface.ModelInfo.TruncationStrategy.LONGEST_FIRST;
 
 @Beta
@@ -110,11 +111,11 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
         prependQuery = embedderConfig.prependQuery();
         prependDocument = embedderConfig.prependDocument();
         var tokenizerPath = modelHelper.getModelPathResolvingIfNecessary(embedderConfig.tokenizerPathReference());
+        var info = HuggingFaceTokenizer.getModelInfo(tokenizerPath);
         var builder = new HuggingFaceTokenizer.Builder()
                 .addSpecialTokens(true)
                 .addDefaultModel(tokenizerPath)
-                .setPadding(false);
-        var info = HuggingFaceTokenizer.getModelInfo(tokenizerPath);
+                .setPadding(info.padding() != DO_NOT_PAD);
         log.fine(() -> Text.format("'%s' has info '%s'", tokenizerPath, info));
         if (info.maxLength() == -1 || info.truncation() != LONGEST_FIRST) {
             // Force truncation to max token vector length accepted by model if tokenizer.json contains no valid truncation configuration


### PR DESCRIPTION
Fix #35600

## Summary
HuggingFaceEmbedder hardcoded `.setPadding(false)`, ignoring padding configuration from `tokenizer.json`. Models like `siglip2-base-patch16-384` that require fixed-length padding produced incorrect embeddings.

Replace hardcoded `false` with `info.padding() != DO_NOT_PAD`, which comes from the tokenizer's own metadata via `ModelInfo`.

Backwards compatible: existing tokenizers without padding config have `padding == DO_NOT_PAD`, producing the same `setPadding(false)` as before.

## Changes
- `HuggingFaceEmbedder.java`: `.setPadding(false)` → `.setPadding(info.padding() != DO_NOT_PAD)`

I've also included a test (`testPadding()` in `HuggingFaceEmbedderTest`) and a test fixture (`tokenizer_with_padding.json`) to verify the fix. I can adjust or remove these if you prefer a different testing approach.

## Test plan
- [x] New `testPadding()` verifies padded tokenizer produces 10 tokens, unpadded produces 6
- [x] All 20 existing embedder tests pass (HuggingFace, ColBert, Splade)

---
Claude Code has been used to assist with this PR.