### PR TITLE
Allow distinguishing feed client instances in access log

### DIFF
--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
@@ -35,7 +35,7 @@ class AccessLogRequestLog extends AbstractLifeCycle implements org.eclipse.jetty
     private static final Logger logger = Logger.getLogger(AccessLogRequestLog.class.getName());
 
     // HTTP headers that are logged as extra key-value-pairs in access log entries
-    private static final List<String> LOGGED_REQUEST_HEADERS = List.of("Vespa-Client-Version");
+    private static final List<String> LOGGED_REQUEST_HEADERS = List.of("Vespa-Client-Version", "Vespa-Client-Id");
 
     private final RequestLog requestLog;
 

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/JettyCluster.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/JettyCluster.java
@@ -110,7 +110,7 @@ class JettyCluster implements Cluster {
                 Request jettyReq = client.httpClient.newRequest(URI.create(client.uri + req.pathAndQuery()))
                         .version(HttpVersion.HTTP_2)
                         .method(HttpMethod.fromString(req.method()))
-                        .headers(hs -> req.headers().forEach((k, v) -> hs.add(k, v.get())))
+                        .headers(hs -> req.headers().forEach((k, v) -> hs.put(k, v.get())))
                         .idleTimeout(reqTimeoutMillis, MILLISECONDS)
                         .timeout(reqTimeoutMillis, MILLISECONDS);
                 if (req.body() != null) {


### PR DESCRIPTION
## Summary
- Log `Vespa-Client-Id` request header as extra attribute in access log, allowing users to identify individual feed client instances
- Use `put` instead of `add` for custom request headers in feed client, so headers like `User-Agent` can be overridden rather than duplicated