### PR TITLE
Support grouping geo distance on array<position> streaming search

### DIFF
--- a/searchlib/src/tests/expression/position_document_field_node/position_document_field_node_test.cpp
+++ b/searchlib/src/tests/expression/position_document_field_node/position_document_field_node_test.cpp
@@ -1,57 +1,71 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/document/datatype/positiondatatype.h>
+#include <vespa/document/fieldvalue/arrayfieldvalue.h>
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/document/fieldvalue/intfieldvalue.h>
 #include <vespa/document/fieldvalue/structfieldvalue.h>
 #include <vespa/document/repo/newconfigbuilder.h>
 #include <vespa/searchlib/expression/position_document_field_node.h>
+#include <vespa/searchlib/expression/resultvector.h>
 #include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/geo/zcurve.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
+using document::ArrayFieldValue;
 using document::Document;
 using document::IntFieldValue;
 using document::PositionDataType;
 using document::StructFieldValue;
 using search::expression::DocumentAccessorNode;
+using search::expression::IntegerResultNodeVector;
 using search::expression::PositionDocumentFieldNode;
+using search::expression::ResultNode;
+using search::expression::ResultNodeVector;
 using search::test::DocBuilder;
 using vespalib::geo::ZCurve;
 
 const std::string field_name("pos");
 
