### PR TITLE
fix ConentHandler to use file.isDirectory to correctly parse all nested content paths

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/ContentHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/ContentHandler.java
@@ -62,7 +62,7 @@ public class ContentHandler {
     }
 
     private static List<ApplicationFile> listSortedFiles(ApplicationFile file, Path path, boolean recursive) {
-        if (path.length() > 0 && ! path.hasTrailingSlash()) {
+        if ( ! file.isDirectory()) {
             return List.of(file);
         }
         List<ApplicationFile> files = file.listFiles(recursive);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/ContentHandlerTestBase.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/ContentHandlerTestBase.java
@@ -26,11 +26,11 @@ public abstract class ContentHandlerTestBase extends SessionHandlerTest {
     public void require_that_content_can_be_retrieved() throws IOException {
         assertContent("/test.txt", "foo\n");
         assertContent("/foo/", generateResultArray("foo/bar/", "foo/test1.json", "foo/test2.txt"), "application/json");
-        assertContent("/foo", generateResultArray("foo/"), "application/json");
+        assertContent("/foo", generateResultArray("foo/bar/", "foo/test1.json", "foo/test2.txt"), "application/json");
         assertContent("/foo/test1.json", "bar\n", "application/json");
         assertContent("/foo/test2.txt", "baz\n");
         assertContent("/foo/bar/", generateResultArray("foo/bar/file-without-extension", "foo/bar/test.jar"), "application/json");
-        assertContent("/foo/bar", generateResultArray("foo/bar/"), "application/json");
+        assertContent("/foo/bar", generateResultArray("foo/bar/file-without-extension", "foo/bar/test.jar"), "application/json");
         assertContent("/foo/bar/file-without-extension", "content");
         assertBinaryContent("/foo/bar/test.jar", "56f62ad750881d2f8276136896ff84fb", "application/java-archive");
         assertContent("/foo/?recursive=true", generateResultArray("foo/bar/", "foo/bar/file-without-extension", "foo/bar/test.jar", "foo/test1.json", "foo/test2.txt"), "application/json");


### PR DESCRIPTION
 Summary                                                                                                                                                         
                                                                                                                                                                  
  - Fix bug in ContentHandler.listSortedFiles where requesting a subdirectory without a trailing slash (e.g. /content/dir) returned only the directory entry      
  itself, not its contents                                                                                                                                        
  - The old check path.length() > 0 && !path.hasTrailingSlash() short-circuited for any non-root path without a trailing slash, bypassing listFiles(). This worked
   for the root content path (/content) only because path.length() was 0, so the condition was never true                                                         
  - Replace with !file.isDirectory() which checks the actual filesystem state. Both callers already guard with file.isDirectory() before calling this method, so
  the early return is effectively for non-directory files only             


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
