### PR TITLE
Add PrefixExpander to SelectParser for sameElement field resolution

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -183,9 +183,44 @@ public class SelectParser implements Parser {
     private final Segmenter segmenter;
     private final Detector detector;
     private IndexFacts.Session indexFactsSession;
+    private IndexNameExpander indexNameExpander = new IndexNameExpander();
+    private boolean insideSameElement = false;
 
     private static final List<String> FUNCTION_CALLS = List.of(WAND, WEIGHTED_SET, DOT_PRODUCT, GEO_BOUNDING_BOX, GEO_LOCATION, NEAREST_NEIGHBOR, PREDICATE, RANK, WEAK_AND);
     private static final Set<String> OPERATOR_KEYS = Set.of(AND, AND_NOT, CONTAINS, EQ, IN, MATCHES, NOT, OR, RANGE);
+    private static final Set<String> COMPOSITE_LEAF_KEYS = Set.of(PHRASE, NEAR, ONEAR, EQUIV, FUZZY, ALTERNATIVES);
+
+    /**
+     * Used by {@link #getIndex} to expand field names.
+     */
+    private static class IndexNameExpander {
+        public String expand(String leaf) { return leaf; }
+    }
+
+    /**
+     * Transforms `leaf` to `prefix.leaf` for a given `prefix`.
+     */
+    private static class PrefixExpander extends IndexNameExpander {
+        private final String prefix;
+
+        public PrefixExpander(String prefix) {
+            this.prefix = prefix + ".";
+        }
+
+        @Override
+        public String expand(String leaf) {
+            return prefix + leaf;
+        }
+    }
+
+    /**
+     * Swaps the current index expander strategy.
+     */
+    private IndexNameExpander swapIndexCreator(IndexNameExpander newExpander) {
+        IndexNameExpander old = indexNameExpander;
+        indexNameExpander = newExpander;
+        return old;
+    }
 
     public SelectParser(ParserEnvironment environment) {
         this.environment = environment;
@@ -226,9 +261,21 @@ public class SelectParser implements Parser {
         if (inspector.type() == BOOL)
             return inspector.asBool() ? new TrueItem() : new FalseItem();
 
+        if (inspector.type() == STRING && insideSameElement) {
+            // Inside sameElement: bare string is a word item with empty field (field comes from sameElement parent)
+            return instantiateWordItem("", inspector.asString(), inspector, false);
+        }
+
         Item[] item = {null};
         inspector.traverse((ObjectTraverser) (key, value) -> {
-            item[0] = buildOperator(key, value);
+            if (insideSameElement && !isOperator(key) && !COMPOSITE_LEAF_KEYS.contains(key)) {
+                // Inside an operator within a sameElement.
+                // e.g. {"sameElement": [{"and": [{"f1": "a"}, {"f2": "b"}]}]} where key="f1" and value="a".
+                // This is the same as in instantiateSameElement.
+                item[0] = instantiateWordItem(getIndex(key), value.asString(), value, false);
+            } else {
+                item[0] = buildOperator(key, value);
+            }
         });
         return item[0];
     }
@@ -815,10 +862,10 @@ public class SelectParser implements Parser {
         String field;
         Inspector boundInspector;
         if (children.get(0).type() == STRING){
-            field = children.get(0).asString();
+            field = getIndex(children.get(0).asString());
             boundInspector = children.get(1);
         } else {
-            field = children.get(1).asString();
+            field = getIndex(children.get(1).asString());
             boundInspector = children.get(0);
         }
         Number[] bounds = {null, null};
@@ -973,7 +1020,7 @@ public class SelectParser implements Parser {
     private Item buildRegExpSearch(String key, Inspector value) {
         assertHasOperator(key, MATCHES);
         HashMap<Integer, Inspector> children = childMap(value);
-        String field = children.get(0).asString();
+        String field = getIndex(children.get(0).asString());
         String wordData = children.get(1).asString();
         RegExpItem regExp = new RegExpItem(field, true, wordData);
         return leafStyleSettings(getAnnotations(value), regExp);
@@ -1029,7 +1076,7 @@ public class SelectParser implements Parser {
 
     private Item buildTermSearch(String key, Inspector value) {
         HashMap<Integer, Inspector> children = childMap(value);
-        String field = children.get(0).asString();
+        String field = getIndex(children.get(0).asString());
 
         return instantiateLeafItem(field, key, value);
     }
@@ -1435,25 +1482,35 @@ public class SelectParser implements Parser {
         return null;
     }
 
+    /** Builds same element item. */
     private Item instantiateSameElementItem(String field, String key, Inspector value) {
         assertHasOperator(key, SAME_ELEMENT);
 
         SameElementItem sameElement = new SameElementItem(field);
-        // All terms below sameElement are relative to this.
+        IndexNameExpander prev = swapIndexCreator(new PrefixExpander(field));
+        boolean prevInsideSameElement = insideSameElement;
+        insideSameElement = true;
         getChildren(value).traverse((ArrayTraverser) (index, term) -> {
             if (term.type() == OBJECT) {
                 term.traverse((ObjectTraverser) (childKey, childValue) -> {
                     if (isOperator(childKey)) {
                         sameElement.addItem(buildOperator(childKey, childValue));
+                    } else if (COMPOSITE_LEAF_KEYS.contains(childKey)) {
+                        // Composite leaf directly in sameElement, e.g. {"phrase": ["a", "b"]}
+                        // Uses empty field name since the sameElement parent provides the field context.
+                        sameElement.addItem(instantiateCompositeLeaf("", childKey, childValue));
                     } else {
-                        // Shorthand: {"fieldName": "value"} is equivalent to {"contains": ["fieldName", "value"]}
-                        sameElement.addItem(instantiateWordItem(childKey, childValue.asString(), childValue, false));
+                        // Any JSON object that is not operator or composite leaf, treated as shorthand.
+                        // e.g. {"sameElement": [{"f1": "a"}]} means sameElement(f1 contains a)
+                        sameElement.addItem(instantiateWordItem(getIndex(childKey), childValue.asString(), childValue, false));
                     }
                 });
             } else {
                 sameElement.addItem(walkJson(term));
             }
         });
+        insideSameElement = prevInsideSameElement;
+        swapIndexCreator(prev);
 
         return sameElement;
     }
@@ -1573,11 +1630,13 @@ public class SelectParser implements Parser {
         return leafStyleSettings(getAnnotations(value), new WordAlternativesItem(field, Boolean.TRUE, null, terms));
     }
 
-    //  Not in use yet
+    /**
+     * Expands the field and checks if it exists.
+     */
     private String getIndex(String field) {
-        Preconditions.checkArgument(indexFactsSession.isIndex(field), "Field '%s' does not exist.", field);
-        //return indexFactsSession.getCanonicName(field);
-        return field;
+        String expanded = indexNameExpander.expand(field);
+        Preconditions.checkArgument(indexFactsSession.isIndex(expanded), "Field '%s' does not exist.", expanded);
+        return indexFactsSession.getCanonicName(field);
     }
 
     private static void assertHasOperator(String key, String expectedKey) {

--- a/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
@@ -12,7 +12,6 @@ import com.yahoo.search.yql.VespaSerializer;
 import com.yahoo.search.yql.YqlParser;
 import com.yahoo.slime.SlimeUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -103,14 +102,12 @@ public class YqlJsonQueryFeatureParityTest {
 
     @Test
     void testNear() {
-        // NOTE: SelectParser sets implicitTransforms:false on near children, YqlParser does not
         assertWhereParity("description contains near({implicitTransforms: false}'a', {implicitTransforms: false}'b')",
                 "{ 'contains' : ['description', { 'near' : ['a', 'b'] }] }");
     }
 
     @Test
     void testOnear() {
-        // NOTE: SelectParser sets implicitTransforms:false on onear children, YqlParser does not
         assertWhereParity("description contains onear({implicitTransforms: false}'a', {implicitTransforms: false}'b')",
                 "{ 'contains' : ['description', { 'onear' : ['a', 'b'] }] }");
     }
@@ -144,36 +141,30 @@ public class YqlJsonQueryFeatureParityTest {
                 "{ 'contains' : ['baz', { 'sameElement' : [ { 'f1' : 'a', 'f2' : 'b' } ] }] }");
     }
 
-    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
     @Test
     void testSameElementWithAndOrChildren() {
-        // AND inside sameElement (string array)
         assertWhereParity("description contains sameElement('a' and 'b')",
-                "{ 'contains' : ['description', { 'sameElement' : [ { 'and' : [ { 'contains' : ['description', 'a'] }, { 'contains' : ['description', 'b'] } ] } ] }] }");
-        // OR inside sameElement (string array)
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'and' : [ 'a', 'b' ] } ] }] }");
         assertWhereParity("description contains sameElement('a' or 'b')",
-                "{ 'contains' : ['description', { 'sameElement' : [ { 'or' : [ { 'contains' : ['description', 'a'] }, { 'contains' : ['description', 'b'] } ] } ] }] }");
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'or' : [ 'a', 'b' ] } ] }] }");
     }
 
