### PR TITLE
Cleanup remove unused bool return in expressions

### DIFF
--- a/searchlib/src/tests/aggregator/attr_test.cpp
+++ b/searchlib/src/tests/aggregator/attr_test.cpp
@@ -127,9 +127,9 @@ TEST(AttrTest, testArrayAt) {
         et.select(treeConf, treeConf);
         EXPECT_TRUE(et.getResult()->getClass().inherits(FloatResultNode::classId));
 
-        EXPECT_TRUE(et.execute(0, HitRank(0.0)));
+        ASSERT_NO_THROW(et.execute(0, HitRank(0.0)));
         EXPECT_EQ(et.getResult()->getFloat(), f1.doc0attr[i]);
-        EXPECT_TRUE(et.execute(1, HitRank(0.0)));
+        ASSERT_NO_THROW(et.execute(1, HitRank(0.0)));
         EXPECT_EQ(et.getResult()->getFloat(), f1.doc1attr[i]);
     }
 }
@@ -146,9 +146,9 @@ TEST(AttrTest, testArrayAtInt) {
         et.select(treeConf, treeConf);
         EXPECT_TRUE(et.getResult()->getClass().inherits(IntegerResultNode::classId));
 
-        EXPECT_TRUE(et.execute(0, HitRank(0.0)));
+        ASSERT_NO_THROW(et.execute(0, HitRank(0.0)));
         EXPECT_EQ(et.getResult()->getInteger(), f1.doc0attr[i]);
-        EXPECT_TRUE(et.execute(1, HitRank(0.0)));
+        ASSERT_NO_THROW(et.execute(1, HitRank(0.0)));
         EXPECT_EQ(static_cast<double>(et.getResult()->getInteger()), f1.doc1attr[i]);
     }
 }
@@ -164,10 +164,10 @@ TEST(AttrTest, testArrayAtString) {
     char mem[64];
     ResultNode::BufferRef buf(&mem, sizeof(mem));
 
-    EXPECT_TRUE(et.execute(0, HitRank(0.0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0.0)));
     EXPECT_EQ(et.getResult()->getString(buf).c_str(), std::string("333"));
 
-    EXPECT_TRUE(et.execute(1, HitRank(0.0)));
+    ASSERT_NO_THROW(et.execute(1, HitRank(0.0)));
     EXPECT_EQ(et.getResult()->getString(buf).c_str(), std::string("4444"));
 }
 
@@ -190,9 +190,9 @@ TEST(AttrTest, testArrayAtBelowRange) {
     ArrayAtExpressionFixture f1(-1);
     EXPECT_TRUE(f1.et.getResult()->getClass().inherits(FloatResultNode::classId));
 
-    EXPECT_TRUE(f1.et.execute(0, HitRank(0.0)));
+    ASSERT_NO_THROW(f1.et.execute(0, HitRank(0.0)));
     EXPECT_EQ(f1.et.getResult()->getFloat(), f1.doc0attr[0]);
-    EXPECT_TRUE(f1.et.execute(1, HitRank(0.0)));
+    ASSERT_NO_THROW(f1.et.execute(1, HitRank(0.0)));
     EXPECT_EQ(f1.et.getResult()->getFloat(), f1.doc1attr[0]);
 }
 
@@ -200,9 +200,9 @@ TEST(AttrTest, testArrayAtAboveRange) {
     ArrayAtExpressionFixture f1(17);
     EXPECT_TRUE(f1.et.getResult()->getClass().inherits(FloatResultNode::classId));
 
-    EXPECT_TRUE(f1.et.execute(0, HitRank(0.0)));
+    ASSERT_NO_THROW(f1.et.execute(0, HitRank(0.0)));
     EXPECT_EQ(f1.et.getResult()->getFloat(), f1.doc0attr[10]);
-    EXPECT_TRUE(f1.et.execute(1, HitRank(0.0)));
+    ASSERT_NO_THROW(f1.et.execute(1, HitRank(0.0)));
     EXPECT_EQ(f1.et.getResult()->getFloat(), f1.doc1attr[10]);
 }
 
@@ -214,10 +214,10 @@ TEST(AttrTest, testInterpolatedLookup) {
 
     EXPECT_TRUE(et.getResult()->getClass().inherits(FloatResultNode::classId));
 
-    EXPECT_TRUE(et.execute(0, HitRank(0.0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0.0)));
     EXPECT_EQ(et.getResult()->getFloat(), 2.0);
 
-    EXPECT_TRUE(et.execute(1, HitRank(0.0)));
+    ASSERT_NO_THROW(et.execute(1, HitRank(0.0)));
     EXPECT_EQ(et.getResult()->getFloat(), 2.053082175617388);
 }
 
@@ -246,38 +246,38 @@ TEST(AttrTest, testWithRelevance) {
         double r = i-1;
         r *= 0.1;
         SCOPED_TRACE(vespalib::make_string("i=%d", i).c_str());
-        EXPECT_TRUE(et.execute(0, HitRank(r)));
+        ASSERT_NO_THROW(et.execute(0, HitRank(r)));
         EXPECT_EQ(et.getResult()->getFloat(), expect0[i]);
-        EXPECT_TRUE(et.execute(1, HitRank(r)));
+        ASSERT_NO_THROW(et.execute(1, HitRank(r)));
     }
 
-    EXPECT_TRUE(et.execute(0, HitRank(f1.doc0attr[2])));
+    ASSERT_NO_THROW(et.execute(0, HitRank(f1.doc0attr[2])));
     EXPECT_EQ(et.getResult()->getFloat(), 2.0);
 
     // docid 1
-    EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[0] - 0.001)));
+    ASSERT_NO_THROW(et.execute(1, HitRank(f1.doc1attr[0] - 0.001)));
     EXPECT_EQ(et.getResult()->getFloat(), 0.0);
-    EXPECT_TRUE(et.execute(0, HitRank(0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0)));
 
-    EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[0])));
+    ASSERT_NO_THROW(et.execute(1, HitRank(f1.doc1attr[0])));
     EXPECT_EQ(et.getResult()->getFloat(), 0.0);
-    EXPECT_TRUE(et.execute(0, HitRank(0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0)));
 
-    EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[2])));
+    ASSERT_NO_THROW(et.execute(1, HitRank(f1.doc1attr[2])));
     EXPECT_EQ(et.getResult()->getFloat(), 2.0);
-    EXPECT_TRUE(et.execute(0, HitRank(0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0)));
                 
-    EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[4])));
+    ASSERT_NO_THROW(et.execute(1, HitRank(f1.doc1attr[4])));
     EXPECT_EQ(et.getResult()->getFloat(), 4.0);
-    EXPECT_TRUE(et.execute(0, HitRank(0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0)));
 
-    EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[10])));
+    ASSERT_NO_THROW(et.execute(1, HitRank(f1.doc1attr[10])));
     EXPECT_EQ(et.getResult()->getFloat(), 10.0);
-    EXPECT_TRUE(et.execute(0, HitRank(0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0)));
 
-    EXPECT_TRUE(et.execute(1, HitRank(f1.doc1attr[10] + 0.01)));
+    ASSERT_NO_THROW(et.execute(1, HitRank(f1.doc1attr[10] + 0.01)));
     EXPECT_EQ(et.getResult()->getFloat(), 10.0);
-    EXPECT_TRUE(et.execute(0, HitRank(0)));
+    ASSERT_NO_THROW(et.execute(0, HitRank(0)));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/aggregator/perdocexpr_test.cpp
+++ b/searchlib/src/tests/aggregator/perdocexpr_test.cpp
@@ -48,12 +48,14 @@ void testMin(const ResultNode & a, const ResultNode & b, const std::string& labe
     ASSERT_TRUE(a.cmp(b) < 0);
     MinFunctionNode func;
     func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone())))
