### PR TITLE
Deprecate yolean chain annotations

### DIFF
--- a/container-disc/src/main/java/com/yahoo/component/chain/model/Chainable.java
+++ b/container-disc/src/main/java/com/yahoo/component/chain/model/Chainable.java
@@ -17,6 +17,7 @@ import java.util.Set;
  */
 public interface Chainable {
 
+    @SuppressWarnings("removal")
     default Dependencies getAnnotatedDependencies() {
         Set<String> provides = new LinkedHashSet<>();
         Set<String> before = new LinkedHashSet<>();

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsPreflightRequestFilter.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsPreflightRequestFilter.java
@@ -30,6 +30,7 @@ import static com.yahoo.jdisc.http.HttpRequest.Method.OPTIONS;
  * @author gv
  * @author bjorncs
  */
+@SuppressWarnings("removal")
 @Provides("CorsPreflightRequestFilter")
 public class CorsPreflightRequestFilter implements SecurityRequestFilter {
     private final CorsLogic cors;

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsResponseFilter.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsResponseFilter.java
@@ -14,6 +14,7 @@ import com.yahoo.yolean.chain.Provides;
  * @author Tony Vaagenes
  * @author bjorncs
  */
+@SuppressWarnings("removal")
 @Provides("CorsResponseFilter")
 public class CorsResponseFilter extends AbstractResource implements SecurityResponseFilter {
 

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/csp/CspResponseFilter.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/filter/security/csp/CspResponseFilter.java
@@ -15,6 +15,7 @@ import com.yahoo.yolean.chain.Provides;
  *
  * @author freva
  */
+@SuppressWarnings("removal")
 @Provides("CspResponseFilter")
 public class CspResponseFilter extends AbstractResource implements SecurityResponseFilter {
 

--- a/container-search/src/main/java/com/yahoo/search/querytransform/RangeQueryOptimizer.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/RangeQueryOptimizer.java
@@ -29,6 +29,7 @@ import java.util.Optional;
  *
  * @author bratseth
  */
+@SuppressWarnings("removal")
 @Before(QueryCanonicalizer.queryCanonicalization)
 @After(PhaseNames.TRANSFORMED_QUERY)
 public class RangeQueryOptimizer extends Searcher {

--- a/container-search/src/main/java/com/yahoo/search/querytransform/SortingDegrader.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/SortingDegrader.java
@@ -32,6 +32,7 @@ import java.util.Set;
 // Query.prepare is done at the same time as canonicalization (by GroupingExecutor), so use that constraint.
 // (we're not adding another constraint at this point because all this preparation and encoding business
 // should be fixed when we move to Slime for serialization. - Jon, in the spring of the year of 2014)
+@SuppressWarnings("removal")
 @Before(QueryCanonicalizer.queryCanonicalization)
 
 // We are checking if there is a grouping expression, not if there is a raw grouping instruction property,

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -20,6 +20,7 @@ import com.yahoo.yolean.chain.Provides;
  *
  * @author karowan
  */
+@SuppressWarnings("removal")
 @Provides(WeakAndReplacementSearcher.REPLACE_OR_WITH_WEAKAND)
 @After(MinimalQueryInserter.EXTERNAL_YQL)
 public class WeakAndReplacementSearcher extends Searcher {

--- a/container-search/src/main/java/com/yahoo/search/searchers/RateLimitingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/RateLimitingSearcher.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *
  * @author bratseth
  */
+@SuppressWarnings("removal")
 @Provides(RateLimitingSearcher.RATE_LIMITING)
 public class RateLimitingSearcher extends Searcher {
 

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateFuzzySearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateFuzzySearcher.java
@@ -26,6 +26,7 @@ import java.util.Set;
  *
  * @author alexeyche
  */
+@SuppressWarnings("removal")
 @Before(GroupingExecutor.COMPONENT_NAME) // Must happen before query.prepare()
 public class ValidateFuzzySearcher extends Searcher {
 

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateNearestNeighborSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateNearestNeighborSearcher.java
@@ -28,6 +28,7 @@ import java.util.Optional;
  *
  * @author arnej
  */
+@SuppressWarnings("removal")
 @Before(GroupingExecutor.COMPONENT_NAME) // Must happen before query.prepare()
 public class ValidateNearestNeighborSearcher extends Searcher {
 

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateSameElementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateSameElementSearcher.java
@@ -28,6 +28,7 @@ import java.util.Optional;
  *
  * @author bratseth
  */
+@SuppressWarnings("removal")
 @Before(GroupingExecutor.COMPONENT_NAME) // Must happen before query.prepare()
 public class ValidateSameElementSearcher extends Searcher {
 

--- a/container-search/src/main/java/com/yahoo/search/yql/MinimalQueryInserter.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/MinimalQueryInserter.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
  */
 // TODO: The query model should do this
 @Beta
+@SuppressWarnings("removal")
 @Provides(MinimalQueryInserter.EXTERNAL_YQL)
 @Before(PhaseNames.TRANSFORMED_QUERY)
 @After("com.yahoo.prelude.statistics.StatisticsSearcher")

--- a/container-search/src/test/java/com/yahoo/search/searchers/test/RateLimitingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/test/RateLimitingSearcherTestCase.java
@@ -136,6 +136,7 @@ public class RateLimitingSearcherTestCase {
     }
 
     /** The purpose of this test is simply to verify that cost is picked up after executing the query */
+    @SuppressWarnings("removal")
     @After(RateLimitingSearcher.RATE_LIMITING)
     private static class CostSettingSearcher extends Searcher {
 

--- a/vespajlib/src/main/java/com/yahoo/yolean/chain/After.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/chain/After.java
@@ -11,8 +11,10 @@ import java.lang.annotation.Target;
  * The component that is annotated with this must be placed later than the components or phases providing names
  * contained in the given list.
  *
+ * @deprecated Use {@link com.yahoo.component.chain.dependencies.After} instead.
  * @author Tony Vaagenes
  */
+@Deprecated(forRemoval = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited

--- a/vespajlib/src/main/java/com/yahoo/yolean/chain/Before.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/chain/Before.java
@@ -11,8 +11,10 @@ import java.lang.annotation.Target;
  * The component that is annotated with this must be placed earlier than the components or phases providing names
  * contained in the given list.
  *
+ * @deprecated Use {@link com.yahoo.component.chain.dependencies.Before} instead.
  * @author Tony Vaagenes
  */
+@Deprecated(forRemoval = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited

--- a/vespajlib/src/main/java/com/yahoo/yolean/chain/Provides.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/chain/Provides.java
@@ -11,8 +11,10 @@ import java.lang.annotation.Target;
  * <p>Mark this component as providing some named functionality. Other components can then mark themselves as "before"
  * and "after" the string provided here, to impose constraints on ordering.</p>
  *
+ * @deprecated Use {@link com.yahoo.component.chain.dependencies.Provides} instead.
  * @author Tony Vaagenes
  */
+@Deprecated(forRemoval = true)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited


### PR DESCRIPTION
Mark `com.yahoo.yolean.chain.{Before,After,Provides}` as `@Deprecated(forRemoval = true)`, pointing users to the original `com.yahoo.component.chain.dependencies` equivalents.

Both annotation sets are functionally identical and both are processed by `Chainable.getAnnotatedDependencies()`. The yolean set was added as part of an unfinished chain redesign. Since both are `@PublicApi`, actual removal is deferred to the next major release.