### PR TITLE
Improved readability, testability and logging in service filtering logic to determine ready to restart generation

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
@@ -34,7 +34,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -44,10 +43,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
-import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
-import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
-import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
 import static java.util.logging.Level.FINE;
 
 /**
@@ -56,38 +51,13 @@ import static java.util.logging.Level.FINE;
 public class ConfigStateChecker extends AbstractComponent {
     private static final Logger log = Logger.getLogger(ConfigStateChecker.class.getName());
 
-    private static final Set<String> serviceTypesToCheck = Set.of(
-            CONTAINER.serviceName,
-            LOGSERVER_CONTAINER.serviceName,
-            CLUSTERCONTROLLER_CONTAINER.serviceName,
-            METRICS_PROXY_CONTAINER.serviceName,
-            "searchnode",
-            "storagenode",
-            "distributor");
-
     private final ExecutorService responseHandlerExecutor =
             Executors.newSingleThreadExecutor(new DaemonThreadFactory("config-state-checker-response-handler-"));
 
     /**
-     * Fetches config states of all services in {@code application} with {@code hostnames}.
-     */
-    public Map<ServiceInfo, ServiceConfigState> getServiceConfigStates(
-            Application application, Duration timeoutPerService, Set<String> hostnames) {
-        List<ServiceInfo> servicesToCheck = application.getModel().getHosts().stream()
-                .flatMap(host -> host.getServices().stream()
-                        .filter(service -> hostnames.contains(host.getHostname())
-                                && serviceTypesToCheck.contains(service.getServiceType())
-                                && getStatePort(service).isPresent()))
-                .toList();
-
-        log.log(FINE, () -> "Services to check for config state: " + servicesToCheck);
-        return getServiceConfigStates(servicesToCheck, timeoutPerService);
-    }
-
-    /**
      * Fetch service config states for a list of services (in parallel).
      */
-    private Map<ServiceInfo, ServiceConfigState> getServiceConfigStates(List<ServiceInfo> services, Duration timeout) {
+    public Map<ServiceInfo, ServiceConfigState> getServiceConfigStates(List<ServiceInfo> services, Duration timeout) {
         try (CloseableHttpAsyncClient client = createHttpClient()) {
             client.start();
             List<CompletableFuture<Void>> inprogressRequests = new ArrayList<>();

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
@@ -111,38 +111,36 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
         }
         return asSuccessFactorDeviation(attempts.get(), failures.get());
     }
-    
-    List<ServiceInfo> getServicesToCheck(Application application, Set<String> hostnames) {
-        Set<ApplicationClusterInfo> clustersToExclude = application.getModel().applicationClusterInfo().stream()
+
+    static List<ServiceInfo> filterServicesToCheck(
+            String appId,
+            List<ApplicationClusterInfo> clusters,
+            List<ServiceInfo> services,
+            Set<String> hostnames,
+            Logger log) {
+        log.fine(() -> Text.format("Services of %s to check: %s", appId, servicesToString(services)));
+
+        List<ServiceInfo> servicesWithTypeToCheck = services.stream()
+                .filter(service -> serviceTypesToCheck.contains(service.getServiceType()))
+                .toList();
+        log.fine(() ->
+                Text.format("Services of %s with type to check: %s", appId, servicesToString(servicesWithTypeToCheck)));
+
+        List<ServiceInfo> servicesWithHostnamesToCheck = servicesWithTypeToCheck.stream()
+                .filter(service -> hostnames.contains(service.getHostName()))
+                .toList();
+        log.fine(() -> Text.format(
+                "Services of %s with hostnames [%s] to check: %s",
+                appId, String.join(", ", hostnames), servicesToString(servicesWithHostnamesToCheck)));
+
+        Set<ApplicationClusterInfo> clustersToExclude = clusters.stream()
                 .filter(ApplicationClusterInfo::getDeferChangesUntilRestart)
                 .collect(Collectors.toSet());
 
         String clustersToExcludeString =
                 clustersToExclude.stream().map(ApplicationClusterInfo::name).collect(Collectors.joining(", "));
 
-        log.fine(() -> Text.format(
-                "Excluded clusters of %s with deferChangesUntilRestart: %s",
-                application.getId().toFullString(), clustersToExcludeString));
-
-        List<ServiceInfo> allServices = application.getModel().getHosts().stream()
-                .flatMap(host -> host.getServices().stream())
-                .toList();
-        log.fine(() -> Text.format(
-                "All services of %s: %s", application.getId().toFullString(), servicesToString(allServices)));
-
-        List<ServiceInfo> servicesWithTypeToCheck = allServices.stream()
-                .filter(service -> serviceTypesToCheck.contains(service.getServiceType()))
-                .toList();
-        log.fine(() -> Text.format(
-                "Services of %s with type to check: %s",
-                application.getId().toFullString(), servicesToString(servicesWithTypeToCheck)));
-
-        List<ServiceInfo> servicesWithHostnamesToCheck = servicesWithTypeToCheck.stream()
-                .filter(service -> hostnames.contains(service.getHostName()))
-                .toList();
-        log.fine(() -> Text.format(
-                "Services of %s with hostnames to check: %s",
-                application.getId().toFullString(), servicesToString(servicesWithHostnamesToCheck)));
+        log.fine(() -> Text.format("Cluster of %s with deferChangesUntilRestart: %s", appId, clustersToExcludeString));
 
         List<ServiceInfo> servicesInClustersToCheck = servicesWithHostnamesToCheck.stream()
                 .filter(service -> clustersToExclude.stream()
@@ -151,7 +149,7 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                 .toList();
         log.fine(() -> Text.format(
                 "Services of %s in clusters without deferChangesUntilRestart to check: %s",
-                application.getId().toFullString(), servicesToString(servicesInClustersToCheck)));
+                appId, servicesToString(servicesInClustersToCheck)));
 
         List<ServiceInfo> servicesWithStatePort = servicesInClustersToCheck.stream()
                 .filter(service -> service.getPorts().stream()
@@ -161,16 +159,20 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                         .isPresent())
                 .toList();
         log.fine(() -> Text.format(
-                "Services of %s with state port to check: %s",
-                application.getId().toFullString(), servicesToString(servicesWithStatePort)));
-        
+                "Services of %s with state port to check: %s", appId, servicesToString(servicesWithStatePort)));
+
         return servicesWithStatePort;
     }
 