-        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false).execute();
+        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false);
+    ASSERT_NO_THROW(func.execute());
     ASSERT_TRUE(func.getResult()->cmp(a) == 0);
 
     MinFunctionNode funcR;
     funcR.appendArg(MU<ConstantNode>(ResultNode::UP(b.clone())))
-         .appendArg(MU<ConstantNode>(ResultNode::UP(a.clone()))).prepare(false).execute();
+         .appendArg(MU<ConstantNode>(ResultNode::UP(a.clone()))).prepare(false);
+    ASSERT_NO_THROW(funcR.execute());
     ASSERT_TRUE(funcR.getResult()->cmp(a) == 0);
 }
 
@@ -93,14 +95,14 @@ void testMax(const ResultNode & a, const ResultNode & b, const std::string& labe
     ASSERT_TRUE(a.cmp(b) < 0);
     MaxFunctionNode func;
     func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone())))
-        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false)
-        .execute();
+        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false);
+    ASSERT_NO_THROW(func.execute());
     ASSERT_TRUE(func.getResult()->cmp(b) == 0);
 
     MaxFunctionNode funcR;
     funcR.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone())))
-         .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false)
-         .execute();
+         .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false);
+    ASSERT_NO_THROW(funcR.execute());
     ASSERT_TRUE(funcR.getResult()->cmp(b) == 0);
 }
 
@@ -265,7 +267,8 @@ TEST(PerDocExprTest, require_that_StandardDeviationAggregationResult_aggregates_
 void testAdd(const ResultNode &a, const ResultNode &b, const ResultNode &c) {
     AddFunctionNode func;
     func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone())))
-        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false).execute();
+        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false);
+    ASSERT_NO_THROW(func.execute());
     EXPECT_EQ(func.getResult()->asString(), c.asString());
     EXPECT_EQ(func.getResult()->cmp(c), 0);
     EXPECT_EQ(c.cmp(*func.getResult()), 0);
@@ -281,7 +284,8 @@ TEST(PerDocExprTest, testAdd) {
 void testDivide(const ResultNode &a, const ResultNode &b, const ResultNode &c) {
     DivideFunctionNode func;
     func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone())))
-        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false).execute();
+        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false);
+    ASSERT_NO_THROW(func.execute());
     EXPECT_EQ(func.getResult()->asString(), c.asString());
     EXPECT_EQ(func.getResult()->getFloat(), c.getFloat());
     EXPECT_EQ(func.getResult()->cmp(c), 0);
@@ -297,7 +301,8 @@ TEST(PerDocExprTest, testDivide) {
 void testModulo(const ResultNode &a, const ResultNode &b, const ResultNode &c) {
     ModuloFunctionNode func;
     func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone())))
-        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false).execute();
+        .appendArg(MU<ConstantNode>(ResultNode::UP(b.clone()))).prepare(false);
+    ASSERT_NO_THROW(func.execute());
     EXPECT_EQ(func.getResult()->asString(), c.asString());
     EXPECT_EQ(func.getResult()->getFloat(), c.getFloat());
     EXPECT_EQ(func.getResult()->cmp(c), 0);
@@ -322,7 +327,8 @@ TEST(PerDocExprTest, testModulo) {
 
 void testNegate(const ResultNode & a, const ResultNode & b) {
     NegateFunctionNode func;
-    func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone()))).prepare(false).execute();
+    func.appendArg(MU<ConstantNode>(ResultNode::UP(a.clone()))).prepare(false);
+    ASSERT_NO_THROW(func.execute());
     EXPECT_EQ(func.getResult()->asString(), b.asString());
     EXPECT_EQ(func.getResult()->cmp(b), 0);
     EXPECT_EQ(b.cmp(*func.getResult()), 0);
