### PR TITLE
use re-compiled library [MERGEOK]

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -118,7 +118,7 @@
         <junit.vespa.version>5.10.2</junit.vespa.version>
         <junit.platform.vespa.version>1.10.2</junit.platform.vespa.version>
         <junit4.vespa.version>4.13.2</junit4.vespa.version>
-        <jllama.vespa.version>4.7.8</jllama.vespa.version>
+        <jllama.vespa.version>4.7.10</jllama.vespa.version>
         <kotlin.vespa.version>1.9.25</kotlin.vespa.version>
         <luben.zstd.vespa.version>1.5.6-4</luben.zstd.vespa.version>
         <lucene.vespa.version>9.11.1</lucene.vespa.version>


### PR DESCRIPTION
The version that was compiled for x86 didn't work on all the machine variants that we use.  Switch to a version re-compiled with less aggressive CPU options.
