### PR TITLE
Add SecretName.isValid() for checking name validity without throwing

### DIFF
--- a/container-disc/src/main/java/ai/vespa/secret/model/SecretName.java
+++ b/container-disc/src/main/java/ai/vespa/secret/model/SecretName.java
@@ -20,4 +20,8 @@ public class SecretName extends PatternedStringWrapper<SecretName> {
         return new SecretName(name);
     }
 
+    public static boolean isValid(String name) {
+        return namePattern.matcher(name).matches();
+    }
+
 }

--- a/container-disc/src/test/java/ai/vespa/secret/model/SecretNameTest.java
+++ b/container-disc/src/test/java/ai/vespa/secret/model/SecretNameTest.java
@@ -2,7 +2,9 @@ package ai.vespa.secret.model;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author gjoranv
@@ -22,6 +24,15 @@ public class SecretNameTest {
 
         for (char c : "+/$ {}[]()!\"@#?\\'".toCharArray())
             assertThrows(IllegalArgumentException.class, () -> SecretName.of("foo" + c + "bar"));
+    }
+
+    @Test
+    void testIsValid() {
+        assertTrue(SecretName.isValid("foo-bar"));
+        assertTrue(SecretName.isValid("my.secret_name-1"));
+        assertFalse(SecretName.isValid("dev/aws_access_key_id"));
+        assertFalse(SecretName.isValid(""));
+        assertFalse(SecretName.isValid("foo bar"));
     }
 
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
