### PR TITLE
Migrate de.kherud:llama -> io.github.arnej27959:jllama

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -163,7 +163,7 @@
                                         <include>com.squareup.okio:okio-jvm:3.6.0:test</include>
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>
-                                        <include>de.kherud:llama:${kherud.llama.vespa.version}:test</include>
+                                        <include>io.github.arnej27959:jllama:${jllama.vespa.version}:test</include>
                                         <include>io.airlift:aircompressor:${aircompressor.vespa.version}:test</include>
                                         <include>io.airlift:airline:${airline.vespa.version}:test</include>
                                         <include>io.micrometer:micrometer-commons:${micrometer.vespa.version}:test</include>

--- a/container-llama/pom.xml
+++ b/container-llama/pom.xml
@@ -34,13 +34,17 @@
     </dependency>
     <!-- compile -->
     <dependency>
-      <groupId>de.kherud</groupId>
-      <artifactId>llama</artifactId>
+      <groupId>io.github.arnej27959</groupId>
+      <artifactId>jllama</artifactId>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -73,7 +77,7 @@
 	     <createDependencyReducedPom>false</createDependencyReducedPom>
 	     <filters>
 	       <filter>
-		<artifact>de.kherud:*</artifact>
+		<artifact>*:jllama</artifact>
 		<excludes>
 		  <exclude>de/kherud/llama/Linux-Android//**</exclude>
 		  <exclude>de/kherud/llama/Linux/**</exclude>

--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -66,12 +66,16 @@
       <artifactId>onnxruntime</artifactId>
     </dependency>
     <dependency>
-      <groupId>de.kherud</groupId>
-      <artifactId>llama</artifactId>
+      <groupId>io.github.arnej27959</groupId>
+      <artifactId>jllama</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -118,7 +118,7 @@
         <junit.vespa.version>5.10.2</junit.vespa.version>
         <junit.platform.vespa.version>1.10.2</junit.platform.vespa.version>
         <junit4.vespa.version>4.13.2</junit4.vespa.version>
-        <kherud.llama.vespa.version>4.1.0</kherud.llama.vespa.version>
+        <jllama.vespa.version>4.7.8</jllama.vespa.version>
         <kotlin.vespa.version>1.9.25</kotlin.vespa.version>
         <luben.zstd.vespa.version>1.5.6-4</luben.zstd.vespa.version>
         <lucene.vespa.version>9.11.1</lucene.vespa.version>

--- a/model-integration/src/main/java/ai/vespa/embedding/GgufEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/GgufEmbedder.java
@@ -35,7 +35,7 @@ public class GgufEmbedder extends AbstractComponent implements Embedder {
     private final boolean normalize;
 
     public static class Exception extends RuntimeException {
-        public Exception(Throwable cause) { super(cause); }
+        public Exception(Throwable cause) { super(cause.getMessage(), cause); }
     }
 
     @Inject
@@ -134,7 +134,8 @@ public class GgufEmbedder extends AbstractComponent implements Embedder {
             var cause = e.getCause();
             if (cause == null) throw e;
             if (cause.getClass().getName().endsWith("de.kherud.llama.LlamaException") // Package-private exception
-                    && cause.getMessage().contains("input is too large to process")) {
+                    && cause.getMessage().contains("too large to process"))
+            {
                 // Illegal input must be propagated as IllegalArgumentException
                 throw new IllegalArgumentException(
                         Text.format("Input text is too large (prompt UTF-16 length: %d). Either set max prompt tokens or adjust batch/context size.", prompt.length()),

--- a/model-integration/src/test/java/ai/vespa/embedding/GgufEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/GgufEmbedderTest.java
@@ -102,7 +102,7 @@ class GgufEmbedderTest {
         private static final String LARGE_PROMPT = "This is a test. ".repeat(100);
 
         @Test
-        void succeeds_when_overriding_batch_and_context_size() {
+        void fails_when_overriding_batch_and_context_size() {
             var config = new GgufEmbedderConfig.Builder()
                     .embeddingModel(ModelReference.valueOf(TINY_LLM_MODEL))
                     .physicalMaxBatchSize(2*1024)
@@ -110,16 +110,14 @@ class GgufEmbedderTest {
                     .contextSize(2*1024)
                     .seed(1)
                     .build();
+
+            // load_model: the slot context (2048) exceeds the training context of the model (128) - capping
+
             var embedder = new GgufEmbedder(config, ModelReference::value);
             try {
-                var tokens = embedder.embed(LARGE_PROMPT, DUMMY_CONTEXT);
-                assertEquals(1001, tokens.size());
-                var tensorType = TensorType.fromSpec("tensor<float>(x[64])");
-                var embedding = embedder.embed(LARGE_PROMPT, DUMMY_CONTEXT, tensorType);
-
-                assertNotNull(embedding);
-                assertEquals(tensorType, embedding.type());
-                assertTrue(embedding.sum().asDouble() != 0.0);
+                var message = assertThrows(RuntimeException.class, () ->
+                    embedder.embed(LARGE_PROMPT, DUMMY_CONTEXT, TensorType.fromSpec("tensor<float>(x[1024])")));
+                assertTrue(message.getMessage().contains("larger than the max context size"));
             } finally {
                 assertDoesNotThrow(embedder::deconstruct);
             }
@@ -156,7 +154,7 @@ class GgufEmbedderTest {
             var embedder = new GgufEmbedder(config, ModelReference::value);
             try {
                 var message = assertThrows(IllegalArgumentException.class, () ->
-                    embedder.embed(LARGE_PROMPT, DUMMY_CONTEXT, TensorType.fromSpec("tensor<float>(x[1024])")));
+                                           embedder.embed(LARGE_PROMPT, DUMMY_CONTEXT, TensorType.fromSpec("tensor<float>(x[1024])")));
                 assertEquals(
                         "Input text is too large (prompt UTF-16 length: 1600). Either set max prompt tokens or adjust batch/context size.",
                         message.getMessage());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -800,9 +800,9 @@
                 <version>${onnxruntime.vespa.version}</version>
             </dependency>
             <dependency>
-                <groupId>de.kherud</groupId>
-                <artifactId>llama</artifactId>
-                <version>${kherud.llama.vespa.version}</version>
+                <groupId>io.github.arnej27959</groupId>
+                <artifactId>jllama</artifactId>
+                <version>${jllama.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -52,10 +52,10 @@ commons-cli:commons-cli:${commons-cli.vespa.version}
 commons-codec:commons-codec:${commons-codec.vespa.version}
 commons-io:commons-io:${commons-io.vespa.version}
 commons-logging:commons-logging:${commons-logging.vespa.version}
-de.kherud:llama:${kherud.llama.vespa.version}
 io.airlift:aircompressor:${aircompressor.vespa.version}
 io.airlift:airline:${airline.vespa.version}
 io.dropwizard.metrics:metrics-core:${dropwizard.metrics.vespa.version}
+io.github.arnej27959:jllama:${jllama.vespa.version}
 io.grpc:grpc-api:${grpc.vespa.version}
 io.grpc:grpc-context:${grpc.vespa.version}
 io.grpc:grpc-core:${grpc.vespa.version}


### PR DESCRIPTION
Switch to the jllama fork (version 4.7.8, up from 4.1.0) to leverage bug fixes and ongoing maintenance. The newer version has stricter validation for context size vs model training context.

Changes:
- Update all Maven dependencies from de.kherud:llama to io.github.arnej27959:jllama
- Exclude Kotlin dependencies to reduce transitive dependencies
- Improve exception handling to include cause messages
- Adjust test expectations to match new library behavior where context size larger than model training context now fails

The test changes reflect that the new llama.cpp rejects attempts to use context sizes that exceed the model's training context (128 tokens in the test model), whereas the old version silently allowed this.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
