### PR TITLE
Add setUnfillable() API on Hit

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -8638,6 +8638,7 @@
       "public void setCached(boolean)",
       "public boolean isCached()",
       "public void setFillable()",
+      "public void setUnfillable()",
       "public void setFilled(java.lang.String)",
       "public boolean isFillable()",
       "public java.util.Set getFilled()",

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -8745,6 +8745,7 @@
       "public void analyze()",
       "public com.yahoo.search.result.HitGroup clone()",
       "public void setFillable()",
+      "public void setUnfillable()",
       "public void setFilled(java.lang.String)",
       "public boolean isFillable()",
       "public java.util.Set getFilled()",

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/GroupingExecutor.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/GroupingExecutor.java
@@ -154,11 +154,8 @@ public class GroupingExecutor extends Searcher {
             Hit hit = it.next();
             if (hit.getSearcherSpecificMetaData(this) instanceof String metaDataString) {
                 if (hit.isFilled(metaDataString)) {
-                    hit.setFilled(null);
-                    // TODO: the above should have been enough
-                    hit.setFilled(summaryClass);
-                    // we could in theory also clear SearcherSpecificMetaData here,
-                    // but there's no gain and some risk involved.
+                    // mark as fully filled:
+                    hit.setUnfillable();
                 }
             }
         }

--- a/container-search/src/main/java/com/yahoo/search/result/Hit.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Hit.java
@@ -329,7 +329,8 @@ public class Hit extends ListenableFreezableClass implements Data, Comparable<Hi
      * summaries. This also enables tracking of which summary classes
      * have been used for filling so far. Invoking this method
      * multiple times is allowed and will have no addition
-     * effect. Note that a fillable hit may not be made unfillable.
+     * effect. Call setUnfillable() if there is no more data fill()
+     * can obtain for that hit.
      */
     public void setFillable() {
         if (filled == null) {
@@ -337,6 +338,14 @@ public class Hit extends ListenableFreezableClass implements Data, Comparable<Hi
             filled = Collections.emptySet();
             unmodifiableFilled = filled;
         }
+    }
+
+    /**
+     * Tag this hit as no longer fillable.
+     */
+    public void setUnfillable() {
+        filled = null;
+        unmodifiableFilled = null;
     }
 
     /**
@@ -354,7 +363,6 @@ public class Hit extends ListenableFreezableClass implements Data, Comparable<Hi
         } else if (filled.size() == 1) {
             filled = new HashSet<>(filled);
             unmodifiableFilled = Collections.unmodifiableSet(filled);
-
             filled.add(summaryClass);
         } else {
             filled.add(summaryClass);
@@ -600,7 +608,7 @@ public class Hit extends ListenableFreezableClass implements Data, Comparable<Hi
 
     final void setFilledInternal(Set<String> filled) {
         this.filled = filled;
-        unmodifiableFilled = (filled != null) ? Collections.unmodifiableSet(filled) : null;
+        unmodifiableFilled = (filled == null) ? null : Collections.unmodifiableSet(filled);
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/result/HitGroup.java
+++ b/container-search/src/main/java/com/yahoo/search/result/HitGroup.java
@@ -864,8 +864,15 @@ public class HitGroup extends Hit implements DataList<Hit>, Cloneable, Iterable<
         return hitGroupClone;
     }
 
+    /** Ignored as this should always be derived from the content hits */
     @Override
     public void setFillable() {}
+
+    /** This does not make sense for a HitGroup, must be done on the content hits */
+    @Override
+    public void setUnfillable() {
+        throw new IllegalArgumentException("calling setUnfillable() on a HitGroup does not make sense, it needs to be called on its individual hits");
+    }
 
     /** Ignored as this should always be derived from the content hits */
     @Override

--- a/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/fastsearch/PartialSummaryHandlerTestCase.java
@@ -43,6 +43,14 @@ public class PartialSummaryHandlerTestCase {
         assertTrue(hit1.isFilled(null));
         assertTrue(hit1.isFilled("default"));
         assertEquals(1, result.hits().getFilled().size());
+        assertTrue(result.hits().isFilled(null));
+        assertFalse(result.hits().isFilled("foobar"));
+        hit2.setUnfillable();
+        assertTrue(result.hits().isFilled("default"));
+        assertTrue(result.hits().isFilled(null));
+        assertFalse(result.hits().isFilled("foobar"));
+        hit1.setUnfillable();
+        assertTrue(result.hits().isFilled("foobar"));
     }
 
     @Test


### PR DESCRIPTION
Add explicit setUnfillable() API on Hit
GroupingExecutor needed to mark hits as fully filled (no more data
obtainable via fill), but had to resort to a hack calling
setFilled(null) followed by setFilled(summaryClass) since there was
no supported way to transition a fillable hit back to unfillable.

Add Hit.setUnfillable() to make this a first-class operation, and
use it in GroupingExecutor to replace the workaround. Also adds test
coverage for the new method and its interaction with HitGroup.isFilled.
