### PR TITLE
Add OpenAI and Mistral embedders; share HTTP scaffolding with VoyageAI

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
@@ -15,6 +15,8 @@ import com.yahoo.vespa.model.container.component.SpladeEmbedder;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.HuggingFaceEmbedder;
 import com.yahoo.vespa.model.container.component.HuggingFaceTokenizer;
+import com.yahoo.vespa.model.container.component.MistralEmbedder;
+import com.yahoo.vespa.model.container.component.OpenAIEmbedder;
 import com.yahoo.vespa.model.container.component.VoyageAIEmbedder;
 import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuilder;
 import org.w3c.dom.Element;
@@ -48,13 +50,16 @@ public class DomComponentBuilder extends VespaDomBuilder.DomConfigProducerBuilde
             Element spec, DeployState state, TreeConfigProducer<AnyConfigProducer> ancestor) {
         if (spec.hasAttribute("type")) {
             var type = spec.getAttribute("type");
+            var cluster = (ApplicationContainerCluster) ancestor;
             return switch (type) {
-                case "hugging-face-embedder" -> new HuggingFaceEmbedder((ApplicationContainerCluster)ancestor, spec, state);
+                case "hugging-face-embedder" -> new HuggingFaceEmbedder(cluster, spec, state);
                 case "hugging-face-tokenizer" -> new HuggingFaceTokenizer(spec, state);
-                case "colbert-embedder" -> new ColBertEmbedder((ApplicationContainerCluster)ancestor, spec, state);
-                case "bert-embedder" -> new BertEmbedder((ApplicationContainerCluster)ancestor, spec, state);
-                case "splade-embedder" -> new SpladeEmbedder((ApplicationContainerCluster)ancestor, spec, state);
-                case "voyage-ai-embedder" -> new VoyageAIEmbedder((ApplicationContainerCluster)ancestor, spec, state);
+                case "colbert-embedder" -> new ColBertEmbedder(cluster, spec, state);
+                case "bert-embedder" -> new BertEmbedder(cluster, spec, state);
+                case "splade-embedder" -> new SpladeEmbedder(cluster, spec, state);
+                case "openai-embedder" -> new OpenAIEmbedder(cluster, spec, state);
+                case "mistral-embedder" -> new MistralEmbedder(cluster, spec, state);
+                case "voyage-ai-embedder" -> new VoyageAIEmbedder(cluster, spec, state);
                 default -> throw new IllegalArgumentException(Text.format("Unknown component type '%s'", type));
             };
         } else {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/MistralEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/MistralEmbedder.java
@@ -1,0 +1,45 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.component;
+
+import ai.vespa.embedding.config.MistralEmbedderConfig;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import org.w3c.dom.Element;
+
+import java.util.Locale;
+
+import static com.yahoo.text.XML.getChildValue;
+import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
+
+/**
+ * Configuration builder for Mistral embedder component.
+ *
+ * @author bjorncs
+ */
+public class MistralEmbedder extends TypedComponent implements MistralEmbedderConfig.Producer {
+
+    private final String apiKeySecretRef;
+    private final String model;
+    private final int dimensions;
+    private final String quantization;
+
+    @SuppressWarnings("unused")
+    public MistralEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
+        super("ai.vespa.embedding.MistralEmbedder", INTEGRATION_BUNDLE_NAME, xml);
+        this.apiKeySecretRef = getChildValue(xml, "api-key-secret-ref").get();
+        this.model = getChildValue(xml, "model").get();
+        this.dimensions = getChildValue(xml, "dimensions")
+                .map(Integer::parseInt).get();
+        this.quantization = getChildValue(xml, "quantization").orElse(null);
+    }
+
+    @Override
+    public void getConfig(MistralEmbedderConfig.Builder builder) {
+        builder.apiKeySecretRef(apiKeySecretRef);
+        builder.model(model);
+        builder.dimensions(dimensions);
+        if (quantization != null) {
+            builder.quantization(MistralEmbedderConfig.Quantization.Enum.valueOf(quantization.toUpperCase(Locale.ROOT)));
+        }
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/OpenAIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/OpenAIEmbedder.java
@@ -1,0 +1,41 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.component;
+
+import ai.vespa.embedding.config.OpenaiEmbedderConfig;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import org.w3c.dom.Element;
+
+import static com.yahoo.text.XML.getChildValue;
+import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
+
+/**
+ * Configuration builder for OpenAI embedder component.
+ *
+ * @author bjorncs
+ */
+public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConfig.Producer {
+
+    private final String apiKeySecretRef;
+    private final String model;
+    private final int dimensions;
+    private final String endpoint;
+
+    @SuppressWarnings("unused")
+    public OpenAIEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
+        super("ai.vespa.embedding.OpenAIEmbedder", INTEGRATION_BUNDLE_NAME, xml);
+        this.apiKeySecretRef = getChildValue(xml, "api-key-secret-ref").orElse("");
+        this.model = getChildValue(xml, "model").get();
+        this.dimensions = getChildValue(xml, "dimensions")
+                .map(Integer::parseInt).get();
+        this.endpoint = getChildValue(xml, "endpoint").orElse(null);
+    }
+
+    @Override
+    public void getConfig(OpenaiEmbedderConfig.Builder builder) {
+        builder.apiKeySecretRef(apiKeySecretRef);
+        builder.model(model);
+        builder.dimensions(dimensions);
+        if (endpoint != null) builder.endpoint(endpoint);
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/VoyageAIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/VoyageAIEmbedder.java
@@ -1,10 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.component;
 
-import com.yahoo.config.model.deploy.DeployState;
 import ai.vespa.embedding.config.VoyageAiEmbedderConfig;
+import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import org.w3c.dom.Element;
+
+import java.util.Locale;
 
 import static com.yahoo.text.XML.getChildValue;
 import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
@@ -12,19 +14,17 @@ import static com.yahoo.vespa.model.container.component.EmbedderBatchingConfig.p
 
 /**
  * Configuration builder for VoyageAI embedder component.
- * Parses XML configuration from services.xml and produces VoyageAiEmbedderConfig.
  *
- * @author VoyageAI team
  * @author bjorncs
  */
 public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedderConfig.Producer {
 
     private final String apiKeySecretRef;
-    private final String endpoint;
     private final String model;
-    private final Boolean truncate;
-    private final Integer dimensions;
+    private final int dimensions;
+    private final String endpoint;
     private final String quantization;
+    private final Boolean truncate;
     private final EmbedderBatchingConfig batching;
 
     @SuppressWarnings("unused")
@@ -34,19 +34,13 @@ public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedder
         this.apiKeySecretRef = getChildValue(xml, "api-key-secret-ref").get();
         this.model = getChildValue(xml, "model").get();
         this.dimensions = getChildValue(xml, "dimensions")
-                .map(Integer::parseInt)
-                .orElseThrow(() -> new IllegalArgumentException("Missing required element 'dimensions'"));
-
+                .map(Integer::parseInt).get();
         this.endpoint = getChildValue(xml, "endpoint").orElse(null);
+        this.quantization = getChildValue(xml, "quantization").orElse(null);
         this.truncate = getChildValue(xml, "truncate").map(Boolean::parseBoolean).orElse(null);
-        this.quantization = getChildValue(xml, "quantization").orElse("auto");
         this.batching = parseBatchingElement(xml);
 
-        validate();
-    }
-
-    public void validate() {
-        if (model != null && !model.startsWith("voyage-")) {
+        if (!model.startsWith("voyage-")) {
             throw new IllegalArgumentException(
                     "Invalid VoyageAI model name: " + model + ". " +
                     "Model name should start with 'voyage-' (e.g., voyage-3, voyage-code-3).");
@@ -58,14 +52,11 @@ public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedder
         builder.apiKeySecretRef(apiKeySecretRef);
         builder.model(model);
         builder.dimensions(dimensions);
-        builder.quantization(VoyageAiEmbedderConfig.Quantization.Enum.valueOf(quantization.toUpperCase(java.util.Locale.ROOT)));
-
-        if (endpoint != null) {
-            builder.endpoint(endpoint);
+        if (endpoint != null) builder.endpoint(endpoint);
+        if (quantization != null) {
+            builder.quantization(VoyageAiEmbedderConfig.Quantization.Enum.valueOf(quantization.toUpperCase(Locale.ROOT)));
         }
-        if (truncate != null) {
-            builder.truncate(truncate);
-        }
+        if (truncate != null) builder.truncate(truncate);
         if (batching != null) {
             builder.batching.maxSize(batching.maxSize());
             builder.batching.maxDelayMillis(batching.maxDelay().toMillis());

--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -82,7 +82,7 @@ ComponentDefinition =
 
 TypedComponentDefinition =
    attribute id { xsd:Name } &
-   (HuggingFaceEmbedder | HuggingFaceTokenizer | BertBaseEmbedder | ColBertEmbedder | SpladeEmbedder | VoyageAIEmbedder ) &
+   (HuggingFaceEmbedder | HuggingFaceTokenizer | BertBaseEmbedder | ColBertEmbedder | SpladeEmbedder | VoyageAIEmbedder | OpenAIEmbedder | MistralEmbedder ) &
    GenericConfig* &
    Component*
 
@@ -159,10 +159,24 @@ VoyageAIEmbedder =
    element model { xsd:string } &
    element api-key-secret-ref { xsd:string } &
    element dimensions { "256" | "512" | "1024" | "1536" | "2048" } &
-   element quantization { "auto" | "float" | "int8" | "binary" }? &
+   EmbedderQuantization &
    element endpoint { xsd:string }? &
    element truncate { xsd:boolean }? &
    EmbedderBatchingParams
+
+OpenAIEmbedder =
+   attribute type { "openai-embedder" } &
+   element model { xsd:string } &
+   element api-key-secret-ref { xsd:string }? &
+   element dimensions { xsd:positiveInteger } &
+   element endpoint { xsd:string }?
+
+MistralEmbedder =
+   attribute type { "mistral-embedder" } &
+   element model { xsd:string } &
+   element api-key-secret-ref { xsd:string } &
+   element dimensions { xsd:positiveInteger } &
+   EmbedderQuantization
 
 OnnxModelExecutionParams =
     element onnx-execution-mode { "parallel" | "sequential" }? &
@@ -184,6 +198,9 @@ EmbedderBatchingParams =
     }?
 
 EmbedderPoolingStrategy = element pooling-strategy { "cls" | "mean" | "none" }?
+
+EmbedderQuantization = element quantization { "auto" | "float" | "int8" | "binary" }?
+
 
 StartOfSequence = element transformer-start-sequence-token { xsd:integer }?
 EndOfSequence = element transformer-end-sequence-token { xsd:integer }?

--- a/config-model/src/test/cfg/application/mistral-embedder/services.xml
+++ b/config-model/src/test/cfg/application/mistral-embedder/services.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+    <container id="container" version="1.0">
+        <search />
+        <document-api />
+
+        <component id="mistral" type="mistral-embedder">
+            <model>mistral-embed</model>
+            <api-key-secret-ref>mistral_key</api-key-secret-ref>
+            <dimensions>1024</dimensions>
+        </component>
+
+        <component id="codestral" type="mistral-embedder">
+            <model>codestral-embed</model>
+            <api-key-secret-ref>mistral_key</api-key-secret-ref>
+            <dimensions>2048</dimensions>
+            <quantization>int8</quantization>
+        </component>
+    </container>
+</services>

--- a/config-model/src/test/cfg/application/openai-embedder/services.xml
+++ b/config-model/src/test/cfg/application/openai-embedder/services.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+    <container id="container" version="1.0">
+        <search />
+        <document-api />
+
+        <!-- OpenAI Embedder with all configuration options -->
+        <component id="openai" type="openai-embedder">
+            <model>text-embedding-3-small</model>
+            <api-key-secret-ref>openai_api_key</api-key-secret-ref>
+            <dimensions>1024</dimensions>
+            <endpoint>https://api.openai.com/v1/embeddings</endpoint>
+        </component>
+
+        <!-- OpenAI Embedder with minimal configuration (uses default endpoint) -->
+        <component id="openai-minimal" type="openai-embedder">
+            <model>text-embedding-3-small</model>
+            <api-key-secret-ref>openai_api_key</api-key-secret-ref>
+            <dimensions>1536</dimensions>
+        </component>
+    </container>
+</services>

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/MistralEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/MistralEmbedderTest.java
@@ -1,0 +1,65 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.xml;
+
+import ai.vespa.embedding.config.MistralEmbedderConfig;
+import com.yahoo.component.ComponentId;
+import com.yahoo.path.Path;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.MistralEmbedder;
+import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for Mistral embedder configuration parsing and validation.
+ *
+ * @author bjorncs
+ */
+public class MistralEmbedderTest {
+
+    @Test
+    void testMistralEmbedderConfiguration() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/mistral-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
+
+        var component = cluster.getComponentsMap().get(new ComponentId("mistral"));
+        assertNotNull(component, "Mistral embedder component should be present");
+        assertInstanceOf(MistralEmbedder.class, component);
+
+        var config = getConfig(cluster, "mistral");
+        assertEquals("mistral-embed", config.model());
+        assertEquals("mistral_key", config.apiKeySecretRef());
+        assertEquals(1024, config.dimensions());
+        assertEquals(MistralEmbedderConfig.Quantization.Enum.AUTO, config.quantization());
+    }
+
+    @Test
+    void testQuantizationConfiguration() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/mistral-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
+
+        var config = getConfig(cluster, "codestral");
+        assertEquals("codestral-embed", config.model());
+        assertEquals(2048, config.dimensions());
+        assertEquals(MistralEmbedderConfig.Quantization.Enum.INT8, config.quantization());
+    }
+
+    private VespaModel loadModel(Path path) {
+        return new VespaModelCreatorWithFilePkg(path.toFile()).create();
+    }
+
+    private MistralEmbedderConfig getConfig(ApplicationContainerCluster cluster, String componentId) {
+        Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId(componentId));
+        assertNotNull(component, "Component " + componentId + " should exist");
+        assertInstanceOf(MistralEmbedder.class, component);
+        var embedder = (MistralEmbedder) component;
+        var builder = new MistralEmbedderConfig.Builder();
+        embedder.getConfig(builder);
+        return builder.build();
+    }
+}

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/OpenAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/OpenAIEmbedderTest.java
@@ -1,0 +1,67 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.xml;
+
+import ai.vespa.embedding.config.OpenaiEmbedderConfig;
+import com.yahoo.component.ComponentId;
+import com.yahoo.path.Path;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.OpenAIEmbedder;
+import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for OpenAI embedder configuration parsing and validation.
+ *
+ * @author bjorncs
+ */
+public class OpenAIEmbedderTest {
+
+    @Test
+    void testOpenAIEmbedderWithFullConfiguration() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/openai-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
+
+        var component = cluster.getComponentsMap().get(new ComponentId("openai"));
+        assertNotNull(component, "OpenAI embedder component should be present");
+        assertInstanceOf(OpenAIEmbedder.class, component);
+
+        var config = getConfig(cluster, "openai");
+        assertEquals("text-embedding-3-small", config.model());
+        assertEquals("openai_api_key", config.apiKeySecretRef());
+        assertEquals(1024, config.dimensions());
+        assertEquals("https://api.openai.com/v1/embeddings", config.endpoint());
+    }
+
+    @Test
+    void testOpenAIEmbedderWithMinimalConfiguration() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/openai-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
+
+        var config = getConfig(cluster, "openai-minimal");
+        assertEquals("text-embedding-3-small", config.model());
+        assertEquals(1536, config.dimensions());
+        assertEquals("https://api.openai.com/v1/embeddings", config.endpoint());
+    }
+
+    // ===== Helper Methods =====
+
+    private VespaModel loadModel(Path path) {
+        return new VespaModelCreatorWithFilePkg(path.toFile()).create();
+    }
+
+    private OpenaiEmbedderConfig getConfig(ApplicationContainerCluster cluster, String componentId) {
+        Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId(componentId));
+        assertNotNull(component, "Component " + componentId + " should exist");
+        assertInstanceOf(OpenAIEmbedder.class, component);
+        var embedder = (OpenAIEmbedder) component;
+        var builder = new OpenaiEmbedderConfig.Builder();
+        embedder.getConfig(builder);
+        return builder.build();
+    }
+}

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/VoyageAIEmbedderTest.java
@@ -1,8 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.xml;
 
-import com.yahoo.component.ComponentId;
 import ai.vespa.embedding.config.VoyageAiEmbedderConfig;
+import com.yahoo.component.ComponentId;
 import com.yahoo.path.Path;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
@@ -22,21 +22,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for VoyageAI embedder configuration parsing and validation.
+ *
+ * @author bjorncs
  */
 public class VoyageAIEmbedderTest {
 
     @Test
-    void testVoyageAIEmbedderWithFullConfiguration() throws Exception {
-        VespaModel model = loadModel(Path.fromString("src/test/cfg/application/voyageai-embedder/"));
-        ApplicationContainerCluster cluster = model.getContainerClusters().get("container");
+    void testVoyageAIEmbedderWithFullConfiguration() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/voyageai-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
 
-        Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId("voyage-full"));
+        var component = cluster.getComponentsMap().get(new ComponentId("voyage-full"));
         assertNotNull(component, "VoyageAI embedder component should be present");
-        assertInstanceOf(VoyageAIEmbedder.class, component, "Component should be VoyageAIEmbedder");
+        assertInstanceOf(VoyageAIEmbedder.class, component);
 
-        VoyageAiEmbedderConfig config = getVoyageAIEmbedderConfig(cluster, "voyage-full");
-
-        // Verify all configuration values
+        var config = getConfig(cluster, "voyage-full");
         assertEquals("voyage-3.5", config.model());
         assertEquals("voyage_api_key", config.apiKeySecretRef());
         assertEquals(1024, config.dimensions());
@@ -47,24 +47,18 @@ public class VoyageAIEmbedderTest {
     }
 
     @Test
-    void testVoyageAIEmbedderWithMinimalConfiguration() throws Exception {
-        VespaModel model = loadModel(Path.fromString("src/test/cfg/application/voyageai-embedder/"));
-        ApplicationContainerCluster cluster = model.getContainerClusters().get("container");
+    void testVoyageAIEmbedderWithMinimalConfiguration() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/voyageai-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
 
-        Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId("voyage-minimal"));
-        assertNotNull(component, "VoyageAI embedder component should be present");
-
-        VoyageAiEmbedderConfig config = getVoyageAIEmbedderConfig(cluster, "voyage-minimal");
-
-        // Verify required fields
+        var config = getConfig(cluster, "voyage-minimal");
         assertEquals("voyage_key", config.apiKeySecretRef());
         assertEquals("voyage-3.5", config.model());
         assertEquals(1024, config.dimensions());
-        assertEquals("https://api.voyageai.com/v1/embeddings", config.endpoint()); // Default endpoint
-        assertEquals(3, config.maxRetries()); // Default retries
-        assertTrue(config.truncate()); // Default truncate
-        assertEquals(0, config.batching().maxSize()); // Default batching
-        assertEquals(0, config.batching().maxDelayMillis()); // Default batching
+        assertEquals("https://api.voyageai.com/v1/embeddings", config.endpoint());
+        assertTrue(config.truncate());
+        assertEquals(0, config.batching().maxSize());
+        assertEquals(0, config.batching().maxDelayMillis());
     }
 
     @Test
@@ -82,14 +76,12 @@ public class VoyageAIEmbedderTest {
                 </services>
                 """;
 
-        // Should fail because model name must start with 'voyage'
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> buildModelFromXml(servicesXml));
+        var exception = assertThrows(IllegalArgumentException.class, () -> buildModelFromXml(servicesXml));
         assertTrue(exception.getMessage().contains("voyage"));
     }
 
     @Test
-    void testVoyageAIEmbedderQuantizationSettings() throws Exception {
-        // Test AUTO (default)
+    void testVoyageAIEmbedderQuantizationSettings() {
         String xmlAuto = """
                 <?xml version="1.0" encoding="utf-8" ?>
                 <services version="1.0">
@@ -103,10 +95,9 @@ public class VoyageAIEmbedderTest {
                 </services>
                 """;
         var modelAuto = buildModelFromXml(xmlAuto);
-        var configAuto = getVoyageAIEmbedderConfig(modelAuto.getContainerClusters().get("container"), "voyage");
+        var configAuto = getConfig(modelAuto.getContainerClusters().get("container"), "voyage");
         assertEquals(VoyageAiEmbedderConfig.Quantization.Enum.AUTO, configAuto.quantization());
 
-        // Test explicit quantization values
         String[] quantizations = {"float", "int8", "binary"};
         VoyageAiEmbedderConfig.Quantization.Enum[] expectedEnums = {
             VoyageAiEmbedderConfig.Quantization.Enum.FLOAT,
@@ -129,46 +120,42 @@ public class VoyageAIEmbedderTest {
                     </services>
                     """, quantizations[i]);
 
-            var model = buildModelFromXml(xml);
-            var config = getVoyageAIEmbedderConfig(model.getContainerClusters().get("container"), "voyage");
+            var vespaModel = buildModelFromXml(xml);
+            var config = getConfig(vespaModel.getContainerClusters().get("container"), "voyage");
             assertEquals(expectedEnums[i], config.quantization());
         }
     }
 
     @Test
-    void testMultipleVoyageAIEmbedders() throws Exception {
-        VespaModel model = loadModel(Path.fromString("src/test/cfg/application/voyageai-embedder/"));
-        ApplicationContainerCluster cluster = model.getContainerClusters().get("container");
+    void testMultipleVoyageAIEmbedders() {
+        var model = loadModel(Path.fromString("src/test/cfg/application/voyageai-embedder/"));
+        var cluster = model.getContainerClusters().get("container");
 
-        // Verify both embedders are present
         assertNotNull(cluster.getComponentsMap().get(new ComponentId("voyage-full")));
         assertNotNull(cluster.getComponentsMap().get(new ComponentId("voyage-minimal")));
 
-        // Verify they have different configurations
-        VoyageAiEmbedderConfig fullConfig = getVoyageAIEmbedderConfig(cluster, "voyage-full");
-        VoyageAiEmbedderConfig minimalConfig = getVoyageAIEmbedderConfig(cluster, "voyage-minimal");
-
+        var fullConfig = getConfig(cluster, "voyage-full");
+        var minimalConfig = getConfig(cluster, "voyage-minimal");
         assertNotEquals(fullConfig.apiKeySecretRef(), minimalConfig.apiKeySecretRef());
     }
 
     // ===== Helper Methods =====
 
-    private VespaModel loadModel(Path path) throws Exception {
+    private VespaModel loadModel(Path path) {
         return new VespaModelCreatorWithFilePkg(path.toFile()).create();
     }
 
-    private VespaModel buildModelFromXml(String servicesXml) throws Exception {
+    private VespaModel buildModelFromXml(String servicesXml) {
         String hosts = "<hosts><host name='localhost'><alias>node1</alias></host></hosts>";
         return new VespaModelCreatorWithMockPkg(hosts, servicesXml).create();
     }
 
-    private VoyageAiEmbedderConfig getVoyageAIEmbedderConfig(ApplicationContainerCluster cluster, String componentId) {
+    private VoyageAiEmbedderConfig getConfig(ApplicationContainerCluster cluster, String componentId) {
         Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId(componentId));
         assertNotNull(component, "Component " + componentId + " should exist");
-        assertInstanceOf(VoyageAIEmbedder.class, component, "Component should be VoyageAIEmbedder");
-
-        VoyageAIEmbedder embedder = (VoyageAIEmbedder) component;
-        VoyageAiEmbedderConfig.Builder builder = new VoyageAiEmbedderConfig.Builder();
+        assertInstanceOf(VoyageAIEmbedder.class, component);
+        var embedder = (VoyageAIEmbedder) component;
+        var builder = new VoyageAiEmbedderConfig.Builder();
         embedder.getConfig(builder);
         return builder.build();
     }

--- a/configdefinitions/src/vespa/http-embedder.def
+++ b/configdefinitions/src/vespa/http-embedder.def
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package=ai.vespa.embedding.config
+
+# Maximum number of retry attempts for failed HTTP requests
+maxRetries               int default=3
+
+# HTTP client timeout in milliseconds for read/write operations
+timeout                  int default=60000

--- a/configdefinitions/src/vespa/mistral-embedder.def
+++ b/configdefinitions/src/vespa/mistral-embedder.def
@@ -1,0 +1,18 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package=ai.vespa.embedding.config
+
+# Reference to the secret in Vespa's secret store containing the API key (required)
+apiKeySecretRef          string
+
+# API endpoint URL
+endpoint                 string default="https://api.mistral.ai/v1/embeddings"
+
+# Model name
+model                    string
+
+# Output dimension
+dimensions               int
+
+# Output quantization mode
+quantization             enum { AUTO, FLOAT, INT8, BINARY } default=AUTO

--- a/configdefinitions/src/vespa/openai-embedder.def
+++ b/configdefinitions/src/vespa/openai-embedder.def
@@ -1,0 +1,15 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package=ai.vespa.embedding.config
+
+# Reference to the secret in Vespa's secret store containing the API key (empty = no auth)
+apiKeySecretRef          string default=""
+
+# API endpoint URL
+endpoint                 string default="https://api.openai.com/v1/embeddings"
+
+# Model name
+model                    string
+
+# Output dimension
+dimensions               int

--- a/configdefinitions/src/vespa/voyage-ai-embedder.def
+++ b/configdefinitions/src/vespa/voyage-ai-embedder.def
@@ -2,34 +2,24 @@
 
 package=ai.vespa.embedding.config
 
-# API Configuration
-
 # Reference to the secret in Vespa's secret store containing the VoyageAI API key
-apiKeySecretRef          string
+apiKeySecretRef          string default=""
 
-# VoyageAI API endpoint URL
+# VoyageAI API endpoint URL (auto-selected between text, multimodal, and contextualized endpoints based on model)
 endpoint                 string default="https://api.voyageai.com/v1/embeddings"
 
 # VoyageAI model name (e.g., voyage-3.5, voyage-3.5-lite, voyage-code-3, voyage-finance-2)
 model                    string
 
 # Output dimension
-dimensions int
+dimensions               int
 
 # Output quantization mode
-quantization enum { AUTO, FLOAT, INT8, BINARY } default=AUTO
-
-# Maximum number of retry attempts for failed requests
-maxRetries int default=3
-
-# HTTP client timeout in milliseconds for read/write operations
-timeout int default=60000
-
-# Input Processing
+quantization             enum { AUTO, FLOAT, INT8, BINARY } default=AUTO
 
 # Truncate inputs that exceed model's maximum token limit
-truncate bool default=true
+truncate                 bool default=true
 
 # Dynamic batching configuration
-batching.maxSize int default=0
-batching.maxDelayMillis long default=0
+batching.maxSize         int default=0
+batching.maxDelayMillis  long default=0

--- a/configdefinitions/src/vespa/voyage-ai-embedder.def
+++ b/configdefinitions/src/vespa/voyage-ai-embedder.def
@@ -3,7 +3,7 @@
 package=ai.vespa.embedding.config
 
 # Reference to the secret in Vespa's secret store containing the VoyageAI API key
-apiKeySecretRef          string default=""
+apiKeySecretRef          string
 
 # VoyageAI API endpoint URL (auto-selected between text, multimodal, and contextualized endpoints based on model)
 endpoint                 string default="https://api.voyageai.com/v1/embeddings"

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -192,9 +192,13 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
 
                     lastStatusCode = code;
                     lastException = null;
-                    if (attempt == maxRetries && response.body() != null)
-                        lastResponseBody = response.body().string();
-                    response.close();
+                    try {
+                        if (attempt == maxRetries && response.body() != null) {
+                                lastResponseBody = response.body().string();
+                        }
+                    } finally {
+                        response.close();
+                    }
                 } catch (InterruptedIOException e) {
                     throw e;
                 } catch (IOException e) {

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -202,7 +202,9 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw new IOException("Retry interrupted", e);
+                    var ioe = new InterruptedIOException("Retry interrupted");
+                    ioe.initCause(e);
+                    throw ioe;
                 }
             }
 

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -181,35 +181,52 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
             var request = chain.request();
             int lastStatusCode = 0;
             var lastResponseBody = "";
+            IOException lastException = null;
 
             for (int attempt = 0; attempt <= maxRetries; attempt++) {
                 try {
                     var response = chain.proceed(request);
                     int code = response.code();
-                    boolean shouldRetry = code == 500 || code == 502 || code == 503 || code == 504;
-                    if (response.isSuccessful() || !shouldRetry) return response;
+                    boolean retryable = code == 500 || code == 502 || code == 503 || code == 504;
+                    if (response.isSuccessful() || !retryable) return response;
 
                     lastStatusCode = code;
-                    if (attempt < maxRetries) {
-                        response.close();
-                        int retryNumber = attempt + 1;
-                        log.fine(() -> "Embedding API server error (%d). Retry %d of %d after %dms"
-                                .formatted(code, retryNumber, maxRetries, RETRY_DELAY_MS));
-                        Thread.sleep(RETRY_DELAY_MS);
-                    } else {
-                        if (response.body() != null) lastResponseBody = response.body().string();
-                        response.close();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    var ioe = new InterruptedIOException("Retry interrupted");
-                    ioe.initCause(e);
-                    throw ioe;
+                    lastException = null;
+                    if (attempt == maxRetries && response.body() != null)
+                        lastResponseBody = response.body().string();
+                    response.close();
+                } catch (InterruptedIOException e) {
+                    throw e;
+                } catch (IOException e) {
+                    lastException = e;
                 }
+                // Both 5xx and IOException paths fall through here for retry
+                if (attempt < maxRetries)
+                    sleepBeforeRetry(chain, attempt + 1);
             }
-
+            if (lastException != null)
+                throw new IOException("Max retries exceeded for embedding API (%d). Last error: %s"
+                        .formatted(maxRetries, lastException.getMessage()), lastException);
             throw new IOException("Max retries exceeded for embedding API (%d). Last response: %d - %s"
                     .formatted(maxRetries, lastStatusCode, lastResponseBody));
+        }
+
+        private void sleepBeforeRetry(Chain chain, int retryNumber) throws IOException {
+            var timeout = chain.call().timeout();
+            if (timeout.hasDeadline()) {
+                long remainingNanos = timeout.deadlineNanoTime() - System.nanoTime();
+                if (remainingNanos <= TimeUnit.MILLISECONDS.toNanos(RETRY_DELAY_MS))
+                    throw new InterruptedIOException("Insufficient time remaining for retry");
+            }
+            log.fine(() -> "Retrying embedding API request (%d of %d) after %dms"
+                    .formatted(retryNumber, maxRetries, RETRY_DELAY_MS));
+            try { Thread.sleep(RETRY_DELAY_MS); }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                var ioe = new InterruptedIOException("Retry interrupted");
+                ioe.initCause(e);
+                throw ioe;
+            }
         }
     }
 }

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -72,7 +72,7 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
 
         log.fine(() -> "Embedding API request: " + jsonPayload);
         var call = httpClient.newCall(httpRequest);
