### PR TITLE
Add Elasticsearch to Vespa query translator

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/querytransform/ElasticsearchQueryTransformer.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/ElasticsearchQueryTransformer.java
@@ -1,80 +1,207 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.querytransform;
 
-import com.yahoo.prelude.query.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.Limit;
+import com.yahoo.prelude.query.NotItem;
+import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.RangeItem;
+import com.yahoo.prelude.query.WordItem;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.searchchain.Execution;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 public class ElasticsearchQueryTransformer extends Searcher {
 
     private static final ObjectMapper mapper = new ObjectMapper();
+    private static final String ES_QUERY_PROPERTY = "elasticsearch.query";
 
     @Override
     public Result search(Query query, Execution execution) {
-        String esQuery = query.properties().getString("elasticsearch.query");
+        String esQuery = query.properties().getString(ES_QUERY_PROPERTY);
         if (esQuery != null) {
             try {
                 JsonNode root = mapper.readTree(esQuery);
                 Item item = translateQuery(root.get("query"));
-                if (item != null) {
-                    query.getModel().getQueryTree().setRoot(item);
-                }
-            } catch (Exception e) {
-                // log and continue
+                query.getModel().getQueryTree().setRoot(item);
+            } catch (JsonProcessingException | IllegalArgumentException e) {
+                throw new IllegalInputException("Failed parsing 'elasticsearch.query'", e);
             }
         }
         return execution.search(query);
     }
 
     private Item translateQuery(JsonNode node) {
-        if (node == null) return null;
+        if (node == null || node.isNull()) {
+            throw new IllegalArgumentException("Missing Elasticsearch 'query' field");
+        }
+        if (!node.isObject()) {
+            throw new IllegalArgumentException("Elasticsearch 'query' must be an object");
+        }
 
         if (node.has("match")) {
             JsonNode match = node.get("match");
-            String field = match.fieldNames().next();
-            return new WordItem(match.get(field).asText(), field);
+            return translateWordClause(match, "match");
         }
         if (node.has("term")) {
             JsonNode term = node.get("term");
-            String field = term.fieldNames().next();
-            return new WordItem(term.get(field).asText(), field);
+            return translateWordClause(term, "term");
         }
         if (node.has("range")) {
-            JsonNode range = node.get("range");
-            String field = range.fieldNames().next();
-            JsonNode bounds = range.get(field);
-            RangeItem item = new RangeItem(field);
-            if (bounds.has("gte")) item.setFromInclusive(bounds.get("gte").asDouble());
-            if (bounds.has("gt"))  item.setFromExclusive(bounds.get("gt").asDouble());
-            if (bounds.has("lte")) item.setToInclusive(bounds.get("lte").asDouble());
-            if (bounds.has("lt"))  item.setToExclusive(bounds.get("lt").asDouble());
-            return item;
+            return translateRangeClause(node.get("range"));
         }
         if (node.has("bool")) {
             JsonNode bool = node.get("bool");
+            if (!bool.isObject()) {
+                throw new IllegalArgumentException("Elasticsearch 'bool' clause must be an object");
+            }
+
             AndItem and = new AndItem();
             OrItem or = new OrItem();
             NotItem not = new NotItem();
 
             if (bool.has("must")) {
-                for (JsonNode clause : bool.get("must"))
+                for (JsonNode clause : clauses(bool.get("must"), "must")) {
                     and.addItem(translateQuery(clause));
+                }
                 return and;
             }
             if (bool.has("should")) {
-                for (JsonNode clause : bool.get("should"))
+                for (JsonNode clause : clauses(bool.get("should"), "should")) {
                     or.addItem(translateQuery(clause));
+                }
                 return or;
             }
             if (bool.has("must_not")) {
-                for (JsonNode clause : bool.get("must_not"))
+                for (JsonNode clause : clauses(bool.get("must_not"), "must_not")) {
                     not.addNegativeItem(translateQuery(clause));
+                }
                 return not;
             }
+            throw new IllegalArgumentException("Elasticsearch 'bool' must contain one of 'must', 'should', or 'must_not'");
         }
-        return null;
+
+        throw new IllegalArgumentException("Unsupported Elasticsearch query type");
+    }
+
+    private WordItem translateWordClause(JsonNode node, String type) {
+        if (!node.isObject()) {
+            throw new IllegalArgumentException("Elasticsearch '" + type + "' clause must be an object");
+        }
+
+        Iterator<String> fields = node.fieldNames();
+        if (!fields.hasNext()) {
+            throw new IllegalArgumentException("Elasticsearch '" + type + "' clause must contain one field");
+        }
+
+        String field = fields.next();
+        JsonNode valueNode = node.get(field);
+        if (valueNode == null || valueNode.isNull()) {
+            throw new IllegalArgumentException("Elasticsearch '" + type + "' value is missing");
+        }
+
+        if (valueNode.isObject()) {
+            JsonNode nestedValue = valueNode.get("value");
+            if (nestedValue == null || nestedValue.isNull()) {
+                nestedValue = valueNode.get("query");
+            }
+            if (nestedValue == null || nestedValue.isNull()) {
+                throw new IllegalArgumentException("Elasticsearch '" + type + "' object must contain 'value' or 'query'");
+            }
+            valueNode = nestedValue;
+        }
+
+        return new WordItem(valueNode.asText(), field);
+    }
+
+    private RangeItem translateRangeClause(JsonNode node) {
+        if (!node.isObject()) {
+            throw new IllegalArgumentException("Elasticsearch 'range' clause must be an object");
+        }
+
+        Iterator<String> fields = node.fieldNames();
+        if (!fields.hasNext()) {
+            throw new IllegalArgumentException("Elasticsearch 'range' clause must contain one field");
+        }
+
+        String field = fields.next();
+        JsonNode bounds = node.get(field);
+        if (bounds == null || !bounds.isObject()) {
+            throw new IllegalArgumentException("Elasticsearch 'range' bounds must be an object");
+        }
+
+        if (bounds.has("gte") && bounds.has("gt")) {
+            throw new IllegalArgumentException("Elasticsearch 'range' cannot contain both 'gte' and 'gt'");
+        }
+        if (bounds.has("lte") && bounds.has("lt")) {
+            throw new IllegalArgumentException("Elasticsearch 'range' cannot contain both 'lte' and 'lt'");
+        }
+
+        Limit from = Limit.NEGATIVE_INFINITY;
+        Limit to = Limit.POSITIVE_INFINITY;
+        boolean hasBounds = false;
+
+        if (bounds.has("gte")) {
+            from = new Limit(numberValue(bounds.get("gte"), "gte"), true);
+            hasBounds = true;
+        }
+        if (bounds.has("gt")) {
+            from = new Limit(numberValue(bounds.get("gt"), "gt"), false);
+            hasBounds = true;
+        }
+        if (bounds.has("lte")) {
+            to = new Limit(numberValue(bounds.get("lte"), "lte"), true);
+            hasBounds = true;
+        }
+        if (bounds.has("lt")) {
+            to = new Limit(numberValue(bounds.get("lt"), "lt"), false);
+            hasBounds = true;
+        }
+
+        if (!hasBounds) {
+            throw new IllegalArgumentException("Elasticsearch 'range' must include one of gte, gt, lte, or lt");
+        }
+
+        return new RangeItem(from, to, field);
+    }
+
+    private Number numberValue(JsonNode node, String operator) {
+        if (node == null || !node.isNumber()) {
+            throw new IllegalArgumentException("Elasticsearch range '" + operator + "' must be numeric");
+        }
+        return node.numberValue();
+    }
+
+    private List<JsonNode> clauses(JsonNode node, String clauseName) {
+        if (node == null || node.isNull()) {
+            throw new IllegalArgumentException("Elasticsearch bool '" + clauseName + "' clause is missing");
+        }
+
+        if (node.isArray()) {
+            List<JsonNode> clauses = new ArrayList<>();
+            for (JsonNode clause : node) {
+                clauses.add(clause);
+            }
+            if (clauses.isEmpty()) {
+                throw new IllegalArgumentException("Elasticsearch bool '" + clauseName + "' clause cannot be empty");
+            }
+            return clauses;
+        }
+
+        if (node.isObject()) {
+            return List.of(node);
+        }
+
+        throw new IllegalArgumentException("Elasticsearch bool '" + clauseName + "' clause must be an object or array");
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/ElasticsearchQueryTransformer.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/ElasticsearchQueryTransformer.java
@@ -1,0 +1,80 @@
+package com.yahoo.search.querytransform;
+
+import com.yahoo.prelude.query.*;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ElasticsearchQueryTransformer extends Searcher {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public Result search(Query query, Execution execution) {
+        String esQuery = query.properties().getString("elasticsearch.query");
+        if (esQuery != null) {
+            try {
+                JsonNode root = mapper.readTree(esQuery);
+                Item item = translateQuery(root.get("query"));
+                if (item != null) {
+                    query.getModel().getQueryTree().setRoot(item);
+                }
+            } catch (Exception e) {
+                // log and continue
+            }
+        }
+        return execution.search(query);
+    }
+
+    private Item translateQuery(JsonNode node) {
+        if (node == null) return null;
+
+        if (node.has("match")) {
+            JsonNode match = node.get("match");
+            String field = match.fieldNames().next();
+            return new WordItem(match.get(field).asText(), field);
+        }
+        if (node.has("term")) {
+            JsonNode term = node.get("term");
+            String field = term.fieldNames().next();
+            return new WordItem(term.get(field).asText(), field);
+        }
+        if (node.has("range")) {
+            JsonNode range = node.get("range");
+            String field = range.fieldNames().next();
+            JsonNode bounds = range.get(field);
+            RangeItem item = new RangeItem(field);
+            if (bounds.has("gte")) item.setFromInclusive(bounds.get("gte").asDouble());
+            if (bounds.has("gt"))  item.setFromExclusive(bounds.get("gt").asDouble());
+            if (bounds.has("lte")) item.setToInclusive(bounds.get("lte").asDouble());
+            if (bounds.has("lt"))  item.setToExclusive(bounds.get("lt").asDouble());
+            return item;
+        }
+        if (node.has("bool")) {
+            JsonNode bool = node.get("bool");
+            AndItem and = new AndItem();
+            OrItem or = new OrItem();
+            NotItem not = new NotItem();
+
+            if (bool.has("must")) {
+                for (JsonNode clause : bool.get("must"))
+                    and.addItem(translateQuery(clause));
+                return and;
+            }
+            if (bool.has("should")) {
+                for (JsonNode clause : bool.get("should"))
+                    or.addItem(translateQuery(clause));
+                return or;
+            }
+            if (bool.has("must_not")) {
+                for (JsonNode clause : bool.get("must_not"))
+                    not.addNegativeItem(translateQuery(clause));
+                return not;
+            }
+        }
+        return null;
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/querytransform/ElasticsearchQueryTransformerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/ElasticsearchQueryTransformerTest.java
@@ -1,0 +1,128 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.querytransform;
+
+import com.yahoo.component.chain.Chain;
+import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.NotItem;
+import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.RangeItem;
+import com.yahoo.prelude.query.TrueItem;
+import com.yahoo.prelude.query.WordItem;
+import com.yahoo.processing.IllegalInputException;
+import com.yahoo.search.Query;
+import com.yahoo.search.searchchain.Execution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ElasticsearchQueryTransformerTest {
+
+	private Execution execution;
+
+	@BeforeEach
+	void setUp() {
+		execution = new Execution(new Chain<>(new ElasticsearchQueryTransformer()),
+								  Execution.Context.createContextStub());
+	}
+
+	@Test
+	void requireThatMatchQueryIsTranslatedToWordItem() {
+		Item root = transformedRoot("{\"query\":{\"match\":{\"title\":\"vespa\"}}}");
+
+		WordItem word = assertInstanceOf(WordItem.class, root);
+		assertEquals("title", word.getIndexName());
+		assertEquals("vespa", word.getWord());
+	}
+
+	@Test
+	void requireThatTermQueryIsTranslatedToWordItem() {
+		Item root = transformedRoot("{\"query\":{\"term\":{\"category\":\"search\"}}}");
+
+		WordItem word = assertInstanceOf(WordItem.class, root);
+		assertEquals("category", word.getIndexName());
+		assertEquals("search", word.getWord());
+	}
+
+	@Test
+	void requireThatRangeQueryIsTranslatedToRangeItem() {
+		Item root = transformedRoot("{\"query\":{\"range\":{\"price\":{\"gte\":10,\"lt\":20}}}}");
+
+		RangeItem range = assertInstanceOf(RangeItem.class, root);
+		assertEquals("price", range.getIndexName());
+		assertEquals(10L, range.getFrom().longValue());
+		assertEquals(20L, range.getTo().longValue());
+		assertTrue(range.getFromLimit().isInclusive());
+		assertFalse(range.getToLimit().isInclusive());
+	}
+
+	@Test
+	void requireThatBoolMustQueryIsTranslatedToAndItem() {
+		Item root = transformedRoot("{\"query\":{\"bool\":{\"must\":[{\"match\":{\"title\":\"vespa\"}},{\"term\":{\"category\":\"search\"}}]}}}");
+
+		AndItem and = assertInstanceOf(AndItem.class, root);
+		assertEquals(2, and.getItemCount());
+
+		WordItem first = assertInstanceOf(WordItem.class, and.getItem(0));
+		WordItem second = assertInstanceOf(WordItem.class, and.getItem(1));
+		assertEquals("title", first.getIndexName());
+		assertEquals("vespa", first.getWord());
+		assertEquals("category", second.getIndexName());
+		assertEquals("search", second.getWord());
+	}
+
+	@Test
+	void requireThatBoolShouldQueryIsTranslatedToOrItem() {
+		Item root = transformedRoot("{\"query\":{\"bool\":{\"should\":[{\"term\":{\"status\":\"active\"}},{\"term\":{\"status\":\"pending\"}}]}}}");
+
+		OrItem or = assertInstanceOf(OrItem.class, root);
+		assertEquals(2, or.getItemCount());
+
+		WordItem first = assertInstanceOf(WordItem.class, or.getItem(0));
+		WordItem second = assertInstanceOf(WordItem.class, or.getItem(1));
+		assertEquals("active", first.getWord());
+		assertEquals("pending", second.getWord());
+	}
+
+	@Test
+	void requireThatBoolMustNotQueryIsTranslatedToNotItem() {
+		Item root = transformedRoot("{\"query\":{\"bool\":{\"must_not\":[{\"term\":{\"status\":\"deleted\"}}]}}}");
+
+		NotItem not = assertInstanceOf(NotItem.class, root);
+		assertEquals(2, not.getItemCount());
+		assertInstanceOf(TrueItem.class, not.getItem(0));
+
+		WordItem negated = assertInstanceOf(WordItem.class, not.getItem(1));
+		assertEquals("status", negated.getIndexName());
+		assertEquals("deleted", negated.getWord());
+	}
+
+	@Test
+	void requireThatMalformedJsonThrowsIllegalInputException() {
+		Query query = new Query("");
+		query.properties().set("elasticsearch.query", "{\"query\":{\"match\":");
+
+		assertThrows(IllegalInputException.class, () -> execution.search(query));
+	}
+
+	@Test
+	void requireThatUnsupportedQueryTypeThrowsIllegalInputException() {
+		Query query = new Query("");
+		query.properties().set("elasticsearch.query", "{\"query\":{\"prefix\":{\"title\":\"ve\"}}}");
+
+		assertThrows(IllegalInputException.class, () -> execution.search(query));
+	}
+
+	private Item transformedRoot(String elasticsearchQuery) {
+		Query query = new Query("");
+		query.properties().set("elasticsearch.query", elasticsearchQuery);
+		execution.search(query);
+		return query.getModel().getQueryTree().getRoot();
+	}
+
+}


### PR DESCRIPTION
Translates ES query DSL to Vespa query items.
Implements issue #16872.

Supported query types:
- match → WordItem
- term → WordItem
- range → RangeItem (gte/gt/lte/lt)
- bool → AndItem/OrItem/NotItem (must/should/must_not)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.