### PR TITLE
Ensure StatisticsSearcher runs before all query processing

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -17,6 +17,7 @@ import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.searchchain.PhaseNames;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +50,7 @@ import static com.yahoo.container.protect.Error.UNSPECIFIED;
  * @author Steinar Knutsen
  * @author bergum
  */
-@Before("*")
+@Before(PhaseNames.RAW_QUERY)
 public class StatisticsSearcher extends Searcher {
 
     private static final CompoundName IGNORE_QUERY = CompoundName.from("metrics.ignore");
@@ -413,4 +414,3 @@ public class StatisticsSearcher extends Searcher {
     }
 
 }
-


### PR DESCRIPTION
Replace @Before("*") with @Before(PhaseNames.RAW_QUERY) because the wildcard annotation was silently ignored by the search chain dependency resolver. Using the explicit RAW_QUERY phase ensures this searcher is ordered before any query transformations, which is needed for accurate end-to-end latency and statistics measurement.

the observed ordering was:
            "message": "Invoke searcher 'com.yahoo.prelude.querytransform.PhrasingSearcher in vespa'"
            "message": "Invoke searcher 'com.yahoo.prelude.searcher.FieldCollapsingSearcher in vespa'"
            "message": "Invoke searcher 'com.yahoo.prelude.searcher.JuniperSearcher in vespa'"
            "message": "Invoke searcher 'com.yahoo.prelude.searcher.PosSearcher in vespa'"
            "message": "Invoke searcher 'com.yahoo.prelude.semantics.SemanticSearcher in vespa'"
            "message": "Invoke searcher 'com.yahoo.search.grouping.GroupingQueryParser in vespa'"
            "message": "Invoke searcher 'com.yahoo.prelude.statistics.StatisticsSearcher in native'"
            "message": "Invoke searcher 'com.yahoo.search.yql.MinimalQueryInserter in vespa'"
...