### PR TITLE
Allow fast-search, fast-access, and paged on position fields

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
@@ -78,6 +78,10 @@ public class ConvertParsedFields {
     }
 
     void convertAttribute(Schema schema, SDField field, ParsedAttribute parsed) {
+        if (GeoPos.isAnyPos(field.getDataType())) {
+            convertPositionAttribute(schema, field, parsed);
+            return;
+        }
         String name = parsed.name();
         String fieldName = field.getName();
         Attribute attribute = null;
@@ -115,6 +119,45 @@ public class ConvertParsedFields {
         if (sorting.isPresent()) {
             convertSorting(schema, field, sorting.get(), name);
         }
+    }
+
+    private void convertPositionAttribute(Schema schema, SDField field, ParsedAttribute parsed) {
+        String fieldName = field.getName();
+
+        // Attribute settings on a position field only make sense if the field actually does attributing
+        if (!field.doesAttributing()) {
+            throw new IllegalArgumentException("For schema '" + schema.getName() +
+                "', field '" + fieldName + "': attribute properties require 'attribute' in the indexing statement");
+        }
+
+        // Reject renamed attributes — position fields only support the default attribute block
+        if (!parsed.name().equals(fieldName)) {
+            throw new IllegalArgumentException("For schema '" + schema.getName() +
+                "', field '" + fieldName + "': position fields do not support named attribute '" + parsed.name() + "'");
+        }
+
+        // Reject settings that are nonsensical or unsupported for position fields
+        if (parsed.getFastRank() || parsed.getMutable() || parsed.getEnableOnlyBitVector()
+                || parsed.getDistanceMetric().isPresent() || parsed.getSorting().isPresent()
+                || !parsed.getAliases().isEmpty()) {
+            throw new IllegalArgumentException("For schema '" + schema.getName() +
+                "', field '" + fieldName + "': position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings");
+        }
+
+        // If only fast-search or empty: no-op. CreatePositionZCurve already sets fast-search on the zcurve attribute.
+        // Avoid creating an Attribute here so AttributesImplicitWord (which runs before CreatePositionZCurve) does not
+        // see a non-empty attributes map and flip this field to WORD matching.
+        if (!parsed.getFastAccess() && !parsed.getPaged()) {
+            return;
+        }
+
+        // Create a temporary Attribute to carry fast-access/paged to CreatePositionZCurve
+        boolean isArray = GeoPos.isPosArray(field.getDataType());
+        Attribute attribute = new Attribute(fieldName, Attribute.Type.LONG,
+            isArray ? Attribute.CollectionType.ARRAY : Attribute.CollectionType.SINGLE);
+        attribute.setFastAccess(parsed.getFastAccess());
+        attribute.setPaged(parsed.getPaged());
+        field.addAttribute(attribute);
     }
 
     private void convertRankType(SDField field, String indexName, String rankType) {

--- a/config-model/src/main/java/com/yahoo/schema/processing/AttributesImplicitWord.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/AttributesImplicitWord.java
@@ -6,6 +6,7 @@ import com.yahoo.document.TensorDataType;
 import com.yahoo.schema.RankProfileRegistry;
 import com.yahoo.document.DataType;
 import com.yahoo.schema.Schema;
+import com.yahoo.schema.document.GeoPos;
 import com.yahoo.schema.document.ImmutableSDField;
 import com.yahoo.schema.document.MatchType;
 import com.yahoo.document.NumericDataType;
@@ -38,6 +39,9 @@ public class AttributesImplicitWord extends Processor {
     }
 
     private void processField(ImmutableSDField field) {
+        // Position fields may carry a temporary attribute for forwarding fast-access/paged to the zcurve attribute;
+        // they should never get implicit WORD matching.
+        if (GeoPos.isAnyPos(field.getDataType())) return;
         if (fieldImplicitlyWordMatch(field)) {
             field.getMatching().setType(MatchType.WORD);
         }

--- a/config-model/src/main/java/com/yahoo/schema/processing/CreatePositionZCurve.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreatePositionZCurve.java
@@ -64,10 +64,22 @@ public class CreatePositionZCurve extends Processor {
             boolean doesSummary = field.doesSummarying();
 
             String fieldName = field.getName();
+
+            // Read user-specified settings before removing the original attribute
+            Attribute originalAttr = field.getAttributes().get(fieldName);
+            boolean fastAccess = originalAttr != null && originalAttr.isFastAccess();
+            boolean paged = originalAttr != null && originalAttr.isPaged();
+
             field.getAttributes().remove(fieldName);
 
             String zName = PositionDataType.getZCurveFieldName(fieldName);
             SDField zCurveField = createZCurveField(field, zName, validate);
+
+            // Forward user-specified settings to the zcurve attribute
+            Attribute zAttr = zCurveField.getAttributes().get(zName);
+            if (fastAccess) zAttr.setFastAccess(true);
+            if (paged) zAttr.setPaged(true);
+
             schema.addExtraField(zCurveField);
             schema.fieldSets().addBuiltInFieldSetItem(BuiltInFieldSets.INTERNAL_FIELDSET_NAME, zCurveField.getName());
 

--- a/config-model/src/main/java/com/yahoo/schema/processing/ValidateFieldTypes.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/ValidateFieldTypes.java
@@ -7,6 +7,7 @@ import com.yahoo.document.TensorDataType;
 import com.yahoo.schema.RankProfileRegistry;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.Attribute;
+import com.yahoo.schema.document.GeoPos;
 import com.yahoo.vespa.documentmodel.DocumentSummary;
 import com.yahoo.vespa.documentmodel.SummaryField;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
@@ -41,6 +42,8 @@ public class ValidateFieldTypes extends Processor {
         schema.allFields().forEach(field -> {
             checkFieldType(searchName, "index field", field.getName(), field.getDataType(), seenFields);
             if (!field.isImportedField()) {
+                // Position field attributes are transient — CreatePositionZCurve replaces them with zcurve attributes
+                if (GeoPos.isAnyPos(field.getDataType())) return;
                 for (Map.Entry<String, Attribute> entry : field.getAttributes().entrySet()) {
                     checkFieldType(searchName, "attribute", entry.getKey(), entry.getValue().getDataType(), seenFields);
                 }

--- a/config-model/src/test/java/com/yahoo/schema/processing/PositionTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/PositionTestCase.java
@@ -8,6 +8,8 @@ import com.yahoo.schema.Schema;
 import com.yahoo.schema.ApplicationBuilder;
 import com.yahoo.schema.document.Attribute;
 import com.yahoo.schema.document.FieldSet;
+import com.yahoo.schema.document.MatchType;
+import com.yahoo.schema.parser.ParseException;
 import com.yahoo.vespa.documentmodel.SummaryField;
 import com.yahoo.vespa.documentmodel.SummaryTransform;
 
@@ -29,6 +31,147 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author hmusum
  */
 public class PositionTestCase {
+
+    private static Schema buildPositionSchema(String fieldType, String attributeBlock) throws ParseException {
+        return ApplicationBuilder.createFromString(
+                "search test {\n" +
+                "  document test {\n" +
+                "    field pos type " + fieldType + " {\n" +
+                "      indexing: attribute | summary\n" +
+                "      " + attributeBlock + "\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n").getSchema();
+    }
+
+    private static void assertNoStrayPositionAttributes(Schema schema, String fieldName) {
+        assertNull(schema.getAttribute(fieldName));
+        assertNull(schema.getAttribute(fieldName + ".x"));
+        assertNull(schema.getAttribute(fieldName + ".y"));
+    }
+
+    @Test
+    void requireThatPositionFastSearchIsAllowed() throws Exception {
+        Schema schema = buildPositionSchema("position", "attribute: fast-search");
+        assertNoStrayPositionAttributes(schema, "pos");
+        Attribute zcurve = schema.getAttribute(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(zcurve);
+        assertTrue(zcurve.isFastSearch());
+    }
+
+    @Test
+    void requireThatPositionFastAccessIsForwarded() throws Exception {
+        Schema schema = buildPositionSchema("position", "attribute { fast-access }");
+        assertNoStrayPositionAttributes(schema, "pos");
+        Attribute zcurve = schema.getAttribute(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(zcurve);
+        assertTrue(zcurve.isFastAccess());
+        // Verify that the temporary attribute did not trigger implicit WORD matching
+        assertNotEquals(MatchType.WORD, schema.getConcreteField("pos").getMatching().getType());
+    }
+
+    @Test
+    void requireThatPositionPagedIsForwarded() throws Exception {
+        Schema schema = buildPositionSchema("position", "attribute { paged }");
+        assertNoStrayPositionAttributes(schema, "pos");
+        Attribute zcurve = schema.getAttribute(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(zcurve);
+        assertTrue(zcurve.isPaged());
+    }
+
+    @Test
+    void requireThatPositionAllSettingsAreForwarded() throws Exception {
+        Schema schema = buildPositionSchema("position", "attribute { fast-search\n fast-access\n paged }");
+        assertNoStrayPositionAttributes(schema, "pos");
+        Attribute zcurve = schema.getAttribute(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(zcurve);
+        assertTrue(zcurve.isFastSearch());
+        assertTrue(zcurve.isFastAccess());
+        assertTrue(zcurve.isPaged());
+    }
+
+    @Test
+    void requireThatPositionEmptyAttributeIsAllowed() throws Exception {
+        Schema schema = buildPositionSchema("position", "attribute { }");
+        assertNoStrayPositionAttributes(schema, "pos");
+        Attribute zcurve = schema.getAttribute(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(zcurve);
+        assertTrue(zcurve.isFastSearch());
+    }
+
+    @Test
+    void requireThatPositionArrayFastAccessIsForwarded() throws Exception {
+        Schema schema = buildPositionSchema("array<position>", "attribute { fast-access }");
+        assertNoStrayPositionAttributes(schema, "pos");
+        Attribute zcurve = schema.getAttribute(PositionDataType.getZCurveFieldName("pos"));
+        assertNotNull(zcurve);
+        assertTrue(zcurve.isFastAccess());
+        assertEquals(Attribute.CollectionType.ARRAY, zcurve.getCollectionType());
+    }
+
+    @Test
+    void requireThatPositionFastRankIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute { fast-rank }"));
+        assertTrue(e.getMessage().contains("position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings"));
+    }
+
+    @Test
+    void requireThatPositionMutableIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute { mutable }"));
+        assertTrue(e.getMessage().contains("position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings"));
+    }
+
+    @Test
+    void requireThatPositionBitVectorIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute { enable-only-bit-vector }"));
+        assertTrue(e.getMessage().contains("position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings"));
+    }
+
+    @Test
+    void requireThatPositionSortingIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute { sorting { ascending } }"));
+        assertTrue(e.getMessage().contains("position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings"));
+    }
+
+    @Test
+    void requireThatPositionDistanceMetricIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute { distance-metric: euclidean }"));
+        assertTrue(e.getMessage().contains("position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings"));
+    }
+
+    @Test
+    void requireThatPositionAliasIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute { alias: my_alias }"));
+        assertTrue(e.getMessage().contains("position fields only support 'fast-search', 'fast-access', and 'paged' attribute settings"));
+    }
+
+    @Test
+    void requireThatPositionNamedAttributeIsRejected() {
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> buildPositionSchema("position", "attribute my_attr { fast-search }"));
+        assertTrue(e.getMessage().contains("position fields do not support named attribute"));
+    }
+
+    @Test
+    void requireThatPositionAttributeSettingsRequireAttributing() {
+        var e = assertThrows(IllegalArgumentException.class, () ->
+                ApplicationBuilder.createFromString(
+                        "search test {\n" +
+                        "  document test {\n" +
+                        "    field pos type position {\n" +
+                        "      indexing: summary\n" +
+                        "      attribute: fast-search\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}\n"));
+        assertTrue(e.getMessage().contains("attribute properties require 'attribute' in the indexing statement"));
+    }
 
     @Test
     void inherited_position_zcurve_field_is_not_added_to_document_fieldset() throws Exception {

--- a/config-model/src/test/java/com/yahoo/schema/processing/PositionTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/PositionTestCase.java
@@ -20,8 +20,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 


### PR DESCRIPTION
If I add `fast-search` or `fast-access` to a position field, I get:

```
% vespa deploy --wait 900
Uploading application package... failed
Error: invalid application package (status 400)
Invalid application:
Don't know which attribute type to convert struct type 'position' [class com.yahoo.document.StructDataType] to
```

This PR adds support for those (+`paged`) and has nicer validation errors for unsupported stuff.

Note: `fast-search` is a no-op; it's implicitly added.

/cc @abhishekkrthakur 