-        call.timeout().timeout(timeoutMs, TimeUnit.MILLISECONDS);
+        call.timeout().deadline(timeoutMs, TimeUnit.MILLISECONDS);
 
         try (var response = call.execute()) {
             var body = response.body() != null ? response.body().string() : "";

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -90,8 +90,10 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
                         "Embedding API request failed with status %d: %s".formatted(response.code(), body));
             };
         } catch (InterruptedIOException e) {
+            runtime.sampleRequestFailure(context, 0);
             throw new TimeoutException("Embedding API call timed out after %dms".formatted(timeoutMs), e);
         } catch (IOException e) {
+            runtime.sampleRequestFailure(context, 0);
             throw new RuntimeException("Embedding API call failed: " + e.getMessage(), e);
         }
     }

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -1,0 +1,211 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.HttpEmbedderConfig;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.InvalidInputException;
+import com.yahoo.language.process.OverloadException;
+import com.yahoo.language.process.TimeoutException;
+import okhttp3.ConnectionPool;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Thin HTTP scaffolding for embedding providers. Owns the {@link OkHttpClient} lifecycle and
+ * exposes {@link #doHttpRequest} for POSTing JSON with per-request timeout and automatic 5xx retries.
+ * Also provides shared JSON (de)serialization helpers for subclasses.
+ *
+ * @author bjorncs
+ */
+public abstract class AbstractHttpEmbedder extends AbstractComponent {
+
+    private static final Logger log = Logger.getLogger(AbstractHttpEmbedder.class.getName());
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+    protected static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Duration defaultTimeout;
+    private final OkHttpClient httpClient;
+
+    protected AbstractHttpEmbedder() {
+        this(new HttpEmbedderConfig.Builder().build());
+    }
+
+    protected AbstractHttpEmbedder(HttpEmbedderConfig config) {
+        this.defaultTimeout = Duration.ofMillis(config.timeout());
+        this.httpClient = createHttpClient(config.maxRetries(), defaultTimeout);
+    }
+
+    /**
+     * POST the given JSON payload to the endpoint with the given headers and return the response body.
+     * Non-2xx responses are mapped to appropriate exceptions (429 → {@link OverloadException},
+     * 400 → {@link InvalidInputException}, 401/403 → authentication {@link RuntimeException}, else → generic
+     * {@link RuntimeException}) and request-failure metrics are sampled on the given runtime.
+     *
+     * @return the response body for a 2xx response
+     * @throws TimeoutException if the context deadline is already expired, or the call times out
+     * @throws RuntimeException on I/O failures other than timeouts, or on a non-retryable non-2xx response
+     */
+    protected String doHttpRequest(String endpoint, String jsonPayload, Map<String, String> headers,
+                                   Embedder.Context context, Embedder.Runtime runtime) {
+        var timeoutMs = calculateTimeoutMs(context);
+        var builder = new Request.Builder()
+                .url(endpoint)
+                .post(RequestBody.create(jsonPayload, JSON_MEDIA_TYPE));
+        headers.forEach(builder::header);
+        var httpRequest = builder.build();
+
+        log.fine(() -> "Embedding API request: " + jsonPayload);
+        var call = httpClient.newCall(httpRequest);
+        call.timeout().timeout(timeoutMs, TimeUnit.MILLISECONDS);
+
+        try (var response = call.execute()) {
+            var body = response.body() != null ? response.body().string() : "";
+            log.fine(() -> "Embedding API response with code %d: %s".formatted(response.code(), body));
+            if (response.isSuccessful()) return body;
+            runtime.sampleRequestFailure(context, response.code());
+            throw switch (response.code()) {
+                case 429 -> new OverloadException("Embedding API rate limited (429)");
+                case 401, 403 -> new RuntimeException(
+                        "Embedding API authentication failed (%d). Please check your API key: %s"
+                                .formatted(response.code(), body));
+                case 400 -> new InvalidInputException(
+                        "Embedding API bad request (400): " + parseErrorMessage(body).orElse(body));
+                default -> new RuntimeException(
+                        "Embedding API request failed with status %d: %s".formatted(response.code(), body));
+            };
+        } catch (InterruptedIOException e) {
+            throw new TimeoutException("Embedding API call timed out after %dms".formatted(timeoutMs), e);
+        } catch (IOException e) {
+            throw new RuntimeException("Embedding API call failed: " + e.getMessage(), e);
+        }
+    }
+
+    /** Serialize an object to JSON. */
+    protected static String toJson(Object o) {
+        try {
+            return objectMapper.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize embedder request", e);
+        }
+    }
+
+    /** Deserialize JSON to the given type. */
+    protected static <T> T fromJson(String body, Class<T> type) {
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse embedder response", e);
+        }
+    }
+
+    /**
+     * Parses an error message from a provider response. Handles both the OpenAI/Mistral shape
+     * ({@code {"error":{"message":"..."}}}) and the VoyageAI shape ({@code {"detail":"..."}}).
+     */
+    private static Optional<String> parseErrorMessage(String body) {
+        try {
+            var openAiStyle = objectMapper.readValue(body, OpenAIStyleError.class);
+            if (openAiStyle.error != null && openAiStyle.error.message != null)
+                return Optional.of(openAiStyle.error.message);
+            var detailStyle = objectMapper.readValue(body, DetailStyleError.class);
+            if (detailStyle.detail != null && !detailStyle.detail.isEmpty())
+                return Optional.of(detailStyle.detail);
+        } catch (JsonProcessingException e) {
+            log.fine(() -> "Failed to parse error response as JSON: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void deconstruct() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+        super.deconstruct();
+    }
+
+    private long calculateTimeoutMs(Embedder.Context context) {
+        long remainingMs = context.getDeadline()
+                .map(d -> d.timeRemaining().toMillis())
+                .orElse(defaultTimeout.toMillis());
+        if (remainingMs <= 0)
+            throw new TimeoutException("Request deadline exceeded before embedding API call");
+        return remainingMs;
+    }
+
+    private static OkHttpClient createHttpClient(int maxRetries, Duration timeout) {
+        return new OkHttpClient.Builder()
+                .addInterceptor(new RetryInterceptor(maxRetries))
+                .retryOnConnectionFailure(true)
+                .connectTimeout(Duration.ofSeconds(10))
+                .readTimeout(timeout)
+                .writeTimeout(timeout)
+                .connectionPool(new ConnectionPool(10, 1, TimeUnit.MINUTES))
+                .build();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record OpenAIStyleError(@JsonProperty("error") ErrorDetail error) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ErrorDetail(@JsonProperty("message") String message) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record DetailStyleError(@JsonProperty("detail") String detail) {}
+
+    private static class RetryInterceptor implements Interceptor {
+        static final long RETRY_DELAY_MS = 100;
+        private final int maxRetries;
+
+        RetryInterceptor(int maxRetries) { this.maxRetries = maxRetries; }
+
+        @Override
+        public okhttp3.Response intercept(Chain chain) throws IOException {
+            var request = chain.request();
+            int lastStatusCode = 0;
+            var lastResponseBody = "";
+
+            for (int attempt = 0; attempt <= maxRetries; attempt++) {
+                try {
+                    var response = chain.proceed(request);
+                    int code = response.code();
+                    boolean shouldRetry = code == 500 || code == 502 || code == 503 || code == 504;
+                    if (response.isSuccessful() || !shouldRetry) return response;
+
+                    lastStatusCode = code;
+                    if (attempt < maxRetries) {
+                        response.close();
+                        int retryNumber = attempt + 1;
+                        log.fine(() -> "Embedding API server error (%d). Retry %d of %d after %dms"
+                                .formatted(code, retryNumber, maxRetries, RETRY_DELAY_MS));
+                        Thread.sleep(RETRY_DELAY_MS);
+                    } else {
+                        if (response.body() != null) lastResponseBody = response.body().string();
+                        response.close();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Retry interrupted", e);
+                }
+            }
+
+            throw new IOException("Max retries exceeded for embedding API (%d). Last response: %d - %s"
+                    .formatted(maxRetries, lastStatusCode, lastResponseBody));
+        }
+    }
+}

--- a/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
@@ -40,9 +40,14 @@ class EmbeddingQuantization {
                         throw new IllegalArgumentException(
                                 Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDimensions));
                 } else if (valueType == TensorType.Value.INT8) {
-                    if (tensorDim != configuredDimensions && tensorDim != configuredDimensions / 8)
+                    long packedBinaryDimensions = configuredDimensions / 8;
+                    if (tensorDim == packedBinaryDimensions && configuredDimensions % 8 != 0)
                         throw new IllegalArgumentException(
-                                Text.format("Tensor dimension %d does not match configured dimension. Expected %d or %d.", tensorDim, configuredDimensions, configuredDimensions / 8));
+                                Text.format("Configured dimension %d must be divisible by 8 to allow packed-binary tensor dimension %d in quantization 'auto'.",
+                                            configuredDimensions, packedBinaryDimensions));
+                    if (tensorDim != configuredDimensions && tensorDim != packedBinaryDimensions)
+                        throw new IllegalArgumentException(
+                                Text.format("Tensor dimension %d does not match configured dimension. Expected %d or %d.", tensorDim, configuredDimensions, packedBinaryDimensions));
                 } else {
                     throw new IllegalArgumentException(
                             "Quantization 'auto' is incompatible with tensor type " + targetType + ".");

--- a/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
@@ -1,0 +1,128 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.yahoo.tensor.IndexedTensor;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.text.Text;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+
+/**
+ * Shared quantization validation, output type resolution, and base64 tensor decoding for cloud-based embedding providers.
+ *
+ * @author bjorncs
+ */
+class EmbeddingQuantization {
+
+    enum Quantization { AUTO, FLOAT, INT8, BINARY }
+
+    private EmbeddingQuantization() {}
+
+    static void validateTensorType(TensorType targetType, int configuredDimensions, Quantization quantization) {
+        if (targetType.dimensions().size() != 1)
+            throw new IllegalArgumentException(
+                    "Error in embedding to type '%s': should only have one dimension.".formatted(targetType));
+        var dim = targetType.dimensions().get(0);
+        if (!dim.isIndexed())
+            throw new IllegalArgumentException(
+                    "Error in embedding to type '%s': dimension should be indexed.".formatted(targetType));
+        var valueType = targetType.valueType();
+        long tensorDim = dim.size().orElseThrow();
+
+        switch (quantization) {
+            case AUTO -> {
+                if (valueType == TensorType.Value.FLOAT || valueType == TensorType.Value.BFLOAT16) {
+                    if (tensorDim != configuredDimensions)
+                        throw new IllegalArgumentException(
+                                Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDimensions));
+                } else if (valueType == TensorType.Value.INT8) {
+                    if (tensorDim != configuredDimensions && tensorDim != configuredDimensions / 8)
+                        throw new IllegalArgumentException(
+                                Text.format("Tensor dimension %d does not match configured dimension. Expected %d or %d.", tensorDim, configuredDimensions, configuredDimensions / 8));
+                } else {
+                    throw new IllegalArgumentException(
+                            "Quantization 'auto' is incompatible with tensor type " + targetType + ".");
+                }
+            }
+            case FLOAT -> {
+                if (valueType != TensorType.Value.FLOAT && valueType != TensorType.Value.BFLOAT16)
+                    throw new IllegalArgumentException(
+                            "Quantization 'float' is incompatible with tensor type " + targetType + ".");
+                if (tensorDim != configuredDimensions)
+                    throw new IllegalArgumentException(
+                            Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDimensions));
+            }
+            case INT8 -> {
+                if (valueType != TensorType.Value.INT8)
+                    throw new IllegalArgumentException(
+                            "Quantization 'int8' is incompatible with tensor type " + targetType + ".");
+                if (tensorDim != configuredDimensions)
+                    throw new IllegalArgumentException(
+                            Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDimensions));
+            }
+            case BINARY -> {
+                if (valueType != TensorType.Value.INT8)
+                    throw new IllegalArgumentException(
+                            "Quantization 'binary' is incompatible with tensor type " + targetType + ".");
+                if (tensorDim != configuredDimensions / 8)
+                    throw new IllegalArgumentException(
+                            Text.format("Tensor dimension %d does not match required dimension %d.", tensorDim, configuredDimensions / 8));
+            }
+        }
+    }
+
+    static String resolveOutputDataType(TensorType targetType, int configuredDimensions, Quantization quantization) {
+        return switch (quantization) {
+            case AUTO -> {
+                if (targetType.valueType() == TensorType.Value.FLOAT || targetType.valueType() == TensorType.Value.BFLOAT16) {
+                    yield "float";
+                } else if (targetType.valueType() == TensorType.Value.INT8) {
+                    long tensorDim = targetType.dimensions().get(0).size().orElseThrow();
+                    yield (tensorDim == configuredDimensions) ? "int8" : "binary";
+                } else {
+                    throw new IllegalStateException();
+                }
+            }
+            case FLOAT -> "float";
+            case INT8 -> "int8";
+            case BINARY -> "binary";
+        };
+    }
+
+    static Tensor decodeBase64FloatTensor(String base64, String dimensionName, TensorType.Value valueType) {
+        var buffer = ByteBuffer.wrap(Base64.getDecoder().decode(base64)).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+        var values = new float[buffer.remaining()];
+        buffer.get(values);
+        var type = new TensorType.Builder(valueType).indexed(dimensionName, values.length).build();
+        return IndexedTensor.Builder.of(type, values).build();
+    }
+
+    static Tensor decodeBase64Int8Tensor(String base64, String dimensionName) {
+        var bytes = Base64.getDecoder().decode(base64);
+        var type = new TensorType.Builder(TensorType.Value.INT8).indexed(dimensionName, bytes.length).build();
+        var builder = IndexedTensor.Builder.of(type);
+        for (int i = 0; i < bytes.length; i++) {
+            builder.cell(bytes[i], i);
+        }
+        return builder.build();
+    }
+
+    static Tensor decodeJsonArrayFloatTensor(JsonNode array, String dimensionName, TensorType.Value valueType) {
+        var values = new float[array.size()];
+        for (int i = 0; i < array.size(); i++) values[i] = array.get(i).floatValue();
+        var type = new TensorType.Builder(valueType).indexed(dimensionName, values.length).build();
+        return IndexedTensor.Builder.of(type, values).build();
+    }
+
+    static Tensor decodeJsonArrayInt8Tensor(JsonNode array, String dimensionName) {
+        var type = new TensorType.Builder(TensorType.Value.INT8).indexed(dimensionName, array.size()).build();
+        var builder = IndexedTensor.Builder.of(type);
+        for (int i = 0; i < array.size(); i++) builder.cell((byte) array.get(i).intValue(), i);
+        return builder.build();
+    }
+
+}

