### PR TITLE
Accept integer distanceThreshold in nearestNeighbor YQL

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -615,9 +615,9 @@ public class YqlParser implements Parser {
         item.setTotalTargetHits(getAnnotation(ast, TOTAL_TARGET_HITS, Integer.class, null, "total hits to produce across all nodes"));
         item.setMinTargetHits(getAnnotation(ast, MIN_TARGET_HITS, Integer.class, null, "min hits to produce on a node"));
 
-        Double distanceThreshold = getAnnotation(ast, DISTANCE_THRESHOLD, Double.class, null, "maximum distance allowed from query point");
+        Number distanceThreshold = getAnnotation(ast, DISTANCE_THRESHOLD, Number.class, null, "maximum distance allowed from query point");
         if (distanceThreshold != null) {
-            item.setDistanceThreshold(distanceThreshold);
+            item.setDistanceThreshold(distanceThreshold.doubleValue());
         }
         Integer hnswExploreAdditionalHits = getAnnotation(ast, HNSW_EXPLORE_ADDITIONAL_HITS,
                                                           Integer.class, null, "number of extra hits to explore for HNSW algorithm");

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -902,6 +902,8 @@ public class YqlParserTestCase {
                 "NEAREST_NEIGHBOR {field=semantic_embedding,queryTensorName=my_vector,targetHits=3,approximate=false,hnsw.exploreAdditionalHits=8}");
         assertParse("select foo from bar where {targetHits: 7, distanceThreshold: 100100.25} nearestNeighbor(semantic_embedding, my_vector)",
                 "NEAREST_NEIGHBOR {field=semantic_embedding,queryTensorName=my_vector,targetHits=7,distanceThreshold=100100.25}");
+        assertParse("select foo from bar where {targetHits: 7, distanceThreshold: 45} nearestNeighbor(semantic_embedding, my_vector)",
+            "NEAREST_NEIGHBOR {field=semantic_embedding,queryTensorName=my_vector,targetHits=7,distanceThreshold=45.0}");
         assertParse("select foo from bar where {totalTargetHits: 100, minTargetHits: 11} nearestNeighbor(semantic_embedding, my_vector)",
                     "NEAREST_NEIGHBOR {field=semantic_embedding,queryTensorName=my_vector,totalTargetHits=100,minTargetHits=11}");
     }


### PR DESCRIPTION
Supports integer values for distanceThreshold in nearestNeighbor YQL by accepting numeric annotations and coercing them to double.
Implements issue #36352.

Changes:
- Accept Number for distanceThreshold annotation during YQL parsing.
- Convert numeric value to double before setting NearestNeighborItem.
- Add parser regression coverage for distanceThreshold: 45.

Verification:
mvn -pl container-search -Dtest=YqlParserTestCase,SelectTestCase,VespaSerializerTestCase test
Tests run: 283, Failures: 0, Errors: 0, Skipped: 0

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.