### PR TITLE
Changed image reference parsing, other improvements for DockerImage

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
@@ -5,48 +5,31 @@ import com.yahoo.component.Version;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
- * A container image.
+ * A docker/container image reference.
  *
- * @author mpolden
+ * @author glebashnik
+ * @author Martin Polden
  */
-// TODO: Rename to ContainerImage. Compatibility with older config-models must be preserved.
-public class DockerImage {
-
+public record DockerImage(String registry, String repository, Optional<String> tag) {
     public static final DockerImage EMPTY = new DockerImage("", "", Optional.empty());
 
-    private final String registry;
-    private final String repository;
-    private final Optional<String> tag;
+    public DockerImage(String registry, String repository, Optional<String> tag) {
+        this.registry = Objects.requireNonNull(registry, "Registry must be non-null");
+        this.repository = Objects.requireNonNull(repository, "Repository must be non-null");
+        this.tag = Objects.requireNonNull(tag, "Tag must be non-null");
 
-    DockerImage(String registry, String repository, Optional<String> tag) {
-        this.registry = Objects.requireNonNull(registry, "registry must be non-null");
-        this.repository = Objects.requireNonNull(repository, "repository must be non-null");
-        this.tag = Objects.requireNonNull(tag, "tag must be non-null");
-
-        if (tag.isPresent() && tag.get().isBlank())
-            throw new IllegalArgumentException("Set tag cannot be empty");
+        if (!registry.isEmpty() || !repository.isEmpty()) {
+            validateRegistry(registry);
+            validateRepository(repository);
+            validateTag(tag);
+        }
     }
-
-    /** Returns the registry-part of this, i.e. the host/port of the registry. */
-    public String registry() {
-        return registry;
-    }
-
-    /** Returns the repository-part of this */
-    public String repository() {
-        return repository;
-    }
-
     /** Returns the registry and repository for this image, excluding its tag */
     public String untagged() {
         return new DockerImage(registry, repository, Optional.empty()).asString();
-    }
-
-    /** Returns this image's tag, if any */
-    public Optional<String> tag() {
-        return tag;
     }
 
     /** Returns the tag as a {@link Version}, {@link Version#emptyVersion} if tag is not set */
@@ -54,20 +37,60 @@ public class DockerImage {
         return tag.map(Version::new).orElse(Version.emptyVersion);
     }
 
-    /** Returns a copy of this tagged with the given version */
-    public DockerImage withTag(Version version) {
-        return new DockerImage(registry, repository, Optional.of(version.toFullString()));
+    public DockerImage withRegistry(String registry) {
+        return new DockerImage(registry, this.repository, this.tag);
     }
 
-    /** Returns a copy of this with registry set to given value */
-    public DockerImage withRegistry(String registry) {
-        if (registry.isBlank()) throw new IllegalArgumentException("Registry cannot be empty");
-        if (registry.charAt(registry.length() - 1) == '/') throw new IllegalArgumentException("Registry cannot end with '/': " + registry);
-        return new DockerImage(registry, repository, tag);
+    public DockerImage withRepository(String repository) {
+        return new DockerImage(this.registry, repository, this.tag);
+    }
+
+    public DockerImage withTag(Optional<String> tag) {
+        return new DockerImage(this.registry, this.repository, tag);
+    }
+
+    public DockerImage withTag(Version version) {
+        return new DockerImage(this.registry, this.repository, Optional.of(version.toFullString()));
+    }
+
+    // Registry pattern per https://github.com/distribution/reference
+    // ip4 is part of the domain name pattern, no need for a separate pattern.
+    private static final String DOMAIN_NAME_COMPONENT = "(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])";
+    private static final String DOMAIN_NAME = DOMAIN_NAME_COMPONENT + "(?:\\." + DOMAIN_NAME_COMPONENT + ")*";
+    private static final String IPV6_ADDRESS = "\\[(?:[a-fA-F0-9:]+)\\]";
+    private static final String HOST = "(?:" + DOMAIN_NAME +  "|" + IPV6_ADDRESS + ")";
+    private static final String PORT = "(?::[0-9]+)?";
+    private static final Pattern REGISTRY_PATTERN = Pattern.compile(HOST + PORT);
+
+    // Repository and tag patterns per OCI distribution spec
+    // (https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+    private static final String PATH_COMPONENT = "[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*";
+    private static final Pattern REPOSITORY_PATTERN = Pattern.compile(PATH_COMPONENT + "(?:/" + PATH_COMPONENT + ")*");
+    private static final Pattern TAG_PATTERN = Pattern.compile("[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}");
+    
+    private static void validateRegistry(String registry) {
+        if (!REGISTRY_PATTERN.matcher(registry).matches()) {
+            throw new IllegalArgumentException("Invalid registry: " + registry);
+        }
+    }
+
+    private static void validateRepository(String repository) {
+        if (!REPOSITORY_PATTERN.matcher(repository).matches()) {
+            throw new IllegalArgumentException("Invalid repository: " + repository);
+        }
+    }
+
+    private static void validateTag(Optional<String> tag) {
+        if (tag.isPresent() && !TAG_PATTERN.matcher(tag.get()).matches()) {
+            throw new IllegalArgumentException("Invalid tag: " + tag.get());
+        }
     }
 
     public String asString() {
-        if (equals(EMPTY)) return "";
+        if (equals(EMPTY)) {
+            return "";
+        }
+        
         return registry + "/" + repository + tag.map(t -> ':' + t).orElse("");
     }
 
@@ -76,37 +99,25 @@ public class DockerImage {
         return asString();
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DockerImage that = (DockerImage) o;
-        return registry.equals(that.registry) &&
-               repository.equals(that.repository) &&
-               tag.equals(that.tag);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(registry, repository, tag);
-    }
-
     public static DockerImage fromString(String s) {
         if (s.isEmpty()) return EMPTY;
 
         int repositoryStart = s.indexOf('/');
-        if (repositoryStart < 0 || s.indexOf('/', repositoryStart + 1) < 0)
-            throw new IllegalArgumentException("Expected to find at least 2 path segments in: " + s);
+        if (repositoryStart < 0) {
+            throw new IllegalArgumentException("Image reference requires at least one / in: " + s);
+        }
 
         String registry = s.substring(0, repositoryStart);
         String repository = s.substring(repositoryStart + 1);
 
         int tagStart = repository.indexOf(':');
-        Optional<String> tag = tagStart < 0 ? Optional.empty() : Optional.of(repository.substring(tagStart + 1));
+        Optional<String> tag = Optional.empty();
 
-        if (tagStart >= 0) repository = repository.substring(0, tagStart);
-        if (repository.isEmpty()) throw new IllegalArgumentException("Repository must be non-empty in '" + s + "'");
+        if (tagStart >= 0) {
+            tag = Optional.of(repository.substring(tagStart + 1));
+            repository = repository.substring(0, tagStart);
+        }
+
         return new DockerImage(registry, repository, tag);
     }
-
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
@@ -49,6 +49,10 @@ public record DockerImage(String registry, String repository, Optional<String> t
         return new DockerImage(this.registry, repository, this.tag);
     }
 
+    public DockerImage withRepositoryPrefix(String prefix) {
+        return withRepository(prefix + "/" + this.repository);
+    }
+
     public DockerImage withTag(Optional<String> tag) {
         return new DockerImage(this.registry, this.repository, tag);
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
@@ -21,11 +21,15 @@ public record DockerImage(String registry, String repository, Optional<String> t
         this.repository = Objects.requireNonNull(repository, "Repository must be non-null");
         this.tag = Objects.requireNonNull(tag, "Tag must be non-null");
 
-        if (!registry.isEmpty() || !repository.isEmpty()) {
-            validateRegistry(registry);
-            validateRepository(repository);
-            validateTag(tag);
+        if (registry.isEmpty() && repository.isEmpty() && tag.isEmpty()) {
+            // This is EMPTY
+            return;
         }
+
+        // Otherwise ensure we don't create invalid images.
+        validateRegistry(registry);
+        validateRepository(repository);
+        validateTag(tag);
     }
     /** Returns the registry and repository for this image, excluding its tag */
     public String untagged() {
@@ -56,9 +60,9 @@ public record DockerImage(String registry, String repository, Optional<String> t
     // Registry pattern per https://github.com/distribution/reference
     // ip4 is part of the domain name pattern, no need for a separate pattern.
     private static final String DOMAIN_NAME_COMPONENT = "(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])";
-    private static final String DOMAIN_NAME = DOMAIN_NAME_COMPONENT + "(?:\\." + DOMAIN_NAME_COMPONENT + ")*";
+    private static final String DOMAIN_NAME = DOMAIN_NAME_COMPONENT + "(?:\\." + DOMAIN_NAME_COMPONENT + ")*\\.?";
     private static final String IPV6_ADDRESS = "\\[(?:[a-fA-F0-9:]+)\\]";
-    private static final String HOST = "(?:" + DOMAIN_NAME +  "|" + IPV6_ADDRESS + ")";
+    private static final String HOST = "(?:" + DOMAIN_NAME + "|" + IPV6_ADDRESS + ")";
     private static final String PORT = "(?::[0-9]+)?";
     private static final Pattern REGISTRY_PATTERN = Pattern.compile(HOST + PORT);
 
@@ -67,7 +71,7 @@ public record DockerImage(String registry, String repository, Optional<String> t
     private static final String PATH_COMPONENT = "[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*";
     private static final Pattern REPOSITORY_PATTERN = Pattern.compile(PATH_COMPONENT + "(?:/" + PATH_COMPONENT + ")*");
     private static final Pattern TAG_PATTERN = Pattern.compile("[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}");
-    
+
     private static void validateRegistry(String registry) {
         if (!REGISTRY_PATTERN.matcher(registry).matches()) {
             throw new IllegalArgumentException("Invalid registry: " + registry);
@@ -90,7 +94,7 @@ public record DockerImage(String registry, String repository, Optional<String> t
         if (equals(EMPTY)) {
             return "";
         }
-        
+
         return registry + "/" + repository + tag.map(t -> ':' + t).orElse("");
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
@@ -94,8 +94,9 @@ public class DockerImage {
     public static DockerImage fromString(String s) {
         if (s.isEmpty()) return EMPTY;
 
-        int repositoryStart = s.lastIndexOf('/', s.lastIndexOf('/') - 1);
-        if (repositoryStart < 0) throw new IllegalArgumentException("Expected to find at least 2 path segments in: " + s);
+        int repositoryStart = s.indexOf('/');
+        if (repositoryStart < 0 || s.indexOf('/', repositoryStart + 1) < 0)
+            throw new IllegalArgumentException("Expected to find at least 2 path segments in: " + s);
 
         String registry = s.substring(0, repositoryStart);
         String repository = s.substring(repositoryStart + 1);

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
@@ -22,6 +22,8 @@ public class DockerImageTest {
         new DockerImage("registry.example.com:5000", "vespa", Optional.empty());
         // Multi-component hostname
         new DockerImage("a.b.c.d", "vespa", Optional.empty());
+        // Domain name with trailing dot
+        new DockerImage("registry.example.com.", "vespa", Optional.empty());
         // IPv4
         new DockerImage("192.168.1.1", "vespa", Optional.empty());
         // IPv4 with port
@@ -35,9 +37,8 @@ public class DockerImageTest {
     void test_registry_invalid() {
         // Empty
         assertThrows(IllegalArgumentException.class, () -> new DockerImage("", "vespa", Optional.empty()));
-        // Starts or ends with dot
+        // Starts with dot
         assertThrows(IllegalArgumentException.class, () -> new DockerImage(".registry.example.com", "vespa", Optional.empty()));
-        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com.", "vespa", Optional.empty()));
         // Invalid characters
         assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry/example", "vespa", Optional.empty()));
         assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry example", "vespa", Optional.empty()));

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
@@ -24,7 +24,7 @@ public class DockerImageTest {
                                "registry.example.com/vespa/vespa:7.42", new DockerImage("registry.example.com", "vespa/vespa", Optional.of("7.42")),
                                "registry.example.com:9999/vespa/vespa", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.empty()),
                                "registry.example.com/vespa/vespa", new DockerImage("registry.example.com", "vespa/vespa", Optional.empty()),
-                               "registry.example.com/project/repo/vespa/vespa", new DockerImage("registry.example.com/project/repo", "vespa/vespa", Optional.empty())
+                               "registry.example.com/prefix/vespa/vespa", new DockerImage("registry.example.com", "prefix/vespa/vespa", Optional.empty())
         );
         tests.forEach((value, expected) -> {
             DockerImage parsed = DockerImage.fromString(value);

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
@@ -109,9 +109,9 @@ public class DockerImageTest {
         // Empty string gives EMPTY
         assertEquals(DockerImage.EMPTY, DockerImage.fromString(""));
         // Correct components are parsed
-        var image = DockerImage.fromString("registry.example.com:5000/vespa/vespa:7.42");
+        var image = DockerImage.fromString("registry.example.com:5000/project/repo/vespa/vespa:7.42");
         assertEquals("registry.example.com:5000", image.registry());
-        assertEquals("vespa/vespa", image.repository());
+        assertEquals("project/repo/vespa/vespa", image.repository());
         assertEquals(Optional.of("7.42"), image.tag());
         // No tag
         assertEquals(Optional.empty(), DockerImage.fromString("registry.example.com/vespa").tag());
@@ -135,7 +135,7 @@ public class DockerImageTest {
     }
 
     @Test
-    void test_withRegistry_valid() {
+    void test_withRegistry() {
         var image = DockerImage.fromString("registry.example.com/vespa:7.42");
         var result = image.withRegistry("other.registry.com");
         assertEquals("other.registry.com", result.registry());
@@ -144,14 +144,7 @@ public class DockerImageTest {
     }
 
     @Test
-    void test_withRegistry_invalid() {
-        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
-        assertThrows(IllegalArgumentException.class, () -> image.withRegistry(""));
-        assertThrows(IllegalArgumentException.class, () -> image.withRegistry("/invalid"));
-    }
-
-    @Test
-    void test_withRepository_valid() {
+    void test_withRepository() {
         var image = DockerImage.fromString("registry.example.com/vespa:7.42");
         var result = image.withRepository("other/repo");
         assertEquals(image.registry(), result.registry());
@@ -160,14 +153,7 @@ public class DockerImageTest {
     }
 
     @Test
-    void test_withRepository_invalid() {
-        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
-        assertThrows(IllegalArgumentException.class, () -> image.withRepository(""));
-        assertThrows(IllegalArgumentException.class, () -> image.withRepository("Invalid"));
-    }
-
-    @Test
-    void test_withTag_valid() {
+    void test_withTag() {
         var image = DockerImage.fromString("registry.example.com/vespa:7.42");
         var result = image.withTag(Optional.of("8.0"));
         assertEquals(image.registry(), result.registry());
@@ -178,9 +164,11 @@ public class DockerImageTest {
     }
 
     @Test
-    void test_withTag_invalid() {
+    void test_withRepositoryPrefix() {
         var image = DockerImage.fromString("registry.example.com/vespa:7.42");
-        assertThrows(IllegalArgumentException.class, () -> image.withTag(Optional.of("")));
-        assertThrows(IllegalArgumentException.class, () -> image.withTag(Optional.of("-invalid")));
+        var result = image.withRepositoryPrefix("prefix");
+        assertEquals(image.registry(), result.registry());
+        assertEquals("prefix/vespa", result.repository());
+        assertEquals(image.tag(), result.tag());
     }
 }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
@@ -3,64 +3,183 @@ package com.yahoo.config.provision;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author mpolden
+ * @author glebashnik
+ * @author Martin Polden
  */
 public class DockerImageTest {
 
     @Test
-    void parse() {
-        Map<String, DockerImage> tests = Map.of(
-                               "", DockerImage.EMPTY,
-                               "registry.example.com:9999/vespa/vespa:7.42", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.of("7.42")),
-                               "registry.example.com/vespa/vespa:7.42", new DockerImage("registry.example.com", "vespa/vespa", Optional.of("7.42")),
-                               "registry.example.com:9999/vespa/vespa", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.empty()),
-                               "registry.example.com/vespa/vespa", new DockerImage("registry.example.com", "vespa/vespa", Optional.empty()),
-                               "registry.example.com/prefix/vespa/vespa", new DockerImage("registry.example.com", "prefix/vespa/vespa", Optional.empty())
-        );
-        tests.forEach((value, expected) -> {
-            DockerImage parsed = DockerImage.fromString(value);
-            assertEquals(value, parsed.asString());
-
-            String untagged = expected.equals(DockerImage.EMPTY)
-                                   ? ""
-                                   : expected.registry() + "/" + expected.repository();
-            assertEquals(untagged, parsed.untagged());
-        });
+    void test_registry_valid() {
+        // Hostname
+        new DockerImage("registry.example.com", "vespa", Optional.empty());
+        // Hostname with port
+        new DockerImage("registry.example.com:5000", "vespa", Optional.empty());
+        // Multi-component hostname
+        new DockerImage("a.b.c.d", "vespa", Optional.empty());
+        // IPv4
+        new DockerImage("192.168.1.1", "vespa", Optional.empty());
+        // IPv4 with port
+        new DockerImage("192.168.1.1:5000", "vespa", Optional.empty());
+        // IPv6
+        new DockerImage("[::1]", "vespa", Optional.empty());
+        new DockerImage("[2001:db8::1]", "vespa", Optional.empty());
     }
 
     @Test
-    void registry_cannot_contain_slash() {
-        DockerImage image = DockerImage.fromString("registry.example.com/vespa/vespa");
+    void test_registry_invalid() {
+        // Empty
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("", "vespa", Optional.empty()));
+        // Starts or ends with dot
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage(".registry.example.com", "vespa", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com.", "vespa", Optional.empty()));
+        // Invalid characters
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry/example", "vespa", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry example", "vespa", Optional.empty()));
+    }
+
+    @Test
+    void test_repository_valid() {
+        // Simple
+        new DockerImage("registry.example.com", "vespa", Optional.empty());
+        // Multi-component
+        new DockerImage("registry.example.com", "vespa/vespa", Optional.empty());
+        new DockerImage("registry.example.com", "prefix/vespa/vespa", Optional.empty());
+        // Separators
+        new DockerImage("registry.example.com", "my.repo", Optional.empty());
+        new DockerImage("registry.example.com", "my_repo", Optional.empty());
+        new DockerImage("registry.example.com", "my__repo", Optional.empty());
+        new DockerImage("registry.example.com", "my-repo", Optional.empty());
+        new DockerImage("registry.example.com", "my--repo", Optional.empty());
+    }
+
+    @Test
+    void test_repository_invalid() {
+        // Empty
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "", Optional.empty()));
+        // Uppercase
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "Vespa", Optional.empty()));
+        // Starts or ends with separator
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "-vespa", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa-", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", ".vespa", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa.", Optional.empty()));
+        // Empty path component
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa//vespa", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "/vespa", Optional.empty()));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa/", Optional.empty()));
+    }
+
+    @Test
+    void test_tag_valid() {
+        new DockerImage("registry.example.com", "vespa", Optional.of("latest"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("7.42"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("7.42.1"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("7.42-ext"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("ext7.42"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("tag-with-hyphen"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("tag_with_underscore"));
+        new DockerImage("registry.example.com", "vespa", Optional.of("tag.with.dot"));
+    }
+
+    @Test
+    void test_tag_invalid() {
+        // Empty
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa", Optional.of("")));
+        // Starts with invalid character
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa", Optional.of("-tag")));
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa", Optional.of(".tag")));
+        // Too long (129 characters)
+        assertThrows(IllegalArgumentException.class, () -> new DockerImage("registry.example.com", "vespa", Optional.of("a".repeat(129))));
+    }
+
+    @Test
+    void test_empty_valid() {
+        assertEquals(DockerImage.EMPTY, new DockerImage("", "", Optional.empty()));
+    }
+
+    @Test
+    void test_fromString_valid() {
+        // Empty string gives EMPTY
+        assertEquals(DockerImage.EMPTY, DockerImage.fromString(""));
+        // Correct components are parsed
+        var image = DockerImage.fromString("registry.example.com:5000/vespa/vespa:7.42");
+        assertEquals("registry.example.com:5000", image.registry());
+        assertEquals("vespa/vespa", image.repository());
+        assertEquals(Optional.of("7.42"), image.tag());
+        // No tag
+        assertEquals(Optional.empty(), DockerImage.fromString("registry.example.com/vespa").tag());
+        // asString roundtrips
+        assertEquals("registry.example.com/vespa:latest", DockerImage.fromString("registry.example.com/vespa:latest").asString());
+        assertEquals("registry.example.com:5000/vespa/vespa:7.42", DockerImage.fromString("registry.example.com:5000/vespa/vespa:7.42").asString());
+        assertEquals("192.168.1.1:5000/vespa", DockerImage.fromString("192.168.1.1:5000/vespa").asString());
+        assertEquals("[::1]/vespa", DockerImage.fromString("[::1]/vespa").asString());
+    }
+
+    @Test
+    void test_fromString_invalid() {
+        // No slash (no registry)
+        assertThrows(IllegalArgumentException.class, () -> DockerImage.fromString("registry.example.com"));
+        assertThrows(IllegalArgumentException.class, () -> DockerImage.fromString("foo"));
+        assertThrows(IllegalArgumentException.class, () -> DockerImage.fromString("foo:1.2.3"));
+        // Empty repository
+        assertThrows(IllegalArgumentException.class, () -> DockerImage.fromString("registry.example.com/"));
+        // Empty tag
+        assertThrows(IllegalArgumentException.class, () -> DockerImage.fromString("registry.example.com/vespa:"));
+    }
+
+    @Test
+    void test_withRegistry_valid() {
+        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
+        var result = image.withRegistry("other.registry.com");
+        assertEquals("other.registry.com", result.registry());
+        assertEquals(image.repository(), result.repository());
+        assertEquals(image.tag(), result.tag());
+    }
+
+    @Test
+    void test_withRegistry_invalid() {
+        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
         assertThrows(IllegalArgumentException.class, () -> image.withRegistry(""));
-        assertThrows(IllegalArgumentException.class, () -> image.withRegistry("my-registry/path/"));
+        assertThrows(IllegalArgumentException.class, () -> image.withRegistry("/invalid"));
     }
 
     @Test
-    void parse_invalid() {
-        List<String> tests = List.of(
-                               "registry.example.com",
-                               "registry.example.com/",
-                               "registry.example.com/repository",
-                               "registry.example.com/repository:",
-                               "foo",
-                               "foo:1.2.3"
-        );
-        for (var value : tests) {
-            try {
-                DockerImage.fromString(value);
-                fail("Expected failure for: " + value);
-            } catch (IllegalArgumentException ignored) {
-            }
-        }
+    void test_withRepository_valid() {
+        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
+        var result = image.withRepository("other/repo");
+        assertEquals(image.registry(), result.registry());
+        assertEquals("other/repo", result.repository());
+        assertEquals(image.tag(), result.tag());
     }
 
+    @Test
+    void test_withRepository_invalid() {
+        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
+        assertThrows(IllegalArgumentException.class, () -> image.withRepository(""));
+        assertThrows(IllegalArgumentException.class, () -> image.withRepository("Invalid"));
+    }
+
+    @Test
+    void test_withTag_valid() {
+        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
+        var result = image.withTag(Optional.of("8.0"));
+        assertEquals(image.registry(), result.registry());
+        assertEquals(image.repository(), result.repository());
+        assertEquals(Optional.of("8.0"), result.tag());
+        // Clear tag
+        assertEquals(Optional.empty(), image.withTag(Optional.empty()).tag());
+    }
+
+    @Test
+    void test_withTag_invalid() {
+        var image = DockerImage.fromString("registry.example.com/vespa:7.42");
+        assertThrows(IllegalArgumentException.class, () -> image.withTag(Optional.of("")));
+        assertThrows(IllegalArgumentException.class, () -> image.withTag(Optional.of("-invalid")));
+    }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This aligns better with how images are handled by ECR, GCR and ACR and the way Vespa handles image names, the repository part is before the first /.
What do you think @hakonhall, @esolitos?