--- a/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
@@ -101,16 +101,18 @@ class EmbeddingQuantization {
         };
     }
 
-    static Tensor decodeBase64FloatTensor(String base64, String dimensionName, TensorType.Value valueType) {
+    static Tensor decodeBase64FloatTensor(String base64, String dimensionName, TensorType.Value valueType, long expectedDimensions) {
         var buffer = ByteBuffer.wrap(Base64.getDecoder().decode(base64)).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
         var values = new float[buffer.remaining()];
         buffer.get(values);
+        validateDimensions(expectedDimensions, values.length);
         var type = new TensorType.Builder(valueType).indexed(dimensionName, values.length).build();
         return IndexedTensor.Builder.of(type, values).build();
     }
 
-    static Tensor decodeBase64Int8Tensor(String base64, String dimensionName) {
+    static Tensor decodeBase64Int8Tensor(String base64, String dimensionName, long expectedDimensions) {
         var bytes = Base64.getDecoder().decode(base64);
+        validateDimensions(expectedDimensions, bytes.length);
         var type = new TensorType.Builder(TensorType.Value.INT8).indexed(dimensionName, bytes.length).build();
         var builder = IndexedTensor.Builder.of(type);
         for (int i = 0; i < bytes.length; i++) {
@@ -119,18 +121,26 @@ class EmbeddingQuantization {
         return builder.build();
     }
 
-    static Tensor decodeJsonArrayFloatTensor(JsonNode array, String dimensionName, TensorType.Value valueType) {
+    static Tensor decodeJsonArrayFloatTensor(JsonNode array, String dimensionName, TensorType.Value valueType, long expectedDimensions) {
         var values = new float[array.size()];
         for (int i = 0; i < array.size(); i++) values[i] = array.get(i).floatValue();
+        validateDimensions(expectedDimensions, values.length);
         var type = new TensorType.Builder(valueType).indexed(dimensionName, values.length).build();
         return IndexedTensor.Builder.of(type, values).build();
     }
 
-    static Tensor decodeJsonArrayInt8Tensor(JsonNode array, String dimensionName) {
+    static Tensor decodeJsonArrayInt8Tensor(JsonNode array, String dimensionName, long expectedDimensions) {
+        validateDimensions(expectedDimensions, array.size());
         var type = new TensorType.Builder(TensorType.Value.INT8).indexed(dimensionName, array.size()).build();
         var builder = IndexedTensor.Builder.of(type);
         for (int i = 0; i < array.size(); i++) builder.cell((byte) array.get(i).intValue(), i);
         return builder.build();
+    }
+
+    private static void validateDimensions(long expected, long actual) {
+        if (actual != expected)
+            throw new IllegalArgumentException(
+                    "Expected %d dimensions from API response, but got %d.".formatted(expected, actual));
     }
 
 }

--- a/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/EmbeddingQuantization.java
@@ -73,6 +73,9 @@ class EmbeddingQuantization {
                 if (valueType != TensorType.Value.INT8)
                     throw new IllegalArgumentException(
                             "Quantization 'binary' is incompatible with tensor type " + targetType + ".");
+                if (configuredDimensions % 8 != 0)
+                    throw new IllegalArgumentException(
+                            Text.format("Configured dimension %d must be divisible by 8 for quantization 'binary'.", configuredDimensions));
                 if (tensorDim != configuredDimensions / 8)
                     throw new IllegalArgumentException(
                             Text.format("Tensor dimension %d does not match required dimension %d.", tensorDim, configuredDimensions / 8));

--- a/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
@@ -1,0 +1,128 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.HttpEmbedderConfig;
+import ai.vespa.embedding.config.MistralEmbedderConfig;
+import ai.vespa.secret.Secret;
+import ai.vespa.secret.Secrets;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.yahoo.api.annotations.Beta;
+import com.yahoo.component.annotation.Inject;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorType;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Embedder using the Mistral embeddings API.
+ *
+ * @see <a href="https://docs.mistral.ai/api/endpoint/embeddings">Mistral Embeddings API</a>
+ * @author bjorncs
+ */
+@Beta
+public class MistralEmbedder extends AbstractHttpEmbedder implements Embedder {
+
+    private final MistralEmbedderConfig config;
+    private final Embedder.Runtime runtime;
+    private final Secret apiKey;
+    private final EmbeddingQuantization.Quantization quantization;
+
+    @Inject
+    public MistralEmbedder(MistralEmbedderConfig config, Embedder.Runtime runtime, Secrets secrets) {
+        this(config, new HttpEmbedderConfig.Builder().build(), runtime, secrets);
+    }
+
+    MistralEmbedder(MistralEmbedderConfig config, HttpEmbedderConfig httpConfig,
+                    Embedder.Runtime runtime, Secrets secrets) {
+        super(httpConfig);
+        this.config = config;
+        this.runtime = runtime;
+        this.apiKey = secrets.get(config.apiKeySecretRef());
+        this.quantization = EmbeddingQuantization.Quantization.valueOf(config.quantization().name());
+    }
+
+    @Override
+    public List<Integer> embed(String text, Context context) {
+        throw new UnsupportedOperationException(
+                "Mistral embedder only supports embed() with TensorType. Use embed(String, Context, TensorType) instead.");
+    }
+
+    @Override
+    public Tensor embed(String text, Context context, TensorType targetType) {
+        return embed(List.of(text), context, targetType).get(0);
+    }
+
+    @Override
+    public List<Tensor> embed(List<String> texts, Context context, TensorType targetType) {
+        long startTime = System.nanoTime();
+        EmbeddingQuantization.validateTensorType(targetType, config.dimensions(), quantization);
+        var outputDataType = EmbeddingQuantization.resolveOutputDataType(targetType, config.dimensions(), quantization);
+
+        record CacheKey(String embedderId, List<String> texts, String outputDataType) {}
+        var cacheKey = new CacheKey(context.getEmbedderId(), texts, outputDataType);
+        var response = context.computeCachedValueIfAbsent(cacheKey, () -> sendRequest(texts, outputDataType, context));
+
+        if (response.usage != null) runtime.sampleSequenceLength(response.usage.totalTokens(), context);
+        var tensors = toTensors(response, targetType, outputDataType);
+        runtime.sampleEmbeddingLatency(Duration.ofNanos(System.nanoTime() - startTime).toMillis(), context);
+        return tensors;
+    }
+
+    private EmbeddingResponse sendRequest(List<String> texts, String outputDataType, Context context) {
+        var outputDimension = hasConfigurableDimensions() ? config.dimensions() : null;
+        var json = toJson(new EmbeddingRequest(texts, config.model(), outputDimension, outputDataType));
+        runtime.sampleRequestCount(context);
+        var body = doHttpRequest(config.endpoint(), json, authHeaders(), context, runtime);
+        return fromJson(body, EmbeddingResponse.class);
+    }
+
+    private Map<String, String> authHeaders() {
+        return Map.of("Authorization", "Bearer " + apiKey.current());
+    }
+
+    private static List<Tensor> toTensors(EmbeddingResponse response, TensorType targetType, String outputDataType) {
+        var dimensionName = targetType.dimensions().get(0).name();
+        return response.data.stream()
+                .sorted(Comparator.comparingInt(EmbeddingData::index))
+                .map(d -> switch (outputDataType) {
+                    case "float" -> EmbeddingQuantization.decodeJsonArrayFloatTensor(d.embedding(), dimensionName, targetType.valueType());
+                    case "int8", "binary" -> EmbeddingQuantization.decodeJsonArrayInt8Tensor(d.embedding(), dimensionName);
+                    default -> throw new IllegalArgumentException("Unsupported output_dtype: " + outputDataType);
+                })
+                .toList();
+    }
+
+    /** Only newer models (e.g. codestral-embed) support configurable dimensions; mistral-embed does not. */
+    private boolean hasConfigurableDimensions() {
+        return !config.model().startsWith("mistral-embed");
+    }
+
+    // ===== DTOs =====
+
+    private record EmbeddingRequest(
+            @JsonProperty("input") List<String> input,
+            @JsonProperty("model") String model,
+            @JsonProperty("output_dimension") @JsonInclude(JsonInclude.Include.NON_NULL) Integer outputDimension,
+            @JsonProperty("output_dtype") String outputDtype) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record EmbeddingResponse(
+            @JsonProperty("data") List<EmbeddingData> data,
+            @JsonProperty("usage") Usage usage) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record EmbeddingData(
+            @JsonProperty("embedding") JsonNode embedding,
+            @JsonProperty("index") int index) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record Usage(@JsonProperty("total_tokens") int totalTokens) {}
+
+}

--- a/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
@@ -44,6 +44,8 @@ public class MistralEmbedder extends AbstractHttpEmbedder implements Embedder {
         super(httpConfig);
         this.config = config;
         this.runtime = runtime;
+        if (config.apiKeySecretRef().isBlank())
+            throw new IllegalArgumentException("'api-key-secret-ref' must be configured for Mistral embedder");
         this.apiKey = secrets.get(config.apiKeySecretRef());
         this.quantization = EmbeddingQuantization.Quantization.valueOf(config.quantization().name());
     }

--- a/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
@@ -88,12 +88,13 @@ public class MistralEmbedder extends AbstractHttpEmbedder implements Embedder {
     }
 
     private static List<Tensor> toTensors(EmbeddingResponse response, TensorType targetType, String outputDataType) {
-        var dimensionName = targetType.dimensions().get(0).name();
+        var dim = targetType.dimensions().get(0);
+        long expectedDimensions = dim.size().orElseThrow();
         return response.data.stream()
                 .sorted(Comparator.comparingInt(EmbeddingData::index))
                 .map(d -> switch (outputDataType) {
-                    case "float" -> EmbeddingQuantization.decodeJsonArrayFloatTensor(d.embedding(), dimensionName, targetType.valueType());
-                    case "int8", "binary" -> EmbeddingQuantization.decodeJsonArrayInt8Tensor(d.embedding(), dimensionName);
+                    case "float" -> EmbeddingQuantization.decodeJsonArrayFloatTensor(d.embedding(), dim.name(), targetType.valueType(), expectedDimensions);
+                    case "int8", "binary" -> EmbeddingQuantization.decodeJsonArrayInt8Tensor(d.embedding(), dim.name(), expectedDimensions);
                     default -> throw new IllegalArgumentException("Unsupported output_dtype: " + outputDataType);
                 })
                 .toList();

--- a/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
@@ -6,6 +6,7 @@ import ai.vespa.embedding.config.OpenaiEmbedderConfig;
 import ai.vespa.secret.Secret;
 import ai.vespa.secret.Secrets;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.annotation.Inject;
@@ -27,6 +28,9 @@ import java.util.Map;
 @Beta
 public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
 
+    private static final String ADA_002_MODEL = "text-embedding-ada-002";
+    private static final int ADA_002_DIMENSIONS = 1536;
+
     private final OpenaiEmbedderConfig config;
     private final Embedder.Runtime runtime;
     private final Secret apiKey;
@@ -42,6 +46,10 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         this.config = config;
         this.runtime = runtime;
         this.apiKey = config.apiKeySecretRef().isEmpty() ? null : secrets.get(config.apiKeySecretRef());
+        if (ADA_002_MODEL.equals(config.model()) && config.dimensions() != ADA_002_DIMENSIONS)
+            throw new IllegalArgumentException(
+                    "Model '%s' has a fixed output size of %d; configure dimensions=%d"
+                            .formatted(ADA_002_MODEL, ADA_002_DIMENSIONS, ADA_002_DIMENSIONS));
     }
 
     @Override
@@ -71,7 +79,9 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     }
 
     private EmbeddingResponse sendRequest(List<String> texts, Context context) {
-        var json = toJson(new EmbeddingRequest(texts, config.model(), config.dimensions(), "base64"));
+        // ada-002 has a fixed 1536 output size and rejects the "dimensions" request field
+        Integer dimensions = ADA_002_MODEL.equals(config.model()) ? null : config.dimensions();
+        var json = toJson(new EmbeddingRequest(texts, config.model(), dimensions, "base64"));
         runtime.sampleRequestCount(context);
         var body = doHttpRequest(config.endpoint(), json, authHeaders(), context, runtime);
         return fromJson(body, EmbeddingResponse.class);
@@ -99,7 +109,7 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     private record EmbeddingRequest(
             @JsonProperty("input") List<String> input,
             @JsonProperty("model") String model,
-            @JsonProperty("dimensions") int dimensions,
+            @JsonProperty("dimensions") @JsonInclude(JsonInclude.Include.NON_NULL) Integer dimensions,
             @JsonProperty("encoding_format") String encodingFormat) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
@@ -85,7 +85,12 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         var dimensionName = targetType.dimensions().get(0).name();
         return response.data.stream()
                 .sorted(Comparator.comparingInt(EmbeddingData::index))
-                .map(d -> EmbeddingQuantization.decodeBase64FloatTensor(d.embedding(), dimensionName, targetType.valueType()))
+                .map(d -> {
+                    if (d.embedding() == null)
+                        throw new IllegalStateException(
+                                "Embedding at index %d is null in API response — the provider may not support base64 encoding.".formatted(d.index()));
+                    return EmbeddingQuantization.decodeBase64FloatTensor(d.embedding(), dimensionName, targetType.valueType());
+                })
                 .toList();
     }
 

--- a/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
@@ -82,14 +82,14 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     }
 
     private static List<Tensor> toTensors(EmbeddingResponse response, TensorType targetType) {
-        var dimensionName = targetType.dimensions().get(0).name();
+        var dim = targetType.dimensions().get(0);
         return response.data.stream()
                 .sorted(Comparator.comparingInt(EmbeddingData::index))
                 .map(d -> {
                     if (d.embedding() == null)
                         throw new IllegalStateException(
                                 "Embedding at index %d is null in API response — the provider may not support base64 encoding.".formatted(d.index()));
-                    return EmbeddingQuantization.decodeBase64FloatTensor(d.embedding(), dimensionName, targetType.valueType());
+                    return EmbeddingQuantization.decodeBase64FloatTensor(d.embedding(), dim.name(), targetType.valueType(), dim.size().orElseThrow());
                 })
                 .toList();
     }

--- a/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
@@ -1,0 +1,113 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.HttpEmbedderConfig;
+import ai.vespa.embedding.config.OpenaiEmbedderConfig;
+import ai.vespa.secret.Secret;
+import ai.vespa.secret.Secrets;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.api.annotations.Beta;
+import com.yahoo.component.annotation.Inject;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorType;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Embedder using the OpenAI (compatible) embeddings API.
+ *
+ * @see <a href="https://developers.openai.com/api/reference/resources/embeddings/methods/create">OpenAI Embeddings API</a>
+ * @author bjorncs
+ */
+@Beta
+public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
+
+    private final OpenaiEmbedderConfig config;
+    private final Embedder.Runtime runtime;
+    private final Secret apiKey;
+
+    @Inject
+    public OpenAIEmbedder(OpenaiEmbedderConfig config, Embedder.Runtime runtime, Secrets secrets) {
+        this(config, new HttpEmbedderConfig.Builder().build(), runtime, secrets);
+    }
+
+    OpenAIEmbedder(OpenaiEmbedderConfig config, HttpEmbedderConfig httpConfig,
+                   Embedder.Runtime runtime, Secrets secrets) {
+        super(httpConfig);
+        this.config = config;
+        this.runtime = runtime;
+        this.apiKey = config.apiKeySecretRef().isEmpty() ? null : secrets.get(config.apiKeySecretRef());
+    }
+
+    @Override
+    public List<Integer> embed(String text, Context context) {
+        throw new UnsupportedOperationException(
+                "OpenAI embedder only supports embed() with TensorType. Use embed(String, Context, TensorType) instead.");
+    }
+
+    @Override
+    public Tensor embed(String text, Context context, TensorType targetType) {
+        return embed(List.of(text), context, targetType).get(0);
+    }
+
+    @Override
+    public List<Tensor> embed(List<String> texts, Context context, TensorType targetType) {
+        long startTime = System.nanoTime();
+        EmbeddingQuantization.validateTensorType(targetType, config.dimensions(), EmbeddingQuantization.Quantization.FLOAT);
+
+        record CacheKey(String embedderId, List<String> texts) {}
+        var cacheKey = new CacheKey(context.getEmbedderId(), texts);
+        var response = context.computeCachedValueIfAbsent(cacheKey, () -> sendRequest(texts, context));
+
+        if (response.usage != null) runtime.sampleSequenceLength(response.usage.totalTokens(), context);
+        var tensors = toTensors(response, targetType);
+        runtime.sampleEmbeddingLatency(Duration.ofNanos(System.nanoTime() - startTime).toMillis(), context);
+        return tensors;
+    }
+
+    private EmbeddingResponse sendRequest(List<String> texts, Context context) {
+        var json = toJson(new EmbeddingRequest(texts, config.model(), config.dimensions(), "base64"));
+        runtime.sampleRequestCount(context);
+        var body = doHttpRequest(config.endpoint(), json, authHeaders(), context, runtime);
+        return fromJson(body, EmbeddingResponse.class);
+    }
+
+    private Map<String, String> authHeaders() {
+        return apiKey == null ? Map.of() : Map.of("Authorization", "Bearer " + apiKey.current());
+    }
+
+    private static List<Tensor> toTensors(EmbeddingResponse response, TensorType targetType) {
+        var dimensionName = targetType.dimensions().get(0).name();
+        return response.data.stream()
+                .sorted(Comparator.comparingInt(EmbeddingData::index))
+                .map(d -> EmbeddingQuantization.decodeBase64FloatTensor(d.embedding(), dimensionName, targetType.valueType()))
+                .toList();
+    }
+
+    // ===== DTOs =====
+
+    private record EmbeddingRequest(
+            @JsonProperty("input") List<String> input,
+            @JsonProperty("model") String model,
+            @JsonProperty("dimensions") int dimensions,
+            @JsonProperty("encoding_format") String encodingFormat) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record EmbeddingResponse(
+            @JsonProperty("data") List<EmbeddingData> data,
+            @JsonProperty("usage") Usage usage) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record EmbeddingData(
+            @JsonProperty("embedding") String embedding,
+            @JsonProperty("index") int index) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record Usage(@JsonProperty("total_tokens") int totalTokens) {}
+
+}

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -149,11 +149,12 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     }
 
     private static List<Tensor> toTensors(VoyageResponse response, TensorType targetType, String outputDataType) {
-        var dimensionName = targetType.dimensions().get(0).name();
+        var dim = targetType.dimensions().get(0);
+        long expectedDimensions = dim.size().orElseThrow();
         return response.encodedEmbeddings().stream()
                 .map(encoded -> switch (outputDataType) {
-                    case "float" -> EmbeddingQuantization.decodeBase64FloatTensor(encoded, dimensionName, targetType.valueType());
-                    case "int8", "binary" -> EmbeddingQuantization.decodeBase64Int8Tensor(encoded, dimensionName);
+                    case "float" -> EmbeddingQuantization.decodeBase64FloatTensor(encoded, dim.name(), targetType.valueType(), expectedDimensions);
+                    case "int8", "binary" -> EmbeddingQuantization.decodeBase64Int8Tensor(encoded, dim.name(), expectedDimensions);
                     default -> throw new IllegalArgumentException("Unsupported output_dtype: " + outputDataType);
                 })
                 .toList();

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -115,8 +115,6 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
             // Contextual API treats the text list as chunks of a single document; batching is
             // disabled to prevent cross-document context contamination from independent embed()
             // calls being combined by the framework
-            if (texts.size() != 1)
-                throw new IllegalArgumentException("Contextual models do not support batching");
             request = ContextualRequest.of(
                     texts, config.model(), inputType, config.dimensions(), outputDataType);
         } else {

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -63,7 +63,7 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         this.resolvedEndpoint = resolveEndpoint(config.endpoint(), isMultimodal, isContextual);
     }
 
-    @Override public Batching batchingConfig() { return batching; }
+    @Override public Batching batchingConfig() { return isMultimodal ? Batching.DISABLED : batching; }
 
     @Override
     public List<Integer> embed(String text, Context context) {
@@ -104,6 +104,10 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     private String buildRequestJson(List<String> texts, String inputType, String outputDataType) {
         Object request;
         if (isMultimodal) {
+            // Multimodal API uses a different input structure (content items with type+text/image);
+            // batching is disabled so only a single text is expected here
+            if (texts.size() != 1)
+                throw new IllegalArgumentException("Multimodal models do not support batching");
             request = MultimodalRequest.of(
                     texts.get(0), config.model(), inputType, config.truncate(), config.dimensions(), outputDataType);
         } else if (isContextual) {

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -63,7 +63,7 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         this.resolvedEndpoint = resolveEndpoint(config.endpoint(), isMultimodal, isContextual);
     }
 
-    @Override public Batching batchingConfig() { return isMultimodal ? Batching.DISABLED : batching; }
+    @Override public Batching batchingConfig() { return (isMultimodal || isContextual) ? Batching.DISABLED : batching; }
 
     @Override
     public List<Integer> embed(String text, Context context) {
@@ -111,6 +111,11 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
             request = MultimodalRequest.of(
                     texts.get(0), config.model(), inputType, config.truncate(), config.dimensions(), outputDataType);
         } else if (isContextual) {
+            // Contextual API treats the text list as chunks of a single document; batching is
+            // disabled to prevent cross-document context contamination from independent embed()
+            // calls being combined by the framework
+            if (texts.size() != 1)
+                throw new IllegalArgumentException("Contextual models do not support batching");
             request = ContextualRequest.of(
                     texts, config.model(), inputType, config.dimensions(), outputDataType);
         } else {

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -1,427 +1,171 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.embedding;
 
+import ai.vespa.embedding.config.HttpEmbedderConfig;
 import ai.vespa.embedding.config.VoyageAiEmbedderConfig;
 import ai.vespa.secret.Secret;
 import ai.vespa.secret.Secrets;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.api.annotations.Beta;
-import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.language.process.Embedder;
-import com.yahoo.language.process.InvalidInputException;
-import com.yahoo.language.process.OverloadException;
-import com.yahoo.language.process.TimeoutException;
-import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
-import com.yahoo.text.Text;
-import okhttp3.ConnectionPool;
-import okhttp3.Interceptor;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
 
-import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.time.Duration;
-import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
+import java.util.Map;
 
 /**
- * VoyageAI embedder that uses the VoyageAI Embeddings API.
+ * Embedder using the VoyageAI embeddings API. Auto-selects between the text, multimodal,
+ * and contextualized endpoints based on the configured model name.
  *
  * @see <a href="https://docs.voyageai.com/">VoyageAI Documentation</a>
- * @author VoyageAI team
  * @author bjorncs
  */
 @Beta
-public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
+public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
 
-    private static final Logger log = Logger.getLogger(VoyageAIEmbedder.class.getName());
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    // VoyageAI API endpoints - auto-selected based on model name
     private static final String EMBEDDINGS_ENDPOINT = "https://api.voyageai.com/v1/embeddings";
     private static final String MULTIMODAL_EMBEDDINGS_ENDPOINT = "https://api.voyageai.com/v1/multimodalembeddings";
     private static final String CONTEXTUALIZED_EMBEDDINGS_ENDPOINT = "https://api.voyageai.com/v1/contextualizedembeddings";
 
-    // Configuration
     private final VoyageAiEmbedderConfig config;
     private final Embedder.Runtime runtime;
-    private final Embedder.Batching batching;
     private final Secret apiKey;
-    private final OkHttpClient httpClient;
+    private final Embedder.Batching batching;
+    private final EmbeddingQuantization.Quantization quantization;
     private final String resolvedEndpoint;
+    private final boolean isMultimodal;
+    private final boolean isContextual;
 
     @Inject
-    public VoyageAIEmbedder(VoyageAiEmbedderConfig config, Embedder.Runtime runtime, Secrets secretStore) {
+    public VoyageAIEmbedder(VoyageAiEmbedderConfig config, Embedder.Runtime runtime, Secrets secrets) {
+        this(config, new HttpEmbedderConfig.Builder().build(), runtime, secrets);
+    }
+
+    VoyageAIEmbedder(VoyageAiEmbedderConfig config, HttpEmbedderConfig httpConfig,
+                     Embedder.Runtime runtime, Secrets secrets) {
+        super(httpConfig);
         this.config = config;
         this.runtime = runtime;
-        this.batching = Embedder.Batching.of(config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));
-        this.apiKey = secretStore.get(config.apiKeySecretRef());
-        this.httpClient = createHttpClient(config);
-        this.resolvedEndpoint = resolveEndpoint(config);
-
-        log.fine(() -> Text.format("VoyageAI embedder initialized with model: %s, endpoint: %s", config.model(), resolvedEndpoint));
+        this.apiKey = secrets.get(config.apiKeySecretRef());
+        this.batching = Embedder.Batching.of(
+                config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));
+        this.quantization = EmbeddingQuantization.Quantization.valueOf(config.quantization().name());
+        this.isMultimodal = config.model().startsWith("voyage-multimodal-");
+        this.isContextual = config.model().startsWith("voyage-context-");
+        this.resolvedEndpoint = resolveEndpoint(config.endpoint(), isMultimodal, isContextual);
     }
 
-    private String resolveEndpoint(VoyageAiEmbedderConfig config) {
-        // If user explicitly configured an endpoint, use it
-        String configuredEndpoint = config.endpoint();
-        if (configuredEndpoint != null && !configuredEndpoint.equals(EMBEDDINGS_ENDPOINT)) {
-            return configuredEndpoint;
-        }
-
-        // Auto-select endpoint based on model name
-        String model = config.model();
-        if (model != null) {
-            if (model.startsWith("voyage-multimodal-")) {
-                return MULTIMODAL_EMBEDDINGS_ENDPOINT;
-            }
-            if (model.startsWith("voyage-context-")) {
-                return CONTEXTUALIZED_EMBEDDINGS_ENDPOINT;
-            }
-        }
-
-        return EMBEDDINGS_ENDPOINT;
-    }
-
-    private OkHttpClient createHttpClient(VoyageAiEmbedderConfig config) {
-        return new OkHttpClient.Builder()
-                .addInterceptor(new RetryInterceptor(config.maxRetries()))
-                .retryOnConnectionFailure(true)
-                .connectTimeout(Duration.ofSeconds(10))
-                .readTimeout(Duration.ofMillis(config.timeout()))
-                .writeTimeout(Duration.ofMillis(config.timeout()))
-                .connectionPool(new ConnectionPool(10, 1, TimeUnit.MINUTES))
-                .build();
-    }
-
-    @Override
-    public Batching batchingConfig() { return batching; }
+    @Override public Batching batchingConfig() { return batching; }
 
     @Override
     public List<Integer> embed(String text, Context context) {
         throw new UnsupportedOperationException(
-            "VoyageAI embedder only supports embed() with TensorType. " +
-            "Use embed(String text, Context context, TensorType targetType) instead."
-        );
+                "VoyageAI embedder only supports embed() with TensorType. Use embed(String, Context, TensorType) instead.");
     }
 
     @Override
     public Tensor embed(String text, Context context, TensorType targetType) {
-        return invokeVoyageAI(List.of(text), context, targetType)
-                .get(0);
+        return embed(List.of(text), context, targetType).get(0);
     }
 
     @Override
     public List<Tensor> embed(List<String> texts, Context context, TensorType targetType) {
-        return invokeVoyageAI(texts, context, targetType);
-    }
-
-    private void validateTensorType(TensorType targetTensorType) {
-        if (targetTensorType.dimensions().size() != 1)
-            throw new IllegalArgumentException(
-                    "Error in embedding to type '" + targetTensorType + "': should only have one dimension.");
-        var tensorDimension = targetTensorType.dimensions().get(0);
-        if (!tensorDimension.isIndexed())
-            throw new IllegalArgumentException(
-                    "Error in embedding to type '" + targetTensorType + "': dimension should be indexed.");
-        var valueType = targetTensorType.valueType();
-
-        int configuredDim = config.dimensions();
-        long tensorDim = tensorDimension.size().orElseThrow();
-
-        switch (config.quantization()) {
-            case AUTO:
-                if (valueType == TensorType.Value.FLOAT || valueType == TensorType.Value.BFLOAT16) {
-                    if (tensorDim != configuredDim)
-                        throw new IllegalArgumentException(Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDim));
-                } else if (valueType == TensorType.Value.INT8) {
-                    if (tensorDim != configuredDim && tensorDim != configuredDim / 8)
-                        throw new IllegalArgumentException(Text.format("Tensor dimension %d does not match configured dimension. Expected %d or %d.", tensorDim, configuredDim, configuredDim / 8));
-                } else {
-                    throw new IllegalArgumentException(
-                            "Quantization 'auto' is incompatible with tensor type " + targetTensorType + ".");
-                }
-                break;
-            case FLOAT:
-                if (valueType != TensorType.Value.FLOAT && valueType != TensorType.Value.BFLOAT16)
-                    throw new IllegalArgumentException(
-                            "Quantization 'float' is incompatible with tensor type " + targetTensorType + ".");
-                if (tensorDim != configuredDim)
-                    throw new IllegalArgumentException(Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDim));
-                break;
-            case INT8:
-                if (valueType != TensorType.Value.INT8)
-                    throw new IllegalArgumentException(
-                            "Quantization 'int8' is incompatible with tensor type " + targetTensorType + ".");
-                if (tensorDim != configuredDim)
-                    throw new IllegalArgumentException(Text.format("Tensor dimension %d does not match configured dimension %d.", tensorDim, configuredDim));
-                break;
-            case BINARY:
-                if (valueType != TensorType.Value.INT8)
-                    throw new IllegalArgumentException(
-                            "Quantization 'binary' is incompatible with tensor type " + targetTensorType + ".");
-                if (tensorDim != configuredDim / 8)
-                    throw new IllegalArgumentException(Text.format("Tensor dimension %d does not match required dimension %d.", tensorDim, configuredDim / 8));
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported quantization: " + config.quantization());
-        }
-    }
-
-    private boolean isMultimodalModel() { return config.model().startsWith("voyage-multimodal-"); }
-    private boolean isContextualModel() { return config.model().startsWith("voyage-context-"); }
-
-    private String resolveOutputDataType(TensorType targetType) {
-        return switch (config.quantization()) {
-            case AUTO -> {
-                if (targetType.valueType() == TensorType.Value.FLOAT || targetType.valueType() == TensorType.Value.BFLOAT16) {
-                    yield "float";
-                } else if (targetType.valueType() == TensorType.Value.INT8) {
-                    long tensorDim = targetType.dimensions().get(0).size().orElseThrow();
-                    yield (tensorDim == config.dimensions()) ? "int8" : "binary";
-                } else {
-                    throw new IllegalStateException();
-                }
-            }
-            case FLOAT -> "float";
-            case INT8 -> "int8";
-            case BINARY -> "binary";
-        };
-    }
-
-    private List<Tensor> invokeVoyageAI(List<String> texts, Context context, TensorType targetType) {
         long startTime = System.nanoTime();
-        validateTensorType(targetType);
+        EmbeddingQuantization.validateTensorType(targetType, config.dimensions(), quantization);
         var inputType = context.getDestinationType() == Context.DestinationType.QUERY ? "query" : "document";
-        var outputDataType = resolveOutputDataType(targetType);
-        var timeoutMs = calculateTimeoutMs(context);
+        var outputDataType = EmbeddingQuantization.resolveOutputDataType(targetType, config.dimensions(), quantization);
 
+        record CacheKey(String embedderId, List<String> texts, String inputType, String outputDataType) {}
         var cacheKey = new CacheKey(context.getEmbedderId(), texts, inputType, outputDataType);
-        var responseBody = context.computeCachedValueIfAbsent(cacheKey, () -> {
-            var jsonRequest = createJsonRequest(texts, inputType, outputDataType);
-            log.fine(() -> "VoyageAI request: " + jsonRequest);
-            return doRequest(jsonRequest, timeoutMs, context);
-        });
+        var response = context.computeCachedValueIfAbsent(
+                cacheKey, () -> sendRequest(texts, inputType, outputDataType, context));
 
-        var tensors = toTensors(responseBody, targetType, outputDataType, context);
-        var latency = Duration.ofNanos(System.nanoTime() - startTime);
-        runtime.sampleEmbeddingLatency(latency.toMillis(), context);
+        runtime.sampleSequenceLength(response.totalTokens(), context);
+        var tensors = toTensors(response, targetType, outputDataType);
+        runtime.sampleEmbeddingLatency(Duration.ofNanos(System.nanoTime() - startTime).toMillis(), context);
         return tensors;
     }
 
-    private List<Tensor> toTensors(String responseBody, TensorType targetType, String outputDtype, Context context) {
-        try {
-            Response response;
-            List<String> encodedEmbeddings;
-            if (isContextualModel()) {
-                var contextualResponse = objectMapper.readValue(responseBody, ContextualResponse.class);
-                response = contextualResponse;
-                encodedEmbeddings = contextualResponse.data.get(0).data.stream()
-                        .map(TextEmbeddingData::embedding)
-                        .toList();
-            } else {
-                var voyageResponse = objectMapper.readValue(responseBody, TextResponse.class);
-                response = voyageResponse;
-                encodedEmbeddings = voyageResponse.data.stream()
-                        .map(TextEmbeddingData::embedding)
-                        .toList();
-            }
-            runtime.sampleSequenceLength(response.usage().totalTokens(), context);
-            String dimensionName = targetType.dimensions().get(0).name();
-            return encodedEmbeddings.stream()
-                    .map(encoded -> switch (outputDtype) {
-                        case "float" -> decodeBase64FloatTensor(encoded, dimensionName, targetType.valueType());
-                        case "int8", "binary" -> decodeBase64Int8Tensor(encoded, dimensionName);
-                        default -> throw new IllegalArgumentException("Unsupported output_dtype: " + outputDtype);
-                    })
-                    .toList();
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to parse VoyageAI response", e);
-        }
+    private VoyageResponse sendRequest(List<String> texts, String inputType, String outputDataType, Context context) {
+        var json = buildRequestJson(texts, inputType, outputDataType);
+        runtime.sampleRequestCount(context);
+        var body = doHttpRequest(resolvedEndpoint, json, authHeaders(), context, runtime);
+        return parseSuccess(body);
     }
 
-    private String createJsonRequest(List<String> texts, String inputType, String outputDataType) {
+    private String buildRequestJson(List<String> texts, String inputType, String outputDataType) {
         Object request;
-        if (isMultimodalModel()) {
+        if (isMultimodal) {
             request = MultimodalRequest.of(
                     texts.get(0), config.model(), inputType, config.truncate(), config.dimensions(), outputDataType);
-        } else if (isContextualModel()) {
+        } else if (isContextual) {
             request = ContextualRequest.of(
                     texts, config.model(), inputType, config.dimensions(), outputDataType);
         } else {
             request = TextRequest.of(
                     texts, config.model(), inputType, config.truncate(), config.dimensions(), outputDataType);
         }
-        try {
-            return objectMapper.writeValueAsString(request);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize VoyageAI request", e);
+        return toJson(request);
+    }
+
+    private VoyageResponse parseSuccess(String body) {
+        List<String> encoded;
+        int totalTokens;
+        if (isContextual) {
+            var response = fromJson(body, ContextualResponse.class);
+            totalTokens = response.usage.totalTokens();
+            encoded = response.data.get(0).data.stream()
+                    .sorted(Comparator.comparingInt(TextEmbeddingData::index))
+                    .map(TextEmbeddingData::embedding)
+                    .toList();
+        } else {
+            var response = fromJson(body, TextResponse.class);
+            totalTokens = response.usage.totalTokens();
+            encoded = response.data.stream()
+                    .sorted(Comparator.comparingInt(TextEmbeddingData::index))
+                    .map(TextEmbeddingData::embedding)
+                    .toList();
         }
+        return new VoyageResponse(encoded, totalTokens);
     }
 
-    private String doRequest(String jsonRequest, long timeoutMs, Context context) {
-        var httpRequest = new Request.Builder()
-                .url(resolvedEndpoint)
-                .header("Authorization", "Bearer " + apiKey.current())
-                .header("Content-Type", "application/json")
-                .post(RequestBody.create(jsonRequest, MediaType.get("application/json; charset=utf-8")))
-                .build();
-
-        runtime.sampleRequestCount(context);
-        var call = httpClient.newCall(httpRequest);
-        call.timeout().timeout(timeoutMs, TimeUnit.MILLISECONDS);
-
-        try (var response = call.execute()) {
-            var responseBody = response.body() != null ? response.body().string() : "";
-            log.fine(() -> "VoyageAI response with code " + response.code() + ": " + responseBody);
-            if (response.isSuccessful()) {
-                return responseBody;
-            } else if (response.code() == 429) {
-                runtime.sampleRequestFailure(context, response.code());
-                throw new OverloadException("VoyageAI API rate limited (429)");
-            } else if (response.code() == 401) {
-                runtime.sampleRequestFailure(context, response.code());
-                throw new RuntimeException("VoyageAI API authentication failed. Please check your API key: " + responseBody);
-            } else if (response.code() == 400) {
-                runtime.sampleRequestFailure(context, response.code());
-                String errorMessage = parseErrorDetail(responseBody).orElse(responseBody);
-                throw new InvalidInputException("VoyageAI API bad request (400): " + errorMessage);
-            } else {
-                runtime.sampleRequestFailure(context, response.code());
-                throw new RuntimeException("VoyageAI API request failed with status " + response.code() + ": " + responseBody);
-            }
-        } catch (InterruptedIOException e) {
-            // Covers both OkHttp timeout (InterruptedIOException) and socket timeout (SocketTimeoutException extends InterruptedIOException)
-            runtime.sampleRequestFailure(context, 0);
-            throw new TimeoutException(
-                    "VoyageAI API call timed out after " + timeoutMs + "ms", e);
-        } catch (IOException e) {
-            runtime.sampleRequestFailure(context, 0);
-            throw new RuntimeException("VoyageAI API call failed: " + e.getMessage(), e);
-        }
+    private static String resolveEndpoint(String configured, boolean isMultimodal, boolean isContextual) {
+        if (!configured.equals(EMBEDDINGS_ENDPOINT)) return configured;
+        if (isMultimodal) return MULTIMODAL_EMBEDDINGS_ENDPOINT;
+        if (isContextual) return CONTEXTUALIZED_EMBEDDINGS_ENDPOINT;
+        return EMBEDDINGS_ENDPOINT;
     }
 
-    private Optional<String> parseErrorDetail(String responseBody) {
-        try {
-            ErrorResponse errorResponse = objectMapper.readValue(responseBody, ErrorResponse.class);
-            if (errorResponse.detail != null && !errorResponse.detail.isEmpty()) {
-                return Optional.of(errorResponse.detail);
-            }
-        } catch (JsonProcessingException e) {
-            log.fine(() -> "Failed to parse error response as JSON: " + e.getMessage());
-        }
-        return Optional.empty();
+    private Map<String, String> authHeaders() {
+        return Map.of("Authorization", "Bearer " + apiKey.current());
     }
 
-    private long calculateTimeoutMs(Context context) {
-        long remainingMs = context.getDeadline()
-                .map(d -> d.timeRemaining().toMillis())
-                .orElse((long) config.timeout());
-        if (remainingMs <= 0)
-            throw new TimeoutException("Request deadline exceeded before VoyageAI API call");
-        return remainingMs;
+    private static List<Tensor> toTensors(VoyageResponse response, TensorType targetType, String outputDataType) {
+        var dimensionName = targetType.dimensions().get(0).name();
+        return response.encodedEmbeddings().stream()
+                .map(encoded -> switch (outputDataType) {
+                    case "float" -> EmbeddingQuantization.decodeBase64FloatTensor(encoded, dimensionName, targetType.valueType());
+                    case "int8", "binary" -> EmbeddingQuantization.decodeBase64Int8Tensor(encoded, dimensionName);
+                    default -> throw new IllegalArgumentException("Unsupported output_dtype: " + outputDataType);
+                })
+                .toList();
     }
 
-    private static Tensor decodeBase64FloatTensor(String base64, String dimensionName, TensorType.Value valueType) {
-        var buffer = ByteBuffer.wrap(Base64.getDecoder().decode(base64)).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
-        var values = new float[buffer.remaining()];
-        buffer.get(values);
-        var type = new TensorType.Builder(valueType).indexed(dimensionName, values.length).build();
-        return IndexedTensor.Builder.of(type, values).build();
-    }
 
-    private static Tensor decodeBase64Int8Tensor(String base64, String dimensionName) {
-        var bytes = Base64.getDecoder().decode(base64);
-        var type = new TensorType.Builder(TensorType.Value.INT8).indexed(dimensionName, bytes.length).build();
-        var builder = IndexedTensor.Builder.of(type);
-        for (int i = 0; i < bytes.length; i++) {
-            builder.cell(bytes[i], i);
-        }
-        return builder.build();
-    }
+    // ===== Normalized internal response =====
 
-    @Override
-    public void deconstruct() {
-        httpClient.dispatcher().executorService().shutdown();
-        httpClient.connectionPool().evictAll();
-        super.deconstruct();
-    }
+    private record VoyageResponse(List<String> encodedEmbeddings, int totalTokens) {}
 
-    private static class RetryInterceptor implements Interceptor {
-        static final long RETRY_DELAY_MS = 100;
-        private final int maxRetries;
-
-        RetryInterceptor(int maxRetries) {
-            this.maxRetries = maxRetries;
-        }
-
-        @Override
-        public okhttp3.Response intercept(Chain chain) throws IOException {
-            var request = chain.request();
-            int lastStatusCode = 0;
-            String lastResponseBody = "";
-
-            for (int attempt = 0; attempt <= maxRetries; attempt++) {
-                try {
-                    var response = chain.proceed(request);
-
-                    int code = response.code();
-                    boolean shouldRetry = code == 500 || code == 502 || code == 503 || code == 504;
-                    if (response.isSuccessful() || !shouldRetry) return response;
-
-                    // Capture response details before closing
-                    lastStatusCode = code;
-                    if (response.body() != null) {
-                        lastResponseBody = response.body().string();
-                    }
-                    response.close();
-
-                    if (attempt < maxRetries) {
-                        int retryNumber = attempt + 1;
-                        log.fine(() -> Text.format("VoyageAI API server error (%d). Retry %d of %d after %dms", code, retryNumber + 1, maxRetries, RETRY_DELAY_MS));
-                        Thread.sleep(RETRY_DELAY_MS);
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IOException("Retry interrupted", e);
-                }
-            }
-
-            var errorMsg = Text.format("Max retries exceeded for VoyageAI API (%d). Last response: %d - %s", maxRetries, lastStatusCode, lastResponseBody);
-            throw new IOException(errorMsg);
-        }
-    }
-
-    // ===== Generic Request/Response DTOs =====
+    // ===== DTOs =====
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record Usage(@JsonProperty("total_tokens") int totalTokens) {}
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static abstract class Response {
-        @JsonProperty("usage") private Usage usage;
-        Usage usage() { return usage; }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ErrorResponse(@JsonProperty("detail") String detail) {}
-
-    // ===== Text Request/Response DTOs =====
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record TextRequest(
@@ -434,7 +178,7 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("encoding_format") String encodingFormat) {
 
         static TextRequest of(List<String> texts, String model, String inputType,
-                              boolean truncation, Integer outputDimension, String outputDtype) {
+                              boolean truncation, int outputDimension, String outputDtype) {
             return new TextRequest(texts, model, inputType, truncation, outputDimension, outputDtype, "base64");
         }
     }
@@ -445,11 +189,10 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("index") int index) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class TextResponse extends Response {
+    private static class TextResponse {
         @JsonProperty("data") List<TextEmbeddingData> data;
+        @JsonProperty("usage") Usage usage;
     }
-
-    // ===== Contextual Request/Response DTOs =====
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record ContextualRequest(
@@ -461,21 +204,19 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("encoding_format") String encodingFormat) {
 
         static ContextualRequest of(List<String> texts, String model, String inputType,
-                                    Integer outputDimension, String outputDtype) {
-            return new ContextualRequest(List.of(texts), model, inputType,
-                                         outputDimension, outputDtype, "base64");
+                                    int outputDimension, String outputDtype) {
+            return new ContextualRequest(List.of(texts), model, inputType, outputDimension, outputDtype, "base64");
         }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class ContextualResponse extends Response {
+    private static class ContextualResponse {
         @JsonProperty("data") List<ContextualDocumentResult> data;
+        @JsonProperty("usage") Usage usage;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record ContextualDocumentResult(@JsonProperty("data") List<TextEmbeddingData> data) {}
-
-    // ===== Multimodal Request DTOs =====
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record MultimodalRequest(
@@ -488,7 +229,7 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
             @JsonProperty("encoding_format") String encodingFormat) {
 
         static MultimodalRequest of(String text, String model, String inputType,
-                                    boolean truncation, Integer outputDimension, String outputDtype) {
+                                    boolean truncation, int outputDimension, String outputDtype) {
             return new MultimodalRequest(List.of(MultimodalInput.of(text)), model, inputType,
                                          truncation, outputDimension, outputDtype, "base64");
         }
@@ -496,21 +237,14 @@ public class VoyageAIEmbedder extends AbstractComponent implements Embedder {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record MultimodalInput(@JsonProperty("content") List<MultimodalContentItem> content) {
-
-        static MultimodalInput of(String text) {
-            return new MultimodalInput(List.of(MultimodalContentItem.of(text)));
-        }
+        static MultimodalInput of(String text) { return new MultimodalInput(List.of(MultimodalContentItem.of(text))); }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record MultimodalContentItem(
             @JsonProperty("type") String type,
             @JsonProperty("text") String text) {
-
         static MultimodalContentItem of(String text) { return new MultimodalContentItem("text", text); }
     }
 
-    // ===== Cache Key =====
-
-    private record CacheKey(String embedderId, List<String> texts, String inputType, String outputDataType) {}
 }

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -52,6 +52,8 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         super(httpConfig);
         this.config = config;
         this.runtime = runtime;
+        if (config.apiKeySecretRef().isBlank())
+            throw new IllegalArgumentException("'api-key-secret-ref' must be configured for VoyageAI embedder");
         this.apiKey = secrets.get(config.apiKeySecretRef());
         this.batching = Embedder.Batching.of(
                 config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -121,14 +121,14 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         int totalTokens;
         if (isContextual) {
             var response = fromJson(body, ContextualResponse.class);
-            totalTokens = response.usage.totalTokens();
+            totalTokens = response.usage != null ? response.usage.totalTokens() : 0;
             encoded = response.data.get(0).data.stream()
                     .sorted(Comparator.comparingInt(TextEmbeddingData::index))
                     .map(TextEmbeddingData::embedding)
                     .toList();
         } else {
             var response = fromJson(body, TextResponse.class);
-            totalTokens = response.usage.totalTokens();
+            totalTokens = response.usage != null ? response.usage.totalTokens() : 0;
             encoded = response.data.stream()
                     .sorted(Comparator.comparingInt(TextEmbeddingData::index))
                     .map(TextEmbeddingData::embedding)

--- a/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/VoyageAIEmbedder.java
@@ -88,7 +88,8 @@ public class VoyageAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         var response = context.computeCachedValueIfAbsent(
                 cacheKey, () -> sendRequest(texts, inputType, outputDataType, context));
 
-        runtime.sampleSequenceLength(response.totalTokens(), context);
+        if (response.totalTokens() > 0)
+            runtime.sampleSequenceLength(response.totalTokens(), context);
         var tensors = toTensors(response, targetType, outputDataType);
         runtime.sampleEmbeddingLatency(Duration.ofNanos(System.nanoTime() - startTime).toMillis(), context);
         return tensors;

--- a/model-integration/src/test/java/ai/vespa/embedding/AbstractHttpEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/AbstractHttpEmbedderTest.java
@@ -1,0 +1,194 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.HttpEmbedderConfig;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.InvalidInputException;
+import com.yahoo.language.process.InvocationContext;
+import com.yahoo.language.process.OverloadException;
+import com.yahoo.language.process.TimeoutException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the HTTP transport behavior of {@link AbstractHttpEmbedder}: status-code-to-exception
+ * mapping, timeouts, retries, and error-body parsing. Provider-specific embedder tests cover only
+ * request building and response parsing; the shared HTTP behavior is verified here.
+ *
+ * @author bjorncs
+ */
+public class AbstractHttpEmbedderTest {
+
+    private MockWebServer mockServer;
+    private Embedder.Runtime runtime;
+    private AbstractHttpEmbedder embedder;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        runtime = Embedder.Runtime.testInstance();
+        embedder = new AbstractHttpEmbedder() {};
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        embedder.deconstruct();
+        mockServer.shutdown();
+    }
+
+    @Test
+    public void testReturnsBodyOn2xx() {
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("hello"));
+        assertEquals("hello", call());
+    }
+
+    @Test
+    public void testThrowsOverloadExceptionOn429() {
+        mockServer.enqueue(new MockResponse().setResponseCode(429).setBody("{\"error\":{\"message\":\"rate_limit\"}}"));
+        var exception = assertThrows(OverloadException.class, this::call);
+        assertEquals("Embedding API rate limited (429)", exception.getMessage());
+        assertEquals(1, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testThrowsAuthErrorOn401() {
+        mockServer.enqueue(new MockResponse().setResponseCode(401).setBody("invalid_api_key"));
+        var exception = assertThrows(RuntimeException.class, this::call);
+        assertTrue(exception.getMessage().contains("authentication failed (401)"));
+    }
+
+    @Test
+    public void testThrowsAuthErrorOn403() {
+        mockServer.enqueue(new MockResponse().setResponseCode(403).setBody("forbidden"));
+        var exception = assertThrows(RuntimeException.class, this::call);
+        assertTrue(exception.getMessage().contains("authentication failed (403)"));
+    }
+
+    @Test
+    public void testParsesOpenAIStyleErrorMessageOn400() {
+        mockServer.enqueue(new MockResponse().setResponseCode(400).setBody("{\"error\":{\"message\":\"invalid input\"}}"));
+        var exception = assertThrows(InvalidInputException.class, this::call);
+        assertEquals("Embedding API bad request (400): invalid input", exception.getMessage());
+    }
+
+    @Test
+    public void testParsesDetailStyleErrorMessageOn400() {
+        mockServer.enqueue(new MockResponse().setResponseCode(400).setBody("{\"detail\":\"too many tokens\"}"));
+        var exception = assertThrows(InvalidInputException.class, this::call);
+        assertEquals("Embedding API bad request (400): too many tokens", exception.getMessage());
+    }
+
+    @Test
+    public void testFallsBackToRawBodyOn400WhenParsingFails() {
+        mockServer.enqueue(new MockResponse().setResponseCode(400).setBody("not json"));
+        var exception = assertThrows(InvalidInputException.class, this::call);
+        assertEquals("Embedding API bad request (400): not json", exception.getMessage());
+    }
+
+    @Test
+    public void testThrowsGenericRuntimeExceptionOnOtherStatusCode() {
+        mockServer.enqueue(new MockResponse().setResponseCode(418).setBody("teapot"));
+        var exception = assertThrows(RuntimeException.class, this::call);
+        assertEquals("Embedding API request failed with status 418: teapot", exception.getMessage());
+    }
+
+    @Test
+    public void testThrowsTimeoutExceptionOnSocketTimeout() {
+        mockServer.enqueue(new MockResponse().setBodyDelay(1, TimeUnit.SECONDS).setBody("{}"));
+        var context = new Embedder.Context("test")
+                .setDeadline(InvocationContext.Deadline.of(Duration.ofMillis(100)));
+
+        var exception = assertThrows(TimeoutException.class,
+                () -> embedder.doHttpRequest(endpointUrl(), "{}", Map.of(), context, runtime));
+        assertTrue(exception.getMessage().contains("Embedding API call timed out after"));
+        assertEquals(1, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testThrowsTimeoutExceptionOnExpiredDeadline() {
+        var context = new Embedder.Context("test")
+                .setDeadline(InvocationContext.Deadline.of(Instant.now().minusSeconds(1)));
+
+        var exception = assertThrows(TimeoutException.class,
+                () -> embedder.doHttpRequest(endpointUrl(), "{}", Map.of(), context, runtime));
+        assertEquals("Request deadline exceeded before embedding API call", exception.getMessage());
+        assertEquals(0, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testRetriesOnServerError() {
+        mockServer.enqueue(new MockResponse().setResponseCode(500).setBody("fail"));
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        assertEquals("ok", call());
+        assertEquals(2, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testMaxRetriesExceeded() {
+        for (int i = 0; i < 10; i++) {
+            mockServer.enqueue(new MockResponse().setResponseCode(500).setBody("{\"error\":{\"message\":\"internal\"}}"));
+        }
+
+        var exception = assertThrows(RuntimeException.class, this::call);
+        assertEquals("Embedding API call failed: Max retries exceeded for embedding API (3). "
+                + "Last response: 500 - {\"error\":{\"message\":\"internal\"}}", exception.getMessage());
+    }
+
+    @Test
+    public void testForwardsHeadersToServer() throws Exception {
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        embedder.doHttpRequest(endpointUrl(), "{\"k\":\"v\"}",
+                Map.of("Authorization", "Bearer xyz", "X-Custom", "hi"),
+                new Embedder.Context("test"), runtime);
+
+        var request = mockServer.takeRequest();
+        assertEquals("Bearer xyz", request.getHeader("Authorization"));
+        assertEquals("hi", request.getHeader("X-Custom"));
+        assertEquals("{\"k\":\"v\"}", request.getBody().readUtf8());
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"));
+    }
+
+    @Test
+    public void testConstructorWithConfigHonorsMaxRetries() {
+        var config = new HttpEmbedderConfig.Builder().maxRetries(1).build();
+        var embedderWithConfig = new AbstractHttpEmbedder(config) {};
+        try {
+            for (int i = 0; i < 5; i++) {
+                mockServer.enqueue(new MockResponse().setResponseCode(503).setBody("x"));
+            }
+            var exception = assertThrows(RuntimeException.class,
+                    () -> embedderWithConfig.doHttpRequest(endpointUrl(), "{}", Map.of(),
+                            new Embedder.Context("test"), runtime));
+            assertTrue(exception.getMessage().contains("Max retries exceeded for embedding API (1)"));
+            assertEquals(2, mockServer.getRequestCount()); // 1 initial + 1 retry
+        } finally {
+            embedderWithConfig.deconstruct();
+        }
+    }
+
+    // ===== Helpers =====
+
+    private String call() {
+        return embedder.doHttpRequest(endpointUrl(), "{}", Map.of(), new Embedder.Context("test"), runtime);
+    }
+
+    private String endpointUrl() {
+        return mockServer.url("/").toString();
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/EmbedderTestUtils.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/EmbedderTestUtils.java
@@ -1,0 +1,72 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.secret.Secrets;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorAddress;
+import com.yahoo.text.Text;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+
+/**
+ * Shared test utilities for embedder tests.
+ *
+ * @author bjorncs
+ */
+class EmbedderTestUtils {
+
+    private EmbedderTestUtils() {}
+
+    static Secrets createMockSecrets() {
+        return key -> {
+            if ("test_key".equals(key)) return () -> "test-api-key-12345";
+            return null;
+        };
+    }
+
+    static double cosineSimilarity(Tensor a, Tensor b) {
+        double dotProduct = 0.0, normA = 0.0, normB = 0.0;
+        for (int i = 0; i < a.size(); i++) {
+            double valA = a.get(TensorAddress.of(i));
+            double valB = b.get(TensorAddress.of(i));
+            dotProduct += valA * valB;
+            normA += valA * valA;
+            normB += valB * valB;
+        }
+        return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+
+    static void assertNonZeroTensor(Tensor tensor) {
+        for (int i = 0; i < tensor.size(); i++) {
+            if (Math.abs(tensor.get(TensorAddress.of(i))) > 0.0001) return;
+        }
+        throw new AssertionError("Embedding should contain non-zero values");
+    }
+
+    static String encodeFloatsToBase64(int dimensions, int batchOffset) {
+        var buffer = ByteBuffer.allocate(dimensions * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (int i = 0; i < dimensions; i++) buffer.putFloat((float) Math.sin((i + batchOffset) * 0.1));
+        return Base64.getEncoder().encodeToString(buffer.array());
+    }
+
+    static String encodeBytesToBase64(int dimensions) {
+        var bytes = new byte[dimensions];
+        for (int i = 0; i < dimensions; i++) bytes[i] = (byte) (i % 128);
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    /** Builds a JSON response body with one or more base64-encoded embeddings (OpenAI/VoyageAI shape). */
+    static String createBase64EmbeddingResponse(String... base64Embeddings) {
+        var dataEntries = new StringBuilder();
+        for (int i = 0; i < base64Embeddings.length; i++) {
+            if (i > 0) dataEntries.append(",");
+            dataEntries.append(Text.format("{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":%d}",
+                    base64Embeddings[i], i));
+        }
+        return Text.format("""
+                {"object":"list","data":[%s],"usage":{"total_tokens":%d}}
+                """, dataEntries, base64Embeddings.length * 10);
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/EmbeddingQuantizationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/EmbeddingQuantizationTest.java
@@ -137,11 +137,14 @@ public class EmbeddingQuantizationTest {
         for (float v : expected) buffer.putFloat(v);
         var base64 = Base64.getEncoder().encodeToString(buffer.array());
 
-        var result = (IndexedTensor) EmbeddingQuantization.decodeBase64FloatTensor(base64, "x", TensorType.Value.FLOAT);
+        var result = (IndexedTensor) EmbeddingQuantization.decodeBase64FloatTensor(base64, "x", TensorType.Value.FLOAT, expected.length);
         assertEquals(expected.length, result.size());
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], result.getFloat(i), 0.0f, "Mismatch at index " + i);
         }
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EmbeddingQuantization.decodeBase64FloatTensor(base64, "x", TensorType.Value.FLOAT, expected.length + 1));
     }
 
     @Test
@@ -149,11 +152,14 @@ public class EmbeddingQuantizationTest {
         byte[] expected = {0, 1, -1, 127, -128, 42};
         var base64 = Base64.getEncoder().encodeToString(expected);
 
-        var result = (IndexedTensor) EmbeddingQuantization.decodeBase64Int8Tensor(base64, "x");
+        var result = (IndexedTensor) EmbeddingQuantization.decodeBase64Int8Tensor(base64, "x", expected.length);
         assertEquals(expected.length, result.size());
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], (byte) result.getFloat(i), "Mismatch at index " + i);
         }
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EmbeddingQuantization.decodeBase64Int8Tensor(base64, "x", expected.length + 1));
     }
 
     // ===== JSON array decoding =====
@@ -163,11 +169,14 @@ public class EmbeddingQuantizationTest {
         float[] expected = {1.0f, -0.5f, 0.0f, 3.14f};
         var array = new ObjectMapper().readTree("[1.0,-0.5,0.0,3.14]");
 
-        var result = (IndexedTensor) EmbeddingQuantization.decodeJsonArrayFloatTensor(array, "x", TensorType.Value.FLOAT);
+        var result = (IndexedTensor) EmbeddingQuantization.decodeJsonArrayFloatTensor(array, "x", TensorType.Value.FLOAT, expected.length);
         assertEquals(expected.length, result.size());
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], result.getFloat(i), 0.0f, "Mismatch at index " + i);
         }
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EmbeddingQuantization.decodeJsonArrayFloatTensor(array, "x", TensorType.Value.FLOAT, expected.length + 1));
     }
 
     @Test
@@ -175,10 +184,13 @@ public class EmbeddingQuantizationTest {
         byte[] expected = {0, 1, -1, 127, -128, 42};
         var array = new ObjectMapper().readTree("[0,1,-1,127,-128,42]");
 
-        var result = (IndexedTensor) EmbeddingQuantization.decodeJsonArrayInt8Tensor(array, "x");
+        var result = (IndexedTensor) EmbeddingQuantization.decodeJsonArrayInt8Tensor(array, "x", expected.length);
         assertEquals(expected.length, result.size());
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], (byte) result.getFloat(i), "Mismatch at index " + i);
         }
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EmbeddingQuantization.decodeJsonArrayInt8Tensor(array, "x", expected.length + 1));
     }
 }

--- a/model-integration/src/test/java/ai/vespa/embedding/EmbeddingQuantizationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/EmbeddingQuantizationTest.java
@@ -80,9 +80,23 @@ public class EmbeddingQuantizationTest {
     }
 
     @Test
+    public void testBinaryQuantizationRejectsNonMultipleOfEightConfiguredDimension() {
+        assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<int8>(x[128])"), 1025, Quantization.BINARY));
+    }
+
+    @Test
     public void testBinaryQuantizationAcceptsCorrectDimension() {
         EmbeddingQuantization.validateTensorType(
                 TensorType.fromSpec("tensor<int8>(x[128])"), 1024, Quantization.BINARY);
+    }
+
+    @Test
+    public void testAutoQuantizationRejectsBinaryShapeWhenConfiguredDimensionIsNotMultipleOfEight() {
+        assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<int8>(x[128])"), 1025, Quantization.AUTO));
     }
 
     @Test

--- a/model-integration/src/test/java/ai/vespa/embedding/EmbeddingQuantizationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/EmbeddingQuantizationTest.java
@@ -1,0 +1,170 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.EmbeddingQuantization.Quantization;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.tensor.IndexedTensor;
+import com.yahoo.tensor.TensorType;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for shared quantization validation and tensor decoding.
+ *
+ * @author bjorncs
+ */
+public class EmbeddingQuantizationTest {
+
+    // ===== validateTensorType =====
+
+    @Test
+    public void testAutoQuantizationWithFloatTensor() {
+        EmbeddingQuantization.validateTensorType(
+                TensorType.fromSpec("tensor<float>(x[1024])"), 1024, Quantization.AUTO);
+    }
+
+    @Test
+    public void testAutoQuantizationWithBfloat16Tensor() {
+        EmbeddingQuantization.validateTensorType(
+                TensorType.fromSpec("tensor<bfloat16>(x[1024])"), 1024, Quantization.AUTO);
+    }
+
+    @Test
+    public void testAutoQuantizationWithInt8FullDimension() {
+        EmbeddingQuantization.validateTensorType(
+                TensorType.fromSpec("tensor<int8>(x[1024])"), 1024, Quantization.AUTO);
+    }
+
+    @Test
+    public void testAutoQuantizationWithInt8BinaryDimension() {
+        EmbeddingQuantization.validateTensorType(
+                TensorType.fromSpec("tensor<int8>(x[128])"), 1024, Quantization.AUTO);
+    }
+
+    @Test
+    public void testAutoQuantizationRejectsDimensionMismatch() {
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<float>(x[512])"), 1024, Quantization.AUTO));
+        assertEquals("Tensor dimension 512 does not match configured dimension 1024.", exception.getMessage());
+    }
+
+    @Test
+    public void testFloatQuantizationRejectsInt8() {
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<int8>(x[1024])"), 1024, Quantization.FLOAT));
+        assertEquals("Quantization 'float' is incompatible with tensor type tensor<int8>(x[1024]).", exception.getMessage());
+    }
+
+    @Test
+    public void testInt8QuantizationRejectsFloat() {
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<float>(x[1024])"), 1024, Quantization.INT8));
+        assertEquals("Quantization 'int8' is incompatible with tensor type tensor<float>(x[1024]).", exception.getMessage());
+    }
+
+    @Test
+    public void testBinaryQuantizationRequiresOnEighthDimension() {
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<int8>(x[1024])"), 1024, Quantization.BINARY));
+        assertEquals("Tensor dimension 1024 does not match required dimension 128.", exception.getMessage());
+    }
+
+    @Test
+    public void testBinaryQuantizationAcceptsCorrectDimension() {
+        EmbeddingQuantization.validateTensorType(
+                TensorType.fromSpec("tensor<int8>(x[128])"), 1024, Quantization.BINARY);
+    }
+
+    @Test
+    public void testRejectsMultipleDimensions() {
+        assertThrows(IllegalArgumentException.class, () ->
+                EmbeddingQuantization.validateTensorType(
+                        TensorType.fromSpec("tensor<float>(d0[32],d1[32])"), 1024, Quantization.AUTO));
+    }
+
+    // ===== resolveOutputDataType =====
+
+    @Test
+    public void testResolveOutputDataTypeAuto() {
+        assertEquals("float", EmbeddingQuantization.resolveOutputDataType(
+                TensorType.fromSpec("tensor<float>(x[1024])"), 1024, Quantization.AUTO));
+        assertEquals("int8", EmbeddingQuantization.resolveOutputDataType(
+                TensorType.fromSpec("tensor<int8>(x[1024])"), 1024, Quantization.AUTO));
+        assertEquals("binary", EmbeddingQuantization.resolveOutputDataType(
+                TensorType.fromSpec("tensor<int8>(x[128])"), 1024, Quantization.AUTO));
+    }
+
+    @Test
+    public void testResolveOutputDataTypeExplicit() {
+        assertEquals("float", EmbeddingQuantization.resolveOutputDataType(
+                TensorType.fromSpec("tensor<float>(x[1024])"), 1024, Quantization.FLOAT));
+        assertEquals("int8", EmbeddingQuantization.resolveOutputDataType(
+                TensorType.fromSpec("tensor<int8>(x[1024])"), 1024, Quantization.INT8));
+        assertEquals("binary", EmbeddingQuantization.resolveOutputDataType(
+                TensorType.fromSpec("tensor<int8>(x[128])"), 1024, Quantization.BINARY));
+    }
+
+    // ===== Base64 decoding =====
+
+    @Test
+    public void testBase64FloatRoundTrip() {
+        float[] expected = {1.0f, -0.5f, 0.0f, Float.MAX_VALUE};
+        var buffer = ByteBuffer.allocate(expected.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (float v : expected) buffer.putFloat(v);
+        var base64 = Base64.getEncoder().encodeToString(buffer.array());
+
+        var result = (IndexedTensor) EmbeddingQuantization.decodeBase64FloatTensor(base64, "x", TensorType.Value.FLOAT);
+        assertEquals(expected.length, result.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], result.getFloat(i), 0.0f, "Mismatch at index " + i);
+        }
+    }
+
+    @Test
+    public void testBase64Int8RoundTrip() {
+        byte[] expected = {0, 1, -1, 127, -128, 42};
+        var base64 = Base64.getEncoder().encodeToString(expected);
+
+        var result = (IndexedTensor) EmbeddingQuantization.decodeBase64Int8Tensor(base64, "x");
+        assertEquals(expected.length, result.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], (byte) result.getFloat(i), "Mismatch at index " + i);
+        }
+    }
+
+    // ===== JSON array decoding =====
+
+    @Test
+    public void testJsonArrayFloatTensorDecode() throws Exception {
+        float[] expected = {1.0f, -0.5f, 0.0f, 3.14f};
+        var array = new ObjectMapper().readTree("[1.0,-0.5,0.0,3.14]");
+
+        var result = (IndexedTensor) EmbeddingQuantization.decodeJsonArrayFloatTensor(array, "x", TensorType.Value.FLOAT);
+        assertEquals(expected.length, result.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], result.getFloat(i), 0.0f, "Mismatch at index " + i);
+        }
+    }
+
+    @Test
+    public void testJsonArrayInt8TensorDecode() throws Exception {
+        byte[] expected = {0, 1, -1, 127, -128, 42};
+        var array = new ObjectMapper().readTree("[0,1,-1,127,-128,42]");
+
+        var result = (IndexedTensor) EmbeddingQuantization.decodeJsonArrayInt8Tensor(array, "x");
+        assertEquals(expected.length, result.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], (byte) result.getFloat(i), "Mismatch at index " + i);
+        }
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderIntegrationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderIntegrationTest.java
@@ -1,0 +1,135 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.MistralEmbedderConfig;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.tensor.TensorType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.List;
+
+import static ai.vespa.embedding.EmbedderTestUtils.assertNonZeroTensor;
+import static ai.vespa.embedding.EmbedderTestUtils.cosineSimilarity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for Mistral embedder with the real API.
+ *
+ * @author bjorncs
+ */
+@EnabledIfEnvironmentVariable(named = "VESPA_TEST_MISTRAL_API_KEY", matches = ".+")
+public class MistralEmbedderIntegrationTest {
+
+    @Test
+    public void testEmbedding() {
+        var embedder = createEmbedder("mistral-embed", 1024, MistralEmbedderConfig.Quantization.Enum.AUTO);
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
+
+        var result = embedder.embed("Hello from Mistral", context, targetType);
+        assertNotNull(result);
+        assertEquals(1024, result.size());
+        assertEquals(targetType, result.type());
+        assertNonZeroTensor(result);
+
+        var embedding1 = embedder.embed("The cat sits on the mat", context, targetType);
+        var embedding2 = embedder.embed("A feline rests on the rug", context, targetType);
+        var embedding3 = embedder.embed("The quick brown fox jumps", context, targetType);
+
+        double similarity12 = cosineSimilarity(embedding1, embedding2);
+        double similarity13 = cosineSimilarity(embedding1, embedding3);
+        assertTrue(similarity12 > similarity13,
+                "Similar texts should have higher similarity. Sim(1,2)=%f, Sim(1,3)=%f"
+                        .formatted(similarity12, similarity13));
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testBatchEmbedding() {
+        var embedder = createEmbedder("mistral-embed", 1024, MistralEmbedderConfig.Quantization.Enum.AUTO);
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
+
+        var texts = List.of(
+                "Machine learning is a branch of artificial intelligence.",
+                "The weather today is sunny and warm.",
+                "Deep learning uses neural networks.");
+
+        var results = embedder.embed(texts, context, targetType);
+
+        assertEquals(3, results.size());
+        for (var result : results) {
+            assertNotNull(result);
+            assertEquals(1024, result.size());
+            assertNonZeroTensor(result);
+        }
+
+        double sim02 = cosineSimilarity(results.get(0), results.get(2));
+        double sim01 = cosineSimilarity(results.get(0), results.get(1));
+        assertTrue(sim02 > sim01,
+                "ML texts should be more similar. Sim(0,2)=%f, Sim(0,1)=%f".formatted(sim02, sim01));
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testCodestralEmbedWithReducedDimensions() {
+        // codestral-embed supports configurable dimensions (unlike mistral-embed)
+        var embedder = createEmbedder("codestral-embed", 512, MistralEmbedderConfig.Quantization.Enum.AUTO);
+        var targetType = TensorType.fromSpec("tensor<float>(d0[512])");
+        var context = new Embedder.Context("integration-test");
+
+        var result = embedder.embed("def hello(): print('world')", context, targetType);
+        assertNotNull(result);
+        assertEquals(512, result.size());
+        assertNonZeroTensor(result);
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testCodestralEmbedWithInt8Quantization() {
+        var embedder = createEmbedder("codestral-embed", 2048, MistralEmbedderConfig.Quantization.Enum.INT8);
+        var targetType = TensorType.fromSpec("tensor<int8>(d0[2048])");
+        var context = new Embedder.Context("integration-test");
+
+        var result = embedder.embed("Testing int8 quantization on codestral-embed", context, targetType);
+        assertNotNull(result);
+        assertEquals(2048, result.size());
+        assertEquals(targetType, result.type());
+        assertNonZeroTensor(result);
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testCodestralEmbedWithBinaryQuantization() {
+        // Binary quantization returns INT8 tensor with 1/8 the configured dimensions
+        var embedder = createEmbedder("codestral-embed", 1024, MistralEmbedderConfig.Quantization.Enum.BINARY);
+        var targetType = TensorType.fromSpec("tensor<int8>(d0[128])");
+        var context = new Embedder.Context("integration-test");
+
+        var result = embedder.embed("Testing binary quantization", context, targetType);
+        assertNotNull(result);
+        assertEquals(128, result.size());
+        assertEquals(targetType, result.type());
+        assertNonZeroTensor(result);
+
+        embedder.deconstruct();
+    }
+
+    private static MistralEmbedder createEmbedder(String model, int dimensions, MistralEmbedderConfig.Quantization.Enum quantization) {
+        var config = new MistralEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .model(model)
+                .dimensions(dimensions)
+                .quantization(quantization)
+                .build();
+        return new MistralEmbedder(config, Embedder.Runtime.testInstance(),
+                key -> () -> System.getenv("VESPA_TEST_MISTRAL_API_KEY"));
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderTest.java
@@ -1,0 +1,114 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.MistralEmbedderConfig;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.text.Text;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static ai.vespa.embedding.EmbedderTestUtils.createMockSecrets;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for Mistral embedder using MockWebServer to simulate API responses.
+ *
+ * @author bjorncs
+ */
+public class MistralEmbedderTest {
+
+    private MockWebServer mockServer;
+    private MistralEmbedder embedder;
+    private Embedder.Runtime runtime;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        runtime = Embedder.Runtime.testInstance();
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (embedder != null) embedder.deconstruct();
+        mockServer.shutdown();
+    }
+
+    @Test
+    public void testMistralEmbedRequest() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createJsonArrayResponse(1024)));
+
+        embedder = createEmbedder("mistral-embed", 1024, MistralEmbedderConfig.Quantization.Enum.INT8);
+
+        var targetType = TensorType.fromSpec("tensor<int8>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
+        var result = embedder.embed("test", context, targetType);
+
+        assertNotNull(result);
+        assertEquals(1024, result.size());
+
+        var request = mockServer.takeRequest();
+        var body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"output_dtype\":\"int8\""));
+        assertFalse(body.contains("\"encoding_format\""));
+        assertFalse(body.contains("\"dimensions\""));
+        assertFalse(body.contains("\"output_dimension\""), "mistral-embed does not support output_dimension");
+    }
+
+    @Test
+    public void testCodestralEmbedRequest() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createJsonArrayResponse(2048)));
+
+        embedder = createEmbedder("codestral-embed", 2048, MistralEmbedderConfig.Quantization.Enum.AUTO);
+
+        var targetType = TensorType.fromSpec("tensor<float>(d0[2048])");
+        var context = new Embedder.Context("test-embedder");
+        var result = embedder.embed("test", context, targetType);
+
+        assertNotNull(result);
+        assertEquals(2048, result.size());
+
+        var request = mockServer.takeRequest();
+        var body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"output_dimension\":2048"), "codestral-embed supports output_dimension");
+        assertTrue(body.contains("\"output_dtype\":\"float\""));
+    }
+
+    // ===== Helpers =====
+
+    private MistralEmbedder createEmbedder(String model, int dimensions, MistralEmbedderConfig.Quantization.Enum quantization) {
+        var config = new MistralEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .endpoint(mockServer.url("/v1/embeddings").toString())
+                .model(model)
+                .dimensions(dimensions)
+                .quantization(quantization);
+        return new MistralEmbedder(config.build(), runtime, createMockSecrets());
+    }
+
+    private static String createJsonArrayResponse(int dimensions) {
+        var values = new StringBuilder();
+        for (int i = 0; i < dimensions; i++) {
+            if (i > 0) values.append(",");
+            values.append((i % 256) - 128);
+        }
+        return Text.format("""
+                {"object":"list","data":[{"object":"embedding","embedding":[%s],"index":0}],"model":"mistral-embed","usage":{"prompt_tokens":10,"total_tokens":10}}
+                """, values);
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderIntegrationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderIntegrationTest.java
@@ -90,6 +90,33 @@ public class OpenAIEmbedderIntegrationTest {
         embedder.deconstruct();
     }
 
+    /**
+     * Verifies that the legacy text-embedding-ada-002 model (fixed 1536 output size, does
+     * not accept the "dimensions" request field) works when configured with the expected
+     * dimensions=1536. The embedder must omit the field from the request for this model.
+     */
+    @Test
+    public void testAda002WithoutDimensionsField() {
+        var config = new OpenaiEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .model("text-embedding-ada-002")
+                .dimensions(1536)
+                .build();
+        var embedder = new OpenAIEmbedder(config, Embedder.Runtime.testInstance(),
+                key -> () -> System.getenv("VESPA_TEST_OPENAI_API_KEY"));
+        try {
+            var targetType = TensorType.fromSpec("tensor<float>(d0[1536])");
+            var context = new Embedder.Context("integration-test");
+            var result = embedder.embed("hello", context, targetType);
+            assertNotNull(result);
+            assertEquals(1536, result.size());
+            assertEquals(targetType, result.type());
+            assertNonZeroTensor(result);
+        } finally {
+            embedder.deconstruct();
+        }
+    }
+
     private static OpenAIEmbedder createEmbedder(int dimensions) {
         var config = new OpenaiEmbedderConfig.Builder()
                 .apiKeySecretRef("test_key")

--- a/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderIntegrationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderIntegrationTest.java
@@ -1,0 +1,102 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.OpenaiEmbedderConfig;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.tensor.TensorType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.List;
+
+import static ai.vespa.embedding.EmbedderTestUtils.assertNonZeroTensor;
+import static ai.vespa.embedding.EmbedderTestUtils.cosineSimilarity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for OpenAI embedder with real API.
+ *
+ * @author bjorncs
+ */
+@EnabledIfEnvironmentVariable(named = "VESPA_TEST_OPENAI_API_KEY", matches = "sk-.+")
+public class OpenAIEmbedderIntegrationTest {
+
+    @Test
+    public void testEmbedding() {
+        var embedder = createEmbedder(1024);
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
+
+        var result = embedder.embed("Hello, this is a test.", context, targetType);
+        assertNotNull(result);
+        assertEquals(1024, result.size());
+        assertEquals(targetType, result.type());
+        assertNonZeroTensor(result);
+
+        var embedding1 = embedder.embed("The cat sits on the mat", context, targetType);
+        var embedding2 = embedder.embed("A feline rests on the rug", context, targetType);
+        var embedding3 = embedder.embed("The quick brown fox jumps", context, targetType);
+
+        double similarity12 = cosineSimilarity(embedding1, embedding2);
+        double similarity13 = cosineSimilarity(embedding1, embedding3);
+        assertTrue(similarity12 > similarity13,
+                "Similar texts should have higher similarity. Sim(1,2)=%f, Sim(1,3)=%f"
+                        .formatted(similarity12, similarity13));
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testBatchEmbedding() {
+        var embedder = createEmbedder(1024);
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
+
+        var texts = List.of(
+                "Machine learning is a branch of artificial intelligence.",
+                "The weather today is sunny and warm.",
+                "Deep learning uses neural networks.");
+
+        var results = embedder.embed(texts, context, targetType);
+
+        assertEquals(3, results.size());
+        for (var result : results) {
+            assertNotNull(result);
+            assertEquals(1024, result.size());
+            assertNonZeroTensor(result);
+        }
+
+        double sim02 = cosineSimilarity(results.get(0), results.get(2));
+        double sim01 = cosineSimilarity(results.get(0), results.get(1));
+        assertTrue(sim02 > sim01,
+                "ML texts should be more similar. Sim(0,2)=%f, Sim(0,1)=%f".formatted(sim02, sim01));
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testReducedDimensions() {
+        var embedder = createEmbedder(512);
+        var targetType = TensorType.fromSpec("tensor<float>(d0[512])");
+        var context = new Embedder.Context("integration-test");
+        var result = embedder.embed("Testing reduced dimensions", context, targetType);
+
+        assertNotNull(result);
+        assertEquals(512, result.size());
+        assertNonZeroTensor(result);
+
+        embedder.deconstruct();
+    }
+
+    private static OpenAIEmbedder createEmbedder(int dimensions) {
+        var config = new OpenaiEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .model("text-embedding-3-small")
+                .dimensions(dimensions)
+                .build();
+        return new OpenAIEmbedder(config, Embedder.Runtime.testInstance(),
+                key -> () -> System.getenv("VESPA_TEST_OPENAI_API_KEY"));
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderTest.java
@@ -1,0 +1,123 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.OpenaiEmbedderConfig;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.tensor.TensorType;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static ai.vespa.embedding.EmbedderTestUtils.createBase64EmbeddingResponse;
+import static ai.vespa.embedding.EmbedderTestUtils.createMockSecrets;
+import static ai.vespa.embedding.EmbedderTestUtils.encodeFloatsToBase64;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for OpenAI embedder request shape and response parsing. Shared HTTP transport behavior
+ * (status-code handling, timeouts, retries) is covered by {@link AbstractHttpEmbedderTest}.
+ *
+ * @author bjorncs
+ */
+public class OpenAIEmbedderTest {
+
+    private MockWebServer mockServer;
+    private OpenAIEmbedder embedder;
+    private Embedder.Runtime runtime;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        runtime = Embedder.Runtime.testInstance();
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (embedder != null) embedder.deconstruct();
+        mockServer.shutdown();
+    }
+
+    @Test
+    public void testSuccessfulEmbedding() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createSuccessResponse(1024)));
+
+        embedder = createEmbedder();
+
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
+        var result = embedder.embed("Hello, world!", context, targetType);
+
+        assertNotNull(result);
+        assertEquals(1024, result.size());
+        assertEquals(targetType, result.type());
+
+        RecordedRequest request = mockServer.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals("/v1/embeddings", request.getPath());
+        assertTrue(request.getHeader("Authorization").startsWith("Bearer "));
+        var body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"model\":\"text-embedding-3-small\""));
+        assertTrue(body.contains("\"encoding_format\":\"base64\""));
+        assertTrue(body.contains("\"dimensions\":1024"));
+    }
+
+    @Test
+    public void testBatchEmbedding() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createBatchSuccessResponse(3, 1024)));
+
+        embedder = createEmbedder();
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
+        var texts = List.of("Hello", "World", "Test");
+        var results = embedder.embed(texts, context, targetType);
+
+        assertEquals(3, results.size());
+        for (var result : results) {
+            assertEquals(1024, result.size());
+            assertEquals(targetType, result.type());
+        }
+        assertEquals(1, mockServer.getRequestCount());
+
+        var request = mockServer.takeRequest();
+        var body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"input\":[\"Hello\",\"World\",\"Test\"]"));
+    }
+
+    // ===== Helper Methods =====
+
+    private OpenAIEmbedder createEmbedder() { return createEmbedder(1024); }
+
+    private OpenAIEmbedder createEmbedder(int dimensions) {
+        var config = new OpenaiEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .endpoint(mockServer.url("/v1/embeddings").toString())
+                .model("text-embedding-3-small")
+                .dimensions(dimensions);
+        return new OpenAIEmbedder(config.build(), runtime, createMockSecrets());
+    }
+
+    private static String createSuccessResponse(int dimensions) {
+        return createBase64EmbeddingResponse(encodeFloatsToBase64(dimensions, 0));
+    }
+
+    private static String createBatchSuccessResponse(int batchSize, int dimensions) {
+        var embeddings = new String[batchSize];
+        for (int b = 0; b < batchSize; b++) embeddings[b] = encodeFloatsToBase64(dimensions, b * 1000);
+        return createBase64EmbeddingResponse(embeddings);
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderIntegrationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderIntegrationTest.java
@@ -5,13 +5,14 @@ import ai.vespa.embedding.config.VoyageAiEmbedderConfig;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.InvalidInputException;
 import com.yahoo.tensor.Tensor;
-import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.List;
 
+import static ai.vespa.embedding.EmbedderTestUtils.assertNonZeroTensor;
+import static ai.vespa.embedding.EmbedderTestUtils.cosineSimilarity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,11 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Integration tests for VoyageAI embedder with real API.
  *
- * These tests are disabled by default and require a real VoyageAI API key.
- * To run these tests:
- * 1. Set environment variable: export VESPA_TEST_VOYAGE_API_KEY="your-api-key"
- * 2. Run with: mvn test -Dtest=VoyageAIEmbedderIntegrationTest
- *
  * @author bjorncs
  */
 @EnabledIfEnvironmentVariable(named = "VESPA_TEST_VOYAGE_API_KEY", matches = "pa-.+")
@@ -32,42 +28,26 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithVoyage3() {
-        var embedder = createEmbedder();
+        var embedder = createEmbedder("voyage-3", 1024);
 
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
 
         Tensor result = embedder.embed("Hello, this is a test.", context, targetType);
 
         assertNotNull(result);
         assertEquals(1024, result.size());
-        assertEquals(targetType, result.type());
-
-        // Verify non-zero embeddings
-        boolean hasNonZero = false;
-        for (int i = 0; i < 1024; i++) {
-            double val = result.get(TensorAddress.of(i));
-            if (Math.abs(val) > 0.0001) {
-                hasNonZero = true;
-                break;
-            }
-        }
-        assertTrue(hasNonZero, "Embedding should contain non-zero values");
+        assertNonZeroTensor(result);
 
         embedder.deconstruct();
     }
 
     @Test
     public void testRealAPIWithVoyage3Lite() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-            .apiKeySecretRef("test_key")
-            .model("voyage-3-lite")
-            .dimensions(512);
+        var embedder = createEmbedder("voyage-3-lite", 512);
 
-        var embedder = createEmbedder(configBuilder);
-
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[512])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[512])");
+        var context = new Embedder.Context("integration-test");
 
         Tensor result = embedder.embed("Test text for voyage-3-lite", context, targetType);
 
