### PR TITLE
Handle empty query stems safely in query side stemming

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
@@ -344,10 +344,7 @@ public class StemmingSearcher extends Searcher {
 
     private Item maybeDropTerm(BlockItem current, StemContext context) {
         Item item = (Item) current;
-        CompositeItem parent = item.getParent();
-        if (parent != null && mayDropTerm(parent, item, context)) {
-            return null;
-        }
+        if (mayDropTerm(item.getParent(), item, context)) return null;
         return item;
     }
 
@@ -356,18 +353,14 @@ public class StemmingSearcher extends Searcher {
     }
 
     private boolean mayDropTerm(CompositeItem parent, Item child, StemContext context) {
-        if (!shouldDropTerm(child, context)) return false;
+        if (context.insidePhrase) return false;
+        if (!(child instanceof BlockItem)) return false;
+        if (child.getParent() == null) return false;
+        if (child.getParent() instanceof PhraseItem || child.getParent() instanceof PhraseSegmentItem) return false;
+        if (child instanceof TaggableItem t && t.getConnectedItem() != null) return false;
+        if (context.reverseConnectivity != null && context.reverseConnectivity.containsKey(child)) return false;
         if (parent.getItemCount() <= 1) return false;
         return parent instanceof AndItem || parent instanceof WeakAndItem;
-    }
-
-    private boolean shouldDropTerm(Item item, StemContext context) {
-        if (context.insidePhrase) return false;
-        if (!(item instanceof BlockItem)) return false;
-        if (item.getParent() == null) return false;
-        if (item.getParent() instanceof PhraseItem || item.getParent() instanceof PhraseSegmentItem) return false;
-        if (item instanceof TaggableItem t && t.getConnectedItem() != null) return false;
-        return context.reverseConnectivity == null || !context.reverseConnectivity.containsKey(item);
     }
 
     private void setMetaData(BlockItem current, Map<Item, TaggableItem> reverseConnectivity, TaggableItem replacement) {

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
@@ -37,6 +37,7 @@ import com.yahoo.prelude.query.SegmentingRule;
 import com.yahoo.prelude.query.Substring;
 import com.yahoo.prelude.query.TaggableItem;
 import com.yahoo.prelude.query.TermItem;
+import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordAlternativesItem;
 import com.yahoo.prelude.query.WordAlternativesItem.Alternative;
 import com.yahoo.prelude.query.WordItem;
@@ -173,8 +174,13 @@ public class StemmingSearcher extends Searcher {
             while (i.hasNext()) {
                 Item original = i.next();
                 Item transformed = scan(original, context, queryType);
-                if (original != transformed)
+                if (transformed == null) {
+                    if (mayDropTerm(composite, original, context)) {
+                        i.remove();
+                    }
+                } else if (original != transformed) {
                     i.set(transformed);
+                }
             }
         }
 
@@ -219,11 +225,14 @@ public class StemmingSearcher extends Searcher {
         Item blockAsItem = (Item)current;
         CompositeItem composite;
         List<StemList> segments = linguistics.getStemmer().stem(current.stringValue(), parameters);
-        if (segments.isEmpty()) return blockAsItem;
+        if (segments.isEmpty()) return maybeDropTerm(current, context);
 
         String indexName = current.getIndexName();
         Substring origin = getOffsets(current);
         if (segments.size() == 1) {
+            if (isEmptyStem(segments.get(0))) {
+                return maybeDropTerm(current, context);
+            }
             TaggableItem w = singleWordSegment(current, segments.get(0), index, origin);
             setMetaData(current, context.reverseConnectivity, w);
             return (Item)w;
@@ -331,6 +340,34 @@ public class StemmingSearcher extends Searcher {
         if (segment.get(0).isEmpty())
             return (TaggableItem)current;
         return singleStemSegment((Item)current, segment.get(0), indexName, origin);
+    }
+
+    private Item maybeDropTerm(BlockItem current, StemContext context) {
+        Item item = (Item) current;
+        CompositeItem parent = item.getParent();
+        if (parent != null && mayDropTerm(parent, item, context)) {
+            return null;
+        }
+        return item;
+    }
+
+    private boolean isEmptyStem(StemList segment) {
+        return segment.isEmpty() || segment.get(0).isEmpty();
+    }
+
+    private boolean mayDropTerm(CompositeItem parent, Item child, StemContext context) {
+        if (!shouldDropTerm(child, context)) return false;
+        if (parent.getItemCount() <= 1) return false;
+        return parent instanceof AndItem || parent instanceof WeakAndItem;
+    }
+
+    private boolean shouldDropTerm(Item item, StemContext context) {
+        if (context.insidePhrase) return false;
+        if (!(item instanceof BlockItem)) return false;
+        if (item.getParent() == null) return false;
+        if (item.getParent() instanceof PhraseItem || item.getParent() instanceof PhraseSegmentItem) return false;
+        if (item instanceof TaggableItem t && t.getConnectedItem() != null) return false;
+        return context.reverseConnectivity == null || !context.reverseConnectivity.containsKey(item);
     }
 
     private void setMetaData(BlockItem current, Map<Item, TaggableItem> reverseConnectivity, TaggableItem replacement) {

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
@@ -22,8 +22,10 @@ import com.yahoo.prelude.SearchDefinition;
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.CompositeItem;
 import com.yahoo.prelude.query.NullItem;
+import com.yahoo.prelude.query.PhraseItem;
 import com.yahoo.prelude.query.PhraseSegmentItem;
 import com.yahoo.prelude.query.DocumentFrequency;
+import com.yahoo.prelude.query.PrefixItem;
 import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordAlternativesItem;
@@ -43,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -111,6 +114,102 @@ public class StemmingSearcherTestCase {
     @Test
     void testDontStemPrefixes() {
         assertStemmed("WEAKAND ist*", "/search?query=ist*&language=de");
+    }
+
+    @Test
+    void testQueryAndDropsTermsWithEmptyStems() {
+        var linguistics = new StopwordDroppingLinguistics("dropme");
+        var indexFacts = new IndexFacts(createDefaultIndexModelWithStemming());
+
+        Query query = new Query(QueryTestCase.httpEncode("/search?language=en"));
+        AndItem root = new AndItem();
+        root.addItem(new WordItem("dropme", "default", true));
+        root.addItem(new WordItem("document", "default", true));
+        query.getModel().getQueryTree().setRoot(root);
+
+        executeStemming(query, linguistics, indexFacts);
+
+        AndItem transformedRoot = (AndItem) query.getModel().getQueryTree().getRoot();
+        assertEquals(1, transformedRoot.getItemCount());
+        assertEquals("document", ((WordItem) transformedRoot.getItem(0)).getWord());
+    }
+
+    @Test
+    void testQueryAndDoesNotCollapseToEmpty() {
+        var linguistics = new StopwordDroppingLinguistics("dropme");
+        var indexFacts = new IndexFacts(createDefaultIndexModelWithStemming());
+
+        Query query = new Query(QueryTestCase.httpEncode("/search?language=en"));
+        AndItem root = new AndItem();
+        root.addItem(new WordItem("dropme", "default", true));
+        query.getModel().getQueryTree().setRoot(root);
+
+        executeStemming(query, linguistics, indexFacts);
+
+        assertTrue(query.getModel().getQueryTree().toString().contains("dropme"));
+    }
+
+    @Test
+    void testUserInputDropsTermsWithEmptyStems() {
+        var linguistics = new StopwordDroppingLinguistics("dropme");
+        var indexModel = createDefaultIndexModelWithStemming();
+        var yql = "select * from sources * where ({grammar: 'all'}userInput(@query))";
+        var query = new Query("?yql=" + QueryTestCase.httpEncode(yql) +
+                              "&query=" + QueryTestCase.httpEncode("dropme document"));
+
+        var result = search(linguistics, indexModel, query);
+        if (result.hits().getError() != null)
+            throw new RuntimeException(result.hits().getError().toString());
+
+        var tree = query.getModel().getQueryTree().toString();
+        assertTrue(tree.contains("document"), "Expected remaining term after stopword removal: " + tree);
+        assertFalse(tree.contains("dropme"), "Expected stopword to be removed from query tree: " + tree);
+    }
+
+    @Test
+    void testUserInputDoesNotCollapseToEmpty() {
+        var linguistics = new StopwordDroppingLinguistics("dropme");
+        var indexModel = createDefaultIndexModelWithStemming();
+        var yql = "select * from sources * where ({grammar: 'all'}userInput(@query))";
+        var query = new Query("?yql=" + QueryTestCase.httpEncode(yql) +
+                              "&query=" + QueryTestCase.httpEncode("dropme"));
+
+        var result = search(linguistics, indexModel, query);
+        if (result.hits().getError() != null)
+            throw new RuntimeException(result.hits().getError().toString());
+
+        assertTrue(query.getModel().getQueryTree().toString().contains("dropme"));
+    }
+
+    @Test
+    void testPhraseTermsAreKeptWhenStemIsEmpty() {
+        var linguistics = new StopwordDroppingLinguistics("dropme");
+        var indexFacts = new IndexFacts(createDefaultIndexModelWithStemming());
+
+        Query query = new Query(QueryTestCase.httpEncode("/search?language=en"));
+        PhraseItem phrase = new PhraseItem();
+        phrase.addItem(new WordItem("dropme", "default", true));
+        phrase.addItem(new WordItem("document", "default", true));
+        query.getModel().getQueryTree().setRoot(phrase);
+
+        executeStemming(query, linguistics, indexFacts);
+
+        String tree = query.getModel().getQueryTree().toString();
+        assertTrue(tree.contains("dropme"), "Phrase terms should remain untouched: " + tree);
+        assertTrue(tree.contains("document"), "Phrase terms should remain untouched: " + tree);
+    }
+
+    @Test
+    void testNonTextOperatorsAreUnchangedWhenStemIsEmpty() {
+        var linguistics = new StopwordDroppingLinguistics("dropme");
+        var indexFacts = new IndexFacts(createDefaultIndexModelWithStemming());
+
+        Query query = new Query(QueryTestCase.httpEncode("/search?language=en"));
+        query.getModel().getQueryTree().setRoot(new PrefixItem("dropme", "default"));
+
+        executeStemming(query, linguistics, indexFacts);
+
+        assertEquals("default:dropme*", query.getModel().getQueryTree().toString());
     }
 
     @Test
@@ -253,6 +352,14 @@ public class StemmingSearcherTestCase {
 
     }
 
+    private IndexModel createDefaultIndexModelWithStemming() {
+        var schema = new SearchDefinition("test");
+        var index = new Index("default");
+        index.setStemMode("BEST");
+        schema.addIndex(index);
+        return new IndexModel(schema);
+    }
+
     private static Optional<WordItem> getFirstWord(Query query) {
         var item = query.getModel().getQueryTree().getRoot();
         if (item instanceof WeakAndItem weakAndItem) {
@@ -274,6 +381,11 @@ public class StemmingSearcherTestCase {
 
     private void executeStemming(Query query) {
         new Execution(new Chain<Searcher>(new StemmingSearcher(linguistics)), newExecutionContext()).search(query);
+    }
+
+    private void executeStemming(Query query, Linguistics linguistics, IndexFacts indexFacts) {
+        new Execution(new Chain<Searcher>(new StemmingSearcher(linguistics)),
+                      Execution.Context.createContextStub(indexFacts, linguistics)).search(query);
     }
 
     private void assertStemmed(String expectedQueryTree, String queryString) {
@@ -494,6 +606,37 @@ public class StemmingSearcherTestCase {
             @Override
             public List<StemList> stem(String input, LinguisticsParameters parameters) {
                 lastLinguisticsProfile = parameters.profile();
+                return super.stem(input, parameters);
+            }
+
+        }
+
+    }
+
+    private static class StopwordDroppingLinguistics extends SimpleLinguistics {
+
+        private final String stopword;
+
+        StopwordDroppingLinguistics(String stopword) {
+            this.stopword = stopword;
+        }
+
+        @Override
+        public Stemmer getStemmer() {
+            return new StopwordDroppingStemmer(getTokenizer());
+        }
+
+        private class StopwordDroppingStemmer extends StemmerImpl {
+
+            StopwordDroppingStemmer(Tokenizer tokenizer) {
+                super(tokenizer);
+            }
+
+            @Override
+            public List<StemList> stem(String input, LinguisticsParameters parameters) {
+                if (input.equalsIgnoreCase(stopword)) {
+                    return List.of(new StemList(""));
+                }
                 return super.stem(input, parameters);
             }
 


### PR DESCRIPTION
Implements issue #33540.

This PR handles empty-stem query terms in query-side stemming with a narrow scope.

Changes:
- Keep phrase and non-text operator behavior unchanged.
- Safely drop empty-stem terms only in query-side AND/WeakAND contexts when at least one sibling term remains.
- Do not allow the whole query to collapse to empty.
- Preserve connectivity-sensitive terms.

Regression tests added for:
- Query.And: drop empty-stem term when another term remains.
- Query.And: do not collapse to empty.
- userInput path: drop empty-stem term when safe.
- userInput path: do not collapse to empty.
- Phrase behavior unchanged.
- Non-text operator behavior unchanged.

Verification:
- mvn -pl container-search -Dtest=StemmingSearcherTestCase test
- mvn -pl container-search -Dtest=StemmingSearcherTestCase,WeakAndTestCase,StopwordTestCase test

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's 
source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.