### PR TITLE
Fix XGBoost UBJ float-vs-double condition mismatch

### DIFF
--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/xgboost/XGBoostUbjParser.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/xgboost/XGBoostUbjParser.java
@@ -463,6 +463,22 @@ class XGBoostUbjParser extends AbstractXGBoostParser {
         return treesValue.asArray();
     }
 
+    // Because XGBoost operates with floats, but the input data will often have
+    // higher precision, there is the risk that Vespa (treating the input data
+    // as double) will think (x < x') where x' is the split created by converting
+    // x to float.  But XGBoost predictions will of course be computed with
+    // (x == x') instead.
+    // Adjust splits to the next float (1 epsilon) down (negative direction)
+    // to alleviate this and give the same results as XGBoost predicts.
+    private static float[] adjustSplitConditions(float[] splitConditions) {
+        for (int i = 0; i < splitConditions.length; i++) {
+            float f = splitConditions[i];
+            float adjusted = Math.nextAfter(f, -Float.MAX_VALUE);
+            splitConditions[i] = adjusted;
+        }
+        return splitConditions;
+    }
+
     /**
      * Converts a UBJ tree (flat array format) to the root XGBoostTree node (hierarchical format).
      *
@@ -478,6 +494,7 @@ class XGBoostUbjParser extends AbstractXGBoostParser {
         float[] baseWeights = treeObj.get("base_weights").asFloat32Array();
         byte[] defaultLeftBytes = extractDefaultLeft(treeObj.get("default_left"));
 
+        splitConditions = adjustSplitConditions(splitConditions);
         // Convert from flat arrays to hierarchical tree structure, starting at root (node 0, depth 0)
         return buildTreeFromArrays(0, 0, leftChildren, rightChildren, splitConditions,
                 splitIndices, baseWeights, defaultLeftBytes);


### PR DESCRIPTION
XGBoost uses float precision internally for split thresholds, but Vespa evaluates ranking expressions in double precision.  When a data value x rounds up to float x' (= the split threshold), XGBoost sees (x < x') = false and goes right, but Vespa sees (x < x') = true and goes left, producing different predictions.

Nudge each split threshold down by one float ULP so that Vespa's double-precision comparison matches XGBoost's float-precision behavior.