@@ -79,47 +59,36 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPISemanticSimilarity() {
-        var embedder = createEmbedder();
+        var embedder = createEmbedder("voyage-3", 1024);
 
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
 
-        // Similar texts
         Tensor embedding1 = embedder.embed("The cat sits on the mat", context, targetType);
         Tensor embedding2 = embedder.embed("A feline rests on the rug", context, targetType);
-
-        // Different text
         Tensor embedding3 = embedder.embed("The quick brown fox jumps", context, targetType);
 
         double similarity12 = cosineSimilarity(embedding1, embedding2);
         double similarity13 = cosineSimilarity(embedding1, embedding3);
 
-        // Similar texts should have higher similarity
         assertTrue(similarity12 > similarity13,
-                "Similar texts should have higher similarity. Sim(1,2)=" + similarity12 +
-                ", Sim(1,3)=" + similarity13);
+                "Similar texts should have higher similarity. Sim(1,2)=%f, Sim(1,3)=%f"
+                        .formatted(similarity12, similarity13));
 
         embedder.deconstruct();
     }
 
     @Test
     public void testRealAPIInputTypes() {
-        var embedder = createEmbedder();
+        var embedder = createEmbedder("voyage-3", 1024);
 
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
 
-        // Query context
-        Embedder.Context queryContext = new Embedder.Context("test-query");
-        Tensor queryEmbedding = embedder.embed("search query text", queryContext, targetType);
-
-        // Document context
-        Embedder.Context docContext = new Embedder.Context("test-doc");
-        Tensor docEmbedding = embedder.embed("document content text", docContext, targetType);
+        Tensor queryEmbedding = embedder.embed("search query text", new Embedder.Context("test-query"), targetType);
+        Tensor docEmbedding = embedder.embed("document content text", new Embedder.Context("test-doc"), targetType);
 
         assertNotNull(queryEmbedding);
         assertNotNull(docEmbedding);
-
-        // Both should have valid embeddings
         assertEquals(1024, queryEmbedding.size());
         assertEquals(1024, docEmbedding.size());
 
@@ -128,12 +97,11 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPILongText() {
-        var embedder = createEmbedder();
+        var embedder = createEmbedder("voyage-3", 1024);
 
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
 
-        // Very long text (will be truncated by API)
         String longText = "This is a test. ".repeat(1000);
         Tensor result = embedder.embed(longText, context, targetType);
 
@@ -145,25 +113,17 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithTruncationDisabledThrowsException() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-                .apiKeySecretRef("test_key")
-                .model("voyage-3")
-                .dimensions(1024)
-                .truncate(false);
-
-        var embedder = createEmbedder(configBuilder);
+        var embedder = createEmbedderWithConfig(b -> b.truncate(false).model("voyage-3").dimensions(1024));
 
         try {
             var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
             var context = new Embedder.Context("integration-test");
 
-            // Generate very long text that exceeds token limit
             var veryLongText = "This is a test sentence. ".repeat(10000);
 
             var exception = assertThrows(InvalidInputException.class, () ->
-                    embedder.embed(veryLongText, context, targetType)
-            );
-            assertEquals("VoyageAI API bad request (400): Request to model 'voyage-3' failed. " +
+                    embedder.embed(veryLongText, context, targetType));
+            assertEquals("Embedding API bad request (400): Request to model 'voyage-3' failed. " +
                     "The example at index 0 in your batch has too many tokens and does not fit into the " +
                     "model's context window of 32000 tokens. Please lower the number of tokens in the listed " +
                     "example(s) or use truncation.", exception.getMessage());
@@ -174,21 +134,13 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithMultimodal35AllDimensions() {
-        // Test all supported dimensions: 256, 512, 1024, 2048
-        // Dimension is inferred from the tensor type specification
         int[] dimensions = {256, 512, 1024, 2048};
 
         for (int dim : dimensions) {
-            VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder();
-            configBuilder.apiKeySecretRef("test_key");
-            configBuilder.model("voyage-multimodal-3.5");
-            configBuilder.dimensions(dim);
+            var embedder = createEmbedder("voyage-multimodal-3.5", dim);
 
-            var embedder = createEmbedder(configBuilder);
-
-            // Dimension is inferred from tensor type
-            TensorType targetType = TensorType.fromSpec("tensor<float>(d0[" + dim + "])");
-            Embedder.Context context = new Embedder.Context("integration-test");
+            var targetType = TensorType.fromSpec("tensor<float>(d0[%d])".formatted(dim));
+            var context = new Embedder.Context("integration-test");
 
             Tensor result = embedder.embed("Testing dimension " + dim, context, targetType);
 
@@ -201,16 +153,10 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithContextual3() {
-        // voyage-context-3 should auto-select the contextualized embeddings endpoint
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder()
-            .apiKeySecretRef("test_key")
-            .model("voyage-context-3")
-            .dimensions(1024);
-        var embedder = createEmbedder(configBuilder);
+        var embedder = createEmbedder("voyage-context-3", 1024);
 
-        // voyage-context-3 outputs 1024 dimensions
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
 
         Tensor result = embedder.embed("Testing contextual embeddings for document retrieval", context, targetType);
 
@@ -223,22 +169,15 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithInt8Quantization() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-            .apiKeySecretRef("test_key")
-            .model("voyage-4-large")
-            .dimensions(1024)
-            .quantization(VoyageAiEmbedderConfig.Quantization.INT8);
+        var embedder = createEmbedder("voyage-4-large", 1024, VoyageAiEmbedderConfig.Quantization.Enum.INT8);
 
-        var embedder = createEmbedder(configBuilder);
-
-        TensorType targetType = TensorType.fromSpec("tensor<int8>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<int8>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
 
         Tensor result = embedder.embed("Testing int8 quantization", context, targetType);
 
         assertNotNull(result);
         assertEquals(1024, result.size());
-        assertEquals(targetType, result.type());
         assertNonZeroTensor(result);
 
         embedder.deconstruct();
@@ -246,22 +185,15 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithBinaryQuantization() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-            .apiKeySecretRef("test_key")
-            .model("voyage-4-large")
-            .dimensions(1024)
-            .quantization(VoyageAiEmbedderConfig.Quantization.BINARY);
+        var embedder = createEmbedder("voyage-4-large", 1024, VoyageAiEmbedderConfig.Quantization.Enum.BINARY);
 
-        var embedder = createEmbedder(configBuilder);
-
-        TensorType targetType = TensorType.fromSpec("tensor<int8>(d0[128])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<int8>(d0[128])");
+        var context = new Embedder.Context("integration-test");
 
         Tensor result = embedder.embed("Testing binary quantization", context, targetType);
 
         assertNotNull(result);
         assertEquals(128, result.size());
-        assertEquals(targetType, result.type());
         assertNonZeroTensor(result);
 
         embedder.deconstruct();
@@ -269,55 +201,39 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithContextual3SemanticSimilarity() {
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder()
-            .apiKeySecretRef("test_key")
-            .model("voyage-context-3")
-            .dimensions(1024);
-        var embedder = createEmbedder(configBuilder);
+        var embedder = createEmbedder("voyage-context-3", 1024);
 
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("integration-test");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
 
-        // Similar document chunks
         Tensor embedding1 = embedder.embed("Machine learning is a subset of artificial intelligence", context, targetType);
         Tensor embedding2 = embedder.embed("AI and ML are closely related fields in computer science", context, targetType);
-
-        // Different topic
         Tensor embedding3 = embedder.embed("The recipe calls for two cups of flour and one egg", context, targetType);
 
         double similarity12 = cosineSimilarity(embedding1, embedding2);
         double similarity13 = cosineSimilarity(embedding1, embedding3);
 
-        // Similar texts should have higher similarity
         assertTrue(similarity12 > similarity13,
-                "Similar texts should have higher similarity. Sim(1,2)=" + similarity12 +
-                ", Sim(1,3)=" + similarity13);
+                "Similar texts should have higher similarity. Sim(1,2)=%f, Sim(1,3)=%f"
+                        .formatted(similarity12, similarity13));
 
         embedder.deconstruct();
     }
 
     @Test
     public void testRealAPIWithContextual3AllDimensions() {
-        // voyage-context-3 supports: 256, 512, 1024, 2048
-        // Dimension is inferred from the tensor type specification
         int[] dimensions = {256, 512, 1024, 2048};
 
         for (int dim : dimensions) {
-            VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder();
-            configBuilder.apiKeySecretRef("test_key");
-            configBuilder.model("voyage-context-3");
-            configBuilder.dimensions(dim);
+            var embedder = createEmbedder("voyage-context-3", dim);
 
-            var embedder = createEmbedder(configBuilder);
-
-            // Dimension is inferred from tensor type
-            TensorType targetType = TensorType.fromSpec("tensor<float>(d0[" + dim + "])");
-            Embedder.Context context = new Embedder.Context("integration-test");
+            var targetType = TensorType.fromSpec("tensor<float>(d0[%d])".formatted(dim));
+            var context = new Embedder.Context("integration-test");
 
             Tensor result = embedder.embed("Testing dimension " + dim, context, targetType);
 
             assertNotNull(result, "Result should not be null for dimension " + dim);
-            assertEquals(dim, result.size(), "Embedding should have " + dim + " dimensions");
+            assertEquals(dim, result.size());
 
             embedder.deconstruct();
         }
@@ -325,20 +241,15 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithContextual3BatchEmbedding() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-            .apiKeySecretRef("test_key")
-            .model("voyage-context-3")
-            .dimensions(1024);
-        var embedder = createEmbedder(configBuilder);
+        var embedder = createEmbedder("voyage-context-3", 1024);
 
         var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
         var context = new Embedder.Context("integration-test");
 
         var chunks = List.of(
-            "Machine learning is a branch of artificial intelligence.",
-            "It enables computers to learn from data.",
-            "Deep learning is a subset of machine learning."
-        );
+                "Machine learning is a branch of artificial intelligence.",
+                "It enables computers to learn from data.",
+                "Deep learning is a subset of machine learning.");
 
         var results = embedder.embed(chunks, context, targetType);
 
@@ -349,11 +260,10 @@ public class VoyageAIEmbedderIntegrationTest {
             assertNonZeroTensor(result);
         }
 
-        // Related chunks should have reasonable similarity
         double sim01 = cosineSimilarity(results.get(0), results.get(1));
         double sim02 = cosineSimilarity(results.get(0), results.get(2));
-        assertTrue(sim01 > 0.5, "Related chunks should have reasonable similarity. Sim(0,1)=" + sim01);
-        assertTrue(sim02 > 0.5, "Related chunks should have reasonable similarity. Sim(0,2)=" + sim02);
+        assertTrue(sim01 > 0.5, "Related chunks should have reasonable similarity. Sim(0,1)=%f".formatted(sim01));
+        assertTrue(sim02 > 0.5, "Related chunks should have reasonable similarity. Sim(0,2)=%f".formatted(sim02));
 
         embedder.deconstruct();
     }
@@ -363,22 +273,18 @@ public class VoyageAIEmbedderIntegrationTest {
         int[] dimensions = {256, 512, 1024, 2048};
 
         for (int dim : dimensions) {
-            var configBuilder = new VoyageAiEmbedderConfig.Builder()
-                .apiKeySecretRef("test_key")
-                .model("voyage-context-3")
-                .dimensions(dim);
-            var embedder = createEmbedder(configBuilder);
+            var embedder = createEmbedder("voyage-context-3", dim);
 
-            var targetType = TensorType.fromSpec("tensor<float>(d0[" + dim + "])");
+            var targetType = TensorType.fromSpec("tensor<float>(d0[%d])".formatted(dim));
             var context = new Embedder.Context("integration-test");
 
             var chunks = List.of("First chunk", "Second chunk");
             var results = embedder.embed(chunks, context, targetType);
 
-            assertEquals(2, results.size(), "Should return 2 embeddings for dimension " + dim);
+            assertEquals(2, results.size());
             for (var result : results) {
-                assertNotNull(result, "Result should not be null for dimension " + dim);
-                assertEquals(dim, result.size(), "Embedding should have " + dim + " dimensions");
+                assertNotNull(result);
+                assertEquals(dim, result.size());
             }
 
             embedder.deconstruct();
@@ -387,16 +293,15 @@ public class VoyageAIEmbedderIntegrationTest {
 
     @Test
     public void testRealAPIWithVoyage3BatchEmbedding() {
-        var embedder = createEmbedder();
+        var embedder = createEmbedder("voyage-3", 1024);
 
         var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
         var context = new Embedder.Context("integration-test");
 
         var texts = List.of(
-            "Machine learning is a branch of artificial intelligence.",
-            "The weather today is sunny and warm.",
-            "Deep learning uses neural networks."
-        );
+                "Machine learning is a branch of artificial intelligence.",
+                "The weather today is sunny and warm.",
+                "Deep learning uses neural networks.");
 
         var results = embedder.embed(texts, context, targetType);
 
@@ -407,51 +312,31 @@ public class VoyageAIEmbedderIntegrationTest {
             assertNonZeroTensor(result);
         }
 
-        // ML-related texts (0, 2) should be more similar to each other than to weather text (1)
         double sim01 = cosineSimilarity(results.get(0), results.get(1));
         double sim02 = cosineSimilarity(results.get(0), results.get(2));
-        assertTrue(sim02 > sim01, "ML texts should be more similar. Sim(0,2)=" + sim02 + ", Sim(0,1)=" + sim01);
+        assertTrue(sim02 > sim01, "ML texts should be more similar. Sim(0,2)=%f, Sim(0,1)=%f".formatted(sim02, sim01));
 
         embedder.deconstruct();
     }
 
     // ===== Helper Methods =====
 
-    private VoyageAIEmbedder createEmbedder() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
+    private static VoyageAIEmbedder createEmbedder(String model, int dimensions) {
+        return createEmbedder(model, dimensions, VoyageAiEmbedderConfig.Quantization.Enum.AUTO);
+    }
+
+    private static VoyageAIEmbedder createEmbedder(String model, int dimensions,
+                                                    VoyageAiEmbedderConfig.Quantization.Enum quantization) {
+        return createEmbedderWithConfig(b -> b.model(model).dimensions(dimensions).quantization(quantization));
+    }
+
+    private static VoyageAIEmbedder createEmbedderWithConfig(
+            java.util.function.Consumer<VoyageAiEmbedderConfig.Builder> customize) {
+        var builder = new VoyageAiEmbedderConfig.Builder()
                 .apiKeySecretRef("test_key")
-                .dimensions(1024)
-                .model("voyage-3");
-        return createEmbedder(configBuilder);
-    }
-
-    private VoyageAIEmbedder createEmbedder(VoyageAiEmbedderConfig.Builder configBuilder) {
-        return new VoyageAIEmbedder(
-                configBuilder.build(),
-                Embedder.Runtime.testInstance(),
+                .endpoint("https://api.voyageai.com/v1/embeddings");
+        customize.accept(builder);
+        return new VoyageAIEmbedder(builder.build(), Embedder.Runtime.testInstance(),
                 key -> () -> System.getenv("VESPA_TEST_VOYAGE_API_KEY"));
-    }
-
-    private double cosineSimilarity(Tensor a, Tensor b) {
-        double dotProduct = 0.0;
-        double normA = 0.0;
-        double normB = 0.0;
-
-        for (int i = 0; i < a.size(); i++) {
-            double valA = a.get(TensorAddress.of(i));
-            double valB = b.get(TensorAddress.of(i));
-            dotProduct += valA * valB;
-            normA += valA * valA;
-            normB += valB * valB;
-        }
-
-        return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
-    }
-
-    private void assertNonZeroTensor(Tensor tensor) {
-        for (int i = 0; i < tensor.size(); i++) {
-            if (Math.abs(tensor.get(TensorAddress.of(i))) > 0.0001) return;
-        }
-        throw new AssertionError("Embedding should contain non-zero values");
     }
 }

--- a/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
@@ -321,6 +321,29 @@ public class VoyageAIEmbedderTest {
     }
 
     @Test
+    public void testBatchingConfigDisabledForContextualModel() {
+        var configBuilder = voyageConfigBuilder(1024).model("voyage-context-3");
+        configBuilder.batching.maxSize(16);
+        embedder = new VoyageAIEmbedder(configBuilder.build(), runtime, createMockSecrets());
+
+        assertEquals(Embedder.Batching.DISABLED, embedder.batchingConfig());
+    }
+
+    @Test
+    public void testContextualModelRejectsMultiTextBatch() {
+        var config = voyageConfigBuilder(1024).model("voyage-context-3").build();
+        embedder = new VoyageAIEmbedder(config, runtime, createMockSecrets());
+
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
+        var texts = List.of("doc1", "doc2");
+
+        var exception = assertThrows(IllegalArgumentException.class,
+                () -> embedder.embed(texts, context, targetType));
+        assertTrue(exception.getMessage().contains("Contextual models do not support batching"));
+    }
+
+    @Test
     public void testBase64FloatRoundTrip() {
         float[] expected = {1.0f, -0.5f, 0.0f, Float.MAX_VALUE};
         var buffer = ByteBuffer.allocate(expected.length * 4).order(ByteOrder.LITTLE_ENDIAN);

--- a/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
@@ -330,20 +330,6 @@ public class VoyageAIEmbedderTest {
     }
 
     @Test
-    public void testContextualModelRejectsMultiTextBatch() {
-        var config = voyageConfigBuilder(1024).model("voyage-context-3").build();
-        embedder = new VoyageAIEmbedder(config, runtime, createMockSecrets());
-
-        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        var context = new Embedder.Context("test-embedder");
-        var texts = List.of("doc1", "doc2");
-
-        var exception = assertThrows(IllegalArgumentException.class,
-                () -> embedder.embed(texts, context, targetType));
-        assertTrue(exception.getMessage().contains("Contextual models do not support batching"));
-    }
-
-    @Test
     public void testBase64FloatRoundTrip() {
         float[] expected = {1.0f, -0.5f, 0.0f, Float.MAX_VALUE};
         var buffer = ByteBuffer.allocate(expected.length * 4).order(ByteOrder.LITTLE_ENDIAN);

--- a/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/VoyageAIEmbedderTest.java
@@ -2,14 +2,10 @@
 package ai.vespa.embedding;
 
 import ai.vespa.embedding.config.VoyageAiEmbedderConfig;
-import ai.vespa.secret.Secrets;
 import com.yahoo.language.process.Embedder;
-import com.yahoo.language.process.InvocationContext;
-import com.yahoo.language.process.TimeoutException;
 import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
-import com.yahoo.text.Text;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -22,9 +18,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.concurrent.TimeUnit;
+import java.util.List;
 
-import static com.yahoo.text.Lowercase.toUpperCase;
+import static ai.vespa.embedding.EmbedderTestUtils.createBase64EmbeddingResponse;
+import static ai.vespa.embedding.EmbedderTestUtils.createMockSecrets;
+import static ai.vespa.embedding.EmbedderTestUtils.encodeBytesToBase64;
+import static ai.vespa.embedding.EmbedderTestUtils.encodeFloatsToBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,280 +49,43 @@ public class VoyageAIEmbedderTest {
 
     @AfterEach
     public void tearDown() throws IOException {
-        if (embedder != null) {
-            embedder.deconstruct();
-        }
+        if (embedder != null) embedder.deconstruct();
         mockServer.shutdown();
     }
 
     @Test
     public void testSuccessfulEmbedding() throws Exception {
-        // Mock successful API response
-        String responseJson = createSuccessResponse(1024);
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
-                .setBody(responseJson));
+                .setBody(createSuccessResponse(1024)));
 
         embedder = createEmbedder();
 
-        // Test embedding
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
         Tensor result = embedder.embed("Hello, world!", context, targetType);
 
-        // Verify
         assertNotNull(result);
         assertEquals(1024, result.size());
         assertEquals(targetType, result.type());
 
-        // Verify API request
         RecordedRequest request = mockServer.takeRequest();
         assertEquals("POST", request.getMethod());
         assertEquals("/v1/embeddings", request.getPath());
         assertTrue(request.getHeader("Authorization").startsWith("Bearer "));
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"model\":\"voyage-3\""));
         assertTrue(body.contains("\"encoding_format\":\"base64\""));
     }
 
     @Test
-    public void testThrowsOverloadExceptionOn429() {
-        // Mock 429 response
-        mockServer.enqueue(new MockResponse()
-                .setResponseCode(429)
-                .setBody("{\"error\":\"rate_limit_exceeded\"}"));
-
-        embedder = createEmbedder();
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-
-        // Should throw OverloadException immediately
-        var exception = assertThrows(
-            com.yahoo.language.process.OverloadException.class,
-            () -> embedder.embed("test", context, targetType)
-        );
-
-        assertEquals("VoyageAI API rate limited (429)", exception.getMessage());
-
-        // Verify only 1 request was made (no retries on 429)
-        assertEquals(1, mockServer.getRequestCount());
-    }
-
-    @Test
-    public void testThrowsTimeoutExceptionOnSocketTimeout() {
-        // Configure mock server with slow response to trigger socket timeout
-        mockServer.enqueue(new MockResponse()
-                .setBodyDelay(1, TimeUnit.SECONDS)
-                .setBody("{\"data\":[{\"embedding\":[0.1,0.2,0.3,0.4]}]}"));
-
-        // Create embedder with 100ms timeout to trigger timeout quickly
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder();
-        configBuilder.apiKeySecretRef("test_key");
-        configBuilder.endpoint(mockServer.url("/v1/embeddings").toString());
-        configBuilder.model("voyage-3");
-        configBuilder.dimensions(1024);
-        configBuilder.timeout(100); // 100ms timeout
-        embedder = new VoyageAIEmbedder(configBuilder.build(), runtime, createMockSecrets());
-
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-
-        var exception = assertThrows(TimeoutException.class, () -> embedder.embed("test", context, targetType));
-
-        var message = exception.getMessage();
-        assertTrue(message.contains("VoyageAI API call timed out after"), "Expected message to contain 'VoyageAI API call timed out after', got: " + message);
-        assertTrue(message.contains("ms"), "Expected message to contain 'ms', got: " + message);
-
-        assertNotNull(exception.getCause());
-        assertTrue(exception.getCause() instanceof java.io.InterruptedIOException
-                || exception.getCause() instanceof java.net.SocketTimeoutException);
-
-        // Verify only 1 request was made (no retries on timeout)
-        assertEquals(1, mockServer.getRequestCount());
-    }
-
-    @Test
-    public void testThrowsTimeoutExceptionOnExpiredDeadline() {
-        embedder = createEmbedder();
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-
-        // Create context with already-expired deadline
-        var context = new Embedder.Context("test-embedder")
-                .setDeadline(com.yahoo.language.process.InvocationContext.Deadline.of(
-                        java.time.Instant.now().minusSeconds(1)));
-
-        // Should throw TimeoutException before making HTTP request
-        var exception = assertThrows(
-                TimeoutException.class,
-                () -> embedder.embed("test", context, targetType)
-        );
-
-        assertEquals("Request deadline exceeded before VoyageAI API call", exception.getMessage());
-
-        // No HTTP request should be made
-        assertEquals(0, mockServer.getRequestCount());
-    }
-
-    @Test
-    public void testMaxRetriesExceeded() {
-        // Create embedder with hardcoded maxRetries=3
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder();
-        configBuilder.apiKeySecretRef("test_key");
-        configBuilder.endpoint(mockServer.url("/v1/embeddings").toString());
-        configBuilder.model("voyage-3");
-        configBuilder.dimensions(1024);
-
-        VoyageAIEmbedder embedder = new VoyageAIEmbedder(
-                configBuilder.build(),
-                runtime,
-                createMockSecrets()
-        );
-
-        // Mock server error responses - more than maxRetries
-        for (int i = 0; i < 10; i++) {
-            mockServer.enqueue(new MockResponse()
-                    .setResponseCode(500)
-                    .setBody("{\"error\":\"internal_server_error\"}"));
-        }
-
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-
-        // Should fail after exhausting retries
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
-            embedder.embed("test", context, targetType);
-        });
-        assertEquals("VoyageAI API call failed: Max retries exceeded for VoyageAI API (3). Last response: 500 - {\"error\":\"internal_server_error\"}", exception.getMessage());
-
-        embedder.deconstruct();
-    }
-
-    @Test
-    public void testDeadlineTimeout() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-                .apiKeySecretRef("test_key")
-                .endpoint(mockServer.url("/v1/embeddings").toString())
-                .model("voyage-3")
-                .dimensions(1024)
-                .maxRetries(100);
-        var embedder = new VoyageAIEmbedder(configBuilder.build(), runtime, createMockSecrets());
-
-        for (int i = 0; i < 100; i++) {
-            mockServer.enqueue(new MockResponse()
-                    .setResponseCode(500)
-                    .setBody("{\"error\":\"internal_server_error\"}"));
-        }
-
-        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-
-        var context = new Embedder.Context("test-embedder")
-                .setDeadline(InvocationContext.Deadline.of(Duration.ofMillis(500)));
-
-        var exception = assertThrows(TimeoutException.class,
-                () -> embedder.embed("test", context, targetType));
-
-        String message = exception.getMessage();
-        assertTrue(message.contains("VoyageAI API call timed out after"), "Expected message to contain 'VoyageAI API call timed out after', got: " + message);
-        assertTrue(message.contains("ms"), "Expected message to contain 'ms', got: " + message);
-        embedder.deconstruct();
-    }
-
-    @Test
-    public void testMaxRetriesSafetyLimit() {
-        // Create embedder with hardcoded maxRetries=3
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder();
-        configBuilder.apiKeySecretRef("test_key");
-        configBuilder.endpoint(mockServer.url("/v1/embeddings").toString());
-        configBuilder.model("voyage-3");
-        configBuilder.dimensions(1024);
-
-        VoyageAIEmbedder embedder = new VoyageAIEmbedder(
-                configBuilder.build(),
-                runtime,
-                createMockSecrets()
-        );
-
-        // Mock 5 server error responses (max retries is 3, so 1 + 3 retries = 4 total attempts)
-        for (int i = 0; i < 5; i++) {
-            mockServer.enqueue(new MockResponse()
-                    .setResponseCode(503)
-                    .setBody("{\"error\":\"service_unavailable\"}"));
-        }
-
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-
-        // Should fail after max retries
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
-            embedder.embed("test", context, targetType);
-        });
-        assertEquals("VoyageAI API call failed: Max retries exceeded for VoyageAI API (3). Last response: 503 - {\"error\":\"service_unavailable\"}", exception.getMessage());
-
-        embedder.deconstruct();
-    }
-
-    @Test
-    public void testAuthenticationError() {
-        mockServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .setBody("{\"error\":\"invalid_api_key\"}"));
-
-        embedder = createEmbedder();
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-
-        // Should fail with authentication error
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> embedder.embed("test", context, targetType));
-        assertTrue(exception.getMessage().contains("authentication"));
-    }
-
-    @Test
     public void testInvalidTensorType() {
-        mockServer.enqueue(new MockResponse()
-                .setResponseCode(200)
-                .setBody(createSuccessResponse(1024)));
-
         embedder = createEmbedder();
+        var invalidType = TensorType.fromSpec("tensor<float>(d0[32],d1[32])");
+        var context = new Embedder.Context("test-embedder");
 
-        // 2D tensor type (invalid for embeddings)
-        TensorType invalidType = TensorType.fromSpec("tensor<float>(d0[32],d1[32])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-
-        // Should fail with validation error
         assertThrows(IllegalArgumentException.class, () -> embedder.embed("test", context, invalidType));
-    }
-
-    @Test
-    public void testMissingApiKeySecret() {
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder();
-        configBuilder.apiKeySecretRef(""); // Empty secret name
-        configBuilder.endpoint(mockServer.url("/v1/embeddings").toString());
-        configBuilder.model("voyage-3");
-
-        // Should fail during construction
-        assertThrows(IllegalArgumentException.class, () -> {
-            new VoyageAIEmbedder(configBuilder.build(), runtime, createMockSecrets());
-        });
-    }
-
-    @Test
-    public void testServerError() {
-        mockServer.enqueue(new MockResponse()
-                .setResponseCode(500)
-                .setBody("{\"error\":\"internal_server_error\"}"));
-        mockServer.enqueue(new MockResponse()
-                .setResponseCode(200)
-                .setBody(createSuccessResponse(1024)));
-
-        embedder = createEmbedder();
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test");
-
-        // Should retry on 500 error
-        Tensor result = embedder.embed("test", context, targetType);
-        assertNotNull(result);
-        assertEquals(2, mockServer.getRequestCount()); // 1 failed + 1 success
     }
 
     @Test
@@ -333,28 +95,27 @@ public class VoyageAIEmbedderTest {
                 .setBody(createSuccessResponse(1024)));
 
         embedder = createEmbedder();
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         embedder.embed("test", context, targetType);
 
-        // Verify request contains input_type
         RecordedRequest request = mockServer.takeRequest();
-        String body = request.getBody().readUtf8();
-        assertTrue(body.contains("\"input_type\":\"document\"")); // Default is document
+        var body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"input_type\":\"document\""));
     }
 
     @Test
     public void testAutoQuantizationWithFloatTensor() throws Exception {
-        embedder = createEmbedder(1024, "auto");
+        embedder = createEmbedder(1024, "AUTO");
 
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(createFloatSuccessResponse(1024)));
 
