### PR TITLE
Make applyOnRestart sticky to keep it true until restart

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
@@ -137,7 +137,7 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
 
         // Minimum observed config generation for all services without applyOnRestart across all pending restart nodes.
         // Services with applyOnRestart set to {@code true} are excluded because they are waiting for restart to apply a
-        // new config and report a new config generation.
+        // new config, while still reporting the old config.
         OptionalLong minObservedGeneration = configStates.values().stream()
                 .flatMap(List::stream)
                 .filter(state -> !state.applyOnRestart().orElse(false))

--- a/container-disc/src/main/java/com/yahoo/container/di/ConfigRetriever.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/ConfigRetriever.java
@@ -177,7 +177,10 @@ public final class ConfigRetriever {
      * @see Subscriber#applyOnRestart()
      */
     private void updateApplyOnRestart() {
-        vespaContainer.setApplyOnRestart(bootstrapSubscriber.applyOnRestart() || componentSubscriber.applyOnRestart());
+        if (!vespaContainer.applyOnRestart()) { // Keep it `true` until restart.
+            vespaContainer.setApplyOnRestart(
+                    bootstrapSubscriber.applyOnRestart() || componentSubscriber.applyOnRestart());
+        }
     }
 
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This might fix the issue when applyOnRestart is never reported as true because it's value is reset back to false when component subscriber is reset.
