### PR TITLE
GH-35630: add support for instance and application arguments for vespa deploy command for self-hosted deployments

### DIFF
--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -27,6 +27,8 @@ const (
 	configFile = "config.yaml"
 )
 
+var ErrNoApplicationSpecified = errHint(fmt.Errorf("no application specified"), "Try the --"+applicationFlag+" flag")
+
 func newConfigCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
@@ -374,7 +376,7 @@ func (c *Config) isQuiet() bool {
 func (c *Config) application() (vespa.ApplicationID, error) {
 	app, ok := c.get(applicationFlag)
 	if !ok {
-		return vespa.ApplicationID{}, errHint(fmt.Errorf("no application specified"), "Try the --"+applicationFlag+" flag")
+		return vespa.ApplicationID{}, ErrNoApplicationSpecified
 	}
 	application, err := vespa.ApplicationFromString(app)
 	if err != nil {

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -27,8 +27,6 @@ const (
 	configFile = "config.yaml"
 )
 
-var ErrNoApplicationSpecified = errHint(fmt.Errorf("no application specified"), "Try the --"+applicationFlag+" flag")
-
 func newConfigCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
@@ -376,7 +374,7 @@ func (c *Config) isQuiet() bool {
 func (c *Config) application() (vespa.ApplicationID, error) {
 	app, ok := c.get(applicationFlag)
 	if !ok {
-		return vespa.ApplicationID{}, ErrNoApplicationSpecified
+		return vespa.ApplicationID{}, errHint(fmt.Errorf("no application specified"), "Try the --"+applicationFlag+" flag")
 	}
 	application, err := vespa.ApplicationFromString(app)
 	if err != nil {

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"reflect"
 	"strings"
 	"time"
 
@@ -541,7 +540,7 @@ func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, er
 	deployment := vespa.DefaultDeployment
 	if app, err := c.config.application(); err == nil {
 		deployment.Application = app
-	} else if reflect.DeepEqual(err, ErrNoApplicationSpecified) {
+	} else if err.Error() == ErrNoApplicationSpecified.Error() {
 		// fall back to DefaultDeployment when the --application was not set
 		deployment.Application = vespa.DefaultApplication
 	} else {

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -533,7 +533,13 @@ func (c *CLI) targetFromURL(customURL string) (string, error) {
 }
 
 func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, error) {
-	tlsOptions, err := c.config.readTLSOptions(vespa.DefaultApplication, targetType)
+
+	// The old default for application ID (with "application" name) is still used for TLS options.
+	// Changing this can break existing pipelines/automations relying on this location for certificates. This only applies here,
+	// the config server still receives the correct default and uses that elsewhere.
+	deprecatedDefaultApplication := vespa.ApplicationID{Tenant: "default", Application: "application", Instance: "default"}
+	tlsOptions, err := c.config.readTLSOptions(deprecatedDefaultApplication, targetType)
+
 	if err != nil {
 		return nil, err
 	}

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -538,15 +538,16 @@ func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, er
 		return nil, err
 	}
 	deployment := vespa.DefaultDeployment
-	if app, err := c.config.application(); err == nil {
-		deployment.Application = app
-	} else if errors.As(err, &ErrNoApplicationSpecified) {
-		// fall back to DefaultDeployment when the --application was not set
-		deployment.Application = vespa.DefaultApplication
-	} else {
-		// The --application is malformed, propagate an error
-		return nil, err
+
+	// Set deployment application or keep default if config is not set
+	if _, ok := c.config.get(applicationFlag); ok {
+		if app, err := c.config.application(); err == nil {
+			deployment.Application = app
+		} else {
+			return nil, err
+		}
 	}
+
 	switch targetType {
 	case vespa.TargetLocal:
 		return vespa.LocalTarget(c.httpClient, tlsOptions, c.retryInterval, deployment), nil

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"time"
 
@@ -540,6 +541,12 @@ func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, er
 	deployment := vespa.DefaultDeployment
 	if app, err := c.config.application(); err == nil {
 		deployment.Application = app
+	} else if reflect.DeepEqual(err, ErrNoApplicationSpecified) {
+		// fall back to DefaultDeployment when the --application was not set
+		deployment.Application = vespa.DefaultApplication
+	} else {
+		// The --application is malformed, propagate an error
+		return nil, err
 	}
 	switch targetType {
 	case vespa.TargetLocal:

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -303,8 +303,8 @@ func (c *CLI) configureFlags() map[string]*pflag.Flag {
 		debugMode   bool
 	)
 	c.cmd.PersistentFlags().StringVarP(&target, targetFlag, "t", "local", `The target platform to use. Must be "local", "cloud", "hosted" or an URL`)
-	c.cmd.PersistentFlags().StringVarP(&application, applicationFlag, "a", "", `The application to use (cloud only). Format "tenant.application.instance" - instance is optional`)
-	c.cmd.PersistentFlags().StringVarP(&instance, instanceFlag, "i", "", "The instance of the application to use (cloud only)")
+	c.cmd.PersistentFlags().StringVarP(&application, applicationFlag, "a", "", `The application to use. Format "tenant.application.instance" - instance is optional (tenant required for cloud targets)`)
+	c.cmd.PersistentFlags().StringVarP(&instance, instanceFlag, "i", "", "The instance of the application to use")
 	c.cmd.PersistentFlags().StringVarP(&cluster, clusterFlag, "C", "", "The container cluster to use. This is only required for applications with multiple clusters")
 	c.cmd.PersistentFlags().StringVarP(&zone, zoneFlag, "z", "", "The zone to use. This defaults to a dev zone (cloud only)")
 	c.cmd.PersistentFlags().StringVarP(&color, colorFlag, "c", "auto", `Whether to use colors in output. Must be "auto", "never", or "always"`)

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -537,11 +537,15 @@ func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, er
 	if err != nil {
 		return nil, err
 	}
+	deployment := vespa.DefaultDeployment
+	if app, err := c.config.application(); err == nil {
+		deployment.Application = app
+	}
 	switch targetType {
 	case vespa.TargetLocal:
-		return vespa.LocalTarget(c.httpClient, tlsOptions, c.retryInterval), nil
+		return vespa.LocalTarget(c.httpClient, tlsOptions, c.retryInterval, deployment), nil
 	case vespa.TargetCustom:
-		return vespa.CustomTarget(c.httpClient, customURL, tlsOptions, c.retryInterval), nil
+		return vespa.CustomTarget(c.httpClient, customURL, tlsOptions, c.retryInterval, deployment), nil
 	default:
 		return nil, fmt.Errorf("invalid custom target: %s", targetType)
 	}

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -540,7 +540,7 @@ func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, er
 	deployment := vespa.DefaultDeployment
 	if app, err := c.config.application(); err == nil {
 		deployment.Application = app
-	} else if err.Error() == ErrNoApplicationSpecified.Error() {
+	} else if errors.As(err, &ErrNoApplicationSpecified) {
 		// fall back to DefaultDeployment when the --application was not set
 		deployment.Application = vespa.DefaultApplication
 	} else {

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -369,16 +369,15 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 	} else {
 		instance := deployment.Target.Deployment().Application.Instance
 		applicationName := deployment.Target.Deployment().Application.Application
-		var params []string
+		params := url.Values{}
 		path := "/application/v2/tenant/default/prepareandactivate"
-		if instance != "" && instance != "default" {
-			params = append(params, "instance="+instance)
-		}
 		if applicationName != "" && applicationName != "application" {
-			params = append(params, "applicationName="+applicationName)
+			params.Set("applicationName", applicationName)
 		}
-		queryParams := strings.Join(params, "&")
-		if queryParams != "" {
+		if instance != "" && instance != "default" {
+			params.Set("instance", instance)
+		}
+		if queryParams := params.Encode(); queryParams != "" {
 			path += "?" + queryParams
 		}
 		u, err = deployment.url(path)

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -74,16 +74,6 @@ type PrepareResult struct {
 	LogLines []LogLinePrepareResponse
 }
 
-func (a ApplicationID) WithDefaults() ApplicationID {
-	if a.Application == "" {
-		a.Application = DefaultApplication.Application
-	}
-	if a.Instance == "" {
-		a.Instance = DefaultApplication.Instance
-	}
-	return a
-}
-
 func (a ApplicationID) String() string {
 	return fmt.Sprintf("%s.%s.%s", a.Tenant, a.Application, a.Instance)
 }
@@ -191,7 +181,7 @@ func fetchFromConfigServer(deployment DeploymentOptions, path string) error {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
-	app := deployment.Target.Deployment().Application.WithDefaults()
+	app := deployment.Target.Deployment().Application
 	endpoint := fmt.Sprintf(
 		"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/content",
 		app.Application,
@@ -381,7 +371,7 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 		}
 		u, err = url.Parse(deployment.Target.Deployment().System.DeployURL(deployment.Target.Deployment()))
 	} else {
-		app := deployment.Target.Deployment().Application.WithDefaults()
+		app := deployment.Target.Deployment().Application
 		u, err = deployment.url("/application/v2/tenant/default/prepareandactivate")
 		if err != nil {
 			return PrepareResult{}, err

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -394,10 +394,10 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 		if instance != "" && instance != DefaultApplication.Instance {
 			params.Set("instance", instance)
 		}
-		if queryParams := params.Encode(); queryParams != "" {
-			path += "?" + queryParams
-		}
 		u, err = deployment.url(path)
+		if u != nil {
+			u.RawQuery = params.Encode()
+		}
 	}
 	if err != nil {
 		return PrepareResult{}, err

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -368,9 +368,18 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 		u, err = url.Parse(deployment.Target.Deployment().System.DeployURL(deployment.Target.Deployment()))
 	} else {
 		instance := deployment.Target.Deployment().Application.Instance
+		applicationName := deployment.Target.Deployment().Application.Application
+		var params []string
 		path := "/application/v2/tenant/default/prepareandactivate"
 		if instance != "" && instance != "default" {
-			path += "?instance=" + instance
+			params = append(params, "instance="+instance)
+		}
+		if applicationName != "" && applicationName != "application" {
+			params = append(params, "applicationName="+applicationName)
+		}
+		queryParams := strings.Join(params, "&")
+		if queryParams != "" {
+			path += "?" + queryParams
 		}
 		u, err = deployment.url(path)
 	}

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -354,7 +354,13 @@ func Deactivate(deployment DeploymentOptions) error {
 		if applicationName == "" {
 			applicationName = DefaultApplication.Application
 		}
-		endpoint := fmt.Sprintf("/application/v2/tenant/default/application/%s", applicationName)
+		instance := deployment.Target.Deployment().Application.Instance
+		if instance == "" {
+			instance = DefaultApplication.Instance
+		}
+		endpoint := fmt.Sprintf(
+			"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s",
+			applicationName, instance)
 		u, err = deployment.url(endpoint)
 	}
 	if err != nil {

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -350,7 +350,12 @@ func Deactivate(deployment DeploymentOptions) error {
 		deploymentURL := deployment.Target.Deployment().System.DeploymentURL(deployment.Target.Deployment())
 		u, err = url.Parse(deploymentURL)
 	} else {
-		u, err = deployment.url("/application/v2/tenant/default/application/default")
+		applicationName := deployment.Target.Deployment().Application.Application
+		if applicationName == "" {
+			applicationName = DefaultApplication.Application
+		}
+		endpoint := fmt.Sprintf("/application/v2/tenant/default/application/%s", applicationName)
+		u, err = deployment.url(endpoint)
 	}
 	if err != nil {
 		return err

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -367,7 +367,12 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 		}
 		u, err = url.Parse(deployment.Target.Deployment().System.DeployURL(deployment.Target.Deployment()))
 	} else {
-		u, err = deployment.url("/application/v2/tenant/default/prepareandactivate")
+		instance := deployment.Target.Deployment().Application.Instance
+		path := "/application/v2/tenant/default/prepareandactivate"
+		if instance != "" && instance != "default" {
+			path += "?instance=" + instance
+		}
+		u, err = deployment.url(path)
 	}
 	if err != nil {
 		return PrepareResult{}, err

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -74,6 +74,16 @@ type PrepareResult struct {
 	LogLines []LogLinePrepareResponse
 }
 
+func (a ApplicationID) WithDefaults() ApplicationID {
+	if a.Application == "" {
+		a.Application = DefaultApplication.Application
+	}
+	if a.Instance == "" {
+		a.Instance = DefaultApplication.Instance
+	}
+	return a
+}
+
 func (a ApplicationID) String() string {
 	return fmt.Sprintf("%s.%s.%s", a.Tenant, a.Application, a.Instance)
 }
@@ -181,18 +191,11 @@ func fetchFromConfigServer(deployment DeploymentOptions, path string) error {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
-	applicationName := deployment.Target.Deployment().Application.Application
-	if applicationName == "" {
-		applicationName = DefaultApplication.Application
-	}
-	instanceName := deployment.Target.Deployment().Application.Instance
-	if instanceName == "" {
-		instanceName = DefaultApplication.Instance
-	}
+	app := deployment.Target.Deployment().Application.WithDefaults()
 	endpoint := fmt.Sprintf(
 		"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/content",
-		applicationName,
-		instanceName)
+		app.Application,
+		app.Instance)
 	u, err := deployment.url(endpoint)
 	if err != nil {
 		return err
@@ -378,19 +381,16 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 		}
 		u, err = url.Parse(deployment.Target.Deployment().System.DeployURL(deployment.Target.Deployment()))
 	} else {
-		instance := deployment.Target.Deployment().Application.Instance
-		applicationName := deployment.Target.Deployment().Application.Application
-		params := url.Values{}
-		path := "/application/v2/tenant/default/prepareandactivate"
-		if applicationName != "" && applicationName != DefaultApplication.Application {
-			params.Set("applicationName", applicationName)
+		app := deployment.Target.Deployment().Application.WithDefaults()
+		u, err = deployment.url("/application/v2/tenant/default/prepareandactivate")
+		if err != nil {
+			return PrepareResult{}, err
 		}
-		if instance != "" && instance != DefaultApplication.Instance {
-			params.Set("instance", instance)
-		}
-		u, err = deployment.url(path)
-		if u != nil {
-			u.RawQuery = params.Encode()
+		if app != DefaultApplication {
+			q := u.Query()
+			q.Set("applicationName", app.Application)
+			q.Set("instance", app.Instance)
+			u.RawQuery = q.Encode()
 		}
 	}
 	if err != nil {

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -181,7 +181,19 @@ func fetchFromConfigServer(deployment DeploymentOptions, path string) error {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
-	u, err := deployment.url("/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default/content")
+	applicationName := deployment.Target.Deployment().Application.Application
+	if applicationName == "" {
+		applicationName = DefaultApplication.Application
+	}
+	instanceName := deployment.Target.Deployment().Application.Instance
+	if instanceName == "" {
+		instanceName = DefaultApplication.Instance
+	}
+	endpoint := fmt.Sprintf(
+		"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/content",
+		applicationName,
+		instanceName)
+	u, err := deployment.url(endpoint)
 	if err != nil {
 		return err
 	}

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	DefaultApplication = ApplicationID{Tenant: "default", Application: "application", Instance: "default"}
+	DefaultApplication = ApplicationID{Tenant: "default", Application: "default", Instance: "default"}
 	DefaultZone        = ZoneID{Environment: "prod", Region: "default"}
 	DefaultDeployment  = Deployment{Application: DefaultApplication, Zone: DefaultZone}
 	ErrUnauthorized    = errors.New("unauthorized")

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -339,30 +339,18 @@ func Activate(sessionID int64, deployment DeploymentOptions, timeout time.Durati
 
 // Deactivate given deployment
 func Deactivate(deployment DeploymentOptions) error {
+	if !deployment.Target.IsCloud() {
+		return fmt.Errorf("%s: deactivate is unsupported by %s target", deployment, deployment.Target.Type())
+	}
 	var (
 		u   *url.URL
 		err error
 	)
-	if deployment.Target.IsCloud() {
-		if deployment.Target.Deployment().Zone.Environment == "" || deployment.Target.Deployment().Zone.Region == "" {
-			return fmt.Errorf("%s: missing zone", deployment)
-		}
-		deploymentURL := deployment.Target.Deployment().System.DeploymentURL(deployment.Target.Deployment())
-		u, err = url.Parse(deploymentURL)
-	} else {
-		applicationName := deployment.Target.Deployment().Application.Application
-		if applicationName == "" {
-			applicationName = DefaultApplication.Application
-		}
-		instance := deployment.Target.Deployment().Application.Instance
-		if instance == "" {
-			instance = DefaultApplication.Instance
-		}
-		endpoint := fmt.Sprintf(
-			"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s",
-			applicationName, instance)
-		u, err = deployment.url(endpoint)
+	if deployment.Target.Deployment().Zone.Environment == "" || deployment.Target.Deployment().Zone.Region == "" {
+		return fmt.Errorf("%s: missing zone", deployment)
 	}
+	deploymentURL := deployment.Target.Deployment().System.DeploymentURL(deployment.Target.Deployment())
+	u, err = url.Parse(deploymentURL)
 	if err != nil {
 		return err
 	}

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -371,10 +371,10 @@ func Deploy(deployment DeploymentOptions) (PrepareResult, error) {
 		applicationName := deployment.Target.Deployment().Application.Application
 		params := url.Values{}
 		path := "/application/v2/tenant/default/prepareandactivate"
-		if applicationName != "" && applicationName != "application" {
+		if applicationName != "" && applicationName != DefaultApplication.Application {
 			params.Set("applicationName", applicationName)
 		}
-		if instance != "" && instance != "default" {
+		if instance != "" && instance != DefaultApplication.Instance {
 			params.Set("instance", instance)
 		}
 		if queryParams := params.Encode(); queryParams != "" {

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -37,7 +37,7 @@ func TestDeploy(t *testing.T) {
 	req.Body.Read(buf)
 	assert.Equal(t, "PK\x03\x04\x14", string(buf))
 }
-
+q
 func TestDeployCustomInstance(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	application := ApplicationID{Tenant: "t1", Application: "a1", Instance: "i1"}
@@ -52,7 +52,7 @@ func TestDeployCustomInstance(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
-	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/prepareandactivate?instance=i1", req.URL.String())
+	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/prepareandactivate?instance=i1&applicationName=a1", req.URL.String())
 	assert.Equal(t, "application/zip", req.Header.Get("content-type"))
 	buf := make([]byte, 5)
 	req.Body.Read(buf)

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -207,7 +207,7 @@ func TestDeactivate(t *testing.T) {
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
 	assert.Equal(t, "DELETE", req.Method)
-	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/default", req.URL.String())
+	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default", req.URL.String())
 }
 
 func TestDeactivateCustomApplication(t *testing.T) {

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -210,6 +210,19 @@ func TestDeactivate(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/default", req.URL.String())
 }
 
+func TestDeactivateCustomApplication(t *testing.T) {
+	httpClient := mock.HTTPClient{}
+	deployment := DefaultDeployment
+	deployment.Application.Application = "a1"
+	target := LocalTarget(&httpClient, TLSOptions{}, 0, deployment)
+	opts := DeploymentOptions{Target: target}
+	require.Nil(t, Deactivate(opts))
+	assert.Equal(t, 1, len(httpClient.Requests))
+	req := httpClient.LastRequest
+	assert.Equal(t, "DELETE", req.Method)
+	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/a1", req.URL.String())
+}
+
 func TestDeactivateCloud(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	target, _ := createCloudTarget(t, io.Discard)

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -37,7 +37,7 @@ func TestDeploy(t *testing.T) {
 	req.Body.Read(buf)
 	assert.Equal(t, "PK\x03\x04\x14", string(buf))
 }
-q
+
 func TestDeployCustomInstance(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	application := ApplicationID{Tenant: "t1", Application: "a1", Instance: "i1"}
@@ -52,7 +52,7 @@ func TestDeployCustomInstance(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
-	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/prepareandactivate?instance=i1&applicationName=a1", req.URL.String())
+	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/prepareandactivate?applicationName=a1&instance=i1", req.URL.String())
 	assert.Equal(t, "application/zip", req.Header.Get("content-type"))
 	buf := make([]byte, 5)
 	req.Body.Read(buf)

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -270,6 +270,55 @@ func TestFetch(t *testing.T) {
 	assert.Equal(t, `music.sd contents`, string(data))
 }
 
+func TestFetchCustomApplication(t *testing.T) {
+	httpClient := mock.HTTPClient{}
+	deployment := DefaultDeployment
+	deployment.Application.Application = "a1"
+	deployment.Application.Instance = "i1"
+	target := LocalTarget(&httpClient, TLSOptions{}, 0, deployment)
+	opts := DeploymentOptions{Target: target}
+	httpClient.NextResponse(mock.HTTPResponse{
+		URI:    "/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content",
+		Status: 200,
+		Body: []byte(`[
+"/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content/schemas/",
+"/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content/services.xml"
+]`),
+	})
+	httpClient.NextResponse(mock.HTTPResponse{
+		URI:    "/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content/schemas/",
+		Status: 200,
+		Body: []byte(`[
+"/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content/schemas/music.sd"
+]`),
+	})
+	httpClient.NextResponse(mock.HTTPResponse{
+		URI:    "/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content/schemas/music.sd",
+		Status: 200,
+		Body:   []byte(`music.sd contents`),
+	})
+	httpClient.NextResponse(mock.HTTPResponse{
+		URI:    "/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/content/services.xml",
+		Status: 200,
+		Body:   []byte(`services.xml contents`),
+	})
+	dir := t.TempDir()
+	dst, err := Fetch(opts, dir)
+	require.Nil(t, err)
+	assert.True(t, ioutil.Exists(dst))
+
+	f, err := os.Open(dst)
+	require.Nil(t, err)
+	defer f.Close()
+	zr, err := zip.NewReader(f, 1000)
+	require.Nil(t, err)
+	schema, err := zr.Open("schemas/music.sd")
+	require.Nil(t, err)
+	data, err := io.ReadAll(schema)
+	require.Nil(t, err)
+	assert.Equal(t, `music.sd contents`, string(data))
+}
+
 func TestFetchCloud(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	target, _ := createCloudTarget(t, io.Discard)

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -214,13 +214,14 @@ func TestDeactivateCustomApplication(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	deployment := DefaultDeployment
 	deployment.Application.Application = "a1"
+	deployment.Application.Instance = "i1"
 	target := LocalTarget(&httpClient, TLSOptions{}, 0, deployment)
 	opts := DeploymentOptions{Target: target}
 	require.Nil(t, Deactivate(opts))
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
 	assert.Equal(t, "DELETE", req.Method)
-	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/a1", req.URL.String())
+	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1", req.URL.String())
 }
 
 func TestDeactivateCloud(t *testing.T) {

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -199,29 +199,13 @@ func TestFindApplicationPackage(t *testing.T) {
 	})
 }
 
-func TestDeactivate(t *testing.T) {
+func TestDeactivateLocalUnsupported(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	target := LocalTarget(&httpClient, TLSOptions{}, 0, DefaultDeployment)
 	opts := DeploymentOptions{Target: target}
-	require.Nil(t, Deactivate(opts))
-	assert.Equal(t, 1, len(httpClient.Requests))
-	req := httpClient.LastRequest
-	assert.Equal(t, "DELETE", req.Method)
-	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default", req.URL.String())
-}
-
-func TestDeactivateCustomApplication(t *testing.T) {
-	httpClient := mock.HTTPClient{}
-	deployment := DefaultDeployment
-	deployment.Application.Application = "a1"
-	deployment.Application.Instance = "i1"
-	target := LocalTarget(&httpClient, TLSOptions{}, 0, deployment)
-	opts := DeploymentOptions{Target: target}
-	require.Nil(t, Deactivate(opts))
-	assert.Equal(t, 1, len(httpClient.Requests))
-	req := httpClient.LastRequest
-	assert.Equal(t, "DELETE", req.Method)
-	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1", req.URL.String())
+	err := Deactivate(opts)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "deactivate is unsupported by local target")
 }
 
 func TestDeactivateCloud(t *testing.T) {

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestDeploy(t *testing.T) {
 	httpClient := mock.HTTPClient{}
-	target := LocalTarget(&httpClient, TLSOptions{}, 0)
+	target := LocalTarget(&httpClient, TLSOptions{}, 0, DefaultDeployment)
 	appDir, _ := mock.ApplicationPackageDir(t, false, false)
 	opts := DeploymentOptions{
 		Target:             target,
@@ -32,6 +32,27 @@ func TestDeploy(t *testing.T) {
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
 	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/prepareandactivate", req.URL.String())
+	assert.Equal(t, "application/zip", req.Header.Get("content-type"))
+	buf := make([]byte, 5)
+	req.Body.Read(buf)
+	assert.Equal(t, "PK\x03\x04\x14", string(buf))
+}
+
+func TestDeployCustomInstance(t *testing.T) {
+	httpClient := mock.HTTPClient{}
+	application := ApplicationID{Tenant: "t1", Application: "a1", Instance: "i1"}
+	deployment := Deployment{Application: application, Zone: DefaultZone}
+	target := LocalTarget(&httpClient, TLSOptions{}, 0, deployment)
+	appDir, _ := mock.ApplicationPackageDir(t, false, false)
+	opts := DeploymentOptions{
+		Target:             target,
+		ApplicationPackage: ApplicationPackage{Path: appDir},
+	}
+	_, err := Deploy(opts)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(httpClient.Requests))
+	req := httpClient.LastRequest
+	assert.Equal(t, "http://127.0.0.1:19071/application/v2/tenant/default/prepareandactivate?instance=i1", req.URL.String())
 	assert.Equal(t, "application/zip", req.Header.Get("content-type"))
 	buf := make([]byte, 5)
 	req.Body.Read(buf)
@@ -180,7 +201,7 @@ func TestFindApplicationPackage(t *testing.T) {
 
 func TestDeactivate(t *testing.T) {
 	httpClient := mock.HTTPClient{}
-	target := LocalTarget(&httpClient, TLSOptions{}, 0)
+	target := LocalTarget(&httpClient, TLSOptions{}, 0, DefaultDeployment)
 	opts := DeploymentOptions{Target: target}
 	require.Nil(t, Deactivate(opts))
 	assert.Equal(t, 1, len(httpClient.Requests))
@@ -205,7 +226,7 @@ func TestDeactivateCloud(t *testing.T) {
 
 func TestFetch(t *testing.T) {
 	httpClient := mock.HTTPClient{}
-	target := LocalTarget(&httpClient, TLSOptions{}, 0)
+	target := LocalTarget(&httpClient, TLSOptions{}, 0, DefaultDeployment)
 	opts := DeploymentOptions{Target: target}
 	httpClient.NextResponse(mock.HTTPResponse{
 		URI:    "/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default/content",

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -18,6 +18,7 @@ import (
 type customTarget struct {
 	targetType    string
 	baseURL       string
+	deployment    Deployment
 	httpClient    httputil.Client
 	tlsOptions    TLSOptions
 	retryInterval time.Duration
@@ -36,10 +37,11 @@ type serviceInfo struct {
 }
 
 // LocalTarget creates a target for a Vespa platform running locally.
-func LocalTarget(httpClient httputil.Client, tlsOptions TLSOptions, retryInterval time.Duration) Target {
+func LocalTarget(httpClient httputil.Client, tlsOptions TLSOptions, retryInterval time.Duration, deployment Deployment) Target {
 	return &customTarget{
 		targetType:    TargetLocal,
 		baseURL:       "http://127.0.0.1",
+		deployment:    deployment,
 		httpClient:    httpClient,
 		tlsOptions:    tlsOptions,
 		retryInterval: retryInterval,
@@ -47,10 +49,11 @@ func LocalTarget(httpClient httputil.Client, tlsOptions TLSOptions, retryInterva
 }
 
 // CustomTarget creates a Target for a Vespa platform running at baseURL.
-func CustomTarget(httpClient httputil.Client, baseURL string, tlsOptions TLSOptions, retryInterval time.Duration) Target {
+func CustomTarget(httpClient httputil.Client, baseURL string, tlsOptions TLSOptions, retryInterval time.Duration, deployment Deployment) Target {
 	return &customTarget{
 		targetType:    TargetCustom,
 		baseURL:       baseURL,
+		deployment:    deployment,
 		httpClient:    httpClient,
 		tlsOptions:    tlsOptions,
 		retryInterval: retryInterval,
@@ -61,7 +64,7 @@ func (t *customTarget) Type() string { return t.targetType }
 
 func (t *customTarget) IsCloud() bool { return false }
 
-func (t *customTarget) Deployment() Deployment { return DefaultDeployment }
+func (t *customTarget) Deployment() Deployment { return t.deployment }
 
 func (t *customTarget) PrintLog(options LogOptions) error {
 	deployService, err := t.DeployService()

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -189,7 +189,18 @@ func (t *customTarget) serviceStatus(wantedGeneration int64, timeout time.Durati
 	if err != nil {
 		return serviceStatus{}, err
 	}
-	url := fmt.Sprintf("%s/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default/serviceconverge", deployService.BaseURL)
+	applicationName := t.deployment.Application.Application
+	if applicationName == "" {
+		applicationName = DefaultApplication.Application
+	}
+	instanceName := t.deployment.Application.Instance
+	if instanceName == "" {
+		instanceName = DefaultApplication.Instance
+	}
+	url := fmt.Sprintf("%s/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/serviceconverge",
+		deployService.BaseURL,
+		applicationName,
+		instanceName)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return serviceStatus{}, err

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -71,18 +71,11 @@ func (t *customTarget) PrintLog(options LogOptions) error {
 	if err != nil {
 		return err
 	}
-	applicationName := t.deployment.Application.Application
-	if applicationName == "" {
-		applicationName = DefaultApplication.Application
-	}
-	instanceName := t.deployment.Application.Instance
-	if instanceName == "" {
-		instanceName = DefaultApplication.Instance
-	}
+	app := t.deployment.Application.WithDefaults()
 	endpoint := fmt.Sprintf(
 		"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/logs",
-		applicationName,
-		instanceName)
+		app.Application,
+		app.Instance)
 	logsURL := deployService.BaseURL + endpoint
 	return pollLogs(t, logsURL, options, t.retryInterval)
 }
@@ -201,19 +194,12 @@ func (t *customTarget) serviceStatus(wantedGeneration int64, timeout time.Durati
 	if err != nil {
 		return serviceStatus{}, err
 	}
-	applicationName := t.deployment.Application.Application
-	if applicationName == "" {
-		applicationName = DefaultApplication.Application
-	}
-	instanceName := t.deployment.Application.Instance
-	if instanceName == "" {
-		instanceName = DefaultApplication.Instance
-	}
+	app := t.deployment.Application.WithDefaults()
 	url := fmt.Sprintf(
 		"%s/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/serviceconverge",
 		deployService.BaseURL,
-		applicationName,
-		instanceName)
+		app.Application,
+		app.Instance)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return serviceStatus{}, err

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -71,7 +71,7 @@ func (t *customTarget) PrintLog(options LogOptions) error {
 	if err != nil {
 		return err
 	}
-	app := t.deployment.Application.WithDefaults()
+	app := t.deployment.Application
 	endpoint := fmt.Sprintf(
 		"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/logs",
 		app.Application,
@@ -194,7 +194,7 @@ func (t *customTarget) serviceStatus(wantedGeneration int64, timeout time.Durati
 	if err != nil {
 		return serviceStatus{}, err
 	}
-	app := t.deployment.Application.WithDefaults()
+	app := t.deployment.Application
 	url := fmt.Sprintf(
 		"%s/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/serviceconverge",
 		deployService.BaseURL,

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -71,7 +71,19 @@ func (t *customTarget) PrintLog(options LogOptions) error {
 	if err != nil {
 		return err
 	}
-	logsURL := deployService.BaseURL + "/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default/logs"
+	applicationName := t.deployment.Application.Application
+	if applicationName == "" {
+		applicationName = DefaultApplication.Application
+	}
+	instanceName := t.deployment.Application.Instance
+	if instanceName == "" {
+		instanceName = DefaultApplication.Instance
+	}
+	endpoint := fmt.Sprintf(
+		"/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/logs",
+		applicationName,
+		instanceName)
+	logsURL := deployService.BaseURL + endpoint
 	return pollLogs(t, logsURL, options, t.retryInterval)
 }
 
@@ -197,7 +209,8 @@ func (t *customTarget) serviceStatus(wantedGeneration int64, timeout time.Durati
 	if instanceName == "" {
 		instanceName = DefaultApplication.Instance
 	}
-	url := fmt.Sprintf("%s/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/serviceconverge",
+	url := fmt.Sprintf(
+		"%s/application/v2/tenant/default/application/%s/environment/prod/region/default/instance/%s/serviceconverge",
 		deployService.BaseURL,
 		applicationName,
 		instanceName)

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -294,6 +294,29 @@ func TestLog(t *testing.T) {
 	assert.Equal(t, expected, buf.String())
 }
 
+func TestCustomTargetLog(t *testing.T) {
+	client := &mock.HTTPClient{}
+	deployment := DefaultDeployment
+	deployment.Application.Application = "a1"
+	deployment.Application.Instance = "i1"
+	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0, deployment)
+
+	client.NextResponse(mock.HTTPResponse{
+		URI:    "/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/logs?from=-62135596800000",
+		Status: 200,
+		Body: []byte(`1632738690.905535	host1a.dev.aws-us-east-1c	806/53	logserver-container	Container.com.yahoo.container.jdisc.ConfiguredApplication	info	Switching to the latest deployed set of configurations and components. Application config generation: 52532
+1632738698.600189	host1a.dev.aws-us-east-1c	1723/33590	config-sentinel	sentinel.sentinel.config-owner	config	Sentinel got 3 service elements [tenant(vespa-team), application(music), instance(mpolden)] for config generation 52532
+`),
+	})
+	var buf bytes.Buffer
+	if err := target.PrintLog(LogOptions{Writer: &buf, Level: 3}); err != nil {
+		t.Fatal(err)
+	}
+	expected := "[2021-09-27 10:31:30.905535] host1a.dev.aws-us-east-1c info    logserver-container Container.com.yahoo.container.jdisc.ConfiguredApplication\tSwitching to the latest deployed set of configurations and components. Application config generation: 52532\n" +
+		"[2021-09-27 10:31:38.600189] host1a.dev.aws-us-east-1c config  config-sentinel  sentinel.sentinel.config-owner\tSentinel got 3 service elements [tenant(vespa-team), application(music), instance(mpolden)] for config generation 52532\n"
+	assert.Equal(t, expected, buf.String())
+}
+
 func TestCloudCompatibleWith(t *testing.T) {
 	target, client := createCloudTarget(t, io.Discard)
 	for range 3 {

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -20,7 +20,7 @@ import (
 func TestLocalTarget(t *testing.T) {
 	// Local target uses discovery
 	client := &mock.HTTPClient{}
-	lt := LocalTarget(client, TLSOptions{}, 0)
+	lt := LocalTarget(client, TLSOptions{}, 0, DefaultDeployment)
 	assertServiceURL(t, "http://127.0.0.1:19071", lt, "deploy")
 	for range 2 {
 		response := `
@@ -70,17 +70,17 @@ func TestLocalTarget(t *testing.T) {
 
 func TestCustomTarget(t *testing.T) {
 	// Custom target always uses URL directly, without discovery
-	ct := CustomTarget(&mock.HTTPClient{}, "http://192.0.2.42", TLSOptions{}, 0)
+	ct := CustomTarget(&mock.HTTPClient{}, "http://192.0.2.42", TLSOptions{}, 0, DefaultDeployment)
 	assertServiceURL(t, "http://192.0.2.42", ct, "deploy")
 	assertServiceURL(t, "http://192.0.2.42", ct, "")
-	ct2 := CustomTarget(&mock.HTTPClient{}, "http://192.0.2.42:60000", TLSOptions{}, 0)
+	ct2 := CustomTarget(&mock.HTTPClient{}, "http://192.0.2.42:60000", TLSOptions{}, 0, DefaultDeployment)
 	assertServiceURL(t, "http://192.0.2.42:60000", ct2, "deploy")
 	assertServiceURL(t, "http://192.0.2.42:60000", ct2, "")
 }
 
 func TestCustomTargetWait(t *testing.T) {
 	client := &mock.HTTPClient{}
-	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0)
+	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0, DefaultDeployment)
 	// Fails once
 	client.NextStatus(500)
 	assertService(t, true, target, "", 0)
@@ -96,7 +96,7 @@ func TestCustomTargetWait(t *testing.T) {
 
 func TestCustomTargetAwaitDeployment(t *testing.T) {
 	client := &mock.HTTPClient{}
-	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0)
+	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0, DefaultDeployment)
 
 	// Not converged initially
 	_, err := target.AwaitDeployment(42, 0)
@@ -121,7 +121,7 @@ func TestCustomTargetAwaitDeployment(t *testing.T) {
 
 func TestCustomTargetCompatibleWith(t *testing.T) {
 	client := &mock.HTTPClient{}
-	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0)
+	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0, DefaultDeployment)
 	for range 3 {
 		client.NextResponse(mock.HTTPResponse{
 			URI:    "/state/v1/version",

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -119,6 +119,34 @@ func TestCustomTargetAwaitDeployment(t *testing.T) {
 	assert.Equal(t, int64(42), convergedID)
 }
 
+func TestCustomTargetCustomApplicationAwaitDeployment(t *testing.T) {
+	client := &mock.HTTPClient{}
+	deployment := DefaultDeployment
+	deployment.Application.Application = "a1"
+	deployment.Application.Instance = "i1"
+	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0, deployment)
+
+	// Not converged initially
+	_, err := target.AwaitDeployment(43, 0)
+	assert.NotNil(t, err)
+
+	// Not converged on this generation
+	response := mock.HTTPResponse{
+		URI:    "/application/v2/tenant/default/application/a1/environment/prod/region/default/instance/i1/serviceconverge",
+		Status: 200,
+		Body:   []byte(`{"currentGeneration": 43}`),
+	}
+	client.NextResponse(response)
+	_, err = target.AwaitDeployment(42, 0)
+	assert.NotNil(t, err)
+
+	// Converged
+	client.NextResponse(response)
+	convergedID, err := target.AwaitDeployment(43, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(43), convergedID)
+}
+
 func TestCustomTargetCompatibleWith(t *testing.T) {
 	client := &mock.HTTPClient{}
 	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0, DefaultDeployment)

--- a/client/go/internal/vespa/vault_test.go
+++ b/client/go/internal/vespa/vault_test.go
@@ -15,7 +15,7 @@ import (
 func TestEnsureVaultAccessForDevNonCloud(t *testing.T) {
 	// Non-cloud targets are a no-op
 	client := &mock.HTTPClient{}
-	lt := LocalTarget(client, TLSOptions{}, 0)
+	lt := LocalTarget(client, TLSOptions{}, 0, DefaultDeployment)
 	err := EnsureVaultAccessForDev(lt, []string{"my-vault"})
 	assert.Nil(t, err)
 	assert.Empty(t, client.Requests)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This PR adds the wiring for the `instance` and `applicationName` parameter.

The rationale is that the non-cloud `prepareandactivate` endpoint supports `instance` and `applicationName` parameters, but the vespa-cli had no wiring to pass it. 

This would help testing applications which leverages services.xml variants and are deployed from one source code base to multiple targets, like PROD and  DEV.

The workaround currently is to use curl to pass these parameters.

Continuation of https://github.com/vespa-engine/vespa/pull/36284

Addresses https://github.com/vespa-engine/vespa/issues/35630

