### PR TITLE
Add todo about removing support for 'maintenance' for content clusters

### DIFF
--- a/config-model/src/main/resources/schema/content.rnc
+++ b/config-model/src/main/resources/schema/content.rnc
@@ -45,6 +45,7 @@ VisitorTuning = element visitors {
     VisitorMaxConcurrent?
 }
 
+# TODO: Unused, remove in Vespa 9
 Maintenance = element maintenance {
     attribute start { xsd:string { pattern = "[0-9]{2}:[0-9]{2}" } },
     attribute stop { xsd:string { pattern = "[0-9]{2}:[0-9]{2}" } },


### PR DESCRIPTION
Has not been used for many years, remove in Vespa 9