### PR TITLE
Add a simple insert/lookup-only set for non-zero u32 values

### DIFF
--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -39,11 +39,26 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     string_escape_test.cpp
     time_test.cpp
     typify_test.cpp
+    unordered_u32_set_test.cpp
     xmlserializabletest.cpp
     DEPENDS
     vespalib
     onnxruntime
     GTest::gtest
+    GTest::gmock
 )
 
 vespa_add_test( NAME vespalib_util_gtest_runner_test_app COMMAND vespalib_util_gtest_runner_test_app)
+
+vespa_add_executable(vespalib_util_unordered_u32_set_benchmark_app TEST
+    SOURCES
+    unordered_u32_set_benchmark.cpp
+    DEPENDS
+    vespalib
+)
+vespa_add_target_external_dependency(vespalib_util_unordered_u32_set_benchmark_app benchmark)
+vespa_add_test(
+    NAME    vespalib_util_unordered_u32_set_benchmark_app
+    COMMAND vespalib_util_unordered_u32_set_benchmark_app
+    BENCHMARK
+)

--- a/vespalib/src/tests/util/unordered_u32_set_benchmark.cpp
+++ b/vespalib/src/tests/util/unordered_u32_set_benchmark.cpp
@@ -1,0 +1,127 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/util/unordered_u32_set.h>
+#include <benchmark/benchmark.h>
+#include <unordered_set>
+
+struct FewCollisions {
+    constexpr static uint32_t apply(uint32_t v) noexcept {
+        return v;
+    }
+};
+
+struct ManyCollisions {
+    constexpr static uint32_t apply(uint32_t v) noexcept {
+        // Multiplying with a power of two will cause massive clustering of
+        // keys for AND-based table lookups since their LSBs will be the same.
+        return v * 128;
+    }
+};
+
+template <typename SetT, typename KeyTransform>
+static void BM_insert_unique_from_empty(benchmark::State& state) {
+    for (auto _ : state) {
+        state.PauseTiming();
+        SetT set{};
+        state.ResumeTiming();
+        benchmark::ClobberMemory();
+        for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
+            auto res = set.insert(KeyTransform::apply(i));
+            benchmark::DoNotOptimize(res);
+        }
+        benchmark::DoNotOptimize(set);
+        benchmark::ClobberMemory();
+    }
+}
+
+template <typename SetT, typename KeyTransform>
+static void BM_insert_unique_from_pre_sized(benchmark::State& state) {
+    for (auto _ : state) {
+        state.PauseTiming();
+        SetT set{static_cast<uint32_t>(state.range())};
+        state.ResumeTiming();
+        benchmark::ClobberMemory();
+        for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
+            auto res = set.insert(KeyTransform::apply(i));
+            benchmark::DoNotOptimize(res);
+        }
+        benchmark::DoNotOptimize(set);
+        benchmark::ClobberMemory();
+    }
+}
+
+template <typename SetT, typename KeyTransform>
+static void BM_lookup_existing(benchmark::State& state) {
+    SetT set{};
+    for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
+        (void)set.insert(KeyTransform::apply(i));
+    }
+    benchmark::ClobberMemory();
+    uint32_t next_lookup = 1;
+    for (auto _ : state) {
+        auto ret = set.contains(KeyTransform::apply(next_lookup));
+        next_lookup = (next_lookup <= state.range()) ? next_lookup + 1 : 1; // Avoid modulo
+        benchmark::DoNotOptimize(ret);
+    }
+}
+
+template <typename SetT, typename KeyTransform>
+static void BM_lookup_missing(benchmark::State& state) {
+    SetT set{};
+    for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
+        (void)set.insert(KeyTransform::apply(i));
+    }
+    benchmark::ClobberMemory();
+    uint32_t next_lookup = state.range() + 1;
+    for (auto _ : state) {
+        auto ret = set.contains(KeyTransform::apply(next_lookup));
+        next_lookup = (next_lookup < UINT32_MAX) ? next_lookup + 1 : state.range() + 1; // Avoid modulo
+        benchmark::DoNotOptimize(ret);
+    }
+}
+
+constexpr static uint32_t range_from = 8;
+constexpr static uint32_t range_to   = 8 << 20;
+
+/// Fill set with N distinct elements from an empty state
+
+BENCHMARK(BM_insert_unique_from_empty<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_empty<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_empty<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to);
+
+BENCHMARK(BM_insert_unique_from_empty<std::unordered_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_empty<vespalib::hash_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_empty<vespalib::UnorderedU32Set,    ManyCollisions>)->Range(range_from, range_to);
+
+/// Fill set with N distinct elements when presized to capacity of N
+
+BENCHMARK(BM_insert_unique_from_pre_sized<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_pre_sized<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_pre_sized<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to);
+
+BENCHMARK(BM_insert_unique_from_pre_sized<std::unordered_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_pre_sized<vespalib::hash_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_insert_unique_from_pre_sized<vespalib::UnorderedU32Set,    ManyCollisions>)->Range(range_from, range_to);
+
+/// Lookup elements that are known to exist in the set
+
+BENCHMARK(BM_lookup_existing<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_existing<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_existing<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to);
+
+BENCHMARK(BM_lookup_existing<std::unordered_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_existing<vespalib::hash_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_existing<vespalib::UnorderedU32Set,    ManyCollisions>)->Range(range_from, range_to);
+
+/// Lookup elements that are known to _not_ exist in the set
+
+BENCHMARK(BM_lookup_missing<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_missing<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_missing<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to);
+
+BENCHMARK(BM_lookup_missing<std::unordered_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_missing<vespalib::hash_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_missing<vespalib::UnorderedU32Set,    ManyCollisions>)->Range(range_from, range_to);
+
+BENCHMARK_MAIN();

