### PR TITLE
Add warning logging for unlogged 500 responses in SearchHandler

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -291,7 +291,11 @@ public class SearchHandler extends LoggingRequestHandler {
 
         // Transform result to response
         Renderer<Result> renderer = toRendererCopy(query.getPresentation().getRenderer());
-        HttpSearchResponse response = new HttpSearchResponse(getHttpResponseStatus(request, result),
+        int status = getHttpResponseStatus(request, result);
+        if (status >= 500 && result.hits().getError() != null) {
+            log.log(Level.WARNING, () -> "Search request returning %d: %s".formatted(status, result.hits().getError().getDetailedMessage()));
+        }
+        HttpSearchResponse response = new HttpSearchResponse(status,
                                                              result, query, renderer,
                                                              extractTraceNode(query),
                                                              metric);


### PR DESCRIPTION
## Summary
- SearchHandler.handleBody() could return HTTP 500 when the search Result contained error messages mapping to 500 via VespaHeaders, but no logging was emitted for this path
- The exception-based 500 paths all log at WARNING/SEVERE, but the non-exception Result error path was silent
- Add a warning log when the resolved HTTP status is >= 500 and the result contains an error