-    Map<String, List<ServiceConfigState>> fetchConfigServiceStates(
-            Application application, Set<String> hostnames) {
-        List<ServiceInfo> servicesToCheck = getServicesToCheck(application, hostnames);
-        
+    Map<String, List<ServiceConfigState>> fetchConfigServiceStates(Application application, Set<String> hostnames) {
+        List<ApplicationClusterInfo> clusters =
+                application.getModel().applicationClusterInfo().stream().toList();
+        List<ServiceInfo> services = application.getModel().getHosts().stream()
+                .flatMap(host -> host.getServices().stream())
+                .toList();
+        List<ServiceInfo> servicesToCheck =
+                filterServicesToCheck(application.getId().toFullString(), clusters, services, hostnames, log);
+
         Map<ServiceInfo, ServiceConfigState> stateByService = applicationRepository
                 .configStateChecker()
                 .getServiceConfigStates(servicesToCheck, Duration.ofSeconds(10));
@@ -285,8 +287,10 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
     static String servicesToString(List<ServiceInfo> services) {
         return Text.format(
                 "[%s]",
-                services.stream().map(service -> Text.format(
-                        "{name=%s, type=%s, host=%s}",
-                        service.getServiceName(), service.getServiceType(), service.getHostName())));
+                services.stream()
+                        .map(service -> Text.format(
+                                "{name=%s, type=%s, host=%s}",
+                                service.getServiceName(), service.getServiceType(), service.getHostName()))
+                        .collect(Collectors.joining(", ")));
     }
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
@@ -2,6 +2,8 @@
 package com.yahoo.vespa.config.server.maintenance;
 
 import com.yahoo.api.annotations.Beta;
+import com.yahoo.config.model.api.ApplicationClusterInfo;
+import com.yahoo.config.model.api.PortInfo;
 import com.yahoo.config.model.api.ServiceConfigState;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.provision.ApplicationId;
@@ -31,6 +33,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
+import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
+
 /**
  * Maintainer that triggers restart of pending restart nodes stored in ZooKeeper.
  * Implements restart conditions to ensure that services converge to the same config generation before restart.
@@ -42,6 +49,14 @@ import java.util.stream.Collectors;
  */
 @Beta
 public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
+    private static final Set<String> serviceTypesToCheck = Set.of(
+            CONTAINER.serviceName,
+            LOGSERVER_CONTAINER.serviceName,
+            CLUSTERCONTROLLER_CONTAINER.serviceName,
+            METRICS_PROXY_CONTAINER.serviceName,
+            "searchnode",
+            "storagenode",
+            "distributor");
 
     private final Clock clock;
     private final BooleanFlag waitForApplyOnRestart;
@@ -76,8 +91,8 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                                     applicationRepository.modifyPendingRestarts(
                                             id,
                                             restarts -> triggerPendingRestarts(
-                                                    restartingHosts -> getConfigServiceStatesByHostname(
-                                                            application, restartingHosts),
+                                                    restartingHosts ->
+                                                            fetchConfigServiceStates(application, restartingHosts),
                                                     this::restart,
                                                     id,
                                                     restarts,
@@ -96,12 +111,69 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
         }
         return asSuccessFactorDeviation(attempts.get(), failures.get());
     }
+    
+    List<ServiceInfo> getServicesToCheck(Application application, Set<String> hostnames) {
+        Set<ApplicationClusterInfo> clustersToExclude = application.getModel().applicationClusterInfo().stream()
+                .filter(ApplicationClusterInfo::getDeferChangesUntilRestart)
+                .collect(Collectors.toSet());
 
-    private Map<String, List<ServiceConfigState>> getConfigServiceStatesByHostname(
+        String clustersToExcludeString =
+                clustersToExclude.stream().map(ApplicationClusterInfo::name).collect(Collectors.joining(", "));
+
+        log.fine(() -> Text.format(
+                "Excluded clusters of %s with deferChangesUntilRestart: %s",
+                application.getId().toFullString(), clustersToExcludeString));
+
+        List<ServiceInfo> allServices = application.getModel().getHosts().stream()
+                .flatMap(host -> host.getServices().stream())
+                .toList();
+        log.fine(() -> Text.format(
+                "All services of %s: %s", application.getId().toFullString(), servicesToString(allServices)));
+
+        List<ServiceInfo> servicesWithTypeToCheck = allServices.stream()
+                .filter(service -> serviceTypesToCheck.contains(service.getServiceType()))
+                .toList();
+        log.fine(() -> Text.format(
+                "Services of %s with type to check: %s",
+                application.getId().toFullString(), servicesToString(servicesWithTypeToCheck)));
+
+        List<ServiceInfo> servicesWithHostnamesToCheck = servicesWithTypeToCheck.stream()
+                .filter(service -> hostnames.contains(service.getHostName()))
+                .toList();
+        log.fine(() -> Text.format(
+                "Services of %s with hostnames to check: %s",
+                application.getId().toFullString(), servicesToString(servicesWithHostnamesToCheck)));
+
+        List<ServiceInfo> servicesInClustersToCheck = servicesWithHostnamesToCheck.stream()
+                .filter(service -> clustersToExclude.stream()
+                        .noneMatch(cluster -> cluster.name()
+                                .equals(service.getProperty("clustername").orElse(""))))
+                .toList();
+        log.fine(() -> Text.format(
+                "Services of %s in clusters without deferChangesUntilRestart to check: %s",
+                application.getId().toFullString(), servicesToString(servicesInClustersToCheck)));
+
+        List<ServiceInfo> servicesWithStatePort = servicesInClustersToCheck.stream()
+                .filter(service -> service.getPorts().stream()
+                        .filter(port -> port.getTags().contains("state"))
+                        .map(PortInfo::getPort)
+                        .findFirst()
+                        .isPresent())
+                .toList();
+        log.fine(() -> Text.format(
+                "Services of %s with state port to check: %s",
+                application.getId().toFullString(), servicesToString(servicesWithStatePort)));
+        
+        return servicesWithStatePort;
+    }
+
+    Map<String, List<ServiceConfigState>> fetchConfigServiceStates(
             Application application, Set<String> hostnames) {
+        List<ServiceInfo> servicesToCheck = getServicesToCheck(application, hostnames);
+        
         Map<ServiceInfo, ServiceConfigState> stateByService = applicationRepository
                 .configStateChecker()
-                .getServiceConfigStates(application, Duration.ofSeconds(10), hostnames);
+                .getServiceConfigStates(servicesToCheck, Duration.ofSeconds(10));
 
         return stateByService.entrySet().stream()
                 .collect(Collectors.groupingBy(
@@ -207,5 +279,13 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                                                 .orElse("empty")))
                                 .collect(Collectors.joining(", "))))
                 .collect(Collectors.joining(", "));
+    }
+
+    static String servicesToString(List<ServiceInfo> services) {
+        return Text.format(
+                "[%s]",
+                services.stream().map(service -> Text.format(
+                        "{name=%s, type=%s, host=%s}",
+                        service.getServiceName(), service.getServiceType(), service.getHostName())));
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ConfigStateCheckerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ConfigStateCheckerTest.java
@@ -88,12 +88,14 @@ public class ConfigStateCheckerTest {
                 .willReturn(okJson("{\"config\":{\"generation\":3}}")));
         wireMock3.stubFor(get(urlEqualTo("/state/v1/config")).willReturn(okJson("{\"config\":{\"generation\":5}}")));
 
-        // Query only services on 127.0.0.1 (should return 2 services, localhost not included)
-        Set<String> hostnames = Set.of("127.0.0.1");
+        // Get all services
+        List<ServiceInfo> servicesToCheck = application.getModel().getHosts().stream()
+                .flatMap(host -> host.getServices().stream())
+                .toList();
         Map<ServiceInfo, ServiceConfigState> response =
-                checker.getServiceConfigStates(application, clientTimeout, hostnames);
+                checker.getServiceConfigStates(servicesToCheck, clientTimeout);
 
-        assertEquals(2, response.size());
+        assertEquals(3, response.size());
 
         List<Map.Entry<ServiceInfo, ServiceConfigState>> entries = List.copyOf(response.entrySet());
 
@@ -111,6 +113,13 @@ public class ConfigStateCheckerTest {
         assertEquals("127.0.0.1", serviceInfo2.getHostName());
         assertEquals(3, state2.currentGeneration());
         assertTrue(state2.applyOnRestart().isEmpty());
+
+        // Third service (localhost)
+        ServiceInfo serviceInfo3 = entries.get(2).getKey();
+        ServiceConfigState state3 = entries.get(2).getValue();
+        assertEquals("localhost", serviceInfo3.getHostName());
+        assertEquals(5, state3.currentGeneration());
+        assertTrue(state3.applyOnRestart().isEmpty());
     }
 
     @Test
@@ -121,9 +130,11 @@ public class ConfigStateCheckerTest {
                                 (int) clientTimeout.plus(Duration.ofSeconds(1)).toMillis())
                         .withBody("response too slow")));
 
