### PR TITLE
Add back 'handler' dimension to handled.latency metric [MERGEOK]

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/core/HandlerMetricContextUtil.java
+++ b/container-disc/src/main/java/com/yahoo/container/core/HandlerMetricContextUtil.java
@@ -4,9 +4,12 @@ package com.yahoo.container.core;
 import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.Request;
+import com.yahoo.jdisc.application.BindingMatch;
+import com.yahoo.jdisc.application.UriPattern;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -19,7 +22,7 @@ public class HandlerMetricContextUtil {
 
     private static final String HANDLER_START_TIME_ATTRIBUTE = HandlerMetricContextUtil.class.getName() + ".startTime";
 
-    private record MetricContextKey(String handlerClassName, int port) {}
+    private record MetricContextKey(String handlerBinding, String handlerClassName, int port) {}
 
     private final ConcurrentHashMap<MetricContextKey, Metric.Context> metricContexts = new ConcurrentHashMap<>();
     private final Metric metric;
@@ -47,13 +50,22 @@ public class HandlerMetricContextUtil {
 
     private Metric.Context contextFor(Request request) {
         return metricContexts.computeIfAbsent(
-                new MetricContextKey(handlerClassName, request.getUri().getPort()),
+                new MetricContextKey(handlerBinding(request).orElse(null), handlerClassName, request.getUri().getPort()),
                 key -> {
                     Map<String, String> dimensions = new HashMap<>();
+                    if (key.handlerBinding != null) dimensions.put("handler", key.handlerBinding);
                     dimensions.put("handler-name", key.handlerClassName);
                     dimensions.put("port", String.valueOf(key.port));
                     return metric.createContext(dimensions);
                 }
         );
+    }
+
+    private static Optional<String> handlerBinding(Request request) {
+        BindingMatch<?> match = request.getBindingMatch();
+        if (match == null) return Optional.empty();
+        UriPattern matched = match.matched();
+        if (matched == null) return Optional.empty();
+        return Optional.ofNullable(matched.toString());
     }
 }


### PR DESCRIPTION
## Summary
- Restore the `handler` dimension (URI binding pattern) to `handled.latency`, `handled.requests`, and `jdisc.http.handler.unhandled_exceptions` metrics
- This dimension was accidentally removed in d6cbf588 alongside the intentional removal of the `endpoint` dimension