@@ -677,7 +683,7 @@ TEST(PerDocExprTest, testMailChecksumExpression) {
     // sfn.prepare(false);
     cfn.prepare(false);
 
-    cfn.execute();
+    ASSERT_NO_THROW(cfn.execute());
     ConstBufferRef ref = static_cast<const RawResultNode &>(*cfn.getResult()).get();
 
     std::string cmp = getVespaChecksumV2(ymumid, folder, flags);
@@ -693,7 +699,7 @@ TEST(PerDocExprTest, testMailChecksumExpression) {
     EXPECT_TRUE(memcmp(cmp.c_str(), ref.c_str(), cmp.size()) == 0);
 
     node.prepare(true);
-    node.execute();
+    ASSERT_NO_THROW(node.execute());
 
     ConstBufferRef ref2 =
         static_cast<const RawResultNode &>(*node.getResult()).get();
@@ -712,7 +718,7 @@ TEST(PerDocExprTest, testDebugFunction) {
         n.prepare(false);
 
         vespalib::Timer timer;
-        n.execute();
+        ASSERT_NO_THROW(n.execute());
         EXPECT_TRUE(timer.elapsed() > 1s);
         EXPECT_EQ(static_cast<const Int64ResultNode &>(*n.getResult()).get(), 7);
     }
@@ -724,7 +730,7 @@ TEST(PerDocExprTest, testDebugFunction) {
         n.prepare(false);
 
         vespalib::Timer timer;
-        n.execute();
+        ASSERT_NO_THROW(n.execute());
         EXPECT_TRUE(timer.elapsed() > 1s);
         EXPECT_EQ(static_cast<const Int64ResultNode &>(*n.getResult()).get(), 7);
     }
@@ -745,40 +751,40 @@ TEST(PerDocExprTest, testDivExpressions) {
     {
         StrLenFunctionNode e(MU<ConstantNode>(MU<Int64ResultNode>(238686)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const Int64ResultNode &>(*e.getResult()).get(), 6);
     }
     {
         NormalizeSubjectFunctionNode e(MU<ConstantNode>(MU<StringResultNode>("Re: Your mail")));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const StringResultNode &>(*e.getResult()).get(), "Your mail");
     }
     {
         NormalizeSubjectFunctionNode e(MU<ConstantNode>(MU<StringResultNode>("Your mail")));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const StringResultNode &>(*e.getResult()).get(), "Your mail");
     }
     {
         StrCatFunctionNode e(MU<ConstantNode>(MU<Int64ResultNode>(238686)));
         e.appendArg(MU<ConstantNode>(MU<StringResultNode>("ARG 2")));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const StringResultNode &>(*e.getResult()).get(), "238686ARG 2");
     }
 
     {
         ToStringFunctionNode e(MU<ConstantNode>(MU<Int64ResultNode>(238686)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(strcmp(static_cast<const StringResultNode &>(*e.getResult()).get().c_str(), "238686"), 0);
     }
 
     {
         ToRawFunctionNode e(MU<ConstantNode>(MU<Int64ResultNode>(238686)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         auto raw_result = static_cast<const RawResultNode &>(*e.getResult()).get();
         EXPECT_EQ(6u, raw_result.size());
         EXPECT_EQ(strncmp(raw_result.c_str(), "238686", 6u), 0);
@@ -787,20 +793,20 @@ TEST(PerDocExprTest, testDivExpressions) {
     {
         CatFunctionNode e(MU<ConstantNode>(MU<Int64ResultNode>(238686)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 8u);
     }
     {
         CatFunctionNode e(MU<ConstantNode>(MU<Int32ResultNode>(23886)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 4u);
     }
     {
         const uint8_t buf[4] = { 0, 0, 0, 7 };
         MD5BitFunctionNode e(MU<ConstantNode>(MU<RawResultNode>(buf, sizeof(buf))), 16*8);
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         ASSERT_TRUE(e.getResult()->getClass().inherits(RawResultNode::classId));
         const RawResultNode &r(static_cast<const RawResultNode &>(*e.getResult()));
         EXPECT_EQ(r.get().size(), 16u);
@@ -809,14 +815,14 @@ TEST(PerDocExprTest, testDivExpressions) {
         const uint8_t buf[4] = { 0, 0, 0, 7 };
         MD5BitFunctionNode e(MU<ConstantNode>(MU<RawResultNode>(buf, sizeof(buf))), 2*8);
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 2u);
     }
     {
         const uint8_t buf[4] = { 0, 0, 0, 7 };
         XorBitFunctionNode e(MU<ConstantNode>(MU<RawResultNode>(buf, sizeof(buf))), 1*8);
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 1u);
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().c_str()[0], 0x7);
     }
@@ -824,7 +830,7 @@ TEST(PerDocExprTest, testDivExpressions) {
         const uint8_t buf[4] = { 6, 0, 7, 7 };
         XorBitFunctionNode e(MU<ConstantNode>(MU<RawResultNode>(buf, sizeof(buf))), 2*8);
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 2u);
         EXPECT_EQ((int)static_cast<const RawResultNode &>(*e.getResult()).get().c_str()[0], 0x1);
         EXPECT_EQ((int)static_cast<const RawResultNode &>(*e.getResult()).get().c_str()[1], 0x7);
@@ -844,7 +850,7 @@ TEST(PerDocExprTest, testDivExpressions) {
 
         MD5BitFunctionNode e(MU<ConstantNode>(MU<RawResultNode>(wantedBuf, sizeof(wantedBuf))), 16*8);
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         ASSERT_TRUE(e.getResult()->getClass().inherits(RawResultNode::classId));
         const RawResultNode &r(static_cast<const RawResultNode &>(*e.getResult()));
         EXPECT_EQ(r.get().size(), 16u);
@@ -862,7 +868,7 @@ TEST(PerDocExprTest, testDivExpressions) {
 
         MD5BitFunctionNode finalCheck(std::move(cat), 32);
         finalCheck.prepare(false);
-        finalCheck.execute();
+        ASSERT_NO_THROW(finalCheck.execute());
         const RawResultNode &rr(static_cast<const RawResultNode &>(*finalCheck.getResult()));
         EXPECT_EQ(rr.get().size(), 4u);
         fastc_md5sum(wantedBuf, sizeof(wantedBuf), md5);
@@ -872,37 +878,37 @@ TEST(PerDocExprTest, testDivExpressions) {
     {
         CatFunctionNode e(MU<ConstantNode>(MU<Int16ResultNode>(23886)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 2u);
     }
     {
         CatFunctionNode e(MU<ConstantNode>(createIntRV<Int8ResultNodeVector>({86, 14})));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 1*2u);
     }
     {
         CatFunctionNode e(MU<ConstantNode>(createIntRV<Int32ResultNodeVector>({238686,2133214})));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(static_cast<const RawResultNode &>(*e.getResult()).get().size(), 4*2u);
     }
     {
         NumElemFunctionNode e(MU<ConstantNode>(MU<Int64ResultNode>(238686)));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(e.getResult()->getInteger(), 1);
     }
     {
         NumElemFunctionNode e(MU<ConstantNode>(createIntRV<Int32ResultNodeVector>({238686,2133214})));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(e.getResult()->getInteger(), 2);
     }
     {
         NumElemFunctionNode e(MU<ConstantNode>(createIntRV<Int32ResultNodeVector>({238686,2133214})));
         e.prepare(false);
-        e.execute();
+        ASSERT_NO_THROW(e.execute());
         EXPECT_EQ(e.getResult()->getInteger(), 2);
     }
 }
@@ -915,7 +921,7 @@ bool test1MultivalueExpression(const MultiArgFunctionNode &exprConst, Expression
     expr.prepare(false);
 
     bool ok = true;
-    EXPECT_TRUE(expr.execute()) << (ok = false, "");
+    expr.execute();
     EXPECT_EQ(0, expr.getResult()->cmp(expected)) << (ok = false, "");
     if (!ok) {
         std::cerr << "Expected:" << expected.asString() << std::endl
@@ -1050,9 +1056,9 @@ TEST(PerDocExprTest, testArithmeticNodes) {
     et.select(treeConf, treeConf);
 
     EXPECT_TRUE(et.getResult()->getClass().inherits(IntegerResultNode::classId));
-    EXPECT_TRUE(et.ExpressionNode::execute());
+    et.ExpressionNode::execute();
     EXPECT_EQ(et.getResult()->getInteger(), 3);
-    EXPECT_TRUE(et.ExpressionNode::execute());
+    et.ExpressionNode::execute();
     EXPECT_EQ(et.getResult()->getInteger(), 3);
     AddFunctionNode add2;
     add2.appendArg(createScalarInt(I1));
@@ -1087,7 +1093,7 @@ void testArith(MultiArgFunctionNode &op, ExpressionNode::UP arg1, ExpressionNode
     op.appendArg(std::move(arg1));
     op.appendArg(std::move(arg2));
     op.prepare(false);
-    op.execute();
+    ASSERT_NO_THROW(op.execute());
     EXPECT_EQ(intResult, op.getResult()->getInteger());
     ASSERT_TRUE(intResult == op.getResult()->getInteger());
     EXPECT_EQ(floatResult, op.getResult()->getFloat());
@@ -1140,7 +1146,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createScalarInt(arg1[0])).appendArg(createScalarInt(arg2[0]));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(Int64ResultNode::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_EQ(function.getResult()->getInteger(), static_cast<int64_t>(result[0]));
 
     function.reset();
@@ -1148,7 +1154,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createScalarInt(arg1[0])).appendArg(createScalarFloat(arg2[0]));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNode::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_EQ(function.getResult()->getFloat(), result[0]);
 
     function.reset();
@@ -1156,7 +1162,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createScalarFloat(arg1[0])).appendArg(createScalarInt(arg2[0]));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNode::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_EQ(function.getResult()->getFloat(), result[0]);
 
     function.reset();
@@ -1164,7 +1170,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createScalarFloat(arg1[0])).appendArg(createScalarFloat(arg2[0]));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNode::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_EQ(function.getResult()->getFloat(), result[0]);
 
     function.reset();
@@ -1172,7 +1178,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createVectorInt(arg1));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(Int64ResultNode::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_EQ(function.getResult()->getInteger(), static_cast<int64_t>(flattenResult));
 
     function.reset();
@@ -1180,7 +1186,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createVectorFloat(arg1));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNode::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_EQ(function.getResult()->getFloat(), flattenResult);
 
     function.reset();
@@ -1188,7 +1194,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createVectorInt(arg1)).appendArg(createVectorInt(arg2));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(IntegerResultNodeVector::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_TRUE(function.getResult()->getClass().equal(IntegerResultNodeVector::classId));
     EXPECT_EQ(static_cast<const IntegerResultNodeVector &>(*function.getResult()).size(), 7u);
     EXPECT_EQ(0, function.getResult()->cmp(ir));
@@ -1198,7 +1204,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createVectorFloat(arg1)).appendArg(createVectorFloat(arg2));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNodeVector::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNodeVector::classId));
     EXPECT_EQ(static_cast<const FloatResultNodeVector &>(*function.getResult()).size(), 7u);
     EXPECT_EQ(0, function.getResult()->cmp(fr));
@@ -1208,7 +1214,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createVectorInt(arg1)).appendArg(createVectorFloat(arg2));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNodeVector::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNodeVector::classId));
     EXPECT_EQ(static_cast<const FloatResultNodeVector &>(*function.getResult()).size(), 7u);
     EXPECT_EQ(0, function.getResult()->cmp(fr));
@@ -1218,7 +1224,7 @@ void testArithmeticArguments(NumericFunctionNode &function,
     function.appendArg(createVectorFloat(arg1)).appendArg(createVectorInt(arg2));
     function.prepare(false);
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNodeVector::classId));
-    EXPECT_TRUE(function.execute());
+    ASSERT_NO_THROW(function.execute());
     EXPECT_TRUE(function.getResult()->getClass().equal(FloatResultNodeVector::classId));
     EXPECT_EQ(static_cast<const FloatResultNodeVector &>(*function.getResult()).size(), 7u);
     EXPECT_EQ(0, function.getResult()->cmp(fr));

--- a/searchlib/src/tests/aggregator/perdocexpr_test.cpp
+++ b/searchlib/src/tests/aggregator/perdocexpr_test.cpp
@@ -1727,28 +1727,28 @@ TEST(PerDocExprTest, testGeoDistance) {
     // Query from OSL (60.20, 11.08) to doc 0 TRD (63.45, 10.92) ~361 km
     {
         auto tree = make_tree(60.20, 11.08, Unit::KM);
-        ASSERT_TRUE(tree.execute(0, 0));
+        ASSERT_NO_THROW(tree.execute(0, 0));
         EXPECT_NEAR(tree.getResult()->getFloat(), 361.0, 5.0);
     }
 
     // Same point: query OSL -> doc 1 OSL, should be ~0
     {
         auto tree = make_tree(60.20, 11.08, Unit::KM);
-        ASSERT_TRUE(tree.execute(1, 0));
+        ASSERT_NO_THROW(tree.execute(1, 0));
         EXPECT_NEAR(tree.getResult()->getFloat(), 0.0, 1.0);
     }
 
     // SFO (37.61, -122.38) -> doc 2 JFK (40.64, -73.78) ~4139 km
     {
         auto tree = make_tree(37.61, -122.38, Unit::KM);
-        ASSERT_TRUE(tree.execute(2, 0));
+        ASSERT_NO_THROW(tree.execute(2, 0));
         EXPECT_NEAR(tree.getResult()->getFloat(), 4139.0, 50.0);
     }
 
     // OSL -> TRD in miles (~224 miles)
     {
         auto tree = make_tree(60.20, 11.08, Unit::MILES);
-        ASSERT_TRUE(tree.execute(0, 0));
+        ASSERT_NO_THROW(tree.execute(0, 0));
         EXPECT_NEAR(tree.getResult()->getFloat(), 224.0, 5.0);
     }
 }

--- a/searchlib/src/tests/expression/interpolated_document_field_lookup_node/interpolated_document_field_lookup_node_test.cpp
+++ b/searchlib/src/tests/expression/interpolated_document_field_lookup_node/interpolated_document_field_lookup_node_test.cpp
@@ -69,7 +69,7 @@ Fixture::setup_node(double lookup_value)
 double
 Fixture::evaluate()
 {
-    EXPECT_TRUE(_node->execute());
+    EXPECT_NO_THROW(_node->execute());
     return _node->getResult()->getFloat();
 }
 

--- a/searchlib/src/tests/expression/interpolated_document_field_lookup_node/interpolated_document_field_lookup_node_test.cpp
+++ b/searchlib/src/tests/expression/interpolated_document_field_lookup_node/interpolated_document_field_lookup_node_test.cpp
@@ -69,7 +69,7 @@ Fixture::setup_node(double lookup_value)
 double
 Fixture::evaluate()
 {
-    EXPECT_NO_THROW(_node->execute());
+    _node->execute();
     return _node->getResult()->getFloat();
 }
 

--- a/searchlib/src/vespa/searchlib/aggregation/aggregation.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregation.cpp
@@ -58,21 +58,14 @@ AggregationResult::~AggregationResult() = default;
 
 void
 AggregationResult::aggregate(const document::Document & doc, HitRank rank) {
-    bool ok(_expressionTree->execute(doc, rank));
-    if (ok) {
-        onAggregate(*_expressionTree->getResult(), doc, rank);
-    } else {
-        throw std::runtime_error(vespalib::make_string("aggregate(%s, %f) failed ", doc.getId().toString().c_str(), rank));
-    }
+    _expressionTree->execute(doc, rank);
+    onAggregate(*_expressionTree->getResult(), doc, rank);
 }
+
 void
 AggregationResult::aggregate(DocId docId, HitRank rank) {
-    bool ok(_expressionTree->execute(docId, rank));
-    if (ok) {
-        onAggregate(*_expressionTree->getResult(), docId, rank);
-    } else {
-        throw std::runtime_error(vespalib::make_string("aggregate(%u, %f) failed ", docId, rank));
-    }
+   _expressionTree->execute(docId, rank);
+    onAggregate(*_expressionTree->getResult(), docId, rank);
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/aggregation/aggregationresult.h
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregationresult.h
@@ -71,7 +71,7 @@ protected:
     AggregationResult();
 private:
     void onPrepare(bool preserveAccurateTypes) override { (void) preserveAccurateTypes; }
-    bool onExecute() const override { return true; }
+    void onExecute() const override { }
 
     void prepare() { if (getExpression() != nullptr) { prepare(getExpression()->getResult(), false); } }
     void prepare(const ResultNode * result, bool useForInit) { if (result) { onPrepare(*result, useForInit); } }

--- a/searchlib/src/vespa/searchlib/aggregation/group.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/group.cpp
@@ -85,9 +85,7 @@ void
 Group::groupNext(const GroupingLevel & level, const Doc & doc, HitRank rank)
 {
     const ExpressionTree &selector = level.getExpression();
-    if (!selector.execute(doc, rank)) {
-        throw std::runtime_error("Does not know how to handle failed select statements");
-    }
+    selector.execute(doc, rank);
     const ResultNode &selectResult = *selector.getResult();
     level.group(*this, selectResult, doc, rank);
 }

--- a/searchlib/src/vespa/searchlib/expression/aggregationrefnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/aggregationrefnode.cpp
@@ -26,12 +26,11 @@ AggregationRefNode & AggregationRefNode::operator = (const AggregationRefNode & 
     return *this;
 }
 
-bool AggregationRefNode::onExecute() const
+void AggregationRefNode::onExecute() const
 {
     if (_expressionNode != nullptr) {
-        return _expressionNode->execute();
+        _expressionNode->execute();
     }
-    return false;
 }
 
 void AggregationRefNode::locateExpression(ExpressionNodeArray & exprVec) const

--- a/searchlib/src/vespa/searchlib/expression/aggregationrefnode.h
+++ b/searchlib/src/vespa/searchlib/expression/aggregationrefnode.h
@@ -20,7 +20,7 @@ public:
     ExpressionNode *getExpression() { return _expressionNode; }
     const ResultNode * getResult() const override { return _expressionNode->getResult(); }
     void onPrepare(bool preserveAccurateTypes) override { _expressionNode->prepare(preserveAccurateTypes); }
-    bool onExecute() const override;
+    void onExecute() const override;
 
     void locateExpression(ExpressionNodeArray & exprVec) const;
 private:

--- a/searchlib/src/vespa/searchlib/expression/arrayatlookupfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/arrayatlookupfunctionnode.cpp
@@ -44,14 +44,13 @@ ArrayAtLookup::ArrayAtLookup(const ArrayAtLookup &rhs)
     setCurrentIndex(&_currentIndex);
 }
 
-bool
+void
 ArrayAtLookup::onExecute() const
 {
     _indexExpression->execute();
     int64_t idx = _indexExpression->getResult()->getInteger();
     _currentIndex.set(idx);
     AttributeNode::onExecute();
-    return true;
 }
 
 Serializer &

--- a/searchlib/src/vespa/searchlib/expression/arrayatlookupfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/arrayatlookupfunctionnode.h
@@ -22,7 +22,7 @@ public:
     ArrayAtLookup(const search::attribute::IAttributeVector &attr, ExpressionNode::UP indexArg);
     ArrayAtLookup(const ArrayAtLookup &rhs);
     ArrayAtLookup & operator= (const ArrayAtLookup &rhs);
-    bool onExecute() const override;
+    void onExecute() const override;
     void visitMembers(vespalib::ObjectVisitor & visitor) const override;
     void selectMembers(const vespalib::ObjectPredicate & predicate, vespalib::ObjectOperation & operation) override;
 private:

--- a/searchlib/src/vespa/searchlib/expression/attributenode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/attributenode.cpp
@@ -388,7 +388,7 @@ AttributeNode::setDocId(DocId docId) {
     }
 }
 
-bool
+void
 AttributeNode::onExecute() const
 {
     if (_handler) {
@@ -414,7 +414,6 @@ AttributeNode::onExecute() const
     } else {
         updateResult().set(*_scratchResult);
     }
-    return true;
 }
 
 void

--- a/searchlib/src/vespa/searchlib/expression/attributenode.h
+++ b/searchlib/src/vespa/searchlib/expression/attributenode.h
@@ -89,7 +89,7 @@ protected:
         _scratchResult = std::move(result);
     }
     virtual void cleanup();
