### PR TITLE
Explicitly initialize Abseil symbolizer on process startup

### DIFF
--- a/searchcore/src/apps/proton/CMakeLists.txt
+++ b/searchcore/src/apps/proton/CMakeLists.txt
@@ -24,4 +24,5 @@ vespa_add_executable(searchcore_proton_app
     searchcore_proton_metrics
     storageserver_storageapp
     absl::failure_signal_handler
+    absl::symbolize
 )

--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -13,6 +13,7 @@
 #include <vespa/fnet/transport.h>
 #include <vespa/fastos/file_interface.h>
 #include <absl/debugging/failure_signal_handler.h>
+#include <absl/debugging/symbolize.h>
 #include <filesystem>
 #include <iostream>
 #include <thread>
@@ -43,7 +44,7 @@ Params::~Params() = default;
 class App
 {
 private:
-    static void setupSignals();
+    static void setupSignals(char **argv);
     static void setup_fadvise();
     Params parseParams(int argc, char **argv);
     void startAndRun(FNET_Transport & transport, int argc, char **argv);
@@ -52,8 +53,12 @@ public:
 };
 
 void
-App::setupSignals()
+App::setupSignals(char **argv)
 {
+    // Ensure that symbolizer global setup/allocation happens prior to any invocations of
+    // the symbolizer itself. Otherwise, we risk nested failures when the symbolizer attempts
+    // to allocate internal structures when processing an abort-signal caused by an OOM.
+    absl::InitializeSymbolizer(argv[0]);
     absl::FailureSignalHandlerOptions opts;
     // Sanitizers set up their own signal handler, so we must ensure that the failure signal
     // handler calls this when it's done, or we won't get a proper report.
@@ -325,7 +330,7 @@ int
 App::main(int argc, char **argv)
 {
     try {
-        setupSignals();
+        setupSignals(argv);
         setup_fadvise();
         FastOS_FileInterface::enableFSync();
         Transport transport(buildTransportConfig());

--- a/storageserver/src/apps/storaged/CMakeLists.txt
+++ b/storageserver/src/apps/storaged/CMakeLists.txt
@@ -9,6 +9,7 @@ vespa_add_executable(storageserver_storaged_app
     storageserver_storageapp
     protobuf::libprotobuf
     absl::failure_signal_handler
+    absl::symbolize
 )
 
 vespa_add_target_package_dependency(storageserver_storaged_app Protobuf)

--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -22,6 +22,7 @@
 #include <vespa/vespalib/util/signalhandler.h>
 #include <google/protobuf/message_lite.h>
 #include <absl/debugging/failure_signal_handler.h>
+#include <absl/debugging/symbolize.h>
 #include <iostream>
 #include <csignal>
 #include <cstdlib>
@@ -214,8 +215,10 @@ int StorageApp::main(int argc, char **argv)
 } // storage
 
 int main(int argc, char **argv) {
+    // See `App::setupSignals` in `searchcore/src/apps/proton/proton.cpp` for
+    // parameter and handler ordering rationale for the Abseil integration.
+    absl::InitializeSymbolizer(argv[0]);
     absl::FailureSignalHandlerOptions opts;
-    // See `searchcore/src/apps/proton/proton.cpp` for parameter and handler ordering rationale.
     opts.call_previous_handler = true;
     opts.use_alternate_stack = false;
     absl::InstallFailureSignalHandler(opts);


### PR DESCRIPTION
@toregge please review.

We must ensure that the symbolizer global setup/allocation happens prior to any invocations of the symbolizer itself. Otherwise, we risk nested failures when the symbolizer attempts to allocate internal structures when processing an abort-signal caused by an OOM.

Now done as first step during proton/distributor startup.

