### PR TITLE
Make expensive cost tier the default for NearestNeighborBlueprint

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -86,6 +86,10 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
 {
     _distance_heap.set_distance_threshold(_hnsw_params.distance_threshold);
     uint32_t est_hits = _attr_tensor.get_num_docs();
+    // Default to the expensive cost tier to allow the WhiteListBlueprint to come before this blueprint.
+    // If we decide to use HNSW (INDEX_TOP_K, INDEX_TOP_K_WITH_FILTER) or exact search with a global filter (EXACT_FALLBACK),
+    // we move the blueprint to the normal cost tier.
+    set_cost_tier(State::COST_TIER_EXPENSIVE);
     setEstimate(HitEstimate(est_hits, false));
 }
 
@@ -122,6 +126,7 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
             est_hits = std::min(est_hits, _global_filter_hits.value());
             if (_global_filter_hit_ratio.value() < _hnsw_params.global_filter_lower_limit) {
                 _algorithm = Algorithm::EXACT_FALLBACK;
+                set_cost_tier(State::COST_TIER_NORMAL);
                 setEstimate(HitEstimate(est_hits, false));
             }
         } else { // post-filtering case
@@ -135,6 +140,7 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
         }
         if (_algorithm != Algorithm::EXACT_FALLBACK) {
             est_hits = std::min(est_hits, _adjusted_target_hits);
+            set_cost_tier(State::COST_TIER_NORMAL);
             setEstimate(HitEstimate(est_hits, false));
             perform_top_k(nns_index);
         }


### PR DESCRIPTION
This allows the `WhiteListBlueprint` to come before the `NearestNeighborBlueprint` in order to avoid that inactive documents are searched when using exact nearest neighbor search. Example traces with this change below.

Fallback to exact search (without computing global filter). WhiteList comes before NearestNeighbor:
```
ann query details (total setup time was 0.000 ms)
┌─────────────────────────┬───────────────────────┐
│ property                │ details               │
├─────────────────────────┼───────────────────────┤
│ attribute tensor        │ tensor<float>(x[128]) │
│ query tensor            │ tensor<float>(x[128]) │
│ target hits             │                   100 │
│ explore additional hits │                     0 │
│ algorithm               │ exact                 │
│ global filter           │ not calculated        │
│ lazy filter             │ not constructed       │
└─────────────────────────┴───────────────────────┘
...
match profiling for thread #0 (total time was 13.672 ms)
┌───────┬──────────┬─────────┬──────┬──────────────────────────┐
│ seeks │ total_ms │ self_ms │ step │ query tree               │
├───────┼──────────┼─────────┼──────┼──────────────────────────┤
│   404 │   13.672 │   4.976 │ S    │  And[1]                  │
│ 86763 │    6.473 │   4.419 │ S    │  ├── DirectMultiTerm[2]  │
│ 86762 │    1.936 │   1.936 │ N    │  ├── WhiteList[3]        │
│  2213 │    0.287 │   0.287 │ N    │  └── NearestNeighbor[4]  │
└───────┴──────────┴─────────┴──────┴──────────────────────────┘
```

Fallback to exact search after global filter was computed. NearestNeighbor comes before WhiteList since it was moved to the normal cost tier:
```
ann query details (total setup time was 0.004 ms)
┌─────────────────────────┬───────────────────────┐
│ property                │ details               │
├─────────────────────────┼───────────────────────┤
│ attribute tensor        │ tensor<float>(x[128]) │
│ query tensor            │ tensor<float>(x[128]) │
│ target hits             │                   100 │
│ explore additional hits │                     0 │
│ algorithm               │ exact fallback        │
│ global filter           │       0.026 hit ratio │
│ lazy filter             │ not constructed       │
└─────────────────────────┴───────────────────────┘
...
match profiling for thread #0 (total time was 2.867 ms)
┌───────┬──────────┬─────────┬──────┬───────────────────────────────────────────────┐
│ seeks │ total_ms │ self_ms │ step │ query tree                                    │
├───────┼──────────┼─────────┼──────┼───────────────────────────────────────────────┤
│   501 │    2.867 │   0.079 │ S    │  And[1]                                       │
│   501 │    2.763 │   2.763 │ S    │  ├── NearestNeighbor[4]                       │
│   500 │    0.012 │   0.012 │ N    │  ├── Attribute{array<int32>,fs}[2] filter:50  │
│   500 │    0.012 │   0.012 │ N    │  └── WhiteList[3]                             │
└───────┴──────────┴─────────┴──────┴───────────────────────────────────────────────┘
```

ANN. NearestNeighbor comes before WhiteList since it was moved to the normal cost tier:
```
ann query details (total setup time was 0.003 ms)
┌─────────────────────────┬──────────────────────────┐
│ property                │ details                  │
├─────────────────────────┼──────────────────────────┤
│ attribute tensor        │ tensor<float>(x[128])    │
│ query tensor            │ tensor<float>(x[128])    │
│ target hits             │                      100 │
│ explore additional hits │                        0 │
│ algorithm               │ index top k using filter │
│ filter-first heuristic  │ not used                 │
│ global filter           │          0.058 hit ratio │
│ lazy filter             │ not constructed          │
│ visited nodes           │                    14167 │
│ computed distances      │                    14167 │
│ found hits              │                      100 │
└─────────────────────────┴──────────────────────────┘
...
match profiling for thread #0 (total time was 0.069 ms)
┌───────┬──────────┬─────────┬──────┬──────────────────────────┐
│ seeks │ total_ms │ self_ms │ step │ query tree               │
├───────┼──────────┼─────────┼──────┼──────────────────────────┤
│   101 │    0.069 │   0.028 │ S    │  And[1]                  │
│   101 │    0.023 │   0.023 │ S    │  ├── NearestNeighbor[4]  │
│   100 │    0.013 │   0.009 │ N    │  ├── DirectMultiTerm[2]  │
│   100 │    0.005 │   0.005 │ N    │  └── WhiteList[3]        │
└───────┴──────────┴─────────┴──────┴──────────────────────────┘
```