### PR TITLE
Add method to InputReader for reading into caller-provided buffer

### DIFF
--- a/vespalib/src/tests/data/input_reader/input_reader_test.cpp
+++ b/vespalib/src/tests/data/input_reader/input_reader_test.cpp
@@ -155,4 +155,31 @@ TEST(InputReaderTest, require_that_try_read_finds_eof_without_failing_the_reader
     EXPECT_TRUE(!src.failed());
 }
 
+TEST(InputReaderTest, can_read_across_chunks_into_caller_buffer) {
+    const char *data = "the quick red fox rocket-jumps over the lazy dog";
+    MemoryInput memory_input(data);
+    ChunkedInput input(memory_input, 3);
+    InputReader src(input);
+    std::string buf(12, '_');
+    ASSERT_TRUE(src.read_into(buf.data(), 1)); // smaller than chunk
+    EXPECT_EQ(buf, "t___________");
+    ASSERT_TRUE(src.read_into(buf.data(), 4)); // remaining of chunk + partial of next chunk
+    EXPECT_EQ(buf, "he q________");
+    ASSERT_TRUE(src.read_into(buf.data(), 5)); // remaining of chunk + full chunk + partial
+    EXPECT_EQ(buf, "uick _______");
+    ASSERT_TRUE(src.read_into(buf.data(), 12)); // spanning multiple full chunks
+    EXPECT_EQ(buf, "red fox rock");
+    ASSERT_TRUE(src.read_into(buf.data(), 12));
+    EXPECT_EQ(buf, "et-jumps ove");
+    ASSERT_TRUE(src.read_into(buf.data(), 12));
+    EXPECT_EQ(buf, "r the lazy d");
+    buf.assign(12, '_');
+    ASSERT_TRUE(src.read_into(buf.data(), 2));
+    EXPECT_EQ(buf, "og__________");
+    EXPECT_FALSE(src.failed());
+    EXPECT_FALSE(src.read_into(buf.data(), 1));
+    EXPECT_TRUE(src.failed());
+    EXPECT_EQ(src.get_error_message(), "input underflow");
+}
+
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/data/input_reader.cpp
+++ b/vespalib/src/vespa/vespalib/data/input_reader.cpp
@@ -44,6 +44,26 @@ InputReader::read_slow(size_t bytes)
     return Memory();
 }
 
+bool
+InputReader::read_into_slow(void *buf, const size_t bytes)
+{
+    char *out = static_cast<char*>(buf);
+    size_t read = 0;
+    while ((read < bytes) && (obtain() > 0)) {
+        const size_t copy_now = std::min(size(), bytes - read);
+        memcpy(out + read, data(), copy_now);
+        read += copy_now;
+        _pos += copy_now;
+    }
+    if (read == bytes) [[likely]] {
+        return true;
+    }
+    if (!failed()) {
+        fail("input underflow");
+    }
+    return false;
+}
+
 InputReader::~InputReader()
 {
     _input.evict(_pos);

--- a/vespalib/src/vespa/vespalib/data/input_reader.h
+++ b/vespalib/src/vespa/vespalib/data/input_reader.h
@@ -33,6 +33,7 @@ private:
     size_t obtain_slow();
     char read_slow();
     Memory read_slow(size_t bytes);
+    bool read_into_slow(void* buf, size_t bytes);
 
 public:
     explicit InputReader(Input &input)
@@ -120,6 +121,27 @@ public:
             return ret;
         }
         return read_slow(bytes);
+    }
+
+    /**
+     * Read data into output buffer `buf`, transparently handling multiple chunks.
+     *
+     * This is an alternative to read() that copies into a receiving buffer
+     * without using a temporary for oversized reads. Useful for interop with
+     * legacy read() usage that already allocates a dedicated receiver buffer
+     * at the caller side.
+     *
+     * @param buf Output buffer for read results.
+     * @param bytes Number of bytes to read into `buf`.
+     * @return true iff reading `bytes` number of bytes into `buf` succeeded.
+     */
+    [[nodiscard]] bool read_into(void *buf, const size_t bytes) {
+        if (obtain() >= bytes) [[likely]] {
+            memcpy(buf, data(), bytes);
+            _pos += bytes;
+            return true;
+        }
+        return read_into_slow(buf, bytes);
     }
 };
 


### PR DESCRIPTION
@havardpe please review

The existing `read(n)` function returns a `Memory` view which will transparently point to an internal intermediate buffer if the read ends up exceeding what's remaining of the current chunk data. This adds an extra copying indirection if the caller intends to copy the data into its own dedicated buffer anyway.

This adds a separate `read_into(buf, n)` function which copies chunk data into the caller buffer without the temporary buffer indirection. Useful for interoperability with callers that are built around standard file read APIs rather than zero-copy style APIs.
