### PR TITLE
Fix thread safety bug in WordPieceEmbedder

### DIFF
--- a/linguistics-components/src/main/java/com/yahoo/language/wordpiece/WordPieceEmbedder.java
+++ b/linguistics-components/src/main/java/com/yahoo/language/wordpiece/WordPieceEmbedder.java
@@ -8,7 +8,6 @@ import com.yahoo.language.tools.Embed;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.Segmenter;
-import com.yahoo.language.process.Tokenizer;
 import com.yahoo.language.simple.SimpleLinguistics;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
@@ -32,7 +31,7 @@ public class WordPieceEmbedder implements Embedder, Segmenter {
 
     private final Map<Language, Model> models;
 
-    private final Tokenizer tokenizer;
+    private final SimpleLinguistics linguistics;
 
     @Inject
     public WordPieceEmbedder(WordPieceConfig config) {
@@ -41,7 +40,7 @@ public class WordPieceEmbedder implements Embedder, Segmenter {
 
     private WordPieceEmbedder(Builder builder) {
         super();
-        this.tokenizer = new SimpleLinguistics().getTokenizer(); // always just split on spaces etc. and lowercase
+        this.linguistics = new SimpleLinguistics(); // always just split on spaces etc. and lowercase
         models = builder.getModels().entrySet()
                         .stream()
                         .map(e -> new Model(builder.getSubwordPrefix(), e.getKey(), e.getValue()))
@@ -58,7 +57,7 @@ public class WordPieceEmbedder implements Embedder, Segmenter {
      */
     @Override
     public List<String> segment(String text, LinguisticsParameters parameters) {
-        return resolveModelFrom(parameters.language()).segment(text, tokenizer, parameters);
+        return resolveModelFrom(parameters.language()).segment(text, linguistics.getTokenizer(), parameters);
     }
 
     /**
@@ -70,7 +69,7 @@ public class WordPieceEmbedder implements Embedder, Segmenter {
      */
     @Override
     public List<Integer> embed(String text, Context context) {
-        return resolveModelFrom(context.getLanguage()).embed(text, tokenizer,
+        return resolveModelFrom(context.getLanguage()).embed(text, linguistics.getTokenizer(),
                                                              new LinguisticsParameters(null,
                                                                                        context.getLanguage(),
                                                                                        StemMode.ALL, true, true));


### PR DESCRIPTION
WordPieceEmbedder stored a single SimpleTokenizer as a field, shared across all document processing threads. SimpleTokenizer contains a KStemmer with mutable instance state (word buffer, index variables) that is modified during each stem() call. Concurrent access corrupts these variables, causing ArrayIndexOutOfBoundsException in production.

Fix by storing the SimpleLinguistics factory (which is thread-safe) and calling getTokenizer() at each use site to get a fresh per-call instance. This follows the Linguistics interface contract: "the processors returned by the factory methods do not [need to be thread safe]. Clients should request separate processor instances for each thread."

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
