### PR TITLE
Fix binaryQuantization method to also handle sentenceEmbedder (2D)

### DIFF
--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
@@ -214,7 +214,8 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
     }
 
     private Tensor binaryQuantization(HuggingFaceEmbedder.HFEmbeddingResult embeddingResult, TensorType targetType) {
-        long outputDimensions = embeddingResult.output().shape()[2];
+        long[] shape = embeddingResult.output().shape();
+        long outputDimensions = shape[shape.length - 1];
         long targetDimensions = targetType.dimensions().get(0).size().get();
         //🪆 flexibility - packing only the first 8*targetDimension float values from the model output
         long targetUnpackagedDimensions = 8 * targetDimensions;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Some huggingface-embedders are 2D, with config:
```xml
<transformer-output>sentence_embedding</transformer-output>
<pooling-strategy>none</pooling-strategy>
```
Before this, for such embedders, we get 

`Error: 500 Server Error from container at abc.def.z.vespa-app.cloud`
```json
{
    "root": {
        "id": "toplevel",
        "relevance": 1.0,
        "fields": {
            "totalCount": 0
        },
        "errors": [
            {
                "code": 18,
                "summary": "Internal server error.",
                "message": "Index 2 out of bounds for length 2"
            }
        ]
    }
}
```

when running a query where embedding should be binarized.

For example with:

```
rank-profile default {
     inputs {
       query(q) tensor<int8>(x[128])
     }
```

Log in container: 

```txt
Failed handling com.yahoo.container.jdisc.HttpRequest
exception=
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at ai.vespa.embedding.HuggingFaceEmbedder.binaryQuantization(HuggingFaceEmbedder.java:217)
	at ai.vespa.embedding.HuggingFaceEmbedder.embed(HuggingFaceEmbedder.java:162)
	at com.yahoo.search.schema.internal.TensorConverter.embed(TensorConverter.java:106)
	at com.yahoo.search.schema.internal.TensorConverter.toTensor(TensorConverter.java:54)
	at com.yahoo.search.schema.internal.TensorConverter.convertTo(TensorConverter.java:44)
	at com.yahoo.search.query.properties.RankProfileInputProperties.set(RankProfileInputProperties.java:49)
	at com.yahoo.processing.request.Properties.set(Properties.java:187)
	at com.yahoo.search.query.properties.PropertyAliases.set(PropertyAliases.java:60)
	at com.yahoo.search.Query.setAllValuesFrom(Query.java:480)
	at com.yahoo.search.Query.setGenericMapFrom(Query.java:464)
```