### PR TITLE
Fix equiv handling for quoted phrase productions in semantic rules

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralPhraseProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralPhraseProduction.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.yahoo.prelude.query.PhraseItem;
+import com.yahoo.prelude.query.TermType;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.prelude.semantics.engine.Match;
 import com.yahoo.prelude.semantics.engine.RuleEvaluation;
@@ -50,8 +51,16 @@ public class LiteralPhraseProduction extends TermProduction {
         for (String term : terms)
             newPhrase.addItem(new WordItem(term, true));
 
-        Match matched = e.getNonreferencedMatch(0);
-        insertMatch(e, matched, List.of(newPhrase), offset);
+        // if replacing we should not wrap matched term in equiv
+        if (!replacing && getTermType() == TermType.EQUIV
+                && e.getNonreferencedMatchCount() > 0
+                && e.getNonreferencedMatch(0).getParent() != null) {
+            collapseMultiWordMatches(e);
+            addEquivItem(e, newPhrase);
+        } else {
+            Match matched = e.getNonreferencedMatch(0);
+            insertMatch(e, matched, List.of(newPhrase), offset);
+        }
     }
 
     public String toInnerTermString() {

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
@@ -1,14 +1,11 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.semantics.rule;
 
-import com.yahoo.prelude.query.CompositeItem;
-import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.TermType;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.prelude.semantics.engine.Match;
 import com.yahoo.prelude.semantics.engine.RuleEvaluation;
 import com.yahoo.protect.Validator;
-import com.yahoo.search.query.QueryTree;
 
 import java.util.List;
 
@@ -76,24 +73,7 @@ public class LiteralTermProduction extends TermProduction {
                 e.trace(6, "Adding '" + newItem + "'");
             if (getTermType() == TermType.EQUIV && e.getNonreferencedMatchCount() > 0
                     && e.getNonreferencedMatch(0).getParent() != null) {
-                // If an EQUIV already exists at the match position
-                // (from a previous EQUIV production), add to it.
-                Match matched = e.getNonreferencedMatch(0);
-                CompositeItem matchParent = matched.getParent();
-                int matchIndex = matched.getPosition();
-                if (matchParent instanceof EquivItem parentEquiv) {
-                    // Matched term is inside an existing EQUIV (cascading from a previous rule)
-                    parentEquiv.addItem(newItem);
-                } else if (matchIndex < matchParent.getItemCount()
-                        && matchParent.getItem(matchIndex) instanceof EquivItem existingEquiv) {
-                    existingEquiv.addItem(newItem);
-                } else if (matchIndex < matchParent.getItemCount()) {
-                    EquivItem equiv = new EquivItem(matchParent.getItem(matchIndex));
-                    equiv.addItem(newItem);
-                    matchParent.setItem(matchIndex, equiv);
-                } else {
-                    e.addItems(List.of(newItem), getTermType());
-                }
+                addEquivItem(e, newItem);
             }
             else if (shouldInsertAtMatch(e)) {
                 // Add to the match's parent when it's a nested composite with default type

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/TermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/TermProduction.java
@@ -2,7 +2,9 @@
 package com.yahoo.prelude.semantics.rule;
 
 import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.PhraseItem;
 import com.yahoo.prelude.query.TermType;
 import com.yahoo.prelude.semantics.engine.Match;
 import com.yahoo.prelude.semantics.engine.RuleEvaluation;
@@ -79,6 +81,76 @@ public abstract class TermProduction extends Production {
         if (e.getTraceLevel() >= 6)
             e.trace(6, "Inserted items '" + newItems + "' at position " + insertPosition + " producing " +
                        e.getEvaluation().getQuery().getModel().getQueryTree());
+    }
+
+    /**
+     * Collapses multiple matched terms from a multi-word condition into a single PhraseItem,
+     * preserving the adjacency constraint of the original query terms. For example, when
+     * "running shoes" matches a two-word condition, this replaces the individual terms with
+     * a single PhraseItem so they can be wrapped in an EQUIV as {@code EQUIV "running shoes" sneakers}.
+     *
+     * @return the PhraseItem that replaced the matched terms, or null if there was only one match
+     */
+    protected PhraseItem collapseMultiWordMatches(RuleEvaluation e) {
+        int count = e.getNonreferencedMatchCount();
+        if (count <= 1) return null;
+
+        Match first = e.getNonreferencedMatch(0);
+        CompositeItem parent = first.getParent();
+        if (parent == null) return null;
+
+        for (int i = 1; i < count; i++) {
+            if (e.getNonreferencedMatch(i).getParent() != parent) return null;
+        }
+
+        PhraseItem phrase = new PhraseItem();
+        phrase.setIndexName(getLabel());
+        for (int i = 0; i < count; i++) {
+            phrase.addItem(e.getNonreferencedMatch(i).toItem(getLabel()));
+        }
+
+        // Remove extra matched terms (1..N-1) from parent
+        for (int i = 1; i < count; i++) {
+            parent.removeItem(e.getNonreferencedMatch(i).getItem());
+        }
+
+        // Replace first matched term with the phrase
+        parent.setItem(first.getPosition(), phrase);
+
+        return phrase;
+    }
+
+    /** Adds newItem into an EQUIV at the match position, creating one if needed. */
+    protected void addEquivItem(RuleEvaluation e, Item newItem) {
+        Match matched = e.getNonreferencedMatch(0);
+        CompositeItem matchParent = matched.getParent();
+        int matchIndex = matched.getPosition();
+        EquivItem ancestor = findAncestorEquiv(matchParent);
+        if (ancestor != null) {
+            ancestor.addItem(newItem);
+        } else if (matchIndex < matchParent.getItemCount()
+                && matchParent.getItem(matchIndex) instanceof EquivItem existingEquiv) {
+            existingEquiv.addItem(newItem);
+        } else if (matchIndex < matchParent.getItemCount()) {
+            collapseMultiWordMatches(e);
+            EquivItem equiv = new EquivItem(matchParent.getItem(matchIndex));
+            equiv.addItem(newItem);
+            matchParent.setItem(matchIndex, equiv);
+        } else {
+            e.addItems(List.of(newItem), getTermType());
+        }
+    }
+
+    /**
+     * Walks up the query tree from item looking for an EquivItem ancestor, up to 4 levels.
+     * Cascading rules may match a term nested inside a composite (e.g. WordItem inside
+     * PhraseItem inside EquivItem), and we need the enclosing EQUIV to add to it.
+     */
+    private static EquivItem findAncestorEquiv(Item item) {
+        for (int i = 0; i < 4 && item != null; i++, item = item.getParent()) {
+            if (item instanceof EquivItem equiv) return equiv;
+        }
+        return null;
     }
 
     protected String getLabelString() {

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/EquivTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/EquivTestCase.java
@@ -14,22 +14,22 @@ public class EquivTestCase extends RuleBaseAbstractTestCase {
 
     @Test
     void testEquiv() {
-        assertSemantics("EQUIV \"lord of the rings\" lotr", "lotr");
+        assertSemantics("EQUIV lotr \"lord of the rings\"", "lotr");
     }
 
     @Test
     void testEquivWithFollowingQuery() {
-        assertSemantics("AND (EQUIV \"lord of the rings\" lotr) is a movie", "lotr is a movie");
+        assertSemantics("AND (EQUIV lotr \"lord of the rings\") is a movie", "lotr is a movie");
     }
 
     @Test
     void testEquivWithPrecedingQuery() {
-        assertSemantics("AND a movie is (EQUIV \"lord of the rings\" lotr)", "a movie is lotr");
+        assertSemantics("AND a movie is (EQUIV lotr \"lord of the rings\")", "a movie is lotr");
     }
 
     @Test
     void testEquivWithSurroundingQuery() {
-        assertSemantics("AND a movie is (EQUIV \"lord of the rings\" lotr) yes", "a movie is lotr yes");
+        assertSemantics("AND a movie is (EQUIV lotr \"lord of the rings\") yes", "a movie is lotr yes");
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExpansionTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ExpansionTestCase.java
@@ -61,4 +61,75 @@ public class ExpansionTestCase extends RuleBaseAbstractTestCase {
         assertSemantics("AND foo (EQUIV cascade1 cascade2 cascade3) bar", "foo cascade1 bar");
     }
 
+    // Multi-word condition with unquoted target
+    @Test
+    void testEquivMultiWordCondition() {
+        assertSemantics("EQUIV \"multi1 multi2\" expanded", "multi1 multi2");
+    }
+
+    @Test
+    void testEquivMultiWordConditionInLongerQuery() {
+        assertSemantics("AND foo (EQUIV \"multi1 multi2\" expanded) bar", "foo multi1 multi2 bar");
+    }
+
+    @Test
+    void testEquivMultiWordConditionMultipleTargets() {
+        assertSemantics("AND foo (EQUIV \"multi3 multi4\" expanded3 expanded4) bar", "foo multi3 multi4 bar");
+    }
+
+    @Test
+    void testEquivMultiWordConditionQuotedTarget() {
+        assertSemantics("EQUIV \"multi5 multi6\" quotedexpanded", "multi5 multi6");
+    }
+
+    @Test
+    void testEquivMultiWordConditionQuotedTargetInLongerQuery() {
+        assertSemantics("AND foo (EQUIV \"multi5 multi6\" quotedexpanded) bar", "foo multi5 multi6 bar");
+    }
+
+    // Multi-word condition with quoted multi-word (phrase) target
+    @Test
+    void testEquivMultiWordConditionQuotedPhraseTarget() {
+        assertSemantics("EQUIV \"multi7 multi8\" \"quoted two words\"", "multi7 multi8");
+    }
+
+    @Test
+    void testEquivMultiWordConditionQuotedPhraseTargetInLongerQuery() {
+        assertSemantics("AND foo (EQUIV \"multi7 multi8\" \"quoted two words\") bar", "foo multi7 multi8 bar");
+    }
+
+    // Mixed quoted and unquoted targets from a multi-word condition
+    @Test
+    void testEquivMultiWordConditionMixedTargets() {
+        assertSemantics("AND foo (EQUIV \"mw1 mw2\" single1 single2) bar", "foo mw1 mw2 bar");
+    }
+
+    // Single-word condition with mixed quoted phrase + unquoted targets
+    @Test
+    void testEquivMixedQuotedAndUnquotedTargets() {
+        assertSemantics("AND foo (EQUIV single1 \"mw1 mw2\" single2) bar", "foo single1 bar");
+    }
+
+    @Test
+    void testEquivMixedQuotedAndUnquotedTargetsReverse() {
+        assertSemantics("AND foo (EQUIV single2 \"mw1 mw2\" single1) bar", "foo single2 bar");
+    }
+
+    // Multiple quoted targets in a single rule
+    @Test
+    void testEquivMultipleQuotedTargets() {
+        assertSemantics("EQUIV phrase1 \"target one\" \"target two\"", "phrase1");
+    }
+
+    @Test
+    void testEquivMultipleQuotedTargetsInLongerQuery() {
+        assertSemantics("AND foo (EQUIV phrase1 \"target one\" \"target two\") bar", "foo phrase1 bar");
+    }
+
+    // Mixed unquoted and quoted targets in a single rule
+    @Test
+    void testEquivUnquotedThenQuotedTarget() {
+        assertSemantics("AND foo (EQUIV phrase2 unquoted \"quoted phrase\") bar", "foo phrase2 bar");
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/expansion.sr
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/expansion.sr
@@ -9,3 +9,15 @@ testfield:[test] -> =testfield:e1 =testfield:e2 =testfield:e3;
 
 cascade1 +> =cascade2;
 cascade2 +> =cascade3;
+
+multi1 multi2 +> =expanded;
+multi3 multi4 +> =expanded3 =expanded4;
+multi5 multi6 +> ="quotedexpanded";
+multi7 multi8 +> ="quoted two words";
+
+mw1 mw2 +> =single1 =single2;
+single1 +> ="mw1 mw2" =single2;
+single2 +> ="mw1 mw2" =single1;
+
+phrase1 +> ="target one" ="target two";
+phrase2 +> =unquoted ="quoted phrase";


### PR DESCRIPTION
Follow-up to #36241. Phrase productions (quoted targets) lacked equiv-aware logic. Because of the offset 2nd+ quoted target in a rule landed on the wrong query term.

Example: `lotr +> ="movie" ="film"` on query `AND lotr is a good show`
  - 1st production (offset=0): correctly wraps "lotr" → `AND (EQUIV lotr movie) is a good show`
  - 2nd production (offset=1): wraps "is" instead of "lotr" → `AND (EQUIV lotr movie) (EQUIV is film) a good show`

This PR extracts equiv handling from the literal term production to its abstract class so that we can reuse this logic in the literal phrase production. We are walking up the query tree to find the ancestor equiv, so we handle cascading rules.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
