### PR TITLE
Add null-query guard in Execution.fill(Result)

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
@@ -541,6 +541,9 @@ public class Execution extends com.yahoo.processing.execution.Execution {
      * @param result the result to fill
      */
     public void fill(Result result) {
+        if (result.getQuery() == null) {
+            throw new IllegalArgumentException("Result without query cannot be used with 'fill(result)'");
+        }
         fill(result, PartialSummaryHandler.resolveSummaryClass(result));
     }
 


### PR DESCRIPTION
Throw a clear IllegalArgumentException when fill(Result) is called with a Result that has no associated Query, instead of letting it propagate as a confusing NullPointerException deeper in the search chain execution.
