### PR TITLE
Decrease scale factor for content node disk resource limit

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
@@ -16,6 +16,7 @@ import static java.util.logging.Level.WARNING;
  * This includes the limits used by the cluster controller and the content nodes (proton).
  *
  * @author Geir Storli
+ * @author hmusum
  */
 public class ClusterResourceLimits {
 
@@ -109,9 +110,9 @@ public class ClusterResourceLimits {
             deriveClusterControllerLimit(ctrlBuilder.getMemoryLimit(), nodeBuilder.getMemoryLimit(), ctrlBuilder::setMemoryLimit);
             deriveClusterControllerLimit(ctrlBuilder.getAddressSpaceLimit(), nodeBuilder.getAddressSpaceLimit(), ctrlBuilder::setAddressSpaceLimit);
 
-            deriveContentNodeLimit(nodeBuilder.getDiskLimit(), ctrlBuilder.getDiskLimit(), 0.6, nodeBuilder::setDiskLimit);
-            deriveContentNodeLimit(nodeBuilder.getMemoryLimit(), ctrlBuilder.getMemoryLimit(), 0.5, nodeBuilder::setMemoryLimit);
-            deriveContentNodeLimit(nodeBuilder.getAddressSpaceLimit(), ctrlBuilder.getAddressSpaceLimit(), 0.5, nodeBuilder::setAddressSpaceLimit);
+            deriveContentNodeLimit(nodeBuilder.getDiskLimit(), ctrlBuilder.getDiskLimit(), nodeBuilder::setDiskLimit);
+            deriveContentNodeLimit(nodeBuilder.getMemoryLimit(), ctrlBuilder.getMemoryLimit(), nodeBuilder::setMemoryLimit);
+            deriveContentNodeLimit(nodeBuilder.getAddressSpaceLimit(), ctrlBuilder.getAddressSpaceLimit(), nodeBuilder::setAddressSpaceLimit);
         }
 
         private void considerSettingDefaultClusterControllerLimit(Optional<Double> clusterControllerLimit,
@@ -135,15 +136,18 @@ public class ClusterResourceLimits {
 
         private void deriveContentNodeLimit(Optional<Double> contentNodeLimit,
                                             Optional<Double> clusterControllerLimit,
-                                            double scaleFactor,
                                             Consumer<Double> setter) {
             if (contentNodeLimit.isEmpty()) {
                 clusterControllerLimit.ifPresent(limit ->
-                        setter.accept(calcContentNodeLimit(limit, scaleFactor)));
+                        setter.accept(calcContentNodeLimit(limit)));
             }
         }
 
-        private double calcContentNodeLimit(double clusterControllerLimit, double scaleFactor) {
+        private double calcContentNodeLimit(double clusterControllerLimit) {
+            // Scale factor used to calculate limit for content node based on limit for
+            // cluster controller. 0.5 will give a content node limit that is halfway between
+            // cluster controller limit and 1.0 (e.g. 0.8 => 0.9)
+            double scaleFactor = 0.5;
             return clusterControllerLimit + ((1.0 - clusterControllerLimit) * scaleFactor);
         }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
@@ -74,9 +74,9 @@ public class ClusterResourceLimitsTest {
 
     @Test
     void content_node_limits_are_derived_from_cluster_controller_limits_if_not_set() {
-        assertLimits(0.4, 0.7, 0.88, 0.76, 0.85, 0.94,
+        assertLimits(0.4, 0.7, 0.88, 0.7, 0.85, 0.94,
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7).ctrlAddressSpace(0.88));
-        assertLimits(0.75, 0.8, 0.80, 0.9, 0.9, 0.9,
+        assertLimits(0.75, 0.8, 0.80, 0.875, 0.9, 0.9,
                 new Fixture());
     }
 
@@ -86,7 +86,7 @@ public class ClusterResourceLimitsTest {
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7).ctrlAddressSpace(0.88).nodeDisk(0.9).nodeMemory(0.95).nodeAddressSpace(0.93));
         assertLimits(0.4, 0.8, 0.80, 0.95, 0.9, 0.9,
                 new Fixture().ctrlDisk(0.4).nodeDisk(0.95));
-        assertLimits(0.75, 0.7, 0.80, 0.9, 0.95, 0.9,
+        assertLimits(0.75, 0.7, 0.80, 0.875, 0.95, 0.9,
                 new Fixture().ctrlMemory(0.7).nodeMemory(0.95));
     }
 
@@ -96,15 +96,15 @@ public class ClusterResourceLimitsTest {
                 new Fixture().nodeDisk(0.9).nodeMemory(0.95));
         assertLimits(0.89, 0.8, 0.80, 0.9, 0.9, 0.9,
                 new Fixture().nodeDisk(0.9));
-        assertLimits(0.75, 0.94, 0.80, 0.9, 0.95, 0.9,
+        assertLimits(0.75, 0.94, 0.80, 0.875, 0.95, 0.9,
                 new Fixture().nodeMemory(0.95));
-        assertLimits(0.75, 0.0, 0.80, 0.9, 0.005, 0.9,
+        assertLimits(0.75, 0.0, 0.80, 0.875, 0.005, 0.9,
                 new Fixture().nodeMemory(0.005));
     }
 
     @Test
     void limits_are_derived_from_the_other_if_not_set() {
-        assertLimits(0.6, 0.94, 0.80, 0.84, 0.95, 0.9,
+        assertLimits(0.6, 0.94, 0.80, 0.8, 0.95, 0.9,
                 new Fixture().ctrlDisk(0.6).nodeMemory(0.95));
         assertLimits(0.89, 0.7, 0.80, 0.9, 0.85, 0.9,
                 new Fixture().ctrlMemory(0.7).nodeDisk(0.9));
@@ -112,7 +112,7 @@ public class ClusterResourceLimitsTest {
 
     @Test
     void default_resource_limits_when_feed_block_is_enabled_in_distributor() {
-        assertLimits(0.75, 0.8, 0.80, 0.9, 0.9, 0.9,
+        assertLimits(0.75, 0.8, 0.80, 0.875, 0.9, 0.9,
                 new Fixture(true));
     }
 
@@ -136,7 +136,7 @@ public class ClusterResourceLimitsTest {
 
         // Verify that limits from feature flags are used
         assertLimits(0.85, 0.90, 0.89, limits.getClusterControllerLimits());
-        assertLimits(0.94, 0.95, 0.945, limits.getContentNodeLimits());
+        assertLimits(0.925, 0.95, 0.945, limits.getContentNodeLimits());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1668,7 +1668,7 @@ public class ContentClusterTest extends ContentBaseTest {
         // Resource limits for content cluster should be changed based on new values above
         var protonConfigBuilder = new ProtonConfig.Builder();
         model.getConfig(protonConfigBuilder, "foo/search/cluster.foo");
-        assertEquals(0.864, protonConfigBuilder.build().writefilter().disklimit(), 0.001);
+        assertEquals(0.83, protonConfigBuilder.build().writefilter().disklimit(), 0.001);
         assertEquals(0.875, protonConfigBuilder.build().writefilter().memorylimit(), 0.001);
 
         // Resource limits for content nodes should be changed based on new values above
@@ -1677,7 +1677,7 @@ public class ContentClusterTest extends ContentBaseTest {
         contentCluster.getSearch().getSearchNodes().get(0).getConfig(protonConfigBuilder2);
         var config2 = protonConfigBuilder2.build();
         assertEquals(0, config2.distributionkey());
-        assertEquals(0.864, config2.writefilter().disklimit(), 0.001);
+        assertEquals(0.83, config2.writefilter().disklimit(), 0.001);
         assertEquals(0.875, config2.writefilter().memorylimit(), 0.001);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
@@ -121,7 +121,7 @@ public class ContentSchemaClusterTest {
 
     @Test
     void requireThatOnlyMemoryLimitCanBeSet() throws Exception {
-        assertProtonResourceLimits(0.9, 0.77, 0.91,
+        assertProtonResourceLimits(0.875, 0.77, 0.91,
                 new ContentClusterBuilder().protonMemoryLimit(0.77).getXml());
     }
 
@@ -134,7 +134,7 @@ public class ContentSchemaClusterTest {
     @Test
     void resource_limits_are_derived_from_the_other_if_not_specified() throws Exception {
         var cluster = createCluster(new ContentClusterBuilder().clusterControllerDiskLimit(0.5).protonMemoryLimit(0.95).getXml());
-        assertProtonResourceLimits(0.8, 0.95, 0.91, cluster);
+        assertProtonResourceLimits(0.75, 0.95, 0.91, cluster);
         assertClusterControllerResourceLimits(0.5, 0.94, 0.80, cluster);
         assertClusterControllerResourceLimits(0.5, 0.94, 0.80, cluster);
     }
@@ -142,7 +142,7 @@ public class ContentSchemaClusterTest {
     @Test
     void default_resource_limits_with_feed_block_in_distributor() throws Exception {
         var cluster = createCluster(new ContentClusterBuilder().getXml());
-        assertProtonResourceLimits(0.9, 0.9, 0.91, cluster);
+        assertProtonResourceLimits(0.875, 0.9, 0.91, cluster);
         assertClusterControllerResourceLimits(0.75, 0.8, 0.80, cluster);
     }
 


### PR DESCRIPTION
## Summary
- Use same scale factor (0.5) for all content node resource limits (disk, memory, address space) instead of a higher factor (0.6) for disk
- Move scale factor into `calcContentNodeLimit()` as a constant
- Preparation for increasing the cluster controller resource usage limit for disk
