### PR TITLE
Wire in ArrayBoolSearch (ArrayBoolSearch 3)

### DIFF
--- a/searchlib/src/tests/queryeval/array_bool/array_bool_test.cpp
+++ b/searchlib/src/tests/queryeval/array_bool/array_bool_test.cpp
@@ -366,6 +366,32 @@ std::unique_ptr<SearchIterator> SameElementBlueprintSearchBuilder::create_search
 
 }
 
+TEST(ArrayBoolSearchTest, require_that_same_element_blueprint_creates_array_bool_search) {
+    TestAttribute test_attribute;
+    test_attribute.attr->addDocs(5);
+    test_attribute.attr->commit();
+
+    for (bool want_true : {false, true}) {
+        for (bool strict : {false, true}) {
+            std::vector<uint32_t> element_filter({1, 2, 3});
+            SameElementBlueprintSearchBuilder builder(test_attribute.bool_attr, test_attribute.attr, element_filter, want_true);
+            auto search = builder.create_search(strict);
+
+            auto se = dynamic_cast<SameElementSearch*>(search.get());
+            ASSERT_TRUE(se);
+            const auto& children = se->children();
+            ASSERT_EQ(children.size(), 1);
+            auto only_child = children[0].get();
+            auto abs = dynamic_cast<ArrayBoolSearch*>(only_child);
+            ASSERT_TRUE(abs);
+            EXPECT_EQ(abs->want_true(), want_true);
+            EXPECT_TRUE(abs->is_strict() == (strict ? vespalib::Trinary::True : vespalib::Trinary::False));
+            EXPECT_TRUE(std::equal(element_filter.begin(), element_filter.begin() + element_filter.size(), abs->get_element_filter().begin()));
+            EXPECT_EQ(test_attribute.bool_attr, &abs->get_attribute());
+        }
+    }
+}
+
 /**
  * Test fixture
  **/

