### PR TITLE
Remove commons-io dependency from vespa-application-maven-plugin

### DIFF
--- a/vespa-application-maven-plugin/pom.xml
+++ b/vespa-application-maven-plugin/pom.xml
@@ -47,10 +47,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -1,11 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.plugin.mojo;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.IOFileFilter;
-import org.apache.commons.io.filefilter.NameFileFilter;
-import org.apache.commons.io.filefilter.NotFileFilter;
-import org.apache.commons.io.filefilter.OrFileFilter;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -21,6 +16,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Locale;
 
@@ -132,19 +129,29 @@ public class ApplicationMojo extends AbstractMojo {
     private void copyApplicationPackage(File applicationPackage, File applicationDestination) throws MojoExecutionException {
         if (applicationPackage.exists()) {
             try {
-                FileUtils.copyDirectory(applicationPackage, applicationDestination, ignoredFilesFilter());
+                copyDirectory(applicationPackage.toPath(), applicationDestination.toPath(), ignoredFilesFilter());
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed copying applicationPackage", e);
             }
         }
     }
 
+    private static void copyDirectory(Path source, Path destination, FileFilter filter) throws IOException {
+        try (var stream = Files.walk(source)) {
+            for (Path path : (Iterable<Path>) stream::iterator) {
+                if (!filter.accept(path.toFile())) continue;
+                Path target = destination.resolve(source.relativize(path));
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.copy(path, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+
     static FileFilter ignoredFilesFilter() {
-        var ioFileFilters = IGNORED_FILES.stream()
-                .map(NameFileFilter::new)
-                .map(IOFileFilter.class::cast)
-                .toList();
-        return new NotFileFilter(new OrFileFilter(ioFileFilters));
+        return file -> !IGNORED_FILES.contains(file.getName());
     }
 
     private void copyModuleBundles(File moduleDir, File componentsDir) throws MojoExecutionException {


### PR DESCRIPTION
## Summary
- Replace `FileUtils.copyDirectory()` with standard Java NIO `Files.walk()`
- Simplify `ignoredFilesFilter()` to a single lambda
- Remove `commons-io` from pom.xml

## Test plan
- [x] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)