### PR TITLE
fix "vespa status" to show all endpoints, not just the first

### DIFF
--- a/client/go/internal/cli/cmd/curl.go
+++ b/client/go/internal/cli/cmd/curl.go
@@ -23,6 +23,7 @@ func newCurlCmd(cli *CLI) *cobra.Command {
 		Long: `Access Vespa directly using curl.
 
 Execute curl with the appropriate URL, certificate and private key for your application.
+Assumes MTLS authentication.
 
 For a more high-level interface to query and feeding, see the 'query' and 'document' commands.
 `,
@@ -38,7 +39,7 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 				return err
 			}
 			waiter := cli.waiter(time.Duration(waitSecs)*time.Second, cmd)
-			service, err := waiter.Service(target, cli.config.cluster())
+			service, err := waiter.ServiceWithAuthMethod(target, cli.config.cluster(), "mtls")
 			if err != nil {
 				return err
 			}

--- a/client/go/internal/cli/cmd/status.go
+++ b/client/go/internal/cli/cmd/status.go
@@ -60,7 +60,11 @@ $ vespa status --no-verify`,
 				return err
 			}
 			if len(services) == 0 {
-				return errHint(fmt.Errorf("no services exist"), "Deployment may not be ready yet", "Try 'vespa status deployment'")
+				if cluster == "" {
+					return errHint(fmt.Errorf("no services exist"), "Deployment may not be ready yet", "Try 'vespa status deployment'")
+				} else {
+					return errHint(fmt.Errorf("no services exist for cluster '%v'", cluster), "Bad cluster name or not ready", "For full status try: vespa status --cluster \"\"")
+				}
 			}
 			for _, s := range services {
 				if !printServiceStatus(s, format, waiter, cli, noVerify) {

--- a/client/go/internal/cli/cmd/status.go
+++ b/client/go/internal/cli/cmd/status.go
@@ -55,24 +55,14 @@ $ vespa status --no-verify`,
 			}
 			waiter := cli.waiter(time.Duration(waitSecs)*time.Second, cmd)
 			var failingContainers []*vespa.Service
-			if cluster == "" {
-				services, err := waiter.Services(t)
-				if err != nil {
-					return err
-				}
-				if len(services) == 0 {
-					return errHint(fmt.Errorf("no services exist"), "Deployment may not be ready yet", "Try 'vespa status deployment'")
-				}
-				for _, s := range services {
-					if !printServiceStatus(s, format, waiter, cli, noVerify) {
-						failingContainers = append(failingContainers, s)
-					}
-				}
-			} else {
-				s, err := waiter.Service(t, cluster)
-				if err != nil {
-					return err
-				}
+			services, err := waiter.NamedServices(cluster, t)
+			if err != nil {
+				return err
+			}
+			if len(services) == 0 {
+				return errHint(fmt.Errorf("no services exist"), "Deployment may not be ready yet", "Try 'vespa status deployment'")
+			}
+			for _, s := range services {
 				if !printServiceStatus(s, format, waiter, cli, noVerify) {
 					failingContainers = append(failingContainers, s)
 				}

--- a/client/go/internal/cli/cmd/waiter.go
+++ b/client/go/internal/cli/cmd/waiter.go
@@ -32,11 +32,7 @@ func (w *Waiter) DeployService(target vespa.Target) (*vespa.Service, error) {
 	return s, nil
 }
 
-// Service returns the service identified by cluster ID, available on target.
-func (w *Waiter) Service(target vespa.Target, cluster string) (*vespa.Service, error) {
-	return w.ServiceWithAuthMethod(target, cluster, "mtls")
-}
-
+// ServiceWithAuthMethod returns the service identified by cluster ID and authentication method, available on target.
 func (w *Waiter) ServiceWithAuthMethod(target vespa.Target, cluster string, authMethod string) (*vespa.Service, error) {
 	targetType, err := w.cli.targetType(anyTarget)
 	if err != nil {
@@ -67,16 +63,27 @@ func (w *Waiter) ServiceWithAuthMethod(target vespa.Target, cluster string, auth
 
 // Services returns all container services available on target.
 func (w *Waiter) Services(target vespa.Target) ([]*vespa.Service, error) {
+	return w.NamedServices("", target)
+}
+
+// NamedServices returns services matching the given name on target, or all services if name is empty.
+func (w *Waiter) NamedServices(name string, target vespa.Target) ([]*vespa.Service, error) {
 	services, err := w.services(target)
 	if err != nil {
 		return nil, err
 	}
+	result := make([]*vespa.Service, 0, len(services))
 	for _, s := range services {
+		if name == "" || name == s.Name {
+			result = append(result, s)
+		}
+	}
+	for _, s := range result {
 		if err := w.maybeWaitFor(s); err != nil {
 			return nil, err
 		}
 	}
-	return services, nil
+	return result, nil
 }
 
 func (w *Waiter) maybeWaitFor(service *vespa.Service) error {

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -264,18 +264,27 @@ func (s *Service) Description() string {
 	return s.Type() + " " + s.Name
 }
 
-// FindService returns the service of given name, found among services, if any.
+// FindService returns the service matching name and authMethod from services,
+// with fallbacks if no exact match was found.
 func FindService(name string, authMethod string, services []*Service) (*Service, error) {
+	// First pass: exact match on both name and authMethod
 	applicableServices := make([]*Service, 0, len(services))
 	for _, s := range services {
+		if name == s.Name && s.AuthMethod == authMethod {
+			return s, nil
+		}
 		if s.AuthMethod == authMethod || s.AuthMethod == "" {
 			applicableServices = append(applicableServices, s)
 		}
 	}
-	if name == "" && len(applicableServices) == 1 {
-		return applicableServices[0], nil
+	// Second pass: match by name among services with compatible authMethod
+	for _, s := range applicableServices {
+		if name == "" || name == s.Name {
+			return s, nil
+		}
 	}
 	names := make([]string, 0, len(services))
+	// Third pass: match by name among all services, or generate error message
 	for _, s := range services {
 		if name == s.Name {
 			return s, nil


### PR DESCRIPTION
When a cluster name was not specified, "vespa status" only returned a single service due to FindService requiring an exact one-match result. Refactor to unify the two code paths (named cluster vs all clusters) into a single NamedServices method that filters and iterates properly.

Also improve FindService to prefer exact name+authMethod matches before falling back to looser matching, and make "vespa curl" explicitly request MTLS authentication instead of relying on the removed Service() wrapper.