--- a/vespalib/src/tests/util/unordered_u32_set_test.cpp
+++ b/vespalib/src/tests/util/unordered_u32_set_test.cpp
@@ -1,0 +1,110 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/unordered_u32_set.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace vespalib {
+
+using namespace ::testing;
+
+TEST(UnorderedU32SetTest, capacity_is_always_at_least_4) {
+    EXPECT_EQ(UnorderedU32Set(0).capacity(), 4);
+    EXPECT_EQ(UnorderedU32Set(1).capacity(), 4);
+    EXPECT_EQ(UnorderedU32Set(3).capacity(), 4);
+    EXPECT_EQ(UnorderedU32Set(4).capacity(), 8); // Adjusted to fit 4 insertions without resize
+}
+
+TEST(UnorderedU32SetTest, bit_indices_defined_for_u32_extents_minus_zero) {
+    UnorderedU32Set set;
+    EXPECT_EQ(set.size(), 0);
+    EXPECT_TRUE(set.empty());
+
+    EXPECT_FALSE(set.contains(1));
+    EXPECT_TRUE(set.insert(1));
+    EXPECT_FALSE(set.insert(1));
+    EXPECT_TRUE(set.contains(1));
+
+    EXPECT_EQ(set.size(), 1);
+    EXPECT_FALSE(set.empty());
+
+    EXPECT_FALSE(set.contains(UINT32_MAX));
+    EXPECT_TRUE(set.insert(UINT32_MAX));
+    EXPECT_FALSE(set.insert(UINT32_MAX));
+    EXPECT_TRUE(set.contains(UINT32_MAX));
+
+    EXPECT_EQ(set.size(), 2);
+}
+
+TEST(UnorderedU32SetTest, can_iterate_over_set_indices) {
+    UnorderedU32Set set;
+    // We check iterator behavior via gmock matchers that use iterators
+    EXPECT_THAT(set, UnorderedElementsAre());
+    ASSERT_TRUE(set.insert(1));
+    EXPECT_THAT(set, UnorderedElementsAre(1));
+    ASSERT_TRUE(set.insert(3));
+    EXPECT_THAT(set, UnorderedElementsAre(1, 3));
+    ASSERT_TRUE(set.insert(7));
+    EXPECT_THAT(set, UnorderedElementsAre(1, 3, 7));
+    ASSERT_TRUE(set.insert(UINT32_MAX));
+    EXPECT_THAT(set, UnorderedElementsAre(1, 3, 7, UINT32_MAX));
+}
+
+namespace {
+
+void set_and_check_bits(UnorderedU32Set& set, uint32_t n) {
+    uint32_t n_set = 0;
+    for (uint32_t i = 2; i < n; i += 2) {
+        ASSERT_FALSE(set.contains(i)) << i;
+        ASSERT_TRUE(set.insert(i)) << i;
+        ++n_set;
+        ASSERT_EQ(set.size(), n_set);
+        // Ensure bits that should be set are still set, and vice versa.
+        for (uint32_t j = 1; j < n; ++j) {
+            if ((j > 1) && (j <= i) && (j % 2 == 0)) {
+                ASSERT_TRUE(set.contains(j)) << "i=" << i << ",j=" << j;
+            } else {
+                ASSERT_FALSE(set.contains(j)) << "i=" << i << ",j=" << j;
+            }
+        }
+    }
+}
+
+} // namespace
+
+TEST(UnorderedU32SetTest, set_grows_on_inserts) {
+    UnorderedU32Set set(16);
+    EXPECT_GE(set.capacity(), 16);
+    uint32_t n = 256;
+    EXPECT_LT(set.capacity(), n);
+    ASSERT_NO_FATAL_FAILURE(set_and_check_bits(set, n));
+    EXPECT_GE(set.capacity(), n);
+}
+
+TEST(UnorderedU32SetTest, quadratic_probe_sequence_visits_all_values_in_range_exactly_once) {
+    // Note: this property holds only for sequences that are a power of two
+    constexpr uint32_t n = 1024;
+    for (size_t hash : {0, 1, 0x1337, 0x12345678}) { // initial "hash" should not matter
+        std::vector<uint32_t> visit_count(n);
+        UnorderedU32Set::quadratic_probe_sequence probe_seq(hash, n);
+        for (uint32_t i = 0; i < n; ++i) {
+            const size_t offset = probe_seq.offset();
+            ASSERT_LT(offset, n);
+            visit_count[offset]++;
+            probe_seq.next();
+        }
+        EXPECT_THAT(visit_count, Each(Eq(1))) << "for hash " << hash;
+    }
+}
+
+TEST(UnorderedU32SetTest, prefer_bitvector_helper_considers_max_load_factor) {
+    // 1024 elements would use 1024/8 = 128 bytes as a dense bitvector, so that's our baseline.
+    EXPECT_FALSE(UnorderedU32Set::prefer_bitvector(0, 1024));
+    EXPECT_FALSE(UnorderedU32Set::prefer_bitvector(1, 1024));
+    // 25 sparse elements would use 25*5 = 125 bytes due to 3/4 max load factor.
+    EXPECT_FALSE(UnorderedU32Set::prefer_bitvector(25, 1024));
+    // 26 sparse elements would use 26*5 = 130 bytes, which exceeds the dense bit vector size.
+    EXPECT_TRUE(UnorderedU32Set::prefer_bitvector(26, 1024));
+}
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -100,6 +100,7 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     threadstackexecutor.cpp
     threadstackexecutorbase.cpp
     time.cpp
+    unordered_u32_set.cpp
     unwind_message.cpp
     valgrind.cpp
     xmlserializable.cpp

--- a/vespalib/src/vespa/vespalib/util/unordered_u32_set.cpp
+++ b/vespalib/src/vespa/vespalib/util/unordered_u32_set.cpp
@@ -1,0 +1,36 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "alloc.h"
+#include "unordered_u32_set.h"
+#include <cassert>
+
+namespace vespalib {
+
+UnorderedU32Set::UnorderedU32Set()
+    : UnorderedU32Set(16)
+{}
+
+UnorderedU32Set::UnorderedU32Set(uint32_t initial_capacity)
+    : _size(0),
+      // Default malloc allocation alignment is 16 bytes, so little point in having less capacity than this.
+      // Adjust capacity up to ensure no resizes up to and including initial_capacity _insertions_.
+      _capacity(std::max(roundUp2inN(initial_capacity + initial_capacity/4), size_t{4u})),
+      _buf(_capacity)
+{
+}
+
+UnorderedU32Set::~UnorderedU32Set() = default;
+
+void UnorderedU32Set::grow_and_rehash() {
+    const size_t new_capacity = _capacity * 2;
+    BufferType new_buf(new_capacity);
+    for (size_t i = 0; i < _capacity; ++i) {
+        if (_buf[i] != 0) [[likely]] {
+            insert_for_rehash(new_buf.data(), _buf[i], new_capacity);
+        }
+    }
+    _buf = std::move(new_buf);
+    _capacity = new_capacity;
+}
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/unordered_u32_set.h
+++ b/vespalib/src/vespa/vespalib/util/unordered_u32_set.h
@@ -1,0 +1,271 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/stllike/allocator.h>
+#include <cstdint>
+#include <vector>
+
+// We don't use __builtin_rev_crc32 intrinsics since they take an explicit polynomial
+// as input, so it's not guaranteed we end up with the native CRC32 instructions. Since
+// we only use this for in-process hashing purposes, the actual underlying polynomial
+// does not really matter. We just want a cheap way to mix bits.
+// This approach is inspired by the integer hash mixing in the Abseil Hash sub-library.
+#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+#include <arm_acle.h>
+#define VESPA_NATIVE_CRC32_U32 __crc32cw
+#elif defined(__x86_64__)
+#include <nmmintrin.h>
+#define VESPA_NATIVE_CRC32_U32 _mm_crc32_u32
+#else
+#error Unknown architecture, no known native CRC32 intrinsic
+#endif
+
+namespace vespalib {
+
+/**
+ * Very simplified unordered set of u32 values (except zero!) that supports only
+ * testing for presence and inserting. This set is always sparse regardless of
+ * the number of elements contained within it. Use a dense bitvector instead if
+ * you know that the number of set elements will be large enough that a sparse
+ * representation does not make sense in practice (see: `prefer_bitvector`).
+ *
+ * The element array stores u32 values verbatim, except the value 0 which is a
+ * sentinel for unset values and should not be inserted or queried for existence.
+ *
+ * The core algorithm used for set lookups and insert is open addressing with
+ * quadratic probing. This is chosen to keep the expected number of cache line
+ * misses per lookup as low as possible, ideally ~1 (assuming a good hash
+ * distribution). Probing starts at the element indicated by its hash, proceeding
+ * with a quadratically increasing array index (wrapping around at the array end)
+ * until _either_ an existing array slot is found with the value _or_ a
+ * zero-valued slot is found. For inserts where the element does not preexist,
+ * the very first observed zero valued slot is used to store the value.
+ *
+ * Through enforcing a maximum load factor, we maintain the invariant that there
+ * will _always_ be at least one free slot in the array, i.e. all probes must
+ * by definition terminate (no infinite loops).
+ *
+ * Always using the first available zero slot for inserts forms the inductive
+ * property that observing a zero-slot during a probe means that the value can
+ * not possibly exist at a _later_ probe point. Consequently, probing for
+ * insertion can insert at that slot without introducing duplicates, and probing
+ * for lookups can immediately return "not found" since the value can not exist
+ * at any later probe point (it would have been inserted in this slot already).
+ *
+ * Note that this particular invariant would be violated if we supported deletes
+ * (or we would need a tombstone sentinel), so that's the main reasons for why
+ * we only support insertion and lookups.
+ *
+ * This is inspired by the Swisstable approach to hash tables, but without a
+ * dedicated metadata section and without SIMD since our slots are 4x the size
+ * of Swisstable's 8-bit entries and the overhead of SIMD vector loading and
+ * mask management costs more than it gains (at least for AArch64 NEON with
+ * 128-bit registers). Since it has explicit per-slot metadata, Swisstable also
+ * supports deletes via tombstone metadata entries.
+ *
+ * As thread safe as a std::vector.
+ */
+class UnorderedU32Set {
+    // Must have implicit zeroing behavior of elements
+    using BufferType = std::vector<uint32_t, allocator_large<uint32_t>>;
+
+    struct PrivateCtorTag {};
+
+    size_t     _size;
+    // Perf note: even though this technically duplicates information that can
+    // be gleaned from _buf.size(), having a dedicated variable for this is
+    // measurably faster. Possibly due to _buf.size() on libstdc++ needing pointer
+    // arithmetic (which will do element size shifting), which introduces a
+    // dependency chain for a value we need very early in the lookup process.
+    size_t     _capacity;
+    BufferType _buf;
+public:
+    using value_type = uint32_t;
+    using size_type  = size_t;
+
+    UnorderedU32Set();
+    explicit UnorderedU32Set(uint32_t initial_capacity);
+    ~UnorderedU32Set();
+
+    [[nodiscard]] size_t size() const noexcept { return _size; }
+    [[nodiscard]] bool empty() const noexcept { return _size == 0; }
+    [[nodiscard]] size_t capacity() const noexcept { return _capacity; }
+
+    // Given a set with `full_set_size` elements where `expected_subset_size`
+    // elements are expected to be used, this function returns whether using
+    // a _dense_ bit vector should be preferred instead of a sparse set. Note
+    // that this does not take memory buffer size alignment into account.
+    [[nodiscard]] constexpr static bool prefer_bitvector(const uint32_t expected_subset_size, const uint32_t full_set_size) noexcept {
+        // Let m be expected size of set size n. A dense bit vector will have memory use
+        // n/8 bytes whereas a sparse set will use 4n + 4(1/4n) = 5n bytes. The extra 1/4n
+        // bytes is because we can never exceed a load factor of 3/4, so add 1/4 on top.
+        // Intersection at 5m = n/8 ==> 5m/5 = n/(8*5) ==> m = n/40
+        return expected_subset_size > (full_set_size / 40);
+    }
+
+    // Quadratic probe sequence for power of two array sizes. This uses the common
+    // triangular numbers sequence, as each of N slots will be visited exactly once
+    // in the course of N sequence increments. Since quadratic probing always starts
+    // out close to the original probe point, there is a high likelihood that a slot
+    // will be found within the same cache line.
+    //
+    // See https://en.wikipedia.org/wiki/Quadratic_probing#Quadratic_function:
+    // "For m = 2^n, a good choice for the constants are c1 = c2 = 1/2, as the
+    //  values of h(k,i) for i in [0, m−1] are all distinct (in fact, it is a
+    //  permutation on [0, m−1]). This leads to a probe sequence of h(k), h(k) + 1,
+    //  h(k) + 3, h(k) + 6 ... (the triangular numbers), where values increase by
+    //  1, 2, 3, ...".
+    //
+    // Inspired by Abseil `probe_seq` to avoid duplicating logic per function that
+    // needs to probe.
+    class quadratic_probe_sequence {
+        const size_t _mask;
+        size_t       _index;
+        size_t       _offset;
+    public:
+        constexpr quadratic_probe_sequence(const uint64_t hash, const size_t capacity) noexcept
+            : _mask(capacity - 1),
+              _index(0),
+              _offset(hash & _mask)
+        {}
+        [[nodiscard]] size_t offset() const noexcept { return _offset; }
+        void next() {
+            ++_index;
+            _offset += _index;
+            _offset &= _mask;
+        }
+    };
+
+    // Simple linear probing with wrap-around for power of two array sizes.
+    // Unsurprisingly also visits each slot exactly once.
+    // See https://en.wikipedia.org/wiki/Linear_probing
+    class linear_probe_sequence {
+        const size_t _mask;
+        size_t       _offset;
+    public:
+        constexpr linear_probe_sequence(const uint64_t hash, const size_t capacity) noexcept
+            : _mask(capacity - 1),
+              _offset(hash & _mask)
+        {}
+        [[nodiscard]] size_t offset() const noexcept { return _offset; }
+        void next() {
+            ++_offset;
+            _offset &= _mask;
+        }
+    };
+
+    using probe_seq_type = quadratic_probe_sequence;
+
+    // Precondition: elem != 0
+    [[nodiscard]] bool contains(const uint32_t elem) const noexcept {
+        probe_seq_type p(hash64(elem), _capacity);
+        while (true) {
+            const size_t slot = p.offset();
+            if (_buf[slot] == elem) {
+                return true;
+            } else if (_buf[slot] == 0) {
+                return false;
+            }
+            p.next();
+        }
+    }
+
+    // Precondition: elem != 0
+    [[nodiscard]] bool insert(const uint32_t elem) noexcept {
+        probe_seq_type p(hash64(elem), _capacity);
+        while (true) {
+            const size_t slot = p.offset();
+            if (_buf[slot] == 0) {
+                _buf[slot] = elem;
+                ++_size; // This may violate max load factor
+                if (should_grow()) [[unlikely]] {
+                    grow_and_rehash();
+                }
+                return true;
+            } else if (_buf[slot] == elem) {
+                return false;
+            }
+            p.next();
+        }
+    }
+
+    class const_iterator {
+    public:
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = const uint32_t;
+        using reference         = const uint32_t&;
+        using pointer           = const uint32_t*;
+        using iterator_category = std::forward_iterator_tag;
+    private:
+        const UnorderedU32Set* _set;
+        size_t                 _idx; // Not u32 since set capacities may exceed UINT32_MAX
+    public:
+        const_iterator(const UnorderedU32Set& set, size_t idx, PrivateCtorTag) noexcept : _set(&set), _idx(idx) {
+            skip_to_next_set_element();
+        }
+        const_iterator& operator++() noexcept {
+            ++_idx;
+            skip_to_next_set_element();
+            return *this;
+        }
+        const_iterator operator++(int) noexcept {
+            const_iterator prev = *this;
+            ++(*this);
+            return prev;
+        }
+        [[nodiscard]] constexpr const uint32_t& operator*()  const noexcept { return  _set->_buf[_idx]; }
+        [[nodiscard]] constexpr const uint32_t* operator->() const noexcept { return &_set->_buf[_idx]; }
+        // Note: iterator equality comparisons do not consider parent container
+        // identity, as crossing the streams is considered undefined behavior
+        // (and/or just plain rude) in general.
+        constexpr bool operator==(const const_iterator& rhs) const noexcept { return _idx == rhs._idx; }
+        constexpr bool operator!=(const const_iterator& rhs) const noexcept { return _idx != rhs._idx; }
+    private:
+        void skip_to_next_set_element() noexcept {
+            while ((_idx < _set->capacity()) && (_set->_buf[_idx] == 0)) {
+                ++_idx;
+            }
+        }
+    };
+
+    [[nodiscard]] const_iterator begin() const noexcept { return {*this, 0, PrivateCtorTag{}}; }
+    [[nodiscard]] const_iterator end() const noexcept { return {*this, _capacity, PrivateCtorTag{}}; }
+
+private:
+    // We need > 32 bits of hash output in the worst case in case our set is at max
+    // capacity and our actual element array has a size that is > UINT32_MAX.
+    [[nodiscard]] static uint64_t hash64(uint32_t h) noexcept {
+        // CRCs are independent and can run in parallel, minimizing the data dependency chain.
+        // Magic values are just 32 MSBs from the Murmurhash3 `fmix64` multiplication
+        // constants and are distinct in order to decorrelate the high and low outputs.
+        // Note that the two outputs must never be XORed together, as the XOR is a fixed
+        // value that will collide every single time...! Ask me how I found out.
+        // Perf note: XXH3 is measurably slower than CRC32 here.
+        return (static_cast<uint64_t>(VESPA_NATIVE_CRC32_U32(0xff51afd7, h)) << 32) | VESPA_NATIVE_CRC32_U32(0xc4ceb9fe, h);
+    }
+
+    [[nodiscard]] constexpr static size_t max_load_factor_adjusted(const size_t capacity) noexcept {
+        return (capacity/4 * 3); // max 3/4 load factor
+    }
+
+    [[nodiscard]] bool should_grow() const noexcept {
+        return _size > max_load_factor_adjusted(_capacity);
+    }
+
+    void grow_and_rehash() __attribute__((noinline));
+
+    // Preconditions:
+    //   - Inserting `elem` will not violate the max load factor of the buffer
+    //     (this also implies the buffer is guaranteed to contain free slots).
+    //   - `elem` does not previously exist in `buf`.
+    static void insert_for_rehash(uint32_t* buf, const uint32_t elem, const size_t new_capacity) noexcept {
+        probe_seq_type p(hash64(elem), new_capacity);
+        while (buf[p.offset()] != 0) {
+            p.next();
+        }
+        buf[p.offset()] = elem;
+    }
+};
+
+} // namespace vespalib


### PR DESCRIPTION
@havardpe please review. Changes from show&tell session is mostly just a rename of `try_set`/`is_set` to the more standard `insert`/`contains`. This has the added benefit that the benchmark container specializations could be removed, since all tested container types have these functions. Also added some comments on benchmark experiment outcomes.

This adds a simple unordered set of _non-zero_ u32 values that supports only testing for presence and inserting. This set is always sparse regardless of the number of elements contained within it. If you know in advance that you will probably need to insert enough elements that a sparse set will not provide space gains, prefer a bitvector instead.

The element array stores u32 values verbatim, except the value 0 which is a sentinel for unset values and should not be inserted or queried for existence.

The core algorithm used for set lookups and insert is open addressing with quadratic probing. This is chosen to keep the expected number of cache line misses per lookup as low as possible, ideally ~1 (assuming a good hash distribution). Probing starts at the element indicated by its hash, proceeding with a quadratically increasing array index (wrapping around at the array end) until _either_ an existing array slot is found with the value _or_ a zero-valued slot is found. For inserts, the very first observed zero valued slot is used to store the value.

This also adds some benchmarks to compare with the most relevant data structures for this use case, specificially `std::unordered_set` and `vespalib::hash_set`. Benchmarks are run both with happy path input and "adversarial" input (i.e. hashes with frequent LSB collisions) to observe the impact on algorithm run-times.