--- a/searchlib/src/vespa/searchcommon/attribute/i_search_context.h
+++ b/searchlib/src/vespa/searchcommon/attribute/i_search_context.h
@@ -17,6 +17,8 @@ namespace search { class QueryTermUCS4; }
 
 namespace search::attribute {
 
+class ArrayBoolSearchContext;
+
 class ISearchContext {
 public:
     using UP = std::unique_ptr<ISearchContext>;
@@ -88,6 +90,8 @@ public:
     // Get element ids. Might call unpack. Assumes element_ids is cleared by caller.
     virtual void get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) const;
     virtual void and_element_ids_into(uint32_t docid, std::vector<uint32_t>& element_ids) const;
+
+    virtual const ArrayBoolSearchContext* as_array_bool_search_context() const { return nullptr; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.cpp
@@ -41,52 +41,6 @@ vespalib::BitSpan decode_bools(std::span<const char> raw) noexcept {
     return vespalib::BitSpan(raw.data() + 1, count);
 }
 
-class ArrayBoolSearchContext : public SearchContext {
-    const ArrayBoolAttribute& _attr;
-    bool _want_true;
-    bool _valid;
-
-    bool valid() const override { return _valid; }
-
-    int32_t onFind(DocId docId, int32_t elemId, int32_t& weight) const override {
-        int32_t result = onFind(docId, elemId);
-        weight = (result >= 0) ? 1 : 0;
-        return result;
-    }
-
-    int32_t onFind(DocId docId, int32_t elemId) const override {
-        auto bools = _attr.get_bools(docId);
-        for (uint32_t i = static_cast<uint32_t>(elemId); i < bools.size(); ++i) {
-            if (bools[i] == _want_true) {
-                return static_cast<int32_t>(i);
-            }
-        }
-        return -1;
-    }
-
-public:
-    ArrayBoolSearchContext(std::unique_ptr<QueryTermSimple> qTerm, const ArrayBoolAttribute& attr)
-        : SearchContext(attr),
-          _attr(attr),
-          _want_true(true),
-          _valid(qTerm->isValid())
-    {
-        if ((strcmp("0", qTerm->getTerm()) == 0) || (strcasecmp("false", qTerm->getTerm()) == 0)) {
-            _want_true = false;
-        } else if ((strcmp("1", qTerm->getTerm()) != 0) && (strcasecmp("true", qTerm->getTerm()) != 0)) {
-            _valid = false;
-        }
-    }
-
-    HitEstimate calc_hit_estimate() const override {
-        return _valid ? HitEstimate(_attr.getCommittedDocIdLimit()) : HitEstimate(0);
-    }
-
-    uint32_t get_committed_docid_limit() const noexcept override {
-        return _attr.getCommittedDocIdLimit();
-    }
-};
-
 class ArrayBoolReadView : public IArrayBoolReadView {
     const vespalib::RcuVectorBase<vespalib::datastore::AtomicEntryRef>& _ref_vector;
     const RawBufferStore& _raw_store;
@@ -113,6 +67,8 @@ public:
 };
 
 } // anonymous namespace
+
+
 
 ArrayBoolAttribute::ArrayBoolAttribute(const std::string& name, const Config& config)
     : ArrayBoolAttributeAccess(name, config),

--- a/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.h
@@ -111,6 +111,8 @@ public:
     uint32_t get_committed_docid_limit() const noexcept override {
         return _attr.getCommittedDocIdLimit();
     }
+
+    const ArrayBoolSearchContext* as_array_bool_search_context() const override { return this; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.h
@@ -113,6 +113,10 @@ public:
     }
 
     const ArrayBoolSearchContext* as_array_bool_search_context() const override { return this; }
+
+    const ArrayBoolAttribute& get_attribute() const { return _attr; }
+    bool get_want_true() const { return _want_true; }
+    bool get_valid() const { return _valid; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/array_bool_attribute.h
@@ -4,7 +4,11 @@
 
 #include "array_bool_attribute_access.h"
 #include "raw_buffer_store.h"
+#include <vespa/searchcommon/attribute/i_multi_value_attribute.h>
+#include <vespa/searchlib/attribute/search_context.h>
+#include <vespa/searchlib/query/query_term_simple.h>
 #include <vespa/vespalib/util/rcuvector.h>
+#include <cstring>
 
 namespace search::attribute {
 
@@ -61,6 +65,52 @@ public:
 
     // IMultiValueAttribute
     const IArrayBoolReadView* make_read_view(ArrayBoolTag, vespalib::Stash&) const override;
+};
+
+class ArrayBoolSearchContext : public SearchContext {
+    const ArrayBoolAttribute& _attr;
+    bool _want_true;
+    bool _valid;
+
+    bool valid() const override { return _valid; }
+
+    int32_t onFind(DocId docId, int32_t elemId, int32_t& weight) const override {
+        int32_t result = onFind(docId, elemId);
+        weight = (result >= 0) ? 1 : 0;
+        return result;
+    }
+
+    int32_t onFind(DocId docId, int32_t elemId) const override {
+        auto bools = _attr.get_bools(docId);
+        for (uint32_t i = static_cast<uint32_t>(elemId); i < bools.size(); ++i) {
+            if (bools[i] == _want_true) {
+                return static_cast<int32_t>(i);
+            }
+        }
+        return -1;
+    }
+
+public:
+    ArrayBoolSearchContext(std::unique_ptr<QueryTermSimple> qTerm, const ArrayBoolAttribute& attr)
+        : SearchContext(attr),
+          _attr(attr),
+          _want_true(true),
+          _valid(qTerm->isValid())
+    {
+        if ((strcmp("0", qTerm->getTerm()) == 0) || (strcasecmp("false", qTerm->getTerm()) == 0)) {
+            _want_true = false;
+        } else if ((strcmp("1", qTerm->getTerm()) != 0) && (strcasecmp("true", qTerm->getTerm()) != 0)) {
+            _valid = false;
+        }
+    }
+
+    HitEstimate calc_hit_estimate() const override {
+        return _valid ? HitEstimate(_attr.getCommittedDocIdLimit()) : HitEstimate(0);
+    }
+
+    uint32_t get_committed_docid_limit() const noexcept override {
+        return _attr.getCommittedDocIdLimit();
+    }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/array_bool_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/array_bool_search.h
@@ -42,6 +42,10 @@ public:
     bool check_array(uint32_t docid) const;
     void get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) override;
 
+    bool want_true() const { return _want_true; }
+    const std::vector<uint32_t>& get_element_filter() const { return _element_filter; }
+    const ArrayBoolAttribute& get_attribute() const { return _attr; }
+
     /**
      * Create an ArrayBoolSearch.
      *

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -1,8 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "same_element_blueprint.h"
+#include "array_bool_search.h"
 #include "same_element_search.h"
 #include "field_spec.hpp"
+#include <vespa/searchcommon/attribute/i_search_context.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>
 #include <vespa/vespalib/objects/visit.hpp>
 #include <algorithm>
@@ -110,6 +112,23 @@ SameElementBlueprint::create_same_element_search(MatchData& md, TermFieldMatchDa
     auto& children = get_children();
     sub_searches.reserve(children.size());
     for (const auto & child : children) {
+        if (!_element_filter.empty()) {
+            const attribute::ISearchContext* search_context = child->get_attribute_search_context();
+            if (search_context) {
+                const attribute::ArrayBoolSearchContext* array_bool_context = search_context->as_array_bool_search_context();
+                const auto& state = child->getState();
+                if (state.numFields() == 1 && array_bool_context && array_bool_context->get_valid()) {
+
+                    sub_searches.push_back(ArrayBoolSearch::create(array_bool_context->get_attribute(),
+                                                                   _element_filter,
+                                                                   array_bool_context->get_want_true(),
+                                                                   child->strict(),
+                                                                   state.field(0).resolve(md)));
+                    continue;
+                }
+            }
+        }
+
         sub_searches.push_back(child->createSearch(md));
     }
     std::vector<TermFieldMatchData*> descendants_index_tfmd;


### PR DESCRIPTION
Continuation of https://github.com/vespa-engine/vespa/pull/36097.

- Create a ArrayBoolSearch in SameElementBlueprint if possible
- Test the iterator constructed by SameElementBlueprint in unit test
- Add test case that checks that the SameElementBlueprint actually constructs an ArrayBoolSearch