### PR TITLE
Upgrade Jetty to 12.0.33

### DIFF
--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
@@ -76,7 +76,7 @@ import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
 import static com.yahoo.jdisc.Response.Status.NOT_FOUND;
 import static com.yahoo.jdisc.Response.Status.OK;
 import static com.yahoo.jdisc.Response.Status.REQUEST_TOO_LONG;
-import static com.yahoo.jdisc.Response.Status.REQUEST_URI_TOO_LONG;
+
 import static com.yahoo.jdisc.Response.Status.UNAUTHORIZED;
 import static com.yahoo.jdisc.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static com.yahoo.jdisc.http.HttpHeaders.Names.CONNECTION;
@@ -156,14 +156,14 @@ public class HttpServerIT {
     }
 
     @Test
-    void requireThatTooLongInitLineReturns414() throws Exception {
+    void requireThatTooLongInitLineReturns431() throws Exception {
         final JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
                 mockRequestHandler(),
                 new ServerConfig.Builder(),
                 new ConnectorConfig.Builder()
                         .requestHeaderSize(1));
         driver.client().get("/status.html")
-                .expectStatusCode(is(REQUEST_URI_TOO_LONG));
+                .expectStatusCode(is(431));
         assertTrue(driver.close());
     }
 
@@ -208,9 +208,9 @@ public class HttpServerIT {
                 new ConnectorConfig.Builder().requestHeaderSize(1),
                 binder -> binder.bind(RequestLog.class).toInstance(requestLogMock));
         driver.client().get("/status.html")
-                .expectStatusCode(is(REQUEST_URI_TOO_LONG));
+                .expectStatusCode(is(431));
         RequestLogEntry entry = requestLogMock.poll(Duration.ofSeconds(5));
-        assertEquals(414, entry.statusCode().getAsInt());
+        assertEquals(431, entry.statusCode().getAsInt());
         assertTrue(driver.close());
     }
 

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -109,7 +109,7 @@
         <io-perfmark.vespa.version>0.27.0</io-perfmark.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.0.32</jetty.vespa.version>
+        <jetty.vespa.version>12.0.33</jetty.vespa.version>
         <jetty.client.vespa.version>12.0.22</jetty.client.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>


### PR DESCRIPTION
## Summary
- Upgrade Jetty server version from 12.0.32 to 12.0.33