-struct Fixture {
+namespace {
+
+StructFieldValue make_position(int32_t x, int32_t y) {
+    auto fv = PositionDataType::getInstance().createFieldValue();
+    auto& pos = dynamic_cast<StructFieldValue&>(*fv);
+    pos.setValue(PositionDataType::FIELD_X, IntFieldValue::make(x));
+    pos.setValue(PositionDataType::FIELD_Y, IntFieldValue::make(y));
+    return pos;
+}
+
+}
+
+struct SingleValueFixture {
     DocBuilder                            _builder;
     std::unique_ptr<Document>             _doc;
     std::unique_ptr<DocumentAccessorNode> _node;
 
-    Fixture();
-    ~Fixture();
+    SingleValueFixture();
+    ~SingleValueFixture();
 
-    Fixture& setup_doc(int32_t x, int32_t y);
-    Fixture& setup_node();
-    int64_t evaluate() const;
+    SingleValueFixture& setup_doc(int32_t x, int32_t y);
+    SingleValueFixture& setup_node();
+    [[nodiscard]] int64_t evaluate() const;
 };
 
-Fixture::Fixture()
+SingleValueFixture::SingleValueFixture()
     : _builder([](auto& builder, auto& doc) noexcept
                { doc.addField(field_name, builder.positionType()); }),
       _doc(_builder.make_document("id:ns:searchdocument::0")) {
 }
 
-Fixture::~Fixture() = default;
+SingleValueFixture::~SingleValueFixture() = default;
 
-Fixture& Fixture::setup_doc(int32_t x, int32_t y) {
-    auto fv = PositionDataType::getInstance().createFieldValue();
-    auto& pos = dynamic_cast<StructFieldValue&>(*fv);
-    pos.setValue(PositionDataType::FIELD_X, IntFieldValue::make(x));
-    pos.setValue(PositionDataType::FIELD_Y, IntFieldValue::make(y));
-    _doc->setValue(field_name, *fv);
+SingleValueFixture& SingleValueFixture::setup_doc(int32_t x, int32_t y) {
+    _doc->setValue(field_name, make_position(x, y));
     return *this;
 }
 
-Fixture& Fixture::setup_node() {
+SingleValueFixture& SingleValueFixture::setup_node() {
     _node = std::make_unique<PositionDocumentFieldNode>(field_name);
     _node->prepare(true);
     _node->setDocType(_doc->getType());
@@ -59,38 +73,126 @@ Fixture& Fixture::setup_node() {
     return *this;
 }
 
-int64_t Fixture::evaluate() const {
+int64_t SingleValueFixture::evaluate() const {
     _node->execute();
     return _node->getResult()->getInteger();
 }
 
-class PositionDocumentFieldNodeTest : public Fixture, public ::testing::Test {
+class SingleValuePositionTest : public SingleValueFixture, public ::testing::Test {
 protected:
-    PositionDocumentFieldNodeTest();
-    ~PositionDocumentFieldNodeTest() override;
+    SingleValuePositionTest();
+    ~SingleValuePositionTest() override;
 };
 
-PositionDocumentFieldNodeTest::PositionDocumentFieldNodeTest() = default;
+SingleValuePositionTest::SingleValuePositionTest() = default;
+SingleValuePositionTest::~SingleValuePositionTest() = default;
 
-PositionDocumentFieldNodeTest::~PositionDocumentFieldNodeTest() = default;
-
-TEST_F(PositionDocumentFieldNodeTest, encodes_position_as_zcurve) {
+TEST_F(SingleValuePositionTest, encodes_position_as_zcurve) {
     int32_t x = 42;
     int32_t y = 21;
     EXPECT_EQ(ZCurve::encode(x, y), setup_doc(x, y).setup_node().evaluate());
 }
 
-TEST_F(PositionDocumentFieldNodeTest, encodes_negative_coordinates) {
+TEST_F(SingleValuePositionTest, encodes_negative_coordinates) {
     int32_t x = -100;
     int32_t y = 200;
     EXPECT_EQ(ZCurve::encode(x, y), setup_doc(x, y).setup_node().evaluate());
 }
 
-TEST_F(PositionDocumentFieldNodeTest, returns_zero_without_document) {
+TEST_F(SingleValuePositionTest, returns_zero_without_document) {
     _node = std::make_unique<PositionDocumentFieldNode>(field_name);
     _node->prepare(true);
     _node->execute();
-    EXPECT_EQ(0, _node->getResult()->getInteger());
+    // No handler set up (onDocType not called), getResult returns nullptr
+}
+
+struct MultiValueFixture {
+    DocBuilder                            _builder;
+    std::unique_ptr<Document>             _doc;
+    std::unique_ptr<DocumentAccessorNode> _node;
+
+    MultiValueFixture();
+    ~MultiValueFixture();
+
+    MultiValueFixture& setup_node();
+};
+
+MultiValueFixture::MultiValueFixture()
+    : _builder([](auto& builder, auto& doc) noexcept {
+          auto arr = doc.createArray(builder.positionType());
+          auto arr_ref = doc.registerArray(std::move(arr));
+          doc.addField(field_name, arr_ref);
+      }),
+      _doc(_builder.make_document("id:ns:searchdocument::0")) {
+}
+
+MultiValueFixture::~MultiValueFixture() = default;
+
+MultiValueFixture& MultiValueFixture::setup_node() {
+    _node = std::make_unique<PositionDocumentFieldNode>(field_name);
+    _node->prepare(true);
+    _node->setDocType(_doc->getType());
+    _node->setDoc(*_doc);
+    return *this;
+}
+
+class MultiValuePositionTest : public MultiValueFixture, public ::testing::Test {
+protected:
+    MultiValuePositionTest();
+    ~MultiValuePositionTest() override;
+};
+
+MultiValuePositionTest::MultiValuePositionTest() = default;
+MultiValuePositionTest::~MultiValuePositionTest() = default;
+
+TEST_F(MultiValuePositionTest, returns_vector_result_for_array_field) {
+    auto arr = _builder.make_array(field_name);
+    arr.add(make_position(10, 20));
+    arr.add(make_position(30, 40));
+    arr.add(make_position(50, 60));
+    _doc->setValue(field_name, arr);
+
+    setup_node();
+    _node->execute();
+
+    const auto* result = _node->getResult();
+    ASSERT_NE(result, nullptr);
+    ASSERT_TRUE(result->inherits(ResultNodeVector::classId));
+    const auto& vec = static_cast<const IntegerResultNodeVector&>(*result);
+    ASSERT_EQ(vec.size(), 3u);
+    EXPECT_EQ(vec.get(0).getInteger(), ZCurve::encode(10, 20));
+    EXPECT_EQ(vec.get(1).getInteger(), ZCurve::encode(30, 40));
+    EXPECT_EQ(vec.get(2).getInteger(), ZCurve::encode(50, 60));
+}
+
+TEST_F(MultiValuePositionTest, returns_empty_vector_for_empty_array) {
+    auto arr = _builder.make_array(field_name);
+    _doc->setValue(field_name, arr);
+
+    setup_node();
+    _node->execute();
+
+    const auto* result = _node->getResult();
+    ASSERT_NE(result, nullptr);
+    ASSERT_TRUE(result->inherits(ResultNodeVector::classId));
+    const auto& vec = static_cast<const IntegerResultNodeVector&>(*result);
+    EXPECT_EQ(vec.size(), 0u);
+}
+
+TEST_F(MultiValuePositionTest, single_element_array) {
+    auto arr = _builder.make_array(field_name);
+    arr.add(make_position(-100, 200));
+    _doc->setValue(field_name, arr);
+
+    setup_node();
+    _node->execute();
+
+    const auto* result = _node->getResult();
+    ASSERT_NE(result, nullptr);
+    ASSERT_TRUE(result->inherits(ResultNodeVector::classId));
+    const auto& vec = static_cast<const IntegerResultNodeVector&>(*result);
+    ASSERT_EQ(vec.size(), 1u);
+    EXPECT_EQ(vec.get(0).getInteger(), ZCurve::encode(-100, 200));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/expression/position_document_field_node/position_document_field_node_test.cpp
+++ b/searchlib/src/tests/expression/position_document_field_node/position_document_field_node_test.cpp
@@ -103,7 +103,7 @@ TEST_F(SingleValuePositionTest, returns_zero_without_document) {
     _node = std::make_unique<PositionDocumentFieldNode>(field_name);
     _node->prepare(true);
     _node->execute();
-    // No handler set up (onDocType not called), getResult returns nullptr
+    ASSERT_EQ(nullptr, _node->getResult());
 }
 
 struct MultiValueFixture {

--- a/searchlib/src/vespa/searchlib/expression/position_document_field_node.cpp
+++ b/searchlib/src/vespa/searchlib/expression/position_document_field_node.cpp
@@ -8,13 +8,15 @@
 #include <vespa/document/fieldvalue/iteratorhandler.h>
 #include <vespa/vespalib/geo/zcurve.h>
 
+#include <algorithm>
 #include <format>
+#include <vector>
 
 namespace search::expression {
 
 using document::Document;
 using document::DocumentType;
-using document::FieldPathEntry;
+using document::FieldPath;
 using document::PositionDataType;
 using document::fieldvalue::IteratorHandler;
 using vespalib::geo::ZCurve;
@@ -42,28 +44,22 @@ PositionDocumentFieldNode& PositionDocumentFieldNode::operator=(const PositionDo
         _x_path.clear();
         _y_path.clear();
         _doc = nullptr;
+        _handler.reset();
     }
     return *this;
 }
 
-void PositionDocumentFieldNode::onDocType(const DocumentType& docType) {
-    _x_path.clear();
-    _y_path.clear();
-    std::string x_name = std::format("{}.{}", _field_name, PositionDataType::FIELD_X);
-    std::string y_name = std::format("{}.{}", _field_name, PositionDataType::FIELD_Y);
-    docType.buildFieldPath(_x_path, x_name);
-    docType.buildFieldPath(_y_path, y_name);
-}
-
-void PositionDocumentFieldNode::onDoc(const Document& doc) {
-    _doc = &doc;
-}
-
-void PositionDocumentFieldNode::onPrepare(bool) {
-    // Result type is always Int64
-}
-
 namespace {
+
+/**
+ * For complex field path access, if the last entry is array this returns true, else false.
+ */
+bool check_multivalue(const FieldPath& field_path) {
+    if (field_path.empty()) {
+        return false;
+    }
+    return field_path.back().getDataType().isArray();
+}
 
 class IntExtractor : public IteratorHandler {
 public:
@@ -73,27 +69,72 @@ public:
     }
 };
 
+class IntListExtractor : public IteratorHandler {
+public:
+    std::vector<int32_t> values;
+    ~IntListExtractor() override;
+    void onPrimitive(uint32_t, const Content& c) override {
+        values.push_back(c.getValue().getAsInt());
+    }
+};
+
+IntListExtractor::~IntListExtractor() = default;
+
+}
+
+void PositionDocumentFieldNode::onDocType(const DocumentType& docType) {
+    _x_path.clear();
+    _y_path.clear();
+    std::string x_name = std::format("{}.{}", _field_name, PositionDataType::FIELD_X);
+    std::string y_name = std::format("{}.{}", _field_name, PositionDataType::FIELD_Y);
+    docType.buildFieldPath(_x_path, x_name);
+    docType.buildFieldPath(_y_path, y_name);
+
+    FieldPath field_path;
+    docType.buildFieldPath(field_path, _field_name);
+    if (check_multivalue(field_path)) {
+        _handler = std::make_unique<MultiValueHandler>();
+    } else {
+        _handler = std::make_unique<SingleValueHandler>();
+    }
+}
+
+void PositionDocumentFieldNode::onDoc(const Document& doc) {
+    _doc = &doc;
+}
+
+void PositionDocumentFieldNode::onPrepare(bool) {
+    // Handler and result type are set up in onDocType
+}
+
+void PositionDocumentFieldNode::SingleValueHandler::handle(const Document& doc, const FieldPath& x_path,
+                                                           const FieldPath& y_path) {
+    IntExtractor x_ext;
+    IntExtractor y_ext;
+    doc.iterateNested(x_path.getFullRange(), x_ext);
+    doc.iterateNested(y_path.getFullRange(), y_ext);
+    _result.set(ZCurve::encode(x_ext.value, y_ext.value));
+}
+
+void PositionDocumentFieldNode::MultiValueHandler::handle(const Document& doc, const FieldPath& x_path,
+                                                          const FieldPath& y_path) {
+    IntListExtractor x_ext;
+    IntListExtractor y_ext;
+    doc.iterateNested(x_path.getFullRange(), x_ext);
+    doc.iterateNested(y_path.getFullRange(), y_ext);
+
+    size_t n = std::min(x_ext.values.size(), y_ext.values.size());
+    _result.getVector().resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        _result.getVector()[i].set(ZCurve::encode(x_ext.values[i], y_ext.values[i]));
+    }
 }
 
 void PositionDocumentFieldNode::onExecute() const {
-    if (_doc == nullptr || _x_path.empty() || _y_path.empty()) {
-        _result.set(0);
+    if (_doc == nullptr || _x_path.empty() || _y_path.empty() || !_handler) {
         return;
     }
-
-    int32_t x = 0;
-    int32_t y = 0;
-
-    IntExtractor x_extractor;
-    _doc->iterateNested(_x_path.getFullRange(), x_extractor);
-    x = x_extractor.value;
-
-    IntExtractor y_extractor;
-    _doc->iterateNested(_y_path.getFullRange(), y_extractor);
-    y = y_extractor.value;
-
-    int64_t zcurve = ZCurve::encode(x, y);
-    _result.set(zcurve);
+    _handler->handle(*_doc, _x_path, _y_path);
 }
 
 vespalib::Serializer& PositionDocumentFieldNode::onSerialize(vespalib::Serializer& os) const {

--- a/searchlib/src/vespa/searchlib/expression/position_document_field_node.h
+++ b/searchlib/src/vespa/searchlib/expression/position_document_field_node.h
@@ -3,9 +3,11 @@
 
 #include "documentaccessornode.h"
 #include "integerresultnode.h"
+#include "resultvector.h"
 
 #include <vespa/document/base/fieldpath.h>
 
+#include <memory>
 #include <string>
 
 namespace search::expression {
@@ -13,7 +15,7 @@ namespace search::expression {
 /**
  * Position field access for streaming search.
  *
- * Reads pos.x and pos.y from the document and encodes as zcurve integer.
+ * Reads pos.x and pos.y from the document and encodes as zcurve integer(s).
  */
 class PositionDocumentFieldNode : public DocumentAccessorNode
 {
@@ -21,7 +23,41 @@ class PositionDocumentFieldNode : public DocumentAccessorNode
     document::FieldPath          _x_path;
     document::FieldPath          _y_path;
     const document::Document*    _doc;
-    mutable Int64ResultNode      _result;
+
+    class Handler {
+    public:
+        virtual ~Handler() = default;
+        virtual void handle(const document::Document& doc,
+                            const document::FieldPath& x_path,
+                            const document::FieldPath& y_path) = 0;
+        [[nodiscard]] virtual const ResultNode* result() const noexcept = 0;
+    };
+
+    /**
+     * For single value result. Reads pos.x and pos.y and computes a single zcurve value.
+     */
+    class SingleValueHandler : public Handler {
+        mutable Int64ResultNode _result;
+    public:
+        void handle(const document::Document& doc,
+                    const document::FieldPath& x_path,
+                    const document::FieldPath& y_path) override;
+        [[nodiscard]] const ResultNode* result() const noexcept override { return &_result; }
+    };
+
+    /**
+     * For multi-value result. Reads pos.x and pos.y for each pos in the array field in the document.
+     */
+    class MultiValueHandler : public Handler {
+        mutable IntegerResultNodeVector _result;
+    public:
+        void handle(const document::Document& doc,
+                    const document::FieldPath& x_path,
+                    const document::FieldPath& y_path) override;
+        [[nodiscard]] const ResultNode* result() const noexcept override { return &_result; }
+    };
+
+    std::unique_ptr<Handler> _handler;
 
 public:
     DECLARE_EXPRESSIONNODE(PositionDocumentFieldNode);
@@ -33,7 +69,7 @@ public:
     PositionDocumentFieldNode& operator=(const PositionDocumentFieldNode&);
 
     // DocumentAccessorNode
-    const std::string& getFieldName() const override { return _field_name; }
+    [[nodiscard]] const std::string& getFieldName() const override { return _field_name; }
 
     // Identifiable
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
@@ -46,7 +82,7 @@ private:
     // ExpressionNode
     void onPrepare(bool preserveAccurateTypes) override;
     void onExecute() const override;
-    const ResultNode* getResult() const override { return &_result; }
+    [[nodiscard]] const ResultNode* getResult() const override { return _handler ? _handler->result() : nullptr; }
 
     // Identifiable
     vespalib::Serializer& onSerialize(vespalib::Serializer& os) const override;


### PR DESCRIPTION
We are supporting geo-distance grouping in streaming search by having the `PositionDocumentFieldNode` convert positions to a z-curve for the `GeoDistanceFunctionNode`. This PR adds support for converting an array of positions to an array of zcurve ints.

Related to https://github.com/vespa-engine/vespa/pull/36222

@arnej27959 please review