### PR TITLE
Include only size of element filter in trace

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/array_bool_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/array_bool_blueprint.cpp
@@ -7,7 +7,6 @@
 #include "flow_tuning.h"
 #include <vespa/searchlib/attribute/array_bool_attribute.h>
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>
-#include <sstream>
 #include <vespa/log/log.h>
 
 LOG_SETUP(".searchlib.queryeval.array_bool_blueprint");
@@ -44,18 +43,7 @@ std::unique_ptr<SearchIterator> ArrayBoolBlueprint::createFilterSearchImpl(Filte
 
 void ArrayBoolBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) const {
     SimpleLeafBlueprint::visitMembers(visitor);
-    std::stringstream ss;
-    ss << "[";
-    bool first = true;
-    for (uint32_t element : _element_filter) {
-        if (!first) {
-            ss << ",";
-        }
-        first = false;
-        ss << element;
-    }
-    ss << "]";
-    visitor.visitString("element_filter", ss.str());
+    visitor.visitInt("element_filter.size", _element_filter.size());
     visitor.visitBool("want_true", _want_true);
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -12,7 +12,6 @@
 #include <cassert>
 #include <map>
 #include <memory>
-#include <sstream>
 
 using search::fef::MatchData;
 using search::fef::TermFieldMatchData;
@@ -157,18 +156,7 @@ void
 SameElementBlueprint::visitMembers(vespalib::ObjectVisitor &visitor) const
 {
     IntermediateBlueprint::visitMembers(visitor);
-    std::stringstream ss;
-    ss << "[";
-    bool first = true;
-    for (uint32_t element : _element_filter) {
-        if (!first) {
-            ss << ",";
-        }
-        first = false;
-        ss << element;
-    }
-    ss << "]";
-    visitor.visitString("element_filter", ss.str());
+    visitor.visitInt("element_filter.size", _element_filter.size());
 }
 
 Blueprint::UP SameElementBlueprint::get_replacement() {


### PR DESCRIPTION
This addresses the concerns raised in https://github.com/vespa-engine/vespa/pull/36171. The size is probably all you need to know in a trace since it determines the behavior (greater than 0 => filter active) and performance (more elements => slower).