### PR TITLE
Explain short circuit on `maxDocumentCount <= 0`

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
@@ -35,6 +35,7 @@ public class SearchGroupsImpl implements SearchGroups {
 
     public boolean isGroupCoverageSufficient(boolean currentIsGroupCoverageSufficient,
                                              long groupDocumentCount, long medianDocumentCount, long maxDocumentCount) {
+        // If no group has any active documents, coverage checks are meaningless — consider all groups sufficient.
         if (maxDocumentCount <= 0) return true;
         if (currentIsGroupCoverageSufficient) {
             if (availabilityPolicy.prioritizeAvailability()) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
@@ -181,7 +181,7 @@ public class SearchClusterCoverageTest {
     }
 
     @Test
-    void twenty_groups_of_which_eleven_were_just_added_with_no_docs() {
+    void prefer_existing_groups_with_coverage_when_added_majority_is_empty() {
         var tester = new SearchClusterTester(20, 3);
 
         for (int i = 0; i < 9; i++)
@@ -189,8 +189,8 @@ public class SearchClusterCoverageTest {
 
         tester.pingIterationCompleted();
 
-        for (int i = 0;  i < 9;  i++) assertTrue(tester.group(i).hasSufficientCoverage());
-        for (int i = 9;  i < 20; i++) assertFalse(tester.group(i).hasSufficientCoverage());
+        for (int i = 0; i < 9;  i++) assertTrue(tester.group(i).hasSufficientCoverage());
+        for (int i = 9; i < 20; i++) assertFalse(tester.group(i).hasSufficientCoverage());
     }
 
     @Test


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Improves https://github.com/vespa-engine/vespa/pull/36059