### PR TITLE
Johsol/select parser same element short form

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -1457,10 +1457,12 @@ public class SelectParser implements Parser {
         return sameElement;
     }
 
+    private static final Set<String> OPERATOR_KEYS =
+            Set.of(AND, AND_NOT, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE);
+
     /** Checks if key is operator keyword or function call keyword. */
     private boolean isOperator(String key) {
-        return Set.of(AND, AND_NOT, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE).contains(key)
-                || FUNCTION_CALLS.contains(key);
+        return OPERATOR_KEYS.contains(key) || FUNCTION_CALLS.contains(key);
     }
 
     private Item instantiatePhraseItem(String field, String key, Inspector value) {

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -185,6 +185,7 @@ public class SelectParser implements Parser {
     private IndexFacts.Session indexFactsSession;
 
     private static final List<String> FUNCTION_CALLS = List.of(WAND, WEIGHTED_SET, DOT_PRODUCT, GEO_BOUNDING_BOX, GEO_LOCATION, NEAREST_NEIGHBOR, PREDICATE, RANK, WEAK_AND);
+    private static final Set<String> OPERATOR_KEYS = Set.of(AND, AND_NOT, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE);
 
     public SelectParser(ParserEnvironment environment) {
         this.environment = environment;
@@ -1456,9 +1457,6 @@ public class SelectParser implements Parser {
 
         return sameElement;
     }
-
-    private static final Set<String> OPERATOR_KEYS =
-            Set.of(AND, AND_NOT, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE);
 
     /** Checks if key is operator keyword or function call keyword. */
     private boolean isOperator(String key) {

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -76,6 +76,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.yahoo.search.yql.YqlParser.MAX_EDIT_DISTANCE;
 import static com.yahoo.search.yql.YqlParser.PREFIX_LENGTH;
@@ -226,22 +227,27 @@ public class SelectParser implements Parser {
 
         Item[] item = {null};
         inspector.traverse((ObjectTraverser) (key, value) -> {
-            String type = (FUNCTION_CALLS.contains(key)) ? CALL : key;
-            switch (type) {
-                case AND -> item[0] = buildAnd(key, value);
-                case AND_NOT -> item[0] = buildNotAnd(key, value);
-                case CALL -> item[0] = buildFunctionCall(key, value);
-                case CONTAINS -> item[0] = buildTermSearch(key, value);
-                case EQ -> item[0] = buildEquals(key, value);
-                case IN -> item[0] = buildIn(key, value);
-                case MATCHES -> item[0] = buildRegExpSearch(key, value);
-                case NOT -> item[0] = buildNot(key, value);
-                case OR -> item[0] = buildOr(key, value);
-                case RANGE -> item[0] = buildRange(key, value);
-                default -> throw newUnexpectedArgumentException(key, AND, AND_NOT, CALL, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE);
-            }
+            item[0] = buildOperator(key, value);
         });
         return item[0];
+    }
+
+    /** Builds a query item from a single operator key and its value. */
+    private Item buildOperator(String key, Inspector value) {
+        String type = (FUNCTION_CALLS.contains(key)) ? CALL : key;
+        return switch (type) {
+            case AND -> buildAnd(key, value);
+            case AND_NOT -> buildNotAnd(key, value);
+            case CALL -> buildFunctionCall(key, value);
+            case CONTAINS -> buildTermSearch(key, value);
+            case EQ -> buildEquals(key, value);
+            case IN -> buildIn(key, value);
+            case MATCHES -> buildRegExpSearch(key, value);
+            case NOT -> buildNot(key, value);
+            case OR -> buildOr(key, value);
+            case RANGE -> buildRange(key, value);
+            default -> throw newUnexpectedArgumentException(key, AND, AND_NOT, CALL, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE);
+        };
     }
 
     public List<VespaGroupingStep> getGroupingSteps(String grouping){
@@ -1434,10 +1440,27 @@ public class SelectParser implements Parser {
         SameElementItem sameElement = new SameElementItem(field);
         // All terms below sameElement are relative to this.
         getChildren(value).traverse((ArrayTraverser) (index, term) -> {
-            sameElement.addItem(walkJson(term));
+            if (term.type() == OBJECT) {
+                term.traverse((ObjectTraverser) (childKey, childValue) -> {
+                    if (isOperator(childKey)) {
+                        sameElement.addItem(buildOperator(childKey, childValue));
+                    } else {
+                        // Shorthand: {"fieldName": "value"} is equivalent to {"contains": ["fieldName", "value"]}
+                        sameElement.addItem(instantiateWordItem(childKey, childValue.asString(), childValue, false));
+                    }
+                });
+            } else {
+                sameElement.addItem(walkJson(term));
+            }
         });
 
         return sameElement;
+    }
+
+    /** Checks if key is operator keyword or function call keyword. */
+    private boolean isOperator(String key) {
+        return Set.of(AND, AND_NOT, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE).contains(key)
+                || FUNCTION_CALLS.contains(key);
     }
 
     private Item instantiatePhraseItem(String field, String key, Inspector value) {

--- a/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
@@ -12,6 +12,7 @@ import com.yahoo.search.yql.VespaSerializer;
 import com.yahoo.search.yql.YqlParser;
 import com.yahoo.slime.SlimeUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -128,8 +129,44 @@ public class YqlJsonQueryFeatureParityTest {
 
     @Test
     void testSameElement() {
+        // Struct field with explicit contains
         assertWhereParity("baz contains sameElement(f1 contains 'a', f2 contains 'b')",
                 "{ 'contains' : ['baz', { 'sameElement' : [ { 'contains' : ['f1', 'a'] }, { 'contains' : ['f2', 'b'] } ] }] }");
+        // Struct field with contains and range
+        assertWhereParity("baz contains sameElement(f1 contains 'a', range(f2, 0L, 10L))",
+                "{ 'contains' : ['baz', { 'sameElement' : [ { 'contains' : ['f1', 'a'] }, { 'range' : ['f2', { '>=': 0, '<=': 10 }] } ] }] }");
+    }
+
+    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
+    @Test
+    void testSameElementWithAndOrChildren() {
+        // AND inside sameElement (string array)
+        assertWhereParity("description contains sameElement('a' and 'b')",
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'and' : [ { 'contains' : ['description', 'a'] }, { 'contains' : ['description', 'b'] } ] } ] }] }");
+        // OR inside sameElement (string array)
+        assertWhereParity("description contains sameElement('a' or 'b')",
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'or' : [ { 'contains' : ['description', 'a'] }, { 'contains' : ['description', 'b'] } ] } ] }] }");
+    }
+
+    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
+    @Test
+    void testSameElementWithNear() {
+        assertWhereParity("description contains sameElement({distance: 3}near('a', 'b'))",
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'contains' : ['description', { 'near' : { 'children' : ['a', 'b'], 'attributes' : { 'distance' : 3 } } }] } ] }] }");
+    }
+
+    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
+    @Test
+    void testSameElementWithPhrase() {
+        assertWhereParity("description contains sameElement(phrase('a', 'b'))",
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'contains' : ['description', { 'phrase' : ['a', 'b'] }] } ] }] }");
+    }
+
+    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
+    @Test
+    void testSameElementWithRank() {
+        assertWhereParity("description contains sameElement(rank('a', 'b'))",
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'rank' : [ { 'contains' : ['description', 'a'] }, { 'contains' : ['description', 'b'] } ] } ] }] }");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
@@ -137,6 +137,13 @@ public class YqlJsonQueryFeatureParityTest {
                 "{ 'contains' : ['baz', { 'sameElement' : [ { 'contains' : ['f1', 'a'] }, { 'range' : ['f2', { '>=': 0, '<=': 10 }] } ] }] }");
     }
 
+    @Test
+    void testSameElementShorthand() {
+        // Shorthand: {"f1": "a"} is equivalent to {"contains": ["f1", "a"]}
+        assertWhereParity("baz contains sameElement(f1 contains 'a', f2 contains 'b')",
+                "{ 'contains' : ['baz', { 'sameElement' : [ { 'f1' : 'a', 'f2' : 'b' } ] }] }");
+    }
+
     @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
     @Test
     void testSameElementWithAndOrChildren() {


### PR DESCRIPTION
1. Adds feature parity test cases for sameElement that are not implemented yet.
2. Adds test case for sameElement shorthand.
3. Fixes sameElement shorthand when input to sameElement is not an operator.

The parity bugs not addressed in this PR are disabled.