### PR TITLE
fix(cli) avoid HTML escaping in CBOR to JSON conversion

### DIFF
--- a/client/go/internal/ioutil/ioutil.go
+++ b/client/go/internal/ioutil/ioutil.go
@@ -110,6 +110,16 @@ func normalizeForJSON(v interface{}) interface{} {
 	return v
 }
 
+// encodeJSON encodes v as JSON into buf without Go's default HTML escaping of <, >, and &.
+func encodeJSON(buf *bytes.Buffer, v interface{}, indent bool) error {
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if indent {
+		enc.SetIndent("", "    ")
+	}
+	return enc.Encode(v)
+}
+
 // CBORToJSON converts CBOR data to indented JSON string.
 func CBORToJSON(data []byte) (string, error) {
 	var v interface{}
@@ -117,11 +127,11 @@ func CBORToJSON(data []byte) (string, error) {
 		return "", err
 	}
 	v = normalizeForJSON(v)
-	jsonBytes, err := json.MarshalIndent(v, "", "    ")
-	if err != nil {
+	var buf bytes.Buffer
+	if err := encodeJSON(&buf, v, true); err != nil {
 		return "", err
 	}
-	return string(jsonBytes), nil
+	return strings.TrimSuffix(buf.String(), "\n"), nil
 }
 
 // CBORToJSONCompact converts CBOR data to compact JSON string.
@@ -131,11 +141,11 @@ func CBORToJSONCompact(data []byte) (string, error) {
 		return "", err
 	}
 	v = normalizeForJSON(v)
-	jsonBytes, err := json.Marshal(v)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := encodeJSON(&buf, v, false); err != nil {
 		return "", err
 	}
-	return string(jsonBytes), nil
+	return strings.TrimSuffix(buf.String(), "\n"), nil
 }
 
 // AtomicWriteFile atomically writes data to filename.

--- a/client/go/internal/ioutil/ioutil_test.go
+++ b/client/go/internal/ioutil/ioutil_test.go
@@ -39,6 +39,22 @@ func TestCBORToJSONNonFiniteFloats(t *testing.T) {
 	assert.Equal(t, "-Infinity", parsedCompact["negInf"])
 }
 
+func TestCBORToJSONNoHTMLEscaping(t *testing.T) {
+	input := map[string]interface{}{
+		"type": "tensor<int8>(x[128])",
+	}
+	data, err := cbor.Marshal(input)
+	assert.Nil(t, err)
+
+	got, err := CBORToJSON(data)
+	assert.Nil(t, err)
+	assert.Contains(t, got, `tensor<int8>(x[128])`)
+
+	gotCompact, err := CBORToJSONCompact(data)
+	assert.Nil(t, err)
+	assert.Contains(t, gotCompact, `tensor<int8>(x[128])`)
+}
+
 func TestPathExists(t *testing.T) {
 	assert.Equal(t, true, Exists("ioutil.go"))
 	assert.Equal(t, false, Exists("nosuchthing.go"))


### PR DESCRIPTION
## Summary

The switch to CBOR introduced a regression where for example `<` and `>` in JSON string values (e.g. tensor type descriptors) are HTML-escaped to `\u003c` and `\u003e`.

<img width="504" height="190" alt="image" src="https://github.com/user-attachments/assets/c487c5a2-6770-48bc-8f01-20e17d879964" />

**Before (JSON path):** `"type": "tensor<int8>(x[128])"`
**After (CBOR path):** `"type": "tensor\u003cint8\u003e(x[128])"`

**Root cause:** `json.Marshal`/`json.MarshalIndent` in Go hardcode `escapeHTML: true`. The only way to disable it is via `json.Encoder.SetEscapeHTML(false)`.

**Fix:** Replace `json.Marshal`/`json.MarshalIndent` with `json.NewEncoder` + `SetEscapeHTML(false)` in `CBORToJSON` and `CBORToJSONCompact`.