### PR TITLE
Sample jdisc.http.latency before access log entry construction

### DIFF
--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -89,8 +89,8 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
             server.setRequestLog(metricAggregatingRequestLog);
         } else {
             server.setRequestLog(new org.eclipse.jetty.server.RequestLog.Collection(
-                    new AccessLogRequestLog(requestLog),
-                    metricAggregatingRequestLog));
+                    metricAggregatingRequestLog,
+                    new AccessLogRequestLog(requestLog)));
         }
         setupJmx(server, serverConfig);
         configureJettyThreadpool(server, serverConfig);


### PR DESCRIPTION
## Summary

- Reorder Jetty `RequestLog.Collection` members so that `MetricAggregatingRequestLog` runs before `AccessLogRequestLog`
- Ensures the latency end-timestamp (`System.currentTimeMillis()`) is captured before access log entry construction, giving a more accurate measurement
- `RequestLog.Collection` iterates members in constructor order (verified in Jetty source)