-        Set<String> hostnames = Set.of(service1.getHost());
+        List<ServiceInfo> servicesToCheck = application.getModel().getHosts().stream()
+                .flatMap(host -> host.getServices().stream())
+                .toList();
         Map<ServiceInfo, ServiceConfigState> response =
-                checker.getServiceConfigStates(application, Duration.ofMillis(1), hostnames);
+                checker.getServiceConfigStates(servicesToCheck, Duration.ofMillis(1));
 
         assertEquals(1, response.size());
         ServiceConfigState state = response.values().iterator().next();
@@ -134,13 +145,11 @@ public class ConfigStateCheckerTest {
     }
 
     @Test
-    public void test_getServiceConfigStates_unknown_host() {
-        // No stub configured, so the service will not be reachable
-        Set<String> hostnames = Set.of("unknown");
+    public void test_getServiceConfigStates_empty_list() {
+        List<ServiceInfo> servicesToCheck = List.of();
         Map<ServiceInfo, ServiceConfigState> response =
-                checker.getServiceConfigStates(application, clientTimeout, hostnames);
+                checker.getServiceConfigStates(servicesToCheck, clientTimeout);
 
-        // Should return empty map since the hostname doesn't match any service in the application
         assertEquals(0, response.size());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
@@ -1,7 +1,9 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.maintenance;
 
+import com.yahoo.config.model.api.ApplicationClusterInfo;
 import com.yahoo.config.model.api.ServiceConfigState;
+import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.config.server.application.PendingRestarts;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.configStatesToString;
+import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.servicesToString;
 import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.triggerPendingRestarts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -180,5 +183,37 @@ class RestartOnDeployMaintainerTest {
                                 List.of(
                                         new ServiceConfigState(20, Optional.empty()),
                                         new ServiceConfigState(21, Optional.of(true))))));
