### PR TITLE
Reduce unit test runtime in RpcSearchInvokerTest

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
@@ -46,11 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author ollivir
+ * @author Olli Virtanen
  */
 public class RpcSearchInvokerTest {
 
@@ -400,10 +399,7 @@ public class RpcSearchInvokerTest {
         DispatchConfig dispatchConfig = new DispatchConfig.Builder().build();
         TopKEstimator hitEstimator = new TopKEstimator(30, dispatchConfig.topKProbability(), 0.05);
         List<SearchInvoker> invokers = new ArrayList<>(nodeInvokers);
-        InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, Set.of());
-        invoker.responseAvailable(invokers.get(0));
-        invoker.responseAvailable(invokers.get(1));
-        return invoker;
+        return new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, Set.of());
     }
 
     RpcSearchInvoker createRpcInvoker(Node node, int maxHits, Holders holders) {
@@ -438,6 +434,7 @@ public class RpcSearchInvokerTest {
                         holders.compressionType.set(compression);
                         holders.payload.set(compressedPayload);
                         holders.length.set(uncompressedLength);
+                        responseReceiver.receive(Client.ResponseOrError.fromError("mock"));
                     }
 
                     @Override


### PR DESCRIPTION
The 3-second delay for the last 3 tests was caused by the mock NodeConnection.request() never calling responseReceiver.receive(). When InterleavedSearchInvoker.getSearchResult() processed each pre-queued invoker, it called RpcSearchInvoker.getSearchResult() which blocked on responses.poll(timeLeftMs, ms) for the full 500ms query timeout. With 6 sub-scenarios, that added up to ~3 seconds.

Fix: Added responseReceiver.receive(Client.ResponseOrError.fromError("mock")) to the mock client's request() method. All invokers now immediately signal availability and getSearchResult() returns instantly with an error result (the tests only care about sent request payloads captured in Holders, not responses). The manual responseAvailable pre-queuing was also removed since it is no longer needed.

Test runtime: ~11s -> ~0.6s