### PR TITLE
Scope equiv production to matched term in adding rules for semantic rules

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
@@ -81,7 +81,10 @@ public class LiteralTermProduction extends TermProduction {
                 Match matched = e.getNonreferencedMatch(0);
                 CompositeItem matchParent = matched.getParent();
                 int matchIndex = matched.getPosition();
-                if (matchIndex < matchParent.getItemCount()
+                if (matchParent instanceof EquivItem parentEquiv) {
+                    // Matched term is inside an existing EQUIV (cascading from a previous rule)
+                    parentEquiv.addItem(newItem);
+                } else if (matchIndex < matchParent.getItemCount()
                         && matchParent.getItem(matchIndex) instanceof EquivItem existingEquiv) {
                     existingEquiv.addItem(newItem);
                 } else if (matchIndex < matchParent.getItemCount()) {

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
@@ -2,6 +2,7 @@
 package com.yahoo.prelude.semantics.rule;
 
 import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.TermType;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.prelude.semantics.engine.Match;
@@ -73,7 +74,25 @@ public class LiteralTermProduction extends TermProduction {
             newItem.setWeight(getWeight());
             if (e.getTraceLevel() >= 6)
                 e.trace(6, "Adding '" + newItem + "'");
-            if (shouldInsertAtMatch(e)) {
+            if (getTermType() == TermType.EQUIV && e.getNonreferencedMatchCount() > 0
+                    && e.getNonreferencedMatch(0).getParent() != null) {
+                // If an EQUIV already exists at the match position
+                // (from a previous EQUIV production), add to it.
+                Match matched = e.getNonreferencedMatch(0);
+                CompositeItem matchParent = matched.getParent();
+                int matchIndex = matched.getPosition();
+                if (matchIndex < matchParent.getItemCount()
+                        && matchParent.getItem(matchIndex) instanceof EquivItem existingEquiv) {
+                    existingEquiv.addItem(newItem);
+                } else if (matchIndex < matchParent.getItemCount()) {
+                    EquivItem equiv = new EquivItem(matchParent.getItem(matchIndex));
+                    equiv.addItem(newItem);
+                    matchParent.setItem(matchIndex, equiv);
+                } else {
+                    e.addItems(List.of(newItem), getTermType());
+                }
+            }
+            else if (shouldInsertAtMatch(e)) {
                 // Add to the match's parent when it's a nested composite with default type
                 Match matched = e.getNonreferencedMatch(0);
                 insertMatch(e, matched, List.of(newItem), offset);

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExpansionTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExpansionTestCase.java
@@ -31,4 +31,22 @@ public class ExpansionTestCase extends RuleBaseAbstractTestCase {
                         "testfield:foo testfield:bar");
     }
 
+    /** EQUIV production should preserve query structure, not collapse into a root-level EQUIV. */
+    @Test
+    void testEquivPreservesQueryStructure() {
+        assertSemantics("AND red running (EQUIV equiv1 equiv2 equiv3)", "red running equiv1");
+    }
+
+    /** EQUIV at the start of a multi-term query should also preserve structure. */
+    @Test
+    void testEquivPreservesQueryStructureMatchFirst() {
+        assertSemantics("AND (EQUIV equiv1 equiv2 equiv3) is great", "equiv1 is great");
+    }
+
+    /** EQUIV in the middle of a multi-term query should also preserve structure. */
+    @Test
+    void testEquivPreservesQueryStructureMatchMiddle() {
+        assertSemantics("AND foo (EQUIV equiv1 equiv2 equiv3) bar", "foo equiv1 bar");
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExpansionTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExpansionTestCase.java
@@ -49,4 +49,16 @@ public class ExpansionTestCase extends RuleBaseAbstractTestCase {
         assertSemantics("AND foo (EQUIV equiv1 equiv2 equiv3) bar", "foo equiv1 bar");
     }
 
+    /** Cascading EQUIV: rule 1 produces cascade2, rule 2 matches it and adds cascade3 to the same EQUIV. */
+    @Test
+    void testEquivCascading() {
+        assertSemantics("EQUIV cascade1 cascade2 cascade3", "cascade1");
+    }
+
+    /** Cascading EQUIV in a multi-term query should preserve structure. */
+    @Test
+    void testEquivCascadingPreservesQueryStructure() {
+        assertSemantics("AND foo (EQUIV cascade1 cascade2 cascade3) bar", "foo cascade1 bar");
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/expansion.sr
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/expansion.sr
@@ -6,3 +6,6 @@ equiv1 +> =equiv2 =equiv3;
 testfield:[test] -> =testfield:e1 =testfield:e2 =testfield:e3;
 
 [test] :- foo, bar, baz;
+
+cascade1 +> =cascade2;
+cascade2 +> =cascade3;


### PR DESCRIPTION
When using adding production (+>) with EQUIV (=), the produced terms should be scoped to the matched query term rather than combined at the root level

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