-    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
     @Test
     void testSameElementWithNear() {
-        assertWhereParity("description contains sameElement({distance: 3}near('a', 'b'))",
-                "{ 'contains' : ['description', { 'sameElement' : [ { 'contains' : ['description', { 'near' : { 'children' : ['a', 'b'], 'attributes' : { 'distance' : 3 } } }] } ] }] }");
+        assertWhereParity("description contains sameElement({distance: 3}near({implicitTransforms: false}'a', {implicitTransforms: false}'b'))",
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'near' : { 'children' : ['a', 'b'], 'attributes' : { 'distance' : 3 } } } ] }] }");
     }
 
-    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
     @Test
     void testSameElementWithPhrase() {
         assertWhereParity("description contains sameElement(phrase('a', 'b'))",
-                "{ 'contains' : ['description', { 'sameElement' : [ { 'contains' : ['description', { 'phrase' : ['a', 'b'] }] } ] }] }");
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'phrase' : ['a', 'b'] } ] }] }");
     }
 
-    @Disabled("SelectParser does not strip field prefix inside sameElement on string arrays — parity bug")
     @Test
     void testSameElementWithRank() {
         assertWhereParity("description contains sameElement(rank('a', 'b'))",
-                "{ 'contains' : ['description', { 'sameElement' : [ { 'rank' : [ { 'contains' : ['description', 'a'] }, { 'contains' : ['description', 'b'] } ] } ] }] }");
+                "{ 'contains' : ['description', { 'sameElement' : [ { 'rank' : [ 'a', 'b' ] } ] }] }");
     }
 
     @Test


### PR DESCRIPTION
Fix `sameElement` handling to mirror YqlParser's IndexNameExpander/PrefixExpander pattern so that field names inside `sameElement` are resolved as relative to the parent field.

For instance, one should be able to write:
```json
{ 
  "contains": [
    "person",
    { "sameElement": [ { "first_name": "John" }, { "last_name": "Doe" } ] }
  ] 
}
``` 
or
```json
{ 
  "contains": [
    "field_name",
    { "sameElement": [ { "near": [ "a", "b" ] } ] }
  ] 
}
```

And this syntax now remembers the field name when parsing the arguments to the `sameElement`.

This PR makes it possible to have:
- leaves (`phrase`, `near`, `equiv`, ...) directly as `sameElement` children without needing to wrap in a contains object.
- string word items inside operators (`and`, `or`, `rank`) within `sameElement`.
- field name validation through IndexFacts using the expanded name.
