### PR TITLE
Flush ANN stats early in NearestNeighborBlueprint

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -93,13 +93,6 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
     setEstimate(HitEstimate(est_hits, false));
 }
 
-NearestNeighborBlueprint::~NearestNeighborBlueprint() {
-    if (_stats) {
-        _stats->add_to_approximate_nns_distances_computed(_nni_stats.distances_computed());
-        _stats->add_to_approximate_nns_nodes_visited(_nni_stats.nodes_visited());
-    }
-}
-
 bool
 NearestNeighborBlueprint::want_global_filter(GlobalFilterLimits& limits) const
 {
@@ -177,6 +170,10 @@ NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighborInd
         _found_hits = nns_index->find_top_k(_nni_stats, k, df, k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _hnsw_params.prefetch_tensors, _doom, _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K;
     }
+
+    // Flush collected statistics if a QueryEvalStats object is already installed.
+    // (This is not the case in the matching pipeline as of now. The stats will be flushed later when install_stats() is called.)
+    flush_stats();
 }
 
 void
@@ -205,6 +202,17 @@ NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
 
 void NearestNeighborBlueprint::install_stats(QueryEvalStats &stats) {
     _stats = stats.shared_from_this();
+
+    // Flush statistics collected so far
+    flush_stats();
+}
+
+void NearestNeighborBlueprint::flush_stats() {
+    if (_stats) {
+        _stats->add_to_approximate_nns_distances_computed(_nni_stats.distances_computed());
+        _stats->add_to_approximate_nns_nodes_visited(_nni_stats.nodes_visited());
+        _nni_stats.reset();
+    }
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -74,7 +74,7 @@ public:
                              const vespalib::Doom& doom);
     NearestNeighborBlueprint(const NearestNeighborBlueprint&) = delete;
     NearestNeighborBlueprint& operator=(const NearestNeighborBlueprint&) = delete;
-    ~NearestNeighborBlueprint() override;
+    ~NearestNeighborBlueprint() override = default;
     const tensor::ITensorAttribute& get_attribute_tensor() const { return _attr_tensor; }
     const vespalib::eval::Value& get_query_tensor() const { return _query_tensor; }
     uint32_t get_target_hits() const { return _target_hits; }
@@ -95,9 +95,13 @@ public:
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
-    // Write stats to the given QueryEvalStats object on destruction, and pass it on to
-    // created exact search iterators, which also write stats to it on destruction.
+    // Install the given QueryEvalStats object in this blueprint. The blueprint writes the stats it collects
+    // to this object. Moreover, this object is also passed to the exact search iterators this blueprint creates,
+    // and these write their stats to this object on their destruction.
     void install_stats(QueryEvalStats &stats);
+    // Flush metrics collected in this blueprint to the QueryEvalStats object installed before with install_stats().
+    // This method is called internally and does not have to be called from the outside.
+    void flush_stats();
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
@@ -51,7 +51,8 @@ public:
         size_t _nodes_visited;
 
     public:
-        Stats() : _distances_computed(0), _nodes_visited(0) {}
+        Stats() { reset(); }
+        void reset() { _distances_computed = 0; _nodes_visited = 0; }
         size_t distances_computed() const { return _distances_computed; }
         void count_computed_distance() { ++_distances_computed; }
         size_t nodes_visited() const { return _nodes_visited; }


### PR DESCRIPTION
Flush the stats early instead of in the destructor of `NearestNeighborBlueprint`. This avoids that the stats are flushed too late and, thus, never reported when query caching is used.

The method `flush_stats()` is also called directly after the ANN search even though this is not necessary at the moment. This is in order to make this more robust since, otherwise, installing the `QueryEvalStats` object too early would break the flushing.

The trace, however, still depends on this. If one would install the object first, the stats would be flushed after the search and not reported in the trace. One could leave this as is or try to make this more robust:

1. Require an explicit call to `flush_stats()` from the outside and only flush stats when this is called.
2. Collect stats for the trace in a separate object that is never cleared.