### PR TITLE
Fix javadoc in deprecated yolean chain annotations [MERGEOK]

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/yolean/chain/After.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/chain/After.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * The component that is annotated with this must be placed later than the components or phases providing names
  * contained in the given list.
  *
- * @deprecated Use {@link com.yahoo.component.chain.dependencies.After} instead.
+ * @deprecated Use com.yahoo.component.chain.dependencies.After instead.
  * @author Tony Vaagenes
  */
 @Deprecated(forRemoval = true)

--- a/vespajlib/src/main/java/com/yahoo/yolean/chain/Before.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/chain/Before.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * The component that is annotated with this must be placed earlier than the components or phases providing names
  * contained in the given list.
  *
- * @deprecated Use {@link com.yahoo.component.chain.dependencies.Before} instead.
+ * @deprecated Use com.yahoo.component.chain.dependencies.Before instead.
  * @author Tony Vaagenes
  */
 @Deprecated(forRemoval = true)

--- a/vespajlib/src/main/java/com/yahoo/yolean/chain/Provides.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/chain/Provides.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * <p>Mark this component as providing some named functionality. Other components can then mark themselves as "before"
  * and "after" the string provided here, to impose constraints on ordering.</p>
  *
- * @deprecated Use {@link com.yahoo.component.chain.dependencies.Provides} instead.
+ * @deprecated Use com.yahoo.component.chain.dependencies.Provides instead.
  * @author Tony Vaagenes
  */
 @Deprecated(forRemoval = true)


### PR DESCRIPTION
Replace `{@link}` with plain text in the `@deprecated` javadoc tags for `com.yahoo.yolean.chain.{Before,After,Provides}`. The link targets are in container-disc, which is not a dependency of vespajlib.