-        TensorType targetType = TensorType.fromSpec("tensor<float>(x[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<float>(x[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         Tensor result = embedder.embed("test", context, targetType);
 
@@ -362,9 +123,8 @@ public class VoyageAIEmbedderTest {
         assertEquals(1024, result.size());
         assertEquals(TensorType.Value.FLOAT, result.type().valueType());
 
-        // Verify request contains output_dtype=float, output_dimension=1024, encoding_format=base64
         RecordedRequest request = mockServer.takeRequest();
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"output_dtype\":\"float\""));
         assertTrue(body.contains("\"output_dimension\":1024"));
         assertTrue(body.contains("\"encoding_format\":\"base64\""));
@@ -372,15 +132,15 @@ public class VoyageAIEmbedderTest {
 
     @Test
     public void testAutoQuantizationWithInt8Tensor() throws Exception {
-        embedder = createEmbedder(1024, "auto");
+        embedder = createEmbedder(1024, "AUTO");
 
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(createInt8SuccessResponse(1024)));
 
-        TensorType targetType = TensorType.fromSpec("tensor<int8>(x[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<int8>(x[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         Tensor result = embedder.embed("test", context, targetType);
 
@@ -388,25 +148,23 @@ public class VoyageAIEmbedderTest {
         assertEquals(1024, result.size());
         assertEquals(TensorType.Value.INT8, result.type().valueType());
 
-        // Verify request contains output_dtype=int8
         RecordedRequest request = mockServer.takeRequest();
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"output_dtype\":\"int8\""));
         assertTrue(body.contains("\"output_dimension\":1024"));
     }
 
     @Test
     public void testAutoQuantizationWithBinaryTensor() throws Exception {
-        embedder = createEmbedder(1024, "auto");
+        embedder = createEmbedder(1024, "AUTO");
 
-        // Binary embedding has 1/8 dimension (1024/8 = 128)
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(createBinarySuccessResponse(128)));
 
