### PR TITLE
Add zero-copy read support to `Fast_BufferedFile` via `vespalib::Input`

### DIFF
--- a/vespalib/src/tests/fastlib/io/bufferedfiletest.cpp
+++ b/vespalib/src/tests/fastlib/io/bufferedfiletest.cpp
@@ -3,24 +3,28 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <filesystem>
 
+using namespace ::testing;
+
 namespace fs = std::filesystem;
-namespace {
 
-void remove_testfiles()
-{
-    fs::remove(fs::path("testfile1"));
-    fs::remove(fs::path("testfile2"));
-    fs::remove(fs::path("testfile3"));
-    fs::remove(fs::path("testfile4"));
-    fs::remove(fs::path("testfile5"));
-}
+struct BufferedFileTest : Test {
+    void SetUp() override {
+        remove_testfiles();
+    }
+    void TearDown() override {
+        remove_testfiles();
+    }
+    static void remove_testfiles() {
+        fs::remove(fs::path("testfile1"));
+        fs::remove(fs::path("testfile2"));
+        fs::remove(fs::path("testfile3"));
+        fs::remove(fs::path("testfile4"));
+        fs::remove(fs::path("testfile5"));
+    }
+};
 
-}
-
-TEST(BufferedFileTest, main) {
+TEST_F(BufferedFileTest, main) {
     int value = 0;
-
-    remove_testfiles();
 
     Fast_BufferedFile bufFile(4096);
 
@@ -72,11 +76,57 @@ TEST(BufferedFileTest, main) {
     ASSERT_TRUE(bufFile.Close());
     ASSERT_EQ(610000u, fs::file_size(fs::path("testfile5")));
     printf (" -- SUCCESS\n\n");
+}
 
-    remove_testfiles();
-
-    printf ("All tests OK for bufferedfiletest\n");
-    printf (" -- SUCCESS\n\n");
+TEST_F(BufferedFileTest, can_access_underlying_buffer_via_input_api) {
+    {
+        Fast_BufferedFile out_file;
+        out_file.WriteOpen("testfile1");
+        // The internal Fast_BufferedFile read buffer has a minimum size of 4Ki, so to
+        // test boundary cases we need to write at least 2 such blocks. Also throw in a
+        // partial block at the end of the file.
+        char buf[8192 + 100];
+        memset(buf, 'A', 4096);
+        memset(buf + 4096, 'B', 4096);
+        memset(buf + 8192, 'C', 100);
+        ASSERT_TRUE(out_file.CheckedWrite(buf, sizeof(buf)));
+        ASSERT_TRUE(out_file.Close());
+    }
+    Fast_BufferedFile f(4096);
+    f.ReadOpenExisting("testfile1");
+    ASSERT_TRUE(f.IsOpened());
+    auto mem = f.obtain();
+    ASSERT_TRUE(mem.data);
+    ASSERT_EQ(mem.size, 4096);
+    ASSERT_EQ(mem.make_string(), std::string(4096, 'A'));
+    // obtain() should be idempotent until evict() is called
+    auto mem2 = f.obtain();
+    ASSERT_EQ(mem2.data, mem.data);
+    ASSERT_EQ(mem2.size, mem.size);
+    f.evict(1);
+    mem = f.obtain();
+    ASSERT_TRUE(mem.data);
+    ASSERT_EQ(mem.size, 4095);
+    ASSERT_EQ(mem.make_string(), std::string(4095, 'A'));
+    f.evict(4094);
+    mem = f.obtain();
+    ASSERT_TRUE(mem.data);
+    ASSERT_EQ(mem.size, 1);
+    ASSERT_EQ(mem.make_string(), "A");
+    f.evict(1);
+    mem = f.obtain(); // --> read new block
+    ASSERT_TRUE(mem.data);
+    ASSERT_EQ(mem.size, 4096);
+    ASSERT_EQ(mem.make_string(), std::string(4096, 'B'));
+    f.evict(4096);
+    mem = f.obtain(); // --> read new block (partial this time)
+    ASSERT_TRUE(mem.data);
+    ASSERT_EQ(mem.size, 100);
+    ASSERT_EQ(mem.make_string(), std::string(100, 'C'));
+    f.evict(100);
+    // EOF
+    mem = f.obtain();
+    ASSERT_EQ(mem.size, 0);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/fastlib/io/bufferedfile.cpp
+++ b/vespalib/src/vespa/fastlib/io/bufferedfile.cpp
@@ -11,8 +11,8 @@ using vespalib::getLastErrorString;
 
 namespace {
 
-const size_t DEFAULT_BUF_SIZE = 0x200000;
-const size_t MIN_ALIGNMENT = 0x1000;
+constexpr size_t DEFAULT_BUF_SIZE = 0x200000;
+constexpr size_t MIN_ALIGNMENT = 0x1000;
 
 }
 
@@ -274,6 +274,21 @@ Fast_BufferedFile::Read(void *dst, size_t dstlen)
             break;
     }
     return p - static_cast<char *>(dst);
+}
+
+vespalib::Memory Fast_BufferedFile::obtain() {
+    if (const size_t avail = _bufe - _bufi; avail > 0) [[likely]] {
+        return {_bufi, avail};
+    }
+    fillReadBuf();
+    const size_t avail = _bufe - _bufi; // Zero if at EOF
+    return {_bufi, avail};
+}
+
+vespalib::Input& Fast_BufferedFile::evict(size_t bytes) {
+    assert(_bufi + bytes <= _bufe);
+    _bufi += bytes;
+    return *this;
 }
 
 void

--- a/vespalib/src/vespa/fastlib/io/bufferedfile.h
+++ b/vespalib/src/vespa/fastlib/io/bufferedfile.h
@@ -2,16 +2,22 @@
 
 #pragma once
 
-#include <vespa/vespalib/util/hdr_abort.h>
-#include <vespa/vespalib/util/alloc.h>
 #include <vespa/fastos/file_interface.h>
+#include <vespa/vespalib/data/input.h>
+#include <vespa/vespalib/util/alloc.h>
 
 /**
  * Provides buffered file access.
+ *
+ * Also provides an implementation of the vespalib Input interface that enables
+ * zero-copy semantics for directly accessing the underlying file read buffer.
+ * Do not cross the streams on the same Fast_BufferedFile instance; use _either_
+ * the classic Read() _or_ the Input API, not both at the same time.
  */
-class Fast_BufferedFile : public FastOS_FileInterface
+class Fast_BufferedFile
+    : public FastOS_FileInterface,
+      public vespalib::Input
 {
-private:
     using Alloc = vespalib::alloc::Alloc;
     /** The number of bytes left in the file. */
     int64_t _fileleft;
@@ -115,6 +121,24 @@ public:
      * @return The number of bytes read.
      */
     [[nodiscard]] ssize_t Read(void *dst, size_t dstlen) override;
+
+    /**
+     * Obtains a view into the underlying file read buffer. Returns a size of
+     * zero iff EOF is reached. Subsequent calls to obtain() are idempotent
+     * (i.e. will return the same buffer region) until evict() is called.
+     *
+     * See vespalib::Input:obtain()
+     */
+    [[nodiscard]] vespalib::Memory obtain() override;
+
+    /**
+     * Evict a number of bytes up to and including the previously obtain()'ed
+     * number of bytes.
+     *
+     * See vespalib::Input::evict()
+     */
+    Input& evict(size_t bytes) override;
+
     /**
      * Write one byte to the buffered file, flushing to
      * file if necessary.

--- a/vespalib/src/vespa/vespalib/data/input.h
+++ b/vespalib/src/vespa/vespalib/data/input.h
@@ -19,7 +19,7 @@ struct Input
      *
      * @return the obtained input data
      **/
-    virtual Memory obtain() = 0;
+    [[nodiscard]] virtual Memory obtain() = 0;
 
     /**
      * Evict processed input data. Never evict more data than you have


### PR DESCRIPTION
@havardpe please review. Not used by anything yet, but this enables certain Future Optimizations™ and just seemed like a neat thing to have in general :eyes:
@toregge FYI

`Fast_BufferedFile` already has an internal buffer for holding bulk read file data (as its name implies), but has until now held this closely to its chest, only exposing it indirectly via virtual `Read` calls that copy to a provided destination buffer. These virtual calls and copying add up, particularly if you've got a lot of small reads.

This adds an implementation of the `vespalib::Input` interface, allowing direct (but well-defined) access to the underlying data buffer, amortizing away the virtual call costs.

