### PR TITLE
Fix soft-doomed search requests returning HTTP 500 instead of 504

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -83,9 +83,11 @@ public class ProtobufSerialization {
         return convertFromQuery(query, hits, nodeId, contentShare, requestTimeout, qrSearchersConfig).toByteArray();
     }
 
-    private static void convertSearchReplyErrors(Result target, List<SearchProtocol.Error> errors) {
+    private static void convertSearchReplyErrors(Result target, List<SearchProtocol.Error> errors, boolean softTimeout) {
         for (var error : errors) {
-            target.hits().addError(ErrorMessage.createSearchReplyError(error.getMessage()));
+            target.hits().addError(softTimeout
+                    ? ErrorMessage.createTimeout(error.getMessage())
+                    : ErrorMessage.createSearchReplyError(error.getMessage()));
         }
     }
 
@@ -296,7 +298,7 @@ public class ProtobufSerialization {
         result.getResult().setTotalHitCount(protobuf.getTotalHitCount());
         result.getResult().setCoverage(convertToCoverage(protobuf));
 
-        convertSearchReplyErrors(result.getResult(), protobuf.getErrorsList());
+        convertSearchReplyErrors(result.getResult(), protobuf.getErrorsList(), protobuf.getDegradedBySoftTimeout());
         List<String> featureNames = protobuf.getMatchFeatureNamesList();
         var haveMatchFeatures = ! featureNames.isEmpty();
         MatchFeatureData matchFeatures = haveMatchFeatures ? new MatchFeatureData(featureNames) : null;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -160,6 +161,20 @@ public class ProtobufSerializationTest {
         assertEquals(3, req.getProfiling().getMatch().getDepth());
         assertFalse(req.getProfiling().hasFirstPhase());
         assertFalse(req.getProfiling().hasSecondPhase());
+    }
+
+    @Test
+    void soft_timeout_errors_use_timeout_error_code() {
+        Query q = new Query("search/?query=test");
+        SearchProtocol.SearchReply reply = SearchProtocol.SearchReply.newBuilder()
+                .setDegradedBySoftTimeout(true)
+                .addErrors(SearchProtocol.Error.newBuilder()
+                        .setMessage("Search request soft doomed during query setup and initialization."))
+                .build();
+        InvokerResult result = ProtobufSerialization.convertToResult(q, reply, null, 1, 2);
+        var error = result.getResult().hits().getError();
+        assertNotNull(error);
+        assertEquals(com.yahoo.container.protect.Error.TIMEOUT.code, error.getCode());
     }
 
 }


### PR DESCRIPTION
## Summary
- When the backend soft dooms a request during query setup and initialization, it sets `degraded_by_soft_timeout=true` in the protobuf reply and adds an error message to the `errors` list
- The container wrapped these errors using `createSearchReplyError()` (code 8, `RESULT_HAS_ERRORS`), which has no HTTP status mapping and defaults to HTTP 500
- Fix: pass `getDegradedBySoftTimeout()` to `convertSearchReplyErrors()` and use `createTimeout()` (code 12) when true, so `VespaHeaders` correctly maps the error to HTTP 504