### PR TITLE
Check HTTP status code before parsing health response as JSON

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcher.java
@@ -37,6 +37,12 @@ public class RemoteHealthStatusFetcher extends HttpMetricFetcher {
         try (CloseableHttpResponse response = getResponse()) {
             HttpEntity entity = response.getEntity();
             try {
+                int statusCode = response.getCode();
+                if (statusCode != 200) {
+                    EntityUtils.consumeQuietly(entity);
+                    log.log(FINE, () -> "Got status code " + statusCode + " for health page of service '" + service + "'");
+                    return HealthMetric.getUnknown("Got status code " + statusCode);
+                }
                 return parse(new BufferedInputStream(entity.getContent(), HttpMetricFetcher.BUFFER_SIZE));
             } catch (Exception e) {
                 handleException(e, entity.getContentType(), fetchCount);

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MockHttpServer.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MockHttpServer.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 public final class MockHttpServer {
 
     private String response;
+    private int statusCode = 200;
     private final HttpServer server;
 
     /**
@@ -37,6 +38,10 @@ public final class MockHttpServer {
         this.response = r;
     }
 
+    public synchronized void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
     public int port() {
         return server.getAddress().getPort();
     }
@@ -49,7 +54,7 @@ public final class MockHttpServer {
         @Override
         public void handle(HttpExchange t) throws IOException {
             synchronized (MockHttpServer.this) {
-                t.sendResponseHeaders(200, response != null ? response.length() : 0);
+                t.sendResponseHeaders(statusCode, response != null ? response.length() : 0);
                 try (OutputStream os = t.getResponseBody()) {
                     if (response != null) os.write(response.getBytes(StandardCharsets.UTF_8));
                 }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcherTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcherTest.java
@@ -2,6 +2,7 @@ package ai.vespa.metricsproxy.service;
 
 import ai.vespa.metricsproxy.metric.HealthMetric;
 import ai.vespa.metricsproxy.metric.model.StatusCode;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -14,7 +15,32 @@ import static org.junit.Assert.assertTrue;
 
 public class RemoteHealthStatusFetcherTest {
 
+  private static final String HEALTH_PATH = "/state/v1/health";
+
   private final RemoteHealthStatusFetcher fetcher = new RemoteHealthStatusFetcher(null, 0);
+
+  @BeforeClass
+  public static void setup() {
+    HttpMetricFetcher.CONNECTION_TIMEOUT = 60000;
+  }
+
+  @Test
+  public void testNon200ResponseReturnsUnknownWithoutParsingBody() throws IOException {
+    MockHttpServer httpServer = new MockHttpServer("{\"status\": {\"code\": \"UP\"}}", HEALTH_PATH);
+    try {
+      httpServer.setResponse("<html><body>Service not available</body></html>");
+      httpServer.setStatusCode(503);
+
+      VespaService service = VespaService.create("service1", "id", httpServer.port());
+      RemoteHealthStatusFetcher healthFetcher = new RemoteHealthStatusFetcher(service, httpServer.port());
+      HealthMetric result = healthFetcher.getHealth(1);
+
+      assertEquals(StatusCode.UNKNOWN, result.getStatus());
+      assertTrue(result.getMessage().contains("503"));
+    } finally {
+      httpServer.close();
+    }
+  }
 
   @Test
   public void testParseValidJson() {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcherTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/RemoteHealthStatusFetcherTest.java
@@ -1,3 +1,4 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.service;
 
 import ai.vespa.metricsproxy.metric.HealthMetric;


### PR DESCRIPTION
RemoteHealthStatusFetcher would attempt to parse any HTTP response body as JSON, including HTML error pages from services that aren't ready yet. This caused noisy log spam with useless InputStream.toString() output. Now check for non-200 status codes first and return UNKNOWN status directly, logging at FINE level since this is expected during startup.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
