### PR TITLE
Acquire application lock before removing application in ZK watcher

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -221,7 +221,10 @@ public class TenantApplications implements RequestHandler, HostValidator {
                     break;
                 // Event CHILD_REMOVED will be triggered on all config servers if deleteApplication() above is called on one of them
                 case CHILD_REMOVED:
-                    removeApplication(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()));
+                    applicationId = ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName());
+                    try (@SuppressWarnings("unused") Lock lock = lock(applicationId)) {
+                        removeApplication(applicationId);
+                    }
                     break;
                 case CHILD_UPDATED:
                     // do nothing, application just got redeployed
@@ -260,9 +263,7 @@ public class TenantApplications implements RequestHandler, HostValidator {
         }
     }
 
-    // Note: Assumes that caller already holds the application lock
-    // (when getting event from zookeeper to remove application,
-    // the lock should be held by the thread that causes the event to happen)
+    // Note: Caller must hold the application lock
     public void removeApplication(ApplicationId applicationId) {
         log.log(Level.FINE, () -> "Removing application " + applicationId);
         if (exists(applicationId)) {
@@ -272,7 +273,6 @@ public class TenantApplications implements RequestHandler, HostValidator {
 
         if (hasApplication(applicationId)) {
             applicationMapper.remove(applicationId);
-            hostRegistry.removeHosts(applicationId);
             configActivationListenersOnRemove(applicationId);
             tenantMetricUpdater.setApplications(applicationMapper.numApplications());
             metrics.removeMetricUpdater(Metrics.createDimensions(applicationId));


### PR DESCRIPTION
## Summary
- The `CHILD_REMOVED` ZK watcher handler called `removeApplication()` without holding the application lock, allowing it to race with `activateApplication()` and corrupt `HostRegistry` state
- Acquire the application lock in the watcher handler, matching what `removeApplicationsExcept` already does
- Remove duplicate `hostRegistry.removeHosts()` call in `removeApplication()`, already done in `configActivationListenersOnRemove()`
