### PR TITLE
Add indexing chain to containers that inherit from it

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -106,6 +106,26 @@ public class Content extends ConfigModel {
         containerCluster.getDocprocChains().add(new IndexingDocprocChain());
     }
 
+    private static boolean inheritsFromIndexing(DocprocChain chain) {
+        for (ComponentSpecification inherited : chain.getChainSpecification().inheritance.chainSpecifications) {
+            if (IndexingDocprocChain.NAME.equals(inherited.getName())) return true;
+        }
+        return false;
+    }
+
+    private static void addIndexingChainToContainersInheritingFromIt(Collection<ContainerModel> containers) {
+        for (ContainerModel containerModel : containers) {
+            ContainerCluster<?> cluster = containerModel.getCluster();
+            if (cluster.getDocproc() == null) continue;
+            for (DocprocChain chain : cluster.getDocprocChains().allChains().allComponents()) {
+                if (inheritsFromIndexing(chain)) {
+                    addIndexingChain(cluster);
+                    break;
+                }
+            }
+        }
+    }
+
     private static ContainerCluster<?> getContainerWithSearch(Collection<ContainerModel> containers) {
         for (ContainerModel container : containers)
             if (container.getCluster().getSearch() != null)
@@ -211,6 +231,7 @@ public class Content extends ConfigModel {
             content.cluster = new ContentCluster.Builder(admin).build(modelContext, xml);
             buildIndexingClusters(content, modelContext,
                                   (ApplicationConfigProducerRoot)modelContext.getParentProducer());
+            addIndexingChainToContainersInheritingFromIt(content.containers);
         }
 
         /** Select/creates and initializes the indexing cluster coupled to this */

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/IndexingAndDocprocRoutingTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/IndexingAndDocprocRoutingTest.java
@@ -226,6 +226,48 @@ public class IndexingAndDocprocRoutingTest extends ContentBaseTest {
         }
     }
 
+    @Test
+    void containerWithDocprocInheritingIndexingButNotReferencedByContent() {
+        String xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<services version=\"1.0\">\n" +
+                "  <admin version=\"2.0\">\n" +
+                "    <adminserver hostalias=\"node0\"/>\n" +
+                "  </admin>\n" +
+                "  <container version='1.0' id='default'>\n" +
+                "    <search/>\n" +
+                "    <nodes>\n" +
+                "      <node hostalias='node0'/>\n" +
+                "    </nodes>\n" +
+                "  </container>\n" +
+                "  <container version='1.0' id='unreferenced'>\n" +
+                "    <document-processing>\n" +
+                "      <chain id='mychain' inherits='indexing'/>\n" +
+                "    </document-processing>\n" +
+                "    <nodes>\n" +
+                "      <node hostalias='node0'/>\n" +
+                "    </nodes>\n" +
+                "    <http>\n" +
+                "      <server id='unreferenced' port='8010'/>\n" +
+                "    </http>\n" +
+                "  </container>\n" +
+                "  <content id='musiccluster' version='1.0'>\n" +
+                "    <redundancy>1</redundancy>\n" +
+                "    <documents>\n" +
+                "      <document type='music' mode='index'/>\n" +
+                "    </documents>\n" +
+                "    <group>\n" +
+                "      <node hostalias='node0' distribution-key='0'/>\n" +
+                "    </group>\n" +
+                "  </content>\n" +
+                "</services>\n";
+        VespaModel model = getIndexedSearchVespaModel(xml);
+        // Verify the unreferenced container has the indexing chain registered
+        ContainerCluster<?> unreferenced = model.getContainerClusters().get("unreferenced");
+        assertNotNull(unreferenced);
+        assertNotNull(unreferenced.getDocprocChains().allChains().getComponent("indexing"));
+    }
+
     private void assertIndexing(VespaModel model, DocprocClusterSpec... expectedDocprocClusters) {
         Map<String, ContainerCluster> docprocClusters = getDocprocClusters(model);
         assertEquals(expectedDocprocClusters.length, docprocClusters.size());


### PR DESCRIPTION
Register IndexingDocprocChain in container clusters that have docproc chains inheriting from 'indexing', even when no content cluster references them.