-    bool onExecute() const override;
+    void onExecute() const override;
     std::string                  _attributeName;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/catfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/catfunctionnode.h
@@ -14,7 +14,7 @@ public:
 private:
     void onPrepare(bool preserveAccurateTypes) override;
     void onPrepareResult() override;
-    bool onExecute() const override;
+    void onExecute() const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/constantnode.h
+++ b/searchlib/src/vespa/searchlib/expression/constantnode.h
@@ -18,7 +18,7 @@ public:
     const ResultNode * getResult() const override { return _result.get(); }
 private:
     void onPrepare(bool preserveAccurateTypes) override { (void) preserveAccurateTypes; }
-    bool onExecute() const override { return true; }
+    void onExecute() const override { }
     ResultNode::CP _result;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/debugwaitfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/debugwaitfunctionnode.cpp
@@ -26,14 +26,13 @@ DebugWaitFunctionNode::DebugWaitFunctionNode(ExpressionNode::UP arg, double wait
 
 using std::chrono::microseconds;
 
-bool
+void
 DebugWaitFunctionNode::onExecute() const
 {
     vespalib::Timer::waitAtLeast(vespalib::from_s(_waitTime), _busyWait);
 
     getArg().execute();
     updateResult().assign(*getArg().getResult());
-    return true;
 }
 
 Serializer &

--- a/searchlib/src/vespa/searchlib/expression/debugwaitfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/debugwaitfunctionnode.h
@@ -15,7 +15,7 @@ public:
     DebugWaitFunctionNode(ExpressionNode::UP arg, double waitTime, bool busyWait);
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     double _waitTime;
     bool   _busyWait;
 };

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.cpp
@@ -223,7 +223,7 @@ void DocumentFieldNode::onDoc(const Document & doc)
     _needExecute = true;
 }
 
