### PR TITLE
Fix stale config keys after failed construction v2

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/Container.java
@@ -149,6 +149,15 @@ public class Container {
                 // Continues loop
 
             } else if (snapshot instanceof ComponentsConfigs) {
+                if (leastGeneration > graph.generation()) {
+                    // Recovery after failed construction with empty config keys:
+                    // ComponentsConfigs only has bootstrap keys, need to rebuild graph
+                    // to discover actual component config keys for next iteration.
+                    throwIfPlatformBundlesChanged(snapshot);
+                    installApplicationBundles(snapshot.configs());
+                    graph = createComponentGraph(snapshot.configs(), getComponentsGeneration(), fallbackInjector);
+                    continue;
+                }
                 break;
             }
         }

--- a/container-disc/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/Container.java
@@ -118,7 +118,11 @@ public class Container {
     {
         ConfigSnapshot snapshot;
         while (true) {
-            snapshot = retriever.getConfigs(graph.configKeys(), leastGeneration, isInitializing);
+            // If the previous generation was invalidated (leastGeneration > graph.generation()),
+            // the old graph's config keys may reference components that no longer exist.
+            // Use empty keys to force a bootstrap-first config retrieval.
+            var configKeys = leastGeneration > graph.generation() ? Set.<ConfigKey<? extends ConfigInstance>>of() : graph.configKeys();
+            snapshot = retriever.getConfigs(configKeys, leastGeneration, isInitializing);
 
             if (log.isLoggable(FINE))
                 log.log(FINE, Text.format("getConfigAndCreateGraph:\n" + "graph.configKeys = %s\n" + "graph.generation = %s\n" + "snapshot = %s\n",

--- a/container-disc/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-disc/src/main/java/com/yahoo/container/di/Container.java
@@ -37,7 +37,8 @@ import static java.util.logging.Level.FINE;
 /**
  * @author gjoranv
  * @author Tony Vaagenes
- * @author ollivir
+ * @author Olli Virtanen
+ * @author glebashnik
  */
 public class Container {
 
@@ -54,6 +55,12 @@ public class Container {
     private List<String> platformBundles;  // Used to verify that platform bundles don't change.
     private long previousConfigGeneration = -1L;
     private long leastGeneration = -1L;
+    
+    // Config keys from the most recently failed graph construction.
+    // Set to the failed graph's keys when constructComponents fails (component class exists, keys are valid);
+    // set to empty when graph creation itself fails (keys may be stale/missing after bootstrap change).
+    // Used in recovery mode to subscribe to the right set of configs.
+    private Set<ConfigKey<? extends ConfigInstance>> failedGraphConfigKeys = Set.of();
 
     public Container(SubscriberFactory subscriberFactory,
                      com.yahoo.container.Container vespaContainer,
@@ -86,16 +93,28 @@ public class Container {
                 }
                 Collection<Bundle> newBundlesFromFailedGen = osgi.completeBundleGeneration(Osgi.GenerationStatus.FAILURE);
                 deconstructComponentsAndBundles(getBootstrapGeneration(), newBundlesFromFailedGen, List.of());
+                
+                // Graph creation failed: config keys may be stale (bootstrap changed, component class missing).
+                // Use empty keys to force bootstrap-first retrieval on next attempt.
+                failedGraphConfigKeys = Set.of();
+                
                 throw t;
             }
+            
             try {
                 constructComponents(newGraph);
             } catch (Throwable e) {
                 log.warning("Failed to construct components for generation '" + newGraph.generation() + "' - scheduling partial graph for deconstruction");
                 Collection<Bundle> newBundlesFromFailedGen = osgi.completeBundleGeneration(Osgi.GenerationStatus.FAILURE);
                 deconstructFailedGraph(oldGraph, newGraph, newBundlesFromFailedGen);
+                
+                // Construction failed: the component class exists, so its config keys are valid and can be
+                // reused in recovery mode to detect config-only changes without needing a bootstrap reload.
+                failedGraphConfigKeys = newGraph.configKeys();
+                
                 throw e;
             }
+            failedGraphConfigKeys = Set.of();
             Collection<Bundle> unusedBundlesFromPreviousGen = osgi.completeBundleGeneration(Osgi.GenerationStatus.SUCCESS);
             Runnable cleanupTask = createPreviousGraphDeconstructionTask(oldGraph, newGraph, unusedBundlesFromPreviousGen);
             return new ComponentGraphResult(newGraph, cleanupTask);
@@ -118,15 +137,19 @@ public class Container {
     {
         ConfigSnapshot snapshot;
         while (true) {
-            // If the previous generation was invalidated (leastGeneration > graph.generation()),
-            // the old graph's config keys may reference components that no longer exist.
-            // Use empty keys to force a bootstrap-first config retrieval.
-            var configKeys = leastGeneration > graph.generation() ? Set.<ConfigKey<? extends ConfigInstance>>of() : graph.configKeys();
+            // In recovery mode (leastGeneration > graph.generation()), use the config keys from the
+            // most recently failed graph rather than the old graph's keys. If construction failed,
+            // failedGraphConfigKeys has the failed graph's keys (valid: component class exists).
+            // If graph creation failed, failedGraphConfigKeys is empty (forces bootstrap-first retrieval
+            // to avoid subscribing to stale keys that no longer exist after a bootstrap change).
+            var configKeys = leastGeneration > graph.generation()
+                    ? failedGraphConfigKeys
+                    : graph.configKeys();
             snapshot = retriever.getConfigs(configKeys, leastGeneration, isInitializing);
 
             if (log.isLoggable(FINE))
-                log.log(FINE, Text.format("getConfigAndCreateGraph:\n" + "graph.configKeys = %s\n" + "graph.generation = %s\n" + "snapshot = %s\n",
-                                            graph.configKeys(), graph.generation(), snapshot));
+                log.log(FINE, Text.format("getConfigAndCreateGraph:\n" + "configKeys = %s\n" + "graph.generation = %s\n" + "snapshot = %s\n",
+                                            configKeys, graph.generation(), snapshot));
 
             if (snapshot instanceof BootstrapConfigs) {
                 if (getBootstrapGeneration() <= previousConfigGeneration) {
@@ -149,10 +172,9 @@ public class Container {
                 // Continues loop
 
             } else if (snapshot instanceof ComponentsConfigs) {
-                if (leastGeneration > graph.generation()) {
-                    // Recovery after failed construction with empty config keys:
-                    // ComponentsConfigs only has bootstrap keys, need to rebuild graph
-                    // to discover actual component config keys for next iteration.
+                if (leastGeneration > graph.generation() && failedGraphConfigKeys.isEmpty()) {
+                    // Recovery with empty config keys: snapshot contains only bootstrap configs.
+                    // Rebuild graph to discover actual component config keys for next iteration.
                     throwIfPlatformBundlesChanged(snapshot);
                     installApplicationBundles(snapshot.configs());
                     graph = createComponentGraph(snapshot.configs(), getComponentsGeneration(), fallbackInjector);

--- a/container-disc/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -403,6 +404,13 @@ public class ContainerTest extends ContainerTestBase {
         }
     }
 
+    public static class ComponentThrowingOnConfigValue extends AbstractComponent {
+        public ComponentThrowingOnConfigValue(TestConfig config) {
+            if (config.stringVal().equals("throw"))
+                throw new RuntimeException("Configured to throw");
+        }
+    }
+
     public static class DestructableComponent extends AbstractComponent {
         private boolean deconstructed = false;
 
@@ -459,6 +467,45 @@ public class ContainerTest extends ContainerTestBase {
             fail("Stale config keys from failed generation caused error: " + e.getCause().getMessage() +
                  ". The old graph's configKeys were used to subscribe after a failed constructComponents, " +
                  "but those keys no longer exist in the config server.");
+        } finally {
+            exec.shutdownNow();
+        }
+    }
+
+    @Test
+    void reconfig_with_unchanged_bootstrap_works_after_failed_construction() throws Exception {
+        // Covers the case where the same component is redeployed with a fixed config after failing
+        // to construct. Bootstrap config (ComponentsConfig) is unchanged across all generations —
+        // only the component-specific config value changes. Without Fix 1, the container gets stuck
+        // waiting for a new bootstrap generation that never comes.
+
+        // Gen 1: ComponentThrowingOnConfigValue with stringVal="ok" — success
+        writeBootstrapConfigs("comp", ComponentThrowingOnConfigValue.class);
+        dirConfigSource.writeConfig("test", "stringVal \"ok\"");
+        Container container = newContainer(dirConfigSource);
+        ComponentGraph gen1Graph = getNewComponentGraph(container);
+        assertEquals(1, gen1Graph.generation());
+
+        // Gen 2: same component, stringVal="throw" — construction fails, bootstrap UNCHANGED
+        dirConfigSource.writeConfig("test", "stringVal \"throw\"");
+        container.reloadConfig(2);
+        assertNewComponentGraphFails(container, gen1Graph, ComponentConstructorException.class);
+        assertEquals(1, gen1Graph.generation());
+
+        // Gen 3: same component, stringVal="ok" — should recover, bootstrap UNCHANGED
+        dirConfigSource.writeConfig("test", "stringVal \"ok\"");
+        container.reloadConfig(3);
+
+        ExecutorService exec = Executors.newFixedThreadPool(1);
+        Future<ComponentGraph> future = exec.submit(() -> getNewComponentGraph(container, gen1Graph));
+        try {
+            ComponentGraph gen3Graph = future.get(5, TimeUnit.SECONDS);
+            assertEquals(3, gen3Graph.generation());
+            container.shutdownConfigRetriever();
+            container.shutdown(gen3Graph);
+        } catch (TimeoutException e) {
+            container.shutdownConfigRetriever();
+            fail("Container got stuck after failed construction with unchanged bootstrap config");
         } finally {
             exec.shutdownNow();
         }

--- a/container-disc/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -163,7 +163,8 @@ public class ContainerTest extends ContainerTestBase {
         container.shutdownConfigRetriever();
     }
 
-    // Failure in component construction phase
+    /** Verifies that the active graph is retained when component construction fails, and that
+     *  recovery succeeds on the next deployment. */
     @Test
     void previous_graph_is_retained_when_new_graph_contains_component_that_throws_exception_in_ctor() {
         ComponentEntry simpleComponentEntry = new ComponentEntry("simpleComponent", SimpleComponent.class);
@@ -220,7 +221,8 @@ public class ContainerTest extends ContainerTestBase {
         container.shutdown(currentGraph);
     }
 
-    // Failure in graph creation phase
+    /** Verifies that the active graph is retained when graph creation fails (component class
+     *  cannot be resolved or its required config key is missing). */
     @Test
     void previous_graph_is_retained_when_new_graph_throws_exception_for_missing_config() {
         ComponentEntry simpleComponentEntry = new ComponentEntry("simpleComponent", SimpleComponent.class);
@@ -424,6 +426,12 @@ public class ContainerTest extends ContainerTestBase {
         return componentGraph.getInstance(ComponentTakingConfig.class);
     }
 
+    /**
+     * Verifies that recovery after a construction failure does not subscribe to the old (active)
+     * graph's config keys. If the failed generation introduces a component with no config, those
+     * keys are empty in recovery, so subscribing to the previous component's now-removed config
+     * key would cause a deadlock.
+     */
     @Test
     void stale_config_keys_from_failed_construction_do_not_block_recovery() throws Exception {
         // Gen 1: ComponentTakingConfig (needs TestConfig) — succeeds
@@ -431,11 +439,13 @@ public class ContainerTest extends ContainerTestBase {
         dirConfigSource.writeConfig("test", "stringVal \"initial\"");
 
         var banningFactory = new BanningSubscriberFactory(dirConfigSource.configSource());
-        Container container = new Container(banningFactory,
-                                            new com.yahoo.container.Container(),
-                                            dirConfigSource.configId(),
-                                            new TestDeconstructor(osgi),
-                                            osgi);
+        Container container = new Container(
+                banningFactory,
+                new com.yahoo.container.Container(),
+                dirConfigSource.configId(),
+                new TestDeconstructor(osgi),
+                osgi
+        );
 
         ComponentGraph gen1Graph = getNewComponentGraph(container);
         assertEquals(1, gen1Graph.generation());
@@ -457,7 +467,7 @@ public class ContainerTest extends ContainerTestBase {
         ExecutorService exec = Executors.newFixedThreadPool(1);
         Future<ComponentGraph> future = exec.submit(() -> getNewComponentGraph(container, gen1Graph));
         try {
-            ComponentGraph gen3Graph = future.get(5, TimeUnit.SECONDS);
+            ComponentGraph gen3Graph = future.get(3, TimeUnit.SECONDS);
             assertEquals(3, gen3Graph.generation());
             assertNotNull(gen3Graph.getInstance(SimpleComponent.class));
             container.shutdownConfigRetriever();
@@ -465,20 +475,27 @@ public class ContainerTest extends ContainerTestBase {
         } catch (ExecutionException e) {
             container.shutdownConfigRetriever();
             fail("Stale config keys from failed generation caused error: " + e.getCause().getMessage() +
-                 ". The old graph's configKeys were used to subscribe after a failed constructComponents, " +
-                 "but those keys no longer exist in the config server.");
+                    ". The old graph's configKeys were used to subscribe after a failed constructComponents, " +
+                    "but those keys no longer exist in the config server.");
+        } catch (TimeoutException e) {
+            container.shutdownConfigRetriever();
+            fail("Container got stuck waiting for recovery — stale config keys may have caused a subscription " +
+                    "deadlock");
         } finally {
             exec.shutdownNow();
         }
     }
 
+    /**
+     * Verifies that the container recovers when the same component is redeployed with a fixed
+     * config value after a construction failure. Bootstrap config (ComponentsConfig) is unchanged
+     * across all generations — only the component-specific config value changes. Without tracking
+     * failedGraphConfigKeys, the container would get stuck waiting for a bootstrap generation
+     * that never comes, because in recovery mode it would only watch bootstrap keys and miss
+     * the component-config-only change.
+     */
     @Test
     void reconfig_with_unchanged_bootstrap_works_after_failed_construction() throws Exception {
-        // Covers the case where the same component is redeployed with a fixed config after failing
-        // to construct. Bootstrap config (ComponentsConfig) is unchanged across all generations —
-        // only the component-specific config value changes. Without Fix 1, the container gets stuck
-        // waiting for a new bootstrap generation that never comes.
-
         // Gen 1: ComponentThrowingOnConfigValue with stringVal="ok" — success
         writeBootstrapConfigs("comp", ComponentThrowingOnConfigValue.class);
         dirConfigSource.writeConfig("test", "stringVal \"ok\"");
@@ -499,13 +516,55 @@ public class ContainerTest extends ContainerTestBase {
         ExecutorService exec = Executors.newFixedThreadPool(1);
         Future<ComponentGraph> future = exec.submit(() -> getNewComponentGraph(container, gen1Graph));
         try {
-            ComponentGraph gen3Graph = future.get(5, TimeUnit.SECONDS);
+            ComponentGraph gen3Graph = future.get(3, TimeUnit.SECONDS);
             assertEquals(3, gen3Graph.generation());
+            assertNotNull(gen3Graph.getInstance(ComponentThrowingOnConfigValue.class));
             container.shutdownConfigRetriever();
             container.shutdown(gen3Graph);
         } catch (TimeoutException e) {
             container.shutdownConfigRetriever();
             fail("Container got stuck after failed construction with unchanged bootstrap config");
+        } finally {
+            exec.shutdownNow();
+        }
+    }
+
+    /**
+     * Verifies that a bootstrap change is correctly detected during recovery when the failed
+     * generation had a component with config (failedGraphConfigKeys is non-empty). The fix
+     * deployment replaces the component entirely, so the bootstrap subscriber must fire and
+     * drive recovery rather than waiting for the old component's config key to change.
+     */
+    @Test
+    void reconfig_with_bootstrap_change_works_after_failed_construction_with_config() throws Exception {
+        // Gen 1: ComponentThrowingOnConfigValue with stringVal="ok" — success
+        writeBootstrapConfigs("comp", ComponentThrowingOnConfigValue.class);
+        dirConfigSource.writeConfig("test", "stringVal \"ok\"");
+        Container container = newContainer(dirConfigSource);
+        ComponentGraph gen1Graph = getNewComponentGraph(container);
+        assertEquals(1, gen1Graph.generation());
+
+        // Gen 2: same component, stringVal="throw" — construction fails, failedGraphConfigKeys = {TestConfig key}
+        dirConfigSource.writeConfig("test", "stringVal \"throw\"");
+        container.reloadConfig(2);
+        assertNewComponentGraphFails(container, gen1Graph, ComponentConstructorException.class);
+        assertEquals(1, gen1Graph.generation());
+
+        // Gen 3: completely different component (bootstrap change: TestConfig no longer needed)
+        writeBootstrapConfigs("simpleComponent", SimpleComponent.class);
+        container.reloadConfig(3);
+
+        ExecutorService exec = Executors.newFixedThreadPool(1);
+        Future<ComponentGraph> future = exec.submit(() -> getNewComponentGraph(container, gen1Graph));
+        try {
+            ComponentGraph gen3Graph = future.get(3, TimeUnit.SECONDS);
+            assertEquals(3, gen3Graph.generation());
+            assertNotNull(gen3Graph.getInstance(SimpleComponent.class));
+            container.shutdownConfigRetriever();
+            container.shutdown(gen3Graph);
+        } catch (TimeoutException e) {
+            container.shutdownConfigRetriever();
+            fail("Container got stuck after failed construction with config when bootstrap changed in recovery");
         } finally {
             exec.shutdownNow();
         }
@@ -538,15 +597,36 @@ public class ContainerTest extends ContainerTestBase {
             Set<ConfigKey<?>> offending = new HashSet<>(configKeys);
             offending.retainAll(bannedKeys);
             return new Subscriber() {
-                @Override public long waitNextGeneration(boolean isInitializing) {
+                @Override
+                public long waitNextGeneration(boolean isInitializing) {
                     throw new IllegalArgumentException(
                             "Config server does not have keys: " + offending);
                 }
-                @Override public long generation() { return sub.generation(); }
-                @Override public boolean configChanged() { return sub.configChanged(); }
-                @Override public Map<ConfigKey<ConfigInstance>, ConfigInstance> config() { return sub.config(); }
-                @Override public void close() { sub.close(); }
-                @Override public boolean applyOnRestart() { return sub.applyOnRestart(); }
+
+                @Override
+                public long generation() {
+                    return sub.generation();
+                }
+
+                @Override
+                public boolean configChanged() {
+                    return sub.configChanged();
+                }
+
+                @Override
+                public Map<ConfigKey<ConfigInstance>, ConfigInstance> config() {
+                    return sub.config();
+                }
+
+                @Override
+                public void close() {
+                    sub.close();
+                }
+
+                @Override
+                public boolean applyOnRestart() {
+                    return sub.applyOnRestart();
+                }
             };
         }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This extends original reverted fix by @thomasht86: https://github.com/vespa-engine/vespa/pull/36052.
The original fix didn't handle a couple of other recovery scenarios. 
Previously failed system tests should pass now.

To make the review easier I generated explanation of the related concepts, different edge cases and the fix. Iterated on this together with claude so this reflects my understanding of the issue and the reconfiguration failures. Let me know if there is anything wrong in this explanation.

# Recovery from Failed Component Graph

## 1. Concepts: Config Keys, Subscribers, and Generations

Every config value in Vespa is identified by a **config key** — a `(config-name, config-id)` pair
that uniquely addresses one instance of one config definition.

A **`Subscriber`** watches a fixed set of config keys. It blocks in `waitNextGeneration()` until
the config server has a new generation ready for all of them. After returning, `configChanged()`
tells you whether at least one of the watched values actually changed — not just that the
generation number advanced. This distinction is critical: a subscriber can receive a new
generation and still report no change if none of its specific keys were modified.

Each application deployment increments a **generation number** globally. All config keys move to
the new generation simultaneously, but only keys whose values changed will have `configChanged()
= true`.

---

## 2. Bootstrap Configs vs. Component Configs

The container uses two kinds of config and maintains two subscribers.

**Bootstrap configs** are the three keys the container needs before it can know what components
exist:

| Key | Purpose |
|---|---|
| `application-bundles` | OSGi bundles to install |
| `platform-bundles` | Platform bundles (must never change at runtime) |
| `components` | The full list of components: class names, config IDs, injections |

The **bootstrap subscriber** watches only these three keys. When any of them changes, the
container reinstalls bundles and rebuilds the component graph from scratch.

**Component configs** are all other keys — one per config-taking constructor parameter of each
component, addressed by that component's config ID (e.g. `ExceptionConfig@default`). They cannot
be known until `components` config has been parsed, because you don't know which components exist
until then.

The **component subscriber** watches bootstrap keys *plus* all current component config keys
together. A single `waitNextGeneration()` on the component subscriber can therefore detect changes
to either group.

### Two-phase config retrieval at startup

Because component keys are not known upfront, the container uses a two-phase loop on each
reconfiguration:

```
1. getConfigs(empty component keys)
      → component subscriber watches bootstrap keys only
      → new bootstrap generation arrives → returns BootstrapConfigs
      → container installs bundles, builds graph skeleton, learns component keys

2. getConfigs(graph.configKeys())
      → component subscriber watches bootstrap + component keys
      → new component generation arrives → returns ComponentsConfigs
      → container configures graph, constructs components
```

In the normal case this two-step sequence completes cleanly. The problem arises when step 2 fails.

---

## 3. The Recovery Problem

### `leastGeneration` and invalidation

When component graph construction fails, `invalidateGeneration()` sets:

```
leastGeneration = max(bootstrapGeneration, componentGeneration) + 1
```

This tells the config retriever to ignore all generations up to and including the one that just
failed, and wait for a strictly newer one before trying again.

On the next call to `waitForNewConfigGenAndCreateGraph`, the container is in **recovery mode**:
`leastGeneration > graph.generation()`. It must choose which config keys to subscribe to while
waiting for the fix deployment.

### The two failure modes and why the key choice matters

**Graph creation failure** (`waitForNewConfigGenAndCreateGraph` throws before returning):

The component graph was never fully built. The component keys it *would* have used may reference
a class from a bad bundle that no longer resolves. Subscribing to those keys in recovery risks
hanging on a key the config server can no longer serve.

**Construction failure** (`constructComponents` throws after the graph is built):

The graph was built successfully. The component class exists and was loaded. Its config keys are
valid and registered with the config server. The failure was in the constructor — a logic error
or a bad config *value*, not a missing key.

The previous fix treated both cases identically — always subscribing to **empty keys** in recovery
mode. This forces the component subscriber to watch bootstrap keys only, which is safe for graph
creation failures. But it breaks construction failures where only a component-specific config value
changed:

> If the subscriber watches only bootstrap keys but the fix deployment only changes a
> component-specific key (e.g. `ExceptionConfig`), the subscriber receives the new generation
> number but `configChanged()` returns `false` — because none of *its* keys changed.
> `ConfigRetriever` returns `Optional.empty()`, the container loops indefinitely. The subscriber
> is alive and receiving new generations, but its key set is blind to the actual change.

---

## 4. The Fix: `failedGraphConfigKeys`

The fix tracks which config keys to use in recovery based on *how* the failure occurred:

| Failure | `failedGraphConfigKeys` set to | Rationale |
|---|---|---|
| Graph creation fails | `Set.of()` (empty) | Keys may be stale; force bootstrap-first |
| Construction fails | `newGraph.configKeys()` | Component exists; keys are valid and needed |
| Success | `Set.of()` (reset) | Recovery mode not active |

In recovery mode (`leastGeneration > graph.generation()`), instead of always using empty keys,
the container now uses `failedGraphConfigKeys`:

```java
var configKeys = leastGeneration > graph.generation()
    ? failedGraphConfigKeys
    : graph.configKeys();
```

### The rebuild-continue block

When `failedGraphConfigKeys` is empty (graph creation failure), the component subscriber watches
only bootstrap keys. If the fix deployment arrives and bootstrap is unchanged (rare), the
`ComponentsConfigs` snapshot contains only bootstrap-level configs — not enough to configure the
components. The rebuild-continue block handles this:

```java
if (leastGeneration > graph.generation() && failedGraphConfigKeys.isEmpty()) {
    // snapshot has bootstrap-only configs — rebuild graph to discover component keys
    graph = createComponentGraph(snapshot.configs(), getComponentsGeneration(), fallbackInjector);
    continue;  // next iteration subscribes to the real component keys
}
```

When `failedGraphConfigKeys` is non-empty (construction failure), the snapshot already contains
the full set of configs — bootstrap and component — so we break immediately and proceed.

---

## 5. Scenarios

> The examples below are drawn from the system test
> `tests/container/component_invalid_app` (`test_bootstrap_reconfig_works_after_failed_reconfig`
> and `test_component_reconfig_works_after_failed_reconfig`).

---

### Scenario 1 — Graph creation fails (e.g. class not found, unresolvable bundle)

**Example:** App2 introduces a bundle with a typo in the class name.
`waitForNewConfigGenAndCreateGraph` throws before returning.

- `failedGraphConfigKeys = Set.of()` (empty)
- Recovery subscribes to bootstrap keys only
- **App3 fixes the bundle** → `componentsConfig` changes → bootstrap subscriber fires →
  `BootstrapConfigs` → normal bootstrap path → success
- **App3 fixes without bootstrap change** (rare) → `ComponentsConfigs` with bootstrap-only configs
  → rebuild-continue block discovers real component keys → next iteration gets full configs →
  success

**Unit tests:** `previous_graph_is_retained_when_new_graph_throws_exception_for_missing_config`,
`bundle_from_generation_that_throws_in_graph_creation_phase_is_uninstalled`,
`getNewComponentGraph_hangs_waiting_for_valid_config_after_invalid_config`

---

### Scenario 2 — Construction fails, component has no config

**Example:** App2 introduces `Fail2Handler` — no config params, throws `NullPointerException` in
its constructor. `constructComponents` fails.

- `failedGraphConfigKeys = newGraph.configKeys() = {}` (no config parameters)
- Recovery subscribes to bootstrap keys only — same behaviour as Scenario 1
- App3 replaces the handler with `Ok3Handler` → bootstrap changes → `BootstrapConfigs` → success

**Unit tests:** `previous_graph_is_retained_when_new_graph_contains_component_that_throws_exception_in_ctor`,
`bundle_from_generation_that_fails_in_component_construction_is_uninstalled`,
`stale_config_keys_from_failed_construction_do_not_block_recovery`

---

### Scenario 3 — Construction fails, component has config *(broken before this fix)*

**Example:** App2 deploys `ConfigurableExceptionHandler` with `doThrow=true`. Same component
class, same bundle — only a config value changed. `constructComponents` fails.

- `failedGraphConfigKeys = newGraph.configKeys() = {ExceptionConfig key}`
- Recovery subscribes to `{ExceptionConfig}` + bootstrap keys
- App3 sets `doThrow=false` → `ExceptionConfig` changes → `configChanged() = true` →
  `ComponentsConfigs` with full configs → `break` → `createAndConfigureComponentGraph` →
  construction succeeds

**Before this fix:** recovery used empty keys → component subscriber watched bootstrap only →
bootstrap unchanged → `configChanged() = false` forever → container stuck, App3 never activated.

**Unit tests:** `reconfig_with_unchanged_bootstrap_works_after_failed_construction`,
`reconfig_with_bootstrap_change_works_after_failed_construction_with_config`

---

### Scenario 4 — Normal reconfig (no failure)

`leastGeneration <= graph.generation()` — `failedGraphConfigKeys` is ignored entirely.
`graph.configKeys()` is used as normal. No behaviour change.

**Unit tests:** `components_are_reconfigured_after_config_update_without_bootstrap_configs`,
`graph_is_updated_after_bootstrap_update`

---

## 6. What `failedGraphConfigKeys` Is NOT

It is **not** the previously active graph's keys. It is the keys from the **most recently
attempted graph** — the one that failed. This distinction matters when the failed graph has
*different* components than the previously active one:

```
Gen 1 (active):  ComponentTakingConfig  →  needs TestConfig
Gen 2 (failed):  SimpleComponent        →  no config  →  failedGraphConfigKeys = {}
Gen 3 (fix):     recovery does NOT subscribe to TestConfig
```

If recovery used the old graph's keys (gen 1), it would subscribe to `TestConfig`. If that key
was removed from the config server for gen 3, the subscriber would hang indefinitely — the
original stale-key bug this fix was also designed to address.

---

## 7. Edge Cases (all handled correctly)

### Component with config is removed in the fix deployment

`failedGraphConfigKeys` holds the failed component's config key, but the fix deployment removes
that component. At first glance this looks like it could produce a stale subscription.

**Why it is safe:** Removing a component always changes `componentsConfig` (a bootstrap key).
During recovery, the component subscriber first catches up to the current generation — one where
the component still exists and its key is valid. After that, the bootstrap subscriber advances to
the new generation and returns `BootstrapConfigs`. This resets the component subscriber entirely;
it is rebuilt from the new graph's keys. The removed component's key is never subscribed to at
the new generation.

### Multiple consecutive construction failures

Each failure overwrites `failedGraphConfigKeys` with the latest failed graph's keys. The
subscriber always reflects the most recent attempt; there is no accumulation of stale keys.

### Construction failure followed by graph creation failure

If the fix deployment itself introduces a bad bundle, the graph-creation catch overwrites
`failedGraphConfigKeys = Set.of()`. Recovery falls back to bootstrap-first on the next attempt.