### PR TITLE
Emit soft errors on invalid summary classes

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/PartialSummaryHandler.java
@@ -9,15 +9,13 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.result.Hit;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -254,22 +252,23 @@ public class PartialSummaryHandler {
         }
     }
 
-    public void validateSummaryClass(String summaryClass, Query query) {
+    public Optional<String> validateSummaryClass(String summaryClass, Query query) {
         if (isFieldListRequest(summaryClass)) {
             var fieldSet = parseFieldList(summaryClass);
             if (fieldSet.isEmpty()) {
-                throw new IllegalArgumentException("invalid fill() with empty fieldset=" + summaryClass);
+                return Optional.of("Invalid fill() request with empty fieldset for summary '" + summaryClass + "'");
             }
         } else if (isPresentationRequest(summaryClass)) {
             String wantClass = query.getPresentation().getSummary();
             if (! ensureKnownClass(wantClass)) {
-                throw new IllegalInputException("invalid presentation.summary=" + wantClass);
+                return Optional.of("Summary '" + wantClass + "' does not exist");
             }
         } else if (summaryClass != null) {
             if (! ensureKnownClass(summaryClass)) {
-                throw new IllegalArgumentException("invalid fill() with summaryClass=" + summaryClass);
+                return Optional.of("Invalid fill() request for non-existing summary '" + summaryClass + "'");
             }
         }
+        return Optional.empty();
     }
 
     private void computeEffectiveDocsumDef() {

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackend.java
@@ -2,14 +2,12 @@
 package com.yahoo.prelude.fastsearch;
 
 import com.yahoo.collections.TinyIdentitySet;
-import com.yahoo.fs4.DocsumPacket;
 import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.GeoLocationItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.NullItem;
 import com.yahoo.prelude.query.textualrepresentation.TextualQueryRepresentation;
 import com.yahoo.prelude.querytransform.QueryRewrite;
-import com.yahoo.processing.IllegalInputException;
 import com.yahoo.protect.Validator;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -207,26 +205,29 @@ public abstract class VespaBackend {
         List<Result> parts = partitionHits(result, summaryClass);
         if (!parts.isEmpty()) { // anything to fill at all?
             for (Result r : parts) {
-                doPartialFill(r, ensureLegalSummaryClass(r.getQuery(), summaryClass));
-                mergeErrorsInto(result, r);
+                if (summaryClass != null && summaryClass.isEmpty())
+                    summaryClass = null;
+                Optional<String> summaryError = validateSummaryClass(summaryClass, r.getQuery());
+                if (summaryError.isPresent()) {
+                    r.hits().addError(ErrorMessage.createInvalidQueryParameter(summaryError.get()));
+                }
+                else {
+                    doPartialFill(r, summaryClass);
+                    mergeErrorsInto(result, r);
+                }
             }
             result.hits().setSorted(false);
             result.analyzeHits();
         }
     }
-    protected String ensureLegalSummaryClass(Query query, String summaryClass) {
-        if (summaryClass != null) {
-            if (summaryClass.isEmpty()) {
-                return null;
-            } else {
-                var db = getDocumentDatabase(query);
-                if (db != null) {
-                    var partialSummaryHandler = new PartialSummaryHandler(db);
-                    partialSummaryHandler.validateSummaryClass(summaryClass, query);
-                }
-            }
+
+    protected Optional<String> validateSummaryClass(String summaryClass, Query query) {
+        if (summaryClass != null && ! summaryClass.isEmpty()) {
+            var db = getDocumentDatabase(query);
+            if (db != null)
+                return new PartialSummaryHandler(db).validateSummaryClass(summaryClass, query);
         }
-        return summaryClass;
+        return Optional.empty();
     }
 
     private void mergeErrorsInto(Result destination, Result source) {

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
@@ -40,6 +40,7 @@ import com.yahoo.yolean.Exceptions;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -148,11 +149,9 @@ public class StreamingBackend extends VespaBackend {
             return new Result(query, ErrorMessage.createIllegalQuery("Streaming search requires either " +
                                                                      "streaming.groupname or streaming.selection"));
         }
-        try {
-            ensureLegalSummaryClass(query, PartialSummaryHandler.PRESENTATION);
-        } catch (IllegalInputException e) {
-            return new Result(query, ErrorMessage.createIllegalQuery(Exceptions.toMessageString(e)));
-        }
+        Optional<String> summaryError = validateSummaryClass(PartialSummaryHandler.PRESENTATION, query);
+        if (summaryError.isPresent())
+            return new Result(query, ErrorMessage.createIllegalQuery(summaryError.get()));
 
         if (query.getTrace().isTraceable(4))
             query.trace("Routing to search cluster " + getSearchClusterName() + " and document type " + schema, 4);


### PR DESCRIPTION
If the result consists of hits from multiple document databases, where some have the requested summary class and others don't, throwing an error when the summary class don't exist will transform a partial result into a complete failure on a second fill call since the only hits that will be attempted filled on the second call are the faulty ones, which breaks the fill contract. Add error messages to the result instead.