+    }
+
+    @Test
+    void test_servicesToString() {
+        assertEquals("[]", servicesToString(List.of()));
+
+        // Note: The actual format includes stream processing, so this tests the expected output structure
+        List<ServiceInfo> services = List.of(
+                MockServiceInfo.create("service1", "container", "host1"),
+                MockServiceInfo.create("service2", "searchnode", "host2")
+        );
+
+        String result = servicesToString(services);
+        // Verify it contains the expected service information
+        assertEquals(true, result.contains("service1"));
+        assertEquals(true, result.contains("container"));
+        assertEquals(true, result.contains("host1"));
+        assertEquals(true, result.contains("service2"));
+        assertEquals(true, result.contains("searchnode"));
+        assertEquals(true, result.contains("host2"));
+    }
+
+    // Simple mock for testing servicesToString
+    private static class MockServiceInfo extends ServiceInfo {
+        static MockServiceInfo create(String name, String type, String hostname) {
+            return new MockServiceInfo(name, type, Set.of(), Map.of(), "", hostname);
+        }
+
+        private MockServiceInfo(String serviceName, String serviceType, Set portInfos, Map properties,
+                                String configId, String hostName) {
+            super(serviceName, serviceType, portInfos, properties, configId, hostName);
+        }
     }
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainerTest.java
@@ -1,20 +1,25 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.maintenance;
 
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
 import com.yahoo.config.model.api.ApplicationClusterInfo;
