### PR TITLE
Optimize ArrayBoolSearch

### DIFF
--- a/searchlib/src/tests/queryeval/array_bool/array_bool_test.cpp
+++ b/searchlib/src/tests/queryeval/array_bool/array_bool_test.cpp
@@ -504,7 +504,7 @@ TEST(ArrayBoolSearchTest, require_that_same_element_blueprint_creates_array_bool
             auto only_child = children[0].get();
             auto abs = dynamic_cast<ArrayBoolSearch*>(only_child);
             ASSERT_TRUE(abs);
-            EXPECT_EQ(abs->want_true(), want_true);
+            EXPECT_EQ(abs->get_want_true(), want_true);
             EXPECT_TRUE(abs->is_strict() == (strict ? vespalib::Trinary::True : vespalib::Trinary::False));
             EXPECT_TRUE(std::equal(element_filter.begin(), element_filter.begin() + element_filter.size(), abs->get_element_filter().begin()));
             EXPECT_EQ(test_attribute.bool_attr, &abs->get_attribute());
@@ -525,7 +525,7 @@ TEST(ArrayBoolSearchTest, require_that_same_element_blueprint_replacement_create
 
             auto abs = dynamic_cast<ArrayBoolSearch*>(search.get());
             ASSERT_TRUE(abs);
-            EXPECT_EQ(abs->want_true(), want_true);
+            EXPECT_EQ(abs->get_want_true(), want_true);
             EXPECT_TRUE(abs->is_strict() == (strict ? vespalib::Trinary::True : vespalib::Trinary::False));
             EXPECT_TRUE(std::equal(element_filter.begin(), element_filter.begin() + element_filter.size(), abs->get_element_filter().begin()));
             EXPECT_EQ(test_attribute.bool_attr, &abs->get_attribute());

--- a/searchlib/src/vespa/searchlib/queryeval/array_bool_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/array_bool_search.cpp
@@ -11,67 +11,170 @@ namespace search::queryeval {
 
 ArrayBoolSearch::ArrayBoolSearch(const ArrayBoolAttribute& attr,
                                  const std::vector<uint32_t>& element_filter,
-                                 bool want_true,
-                                 bool strict,
                                  fef::TermFieldMatchData* tfmd)
     : _attr(attr),
       _element_filter(element_filter),
-      _want_true(want_true),
-      _strict(strict),
       _tfmd(tfmd) {
     assert(!_element_filter.empty());
     assert(tfmd != nullptr);
 }
 
-void ArrayBoolSearch::doSeek(uint32_t docid) {
-    while (docid < getEndId()) {
-        if (check_array(docid)) {
-            setDocId(docid);
-            return;
-        }
-        if (_strict) {
-            ++docid;
-        } else {
-            return;
-        }
-    }
-    setAtEnd();
-}
-
-void ArrayBoolSearch::doUnpack(uint32_t docid) {
-    _tfmd->resetOnlyDocId(docid);
-}
-
-SearchIterator::Trinary ArrayBoolSearch::is_strict() const {
-    return _strict ? Trinary::True : Trinary::False;
-}
-
-bool ArrayBoolSearch::check_array(uint32_t docid) const {
-    auto bools = _attr.get_bools(docid);
-
-    for (auto i : _element_filter) {
-        if (i >= bools.size()) {
-            break;
-        }
-        if (bools[i] == _want_true) {
-            return true;
-        }
+/**
+ * Implementation of ArrayBoolSearch that handles only a single element id.
+ */
+template<bool want_true, bool strict>
+class ArrayBoolSearchSingleImpl : public ArrayBoolSearch {
+    uint32_t _element_id;
+public:
+    ArrayBoolSearchSingleImpl(const ArrayBoolAttribute& attr,
+                    const std::vector<uint32_t>& element_filter,
+                    fef::TermFieldMatchData* tfmd)
+                        : ArrayBoolSearch(attr, element_filter, tfmd),
+                          _element_id(0) {
+        assert(element_filter.size() == 1);
+        _element_id = element_filter[0];
     }
 
-    return false;
-}
+    Trinary is_strict() const override {
+        return strict ? Trinary::True : Trinary::False;
+    }
 
-void ArrayBoolSearch::get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) {
-    auto bools = _attr.get_bools(docid);
-
-    for (auto i : _element_filter) {
-        if (i >= bools.size()) {
-            break;
+    void doSeek(uint32_t docid) override {
+        while (docid < getEndId()) {
+            if (check_array(docid)) {
+                setDocId(docid);
+                return;
+            }
+            if (strict) {
+                ++docid;
+            } else {
+                return;
+            }
         }
-        if (bools[i] == _want_true) {
-            element_ids.push_back(i);
+        setAtEnd();
+    }
+
+    void doUnpack(uint32_t docid) override {
+        _tfmd->resetOnlyDocId(docid);
+    }
+
+    bool check_array(uint32_t docid) const {
+        auto bools = _attr.get_bools(docid);
+        return _element_id < bools.size() && bools[_element_id] == want_true;
+    }
+
+    void get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) override {
+        auto bools = _attr.get_bools(docid);
+
+        if (_element_id < bools.size() && bools[_element_id] == want_true) {
+            element_ids.push_back(_element_id);
         }
     }
+
+    bool get_want_true() const override { return want_true; }
+};
+
+/**
+ * Standard implementation of ArrayBoolSearch (with support for multiple element ids).
+ */
+template<bool want_true, bool strict>
+class ArrayBoolSearchMultiImpl : public ArrayBoolSearch {
+public:
+    ArrayBoolSearchMultiImpl(const ArrayBoolAttribute& attr,
+                    const std::vector<uint32_t>& element_filter,
+                    fef::TermFieldMatchData* tfmd)
+                        : ArrayBoolSearch(attr, element_filter, tfmd) {
+    }
+
+    Trinary is_strict() const override {
+        return strict ? Trinary::True : Trinary::False;
+    }
+
+    void doSeek(uint32_t docid) override {
+        while (docid < getEndId()) {
+            if (check_array(docid)) {
+                setDocId(docid);
+                return;
+            }
+            if (strict) {
+                ++docid;
+            } else {
+                return;
+            }
+        }
+        setAtEnd();
+    }
+
+    void doUnpack(uint32_t docid) override {
+        _tfmd->resetOnlyDocId(docid);
+    }
+
+    bool check_array(uint32_t docid) const {
+        auto bools = _attr.get_bools(docid);
+
+        for (auto i : _element_filter) {
+            if (i >= bools.size()) {
+                break;
+            }
+            if (bools[i] == want_true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) override {
+        auto bools = _attr.get_bools(docid);
+
+        for (auto i : _element_filter) {
+            if (i >= bools.size()) {
+                break;
+            }
+            if (bools[i] == want_true) {
+                element_ids.push_back(i);
+            }
+        }
+    }
+
+    bool get_want_true() const override { return want_true; }
+
+};
+
+namespace {
+
+template <bool want_true, bool strict>
+std::unique_ptr<ArrayBoolSearch>
+resolve_multi(const attribute::ArrayBoolAttribute& attr,
+              const std::vector<uint32_t>& element_filter, fef::TermFieldMatchData* tfmd) {
+    if (element_filter.size() == 1) {
+        return std::make_unique<ArrayBoolSearchSingleImpl<want_true, strict>>(attr, element_filter, tfmd);
+    } else {
+        return std::make_unique<ArrayBoolSearchMultiImpl<want_true, strict>>(attr, element_filter, tfmd);
+    }
+}
+
+template <bool want_true>
+std::unique_ptr<ArrayBoolSearch>
+resolve_strict(bool strict, const attribute::ArrayBoolAttribute& attr,
+               const std::vector<uint32_t>& element_filter, fef::TermFieldMatchData* tfmd) {
+    if (strict) {
+        return resolve_multi<want_true, true>(attr, element_filter, tfmd);
+    } else {
+        return resolve_multi<want_true, false>(attr, element_filter, tfmd);
+    }
+}
+
+std::unique_ptr<ArrayBoolSearch>
+resolve_want_true(bool want_true, bool strict, const attribute::ArrayBoolAttribute& attr,
+                  const std::vector<uint32_t>& element_filter, fef::TermFieldMatchData* tfmd) {
+    if (want_true) {
+        return resolve_strict<true>(strict, attr, element_filter, tfmd);
+    } else {
+        return resolve_strict<false>(strict, attr, element_filter, tfmd);
+    }
+}
+
 }
 
 std::unique_ptr<ArrayBoolSearch> ArrayBoolSearch::create(const ArrayBoolAttribute& attr,
@@ -79,7 +182,7 @@ std::unique_ptr<ArrayBoolSearch> ArrayBoolSearch::create(const ArrayBoolAttribut
                                                          bool want_true,
                                                          bool strict,
                                                          fef::TermFieldMatchData* tfmd) {
-    return std::make_unique<ArrayBoolSearch>(attr, element_filter, want_true, strict, tfmd);
+    return resolve_want_true(want_true, strict, attr, element_filter, tfmd);
 }
 
 } // namespace

--- a/searchlib/src/vespa/searchlib/queryeval/array_bool_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/array_bool_search.h
@@ -20,29 +20,19 @@ namespace search::queryeval {
  * as it does the same things but faster.
  */
 class ArrayBoolSearch : public SearchIterator {
+protected:
     using ArrayBoolAttribute = search::attribute::ArrayBoolAttribute;
 
     const ArrayBoolAttribute&    _attr;
     const std::vector<uint32_t>& _element_filter;
-    bool                         _want_true;
-    bool                         _strict;
     fef::TermFieldMatchData*     _tfmd;
 
-public:
-    // Use the create(...) method instead.
     ArrayBoolSearch(const ArrayBoolAttribute& attr,
                     const std::vector<uint32_t>& element_filter,
-                    bool want_true,
-                    bool strict,
                     fef::TermFieldMatchData* tfmd);
-    void doSeek(uint32_t docid) override;
-    void doUnpack(uint32_t docid) override;
-    Trinary is_strict() const override;
 
-    bool check_array(uint32_t docid) const;
-    void get_element_ids(uint32_t docid, std::vector<uint32_t>& element_ids) override;
-
-    bool want_true() const { return _want_true; }
+public:
+    virtual bool get_want_true() const = 0;
     const std::vector<uint32_t>& get_element_filter() const { return _element_filter; }
     const ArrayBoolAttribute& get_attribute() const { return _attr; }
 


### PR DESCRIPTION
Use template for `want_true` and `strict`. Moreover, own implementation for just a single element id.
Not sure how much of a difference this really makes. Will be interesting to see.