### PR TITLE
Always install CloudAsmSecrets in hosted public cloud

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -339,6 +339,11 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private void addSecrets(ApplicationContainerCluster cluster, Element spec, DeployState deployState) {
         if ( ! deployState.isHosted() || ! cluster.getZone().system().isPublicCloudLike())
             return;
+        cluster.addComponent(new CloudAsmSecrets(deployState.getProperties().ztsUrl(),
+                                                 deployState.getProperties().tenantSecretDomain(),
+                                                 deployState.zone().system(),
+                                                 deployState.getProperties().applicationId().tenant(),
+                                                 deployState.getProperties().tenantVaults()));
         Element secretsElement = XML.getChild(spec, "secrets");
         if (secretsElement != null) {
             CloudSecrets secretsConfig = new CloudSecrets();
@@ -349,11 +354,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                 secretsConfig.addSecret(key, name, vault);
             }
             cluster.setTenantSecretsConfig(secretsConfig);
-            cluster.addComponent(new CloudAsmSecrets(deployState.getProperties().ztsUrl(),
-                                                     deployState.getProperties().tenantSecretDomain(),
-                                                     deployState.zone().system(),
-                                                     deployState.getProperties().applicationId().tenant(),
-                                                     deployState.getProperties().tenantVaults()));
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SecretsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SecretsTest.java
@@ -20,6 +20,7 @@ import org.w3c.dom.Element;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -34,8 +35,20 @@ public class SecretsTest extends ContainerModelBuilderTestBase {
     void testCloudSecretsNeedHosted() {
         createModel(root, containerXml());
         ApplicationContainerCluster container = getContainerCluster("container");
-        Component<?, ?> component = container.getComponentsMap().get(ComponentId.fromString(SECRETS_IMPL_ID));
-        assertNull(component);
+        assertNull(container.getComponentsMap().get(ComponentId.fromString(SECRETS_IMPL_ID)));
+        assertNull(container.getComponentsMap().get(ComponentId.fromString(CloudAsmSecrets.CLASS)));
+    }
+
+    @Test
+    void cloud_asm_secrets_always_installed_in_hosted() {
+        DeployState state = new DeployState.Builder()
+                .properties(new TestProperties().setHostedVespa(true))
+                .zone(new Zone(SystemName.Public, Environment.prod, RegionName.defaultName()))
+                .build();
+        createModel(root, state, null, containerXmlWithoutSecrets());
+        ApplicationContainerCluster container = getContainerCluster("container");
+        assertNotNull(container.getComponentsMap().get(ComponentId.fromString(CloudAsmSecrets.CLASS)));
+        assertNull(container.getComponentsMap().get(ComponentId.fromString(SECRETS_IMPL_ID)));
     }
 
     @Test
@@ -117,6 +130,10 @@ public class SecretsTest extends ContainerModelBuilderTestBase {
                 "    <openAiApiKey vault='prod' name='openai-apikey' />",
                 "  </secrets>",
                 "</container>");
+    }
+
+    private static Element containerXmlWithoutSecrets() {
+        return DomBuilderTest.parse("<container version='1.0' />");
     }
 
 }


### PR DESCRIPTION
## Summary

- Install `CloudAsmSecrets` unconditionally in hosted public cloud, even when customer has not configured `<secrets>` in services.xml
- `CloudSecrets` (key-to-vault mapping) is still only added when `<secrets>` is explicitly configured

This should improve feedback to user when when deploying an application with reference to a secret (but not vault in secret store). This would earlier give a hard-to-understand error message and hanging deployment.