### PR TITLE
Rename flag for restart on deploy maintainer

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
@@ -56,7 +56,7 @@ public class ConfigServerMaintenance {
                                                  Duration.ofMinutes(3), convergenceChecker, Clock.systemUTC()));
         if (applicationRepository.configserverConfig().hostedVespa()) {
             // Only one of these maintainers is used per application controlled by
-            // {@code Flags.WAIT_FOR_APPLY_ON_RESTART} feature flag.
+            // {@code Flags.RESTART_ON_DEPLOY_MAINTAINER} feature flag.
             // {@code PendingRestartsMaintainer} is active when the flag is {@code false} - default.
             // {@code RestartOnDeployMaintainer} is active when the flag is {@code true} - experimental.
             maintainers.add(new PendingRestartsMaintainer(

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/PendingRestartsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/PendingRestartsMaintainer.java
@@ -26,7 +26,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 
 /**
  * @author Jon Marius Venstad
@@ -34,12 +33,12 @@ import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 public class PendingRestartsMaintainer extends ConfigServerMaintainer {
 
     private final Clock clock;
-    private final BooleanFlag waitForApplyOnRestart;
+    private final BooleanFlag restartOnDeployMaintainer;
 
     public PendingRestartsMaintainer(ApplicationRepository applicationRepository, Curator curator, Clock clock, Duration interval) {
         super(applicationRepository, curator, applicationRepository.flagSource(), clock, interval, true);
         this.clock = clock;
-        this.waitForApplyOnRestart = Flags.WAIT_FOR_APPLY_ON_RESTART.bindTo(applicationRepository.flagSource());
+        this.restartOnDeployMaintainer = Flags.RESTART_ON_DEPLOY_MAINTAINER.bindTo(applicationRepository.flagSource());
     }
 
     @Override
@@ -49,11 +48,7 @@ public class PendingRestartsMaintainer extends ConfigServerMaintainer {
         for (Tenant tenant : tenantRepository.getAllTenants()) {
             ApplicationCuratorDatabase database = tenant.getApplicationRepo().database();
             for (ApplicationId id : database.activeApplications()) {
-                boolean shouldWaitForApplyOnRestart = waitForApplyOnRestart
-                        .with(id)
-                        .value();
-
-                if (!shouldWaitForApplyOnRestart) {
+                if (!restartOnDeployMaintainer.with(id).value()) {
                     applicationRepository.getActiveApplicationVersions(id)
                             .map(application -> application.getForVersionOrLatest(Optional.empty(), clock.instant()))
                             .ifPresent(application -> {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/RestartOnDeployMaintainer.java
@@ -34,7 +34,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
-import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
 
@@ -43,7 +42,7 @@ import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_
  * Implements restart conditions to ensure that services converge to the same config generation before restart.
  * Removes restarted nodes from ZooKeeper.
  * This is an experimental replacement for {@link PendingRestartsMaintainer}, enabled by
- * {@link Flags#WAIT_FOR_APPLY_ON_RESTART} feature flag.
+ * {@link Flags#RESTART_ON_DEPLOY_MAINTAINER} feature flag.
  *
  * @author glebashnik
  */
@@ -58,13 +57,13 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
             "distributor");
 
     private final Clock clock;
-    private final BooleanFlag waitForApplyOnRestart;
+    private final BooleanFlag restartOnDeployMaintainer;
 
     public RestartOnDeployMaintainer(
             ApplicationRepository applicationRepository, Curator curator, Clock clock, Duration interval) {
         super(applicationRepository, curator, applicationRepository.flagSource(), clock, interval, true);
         this.clock = clock;
-        this.waitForApplyOnRestart = Flags.WAIT_FOR_APPLY_ON_RESTART.bindTo(applicationRepository.flagSource());
+        this.restartOnDeployMaintainer = Flags.RESTART_ON_DEPLOY_MAINTAINER.bindTo(applicationRepository.flagSource());
     }
 
     @Override
@@ -77,10 +76,7 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
             for (ApplicationId id : database.activeApplications()) {
                 // Controls whether to use this maintainer for a specific instance with the feature flag.
                 // Alternatively, the older PendingRestartsMaintainer will be used.
-                boolean shouldWaitForApplyOnRestart =
-                        waitForApplyOnRestart.with(id).value();
-
-                if (shouldWaitForApplyOnRestart) {
+                if (restartOnDeployMaintainer.with(id).value()) {
                     applicationRepository
                             .getActiveApplicationVersions(id)
                             .map(application -> application.getForVersionOrLatest(Optional.empty(), clock.instant()))
@@ -208,9 +204,9 @@ public class RestartOnDeployMaintainer extends ConfigServerMaintainer {
                     id.toFullString(), String.join(", ", restarts.hostnames()), configStatesToString(configStates)));
         }
 
-        // Minimum observed config generation for all services without applyOnRestart across all pending restart nodes.
-        // Services with applyOnRestart set to {@code true} are excluded because they are waiting for restart to apply a
-        // new config, while still reporting the old config.
+        // Minimum observed config generation for all services across all pending restart nodes.
+        // Services with {@code applyOnRestart} set to {@code true} are excluded 
+        // because they are waiting for restart to apply a new config while reporting older {@code currentGeneration}.
         OptionalLong minObservedGeneration = configStates.values().stream()
                 .flatMap(List::stream)
                 .filter(state -> !state.applyOnRestart().orElse(false))

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -369,12 +369,20 @@ public class Flags {
             TENANT_ID, APPLICATION, INSTANCE_ID, HOSTNAME, CLUSTER_TYPE
     );
 
+    public static final UnboundBooleanFlag RESTART_ON_DEPLOY_MAINTAINER = defineFeatureFlag(
+            "restart-on-deploy-maintainer", false,
+            List.of("glebashnik"), "2026-04-07", "2026-10-07",
+            "When enabled, RestartOnDeployMaintainer is used instead of PendingRestartsMaintainer " +
+                    "to trigger pending restarts.",
+            "Takes effect at next run of RestartOnDeployMaintainer and PendingRestartsMaintainer.",
+            INSTANCE_ID
+    );
+
     public static final UnboundBooleanFlag WAIT_FOR_APPLY_ON_RESTART = defineFeatureFlag(
             "wait-for-apply-on-restart", false,
             List.of("glebashnik"), "2026-02-01", "2026-08-01",
             "Determines whether triggering of a pending restart waits for `applyOnRestart` to be set to `true` " +
-                    "in the observed config state. In addition, changes service convergence condition bounded to a " +
-                    "current node instead of across multiple nodes, see `RestartOnDeployMaintainer`.",
+                    "in the observed config state.",
             "Takes effect at next run of RestartOnDeployMaintainer.",
             INSTANCE_ID
     );


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Old flag name doesn't make sense anymore so created a new flag for this with more meaningful name.
