### PR TITLE
Use permuted/randomized access patterns for u32 hash set benchmarks

### DIFF
--- a/vespalib/src/tests/util/unordered_u32_set_benchmark.cpp
+++ b/vespalib/src/tests/util/unordered_u32_set_benchmark.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/unordered_u32_set.h>
 #include <benchmark/benchmark.h>
 #include <unordered_set>
+#include <random>
 
 struct FewCollisions {
     constexpr static uint32_t apply(uint32_t v) noexcept {
@@ -19,15 +20,34 @@ struct ManyCollisions {
     }
 };
 
+// Xorshift linear shift feedback register (LSFR) PRNG with a period of 2^32-1.
+// See https://en.wikipedia.org/wiki/Xorshift.
+// Pre -and postcondition: `state` is non-zero (which happens to be exactly what we want).
+inline void xorshift32_step(uint32_t& state) noexcept {
+    uint32_t x = state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    state = x;
+}
+
+// To ensure cosmic fairness and good fortune, this initial PRNG seed value is the
+// 32 MSBs of the SHA-256 of the most blessed string "no bli det liv, rai rai!".
+constexpr uint32_t initial_seed = 0x876ca8fb;
+
 template <typename SetT, typename KeyTransform>
 static void BM_insert_unique_from_empty(benchmark::State& state) {
     for (auto _ : state) {
         state.PauseTiming();
-        SetT set{};
+        SetT set;
         state.ResumeTiming();
         benchmark::ClobberMemory();
+        // We use an LSFR to insert in an "as-if randomized" order that still guarantees
+        // that none of the inserted values are duplicated (unlike if we used a generic PRNG).
+        uint32_t prng_state = initial_seed;
         for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
-            auto res = set.insert(KeyTransform::apply(i));
+            auto res = set.insert(KeyTransform::apply(prng_state));
+            xorshift32_step(prng_state);
             benchmark::DoNotOptimize(res);
         }
         benchmark::DoNotOptimize(set);
@@ -37,13 +57,16 @@ static void BM_insert_unique_from_empty(benchmark::State& state) {
 
 template <typename SetT, typename KeyTransform>
 static void BM_insert_unique_from_pre_sized(benchmark::State& state) {
+    const uint32_t range_len = static_cast<uint32_t>(state.range());
     for (auto _ : state) {
         state.PauseTiming();
-        SetT set{static_cast<uint32_t>(state.range())};
+        SetT set(range_len);
         state.ResumeTiming();
         benchmark::ClobberMemory();
-        for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
-            auto res = set.insert(KeyTransform::apply(i));
+        uint32_t prng_state = initial_seed;
+        for (uint32_t i = 1; i <= range_len; ++i) { // assume range always < UINT32_MAX
+            auto res = set.insert(KeyTransform::apply(prng_state));
+            xorshift32_step(prng_state);
             benchmark::DoNotOptimize(res);
         }
         benchmark::DoNotOptimize(set);
@@ -53,30 +76,42 @@ static void BM_insert_unique_from_pre_sized(benchmark::State& state) {
 
 template <typename SetT, typename KeyTransform>
 static void BM_lookup_existing(benchmark::State& state) {
-    SetT set{};
-    for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
+    const uint32_t range_len = static_cast<uint32_t>(state.range());
+    SetT set(range_len);
+    for (uint32_t i = 1; i <= range_len; ++i) { // assume range always < UINT32_MAX/128
         (void)set.insert(KeyTransform::apply(i));
     }
+    assert(set.size() == range_len);
     benchmark::ClobberMemory();
-    uint32_t next_lookup = 1;
+    // For simplicity, we spray&pray with pseudo-random values in the inserted
+    // range. The use of uniform_int_distribution adds a bit of constant overhead
+    // to each iteration, but it's the same for each set type so it evens out.
+    std::minstd_rand prng;
+    std::uniform_int_distribution dist(1u, range_len);
     for (auto _ : state) {
-        auto ret = set.contains(KeyTransform::apply(next_lookup));
-        next_lookup = (next_lookup <= state.range()) ? next_lookup + 1 : 1; // Avoid modulo
+        auto ret = set.contains(KeyTransform::apply(dist(prng)));
+        assert(ret);
         benchmark::DoNotOptimize(ret);
     }
 }
 
 template <typename SetT, typename KeyTransform>
 static void BM_lookup_missing(benchmark::State& state) {
-    SetT set{};
-    for (ssize_t i = 1; i <= state.range(); ++i) { // assume range always < UINT32_MAX
+    const uint32_t range_len = static_cast<uint32_t>(state.range());
+    SetT set(range_len);
+    for (uint32_t i = 1; i <= range_len; ++i) { // assume range always <= INT32_MAX/128
         (void)set.insert(KeyTransform::apply(i));
     }
+    assert(set.size() == range_len);
     benchmark::ClobberMemory();
-    uint32_t next_lookup = state.range() + 1;
+    std::minstd_rand prng;
+    std::uniform_int_distribution dist(1u, UINT32_MAX);
     for (auto _ : state) {
-        auto ret = set.contains(KeyTransform::apply(next_lookup));
-        next_lookup = (next_lookup < UINT32_MAX) ? next_lookup + 1 : state.range() + 1; // Avoid modulo
+        // Toggle MSB so that no matter what value we end up with, it won't match
+        // any of the inserted values.
+        const uint32_t k = KeyTransform::apply(dist(prng)) | 0x80000000;
+        auto ret = set.contains(k);
+        assert(!ret);
         benchmark::DoNotOptimize(ret);
     }
 }
@@ -106,9 +141,9 @@ BENCHMARK(BM_insert_unique_from_pre_sized<vespalib::UnorderedU32Set,    ManyColl
 
 /// Lookup elements that are known to exist in the set
 
-BENCHMARK(BM_lookup_existing<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
-BENCHMARK(BM_lookup_existing<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
-BENCHMARK(BM_lookup_existing<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_existing<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to << 2);
+BENCHMARK(BM_lookup_existing<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to << 2);
+BENCHMARK(BM_lookup_existing<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to << 2);
 
 BENCHMARK(BM_lookup_existing<std::unordered_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
 BENCHMARK(BM_lookup_existing<vespalib::hash_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
@@ -116,9 +151,9 @@ BENCHMARK(BM_lookup_existing<vespalib::UnorderedU32Set,    ManyCollisions>)->Ran
 
 /// Lookup elements that are known to _not_ exist in the set
 
-BENCHMARK(BM_lookup_missing<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
-BENCHMARK(BM_lookup_missing<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to);
-BENCHMARK(BM_lookup_missing<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to);
+BENCHMARK(BM_lookup_missing<std::unordered_set<uint32_t>, FewCollisions>)->Range(range_from, range_to << 2);
+BENCHMARK(BM_lookup_missing<vespalib::hash_set<uint32_t>, FewCollisions>)->Range(range_from, range_to << 2);
+BENCHMARK(BM_lookup_missing<vespalib::UnorderedU32Set,    FewCollisions>)->Range(range_from, range_to << 2);
 
 BENCHMARK(BM_lookup_missing<std::unordered_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);
 BENCHMARK(BM_lookup_missing<vespalib::hash_set<uint32_t>, ManyCollisions>)->Range(range_from, range_to);


### PR DESCRIPTION
@havardpe please review. Follow-up of #36267.

This pseudo-randomly permutes the order of inserted values for insertion benchmarks and randomizes lookup values for lookup benchmarks (insertion can still be sequential for those).

The rationale for doing this is that sequential access patterns unfairly benefit implementations that use identity hashing for values. If lookup value _n_ is hot in the cache, _n+1_ is also likely giving off smoke.

Inserts of N unique values uses a 32-bit xorshift linear shift feedback register to efficiently generate a pseudo-random permutation of N values in the interval [1, 2^32-1].

Also fix a very silly bug where an `initializer_list` constructor was unintentionally used instead of the initial set size constructor.