-bool
+void
 DocumentFieldNode::onExecute() const
 {
     if (_needExecute) {
@@ -243,7 +243,6 @@ DocumentFieldNode::onExecute() const
             _value->set(_keepAliveForIndexLookups->get(idx));
         }
     }
-    return true;
 }
 
 DefaultValue DocumentFieldNode::SingleHandler::_defaultValue;

--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.h
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.h
@@ -76,7 +76,7 @@ private:
 
     const ResultNode * getResult() const override { return _value.get(); }
     void onPrepare(bool preserveAccurateTypes) override;
-    bool onExecute() const override;
+    void onExecute() const override;
     void onDoc(const document::Document & doc) override;
     void onDocType(const document::DocumentType & docType) override;
 protected:

--- a/searchlib/src/vespa/searchlib/expression/expressionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/expressionnode.h
@@ -38,7 +38,7 @@ public:
     using UP = std::unique_ptr<ExpressionNode>;
     using CP = vespalib::IdentifiablePtr<ExpressionNode>;
     virtual const ResultNode * getResult() const = 0;
-    bool execute() const { return onExecute(); }
+    void execute() const { return onExecute(); }
     ExpressionNode & prepare(bool preserveAccurateTypes) { onPrepare(preserveAccurateTypes); return *this; }
     virtual ExpressionNode * clone() const = 0;
     void executeIterative(const ResultNode & arg, ResultNode & result) const;
@@ -47,7 +47,7 @@ protected:
 private:
     virtual void onArgument(const ResultNode & arg, ResultNode & result) const;
     virtual void onPrepare(bool preserveAccurateTypes) = 0;
-    virtual bool onExecute() const = 0;
+    virtual void onExecute() const = 0;
 };
 
 using ExpressionNodeArray = ExpressionNode::CP *;

--- a/searchlib/src/vespa/searchlib/expression/expressiontree.cpp
+++ b/searchlib/src/vespa/searchlib/expression/expressiontree.cpp
@@ -127,21 +127,20 @@ ExpressionTree::swap(ExpressionTree & e)
 
 ExpressionTree::~ExpressionTree() = default;
 
-bool
+void
 ExpressionTree::execute(const document::Document & doc, HitRank rank) const
 {
     std::for_each(_documentAccessorNodes.cbegin(), _documentAccessorNodes.cend(), [&doc](DocumentAccessorNode * node) { node->setDoc(doc); });
     std::for_each(_relevanceNodes.cbegin(), _relevanceNodes.cend(), [rank](RelevanceNode * node) { node->setRelevance(rank); });
-    return _root->execute();
+    _root->execute();
 }
 
-bool
+void
 ExpressionTree::execute(DocId docId, HitRank rank) const
 {
     std::for_each(_attributeNodes.cbegin(), _attributeNodes.cend(), [docId](AttributeNode * node) { node->setDocId(docId); });
     std::for_each(_relevanceNodes.cbegin(), _relevanceNodes.cend(), [rank](RelevanceNode * node) { node->setRelevance(rank); });
-
-    return _root->execute();
+    _root->execute();
 }
 
 void

--- a/searchlib/src/vespa/searchlib/expression/expressiontree.h
+++ b/searchlib/src/vespa/searchlib/expression/expressiontree.h
@@ -59,8 +59,8 @@ public:
     ExpressionTree & operator = (const ExpressionTree & rhs);
     ExpressionTree & operator = (ExpressionTree &&) noexcept = default;
 
-    bool execute(DocId docId, HitRank rank) const;
-    bool execute(const document::Document & doc, HitRank rank) const;
+    void execute(DocId docId, HitRank rank) const;
+    void execute(const document::Document & doc, HitRank rank) const;
     const ExpressionNode * getRoot() const { return _root.get(); }
     ExpressionNode * getRoot() { return _root.get(); }
     void changeRoot(ExpressionNode::UP root) { _root = std::move(root); }
@@ -71,7 +71,7 @@ public:
 private:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void selectMembers(const vespalib::ObjectPredicate &predicate, vespalib::ObjectOperation &operation) override;
-    bool onExecute() const override { return _root->execute(); }
+    void onExecute() const override { _root->execute(); }
     void onPrepare(bool preserveAccurateTypes) override;
 
     using AttributeNodeList = std::vector<AttributeNode *>;

--- a/searchlib/src/vespa/searchlib/expression/fixedwidthbucketfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/fixedwidthbucketfunctionnode.cpp
@@ -102,12 +102,11 @@ FixedWidthBucketFunctionNode::onPrepareResult()
     }
 }
 
