### PR TITLE
Don't forget the summary class

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/GroupingExecutor.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/GroupingExecutor.java
@@ -104,9 +104,7 @@ public class GroupingExecutor extends Searcher {
         Object metaData = hit.getSearcherSpecificMetaData(this);
         if (metaData instanceof String metaDataString) {
             // Use the summary class specified by grouping, set in
-            // HitConverter, in the fill request indented for presentation.
-            // We reset the summary class here as cleanup.
-            hit.setSearcherSpecificMetaData(this, null);
+            // HitConverter, in the fill request intended for presentation.
             return metaDataString;
         }
         return summaryClass;


### PR DESCRIPTION
When the summary class is forgotten after first use, any subsequent fill call will request the query level summary instead of the grouping one, which breaks the contract.
