### PR TITLE
Feeding to synthetic fields return 400

### DIFF
--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
@@ -19,6 +19,7 @@ import com.yahoo.document.update.MapValueUpdate;
 import com.yahoo.document.update.ValueUpdate;
 import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.expressions.InvalidInputException;
 import com.yahoo.vespa.indexinglanguage.expressions.ScriptExpression;
 
 import java.time.Instant;
@@ -73,7 +74,7 @@ class DocumentScript {
 
     private void requireThatFieldIsDeclaredInDocument(Field field) {
         if (field != null && !inputFields.contains(field.getName()))
-            throw new IllegalArgumentException("Field '" + field.getName() + "' is not part of the declared " + documentType);
+            throw new InvalidInputException("Field '" + field.getName() + "' is not part of the declared " + documentType);
     }
 
     private void removeAnyLinguisticsSpanTree(ValueUpdate<?> valueUpdate) {

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -25,6 +25,7 @@ import com.yahoo.document.update.ValueUpdate;
 import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
 import com.yahoo.vespa.indexinglanguage.expressions.IndexExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.InputExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.InvalidInputException;
 import com.yahoo.vespa.indexinglanguage.expressions.ScriptExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.StatementExpression;
 import org.junit.Test;
@@ -332,7 +333,7 @@ public class DocumentScriptTestCase {
         try {
             execute(document);
             fail();
-        } catch (IllegalArgumentException e) {
+        } catch (InvalidInputException e) {
             assertEquals(expectedException, e.getMessage());
         }
     }
@@ -341,7 +342,7 @@ public class DocumentScriptTestCase {
         try {
             execute(update);
             fail();
-        } catch (IllegalArgumentException e) {
+        } catch (InvalidInputException e) {
             assertEquals(expectedException, e.getMessage());
         }
     }


### PR DESCRIPTION
- IllegalArgumentException is not mapped and gives a 500 error code.
- InvalidInputException is mapped to 400.
