### PR TITLE
Revert "Cluster type required in ClusterCapacity"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/ClusterCapacity.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/ClusterCapacity.java
@@ -56,7 +56,7 @@ public class ClusterCapacity {
         this.diskSpeed = validateEnum("diskSpeed", validDiskSpeeds, diskSpeed == null ? "fast" : diskSpeed);
         this.storageType = validateEnum("storageType", validStorageTypes, storageType == null ? "any" : storageType);
         this.architecture = validateEnum("architecture", validArchitectures, architecture == null ? "x86_64" : architecture);
-        this.clusterType = validateEnum("clusterType", validClusterTypes, clusterType);
+        this.clusterType = clusterType == null ? null : validateEnum("clusterType", validClusterTypes, clusterType);
         this.cloudAccount = Optional.ofNullable(cloudAccount);
         this.tenant = Optional.ofNullable(tenant);
         validate(this.tenant, this.cloudAccount);

--- a/flags/src/test/java/com/yahoo/vespa/flags/custom/ClusterCapacityTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/custom/ClusterCapacityTest.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags.custom;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.yahoo.test.json.Jackson;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +14,11 @@ public class ClusterCapacityTest {
 
     @Test
     void serialization() throws IOException {
-        ClusterCapacity clusterCapacity = new ClusterCapacity(7, 1.2, 3.4, 5.6, null, "fast", "local", "x86_64", "content", null, null);
+        ClusterCapacity clusterCapacity = new ClusterCapacity(7, 1.2, 3.4, 5.6, null, "fast", "local", "x86_64", null, null, null);
         var mapper = Jackson.mapper();
         String json = mapper.writeValueAsString(clusterCapacity);
         assertEquals("""
-                             {"count":7,"vcpu":1.2,"memoryGb":3.4,"diskGb":5.6,"diskSpeed":"fast","storageType":"local","architecture":"x86_64","clusterType":"content"}""",
+                             {"count":7,"vcpu":1.2,"memoryGb":3.4,"diskGb":5.6,"diskSpeed":"fast","storageType":"local","architecture":"x86_64"}""",
                      json);
 
         ClusterCapacity deserialized = mapper.readValue(json, ClusterCapacity.class);
@@ -31,16 +30,15 @@ public class ClusterCapacityTest {
         assertEquals("fast", deserialized.diskSpeed());
         assertEquals("local", deserialized.storageType());
         assertEquals("x86_64", deserialized.architecture());
-        assertEquals("content", deserialized.clusterType());
     }
 
     @Test
     void serialization2() throws IOException {
-        ClusterCapacity clusterCapacity = new ClusterCapacity(7, 1.2, 3.4, 5.6, 2.3, "any", "remote", "arm64", "content", null, null);
+        ClusterCapacity clusterCapacity = new ClusterCapacity(7, 1.2, 3.4, 5.6, 2.3, "any", "remote", "arm64", null, null, null);
         var mapper = Jackson.mapper();
         String json = mapper.writeValueAsString(clusterCapacity);
         assertEquals("""
-                             {"count":7,"vcpu":1.2,"memoryGb":3.4,"diskGb":5.6,"bandwidthGbps":2.3,"diskSpeed":"any","storageType":"remote","architecture":"arm64","clusterType":"content"}""",
+                             {"count":7,"vcpu":1.2,"memoryGb":3.4,"diskGb":5.6,"bandwidthGbps":2.3,"diskSpeed":"any","storageType":"remote","architecture":"arm64"}""",
                      json);
 
         ClusterCapacity deserialized = mapper.readValue(json, ClusterCapacity.class);
@@ -52,7 +50,6 @@ public class ClusterCapacityTest {
         assertEquals("any", deserialized.diskSpeed());
         assertEquals("remote", deserialized.storageType());
         assertEquals("arm64", deserialized.architecture());
-        assertEquals("content", deserialized.clusterType());
     }
 
     @Test
@@ -100,13 +97,6 @@ public class ClusterCapacityTest {
     }
 
     @Test
-    void cluster_type_must_be_specified() {
-        assertThrows(NullPointerException.class, () -> new ClusterCapacity(7, 1.2, 3.4, 5.6, null, "fast", "local", "x86_64", null, null, null));
-        var mapper = Jackson.mapper();
-        assertThrows(JsonMappingException.class, () -> mapper.readValue("{\"count\":7}", ClusterCapacity.class));
-    }
-
-    @Test
     void both_cloud_account_and_tenant_must_be_specified() {
         assertThrows(IllegalArgumentException.class, () -> new ClusterCapacity(7, 1.2, 3.4, 5.6, 2.3, "any", "remote", "arm64", "admin", "aws:123", null));
         assertThrows(IllegalArgumentException.class, () -> new ClusterCapacity(7, 1.2, 3.4, 5.6, 2.3, "any", "remote", "arm64", "admin", null, "mytenant"));
@@ -114,10 +104,10 @@ public class ClusterCapacityTest {
 
     @Test
     void serializationWithNoNodeResources() throws IOException {
-        ClusterCapacity clusterCapacity = new ClusterCapacity(7, null, null, null, null, null, null, null, "content", null, null);
+        ClusterCapacity clusterCapacity = new ClusterCapacity(7, null, null, null, null, null, null, null, null, null, null);
         var mapper = Jackson.mapper();
         String json = mapper.writeValueAsString(clusterCapacity);
-        assertEquals("{\"count\":7,\"diskSpeed\":\"fast\",\"storageType\":\"any\",\"architecture\":\"x86_64\",\"clusterType\":\"content\"}", json);
+        assertEquals("{\"count\":7,\"diskSpeed\":\"fast\",\"storageType\":\"any\",\"architecture\":\"x86_64\"}", json);
 
         ClusterCapacity deserialized = mapper.readValue(json, ClusterCapacity.class);
         assertEquals(7, deserialized.count());
@@ -128,11 +118,10 @@ public class ClusterCapacityTest {
         assertEquals("fast", deserialized.diskSpeed());
         assertEquals("any", deserialized.storageType());
         assertEquals("x86_64", deserialized.architecture());
-        assertEquals("content", deserialized.clusterType());
 
 
         // Test that using no values for diskSpeed, storageType and architecture will give expected values (the default values)
-        var input = "{\"count\":7,\"clusterType\":\"content\"}";
+        var input = "{\"count\":7}";
         deserialized = mapper.readValue(input, ClusterCapacity.class);
         assertEquals(7, deserialized.count());
         assertEquals(0.0, deserialized.vcpu(), 0.0001);
@@ -142,7 +131,6 @@ public class ClusterCapacityTest {
         assertEquals("fast", deserialized.diskSpeed());
         assertEquals("any", deserialized.storageType());
         assertEquals("x86_64", deserialized.architecture());
-        assertEquals("content", deserialized.clusterType());
     }
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#36372

Public, yahoo and k8s builds fail with 

[ERROR] Errors: [ERROR] HostCapacityMaintainerTest.does_not_deprovision_when_preprovisioning_enabled:100 » NullPointer 'clusterType' has not been specified [ERROR] HostCapacityMaintainerTest.preprovision_with_shared_host:150 » NullPointer 'clusterType' has not been specified [ERROR] HostCapacityMaintainerTest.preprovision_with_shared_host_no_resources_specified:230 » NullPointer 'clusterType' has not been specified [ERROR] HostCapacityMaintainerTest.provision_deficit_and_deprovision_excess:113 » NullPointer 'clusterType' has not been specified [ERROR] HostCapacityMaintainerTest.respects_exclusive_allocation:292 » NullPointer 'clusterType' has not been specified [ERROR] HostCapacityMaintainerTest.tenant_is_used_as_owner_when_provisioning_exclave_host:371 » NullPointer 'clusterType' has not been specified [ERROR] HostCapacityMaintainerTest.test_minimum_capacity:387 » NullPointer 'clusterType' has not been specified [INFO] [ERROR] 