### PR TITLE
Mark grouping hits to avoid redundant re-fills

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/GroupingExecutor.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/GroupingExecutor.java
@@ -150,6 +150,18 @@ public class GroupingExecutor extends Searcher {
                 hit.setFilled(null);
             }
         }
+        for (Iterator<Hit> it = result.hits().unorderedDeepIterator(); it.hasNext(); ) {
+            Hit hit = it.next();
+            if (hit.getSearcherSpecificMetaData(this) instanceof String metaDataString) {
+                if (hit.isFilled(metaDataString)) {
+                    hit.setFilled(null);
+                    // TODO: the above should have been enough
+                    hit.setFilled(summaryClass);
+                    // we could in theory also clear SearcherSpecificMetaData here,
+                    // but there's no gain and some risk involved.
+                }
+            }
+        }
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/result/Hit.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Hit.java
@@ -385,6 +385,7 @@ public class Hit extends ListenableFreezableClass implements Data, Comparable<Hi
      * will also return true if this hit is not fillable.
      */
     public boolean isFilled(String summaryClass) {
+        // TODO: consider also checking filled.contains(null) which signals "filled completely"
         return (filled == null) || filled.contains(summaryClass);
     }
 


### PR DESCRIPTION
When grouping requests a specific summary class for its hits (via HitConverter metadata), the fill is done correctly, but the hits were not marked as filled for the presentation summary class. This caused later fill passes to redundantly try to re-fill those hits.

After filling hits with their grouping-specified summary class, mark them as also filled for the "complete" summary class (null) so subsequent fill operations recognize them as already complete.

Ref for context: https://github.com/vespa-engine/vespa/pull/36177