### PR TITLE
Clean up a bit in SameElementBlueprint

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
@@ -130,8 +130,8 @@ private:
             auto se = std::make_unique<SameElementBlueprint>(n.field(0).fieldSpec(),
                                                              n.descendants_index_handles,
                                                              n.is_expensive(),
-                                                             n.get_element_filter(),
-                                                             n.expose_match_data_for_same_element); // Copy element filter
+                                                             n.expose_match_data_for_same_element,
+                                                             n.get_element_filter()); // Copy element filter
             for (auto* node : n.getChildren()) {
                 se->addChild(build(_requestContext, *node, _context, _global_layout));
             }

--- a/searchlib/src/tests/queryeval/array_bool/array_bool_test.cpp
+++ b/searchlib/src/tests/queryeval/array_bool/array_bool_test.cpp
@@ -366,7 +366,7 @@ SameElementBlueprintSearchBuilder::SameElementBlueprintSearchBuilder(ArrayBoolAt
     std::vector<TermFieldHandle> descendant_handles;
     descendant_handles.push_back(_tmd.handle2);
 
-    _blueprint = std::make_unique<SameElementBlueprint>(_tmd.field_spec, descendant_handles, false, element_filter, expose_match_data_for_same_element);
+    _blueprint = std::make_unique<SameElementBlueprint>(_tmd.field_spec, descendant_handles, false, expose_match_data_for_same_element, element_filter);
     _blueprint->addChild(std::move(child_blueprint));
 }
 

--- a/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
+++ b/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
@@ -406,7 +406,7 @@ struct SameElementAdapter {
     void make_blueprint() const {
         if (!blueprint) {
             std::vector<TermFieldHandle> descendants_index_handles;
-            blueprint = std::make_unique<SameElementBlueprint>(field, descendants_index_handles, false);
+            blueprint = std::make_unique<SameElementBlueprint>(field, descendants_index_handles, false, true);
             for (auto& child : children) {
                 blueprint->addChild(std::move(child));
             }

--- a/searchlib/src/tests/queryeval/same_element/same_element_test.cpp
+++ b/searchlib/src/tests/queryeval/same_element/same_element_test.cpp
@@ -115,7 +115,7 @@ std::unique_ptr<SameElementBlueprint> make_blueprint(QueryTweak query_tweak, Mat
         bp_children.emplace_back(std::move(bp_tweak));
     }
     auto result = std::make_unique<SameElementBlueprint>(make_field_spec(mdl), descendants_index_handles,
-                                                         false, std::move(element_filter));
+                                                         false, true, std::move(element_filter));
     for (auto& fake : bp_children) {
         result->addChild(std::move(fake));
     }

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <map>
 #include <memory>
+#include <sstream>
 
 using search::fef::MatchData;
 using search::fef::TermFieldMatchData;
@@ -156,6 +157,18 @@ void
 SameElementBlueprint::visitMembers(vespalib::ObjectVisitor &visitor) const
 {
     IntermediateBlueprint::visitMembers(visitor);
+    std::stringstream ss;
+    ss << "[";
+    bool first = true;
+    for (uint32_t element : _element_filter) {
+        if (!first) {
+            ss << ",";
+        }
+        first = false;
+        ss << element;
+    }
+    ss << "]";
+    visitor.visitString("element_filter", ss.str());
 }
 
 Blueprint::UP SameElementBlueprint::get_replacement() {

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -21,14 +21,14 @@ namespace search::queryeval {
 SameElementBlueprint::SameElementBlueprint(const FieldSpec &field,
                                            const std::vector<search::fef::TermFieldHandle>& descendants_index_handles,
                                            bool expensive,
-                                           std::vector<uint32_t> element_filter,
-                                           bool expose_match_data_for_same_element)
+                                           bool expose_match_data_for_same_element,
+                                           std::vector<uint32_t> element_filter)
     : IntermediateBlueprint(),
       _field(field),
       _descendants_index_handles(descendants_index_handles),
       _expensive(expensive),
-      _element_filter(std::move(element_filter)),
-      _expose_match_data_for_same_element(expose_match_data_for_same_element)
+      _expose_match_data_for_same_element(expose_match_data_for_same_element),
+      _element_filter(std::move(element_filter))
 {
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -17,15 +17,15 @@ private:
     FieldSpec             _field;
     std::vector<search::fef::TermFieldHandle> _descendants_index_handles; // handles with early unpack
     bool                  _expensive;
-    std::vector<uint32_t> _element_filter;
     bool                  _expose_match_data_for_same_element;
+    std::vector<uint32_t> _element_filter;
     AnyFlow my_flow(InFlow in_flow) const override;
 public:
     SameElementBlueprint(const FieldSpec &field,
                          const std::vector<search::fef::TermFieldHandle>& descendants_index_handles,
                          bool expensive,
-                         std::vector<uint32_t> element_filter = std::vector<uint32_t>(),
-                         bool expose_match_data_for_same_element = true);
+                         bool expose_match_data_for_same_element,
+                         std::vector<uint32_t> element_filter = std::vector<uint32_t>());
     SameElementBlueprint(const SameElementBlueprint &) = delete;
     SameElementBlueprint &operator=(const SameElementBlueprint &) = delete;
     ~SameElementBlueprint() override;


### PR DESCRIPTION
Removes the default value of `expose_match_data_for_same_element` and adds the element filter to the trace.