### PR TITLE
Add responseJsonSchema config parameter to LanguageModelFieldGenerator

### DIFF
--- a/model-integration/abi-spec.json
+++ b/model-integration/abi-spec.json
@@ -414,6 +414,7 @@
       "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$Builder promptTemplate(java.lang.String)",
       "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$Builder promptTemplateFile(java.util.Optional)",
       "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$Builder responseFormatType(ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$ResponseFormatType$Enum)",
+      "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$Builder responseJsonSchema(java.lang.String)",
       "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$Builder invalidResponseFormatPolicy(ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$InvalidResponseFormatPolicy$Enum)",
       "public final boolean dispatchGetConfig(com.yahoo.config.ConfigInstance$Producer)",
       "public final java.lang.String getDefMd5()",
@@ -524,6 +525,7 @@
       "public java.lang.String promptTemplate()",
       "public java.util.Optional promptTemplateFile()",
       "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$ResponseFormatType$Enum responseFormatType()",
+      "public java.lang.String responseJsonSchema()",
       "public ai.vespa.llm.generation.LanguageModelFieldGeneratorConfig$InvalidResponseFormatPolicy$Enum invalidResponseFormatPolicy()"
     ],
     "fields" : [

--- a/model-integration/src/main/java/ai/vespa/llm/generation/LanguageModelFieldGenerator.java
+++ b/model-integration/src/main/java/ai/vespa/llm/generation/LanguageModelFieldGenerator.java
@@ -36,12 +36,14 @@ public class LanguageModelFieldGenerator extends AbstractComponent implements Fi
 
     private final LanguageModelFieldGeneratorConfig config;
     private final String promptTemplate;
-    
+    private final String responseJsonSchema;
+
     @Inject
     public LanguageModelFieldGenerator(LanguageModelFieldGeneratorConfig config, ComponentRegistry<LanguageModel> languageModels) {
         this.languageModel = LanguageModelUtils.findLanguageModel(config.providerId(), languageModels, logger);
         this.config = config;
         this.promptTemplate = loadPromptTemplate(config);
+        this.responseJsonSchema = config.responseJsonSchema().isEmpty() ? null : config.responseJsonSchema();
     }
 
     private String loadPromptTemplate(LanguageModelFieldGeneratorConfig config) {
@@ -79,7 +81,9 @@ public class LanguageModelFieldGenerator extends AbstractComponent implements Fi
         String jsonSchema = null;
         
         if (config.responseFormatType() == LanguageModelFieldGeneratorConfig.ResponseFormatType.JSON) {
-            jsonSchema = FieldGeneratorUtils.generateJsonSchemaForField(destination, targetType);
+            jsonSchema = (responseJsonSchema != null)
+                    ? responseJsonSchema
+                    : FieldGeneratorUtils.generateJsonSchemaForField(destination, targetType);
             options.put(InferenceParameters.OPTION_JSON_SCHEMA, jsonSchema);
         }
         

--- a/model-integration/src/main/resources/configdefinitions/language-model-field-generator.def
+++ b/model-integration/src/main/resources/configdefinitions/language-model-field-generator.def
@@ -23,6 +23,10 @@ promptTemplateFile path optional
 # TEXT - text output, useful for LLMs that have poor support for structured output, e.g. when using tiny (and dumb) LLMs for testing.
 responseFormatType enum {JSON, TEXT} default=JSON
 
+# JSON schema for structured output.
+# Overrides the schema auto-generated from the target field type.
+responseJsonSchema string default=""
+
 # Defines what to do when the response is not in the expected format.
 # DISCARD - discard the response and return null.
 # WARN - discard the response, return null and log a warning.

--- a/model-integration/src/test/java/ai/vespa/llm/generation/LanguageModelFieldGeneratorTest.java
+++ b/model-integration/src/test/java/ai/vespa/llm/generation/LanguageModelFieldGeneratorTest.java
@@ -14,7 +14,6 @@ import com.yahoo.text.Text;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -188,7 +187,39 @@ public class LanguageModelFieldGeneratorTest {
         var result1 = generator.generate(StringPrompt.from("world"), context);
         assertEquals("bye world bye world", result1.toString());
     }
-    
+
+    @Test
+    public void testGenerateWithResponseJsonSchema() {
+        var languageModel = new CaptureCompleteArgsLanguageModel();
+        Map<String, LanguageModel> languageModels = Map.of("languageModel", languageModel);
+
+        var customSchema = """
+            {
+              "type": "object",
+              "properties": {
+                "doc.text": {
+                  "type": "string",
+                  "enum": ["electronics", "clothing"]
+                }
+              },
+              "required": ["doc.text"],
+              "additionalProperties": false
+            }
+            """;
+        var config = new LanguageModelFieldGeneratorConfig.Builder()
+                .providerId("languageModel")
+                .responseJsonSchema(customSchema)
+                .build();
+        var generator = createGenerator(config, languageModels);
+        var context = new FieldGenerator.Context("doc.text", DataType.STRING);
+        generator.generate(StringPrompt.from("hello"), context);
+
+        // Verify the schema was passed to the language model
+        assertEquals(
+                customSchema,
+                languageModel.lastCompleteParams.get(InferenceParameters.OPTION_JSON_SCHEMA).orElseThrow());
+    }
+
     @Test
     public void testGenerateWithLocalLLM() {
         var localLLMPath = "src/test/models/llm/tinyllm.gguf";
@@ -340,6 +371,25 @@ public class LanguageModelFieldGeneratorTest {
         public List<Completion> complete(Prompt prompt, InferenceParameters params) {
             var invalidJson = "{doc.text:: test347ukdrjfhds";
             return List.of(Completion.from(invalidJson));
+        }
+
+        @Override
+        public CompletableFuture<Completion.FinishReason> completeAsync(Prompt prompt,
+                                                                        InferenceParameters params,
+                                                                        Consumer<Completion> consumer) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class CaptureCompleteArgsLanguageModel implements LanguageModel {
+        public Prompt lastCompletePrompt;
+        public InferenceParameters lastCompleteParams;
+
+        @Override
+        public List<Completion> complete(Prompt prompt, InferenceParameters params) {
+            this.lastCompletePrompt = prompt;
+            this.lastCompleteParams = params;
+            return List.of(Completion.from(""));
         }
 
         @Override


### PR DESCRIPTION
## Summary
Adds a `responseJsonSchema` config parameter to allow custom JSON schema for structured output at feed time, as proposed in #35826. Invalid or malformed schemas are handled downstream by the LLM client, consistent with how auto-generated schemas are treated today.

This should be a minimal implementation based on a requested feature, understandable if it's not needed right now @glebashnik.

## Changes
- Add `responseJsonSchema string default=""` to `language-model-field-generator.def`
- When set, use it instead of the schema auto-generated from the target field type

Claude Code has been used to assist with this PR.