### PR TITLE
Snapshot flag source and support per-hostname JVM GC options

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1343,6 +1343,41 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.config.model.api.ModelContext$FeatureFlag$Static" : {
+    "superClass" : "java.lang.Record",
+    "interfaces" : [
+      "com.yahoo.config.model.api.ModelContext$FeatureFlag"
+    ],
+    "attributes" : [
+      "public",
+      "final",
+      "record"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.Object)",
+      "public final java.lang.String toString()",
+      "public final int hashCode()",
+      "public final boolean equals(java.lang.Object)",
+      "public java.lang.Object value()"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.config.model.api.ModelContext$FeatureFlag" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "interface",
+      "abstract"
+    ],
+    "methods" : [
+      "public com.yahoo.config.model.api.ModelContext$FeatureFlag withClusterType(com.yahoo.config.provision.ClusterSpec$Type)",
+      "public com.yahoo.config.model.api.ModelContext$FeatureFlag withClusterId(com.yahoo.config.provision.ClusterSpec$Id)",
+      "public com.yahoo.config.model.api.ModelContext$FeatureFlag withHostname(java.lang.String)",
+      "public abstract java.lang.Object value()"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.config.model.api.ModelContext$FeatureFlags" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [ ],
@@ -1449,6 +1484,7 @@
       "public java.lang.String jvmGCOptions()",
       "public java.lang.String jvmGCOptions(java.util.Optional)",
       "public abstract java.lang.String jvmGCOptions(java.util.Optional, java.util.Optional)",
+      "public com.yahoo.config.model.api.ModelContext$FeatureFlag jvmGCOptionsFlag()",
       "public java.lang.String mallocImpl(java.util.Optional)",
       "public int searchNodeInitializerThreads(java.lang.String)",
       "public int heapSizePercentage(java.lang.String)",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -157,7 +157,13 @@ public interface ModelContext {
         }
 
         // Default setting for the gc-options attribute if not specified explicitly by application
+        @Deprecated(forRemoval = true)
         String jvmGCOptions(Optional<ClusterSpec.Type> clusterType, Optional<ClusterSpec.Id> clusterId);
+
+        /** Returns a flag for resolving JVM GC options with per-hostname granularity. */
+        default FeatureFlag<String> jvmGCOptionsFlag() {
+            return new FeatureFlag.Static<>(jvmGCOptions(Optional.empty(), Optional.empty()));
+        }
 
         default String mallocImpl(Optional<ClusterSpec.Type> clusterType) { return ""; }
 
@@ -190,6 +196,18 @@ public interface ModelContext {
         default List<String> jdiscHttpComplianceViolations() { return List.of(); }
     }
 
+    /** A flag value that can be refined with additional dimensions before resolving. */
+    interface FeatureFlag<T> {
+        default FeatureFlag<T> withClusterType(ClusterSpec.Type clusterType) { return this; }
+        default FeatureFlag<T> withClusterId(ClusterSpec.Id clusterId) { return this; }
+        default FeatureFlag<T> withHostname(String hostname) { return this; }
+        T value();
+
+        /** A flag with a fixed value, ignoring all dimensions. */
+        record Static<T>(T value) implements FeatureFlag<T> {}
+    }
+
+    /** Annotation for manual bookkeeping for life-cycle of config-model flags */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @interface ModelFeatureFlag {

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -91,6 +91,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public String athenzDnsSuffix() { return null; }
     @Override public boolean hostedVespa() { return hostedVespa; }
     @Override public Set<ContainerEndpoint> endpoints() { return endpoints; }
+    @SuppressWarnings("removal")
     @Override public String jvmGCOptions(Optional<ClusterSpec.Type> clusterType, Optional<ClusterSpec.Id> clusterId) { return jvmGCOptions; }
     @Override public boolean isBootstrap() { return false; }
     @Override public boolean isFirstTimeDeployment() { return firstTimeDeployment; }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -11,7 +11,6 @@ import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -26,8 +25,10 @@ public class LogserverContainerCluster extends ContainerCluster<LogserverContain
 
         addDefaultHandlersWithVip();
         addLogHandler();
-        setJvmGCOptions(deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.admin),
-                                                                 Optional.of(ClusterSpec.Id.from(name))));
+        setJvmGCOptions(deployState.getProperties().jvmGCOptionsFlag()
+                                .withClusterType(ClusterSpec.Type.admin)
+                                .withClusterId(ClusterSpec.Id.from(name))
+                                .value());
         if (isHostedVespa())
             addAccessLog(getName());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.PlatformBundles;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -32,8 +31,10 @@ public class ClusterControllerContainerCluster extends ContainerCluster<ClusterC
         super(parent, subId, name, deployState, false);
         addDefaultHandlersWithVip();
         this.reindexingContext = createReindexingContext(deployState);
-        setJvmGCOptions(deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.admin),
-                                                                 Optional.of(ClusterSpec.Id.from(name))));
+        setJvmGCOptions(deployState.getProperties().jvmGCOptionsFlag()
+                                .withClusterType(ClusterSpec.Type.admin)
+                                .withClusterId(ClusterSpec.Id.from(name))
+                                .value());
         if (isHostedVespa())
             addAccessLog("controller");
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -104,10 +104,10 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         addPlatformBundle(METRICS_PROXY_BUNDLE_FILE);
         addClusterComponents();
 