+import com.yahoo.config.model.api.PortInfo;
 import com.yahoo.config.model.api.ServiceConfigState;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.config.server.application.PendingRestarts;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.configStatesToString;
+import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.filterServicesToCheck;
 import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.servicesToString;
 import static com.yahoo.vespa.config.server.maintenance.RestartOnDeployMaintainer.triggerPendingRestarts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -190,31 +195,124 @@ class RestartOnDeployMaintainerTest {
     void test_servicesToString() {
         assertEquals("[]", servicesToString(List.of()));
 
-        // Note: The actual format includes stream processing, so this tests the expected output structure
         List<ServiceInfo> services = List.of(
                 MockServiceInfo.create("service1", "container", "host1"),
-                MockServiceInfo.create("service2", "searchnode", "host2")
-        );
+                MockServiceInfo.create("service2", "searchnode", "host2"));
 
-        String result = servicesToString(services);
-        // Verify it contains the expected service information
-        assertEquals(true, result.contains("service1"));
-        assertEquals(true, result.contains("container"));
-        assertEquals(true, result.contains("host1"));
-        assertEquals(true, result.contains("service2"));
-        assertEquals(true, result.contains("searchnode"));
-        assertEquals(true, result.contains("host2"));
+        assertEquals(
+                "[{name=service1, type=container, host=host1}, {name=service2, type=searchnode, host=host2}]",
+                servicesToString(services));
+    }
+
+    @Test
+    void test_filterServicesToCheck_filters_by_service_type() {
+        List<ServiceInfo> services = List.of(
+                createService("container1", "container", "host1", 8080, "state", "cluster1"),
+                createService("searchnode1", "searchnode", "host1", 8081, "state", "cluster1"),
+                createService("unknown1", "unknown-type", "host1", 8082, "state", "cluster1"));
+
+        List<ServiceInfo> filtered = filterServicesToCheck("app1", List.of(), services, Set.of("host1"), log);
+
+        Set<String> serviceTypes =
+                filtered.stream().map(ServiceInfo::getServiceType).collect(Collectors.toSet());
+        assertEquals(Set.of("container", "searchnode"), serviceTypes);
+    }
+
+    @Test
+    void test_filterServicesToCheck_filters_by_hostname() {
+        ServiceInfo service1 = createService("container1", "container", "host1", 8080, "state", "cluster1");
+        ServiceInfo service2 = createService("container2", "container", "host2", 8080, "state", "cluster1");
+
+        List<ServiceInfo> filtered = filterServicesToCheck("app1", List.of(), List.of(service1, service2), Set.of("host1"), log);
+
+        assertEquals(List.of(service1), filtered);
+    }
+
+    @Test
+    void test_filterServicesToCheck_filters_by_state_port() {
+        ServiceInfo serviceWithState = createService("container1", "container", "host1", 8080, "state", "cluster1");
+        ServiceInfo serviceWithoutState = createService("container2", "container", "host1", 8081, "http", "cluster1");
+
+        List<ServiceInfo> filtered = filterServicesToCheck("app1", List.of(), List.of(serviceWithState, serviceWithoutState), Set.of("host1"), log);
+
+        assertEquals(List.of(serviceWithState), filtered);
+    }
+
+    @Test
+    void test_filterServicesToCheck_excludes_defer_changes_clusters() {
+        MockApplicationClusterInfo deferCluster = new MockApplicationClusterInfo("deferCluster", true);
+        MockApplicationClusterInfo normalCluster = new MockApplicationClusterInfo("normalCluster", false);
+
+        ServiceInfo deferredService = createService("container1", "container", "host1", 8080, "state", "deferCluster");
+        ServiceInfo normalService = createService("container2", "container", "host1", 8081, "state", "normalCluster");
+
+        List<ServiceInfo> filtered = filterServicesToCheck(
+                "app1", List.of(deferCluster, normalCluster), List.of(deferredService, normalService), Set.of("host1"), log);
+
+        assertEquals(List.of(normalService), filtered);
+    }
+
+    @Test
+    void test_filterServicesToCheck_all_filters_combined() {
+        MockApplicationClusterInfo deferCluster = new MockApplicationClusterInfo("deferCluster", true);
+        MockApplicationClusterInfo normalCluster = new MockApplicationClusterInfo("normalCluster", false);
+
+        ServiceInfo passesAll = createService("container1", "container", "host1", 8080, "state", "normalCluster");
+        ServiceInfo wrongHost = createService("container2", "container", "host2", 8080, "state", "normalCluster");
+        ServiceInfo wrongType = createService("unknown1", "unknown", "host1", 8080, "state", "normalCluster");
+        ServiceInfo noStatePort = createService("container3", "container", "host1", 8080, "http", "normalCluster");
+        ServiceInfo deferredCluster = createService("container4", "container", "host1", 8080, "state", "deferCluster");
+
+        List<ServiceInfo> filtered = filterServicesToCheck(
+                "app1", List.of(deferCluster, normalCluster),
+                List.of(passesAll, wrongHost, wrongType, noStatePort, deferredCluster), Set.of("host1"), log);
+
+        assertEquals(List.of(passesAll), filtered);
+    }
+
+    // Helper methods
+    private ServiceInfo createService(
+            String name, String type, String hostname, int port, String portTag, String clusterName) {
+        PortInfo portInfo = new PortInfo(port, Set.of(portTag));
+        Map<String, String> properties = new HashMap<>();
+        properties.put("clustername", clusterName);
+        properties.put("clustertype", "container");
+        return new ServiceInfo(name, type, Set.of(portInfo), properties, "", hostname);
     }
 
     // Simple mock for testing servicesToString
     private static class MockServiceInfo extends ServiceInfo {
         static MockServiceInfo create(String name, String type, String hostname) {
-            return new MockServiceInfo(name, type, Set.of(), Map.of(), "", hostname);
+            return new MockServiceInfo(name, type, Set.<PortInfo>of(), Map.<String, String>of(), "", hostname);
         }
 
-        private MockServiceInfo(String serviceName, String serviceType, Set portInfos, Map properties,
-                                String configId, String hostName) {
+        private MockServiceInfo(
+                String serviceName,
+                String serviceType,
+                Set<PortInfo> portInfos,
+                Map<String, String> properties,
+                String configId,
+                String hostName) {
             super(serviceName, serviceType, portInfos, properties, configId, hostName);
+        }
+    }
+
+    private record MockApplicationClusterInfo(String clusterName, boolean deferChangesUntilRestart)
+            implements ApplicationClusterInfo {
+
+        @Override
+        public List<ApplicationClusterEndpoint> endpoints() {
+            return List.of();
+        }
+
+        @Override
+        public boolean getDeferChangesUntilRestart() {
+            return deferChangesUntilRestart;
+        }
+
+        @Override
+        public String name() {
+            return clusterName;
         }
     }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This makes pending restarts more robust and provide detailed logs to diagnose issues.
Service filtering logic is moved from ConfigStateChecker to RestartOnDeployMaintainer and isolated in a static method to make it easier to test.