-bool
+void
 FixedWidthBucketFunctionNode::onExecute() const
 {
     getArg().execute();
     _bucketHandler->update(updateResult(), *getArg().getResult());
-    return true;
 }
 
 vespalib::Serializer &

--- a/searchlib/src/vespa/searchlib/expression/fixedwidthbucketfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/fixedwidthbucketfunctionnode.h
@@ -48,7 +48,7 @@ public:
     };
 private:
     void onPrepareResult() override;
-    bool onExecute() const override;
+    void onExecute() const override;
 
     NumericResultNode::CP _width;
     BucketHandler::CP     _bucketHandler;

--- a/searchlib/src/vespa/searchlib/expression/functionnodes.cpp
+++ b/searchlib/src/vespa/searchlib/expression/functionnodes.cpp
@@ -232,14 +232,13 @@ MultiArgFunctionNode::onExecute() const
     calculate(_args, updateResult());
 }
 
-bool
+void
 MultiArgFunctionNode::onCalculate(const ExpressionNodeVector & args, ResultNode & result) const
 {
     result.set(*args[0]->getResult());
     for (size_t i(1), m(args.size()); i < m; i++) {
         executeIterative(*args[i]->getResult(), result);
     }
-    return true;
 }
 
 void

--- a/searchlib/src/vespa/searchlib/expression/functionnodes.cpp
+++ b/searchlib/src/vespa/searchlib/expression/functionnodes.cpp
@@ -223,13 +223,13 @@ MultiArgFunctionNode::onPrepareResult()
     }
 }
 
-bool
+void
 MultiArgFunctionNode::onExecute() const
 {
     for(size_t i(0), m(_args.size()); i < m; i++) {
         _args[i]->execute();
     }
-    return calculate(_args, updateResult());
+    calculate(_args, updateResult());
 }
 
 bool
@@ -364,12 +364,11 @@ ToStringFunctionNode::onPrepareResult()
     setResultType(std::make_unique<StringResultNode>());
 }
 
-bool
+void
 ToStringFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().set(*getArg().getResult());
-    return true;
 }
 
 void
@@ -378,12 +377,11 @@ ToRawFunctionNode::onPrepareResult()
     setResultType(std::make_unique<RawResultNode>());
 }
 
-bool
+void
 ToRawFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().set(*getArg().getResult());
-    return true;
 }
 
 void
@@ -392,12 +390,11 @@ ToIntFunctionNode::onPrepareResult()
     setResultType(std::make_unique<Int64ResultNode>());
 }
 
-bool
+void
 ToIntFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().set(*getArg().getResult());
-    return true;
 }
 
 void
@@ -406,12 +403,11 @@ ToFloatFunctionNode::onPrepareResult()
     setResultType(std::make_unique<FloatResultNode>());
 }
 
-bool
+void
 ToFloatFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().set(*getArg().getResult());
-    return true;
 }
 
 void
@@ -420,13 +416,12 @@ StrLenFunctionNode::onPrepareResult()
     setResultType(std::make_unique<Int64ResultNode>());
 }
 
-bool
+void
 StrLenFunctionNode::onExecute() const
 {
     getArg().execute();
     HoldString tmp(*getArg().getResult());
     static_cast<Int64ResultNode &> (updateResult()).set(tmp.size());
-    return true;
 }
 
 void
@@ -435,7 +430,7 @@ NormalizeSubjectFunctionNode::onPrepareResult()
     setResultType(std::make_unique<StringResultNode>());
 }
 
-bool
+void
 NormalizeSubjectFunctionNode::onExecute() const
 {
     getArg().execute();
@@ -455,7 +450,6 @@ NormalizeSubjectFunctionNode::onExecute() const
         }
     }
     static_cast<StringResultNode &> (updateResult()).set(tmp.substr(pos));
-    return true;
 }
 
 void
@@ -464,44 +458,40 @@ NumElemFunctionNode::onPrepareResult()
     setResultType(std::make_unique<Int64ResultNode>(1));
 }
 
-bool
+void
 NumElemFunctionNode::onExecute() const
 {
     getArg().execute();
     if (getArg().getResult()->inherits(ResultNodeVector::classId)) {
         static_cast<Int64ResultNode &> (updateResult()).set(static_cast<const ResultNodeVector &>(*getArg().getResult()).size());
     }
-    return true;
 }
 
-bool
+void
 NegateFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().assign(*getArg().getResult());
     updateResult().negate();
-    return true;
 }
 
-bool
+void
 SortFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().assign(*getArg().getResult());
     updateResult().sort();
-    return true;
 }
 
-bool
+void
 ReverseFunctionNode::onExecute() const
 {
     getArg().execute();
     updateResult().assign(*getArg().getResult());
     updateResult().reverse();
-    return true;
 }
 
-bool
+void
 StrCatFunctionNode::onExecute() const
 {
     asciistream os;
@@ -511,10 +501,9 @@ StrCatFunctionNode::onExecute() const
         getArg(i).getResult()->serialize(nos);
     }
     static_cast<StringResultNode &>(updateResult()).set(os.view());
-    return true;
 }
 
-bool
+void
 CatFunctionNode::onExecute() const
 {
     nbostream os;
@@ -524,7 +513,6 @@ CatFunctionNode::onExecute() const
         getArg(i).getResult()->serialize(nos);
     }
     static_cast<RawResultNode &>(updateResult()).setBuffer(os.data(), os.size());
-    return true;
 }
 
 XorBitFunctionNode::XorBitFunctionNode() = default;
@@ -535,14 +523,14 @@ XorBitFunctionNode::XorBitFunctionNode(ExpressionNode::UP arg, unsigned numBits)
     _tmpXor(getNumBytes(), 0)
 {}
 
-bool
+void
 UnaryBitFunctionNode::onExecute() const
 {
     _tmpOs.clear();
     getArg().execute();
     CatSerializer os(_tmpOs);
     getArg().getResult()->serialize(os);
-    return internalExecute(_tmpOs);
+    internalExecute(_tmpOs);
 }
 
 void
@@ -552,7 +540,7 @@ XorBitFunctionNode::onPrepareResult()
     _tmpXor.resize(getNumBytes());
 }
 
-bool
+void
 XorBitFunctionNode::internalExecute(const nbostream & os) const
 {
     const size_t numBytes(_tmpXor.size());
@@ -567,17 +555,15 @@ XorBitFunctionNode::internalExecute(const nbostream & os) const
         _tmpXor[i%numBytes] = os.data()[i];
     }
     static_cast<RawResultNode &>(updateResult()).setBuffer(&_tmpXor[0], numBytes);
-    return true;
 }
 
-bool
+void
 MD5BitFunctionNode::internalExecute(const nbostream & os) const
 {
     const unsigned int MD5_DIGEST_LENGTH = 16;
     unsigned char md5ScratchPad[MD5_DIGEST_LENGTH];
     fastc_md5sum(os.data(), os.size(), md5ScratchPad);
     static_cast<RawResultNode &>(updateResult()).setBuffer(md5ScratchPad, std::min(sizeof(md5ScratchPad), getNumBytes()));
-    return true;
 }
 
 Serializer &

