### PR TITLE
Add FINE-level logging for 500 responses in SearchHandler

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -291,7 +291,11 @@ public class SearchHandler extends LoggingRequestHandler {
 
         // Transform result to response
         Renderer<Result> renderer = toRendererCopy(query.getPresentation().getRenderer());
-        HttpSearchResponse response = new HttpSearchResponse(getHttpResponseStatus(request, result),
+        int status = getHttpResponseStatus(request, result);
+        if (status == 500 && result.hits().getError() != null) {
+            log.log(Level.FINE, () -> "Search request returning %d: %s".formatted(status, result.hits().getError().getDetailedMessage()));
+        }
+        HttpSearchResponse response = new HttpSearchResponse(status,
                                                              result, query, renderer,
                                                              extractTraceNode(query),
                                                              metric);


### PR DESCRIPTION
## Summary
Reland of #36317 which was reverted in #36318 because WARNING-level logging triggered on 503 responses in tests.

Changes from the original PR:
- Log at `Level.FINE` instead of `WARNING` to avoid noise in test and production logs
- Only log for HTTP 500 specifically, not all 5xx (excludes e.g. 503 backend connection failures)
- Wrap `IllegalArgumentException` from `Query.Builder` in `IllegalInputException` so malformed query parameters return 400 instead of 500