-        TensorType targetType = TensorType.fromSpec("tensor<int8>(x[128])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<int8>(x[128])");
+        var context = new Embedder.Context("test-embedder");
 
         Tensor result = embedder.embed("test", context, targetType);
 
@@ -414,20 +172,18 @@ public class VoyageAIEmbedderTest {
         assertEquals(128, result.size());
         assertEquals(TensorType.Value.INT8, result.type().valueType());
 
-        // Verify request contains output_dtype=binary but output_dimension=1024 (full dimension)
         RecordedRequest request = mockServer.takeRequest();
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"output_dtype\":\"binary\""));
         assertTrue(body.contains("\"output_dimension\":1024"));
     }
 
     @Test
     public void testExplicitFloatQuantizationValidation() {
-        // Float quantization requires float tensor
-        embedder = createEmbedder(1024, "float");
+        embedder = createEmbedder(1024, "FLOAT");
 
-        TensorType int8Type = TensorType.fromSpec("tensor<int8>(x[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var int8Type = TensorType.fromSpec("tensor<int8>(x[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         var exception = assertThrows(IllegalArgumentException.class,
                 () -> embedder.embed("test", context, int8Type));
@@ -436,11 +192,10 @@ public class VoyageAIEmbedderTest {
 
     @Test
     public void testExplicitInt8QuantizationValidation() {
-        // Int8 quantization requires int8 tensor
-        embedder = createEmbedder(1024, "int8");
+        embedder = createEmbedder(1024, "INT8");
 
-        TensorType floatType = TensorType.fromSpec("tensor<float>(x[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var floatType = TensorType.fromSpec("tensor<float>(x[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         var exception = assertThrows(IllegalArgumentException.class,
                 () -> embedder.embed("test", context, floatType));
@@ -449,10 +204,8 @@ public class VoyageAIEmbedderTest {
 
     @Test
     public void testExplicitBinaryQuantizationValidation() {
-        // Binary quantization requires int8 tensor with dimension/8
-        embedder = createEmbedder(1024, "binary");
+        embedder = createEmbedder(1024, "BINARY");
 
-        // Tensor has full dimension instead of 1/8
         var targetType = TensorType.fromSpec("tensor<int8>(x[1024])");
         var context = new Embedder.Context("test-embedder");
 
@@ -463,14 +216,8 @@ public class VoyageAIEmbedderTest {
 
     @Test
     public void testDimensionMismatchBetweenConfigAndTensorType() {
-        embedder = createEmbedder(512, "auto");
+        embedder = createEmbedder(512, "AUTO");
 
-        mockServer.enqueue(new MockResponse()
-                .setResponseCode(200)
-                .setHeader("Content-Type", "application/json")
-                .setBody(createFloatSuccessResponse(512)));
-
-        // Tensor type has different dimension than config
         var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
         var context = new Embedder.Context("test-embedder");
 
@@ -480,15 +227,15 @@ public class VoyageAIEmbedderTest {
 
     @Test
     public void testAutoQuantizationWithBfloat16Tensor() throws Exception {
-        embedder = createEmbedder(1024, "auto");
+        embedder = createEmbedder(1024, "AUTO");
 
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(createFloatSuccessResponse(1024)));
 
-        TensorType targetType = TensorType.fromSpec("tensor<bfloat16>(x[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<bfloat16>(x[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         Tensor result = embedder.embed("test", context, targetType);
 
@@ -497,22 +244,22 @@ public class VoyageAIEmbedderTest {
         assertEquals(TensorType.Value.BFLOAT16, result.type().valueType());
 
         RecordedRequest request = mockServer.takeRequest();
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"output_dtype\":\"float\""));
         assertTrue(body.contains("\"output_dimension\":1024"));
     }
 
     @Test
     public void testExplicitFloatQuantizationWithBfloat16Tensor() throws Exception {
-        embedder = createEmbedder(1024, "float");
+        embedder = createEmbedder(1024, "FLOAT");
 
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(createFloatSuccessResponse(1024)));
 
-        TensorType targetType = TensorType.fromSpec("tensor<bfloat16>(x[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
+        var targetType = TensorType.fromSpec("tensor<bfloat16>(x[1024])");
+        var context = new Embedder.Context("test-embedder");
 
         Tensor result = embedder.embed("test", context, targetType);
 
@@ -521,28 +268,24 @@ public class VoyageAIEmbedderTest {
         assertEquals(TensorType.Value.BFLOAT16, result.type().valueType());
 
         RecordedRequest request = mockServer.takeRequest();
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"output_dtype\":\"float\""));
     }
 
     @Test
     public void testBatchEmbeddingNonContextualModel() throws Exception {
-        // Mock batch API response with 3 embeddings
-        String responseJson = createFloatBatchSuccessResponse(3, 1024);
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
-                .setBody(responseJson));
+                .setBody(createFloatBatchSuccessResponse(3, 1024)));
 
         embedder = createEmbedder();
 
-        // Test batch embedding
-        TensorType targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
-        Embedder.Context context = new Embedder.Context("test-embedder");
-        var texts = java.util.List.of("Hello, world!", "Second text", "Third text");
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
+        var texts = List.of("Hello, world!", "Second text", "Third text");
         var results = embedder.embed(texts, context, targetType);
 
-        // Verify results
         assertNotNull(results);
         assertEquals(3, results.size());
         for (var result : results) {
@@ -550,13 +293,10 @@ public class VoyageAIEmbedderTest {
             assertEquals(targetType, result.type());
         }
 
-        // Verify only 1 API request was made (batch request)
         assertEquals(1, mockServer.getRequestCount());
 
-        // Verify API request contains all inputs
         RecordedRequest request = mockServer.takeRequest();
-        assertEquals("POST", request.getMethod());
-        String body = request.getBody().readUtf8();
+        var body = request.getBody().readUtf8();
         assertTrue(body.contains("\"input\":[\"Hello, world!\",\"Second text\",\"Third text\"]"));
         assertTrue(body.contains("\"model\":\"voyage-3\""));
     }
@@ -564,19 +304,12 @@ public class VoyageAIEmbedderTest {
     @Test
     public void testBatchingConfigDisabledByDefault() {
         embedder = createEmbedder();
-        var batching = embedder.batchingConfig();
-        assertNotNull(batching);
-        assertEquals(Embedder.Batching.DISABLED, batching);
+        assertEquals(Embedder.Batching.DISABLED, embedder.batchingConfig());
     }
 
     @Test
     public void testBatchingConfigEnabled() {
-        var configBuilder = new VoyageAiEmbedderConfig.Builder()
-                .apiKeySecretRef("test_key")
-                .endpoint(mockServer.url("/v1/embeddings").toString())
-                .model("voyage-3")
-                .dimensions(1024)
-                .timeout(5000);
+        var configBuilder = voyageConfigBuilder(1024);
         configBuilder.batching.maxSize(16);
         configBuilder.batching.maxDelayMillis(200);
         embedder = new VoyageAIEmbedder(configBuilder.build(), runtime, createMockSecrets());
@@ -597,9 +330,9 @@ public class VoyageAIEmbedderTest {
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
-                .setBody(createBase64Response(1, base64)));
+                .setBody(createBase64EmbeddingResponse(base64)));
 
-        embedder = createEmbedder(4, "float");
+        embedder = createEmbedder(4, "FLOAT");
         var targetType = TensorType.fromSpec("tensor<float>(x[4])");
         var context = new Embedder.Context("test-embedder");
         var result = (IndexedTensor) embedder.embed("test", context, targetType);
@@ -617,9 +350,9 @@ public class VoyageAIEmbedderTest {
         mockServer.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
-                .setBody(createBase64Response(1, base64)));
+                .setBody(createBase64EmbeddingResponse(base64)));
 
-        embedder = createEmbedder(6, "int8");
+        embedder = createEmbedder(6, "INT8");
         var targetType = TensorType.fromSpec("tensor<int8>(x[6])");
         var context = new Embedder.Context("test-embedder");
         var result = (IndexedTensor) embedder.embed("test", context, targetType);
@@ -631,80 +364,38 @@ public class VoyageAIEmbedderTest {
 
     // ===== Helper Methods =====
 
-    private VoyageAIEmbedder createEmbedder() {
-        return createEmbedder(1024, "auto");
-    }
+    private VoyageAIEmbedder createEmbedder() { return createEmbedder(1024, "AUTO"); }
 
     private VoyageAIEmbedder createEmbedder(int dimensions, String quantization) {
-        VoyageAiEmbedderConfig.Builder configBuilder = new VoyageAiEmbedderConfig.Builder()
+        var config = voyageConfigBuilder(dimensions)
+                .quantization(VoyageAiEmbedderConfig.Quantization.Enum.valueOf(quantization))
+                .build();
+        return new VoyageAIEmbedder(config, runtime, createMockSecrets());
+    }
+
+    private VoyageAiEmbedderConfig.Builder voyageConfigBuilder(int dimensions) {
+        return new VoyageAiEmbedderConfig.Builder()
                 .apiKeySecretRef("test_key")
                 .endpoint(mockServer.url("/v1/embeddings").toString())
                 .model("voyage-3")
-                .dimensions(dimensions)
-                .quantization(VoyageAiEmbedderConfig.Quantization.Enum.valueOf(toUpperCase(quantization)))
-                .timeout(5000);
-
-        return new VoyageAIEmbedder(configBuilder.build(), runtime, createMockSecrets());
-    }
-
-    private Secrets createMockSecrets() {
-        return key -> {
-            if ("test_key".equals(key)) {
-                return () -> "test-api-key-12345";
-            }
-            return null;
-        };
-    }
-
-    private static String encodeFloatsToBase64(int dimensions, int batchOffset) {
-        var buffer = ByteBuffer.allocate(dimensions * 4).order(ByteOrder.LITTLE_ENDIAN);
-        for (int i = 0; i < dimensions; i++) {
-            buffer.putFloat((float) Math.sin((i + batchOffset) * 0.1));
-        }
-        return Base64.getEncoder().encodeToString(buffer.array());
-    }
-
-    private static String encodeBytesToBase64(int dimensions) {
-        var bytes = new byte[dimensions];
-        for (int i = 0; i < dimensions; i++) {
-            bytes[i] = (byte) (i % 128);
-        }
-        return Base64.getEncoder().encodeToString(bytes);
+                .dimensions(dimensions);
     }
 
     private static String createSuccessResponse(int dimensions) { return createFloatSuccessResponse(dimensions); }
 
     private static String createFloatSuccessResponse(int dimensions) {
-        return createBase64Response(1, encodeFloatsToBase64(dimensions, 0));
+        return createBase64EmbeddingResponse(encodeFloatsToBase64(dimensions, 0));
     }
 
     private static String createFloatBatchSuccessResponse(int batchSize, int dimensions) {
-        var dataEntries = new StringBuilder();
-        for (int b = 0; b < batchSize; b++) {
-            if (b > 0) dataEntries.append(",");
-            dataEntries.append(Text.format("{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":%d}",
-                    encodeFloatsToBase64(dimensions, b * 1000), b));
-        }
-        return Text.format("""
-                {"object":"list","data":[%s],"model":"voyage-3","usage":{"total_tokens":%d}}
-                """, dataEntries, batchSize * 10);
+        var embeddings = new String[batchSize];
+        for (int b = 0; b < batchSize; b++) embeddings[b] = encodeFloatsToBase64(dimensions, b * 1000);
+        return createBase64EmbeddingResponse(embeddings);
     }
 
     private static String createInt8SuccessResponse(int dimensions) {
-        return createBase64Response(1, encodeBytesToBase64(dimensions));
+        return createBase64EmbeddingResponse(encodeBytesToBase64(dimensions));
     }
 
     private static String createBinarySuccessResponse(int dimensions) { return createInt8SuccessResponse(dimensions); }
-
-    private static String createBase64Response(int batchSize, String... base64Embeddings) {
-        var dataEntries = new StringBuilder();
-        for (int b = 0; b < base64Embeddings.length; b++) {
-            if (b > 0) dataEntries.append(",");
-            dataEntries.append(Text.format("{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":%d}",
-                    base64Embeddings[b], b));
-        }
-        return Text.format("""
-                {"object":"list","data":[%s],"model":"voyage-3","usage":{"total_tokens":%d}}
-                """, dataEntries, batchSize * 10);
-    }
 }


### PR DESCRIPTION
## Summary

Two new embedder component types — `openai-embedder` and `mistral-embedder` — plus a refactor of VoyageAI onto shared HTTP scaffolding. All three are self-contained `Embedder` implementations sharing an `AbstractHttpEmbedder` base.

`AbstractHttpEmbedder` owns the OkHttpClient lifecycle, JSON (de)serialization helpers, and a `doHttpRequest(endpoint, json, headers, context, runtime) -> String` method that POSTs the JSON payload, logs request/response, honors the context deadline, retries 5xx failures, maps non-2xx responses to the appropriate exception (429 → `OverloadException`, 400 → `InvalidInputException`, 401/403 → authentication error), and samples failure metrics. The shared error-body parser handles both the OpenAI/Mistral `{"error":{"message":"..."}}` and the VoyageAI `{"detail":"..."}` formats. Each concrete embedder handles tensor validation, quantization, caching, request counting, and provider-specific request/response DTOs.

### Provider specifics

- **OpenAI** — base64-encoded float32 responses. The API does not support quantization, so only float/bfloat16 tensor types are accepted.
- **Mistral** — JSON-array responses with `output_dtype` and `output_dimension`. Supports int8/binary quantization on models that offer it. Endpoint is not configurable via services.xml — the `.def` default always applies.
- **VoyageAI** — base64 responses, auto-selection between text/multimodal/contextualized endpoints by model name prefix, `truncate`, dynamic batching, and quantization.

### Configuration split

- `http-embedder.def` — shared HTTP transport params (`maxRetries`, `timeout`).
- `openai-embedder.def`, `mistral-embedder.def`, `voyage-ai-embedder.def` — per-provider params (model, dimensions, api-key-secret-ref, endpoint, quantization, truncate, batching, …).

### Shared utilities

- `EmbeddingQuantization` — tensor type validation, output dtype resolution, base64 and JSON-array tensor decoding. Used by all three embedders.
- `EmbedderTestUtils.createBase64EmbeddingResponse` — mock response builder shared by OpenAI and VoyageAI tests.
- `AbstractHttpEmbedderTest` — centralizes HTTP-layer tests (status codes, timeouts, retries, error-body parsing) so provider-specific tests cover only request/response shape.

Batch response embeddings are sorted by index in all three embedders to guard against out-of-order API responses.

## Test plan

- [x] Unit tests in `model-integration` (`AbstractHttpEmbedderTest`, `OpenAIEmbedderTest`, `MistralEmbedderTest`, `VoyageAIEmbedderTest`)
- [x] Config-model tests (`OpenAIEmbedderTest`, `MistralEmbedderTest`, `VoyageAIEmbedderTest`)
- [x] Integration tests against real APIs (gated by `VESPA_TEST_OPENAI_API_KEY`, `VESPA_TEST_MISTRAL_API_KEY`, `VESPA_TEST_VOYAGE_API_KEY`)