--- a/searchlib/src/vespa/searchlib/expression/geo_distance_function_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/geo_distance_function_node.cpp
@@ -39,13 +39,11 @@ GeoDistanceFunctionNode& GeoDistanceFunctionNode::operator=(const GeoDistanceFun
 
 void GeoDistanceFunctionNode::onPrepareResult() { setResultType(std::make_unique<FloatResultNode>()); }
 
-bool GeoDistanceFunctionNode::onExecute() const {
+void GeoDistanceFunctionNode::onExecute() const {
     assert(getNumArgs() == 3 && "Expect 3 arguments: position attribute, lat, lon");
 
     for (size_t i = 0; i < 3; i++) {
-        if (!getArg(i).execute()) {
-            return false;
-        }
+        getArg(i).execute();
     }
 
     int64_t zcurve = getArg(0).getResult()->getInteger();

--- a/searchlib/src/vespa/searchlib/expression/geo_distance_function_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/geo_distance_function_node.cpp
@@ -64,8 +64,6 @@ void GeoDistanceFunctionNode::onExecute() const {
 
     auto& result = static_cast<FloatResultNode&>(updateResult());
     result.set(distance);
-
-    return true;
 }
 
 Serializer& GeoDistanceFunctionNode::onSerialize(Serializer& os) const {

--- a/searchlib/src/vespa/searchlib/expression/geo_distance_function_node.h
+++ b/searchlib/src/vespa/searchlib/expression/geo_distance_function_node.h
@@ -31,7 +31,7 @@ public:
 
 private:
     void onPrepareResult() override;
-    bool onExecute() const override;
+    void onExecute() const override;
     vespalib::Serializer& onSerialize(vespalib::Serializer& os) const override;
     vespalib::Deserializer& onDeserialize(vespalib::Deserializer& is) override;
 };

--- a/searchlib/src/vespa/searchlib/expression/getdocidnamespacespecificfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/getdocidnamespacespecificfunctionnode.h
@@ -21,7 +21,7 @@ private:
     void onDocType(const document::DocumentType & docType) override { (void) docType; }
     void onDoc(const document::Document & doc) override;
     void onPrepare(bool preserveAccurateTypes) override { (void) preserveAccurateTypes; }
-    bool onExecute() const override { return true; }
+    void onExecute() const override { }
     ResultNode::CP _value;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/getymumchecksumfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/getymumchecksumfunctionnode.h
@@ -18,7 +18,7 @@ private:
     const ResultNode * getResult() const override { return &_checkSum; }
     void onDocType(const document::DocumentType & docType) override { (void) docType; }
     void onDoc(const document::Document & doc) override;
-    bool onExecute() const override { return true; }
+    void onExecute() const override { }
     Int64ResultNode _checkSum;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/interpolated_document_field_lookup_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/interpolated_document_field_lookup_node.cpp
@@ -113,7 +113,7 @@ InterpolatedDocumentFieldLookupNode::onPrepare(bool)
     _value = std::make_unique<FloatResultNode>();
 }
 
-bool
+void
 InterpolatedDocumentFieldLookupNode::onExecute() const
 {
     if (_lookup_expression) {
@@ -127,7 +127,6 @@ InterpolatedDocumentFieldLookupNode::onExecute() const
         _float_result.set(0.0);
     }
     _value->set(_float_result);
-    return true;
 }
 
 }

--- a/searchlib/src/vespa/searchlib/expression/interpolated_document_field_lookup_node.h
+++ b/searchlib/src/vespa/searchlib/expression/interpolated_document_field_lookup_node.h
@@ -24,7 +24,7 @@ public:
     void selectMembers(const vespalib::ObjectPredicate& predicate, vespalib::ObjectOperation& operation) override;
 private:
     void onPrepare(bool preserveAccurateTypes) override;
-    bool onExecute() const override;
+    void onExecute() const override;
     vespalib::IdentifiablePtr<ExpressionNode>  _lookup_expression;
     mutable std::vector<double>                _values;
     mutable FloatResultNode                    _float_result;

--- a/searchlib/src/vespa/searchlib/expression/mathfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/mathfunctionnode.cpp
@@ -31,7 +31,7 @@ void MathFunctionNode::onPrepareResult()
     setResultType(std::unique_ptr<ResultNode>(new FloatResultNode()));
 }
 
-bool MathFunctionNode::onExecute() const
+void MathFunctionNode::onExecute() const
 {
     getArg(0).execute();
     double result(0.0);
@@ -59,7 +59,6 @@ bool MathFunctionNode::onExecute() const
     case FLOOR: result = std::floor(getArg(0).getResult()->getFloat()); break;
     }
     static_cast<FloatResultNode &>(updateResult()).set(result);
-    return true;
 }
 
 }

--- a/searchlib/src/vespa/searchlib/expression/mathfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/mathfunctionnode.h
@@ -16,7 +16,7 @@ public:
 
     MathFunctionNode() { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
     Function _function;
 };

--- a/searchlib/src/vespa/searchlib/expression/md5bitfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/md5bitfunctionnode.h
@@ -13,7 +13,7 @@ public:
     MD5BitFunctionNode() { }
     MD5BitFunctionNode(ExpressionNode::UP arg, unsigned numBits) : UnaryBitFunctionNode(std::move(arg), numBits) { }
 private:
-    bool internalExecute(const vespalib::nbostream & os) const override;
+    void internalExecute(const vespalib::nbostream & os) const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/multiargfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/multiargfunctionnode.h
@@ -26,7 +26,7 @@ public:
     void reset() override { _args.clear(); FunctionNode::reset(); }
     ExpressionNodeVector & expressionNodeVector() { return _args; }
 protected:
-    virtual bool onCalculate(const ExpressionNodeVector & args, ResultNode & result) const;
+    virtual void onCalculate(const ExpressionNodeVector & args, ResultNode & result) const;
     void onExecute() const override;
     void onPrepare(bool preserveAccurateTypes) override;
     size_t getNumArgs() const { return _args.size(); }
@@ -34,7 +34,7 @@ protected:
     ExpressionNode &       getArg(size_t n)       { return *_args[n]; }
 private:
     void selectMembers(const vespalib::ObjectPredicate & predicate, vespalib::ObjectOperation & operation) override;
-    bool calculate(const ExpressionNodeVector & args, ResultNode & result) const { return onCalculate(args, result); }
+    void calculate(const ExpressionNodeVector & args, ResultNode & result) const { onCalculate(args, result); }
     void prepareResult() { onPrepareResult(); }
     virtual void onPrepareResult();
     ExpressionNodeVector _args;

--- a/searchlib/src/vespa/searchlib/expression/multiargfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/multiargfunctionnode.h
@@ -27,7 +27,7 @@ public:
     ExpressionNodeVector & expressionNodeVector() { return _args; }
 protected:
     virtual bool onCalculate(const ExpressionNodeVector & args, ResultNode & result) const;
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepare(bool preserveAccurateTypes) override;
     size_t getNumArgs() const { return _args.size(); }
     const ExpressionNode & getArg(size_t n) const { return *_args[n]; }

--- a/searchlib/src/vespa/searchlib/expression/negatefunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/negatefunctionnode.h
@@ -13,7 +13,7 @@ public:
     NegateFunctionNode() { }
     NegateFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/normalizesubjectfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/normalizesubjectfunctionnode.h
@@ -13,7 +13,7 @@ public:
     NormalizeSubjectFunctionNode() { }
     NormalizeSubjectFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/numelemfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/numelemfunctionnode.h
@@ -13,7 +13,7 @@ public:
     NumElemFunctionNode() { }
     NumElemFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/numericfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/numericfunctionnode.cpp
@@ -58,15 +58,13 @@ void NumericFunctionNode::onPrepare(bool preserveAccurateTypes)
     }
 }
 
-bool NumericFunctionNode::onCalculate(const ExpressionNodeVector & args, ResultNode & result) const
+void NumericFunctionNode::onCalculate(const ExpressionNodeVector & args, ResultNode & result) const
 {
-    bool retval(true);
     (void) result;
     _handler->handleFirst(*args[0]->getResult());
     for (size_t i(1), m(args.size()); i < m; i++) {
         _handler->handle(*args[i]->getResult());
     }
-    return retval;
 }
 
 template <typename T>

