### PR TITLE
Add a tiny utility function for logical implication

### DIFF
--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -19,6 +19,7 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     generation_hold_list_test.cpp
     generationhandler_test.cpp
     json.cpp
+    logic_test.cpp
     issue_test.cpp
     memory_trap_test.cpp
     mmap_file_allocator_factory_test.cpp

--- a/vespalib/src/tests/util/logic_test.cpp
+++ b/vespalib/src/tests/util/logic_test.cpp
@@ -1,0 +1,15 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/logic.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+namespace vespalib {
+
+TEST(LogicTest, material_implication_has_expected_truth_table) {
+    EXPECT_TRUE( implies(true,  true));
+    EXPECT_FALSE(implies(true,  false));
+    EXPECT_TRUE( implies(false, true));
+    EXPECT_TRUE( implies(false, false));
+}
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/logic.h
+++ b/vespalib/src/vespa/vespalib/util/logic.h
@@ -1,0 +1,12 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace vespalib {
+
+// Material implication: P ==> Q
+[[nodiscard]] constexpr bool implies(const bool p, const bool q) noexcept {
+    return !p || q; // (P ==> Q) <==> (~P \/ Q)
+}
+
+} // namespace vespalib


### PR DESCRIPTION
@toregge please review

Because too few programming languages have a dedicated operator for $P \implies Q$, this is the next best thing.

Useful for e.g. assertions where you want to check that if P holds, then Q must also hold (but not necessarily vice versa).

