### PR TITLE
Fix semantic rule production item insertion

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/semantics/engine/Evaluation.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/engine/Evaluation.java
@@ -100,9 +100,9 @@ public class Evaluation {
     /** Sets the item iterator to point to the last item: */
     public void setToLast() {
         if (flattenedItems != null)
-                currentIndex = flattenedItems.size() - 1;
+            currentIndex = flattenedItems.size() - 1;
         else
-                currentIndex = -1;
+            currentIndex = -1;
     }
 
     /** Resets the item iterator to point to the last item: */
@@ -285,7 +285,8 @@ public class Evaluation {
         }
 
         if (( desiredParentType == TermType.DEFAULT || desiredParentType.hasItemClass(parent.getClass()) )
-             && equalIndexNameIfParentIsPhrase(items, parent)) {
+            && equalIndexNameIfParentIsPhrase(items, parent))
+        {
             for (Item item : items)
                 addItem(parent, index, item, desiredParentType);
         }
@@ -362,13 +363,12 @@ public class Evaluation {
             return;
         }
 
-        for (Item item : items)
-            newParent.addItem(item);
-
         Item current = parent;
         if (parent instanceof QueryTree && parent.getItemCount() > 0)
             current = parent.getItem(0);
         if (current instanceof CompositeItem && !replacing) { // insert new parent below the current
+            for (Item item : items)
+                newParent.addItem(item);
             if (parent.getItemCount() > index) {
                 var combinedItem = combineItems(newParent, parent.getItem(index), desiredParentType);
                 parent.setItem(index, combinedItem);
@@ -379,6 +379,8 @@ public class Evaluation {
         }
         else if (newParent.acceptsItemsOfType(current.getItemType())) { // insert new parent above the current
             newParent.addItem(current);
+            for (Item item : items)
+                newParent.addItem(item);
             if (newParent != parentsParent) { // Insert new parent as root or child of old parent's parent
                 if (parentsParent != null)
                     parentsParent.setItem(parentsParent.getItemIndex(current), newParent);
@@ -387,6 +389,8 @@ public class Evaluation {
             }
         }
         else {
+            for (Item item : items)
+                newParent.addItem(item);
             ((CompositeItem)current).addItem(newParent); // not an acceptable child -> composite
         }
     }
@@ -457,15 +461,11 @@ public class Evaluation {
     private CompositeItem createType(TermType termType) {
         if (termType == TermType.DEFAULT) {
             if (query.getModel().getType() == Query.Type.ANY)
-                return new OrItem();
+                termType = TermType.OR;
             else if (query.getModel().getType() == Query.Type.WEAKAND)
-                return new WeakAndItem();
-            else
-                return new AndItem();
+                termType = TermType.WEAK_AND;
         }
-        else {
-            return (CompositeItem)termType.createItemClass();
-        }
+        return (CompositeItem)termType.createItemClass();
     }
 
     private void flatten(Item item,int position,List<FlattenedItem> toList) {

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/LiteralTermProduction.java
@@ -80,6 +80,11 @@ public class LiteralTermProduction extends TermProduction {
                 Match matched = e.getNonreferencedMatch(0);
                 insertMatch(e, matched, List.of(newItem), offset);
             }
+            else if (e.getNonreferencedMatchCount() > 0 && parentHasCompatibleType(e.getNonreferencedMatch(0))) {
+                // Parent already has the right type (e.g., OR inside OR) - insert after match
+                Match matched = e.getNonreferencedMatch(0);
+                insertMatch(e, matched, List.of(newItem), offset + 1);
+            }
             else {
                 // Use root-level combining for specific types (RANK, OR, etc.) and non-nested cases
                 e.addItems(List.of(newItem), getTermType());

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/ReferenceTermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/ReferenceTermProduction.java
@@ -130,8 +130,12 @@ public class ReferenceTermProduction extends TermProduction {
             insertMatch(e, match, items, offset);
         }
         else if (shouldInsertAtMatch(match)) {
-            // Add to the match's parent when it's a nested composite (handles WeakAnd correctly)
+            // Add to the match's parent when it's a nested composite with default type
             insertMatch(e, match, items, offset);
+        }
+        else if (parentHasCompatibleType(match)) {
+            // Parent already has the right type - insert after match
+            insertMatch(e, match, items, offset + 1);
         }
         else {
             // Use root-level combining for other cases

--- a/container-search/src/main/java/com/yahoo/prelude/semantics/rule/TermProduction.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/rule/TermProduction.java
@@ -180,4 +180,18 @@ public abstract class TermProduction extends Production {
         return grandparent != null && !(grandparent instanceof QueryTree);
     }
 
+    /**
+     * Returns true if the match's parent already has the same type as this production's term type,
+     * and is nested (not directly under root). In this case we should add to the existing parent
+     * rather than creating a new one at root level.
+     */
+    protected boolean parentHasCompatibleType(Match match) {
+        if (getTermType() == TermType.DEFAULT) return false;
+        CompositeItem parent = match.getParent();
+        if (parent == null) return false;
+        if (!getTermType().hasItemClass(parent.getClass())) return false;
+        CompositeItem grandparent = parent.getParent();
+        return grandparent != null && !(grandparent instanceof QueryTree);
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/MatchOnlyIfNotOnlyTermTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/MatchOnlyIfNotOnlyTermTestCase.java
@@ -17,8 +17,8 @@ public class MatchOnlyIfNotOnlyTermTestCase extends RuleBaseAbstractTestCase {
 
     @Test
     void testMatch() {
-        assertSemantics("RANK showname:\"saturday night live\"!1000 (AND justin timberlake)", "justin timberlake snl");
-        assertSemantics("RANK showname:\"saturday night live\"!1000 (AND justin timberlake)", "justin timberlake saturday night live");
+        assertSemantics("RANK (AND justin timberlake) showname:\"saturday night live\"!1000", "justin timberlake snl");
+        assertSemantics("RANK (AND justin timberlake) showname:\"saturday night live\"!1000", "justin timberlake saturday night live");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/OrPhraseTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/OrPhraseTestCase.java
@@ -14,13 +14,13 @@ public class OrPhraseTestCase extends RuleBaseAbstractTestCase {
 
     @Test
     void testReplacing1() {
-        assertSemantics("OR title:\"software engineer\" (AND new york)", "software engineer new york");
+        assertSemantics("OR (AND new york) title:\"software engineer\"", "software engineer new york");
         assertSemantics("title:\"software engineer\"", "software engineer"); // Skip OR when there is nothing else
     }
 
     @Test
     void testReplacing2() {
-        assertSemantics("OR \"lord of the rings\" lotr", "lotr");
+        assertSemantics("OR lotr \"lord of the rings\"", "lotr");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/SemanticSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/SemanticSearcherTestCase.java
@@ -131,12 +131,12 @@ public class SemanticSearcherTestCase extends RuleBaseAbstractTestCase {
 
     @Test
     void testTypeChange() {
-        assertSemantics("RANK default:typechange doors", "typechange doors");
+        assertSemantics("RANK doors default:typechange", "typechange doors");
     }
 
     @Test
     void testTypeChangeWithSingularToPluralButNonReplaceWillNotSingularify() {
-        assertSemantics("RANK default:typechange door", "typechange door");
+        assertSemantics("RANK door default:typechange", "typechange door");
     }
 
     @Test
@@ -147,11 +147,12 @@ public class SemanticSearcherTestCase extends RuleBaseAbstractTestCase {
     @Test
     void testOrProduction() {
         assertSemantics("OR something somethingelse", "something");
+
         // I did not expect this:
         assertSemantics("OR (AND foo1 something bar2) somethingelse", "foo1 something bar2");
-        // Nor this; we should fix documentation to emphasize that "+>" adding terms
-        // always happens at the root of the query:
-        assertSemantics("OR (RANK (AND foo1 (OR foo2 something bar1) bar2) bar3) somethingelse",
+
+        // but at least works like expected:
+        assertSemantics("RANK (AND foo1 (OR foo2 something somethingelse bar1) bar2) bar3",
                         "foo1 AND (foo2 OR something OR bar1) AND bar2 RANK bar3",
                         0, Query.Type.ADVANCED);
     }
@@ -160,7 +161,7 @@ public class SemanticSearcherTestCase extends RuleBaseAbstractTestCase {
     void testDoubleOrProduction() {
         assertSemantics("OR more evenmore", "somethingmore");
         // Strange ordering:
-        assertSemantics("OR more (AND foo1 bar2) evenmore", "foo1 somethingmore bar2");
+        assertSemantics("OR (AND foo1 bar2) more evenmore", "foo1 somethingmore bar2");
     }
 
     // This test is order dependent. Fix it!!
@@ -186,8 +187,8 @@ public class SemanticSearcherTestCase extends RuleBaseAbstractTestCase {
         assertSemantics("brand:smashtogether", "\"smash together\"");
         assertSemantics("brand:smashtogether", "smash-together");
         assertSemantics("AND foo1 brand:smashtogether bar2", "foo1 \"smash together\" bar2");
-        assertSemantics("AND brand:smashtogether \"foo1 bar2\"", "\"foo1 smash together bar2\"");
-        assertSemantics("OR brand:smashtogether \"foo1 bar2\"", "\"foo1 smash together bar2\"", 0, Query.Type.ANY);
+        assertSemantics("AND \"foo1 bar2\" brand:smashtogether", "\"foo1 smash together bar2\"");
+        assertSemantics("OR \"foo1 bar2\" brand:smashtogether", "\"foo1 smash together bar2\"", 0, Query.Type.ANY);
         // the difference in ordering here is because the parsed query already has a WEAKAND root (with 1 child):
         assertSemantics("WEAKAND \"foo1 bar2\" brand:smashtogether", "\"foo1 smash together bar2\"", 0, Query.Type.WEAKAND);
     }
@@ -205,11 +206,10 @@ public class SemanticSearcherTestCase extends RuleBaseAbstractTestCase {
     @Test
     void testWandReplacement() {
         assertSemantics("WEAKAND greatest", "goat");
-        assertSemantics("WEAKAND greatest dazed", "dazed goat");
-        assertSemantics("WEAKAND greatest (AND dazed disoriented)", "dazed goat disoriented");
+        assertSemantics("WEAKAND dazed greatest", "dazed goat");
+        assertSemantics("WEAKAND (AND dazed disoriented) greatest", "dazed goat disoriented");
         assertSemantics("WEAKAND the greatest of all time", "thegoat");
-        // Strange ordering again:
-        assertSemantics("WEAKAND the (AND dazed disoriented) greatest of all time", "dazed thegoat disoriented");
+        assertSemantics("WEAKAND (AND dazed disoriented) the greatest of all time", "dazed thegoat disoriented");
     }
 
     private Result doSearch(Searcher searcher, Query query, int offset, int hits) {


### PR DESCRIPTION
Move newParent.addItem() into each insertion branch in Evaluation so items are added in the correct context-dependent order. Add parentHasCompatibleType() to TermProduction so that when a match's parent already has the desired type (e.g. OR inside OR), new items are inserted at the match position rather than wrapped at root level.

Refactor createType() to always delegate to TermType.createItemClass().

@sebastiannberg FYI
