### PR TITLE
Expose custom annotations on compound query items

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -1472,25 +1472,25 @@ public class YqlParser implements Parser {
         NotItem notItem = new NotItem();
         convertVarArgsAnd(ast, 0, andItem, notItem, currentField);
         if (notItem.getItemCount() == 0) {
-            return andItem;
+            return itemAnnotations(ast, andItem);
         }
         if (andItem.getItemCount() == 1) {
             notItem.setPositiveItem(andItem.getItem(0));
         } else if (andItem.getItemCount() > 1) {
             notItem.setPositiveItem(andItem);
         } // else no positives, which is ok
-        return notItem;
+        return itemAnnotations(ast, notItem);
     }
 
     /** Build a "pure" not, without any positive terms. */
     private CompositeItem buildNot(OperatorNode<ExpressionOperator> ast) {
         NotItem notItem = new NotItem();
         notItem.addNegativeItem(convertExpression(ast.getArgument(0), null));
-        return notItem;
+        return itemAnnotations(ast, notItem);
     }
 
     private CompositeItem buildOr(OperatorNode<ExpressionOperator> spec, String currentField) {
-        return convertVarArgs(spec, 0, new OrItem(), currentField);
+        return itemAnnotations(spec, convertVarArgs(spec, 0, new OrItem(), currentField));
     }
 
     private Integer buildTargetHits(OperatorNode<ExpressionOperator> spec) {
@@ -1504,11 +1504,11 @@ public class YqlParser implements Parser {
         WeakAndItem weakAnd = new WeakAndItem();
         weakAnd.setTargetHits(buildTargetHits(spec));
         weakAnd.setTotalTargetHits(getAnnotation(spec, TOTAL_TARGET_HITS, Integer.class, null, "total hits to produce across all nodes"));
-        return convertVarArgs(spec, 1, weakAnd, null);
+        return itemAnnotations(spec, convertVarArgs(spec, 1, weakAnd, null));
     }
 
     private CompositeItem buildRank(OperatorNode<ExpressionOperator> spec, String currentField) {
-        return convertVarArgs(spec, 1, new RankItem(), currentField);
+        return itemAnnotations(spec, convertVarArgs(spec, 1, new RankItem(), currentField));
     }
 
     private CompositeItem convertVarArgs(OperatorNode<ExpressionOperator> ast, int argIdx, CompositeItem out,
@@ -1988,7 +1988,7 @@ public class YqlParser implements Parser {
         wordStyleSettings(ast, wordItem);
     }
 
-    private <T extends Item> T nonTaggableLeafStyleSettings(OperatorNode<?> ast, T leaf) {
+    private <T extends Item> T itemAnnotations(OperatorNode<?> ast, T item) {
         Map<?, ?> itemAnnotations = getAnnotation(ast, ANNOTATIONS,
                                                   Map.class, Map.of(), "item annotation map");
         for (Map.Entry<?, ?> entry : itemAnnotations.entrySet()) {
@@ -1996,8 +1996,13 @@ public class YqlParser implements Parser {
                                         "Expected String annotation key, got %s.", entry.getKey().getClass());
             Preconditions.checkArgument(entry.getValue() instanceof String,
                                         "Expected String annotation value, got %s.", entry.getValue().getClass());
-            leaf.addAnnotation((String) entry.getKey(), entry.getValue());
+            item.addAnnotation((String) entry.getKey(), entry.getValue());
         }
+        return item;
+    }
+
+    private <T extends Item> T nonTaggableLeafStyleSettings(OperatorNode<?> ast, T leaf) {
+        itemAnnotations(ast, leaf);
         Boolean filter = getAnnotation(ast, FILTER, Boolean.class, null, FILTER_DESCRIPTION);
         if (filter != null) {
             leaf.setFilter(filter);

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -409,6 +409,20 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testCompoundItemAnnotations() {
+        assertEquals("and", parse("select foo from bar where ({annotations: {scope: \"and\"}}(a contains \"A\" and b contains \"B\"))")
+            .getRoot().getAnnotation("scope"));
+        assertEquals("not", parse("select foo from bar where ({annotations: {scope: \"not\"}}!(a contains \"A\"))")
+            .getRoot().getAnnotation("scope"));
+        assertEquals("or", parse("select foo from bar where ({annotations: {scope: \"or\"}}(a contains \"A\" or b contains \"B\"))")
+            .getRoot().getAnnotation("scope"));
+        assertEquals("rank", parse("select foo from bar where ({annotations: {scope: \"rank\"}}rank(a contains \"A\", b contains \"B\"))")
+            .getRoot().getAnnotation("scope"));
+        assertEquals("weakAnd", parse("select foo from bar where ({annotations: {scope: \"weakAnd\"}}weakAnd(a contains \"A\", b contains \"B\"))")
+            .getRoot().getAnnotation("scope"));
+    }
+
+    @Test
     void testAnnotationsCanBeInBrackets() {
         assertEquals("merkelapp",
                 getRootWord("select foo from bar where baz contains " +


### PR DESCRIPTION
Implements #35821.

This PR makes custom item annotations available on compound query items, not only leaf items.

Changes:
- Add parser support to attach annotations from the annotations map to compound roots created by:
  - and
  - or
  - not
  - rank
  - weakAnd
- Keep existing leaf-item annotation behavior unchanged.
- Add regression tests verifying annotation accessibility on those compound roots.

Verification:
- mvn -pl container-search -Dtest=YqlParserTestCase test
- mvn -pl container-search -Dtest=YqlParserTestCase,VespaSerializerTestCase test

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
