### PR TITLE
Log without stack trace when getting connection timeout

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.service;
 
+import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -34,6 +35,8 @@ public class RemoteMetricsFetcher extends HttpMetricFetcher {
             } finally {
                 EntityUtils.consumeQuietly(entity);
             }
+        } catch (ConnectTimeoutException cte) {
+            logMessageNoResponse("Got connect timeout when getting metrics for service '" + service + "'", fetchCount);
         } catch (IOException e) {
             logMessage("Got exception when getting metrics for service '" + service + "'", e, fetchCount);
         }


### PR DESCRIPTION
It could be that this logging will be on too high level (if it happens more than 5 times), but I still think this is better than the stack trace

