### PR TITLE
Expose HTTP/2 rate control configuration for jdisc connector

### DIFF
--- a/container-disc/abi-spec.json
+++ b/container-disc/abi-spec.json
@@ -1832,6 +1832,7 @@
       "public void <init>(com.yahoo.jdisc.http.ConnectorConfig$Http2)",
       "public com.yahoo.jdisc.http.ConnectorConfig$Http2$Builder streamIdleTimeout(double)",
       "public com.yahoo.jdisc.http.ConnectorConfig$Http2$Builder maxConcurrentStreams(int)",
+      "public com.yahoo.jdisc.http.ConnectorConfig$Http2$Builder maxRateControlEvents(int)",
       "public com.yahoo.jdisc.http.ConnectorConfig$Http2 build()"
     ],
     "fields" : [ ]
@@ -1846,7 +1847,8 @@
     "methods" : [
       "public void <init>(com.yahoo.jdisc.http.ConnectorConfig$Http2$Builder)",
       "public double streamIdleTimeout()",
-      "public int maxConcurrentStreams()"
+      "public int maxConcurrentStreams()",
+      "public int maxRateControlEvents()"
     ],
     "fields" : [ ]
   },

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -14,6 +14,8 @@ import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.http2.RateControl;
+import org.eclipse.jetty.http2.WindowRateControl;
 import org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
@@ -209,6 +211,12 @@ public class ConnectorFactory {
         factory.setMaxConcurrentStreams(connectorConfig.http2().maxConcurrentStreams());
         factory.setInitialSessionRecvWindow(1 << 24);
         factory.setInitialStreamRecvWindow(1 << 20);
+        int maxRateControlEvents = connectorConfig.http2().maxRateControlEvents();
+        if (maxRateControlEvents > 0) {
+            factory.setRateControlFactory(new WindowRateControl.Factory(maxRateControlEvents));
+        } else if (maxRateControlEvents < 0) {
+            factory.setRateControlFactory(new RateControl.Factory() {});
+        }
     }
 
     private SslConnectionFactory newSslConnectionFactory(Metric metric, ConnectionFactory wrappedFactory) {

--- a/container-disc/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
+++ b/container-disc/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
@@ -140,6 +140,11 @@ http2.streamIdleTimeout double default=600
 
 http2.maxConcurrentStreams int default=512
 
+# Maximum number of HTTP/2 rate-controlled events per second (e.g. WINDOW_UPDATE, RST_STREAM).
+# Jetty's default of 128 is too low given Vespa's default of 512 max concurrent streams.
+# Set to 0 to use Jetty's built-in default. A value of -1 disables rate control entirely.
+http2.maxRateControlEvents int default=50000
+
 # Override the default server name when authority is missing from request.
 serverName.fallback string default=""
 


### PR DESCRIPTION
## Problem

Jetty's `WindowRateControl` defaults to 128 events/second. Workloads with many concurrent HTTP/2 streams (e.g., bulk document operations, data exports) can exceed this limit through normal WINDOW_UPDATE frame flow control, causing the server to send GOAWAY with `ENHANCE_YOUR_CALM` and `debug="invalid_window_update_frame_rate"` — even when the server has ample thread capacity.

This is not configurable through the current `jdisc.http.connector` config.

Relates to #36319.

## Changes

Adds `http2.maxRateControlEvents` to the `jdisc.http.connector` config definition:

- `50000` (default): solves the problem out of the box — comfortably accommodates Vespa's default of 512 max concurrent streams while still providing flood protection
- `0`: use Jetty's built-in default (128 events/second)
- `< 0`: disable rate control entirely

Wires the setting through `ConnectorFactory.setHttp2Config()` via `setRateControlFactory()`.

## Testing

- Built and ran `mvn verify` on `container-disc` — 168 tests pass, ABI spec updated
- Tested locally by building the JAR from the v8.629.20 tag, swapping it into a running Vespa cluster, and running 5 concurrent bulk exports. Zero ENHANCE_YOUR_CALM errors with the 50000 limit vs consistent failures with the Jetty default of 128

## Example Configuration

```xml
<server id="default" port="8080">
  <config name="jdisc.http.connector">
    <http2>
      <maxRateControlEvents>50000</maxRateControlEvents>
    </http2>
  </config>
</server>
```