### PR TITLE
Add retry loop for local LLM generation test

### DIFF
--- a/model-integration/src/test/java/ai/vespa/llm/generation/LanguageModelFieldGeneratorTest.java
+++ b/model-integration/src/test/java/ai/vespa/llm/generation/LanguageModelFieldGeneratorTest.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 import com.yahoo.config.FileReference;
 import com.yahoo.config.ModelReference;
 import com.yahoo.document.DataType;
+import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.language.process.FieldGenerator;
 import org.junit.jupiter.api.Test;
 
@@ -58,20 +59,20 @@ public class LanguageModelFieldGeneratorTest {
         assertNotNull(result);
         assertEquals("hello hello", result.toString());
     }
-    
+
     @Test
     public void testGenerateWithTwoLanguageModel() {
         LanguageModel languageModel1 = new RepeatInputLanguageModel(2);
         LanguageModel languageModel2 = new RepeatInputLanguageModel(3);
         var languageModels = Map.of("languageModel1", languageModel1, "languageModel2", languageModel2);
-        
+
         var config1 = new LanguageModelFieldGeneratorConfig.Builder().providerId("languageModel1").build();
         var generator1 = createGenerator(config1, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
         var result1 = generator1.generate(StringPrompt.from("hello"), context);
         assertNotNull(result1);
         assertEquals("hello hello", result1.toString());
-    
+
         var config2 = new LanguageModelFieldGeneratorConfig.Builder().providerId("languageModel2").build();
         var generator2 = createGenerator(config2, languageModels);
         var result2 = generator2.generate(StringPrompt.from("hello"), context);
@@ -90,7 +91,7 @@ public class LanguageModelFieldGeneratorTest {
                 .build();
         var generator = createGenerator(config, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
-        
+
         var result1 = generator.generate(StringPrompt.from("world"), context);
         assertNotNull(result1);
         assertEquals("hello world hello world", result1.toString());
@@ -137,7 +138,7 @@ public class LanguageModelFieldGeneratorTest {
         assertNotNull(result2);
         assertEquals("hello hello", result2.toString());
     }
-    
+
     @Test
     public void testGenerateWithPromptTemplateFile() {
         LanguageModel languageModel = new RepeatInputLanguageModel(2);
@@ -147,7 +148,7 @@ public class LanguageModelFieldGeneratorTest {
                 .providerId("languageModel")
                 .promptTemplateFile(Optional.of(new FileReference("src/test/prompts/prompt_with_input.txt")))
                 .build();
-        
+
         var generator = createGenerator(config, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
 
@@ -165,7 +166,7 @@ public class LanguageModelFieldGeneratorTest {
                 .providerId("languageModel")
                 .promptTemplateFile(Optional.of(new FileReference("src/test/prompts/empty_prompt.txt")))
                 .build();
-        
+
         assertThrows(IllegalArgumentException.class, () -> createGenerator(config, languageModels));
     }
 
@@ -186,7 +187,7 @@ public class LanguageModelFieldGeneratorTest {
             assertEquals("Could not read prompt template file: src/test/prompts/missing_prompt.txt", e.getMessage());
         }
     }
-    
+
     @Test
     public void testGenerateWithPromptTemplateOverridesPromptTemplateFile() {
         LanguageModel languageModel = new RepeatInputLanguageModel(2);
@@ -285,29 +286,34 @@ public class LanguageModelFieldGeneratorTest {
 
         var generator = createGenerator(generatorConfig, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
-        var result = generator.generate(StringPrompt.from("hello"), context);
+        FieldValue result = null;
+        for (int attempt = 0; attempt <= 10; attempt++) {
+            result = generator.generate(StringPrompt.from("hello"), context);
+            if (result != null && !result.toString().isEmpty()) break;
+            log.info("LLM.generate retry: " + attempt);
+        }
         assertNotNull(result);
         assertFalse(result.toString().isEmpty());
     }
-    
+
     @Test
     public void testGenerateWithTextOutput() {
         LanguageModel languageModel = new RepeatInputLanguageModel(2);
         var languageModels = Map.of("languageModel", languageModel);
-        
+
         var generatorConfig = new LanguageModelFieldGeneratorConfig.Builder()
                 .providerId("languageModel").responseFormatType(
                         LanguageModelFieldGeneratorConfig.ResponseFormatType.Enum.TEXT
                 ).build();
-        
+
         var generator = createGenerator(generatorConfig, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
-        
+
         var result = generator.generate(StringPrompt.from("hello world"), context);
         assertNotNull(result);
         assertEquals("hello world hello world", result.toString());
     }
-    
+
     @Test
     public void testGenerateInvalidResponseFormatPolicyDiscard() {
         LanguageModel languageModel = new IvalidJsonLanguageModel();
@@ -323,17 +329,17 @@ public class LanguageModelFieldGeneratorTest {
         var result = generator.generate(StringPrompt.from("hello world"), context);
         assertEquals(null, result);
     }
-    
+
     @Test
     public void testGenerateInvalidResponseFormatPolicyFail() {
         LanguageModel languageModel = new IvalidJsonLanguageModel();
         var languageModels = Map.of("languageModel", languageModel);
-        
+
         var generatorConfig = new LanguageModelFieldGeneratorConfig.Builder()
                 .providerId("languageModel").invalidResponseFormatPolicy(
                         LanguageModelFieldGeneratorConfig.InvalidResponseFormatPolicy.Enum.FAIL
                 ).build();
-        
+
         var generator = createGenerator(generatorConfig, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
         assertThrows(IllegalArgumentException.class, () -> generator.generate(StringPrompt.from("hello world"), context));
@@ -344,7 +350,7 @@ public class LanguageModelFieldGeneratorTest {
         var logger = Logger.getLogger(LanguageModelFieldGenerator.class.getName());
         var testLogHandler = new TestLogHandler();
         logger.addHandler(testLogHandler);
-        
+
         LanguageModel languageModel = new IvalidJsonLanguageModel();
         var languageModels = Map.of("languageModel", languageModel);
 
@@ -356,12 +362,12 @@ public class LanguageModelFieldGeneratorTest {
         var generator = createGenerator(generatorConfig, languageModels);
         var context = new FieldGenerator.Context("doc.text", DataType.STRING);
         var result = generator.generate(StringPrompt.from("hello world"), context);
-        
+
         assertEquals(null, result);
 
 
         boolean foundWarning = false;
-        
+
         for (var record : testLogHandler.getRecords()) {
             if (record.getLevel() == Level.WARNING) {
                 if (record.getMessage().contains("Failed to parse JSON value")) {
@@ -370,7 +376,7 @@ public class LanguageModelFieldGeneratorTest {
                 }
             }
         }
-        
+
         assertTrue(foundWarning);
     }
 
@@ -380,14 +386,14 @@ public class LanguageModelFieldGeneratorTest {
         languageModelsRegistry.freeze();
         return new LanguageModelFieldGenerator(config, languageModelsRegistry);
     }
-    
+
     public static class RepeatInputLanguageModel implements LanguageModel {
         private final int repetitions;
-        
+
         public RepeatInputLanguageModel(int repetitions) {
             this.repetitions = repetitions;
         }
-        
+
         @Override
         public List<Completion> complete(Prompt prompt, InferenceParameters params) {
             var stringBuilder = new StringBuilder();
@@ -396,16 +402,16 @@ public class LanguageModelFieldGeneratorTest {
                 stringBuilder.append(prompt.asString());
                 stringBuilder.append(" ");
             }
-            
+
             var completionStr = stringBuilder.toString().trim();
-            
+
             if (params.get(InferenceParameters.OPTION_JSON_SCHEMA).isPresent())
                 completionStr = Text.format("""
                        {
                         "doc.text": "%s"
                        }
                        """, completionStr);
-            
+
             return List.of(Completion.from(completionStr));
         }
 


### PR DESCRIPTION
Small local LLM models can sometimes produce null or empty output on a single attempt. Retry up to 10 times to reduce test flakiness. Also clean up trailing whitespace in test file.

NOTE: adding a debug print showed the LLM would sometimes get stuck generating and producing invalid JSON output, like this:

`
completions: [Completion[text={"doc.text" : "}}(text)  : (type) : (version) : (format)  : (system) : (os) : (model) : (api) : (topic) : (category) : (page) : (previous) : (next) : (back) : (forward) : (help) : (copy) : (delete) : (run) : (create) : (edit) : (view) : (update) : (save) : (load) : (logout) : (quit) : (help) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) : (quit) :, finishReason=stop]]
`
