### PR TITLE
Revert "Filter match data on match spans for near and onear."

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/near_search_flags.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/near_search_flags.cpp
@@ -4,7 +4,7 @@
 
 namespace search::queryeval {
 
-bool NearSearchFlags::_filter_terms = true;
+bool NearSearchFlags::_filter_terms = false;
 
 NearSearchFlags::FilterTermsTweak::FilterTermsTweak(bool filter_terms_in)
     : _old_filter_terms(_filter_terms)


### PR DESCRIPTION
Reverts vespa-engine/vespa#36193

In case #36193 has bad side effects.