--- a/searchlib/src/vespa/searchlib/expression/numericfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/numericfunctionnode.h
@@ -166,7 +166,7 @@ private:
         StringResultNode _initial;
     };
 
-    bool onCalculate(const ExpressionNodeVector & args, ResultNode & result) const override;
+    void onCalculate(const ExpressionNodeVector & args, ResultNode & result) const override;
     std::unique_ptr<Handler> _handler;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/rangebucketpredef.cpp
+++ b/searchlib/src/vespa/searchlib/expression/rangebucketpredef.cpp
@@ -48,13 +48,12 @@ RangeBucketPreDefFunctionNode::onPrepareResult()
     }
 }
 
-bool
+void
 RangeBucketPreDefFunctionNode::onExecute() const
 {
     getArg().execute();
     const ResultNode * result = _handler->handle(*getArg().getResult());
     _result = result ? result : _nullResult;
-    return true;
 }
 
 const ResultNode * RangeBucketPreDefFunctionNode::SingleValueHandler::handle(const ResultNode & arg)

--- a/searchlib/src/vespa/searchlib/expression/rangebucketpredef.h
+++ b/searchlib/src/vespa/searchlib/expression/rangebucketpredef.h
@@ -13,7 +13,7 @@ class RangeBucketPreDefFunctionNode : public UnaryFunctionNode
 {
 private:
     void onPrepareResult() override;
-    bool onExecute() const override;
+    void onExecute() const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
 
     class Handler {

--- a/searchlib/src/vespa/searchlib/expression/relevancenode.h
+++ b/searchlib/src/vespa/searchlib/expression/relevancenode.h
@@ -16,7 +16,7 @@ public:
     void setRelevance(double relevance) { _relevance.set(relevance); }
 private:
     void onPrepare(bool preserveAccurateTypes) override { (void) preserveAccurateTypes; }
-    bool onExecute() const override { return true; }
+    void onExecute() const override { }
     FloatResultNode _relevance;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/reversefunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/reversefunctionnode.h
@@ -13,7 +13,7 @@ public:
     ReverseFunctionNode() { }
     ReverseFunctionNode(ExpressionNode::UP  arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/sortfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/sortfunctionnode.h
@@ -13,7 +13,7 @@ public:
     SortFunctionNode() { }
     SortFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/strcatfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/strcatfunctionnode.h
@@ -14,7 +14,7 @@ public:
     StrCatFunctionNode(ExpressionNode::UP arg) { addArg(std::move(arg)); }
 private:
     void onPrepareResult() override;
-    bool onExecute() const override;
+    void onExecute() const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/expression/strlenfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/strlenfunctionnode.h
@@ -13,7 +13,7 @@ public:
     StrLenFunctionNode() { }
     StrLenFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/timestamp.cpp
+++ b/searchlib/src/vespa/searchlib/expression/timestamp.cpp
@@ -72,11 +72,10 @@ unsigned TimeStampFunctionNode::getTimePart(time_t secSince70, TimePart tp, bool
     return 0;
 }
 
-bool TimeStampFunctionNode::onExecute() const
+void TimeStampFunctionNode::onExecute() const
 {
     getArg().execute();
     _handler->handle(*getArg().getResult());
-    return true;
 }
 
 void TimeStampFunctionNode::SingleValueHandler::handle(const ResultNode & arg)

--- a/searchlib/src/vespa/searchlib/expression/timestamp.h
+++ b/searchlib/src/vespa/searchlib/expression/timestamp.h
@@ -33,7 +33,7 @@ unsigned hour(timestamp); [0-23]
 unsigned minute(timestamp);[0-59]
 unsigned second(timestamp);[0-59]
 */
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 private:
     class Handler {

--- a/searchlib/src/vespa/searchlib/expression/tofloatfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/tofloatfunctionnode.h
@@ -13,7 +13,7 @@ public:
     ToFloatFunctionNode() { }
     ToFloatFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/tointfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/tointfunctionnode.h
@@ -13,7 +13,7 @@ public:
     ToIntFunctionNode() { }
     ToIntFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/torawfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/torawfunctionnode.h
@@ -13,7 +13,7 @@ public:
     ToRawFunctionNode() { }
     ToRawFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/tostringfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/tostringfunctionnode.h
@@ -13,7 +13,7 @@ public:
     ToStringFunctionNode() { }
     ToStringFunctionNode(ExpressionNode::UP arg) : UnaryFunctionNode(std::move(arg)) { }
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/unarybitfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/unarybitfunctionnode.h
@@ -21,8 +21,8 @@ protected:
     void onPrepareResult() override;
 private:
     void onPrepare(bool preserveAccurateTypes) override;
-    virtual bool internalExecute(const vespalib::nbostream & os) const = 0;
-    bool onExecute() const override;
+    virtual void internalExecute(const vespalib::nbostream & os) const = 0;
+    void onExecute() const override;
     uint32_t _numBits;
     mutable vespalib::nbostream _tmpOs;
 };

--- a/searchlib/src/vespa/searchlib/expression/xorbitfunctionnode.h
+++ b/searchlib/src/vespa/searchlib/expression/xorbitfunctionnode.h
@@ -14,7 +14,7 @@ public:
     ~XorBitFunctionNode();
 private:
     mutable std::vector<uint8_t> _tmpXor;
-    bool internalExecute(const vespalib::nbostream & os) const override;
+    void internalExecute(const vespalib::nbostream & os) const override;
     void onPrepareResult() override;
 };
 

--- a/searchlib/src/vespa/searchlib/expression/zcurve.cpp
+++ b/searchlib/src/vespa/searchlib/expression/zcurve.cpp
@@ -47,11 +47,10 @@ int32_t ZCurveFunctionNode::Handler::getXorY(uint64_t z) const
     return (_dim==X) ? x : y;
 }
 
-bool ZCurveFunctionNode::onExecute() const
+void ZCurveFunctionNode::onExecute() const
 {
     getArg().execute();
     _handler->handle(*getArg().getResult());
-    return true;
 }
 
 void ZCurveFunctionNode::SingleValueHandler::handle(const ResultNode & arg)

--- a/searchlib/src/vespa/searchlib/expression/zcurve.h
+++ b/searchlib/src/vespa/searchlib/expression/zcurve.h
@@ -49,7 +49,7 @@ private:
         IntegerResultNodeVector & _result;
     };
 
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
     Dimension _dim;
     std::unique_ptr<Handler> _handler;

--- a/searchlib/src/vespa/searchlib/uca/ucafunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/uca/ucafunctionnode.cpp
@@ -65,11 +65,10 @@ void UcaFunctionNode::Handler::handleOne(const ResultNode & arg, RawResultNode &
     result.set(RawResultNode(buf.c_str(), buf.size()));
 }
 
-bool UcaFunctionNode::onExecute() const
+void UcaFunctionNode::onExecute() const
 {
     getArg().execute();
     _handler->handle(*getArg().getResult());
-    return true;
 }
 
 void UcaFunctionNode::SingleValueHandler::handle(const ResultNode & arg)

--- a/searchlib/src/vespa/searchlib/uca/ucafunctionnode.h
+++ b/searchlib/src/vespa/searchlib/uca/ucafunctionnode.h
@@ -20,7 +20,7 @@ public:
     UcaFunctionNode(const UcaFunctionNode & rhs);
     UcaFunctionNode & operator = (const UcaFunctionNode & rhs);
 private:
-    bool onExecute() const override;
+    void onExecute() const override;
     void onPrepareResult() override;
     class Handler {
     public:


### PR DESCRIPTION
- ExpressionNode onExecute returned a bool, but all instances returned true, and almost no descendants checked the output.
- Make onExecute return void.
- Make onCalculate return void.
- Checked that grouping_adv tests run successfully.