-        setJvmGCOptions(deployState.getProperties().jvmGCOptions(
-                Optional.of(ClusterSpec.Type.admin),
-                Optional.of(ClusterSpec.Id.from(name))
-        ));
+        setJvmGCOptions(deployState.getProperties().jvmGCOptionsFlag()
+                .withClusterType(ClusterSpec.Type.admin)
+                .withClusterId(ClusterSpec.Id.from(name))
+                .value());
         
         if (isHostedVespa())
             addAccessLog("metrics-proxy");

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -24,6 +24,7 @@ public final class ApplicationContainer extends Container implements
         ZookeeperServerConfig.Producer {
 
     private final boolean isHostedVespa;
+    private String jvmGCOptions;
 
     public ApplicationContainer(TreeConfigProducer<?> parent, String name, int index, DeployState deployState) {
         this(parent, name, false, index, deployState);
@@ -51,9 +52,12 @@ public final class ApplicationContainer extends Container implements
         MallocImplResolver.pathToLibrary(mallocImpl).ifPresent(this::setPreLoad);
     }
 
+    public void setJvmGCOptions(String jvmGCOptions) { this.jvmGCOptions = jvmGCOptions; }
+
     @Override
     public void getConfig(QrStartConfig.Builder builder) {
         realResources().ifPresent(r -> builder.jvm.availableProcessors(Math.max(2, (int) Math.ceil(r.vcpu()))));
+        if (jvmGCOptions != null) builder.jvm.gcopts(jvmGCOptions);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1081,6 +1081,20 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         return new JvmGcOptions(context.getDeployState(), cluster.getName(), jvmGCOptions).build();
     }
 
+    private static void applyPerContainerGCOptions(List<ApplicationContainer> containers, ConfigModelContext context,
+                                                   ApplicationContainerCluster cluster, String xmlGcOptions) {
+        if (xmlGcOptions != null) return; // XML-specified gc-options apply uniformly (set on cluster)
+        var flag = context.getDeployState().getProperties().jvmGCOptionsFlag()
+                .withClusterType(ClusterSpec.Type.container)
+                .withClusterId(ClusterSpec.Id.from(cluster.getName()));
+        for (var container : containers) {
+            var resolved = flag.withHostname(container.getHostName()).value();
+            if (resolved != null && !resolved.isEmpty()) {
+                container.setJvmGCOptions(resolved);
+            }
+        }
+    }
+
     private static String getJvmOptions(Element nodesElement,
                                         DeployState deployState,
                                         boolean legacyOptions) {
@@ -1091,24 +1105,27 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         return element.hasAttribute(attrName) ? element.getAttribute(attrName) : null;
     }
 
-    private void extractJvmOptions(List<ApplicationContainer> nodes,
-                                   ApplicationContainerCluster cluster,
-                                   Element nodesElement,
-                                   ConfigModelContext context) {
+    /** Returns the XML-specified gc-options, or null if not specified in XML. */
+    private String extractJvmOptions(List<ApplicationContainer> nodes,
+                                     ApplicationContainerCluster cluster,
+                                     Element nodesElement,
+                                     ConfigModelContext context) {
         Element jvmElement = XML.getChild(nodesElement, "jvm");
         if (jvmElement == null) {
-            extractJvmFromLegacyNodesTag(nodes, cluster, nodesElement, context);
+            return extractJvmFromLegacyNodesTag(nodes, cluster, nodesElement, context);
         } else {
-            extractJvmTag(nodes, cluster, nodesElement, jvmElement, context);
+            return extractJvmTag(nodes, cluster, nodesElement, jvmElement, context);
         }
     }
 
-    private void extractJvmFromLegacyNodesTag(List<ApplicationContainer> nodes, ApplicationContainerCluster cluster,
-                                              Element nodesElement, ConfigModelContext context) {
+    /** Returns the XML-specified gc-options, or null if not specified in XML. */
+    private String extractJvmFromLegacyNodesTag(List<ApplicationContainer> nodes, ApplicationContainerCluster cluster,
+                                                Element nodesElement, ConfigModelContext context) {
         applyNodesTagJvmArgs(nodes, getJvmOptions(nodesElement, context.getDeployState(), true));
 
+        String jvmGCOptions = null;
         if (cluster.getJvmGCOptions().isEmpty()) {
-            String jvmGCOptions = extractAttribute(nodesElement, VespaDomBuilder.JVM_GC_OPTIONS);
+            jvmGCOptions = extractAttribute(nodesElement, VespaDomBuilder.JVM_GC_OPTIONS);
 
             if (jvmGCOptions != null && !jvmGCOptions.isEmpty()) {
                 DeployLogger logger = context.getDeployState().getDeployLogger();
@@ -1125,14 +1142,17 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                    .logApplicationPackage(WARNING, "'allocated-memory' is deprecated and will be removed in Vespa 9." +
                            " Please merge into 'allocated-memory' in 'jvm' element." +
                            " See https://docs.vespa.ai/en/reference/services/container.html#jvm");
+        return jvmGCOptions;
     }
 
-    private void extractJvmTag(List<ApplicationContainer> nodes, ApplicationContainerCluster cluster,
-                               Element nodesElement, Element jvmElement, ConfigModelContext context) {
+    /** Returns the XML-specified gc-options, or null if not specified in XML. */
+    private String extractJvmTag(List<ApplicationContainer> nodes, ApplicationContainerCluster cluster,
+                                 Element nodesElement, Element jvmElement, ConfigModelContext context) {
         applyNodesTagJvmArgs(nodes, getJvmOptions(nodesElement, context.getDeployState(), false));
         applyMemoryPercentage(cluster, jvmElement.getAttribute(VespaDomBuilder.Allocated_MEMORY_ATTRIB_NAME));
-        String jvmGCOptions = extractAttribute(jvmElement, VespaDomBuilder.GC_OPTIONS);
+        var jvmGCOptions = extractAttribute(jvmElement, VespaDomBuilder.GC_OPTIONS);
         cluster.setJvmGCOptions(buildJvmGCOptions(context, cluster, jvmGCOptions));
+        return jvmGCOptions;
     }
 
     /**
@@ -1145,12 +1165,14 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private void addNodesFromXml(ApplicationContainerCluster cluster, Element containerElement, ConfigModelContext context) {
         Element nodesElement = XML.getChild(containerElement, "nodes");
         if (nodesElement == null) {
-            cluster.addContainers(allocateWithoutNodesTag(cluster, context));
+            var nodes = allocateWithoutNodesTag(cluster, context);
+            cluster.addContainers(nodes);
             cluster.setJvmGCOptions(buildJvmGCOptions(context, cluster, null));
+            applyPerContainerGCOptions(nodes, context, cluster, null);
         } else {
             List<ApplicationContainer> nodes = createNodes(cluster, containerElement, nodesElement, context);
 
-            extractJvmOptions(nodes, cluster, nodesElement, context);
+            var xmlGcOptions = extractJvmOptions(nodes, cluster, nodesElement, context);
             applyDefaultPreload(nodes, nodesElement);
             var envVars = getEnvironmentVariables(XML.getChild(nodesElement, ENVIRONMENT_VARIABLES_ELEMENT)).entrySet();
             for (var container : nodes) {
@@ -1161,6 +1183,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             if (useCpuSocketAffinity(nodesElement))
                 AbstractService.distributeCpuSocketAffinity(nodes);
             cluster.addContainers(nodes);
+            applyPerContainerGCOptions(nodes, context, cluster, xmlGcOptions);
         }
     }
 
@@ -1609,8 +1632,10 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
 
         private String build() {
-            String options = deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.container),
-                                                                     Optional.of(ClusterSpec.Id.from(clusterName)));
+            var options = deployState.getProperties().jvmGCOptionsFlag()
+                    .withClusterType(ClusterSpec.Type.container)
+                    .withClusterId(ClusterSpec.Id.from(clusterName))
+                    .value();
             if (jvmGcOptions != null) {
                 options = jvmGcOptions;
                 String[] optionList = options.split(" ");

--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/BootstrapFlagSource.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/BootstrapFlagSource.java
@@ -26,7 +26,7 @@ public class BootstrapFlagSource implements FlagSource {
 
     public BootstrapFlagSource(FileSystem fileSystem) {
         // The flags on disk is read once now and never again.
-        this.flagData = new FlagDbFile(fileSystem).read();
+        this.flagData = Map.copyOf(new FlagDbFile(fileSystem).read());
     }
 
     @Override

--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/BootstrapFlagSource.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/BootstrapFlagSource.java
@@ -33,4 +33,7 @@ public class BootstrapFlagSource implements FlagSource {
     public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
         return Optional.ofNullable(flagData.get(id)).flatMap(data -> data.resolve(vector));
     }
+
+    @Override
+    public FlagSource snapshot() { return this; }
 }

--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/ZooKeeperFlagSource.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/db/ZooKeeperFlagSource.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.FlagId;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.RawFlag;
+import com.yahoo.vespa.flags.SnapshotFlagSource;
 
 import java.util.Optional;
 
@@ -24,5 +25,8 @@ public class ZooKeeperFlagSource implements FlagSource {
     public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
         return flagsDb.getValue(id).flatMap(data -> data.resolve(vector));
     }
+
+    @Override
+    public FlagSource snapshot() { return new SnapshotFlagSource(flagsDb.getAllFlagData()); }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -29,11 +29,13 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeResources.Architecture;
 import com.yahoo.config.provision.SharedHosts;
 import com.yahoo.vespa.flags.DoubleFlag;
+import com.yahoo.vespa.flags.Flag;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.flags.IntFlag;
 import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.flags.StringFlag;
+import com.yahoo.vespa.flags.UnboundFlag;
 import com.yahoo.vespa.flags.custom.Sidecars;
 
 import java.io.File;
@@ -48,6 +50,7 @@ import java.util.concurrent.ExecutorService;
 import static com.yahoo.vespa.config.server.ConfigServerSpec.fromConfig;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_ID;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_TYPE;
+import static com.yahoo.vespa.flags.Dimension.HOSTNAME;
 
 /**
  * Implementation of {@link ModelContext} for configserver.
@@ -320,6 +323,8 @@ public class ModelContextImpl implements ModelContext {
 
         private final ModelContext.FeatureFlags featureFlags;
         private final ApplicationId applicationId;
+        private final FlagSource flagSource;
+        private final Version modelVersion;
         private final boolean multitenant;
         private final List<ConfigServerSpec> configServerSpecs;
         private final HostName loadBalancerName;
@@ -367,6 +372,8 @@ public class ModelContextImpl implements ModelContext {
                           List<DataplaneToken> dataplaneTokens) {
             this.featureFlags = new FeatureFlags(flagSource, applicationId, modelVersion);
             this.applicationId = applicationId;
+            this.flagSource = flagSource;
+            this.modelVersion = modelVersion;
             this.multitenant = configserverConfig.multitenant() || configserverConfig.hostedVespa() || Boolean.getBoolean("multitenant");
             this.configServerSpecs = fromConfig(configserverConfig);
             this.loadBalancerName = configserverConfig.loadBalancerAddress().isEmpty() ? null : HostName.of(configserverConfig.loadBalancerAddress());
@@ -382,7 +389,7 @@ public class ModelContextImpl implements ModelContext {
             this.quota = maybeQuota.orElseGet(Quota::unlimited);
             this.tenantVaults = tenantVaults;
             this.tenantSecretStores = tenantSecretStores;
-            this.jvmGCOptionsFlag = PermanentFlags.JVM_GC_OPTIONS.bindTo(flagSource)
+        this.jvmGCOptionsFlag = PermanentFlags.JVM_GC_OPTIONS.bindTo(flagSource)
                     .with(applicationId)
                     .withVersion(Optional.of(modelVersion));
             this.searchNodeInitializerThreadsFlag = PermanentFlags.SEARCHNODE_INITIALIZER_THREADS.bindTo(flagSource).with(applicationId);
@@ -466,8 +473,13 @@ public class ModelContextImpl implements ModelContext {
             return tenantSecretStores;
         }
 
+        @SuppressWarnings("removal")
         @Override public String jvmGCOptions(Optional<ClusterSpec.Type> clusterType, Optional<ClusterSpec.Id> clusterId) {
             return flagValueForClusterTypeAndClusterId(jvmGCOptionsFlag, clusterType, clusterId);
+        }
+
+        @Override public ModelContext.FeatureFlag<String> jvmGCOptionsFlag() {
+            return new FeatureFlag<>(PermanentFlags.JVM_GC_OPTIONS, flagSource, applicationId, modelVersion);
         }
 
         @Override public String mallocImpl(Optional<ClusterSpec.Type> clusterType) {
@@ -533,6 +545,31 @@ public class ModelContextImpl implements ModelContext {
         @Override public List<String> requestPrefixForLoggingContent() { return requestPrefixForLoggingContent; }
 
         @Override public List<String> jdiscHttpComplianceViolations() { return jdiscHttpComplianceViolations; }
+
+        private record FeatureFlag<T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>>(F flag)
+                implements ModelContext.FeatureFlag<T> {
+
+            FeatureFlag(U unboundFlag, FlagSource source, ApplicationId appId, Version version) {
+                this(unboundFlag.bindTo(source).with(appId).with(version));
+            }
+
+            @Override
+            public ModelContext.FeatureFlag<T> withClusterType(ClusterSpec.Type clusterType) {
+                return new FeatureFlag<>(flag.with(CLUSTER_TYPE, clusterType.name()));
+            }
+
+            @Override
+            public ModelContext.FeatureFlag<T> withClusterId(ClusterSpec.Id clusterId) {
+                return new FeatureFlag<>(flag.with(CLUSTER_ID, clusterId.value()));
+            }
+
+            @Override
+            public ModelContext.FeatureFlag<T> withHostname(String hostname) {
+                return new FeatureFlag<>(flag.with(HOSTNAME, hostname));
+            }
+
+            @Override public T value() { return flag.boxedValue(); }
+        }
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -28,15 +28,11 @@ import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeResources.Architecture;
 import com.yahoo.config.provision.SharedHosts;
-import com.yahoo.vespa.flags.DoubleFlag;
 import com.yahoo.vespa.flags.Flag;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
-import com.yahoo.vespa.flags.IntFlag;
 import com.yahoo.vespa.flags.PermanentFlags;
-import com.yahoo.vespa.flags.StringFlag;
 import com.yahoo.vespa.flags.UnboundFlag;
-import com.yahoo.vespa.flags.custom.Sidecars;
 
 import java.io.File;
 import java.net.URI;
@@ -168,155 +164,103 @@ public class ModelContextImpl implements ModelContext {
     @Override
     public Version wantedNodeVespaVersion() { return wantedNodeVespaVersion; }
 
+    /** A flag wrapper that can be safely exposed to the config model implementation.
+     * Used to set fine-grained flag dimensions (e.g. hostname, cluster type, cluster id).
+     * @see Properties#jvmGCOptionsFlag() for an example of this.
+     */
+    private record FeatureFlag<T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>>(F flag)
+            implements ModelContext.FeatureFlag<T> {
+
+        FeatureFlag(U unboundFlag, FlagSource source, ApplicationId appId, Version version) {
+            this(unboundFlag.bindTo(source).with(appId).with(version));
+        }
+
+        @Override
+        public ModelContext.FeatureFlag<T> withClusterType(ClusterSpec.Type clusterType) {
+            return new FeatureFlag<>(flag.with(CLUSTER_TYPE, clusterType.name()));
+        }
+
+        @Override
+        public ModelContext.FeatureFlag<T> withClusterId(ClusterSpec.Id clusterId) {
+            return new FeatureFlag<>(flag.with(CLUSTER_ID, clusterId.value()));
+        }
+
+        @Override
+        public ModelContext.FeatureFlag<T> withHostname(String hostname) {
+            return new FeatureFlag<>(flag.with(HOSTNAME, hostname));
+        }
+
+        @Override public T value() { return flag.boxedValue(); }
+    }
+
     public static class FeatureFlags implements ModelContext.FeatureFlags {
 
-        private final boolean useNonPublicEndpointForTest;
-        private final double queryDispatchWarmup;
-        private final String responseSequencer;
-        private final int numResponseThreads;
-        private final boolean useAsyncMessageHandlingOnSchedule;
-        private final double feedConcurrency;
-        private final double feedNiceness;
-        private final List<String> allowedAthenzProxyIdentities;
-        private final int maxActivationInhibitedOutOfSyncGroups;
-        private final double resourceLimitDisk;
-        private final double resourceLimitMemory;
-        private final double resourceLimitAddressSpace;
-        private final boolean containerDumpHeapOnShutdownTimeout;
-        private final int maxUnCommittedMemory;
-        private final boolean forwardIssuesAsErrors;
-        private final List<String> ignoredHttpUserAgents;
-        private final int mbus_network_threads;
-        private final int mbus_java_num_targets;
-        private final int mbus_java_events_before_wakeup;
-        private final int mbus_cpp_num_targets;
-        private final int mbus_cpp_events_before_wakeup;
-        private final int rpc_num_targets;
-        private final int rpc_events_before_wakeup;
-        private final boolean sortBlueprintsByCost;
-        private final String unknownConfigDefinition;
-        private final boolean logserverOtelCol;
-        private final SharedHosts sharedHosts;
-        private final Architecture adminClusterArchitecture;
-        private final double logserverNodeMemory;
-        private final double clusterControllerNodeMemory;
-        private final boolean useLegacyWandQueryParsing;
-        private final boolean useSimpleAnnotations;
-        private final boolean sendProtobufQuerytree;
-        private final boolean forwardAllLogLevels;
-        private final long zookeeperPreAllocSize;
-        private final int maxContentNodeMaintenanceOpConcurrency;
-        private final int maxDocumentOperationRequestSizeMib;
-        private final Sidecars sidecarsForTest;
-        private final boolean useTriton;
-        private final boolean ignoreConnectivityChecksAtStartup;
-        private final int searchCoreMaxOutstandingMoveOps;
-        private final double docprocHandlerThreadpool;
-        private final boolean applyOnRestartForApplicationMetadataConfig;
-        private final DoubleFlag autoscalerTargetWriteCpuPercentageFlag;
-        private final IntFlag heapSizePercentageFlag;
-        private final double searchNodeReservedDiskSpaceFactor;
+        private final FlagSource source;
+        private final ApplicationId appId;
+        private final Version version;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
-            this.useNonPublicEndpointForTest = Flags.USE_NON_PUBLIC_ENDPOINT_FOR_TEST.bindTo(source).with(appId).with(version).value();
-            this.responseSequencer = Flags.RESPONSE_SEQUENCER_TYPE.bindTo(source).with(appId).with(version).value();
-            this.numResponseThreads = Flags.RESPONSE_NUM_THREADS.bindTo(source).with(appId).with(version).value();
-            this.useAsyncMessageHandlingOnSchedule = Flags.USE_ASYNC_MESSAGE_HANDLING_ON_SCHEDULE.bindTo(source).with(appId).with(version).value();
-            this.feedConcurrency = PermanentFlags.FEED_CONCURRENCY.bindTo(source).with(appId).with(version).value();
-            this.feedNiceness = PermanentFlags.FEED_NICENESS.bindTo(source).with(appId).with(version).value();
-            this.mbus_network_threads = Flags.MBUS_NUM_NETWORK_THREADS.bindTo(source).with(appId).with(version).value();
-            this.allowedAthenzProxyIdentities = PermanentFlags.ALLOWED_ATHENZ_PROXY_IDENTITIES.bindTo(source).with(appId).with(version).value();
-            this.maxActivationInhibitedOutOfSyncGroups = Flags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS.bindTo(source).with(appId).with(version).value();
-            this.resourceLimitDisk = PermanentFlags.RESOURCE_LIMIT_DISK.bindTo(source).with(appId).with(version).value();
-            this.resourceLimitMemory = PermanentFlags.RESOURCE_LIMIT_MEMORY.bindTo(source).with(appId).with(version).value();
-            this.resourceLimitAddressSpace = PermanentFlags.RESOURCE_LIMIT_ADDRESS_SPACE.bindTo(source).with(appId).with(version).value();
-            this.containerDumpHeapOnShutdownTimeout = PermanentFlags.CONTAINER_DUMP_HEAP_ON_SHUTDOWN_TIMEOUT.bindTo(source).with(appId).with(version).value();
-            this.maxUnCommittedMemory = PermanentFlags.MAX_UNCOMMITTED_MEMORY.bindTo(source).with(appId).with(version).value();
-            this.forwardIssuesAsErrors = PermanentFlags.FORWARD_ISSUES_AS_ERRORS.bindTo(source).with(appId).with(version).value();
-            this.ignoredHttpUserAgents = PermanentFlags.IGNORED_HTTP_USER_AGENTS.bindTo(source).with(appId).with(version).value();
-            this.mbus_java_num_targets = Flags.MBUS_JAVA_NUM_TARGETS.bindTo(source).with(appId).with(version).value();
-            this.mbus_java_events_before_wakeup = Flags.MBUS_JAVA_EVENTS_BEFORE_WAKEUP.bindTo(source).with(appId).with(version).value();
-            this.mbus_cpp_num_targets = Flags.MBUS_CPP_NUM_TARGETS.bindTo(source).with(appId).with(version).value();
-            this.mbus_cpp_events_before_wakeup = Flags.MBUS_CPP_EVENTS_BEFORE_WAKEUP.bindTo(source).with(appId).with(version).value();
-            this.rpc_num_targets = Flags.RPC_NUM_TARGETS.bindTo(source).with(appId).with(version).value();
-            this.rpc_events_before_wakeup = Flags.RPC_EVENTS_BEFORE_WAKEUP.bindTo(source).with(appId).with(version).value();
-            this.queryDispatchWarmup = PermanentFlags.QUERY_DISPATCH_WARMUP.bindTo(source).with(appId).with(version).value();
-            this.heapSizePercentageFlag = PermanentFlags.HEAP_SIZE_PERCENTAGE.bindTo(source).with(appId).with(version);
-            this.unknownConfigDefinition = PermanentFlags.UNKNOWN_CONFIG_DEFINITION.bindTo(source).with(appId).with(version).value();
-            this.sortBlueprintsByCost = PermanentFlags.SORT_BLUEPRINTS_BY_COST.bindTo(source).with(appId).with(version).value();
-            this.logserverOtelCol = Flags.LOGSERVER_OTELCOL_AGENT.bindTo(source).with(appId).with(version).value();
-            this.sharedHosts = PermanentFlags.SHARED_HOST.bindTo(source).with(appId).with(version).value();
-            this.adminClusterArchitecture = Architecture.valueOf(PermanentFlags.ADMIN_CLUSTER_NODE_ARCHITECTURE.bindTo(source).with(appId).with(version).value());
-            this.logserverNodeMemory = PermanentFlags.LOGSERVER_NODE_MEMORY.bindTo(source).with(appId).with(version).value();
-            this.clusterControllerNodeMemory = PermanentFlags.CLUSTER_CONTROLLER_NODE_MEMORY.bindTo(source).with(appId).with(version).value();
-            this.useLegacyWandQueryParsing = Flags.USE_LEGACY_WAND_QUERY_PARSING.bindTo(source).with(appId).with(version).value();
-            this.useSimpleAnnotations = Flags.USE_SIMPLE_ANNOTATIONS.bindTo(source).with(appId).with(version).value();
-            this.sendProtobufQuerytree = Flags.SEND_PROTOBUF_QUERYTREE.bindTo(source).with(appId).with(version).value();
-            this.forwardAllLogLevels = PermanentFlags.FORWARD_ALL_LOG_LEVELS.bindTo(source).with(appId).with(version).value();
-            this.zookeeperPreAllocSize = Flags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB.bindTo(source).value();
-            this.maxContentNodeMaintenanceOpConcurrency = Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY.bindTo(source).with(appId).with(version).value();
-            this.maxDocumentOperationRequestSizeMib = Flags.MAX_DOCUMENT_OPERATION_REQUEST_SIZE_MIB.bindTo(source).with(appId).with(version).value();
-            this.sidecarsForTest = Flags.SIDECARS_FOR_TEST.bindTo(source).with(appId).with(version).value();
-            this.useTriton = Flags.USE_TRITON.bindTo(source).with(appId).with(version).value();
-            this.ignoreConnectivityChecksAtStartup = PermanentFlags.IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP.bindTo(source).with(appId).value();
-            this.searchCoreMaxOutstandingMoveOps = Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS.bindTo(source).with(appId).with(version).value();
-            this.docprocHandlerThreadpool = Flags.DOCPROC_HANDLER_THREADPOOL.bindTo(source).with(appId).with(version).value();
-            this.applyOnRestartForApplicationMetadataConfig = Flags.APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG.bindTo(source).with(appId).with(version).value();
-            this.autoscalerTargetWriteCpuPercentageFlag = Flags.AUTOSCALER_TARGET_WRITE_CPU_PERCENTAGE.bindTo(source).with(appId).with(version);
-            this.searchNodeReservedDiskSpaceFactor = Flags.SEARCHNODE_RESERVED_DISK_SPACE_FACTOR.bindTo(source).with(appId).with(version).value();
+            this.source = source;
+            this.appId = appId;
+            this.version = version;
         }
 
-        @Override public boolean useNonPublicEndpointForTest() { return useNonPublicEndpointForTest; }
-        @Override public int heapSizePercentage(Optional<String> clusterId) {
-            return clusterId.map(id -> heapSizePercentageFlag.with(ClusterSpec.Id.from(id)).value())
-                            .orElseGet(heapSizePercentageFlag::value); }
-        @Override public double queryDispatchWarmup() { return queryDispatchWarmup; }
-        @Override public String responseSequencerType() { return responseSequencer; }
-        @Override public int defaultNumResponseThreads() { return numResponseThreads; }
-        @Override public boolean useAsyncMessageHandlingOnSchedule() { return useAsyncMessageHandlingOnSchedule; }
-        @Override public double feedConcurrency() { return feedConcurrency; }
-        @Override public double feedNiceness() { return feedNiceness; }
-        @Override public int mbusNetworkThreads() { return mbus_network_threads; }
-        @Override public List<String> allowedAthenzProxyIdentities() { return allowedAthenzProxyIdentities; }
-        @Override public int maxActivationInhibitedOutOfSyncGroups() { return maxActivationInhibitedOutOfSyncGroups; }
-        @Override public double resourceLimitDisk() { return resourceLimitDisk; }
-        @Override public double resourceLimitMemory() { return resourceLimitMemory; }
-        @Override public double resourceLimitAddressSpace() { return resourceLimitAddressSpace; }
-        @Override public boolean containerDumpHeapOnShutdownTimeout() { return containerDumpHeapOnShutdownTimeout; }
-        @Override public int maxUnCommittedMemory() { return maxUnCommittedMemory; }
-        @Override public boolean forwardIssuesAsErrors() { return forwardIssuesAsErrors; }
-        @Override public List<String> ignoredHttpUserAgents() { return ignoredHttpUserAgents; }
-        @Override public int mbusJavaRpcNumTargets() { return mbus_java_num_targets; }
-        @Override public int mbusJavaEventsBeforeWakeup() { return mbus_java_events_before_wakeup; }
-        @Override public int mbusCppRpcNumTargets() { return mbus_cpp_num_targets; }
-        @Override public int mbusCppEventsBeforeWakeup() { return mbus_cpp_events_before_wakeup; }
-        @Override public int rpcNumTargets() { return rpc_num_targets; }
-        @Override public int rpcEventsBeforeWakeup() { return rpc_events_before_wakeup; }
-        @Override public String unknownConfigDefinition() { return unknownConfigDefinition; }
-        @Override public boolean sortBlueprintsByCost() { return sortBlueprintsByCost; }
-        @Override public boolean logserverOtelCol() { return logserverOtelCol; }
-        @Override public SharedHosts sharedHosts() { return sharedHosts; }
-        @Override public Architecture adminClusterArchitecture() { return adminClusterArchitecture; }
-        @Override public double logserverNodeMemory() { return logserverNodeMemory; }
-        @Override public double clusterControllerNodeMemory() { return clusterControllerNodeMemory; }
-        @Override public boolean useLegacyWandQueryParsing() { return useLegacyWandQueryParsing; }
-        @Override public boolean useSimpleAnnotations() { return useSimpleAnnotations; }
-        @Override public boolean sendProtobufQuerytree() { return sendProtobufQuerytree; }
-        @Override public boolean forwardAllLogLevels() { return forwardAllLogLevels; }
-        @Override public long zookeeperPreAllocSize() { return zookeeperPreAllocSize; }
-        @Override public int maxContentNodeMaintenanceOpConcurrency() { return maxContentNodeMaintenanceOpConcurrency; }
-        @Override public int maxDocumentOperationRequestSizeMib() { return maxDocumentOperationRequestSizeMib; }
-        @Override public Object sidecarsForTest() { return sidecarsForTest; }
-        @Override public boolean useTriton() { return useTriton; }
-        @Override public boolean ignoreConnectivityChecksAtStartup() { return ignoreConnectivityChecksAtStartup; }
-        @Override public int searchCoreMaxOutstandingMoveOps() { return searchCoreMaxOutstandingMoveOps; }
-        @Override public double docprocHandlerThreadpool() { return docprocHandlerThreadpool; }
-        @Override public boolean applyOnRestartForApplicationMetadataConfig() { return applyOnRestartForApplicationMetadataConfig; }
-        @Override public double autoscalerTargetWriteCpuPercentage(Optional<String> clusterId) {
-            return clusterId.map(id -> autoscalerTargetWriteCpuPercentageFlag.with(ClusterSpec.Id.from(id)).value())
-                            .orElseGet(autoscalerTargetWriteCpuPercentageFlag::value);
+        private <T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>> ModelContext.FeatureFlag<T> flag(U unboundFlag) {
+            return new FeatureFlag<>(unboundFlag, source, appId, version);
         }
-        @Override public double searchNodeReservedDiskSpaceFactor() { return searchNodeReservedDiskSpaceFactor; }
+
+        @Override public boolean useNonPublicEndpointForTest() { return flag(Flags.USE_NON_PUBLIC_ENDPOINT_FOR_TEST).value(); }
+        @Override public int heapSizePercentage(Optional<String> clusterId) {
+            var flag = flag(PermanentFlags.HEAP_SIZE_PERCENTAGE);
+            return clusterId.map(id -> flag.withClusterId(ClusterSpec.Id.from(id)).value()).orElseGet(flag::value);
+        }
+        @Override public double queryDispatchWarmup() { return flag(PermanentFlags.QUERY_DISPATCH_WARMUP).value(); }
+        @Override public String responseSequencerType() { return flag(Flags.RESPONSE_SEQUENCER_TYPE).value(); }
+        @Override public int defaultNumResponseThreads() { return flag(Flags.RESPONSE_NUM_THREADS).value(); }
+        @Override public boolean useAsyncMessageHandlingOnSchedule() { return flag(Flags.USE_ASYNC_MESSAGE_HANDLING_ON_SCHEDULE).value(); }
+        @Override public double feedConcurrency() { return flag(PermanentFlags.FEED_CONCURRENCY).value(); }
+        @Override public double feedNiceness() { return flag(PermanentFlags.FEED_NICENESS).value(); }
+        @Override public int mbusNetworkThreads() { return flag(Flags.MBUS_NUM_NETWORK_THREADS).value(); }
+        @Override public List<String> allowedAthenzProxyIdentities() { return flag(PermanentFlags.ALLOWED_ATHENZ_PROXY_IDENTITIES).value(); }
+        @Override public int maxActivationInhibitedOutOfSyncGroups() { return flag(Flags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS).value(); }
+        @Override public double resourceLimitDisk() { return flag(PermanentFlags.RESOURCE_LIMIT_DISK).value(); }
+        @Override public double resourceLimitMemory() { return flag(PermanentFlags.RESOURCE_LIMIT_MEMORY).value(); }
+        @Override public double resourceLimitAddressSpace() { return flag(PermanentFlags.RESOURCE_LIMIT_ADDRESS_SPACE).value(); }
+        @Override public boolean containerDumpHeapOnShutdownTimeout() { return flag(PermanentFlags.CONTAINER_DUMP_HEAP_ON_SHUTDOWN_TIMEOUT).value(); }
+        @Override public int maxUnCommittedMemory() { return flag(PermanentFlags.MAX_UNCOMMITTED_MEMORY).value(); }
+        @Override public boolean forwardIssuesAsErrors() { return flag(PermanentFlags.FORWARD_ISSUES_AS_ERRORS).value(); }
+        @Override public List<String> ignoredHttpUserAgents() { return flag(PermanentFlags.IGNORED_HTTP_USER_AGENTS).value(); }
+        @Override public int mbusJavaRpcNumTargets() { return flag(Flags.MBUS_JAVA_NUM_TARGETS).value(); }
+        @Override public int mbusJavaEventsBeforeWakeup() { return flag(Flags.MBUS_JAVA_EVENTS_BEFORE_WAKEUP).value(); }
+        @Override public int mbusCppRpcNumTargets() { return flag(Flags.MBUS_CPP_NUM_TARGETS).value(); }
+        @Override public int mbusCppEventsBeforeWakeup() { return flag(Flags.MBUS_CPP_EVENTS_BEFORE_WAKEUP).value(); }
+        @Override public int rpcNumTargets() { return flag(Flags.RPC_NUM_TARGETS).value(); }
+        @Override public int rpcEventsBeforeWakeup() { return flag(Flags.RPC_EVENTS_BEFORE_WAKEUP).value(); }
+        @Override public String unknownConfigDefinition() { return flag(PermanentFlags.UNKNOWN_CONFIG_DEFINITION).value(); }
+        @Override public boolean sortBlueprintsByCost() { return flag(PermanentFlags.SORT_BLUEPRINTS_BY_COST).value(); }
+        @Override public boolean logserverOtelCol() { return flag(Flags.LOGSERVER_OTELCOL_AGENT).value(); }
+        @Override public SharedHosts sharedHosts() { return flag(PermanentFlags.SHARED_HOST).value(); }
+        @Override public Architecture adminClusterArchitecture() { return Architecture.valueOf(flag(PermanentFlags.ADMIN_CLUSTER_NODE_ARCHITECTURE).value()); }
+        @Override public double logserverNodeMemory() { return flag(PermanentFlags.LOGSERVER_NODE_MEMORY).value(); }
+        @Override public double clusterControllerNodeMemory() { return flag(PermanentFlags.CLUSTER_CONTROLLER_NODE_MEMORY).value(); }
+        @Override public boolean useLegacyWandQueryParsing() { return flag(Flags.USE_LEGACY_WAND_QUERY_PARSING).value(); }
+        @Override public boolean useSimpleAnnotations() { return flag(Flags.USE_SIMPLE_ANNOTATIONS).value(); }
+        @Override public boolean sendProtobufQuerytree() { return flag(Flags.SEND_PROTOBUF_QUERYTREE).value(); }
+        @Override public boolean forwardAllLogLevels() { return flag(PermanentFlags.FORWARD_ALL_LOG_LEVELS).value(); }
+        @Override public long zookeeperPreAllocSize() { return flag(Flags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
+        @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }
+        @Override public int maxDocumentOperationRequestSizeMib() { return flag(Flags.MAX_DOCUMENT_OPERATION_REQUEST_SIZE_MIB).value(); }
+        @Override public Object sidecarsForTest() { return flag(Flags.SIDECARS_FOR_TEST).value(); }
+        @Override public boolean useTriton() { return flag(Flags.USE_TRITON).value(); }
+        @Override public boolean ignoreConnectivityChecksAtStartup() { return flag(PermanentFlags.IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP).value(); }
+        @Override public int searchCoreMaxOutstandingMoveOps() { return flag(Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS).value(); }
+        @Override public double docprocHandlerThreadpool() { return flag(Flags.DOCPROC_HANDLER_THREADPOOL).value(); }
+        @Override public boolean applyOnRestartForApplicationMetadataConfig() { return flag(Flags.APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG).value(); }
+        @Override public double autoscalerTargetWriteCpuPercentage(Optional<String> clusterId) {
+            var flag = flag(Flags.AUTOSCALER_TARGET_WRITE_CPU_PERCENTAGE);
+            return clusterId.map(id -> flag.withClusterId(ClusterSpec.Id.from(id)).value()).orElseGet(flag::value);
+        }
+        @Override public double searchNodeReservedDiskSpaceFactor() { return flag(Flags.SEARCHNODE_RESERVED_DISK_SPACE_FACTOR).value(); }
     }
 
     public static class Properties implements ModelContext.Properties {
@@ -340,20 +284,9 @@ public class ModelContextImpl implements ModelContext {
         private final Quota quota;
         private final List<TenantVault> tenantVaults;
         private final List<TenantSecretStore> tenantSecretStores;
-        private final StringFlag jvmGCOptionsFlag;
-        private final IntFlag searchNodeInitializerThreadsFlag;
-        private final boolean allowDisableMtls;
         private final List<X509Certificate> operatorCertificates;
-        private final List<String> tlsCiphersOverride;
-        private final List<String> environmentVariables;
         private final Optional<CloudAccount> cloudAccount;
         private final List<DataplaneToken> dataplaneTokens;
-        private final boolean allowUserFilters;
-        private final Duration endpointConnectionTtl;
-        private final List<String> requestPrefixForLoggingContent;
-        private final List<String> jdiscHttpComplianceViolations;
-        private final StringFlag mallocImplFlag;
-        private final IntFlag heapSizePercentageFlag;
 
         public Properties(ApplicationId applicationId,
                           Version modelVersion,
@@ -389,186 +322,69 @@ public class ModelContextImpl implements ModelContext {
             this.quota = maybeQuota.orElseGet(Quota::unlimited);
             this.tenantVaults = tenantVaults;
             this.tenantSecretStores = tenantSecretStores;
-        this.jvmGCOptionsFlag = PermanentFlags.JVM_GC_OPTIONS.bindTo(flagSource)
-                    .with(applicationId)
-                    .withVersion(Optional.of(modelVersion));
-            this.searchNodeInitializerThreadsFlag = PermanentFlags.SEARCHNODE_INITIALIZER_THREADS.bindTo(flagSource).with(applicationId);
-            this.allowDisableMtls = PermanentFlags.ALLOW_DISABLE_MTLS.bindTo(flagSource).with(applicationId).value();
             this.operatorCertificates = operatorCertificates;
-            this.tlsCiphersOverride = PermanentFlags.TLS_CIPHERS_OVERRIDE.bindTo(flagSource).with(applicationId).value();
-            this.environmentVariables = PermanentFlags.ENVIRONMENT_VARIABLES.bindTo(flagSource).with(applicationId).value();
             this.cloudAccount = cloudAccount;
-            this.allowUserFilters = PermanentFlags.ALLOW_USER_FILTERS.bindTo(flagSource).with(applicationId).value();
-            this.endpointConnectionTtl = Duration.ofSeconds(PermanentFlags.ENDPOINT_CONNECTION_TTL.bindTo(flagSource).with(applicationId).value());
             this.dataplaneTokens = dataplaneTokens;
-            this.requestPrefixForLoggingContent = PermanentFlags.LOG_REQUEST_CONTENT.bindTo(flagSource).with(applicationId).value();
-            this.jdiscHttpComplianceViolations = PermanentFlags.JDISC_HTTP_COMPLIANCE_VIOLATIONS.bindTo(flagSource)
-                    .with(applicationId).with(modelVersion).value();
-            this.mallocImplFlag = Flags.VESPA_USE_MALLOC_IMPL.bindTo(flagSource)
-                    .with(applicationId)
-                    .withVersion(Optional.of(modelVersion));
-            this.heapSizePercentageFlag = PermanentFlags.HEAP_SIZE_PERCENTAGE.bindTo(flagSource)
-                                                                             .with(applicationId)
-                                                                             .with(modelVersion);
         }
 
         @Override public ModelContext.FeatureFlags featureFlags() { return featureFlags; }
+        @Override public boolean multitenant() { return multitenant; }
+        @Override public ApplicationId applicationId() { return applicationId; }
+        @Override public List<ConfigServerSpec> configServerSpecs() { return configServerSpecs; }
+        @Override public HostName loadBalancerName() { return loadBalancerName; }
+        @Override public URI ztsUrl() { return ztsUrl; }
+        @Override public String athenzDnsSuffix() { return athenzDnsSuffix; }
+        @Override public boolean hostedVespa() { return hostedVespa; }
+        @Override public Set<ContainerEndpoint> endpoints() { return endpoints; }
+        @Override public boolean isBootstrap() { return isBootstrap; }
+        @Override public boolean isFirstTimeDeployment() { return isFirstTimeDeployment; }
+        @Override public Optional<EndpointCertificateSecrets> endpointCertificateSecrets() { return endpointCertificateSecrets; }
+        @Override public Optional<AthenzDomain> athenzDomain() { return athenzDomain; }
+        @Override public Quota quota() { return quota; }
+        @Override public List<TenantVault> tenantVaults() { return tenantVaults; }
+        @Override public List<TenantSecretStore> tenantSecretStores() { return tenantSecretStores; }
+        @Override public List<X509Certificate> operatorCertificates() { return operatorCertificates; }
+        @Override public Optional<CloudAccount> cloudAccount() { return cloudAccount; }
+        @Override public List<DataplaneToken> dataplaneTokens() { return dataplaneTokens; }
+        @Override public boolean allowDisableMtls() { return flag(PermanentFlags.ALLOW_DISABLE_MTLS).value(); }
+        @Override public List<String> tlsCiphersOverride() { return flag(PermanentFlags.TLS_CIPHERS_OVERRIDE).value(); }
+        @Override public List<String> environmentVariables() { return flag(PermanentFlags.ENVIRONMENT_VARIABLES).value(); }
+        @Override public boolean allowUserFilters() { return flag(PermanentFlags.ALLOW_USER_FILTERS).value(); }
+        @Override public Duration endpointConnectionTtl() { return Duration.ofSeconds(flag(PermanentFlags.ENDPOINT_CONNECTION_TTL).value()); }
+        @Override public List<String> requestPrefixForLoggingContent() { return flag(PermanentFlags.LOG_REQUEST_CONTENT).value(); }
+        @Override public List<String> jdiscHttpComplianceViolations() { return flag(PermanentFlags.JDISC_HTTP_COMPLIANCE_VIOLATIONS).value(); }
+        @Override public ModelContext.FeatureFlag<String> jvmGCOptionsFlag() { return flag(PermanentFlags.JVM_GC_OPTIONS); }
 
-        @Override
-        public boolean multitenant() { return multitenant; }
-
-        @Override
-        public ApplicationId applicationId() { return applicationId; }
-
-        @Override
-        public List<ConfigServerSpec> configServerSpecs() { return configServerSpecs; }
-
-        @Override
-        public HostName loadBalancerName() { return loadBalancerName; }
-
-        @Override
-        public URI ztsUrl() {
-            return ztsUrl;
+        private <T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>> ModelContext.FeatureFlag<T> flag(U unboundFlag) {
+            return new FeatureFlag<>(unboundFlag, flagSource, applicationId, modelVersion);
         }
 
-        @Override
-        public AthenzDomain tenantSecretDomain() {
+        @Override public AthenzDomain tenantSecretDomain() {
             if (tenantSecretDomain.isEmpty())
                 throw new IllegalArgumentException("Tenant secret domain is not set");
             return AthenzDomain.from(tenantSecretDomain);
         }
 
-        @Override
-        public String athenzDnsSuffix() {
-            return athenzDnsSuffix;
-        }
-
-        @Override
-        public boolean hostedVespa() { return hostedVespa; }
-
-        @Override
-        public Set<ContainerEndpoint> endpoints() { return endpoints; }
-
-        @Override
-        public boolean isBootstrap() { return isBootstrap; }
-
-        @Override
-        public boolean isFirstTimeDeployment() { return isFirstTimeDeployment; }
-
-        @Override
-        public Optional<EndpointCertificateSecrets> endpointCertificateSecrets() { return endpointCertificateSecrets; }
-
-        @Override
-        public Optional<AthenzDomain> athenzDomain() { return athenzDomain; }
-
-        @Override public Quota quota() { return quota; }
-
-        @Override
-        public List<TenantVault> tenantVaults() {
-            return tenantVaults;
-        }
-
-        @Override
-        public List<TenantSecretStore> tenantSecretStores() {
-            return tenantSecretStores;
-        }
-
         @SuppressWarnings("removal")
         @Override public String jvmGCOptions(Optional<ClusterSpec.Type> clusterType, Optional<ClusterSpec.Id> clusterId) {
-            return flagValueForClusterTypeAndClusterId(jvmGCOptionsFlag, clusterType, clusterId);
-        }
-
-        @Override public ModelContext.FeatureFlag<String> jvmGCOptionsFlag() {
-            return new FeatureFlag<>(PermanentFlags.JVM_GC_OPTIONS, flagSource, applicationId, modelVersion);
+            var flag = flag(PermanentFlags.JVM_GC_OPTIONS);
+            var withType = clusterType.map(type -> flag.withClusterType(type)).orElse(flag);
+            return clusterId.map(id -> withType.withClusterId(id)).orElse(withType).value();
         }
 
         @Override public String mallocImpl(Optional<ClusterSpec.Type> clusterType) {
-            return flagValueForClusterTypeAndClusterId(mallocImplFlag, clusterType, Optional.empty());
+            var flag = flag(Flags.VESPA_USE_MALLOC_IMPL);
+            return clusterType.map(type -> flag.withClusterType(type)).orElse(flag).value();
         }
 
         @Override public int searchNodeInitializerThreads(String clusterId) {
-            return intFlagValueForClusterId(searchNodeInitializerThreadsFlag, clusterId);
+            return flag(PermanentFlags.SEARCHNODE_INITIALIZER_THREADS)
+                    .withClusterId(ClusterSpec.Id.from(clusterId)).value();
         }
 
         @Override public int heapSizePercentage(String clusterId) {
-            return intFlagValueForClusterId(heapSizePercentageFlag, clusterId);
-        }
-
-        @Override
-        public boolean allowDisableMtls() {
-            return allowDisableMtls;
-        }
-
-        @Override
-        public List<X509Certificate> operatorCertificates() {
-            return operatorCertificates;
-        }
-
-        @Override public List<String> tlsCiphersOverride() { return tlsCiphersOverride; }
-
-        public String flagValueForClusterTypeAndClusterId(
-                StringFlag flag, Optional<ClusterSpec.Type> clusterType, Optional<ClusterSpec.Id> clusterId) {
-            // Resolving the value here instead of the model context constructor is
-            // suboptimal as the flag value may change during a single config generation,
-            // which may trigger a warning from the jdisc container at best and potentially result in bad stuff.
-            // Luckily this is feature flag that's rarely modified.
-            var flagWithClusterType = clusterType.map(type -> flag.with(CLUSTER_TYPE, type.name()))
-                    .orElse(flag);
-
-            var flagWithContainerId = clusterId.map(id -> flagWithClusterType.with(CLUSTER_ID, id.value()))
-                    .orElse(flagWithClusterType);
-
-            return flagWithContainerId.value();
-        }
-
-        public int intFlagValueForClusterId(IntFlag flag, String clusterId) {
-            return flag.with(CLUSTER_ID, clusterId).value();
-        }
-
-        @Override
-        public List<String> environmentVariables() { return environmentVariables; }
-
-        @Override
-        public Optional<CloudAccount> cloudAccount() {
-            return cloudAccount;
-        }
-
-        @Override
-        public List<DataplaneToken> dataplaneTokens() {
-            return dataplaneTokens;
-        }
-
-        @Override public boolean allowUserFilters() { return allowUserFilters; }
-
-        @Override public Duration endpointConnectionTtl() { return endpointConnectionTtl; }
-
-        @Override public List<String> requestPrefixForLoggingContent() { return requestPrefixForLoggingContent; }
-
-        @Override public List<String> jdiscHttpComplianceViolations() { return jdiscHttpComplianceViolations; }
-
-        private record FeatureFlag<T, F extends Flag<T, F>, U extends UnboundFlag<T, F, U>>(F flag)
-                implements ModelContext.FeatureFlag<T> {
-
-            FeatureFlag(U unboundFlag, FlagSource source, ApplicationId appId, Version version) {
-                this(unboundFlag.bindTo(source).with(appId).with(version));
-            }
-
-            @Override
-            public ModelContext.FeatureFlag<T> withClusterType(ClusterSpec.Type clusterType) {
-                return new FeatureFlag<>(flag.with(CLUSTER_TYPE, clusterType.name()));
-            }
-
-            @Override
-            public ModelContext.FeatureFlag<T> withClusterId(ClusterSpec.Id clusterId) {
-                return new FeatureFlag<>(flag.with(CLUSTER_ID, clusterId.value()));
-            }
-
-            @Override
-            public ModelContext.FeatureFlag<T> withHostname(String hostname) {
-                return new FeatureFlag<>(flag.with(HOSTNAME, hostname));
-            }
-
-            @Override public T value() { return flag.boxedValue(); }
+            return flag(PermanentFlags.HEAP_SIZE_PERCENTAGE)
+                    .withClusterId(ClusterSpec.Id.from(clusterId)).value();
         }
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -154,7 +154,7 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                                                ImmutableSet.copyOf(new ContainerEndpointsCache(TenantRepository.getTenantPath(tenant), curator).read(applicationId)),
                                                false, // We may be bootstrapping, but we only know and care during prepare
                                                false, // Always false, assume no one uses it when activating
-                                               LegacyFlags.from(applicationPackage, flagSource),
+                                               LegacyFlags.from(applicationPackage, flagSource.snapshot()),
                                                new EndpointCertificateMetadataStore(curator, TenantRepository.getTenantPath(tenant))
                                                        .readEndpointCertificateMetadata(applicationId)
                                                        .flatMap(new EndpointCertificateRetriever(endpointCertificateSecretStores)::readEndpointCertificateSecrets),

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -215,7 +215,7 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
                                                Set.copyOf(containerEndpoints),
                                                params.isBootstrap(),
                                                activeApplicationVersions.isEmpty(),
-                                               LegacyFlags.from(applicationPackage, flagSource),
+                                               LegacyFlags.from(applicationPackage, flagSource.snapshot()),
                                                endpointCertificateSecrets,
                                                params.athenzDomain(),
                                                params.quota(),

--- a/flags/src/main/java/com/yahoo/vespa/flags/FlagSource.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FlagSource.java
@@ -13,4 +13,7 @@ public interface FlagSource {
     /** Returns the raw flag for the given vector (specifying hostname, application id, etc). */
     Optional<RawFlag> fetch(FlagId id, FetchVector vector);
 
+    /** Returns a snapshot of this flag source where all values are frozen at the current point in time. */
+    FlagSource snapshot();
+
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/InMemoryFlagSource.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/InMemoryFlagSource.java
@@ -64,5 +64,13 @@ public class InMemoryFlagSource extends AbstractComponent implements FlagSource 
     }
 
     @Override
-    public FlagSource snapshot() { return this; }
+    public FlagSource snapshot() {
+        Map<FlagId, RawFlag> frozen = Map.copyOf(rawFlagsById);
+        return new FlagSource() {
+            @Override public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
+                return Optional.ofNullable(frozen.get(id));
+            }
+            @Override public FlagSource snapshot() { return this; }
+        };
+    }
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/InMemoryFlagSource.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/InMemoryFlagSource.java
@@ -62,4 +62,7 @@ public class InMemoryFlagSource extends AbstractComponent implements FlagSource 
     public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
         return Optional.ofNullable(rawFlagsById.get(id));
     }
+
+    @Override
+    public FlagSource snapshot() { return this; }
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/OrderedFlagSource.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/OrderedFlagSource.java
@@ -28,4 +28,10 @@ public class OrderedFlagSource implements FlagSource {
                 .map(Optional::get)
                 .findFirst();
     }
+
+    @Override
+    public FlagSource snapshot() {
+        var snapshotted = sources.stream().map(FlagSource::snapshot).toArray(FlagSource[]::new);
+        return new OrderedFlagSource(snapshotted);
+    }
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -52,7 +52,7 @@ public class PermanentFlags {
             "jvm-gc-options", "",
             "Sets default jvm gc options",
             "Takes effect at redeployment",
-            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID);
+            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, HOSTNAME);
 
     public static final UnboundIntFlag HEAP_SIZE_PERCENTAGE = defineIntFlag(
             "heap-size-percentage", 69,

--- a/flags/src/main/java/com/yahoo/vespa/flags/SnapshotFlagSource.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/SnapshotFlagSource.java
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import com.yahoo.vespa.flags.json.FlagData;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An immutable {@link FlagSource} backed by a snapshot of {@link FlagData} entries.
+ *
+ * @author bjorncs
+ */
+public class SnapshotFlagSource implements FlagSource {
+
+    private final Map<FlagId, FlagData> data;
+
+    public SnapshotFlagSource(Map<FlagId, FlagData> data) {
+        this.data = Map.copyOf(data);
+    }
+
+    @Override
+    public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
+        return Optional.ofNullable(data.get(id)).flatMap(d -> d.resolve(vector));
+    }
+
+    @Override public FlagSource snapshot() { return this; }
+
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/file/FlagDbFile.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/file/FlagDbFile.java
@@ -7,6 +7,7 @@ import com.yahoo.vespa.flags.FlagId;
 import com.yahoo.vespa.flags.FlagRepository;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.RawFlag;
+import com.yahoo.vespa.flags.SnapshotFlagSource;
 import com.yahoo.vespa.flags.json.FlagData;
 
 import java.io.IOException;
@@ -57,6 +58,9 @@ public class FlagDbFile implements FlagRepository, FlagSource {
     public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
         return Optional.ofNullable(getAllFlagData().get(id)).flatMap(flagData -> flagData.resolve(vector));
     }
+
+    @Override
+    public FlagSource snapshot() { return new SnapshotFlagSource(read()); }
 
     public Map<FlagId, FlagData> read() {
         Optional<byte[]> bytes = readFile();

--- a/flags/src/test/java/com/yahoo/vespa/flags/json/SerializationTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/json/SerializationTest.java
@@ -190,5 +190,8 @@ public class SerializationTest {
         public Optional<RawFlag> fetch(FlagId id, FetchVector vector) {
             return flagData.id().equals(id) ? flagData.resolve(vector) : Optional.empty();
         }
+
+        @Override
+        public FlagSource snapshot() { return this; }
     }
 }


### PR DESCRIPTION
## Summary
- Snapshot `FlagSource` before config model building to prevent mid-generation inconsistencies when ZooKeeper-backed flags change during a single config generation
- Introduce `ModelContext.FeatureFlag<T>` interface for dimension-aware flag resolution, enabling deferred binding with cluster type, cluster id, and hostname
- Refactor `FeatureFlags` and `Properties` in `ModelContextImpl` to resolve flags lazily, replacing pre-bound fields with a compact `flag()` helper pattern
- Add per-container JVM GC option resolution in `ContainerModelBuilder` via `jvmGCOptionsFlag()` with hostname dimension