### PR TITLE
Add resource-tags support for enclave deployments

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -252,7 +252,7 @@
       "final"
     ],
     "methods" : [
-      "public void <init>(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Tags, java.util.List, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, com.yahoo.config.application.api.DeploymentSpec$RevisionTarget, com.yahoo.config.application.api.DeploymentSpec$RevisionChange, com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout, int, int, int, java.util.List, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.application.api.Notifications, java.util.List, java.util.Map, com.yahoo.config.application.api.Bcp, java.util.Optional, java.time.Instant)",
+      "public void <init>(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Tags, java.util.List, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, com.yahoo.config.application.api.DeploymentSpec$RevisionTarget, com.yahoo.config.application.api.DeploymentSpec$RevisionChange, com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout, int, int, int, java.util.List, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags, com.yahoo.config.application.api.Notifications, java.util.List, java.util.Map, com.yahoo.config.application.api.Bcp, java.util.Optional, java.time.Instant)",
       "public com.yahoo.config.provision.InstanceName name()",
       "public com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy upgradePolicy()",
       "public com.yahoo.config.application.api.DeploymentSpec$RevisionTarget revisionTarget()",
@@ -266,6 +266,8 @@
       "public boolean canChangeRevisionAt(java.time.Instant)",
       "public java.util.Optional athenzService(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public java.util.Map cloudAccounts(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
+      "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags()",
+      "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public java.util.Optional hostTTL(com.yahoo.config.provision.Environment, java.util.Optional)",
       "public com.yahoo.config.application.api.Notifications notifications()",
       "public java.util.List endpoints()",
@@ -353,7 +355,7 @@
     ],
     "methods" : [
       "public void <init>(com.yahoo.config.provision.Environment)",
-      "public void <init>(com.yahoo.config.provision.Environment, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Map, java.util.Optional)",
+      "public void <init>(com.yahoo.config.provision.Environment, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags)",
       "public com.yahoo.config.provision.Environment environment()",
       "public java.util.Optional region()",
       "public java.util.Optional testerNodes()",
@@ -402,7 +404,7 @@
       "public"
     ],
     "methods" : [
-      "public void <init>(java.util.Optional, java.util.Optional, java.util.Optional, com.yahoo.config.provision.Tags, java.util.Map)",
+      "public void <init>(java.util.Optional, java.util.Optional, java.util.Optional, com.yahoo.config.provision.Tags, com.yahoo.config.provision.CloudResourceTags, java.util.Map)",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",
       "public java.lang.String toString()"
@@ -544,7 +546,7 @@
       "final"
     ],
     "methods" : [
-      "public void <init>(java.util.List, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Map, java.util.Optional, java.util.List, java.lang.String, java.util.List, com.yahoo.config.application.api.DeploymentSpec$DevSpec)",
+      "public void <init>(java.util.List, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags, java.util.List, java.lang.String, java.util.List, com.yahoo.config.application.api.DeploymentSpec$DevSpec)",
       "public boolean isEmpty()",
       "public java.util.Optional majorVersion()",
       "public java.util.List steps()",
@@ -554,6 +556,8 @@
       "public java.util.Optional athenzService(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public com.yahoo.config.provision.CloudAccount cloudAccount(com.yahoo.config.provision.CloudName, com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.zone.ZoneId)",
       "public java.util.Map cloudAccounts()",
+      "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags()",
+      "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.zone.ZoneId)",
       "public com.yahoo.config.provision.Tags tags(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment)",
       "public java.util.Optional hostTTL(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public com.yahoo.config.provision.ZoneEndpoint zoneEndpoint(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Zone, com.yahoo.config.provision.ClusterSpec$Id, boolean)",
@@ -1495,6 +1499,7 @@
       "public java.util.List tlsCiphersOverride()",
       "public abstract java.util.List environmentVariables()",
       "public java.util.Optional cloudAccount()",
+      "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags()",
       "public boolean allowUserFilters()",
       "public java.time.Duration endpointConnectionTtl()",
       "public java.util.List dataplaneTokens()",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
@@ -4,6 +4,7 @@ package com.yahoo.config.application.api;
 import com.yahoo.config.provision.AthenzService;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
@@ -60,6 +61,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
     private final Optional<AthenzService> athenzService;
     private final Map<CloudName, CloudAccount> cloudAccounts;
     private final Optional<Duration> hostTTL;
+    private final CloudResourceTags cloudResourceTags;
     private final Notifications notifications;
     private final List<Endpoint> endpoints;
     private final Map<ClusterSpec.Id, Map<ZoneId, ZoneEndpoint>> zoneEndpoints;
@@ -78,6 +80,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
                                   Optional<AthenzService> athenzService,
                                   Map<CloudName, CloudAccount> cloudAccounts,
                                   Optional<Duration> hostTTL,
+                                  CloudResourceTags cloudResourceTags,
                                   Notifications notifications,
                                   List<Endpoint> endpoints,
                                   Map<ClusterSpec.Id, Map<ZoneId, ZoneEndpoint>> zoneEndpoints,
@@ -102,6 +105,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
         this.athenzService = Objects.requireNonNull(athenzService);
         this.cloudAccounts = Map.copyOf(cloudAccounts);
         this.hostTTL = Objects.requireNonNull(hostTTL);
+        this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
         this.notifications = Objects.requireNonNull(notifications);
         this.endpoints = List.copyOf(Objects.requireNonNull(endpoints));
         Map<ClusterSpec.Id, Map<ZoneId, ZoneEndpoint>> zoneEndpointsCopy =  new HashMap<>();
@@ -266,6 +270,19 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
                       .findFirst()
                       .map(DeploymentSpec.DeclaredZone::cloudAccounts)
                       .orElse(cloudAccounts);
+    }
+
+    /** Returns the cloud resource tags for this instance. */
+    public CloudResourceTags cloudResourceTags() { return cloudResourceTags; }
+
+    /** Returns the cloud resource tags for the given environment and region, merged with zone-specific tags. */
+    public CloudResourceTags cloudResourceTags(Environment environment, RegionName region) {
+        CloudResourceTags zoneTags = zones().stream()
+                                            .filter(zone -> zone.concerns(environment, Optional.of(region)))
+                                            .findFirst()
+                                            .map(DeploymentSpec.DeclaredZone::cloudResourceTags)
+                                            .orElse(CloudResourceTags.empty());
+        return cloudResourceTags.mergedWith(zoneTags);
     }
 
     /** Returns the host TTL to use for given environment and region, if any */

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.config.provision.AthenzService;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
@@ -54,6 +55,7 @@ public final class DeploymentSpec {
                                                                   Optional.empty(),
                                                                   Map.of(),
                                                                   Optional.empty(),
+                                                                  CloudResourceTags.empty(),
                                                                   List.of(),
                                                                   "<deployment version='1.0'/>",
                                                                   List.of(),
@@ -67,6 +69,7 @@ public final class DeploymentSpec {
     private final Optional<AthenzService> athenzService;
     private final Map<CloudName, CloudAccount> cloudAccounts;
     private final Optional<Duration> hostTTL;
+    private final CloudResourceTags cloudResourceTags;
     private final List<Endpoint> endpoints;
     private final List<DeprecatedElement> deprecatedElements;
     private final DevSpec devSpec;
@@ -79,6 +82,7 @@ public final class DeploymentSpec {
                           Optional<AthenzService> athenzService,
                           Map<CloudName, CloudAccount> cloudAccounts,
                           Optional<Duration> hostTTL,
+                          CloudResourceTags cloudResourceTags,
                           List<Endpoint> endpoints,
                           String xmlForm,
                           List<DeprecatedElement> deprecatedElements,
@@ -89,6 +93,7 @@ public final class DeploymentSpec {
         this.athenzService = Objects.requireNonNull(athenzService);
         this.cloudAccounts = Map.copyOf(cloudAccounts);
         this.hostTTL = Objects.requireNonNull(hostTTL);
+        this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
         this.xmlForm = Objects.requireNonNull(xmlForm);
         this.endpoints = List.copyOf(Objects.requireNonNull(endpoints));
         this.deprecatedElements = List.copyOf(Objects.requireNonNull(deprecatedElements));
@@ -221,6 +226,18 @@ public final class DeploymentSpec {
     }
 
     public Map<CloudName, CloudAccount> cloudAccounts() { return cloudAccounts; }
+
+    /** Returns the cloud resource tags set on the root tag. */
+    public CloudResourceTags cloudResourceTags() { return cloudResourceTags; }
+
+    /** Returns cloud resource tags merged from root, instance, and zone levels. More specific levels take precedence. */
+    public CloudResourceTags cloudResourceTags(InstanceName instance, ZoneId zone) {
+        CloudResourceTags specificTags = zone.environment().isManuallyDeployed()
+                ? devSpec.cloudResourceTags
+                : instance(instance).map(spec -> spec.cloudResourceTags(zone.environment(), zone.region()))
+                                    .orElse(CloudResourceTags.empty());
+        return cloudResourceTags.mergedWith(specificTags);
+    }
 
     public Tags tags(InstanceName instance, Environment environment) {
         return environment.isManuallyDeployed() ? devSpec.tags
@@ -494,13 +511,15 @@ public final class DeploymentSpec {
         private final Optional<String> testerNodes;
         private final Map<CloudName, CloudAccount> cloudAccounts;
         private final Optional<Duration> hostTTL;
+        private final CloudResourceTags cloudResourceTags;
 
         public DeclaredZone(Environment environment) {
-            this(environment, Optional.empty(), Optional.empty(), Optional.empty(), Map.of(), Optional.empty());
+            this(environment, Optional.empty(), Optional.empty(), Optional.empty(), Map.of(), Optional.empty(), CloudResourceTags.empty());
         }
 
         public DeclaredZone(Environment environment, Optional<RegionName> region, Optional<AthenzService> athenzService,
-                            Optional<String> testerNodes, Map<CloudName, CloudAccount> cloudAccounts, Optional<Duration> hostTTL) {
+                            Optional<String> testerNodes, Map<CloudName, CloudAccount> cloudAccounts, Optional<Duration> hostTTL,
+                            CloudResourceTags cloudResourceTags) {
             if (environment != Environment.prod && region.isPresent())
                 illegal("Non-prod environments cannot specify a region");
             if (environment == Environment.prod && region.isEmpty())
@@ -512,6 +531,7 @@ public final class DeploymentSpec {
             this.testerNodes = Objects.requireNonNull(testerNodes);
             this.cloudAccounts = Map.copyOf(cloudAccounts);
             this.hostTTL = Objects.requireNonNull(hostTTL);
+            this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
         }
 
         public Environment environment() { return environment; }
@@ -525,6 +545,8 @@ public final class DeploymentSpec {
         Optional<AthenzService> athenzService() { return athenzService; }
 
         Map<CloudName, CloudAccount> cloudAccounts() { return cloudAccounts; }
+
+        CloudResourceTags cloudResourceTags() { return cloudResourceTags; }
 
         @Override
         public List<DeclaredZone> zones() { return List.of(this); }
@@ -844,23 +866,26 @@ public final class DeploymentSpec {
 
     public static class DevSpec {
 
-        public static final DevSpec empty = new DevSpec(Optional.empty(), Optional.empty(), Optional.empty(), Tags.empty(), Map.of());
+        public static final DevSpec empty = new DevSpec(Optional.empty(), Optional.empty(), Optional.empty(), Tags.empty(), CloudResourceTags.empty(), Map.of());
 
         private final Optional<AthenzService> athenzService;
         private final Optional<Map<CloudName, CloudAccount>> cloudAccounts;
         private final Optional<Duration> hostTTL;
         private final Tags tags;
+        private final CloudResourceTags cloudResourceTags;
         private final Map<ClusterSpec.Id, ZoneEndpoint> zoneEndpoints;
 
         public DevSpec(Optional<AthenzService> athenzService,
                        Optional<Map<CloudName, CloudAccount>> cloudAccounts,
                        Optional<Duration> hostTTL,
                        Tags tags,
+                       CloudResourceTags cloudResourceTags,
                        Map<ClusterSpec.Id, ZoneEndpoint> zoneEndpoints) {
             this.athenzService = Objects.requireNonNull(athenzService);
             this.cloudAccounts = cloudAccounts.map(Map::copyOf);
             this.hostTTL = Objects.requireNonNull(hostTTL);
             this.tags = Objects.requireNonNull(tags);
+            this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
             this.zoneEndpoints = Map.copyOf(zoneEndpoints);
         }
 
@@ -869,12 +894,12 @@ public final class DeploymentSpec {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             DevSpec devSpec = (DevSpec) o;
-            return Objects.equals(athenzService, devSpec.athenzService) && Objects.equals(cloudAccounts, devSpec.cloudAccounts) && Objects.equals(hostTTL, devSpec.hostTTL) && Objects.equals(tags, devSpec.tags) && Objects.equals(zoneEndpoints, devSpec.zoneEndpoints);
+            return Objects.equals(athenzService, devSpec.athenzService) && Objects.equals(cloudAccounts, devSpec.cloudAccounts) && Objects.equals(hostTTL, devSpec.hostTTL) && Objects.equals(tags, devSpec.tags) && Objects.equals(cloudResourceTags, devSpec.cloudResourceTags) && Objects.equals(zoneEndpoints, devSpec.zoneEndpoints);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(athenzService, cloudAccounts, hostTTL, tags, zoneEndpoints);
+            return Objects.hash(athenzService, cloudAccounts, hostTTL, tags, cloudResourceTags, zoneEndpoints);
         }
 
         @Override
@@ -884,6 +909,7 @@ public final class DeploymentSpec {
             cloudAccounts.ifPresent(cas -> joiner.add(cas.entrySet().stream().map(ca -> ca.getKey() + ": " + ca.getValue()).collect(joining(", ", "cloud accounts: ", ""))));
             hostTTL.ifPresent(ttl -> joiner.add("host-ttl: " + ttl));
             if ( ! tags.isEmpty()) joiner.add("tags: " + tags);
+            if ( ! cloudResourceTags.isEmpty()) joiner.add("resource-tags: " + cloudResourceTags);
             if ( ! zoneEndpoints.isEmpty()) joiner.add("endpoint settings for clusters: " + zoneEndpoints.keySet().stream().map(ClusterSpec.Id::value).collect(joining(", ")));
             return joiner.toString();
         }

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -27,6 +27,7 @@ import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.config.provision.AthenzService;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
@@ -98,6 +99,7 @@ public class DeploymentSpecXmlReader {
     private static final String majorVersionAttribute = "major-version";
     private static final String cloudAccountAttribute = "cloud-account";
     private static final String hostTTLAttribute = "empty-host-ttl";
+    private static final String cloudResourceTagsTag = "resource-tags";
 
     private final boolean validate;
     private final Clock clock;
@@ -171,6 +173,7 @@ public class DeploymentSpecXmlReader {
                                   stringAttribute(athenzServiceAttribute, root).map(AthenzService::from),
                                   readCloudAccounts(root),
                                   readHostTTL(root),
+                                  readCloudResourceTags(root),
                                   applicationEndpoints,
                                   xmlForm,
                                   deprecatedElements,
@@ -213,6 +216,7 @@ public class DeploymentSpecXmlReader {
         Optional<AthenzService> athenzService = mostSpecificAttribute(instanceElement, athenzServiceAttribute).map(AthenzService::from);
         Map<CloudName, CloudAccount> cloudAccounts = readCloudAccounts(instanceElement);
         Optional<Duration> hostTTL = readHostTTL(instanceElement);
+        CloudResourceTags cloudResourceTags = readCloudResourceTags(instanceElement);
         Notifications notifications = readNotifications(instanceElement, parentTag);
 
         // Values where there is no default
@@ -242,6 +246,7 @@ public class DeploymentSpecXmlReader {
                                                              athenzService,
                                                              cloudAccounts,
                                                              hostTTL,
+                                                             cloudResourceTags,
                                                              notifications,
                                                              endpoints,
                                                              zoneEndpoints,
@@ -280,7 +285,7 @@ public class DeploymentSpecXmlReader {
                     return List.of(new DeclaredTest(RegionName.from(XML.getValue(stepTag).trim()), readHostTTL(stepTag))); // A production test
                 }
             case stagingTag: // Intentional fallthrough from test tag.
-                return List.of(new DeclaredZone(Environment.from(stepTag.getTagName()), Optional.empty(), athenzService, testerNodes, readCloudAccounts(stepTag), readHostTTL(stepTag)));
+                return List.of(new DeclaredZone(Environment.from(stepTag.getTagName()), Optional.empty(), athenzService, testerNodes, readCloudAccounts(stepTag), readHostTTL(stepTag), readCloudResourceTags(stepTag)));
             case prodTag: // regions, delay and parallel may be nested within, but we can flatten them
                 return XML.getChildren(stepTag).stream()
                                                .flatMap(child -> readNonInstanceSteps(child, prodAttributes, stepTag, defaultBcp).stream())
@@ -714,7 +719,7 @@ public class DeploymentSpecXmlReader {
                                           Optional<String> testerNodes, Element regionTag) {
         return new DeclaredZone(environment, Optional.of(RegionName.from(XML.getValue(regionTag).trim())),
                                 athenzService, testerNodes,
-                                readCloudAccounts(regionTag), readHostTTL(regionTag));
+                                readCloudAccounts(regionTag), readHostTTL(regionTag), readCloudResourceTags(regionTag));
     }
 
     private Map<CloudName, CloudAccount> readCloudAccounts(Element tag) {
@@ -735,6 +740,20 @@ public class DeploymentSpecXmlReader {
 
     private Optional<Duration> readHostTTL(Element tag) {
         return mostSpecificAttribute(tag, hostTTLAttribute).map(s -> toDuration(s, "empty host TTL"));
+    }
+
+    private CloudResourceTags readCloudResourceTags(Element tag) {
+        return mostSpecificSibling(tag, cloudResourceTagsTag)
+                .map(element -> {
+                    Map<String, String> tags = new LinkedHashMap<>();
+                    for (Element tagChild : XML.getChildren(element, "tag")) {
+                        String key = requireStringAttribute("key", tagChild);
+                        String value = tagChild.hasAttribute("value") ? tagChild.getAttribute("value") : "";
+                        tags.put(key, value);
+                    }
+                    return CloudResourceTags.from(tags);
+                })
+                .orElse(CloudResourceTags.empty());
     }
 
     private List<DeploymentSpec.ChangeBlocker> readChangeBlockers(Element parent, Element globalBlockersParent) {
@@ -854,6 +873,7 @@ public class DeploymentSpecXmlReader {
         Map<CloudName, CloudAccount> cloudAccounts = readCloudAccounts(devElement);
         Optional<Duration> hostTTL = XML.attribute(hostTTLAttribute, devElement).map(s -> toDuration(s, "host TTL"));
         Tags tags = XML.attribute(tagsTag, devElement).map(Tags::fromString).orElse(Tags.empty());
+        CloudResourceTags cloudResourceTags = readCloudResourceTags(devElement);
 
         Map<ClusterSpec.Id, ZoneEndpoint> endpoints = new LinkedHashMap<>();
         Element endpointsElement = XML.getChild(devElement, endpointsTag);
@@ -862,7 +882,7 @@ public class DeploymentSpecXmlReader {
                 readDevZoneEndpoint(endpointElement, endpoints);
             }
         }
-        return new DevSpec(athenzService, Optional.of(cloudAccounts), hostTTL, tags, endpoints);
+        return new DevSpec(athenzService, Optional.of(cloudAccounts), hostTTL, tags, cloudResourceTags, endpoints);
     }
 
     // TODO: if the other readEndpoints is ever refactored, factor in this, too.

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -8,6 +8,7 @@ import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.config.provision.CloudAccount;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DataplaneToken;
 import com.yahoo.config.provision.DockerImage;
@@ -185,6 +186,8 @@ public interface ModelContext {
         List<String> environmentVariables();
 
         default Optional<CloudAccount> cloudAccount() { return Optional.empty(); }
+
+        default CloudResourceTags cloudResourceTags() { return CloudResourceTags.empty(); }
 
         default boolean allowUserFilters() { return true; }
 

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -7,6 +7,7 @@ import com.yahoo.config.application.api.Endpoint.Target;
 import com.yahoo.config.application.api.xml.DeploymentSpecXmlReader;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
@@ -2102,6 +2103,154 @@ public class DeploymentSpecTest {
     private void assertCloudAccount(String expected, DeploymentSpec spec, CloudName cloud, String instance, Environment environment, String region) {
         assertEquals(CloudAccount.from(expected),
                      spec.cloudAccount(cloud, InstanceName.from(instance), com.yahoo.config.provision.zone.ZoneId.from(environment, RegionName.from(region))));
+    }
+
+    @Test
+    public void cloudResourceTags() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <resource-tags>
+                        <tag key='env' value='production'/>
+                        <tag key='team' value='search'/>
+                    </resource-tags>
+                    <instance id='alpha'>
+                        <resource-tags>
+                            <tag key='team' value='alpha-team'/>
+                            <tag key='cost-center' value='123'/>
+                        </resource-tags>
+                        <prod>
+                            <region>us-east-1</region>
+                            <region>us-west-1</region>
+                        </prod>
+                    </instance>
+                    <instance id='beta'>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                    <instance id='gamma'>
+                        <resource-tags>
+                            <tag key='team' value='gamma-team'/>
+                        </resource-tags>
+                        <staging/>
+                        <prod>
+                            <region>eu-west-1</region>
+                        </prod>
+                    </instance>
+                    <dev>
+                        <resource-tags>
+                            <tag key='env' value='dev'/>
+                            <tag key='dev-owner' value='tester'/>
+                        </resource-tags>
+                    </dev>
+                </deployment>
+                """;
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+
+        // Root-level tags
+        assertEquals(CloudResourceTags.from(Map.of("env", "production", "team", "search")),
+                     spec.cloudResourceTags());
+
+        // Alpha instance: root tags merged with instance tags (instance overrides root)
+        assertCloudResourceTags(Map.of("env", "production", "team", "alpha-team", "cost-center", "123"),
+                                spec, "alpha", prod, "us-east-1");
+        assertCloudResourceTags(Map.of("env", "production", "team", "alpha-team", "cost-center", "123"),
+                                spec, "alpha", prod, "us-west-1");
+
+        // Beta instance: only root tags (no instance-level override)
+        assertCloudResourceTags(Map.of("env", "production", "team", "search"),
+                                spec, "beta", prod, "us-east-1");
+
+        // Gamma instance: root merged with instance tags
+        assertCloudResourceTags(Map.of("env", "production", "team", "gamma-team"),
+                                spec, "gamma", prod, "eu-west-1");
+        assertCloudResourceTags(Map.of("env", "production", "team", "gamma-team"),
+                                spec, "gamma", staging, "default");
+
+        // Dev environment uses DevSpec tags merged with root
+        assertCloudResourceTags(Map.of("env", "dev", "team", "search", "dev-owner", "tester"),
+                                spec, "alpha", dev, "default");
+        assertCloudResourceTags(Map.of("env", "dev", "team", "search", "dev-owner", "tester"),
+                                spec, "beta", dev, "default");
+
+        // Unknown instance in dev still uses dev tags merged with root
+        assertCloudResourceTags(Map.of("env", "dev", "team", "search", "dev-owner", "tester"),
+                                spec, "unknown", dev, "default");
+    }
+
+    @Test
+    public void cloudResourceTagsWithZoneLevelOverride() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <resource-tags>
+                        <tag key='env' value='production'/>
+                    </resource-tags>
+                    <instance id='default'>
+                        <resource-tags>
+                            <tag key='team' value='my-team'/>
+                        </resource-tags>
+                        <staging>
+                            <resource-tags>
+                                <tag key='env' value='staging'/>
+                                <tag key='staging-only' value='true'/>
+                            </resource-tags>
+                        </staging>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                </deployment>
+                """;
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+
+        // Staging zone: root + instance + zone-level tags (zone overrides instance and root)
+        assertCloudResourceTags(Map.of("env", "staging", "team", "my-team", "staging-only", "true"),
+                                spec, "default", staging, "default");
+
+        // Prod region: root + instance tags only
+        assertCloudResourceTags(Map.of("env", "production", "team", "my-team"),
+                                spec, "default", prod, "us-east-1");
+    }
+
+    @Test
+    public void cloudResourceTagsEmpty() {
+        String r = "<deployment version='1.0'><instance id='default'><prod><region>us-east-1</region></prod></instance></deployment>";
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        assertTrue(spec.cloudResourceTags().isEmpty());
+        assertTrue(spec.cloudResourceTags(InstanceName.from("default"),
+                                          com.yahoo.config.provision.zone.ZoneId.from(prod, RegionName.from("us-east-1"))).isEmpty());
+    }
+
+    @Test
+    public void cloudResourceTagsWithEmptyValue() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <resource-tags>
+                        <tag key='marker' value=''/>
+                        <tag key='no-value'/>
+                    </resource-tags>
+                    <instance id='default'>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                </deployment>
+                """;
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        Map<String, String> tags = spec.cloudResourceTags(InstanceName.from("default"),
+                                                          com.yahoo.config.provision.zone.ZoneId.from(prod, RegionName.from("us-east-1"))).asMap();
+        assertEquals("", tags.get("marker"));
+        assertEquals("", tags.get("no-value"));
+    }
+
+    private void assertCloudResourceTags(Map<String, String> expected, DeploymentSpec spec,
+                                          String instance, Environment environment, String region) {
+        assertEquals(CloudResourceTags.from(expected),
+                     spec.cloudResourceTags(InstanceName.from(instance),
+                                            com.yahoo.config.provision.zone.ZoneId.from(environment, RegionName.from(region))));
     }
 
     private void assertHostTTL(Duration expected, DeploymentSpec spec, String instance, Environment environment, String region) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
@@ -7,6 +7,7 @@ import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.CloudAccount;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterInfo;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterResources;
@@ -60,6 +61,9 @@ public class NodesSpecification {
     /** The cloud account to use for nodes in this spec, if any */
     private final Optional<CloudAccount> cloudAccount;
 
+    /** The cloud resource tags to apply to nodes in this spec */
+    private final CloudResourceTags cloudResourceTags;
+
     /* Whether the count attribute was present on the nodes element. */
     private final boolean hasCountAttribute;
 
@@ -70,6 +74,7 @@ public class NodesSpecification {
                                boolean required, boolean canFail, boolean exclusive,
                                Optional<DockerImage> dockerImageRepo,
                                Optional<CloudAccount> cloudAccount,
+                               CloudResourceTags cloudResourceTags,
                                boolean hasCountAttribute) {
         if (max.smallerThan(min))
             throw new IllegalArgumentException("Max resources must be larger or equal to min resources, but " +
@@ -95,12 +100,14 @@ public class NodesSpecification {
         this.exclusive = exclusive;
         this.dockerImageRepo = dockerImageRepo;
         this.cloudAccount = cloudAccount;
+        this.cloudResourceTags = cloudResourceTags;
         this.hasCountAttribute = hasCountAttribute;
     }
 
     static NodesSpecification create(boolean dedicated, boolean canFail, Version version,
                                      ModelElement nodesElement, Optional<DockerImage> dockerImageRepo,
-                                     Optional<CloudAccount> cloudAccount) {
+                                     Optional<CloudAccount> cloudAccount,
+                                     CloudResourceTags cloudResourceTags) {
         var resolvedElement = resolveElement(nodesElement);
         var resourceConstraints = toResourceConstraints(resolvedElement);
         boolean hasCountAttribute = resolvedElement.stringAttribute("count") != null;
@@ -114,6 +121,7 @@ public class NodesSpecification {
                                       resolvedElement.booleanAttribute("exclusive", false),
                                       dockerImageToUse(resolvedElement, dockerImageRepo),
                                       cloudAccount,
+                                      cloudResourceTags,
                                       hasCountAttribute);
     }
 
@@ -161,7 +169,8 @@ public class NodesSpecification {
                       context.getDeployState().getWantedNodeVespaVersion(),
                       nodesElement,
                       context.getDeployState().getWantedDockerImageRepo(),
-                      context.getDeployState().getProperties().cloudAccount());
+                      context.getDeployState().getProperties().cloudAccount(),
+                      context.getDeployState().getProperties().cloudResourceTags());
     }
 
     /**
@@ -179,7 +188,8 @@ public class NodesSpecification {
                                   context.getDeployState().getWantedNodeVespaVersion(),
                                   nodesElement,
                                   context.getDeployState().getWantedDockerImageRepo(),
-                                  context.getDeployState().getProperties().cloudAccount()));
+                                  context.getDeployState().getProperties().cloudAccount(),
+                                  context.getDeployState().getProperties().cloudResourceTags()));
     }
 
     /**
@@ -196,6 +206,7 @@ public class NodesSpecification {
                                       false,
                                       context.getDeployState().getWantedDockerImageRepo(),
                                       context.getDeployState().getProperties().cloudAccount(),
+                                      context.getDeployState().getProperties().cloudResourceTags(),
                                       false);
     }
 
@@ -211,6 +222,7 @@ public class NodesSpecification {
                                       false,
                                       context.getDeployState().getWantedDockerImageRepo(),
                                       context.getDeployState().getProperties().cloudAccount(),
+                                      context.getDeployState().getProperties().cloudResourceTags(),
                                       false);
     }
 
@@ -237,6 +249,7 @@ public class NodesSpecification {
                                       false,
                                       context.getDeployState().getWantedDockerImageRepo(),
                                       context.getDeployState().getProperties().cloudAccount(),
+                                      context.getDeployState().getProperties().cloudResourceTags(),
                                       false);
     }
 
@@ -288,7 +301,7 @@ public class NodesSpecification {
                 .sidecars(sidecars)
                 .build();
 
-        return hostSystem.allocateHosts(cluster, Capacity.from(min, max, groupSize, required, canFail, cloudAccount, info), logger);
+        return hostSystem.allocateHosts(cluster, Capacity.from(min, max, groupSize, required, canFail, cloudAccount, cloudResourceTags, info), logger);
     }
 
     private static Pair<NodeResources, NodeResources> nodeResources(ModelElement nodesElement) {

--- a/config-model/src/main/resources/schema/deployment.rnc
+++ b/config-model/src/main/resources/schema/deployment.rnc
@@ -11,6 +11,7 @@ start = element deployment {
    attribute athenz-service { xsd:string }? &
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
+   CloudResourceTags? &
    Step &
    Dev?
 }
@@ -43,6 +44,7 @@ Instance = element instance {
    attribute athenz-service { xsd:string }? &
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
+   CloudResourceTags? &
    StepExceptInstance
 }
 
@@ -106,6 +108,7 @@ Test = element test {
    attribute athenz-service { xsd:string }? &
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
+   CloudResourceTags? &
    Tester?
 }
 
@@ -113,6 +116,7 @@ Staging = element staging {
    attribute athenz-service { xsd:string }? &
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
+   CloudResourceTags? &
    Tester?
 }
 
@@ -121,6 +125,7 @@ Dev = element dev {
    attribute empty-host-ttl { xsd:string }? &
    attribute athenz-service { xsd:string }? &
    attribute tags { xsd:string }? &
+   CloudResourceTags? &
    Endpoints?
 }
 
@@ -128,6 +133,7 @@ Prod = element prod {
    attribute athenz-service { xsd:string }? &
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
+   CloudResourceTags? &
    Region* &
    Delay* &
    ProdTest* &
@@ -145,6 +151,7 @@ Region = element region {
    attribute athenz-service { xsd:string }? &
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
+   CloudResourceTags? &
    text
 }
 
@@ -200,6 +207,15 @@ Group = element group {
 MemberRegion = element region {
     attribute fraction { xsd:double }? &
     text
+}
+
+CloudResourceTags = element resource-tags {
+    CloudResourceTag*
+}
+
+CloudResourceTag = element tag {
+    attribute key { xsd:string } &
+    attribute value { xsd:string }
 }
 
 Tester = element tester {

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecificationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecificationTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom;
 
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.NodeResources.Architecture;
 import com.yahoo.config.provision.NodeResources.DiskSpeed;
 import com.yahoo.config.provision.NodeResources.StorageType;
@@ -228,7 +229,8 @@ public class NodesSpecificationTest {
         Document nodesXml = XML.getDocument(nodesElement);
         return NodesSpecification.create(false, false, Version.emptyVersion,
                                          new ModelElement(nodesXml.getDocumentElement()),
-                                         Optional.empty(), Optional.empty());
+                                         Optional.empty(), Optional.empty(),
+                                         CloudResourceTags.empty());
 
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Capacity.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Capacity.java
@@ -5,6 +5,8 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A capacity request.
  *
@@ -20,6 +22,7 @@ public final class Capacity {
     private final boolean canFail;
     private final NodeType type;
     private final Optional<CloudAccount> cloudAccount;
+    private final CloudResourceTags cloudResourceTags;
     private final ClusterInfo clusterInfo;
 
     private Capacity(ClusterResources min,
@@ -29,6 +32,7 @@ public final class Capacity {
                      boolean canFail,
                      NodeType type,
                      Optional<CloudAccount> cloudAccount,
+                     CloudResourceTags cloudResourceTags,
                      ClusterInfo clusterInfo) {
         validate(min);
         validate(max);
@@ -44,6 +48,7 @@ public final class Capacity {
         this.canFail = canFail;
         this.type = type;
         this.cloudAccount = Objects.requireNonNull(cloudAccount);
+        this.cloudResourceTags = requireNonNull(cloudResourceTags);
         this.clusterInfo = clusterInfo;
     }
 
@@ -80,6 +85,11 @@ public final class Capacity {
         return cloudAccount;
     }
 
+    /** Returns the cloud resource tags for this capacity */
+    public CloudResourceTags cloudResourceTags() {
+        return cloudResourceTags;
+    }
+
     public ClusterInfo clusterInfo() { return clusterInfo; }
 
     public Capacity withLimits(ClusterResources min, ClusterResources max) {
@@ -87,7 +97,7 @@ public final class Capacity {
     }
 
     public Capacity withLimits(ClusterResources min, ClusterResources max, IntRange groupSize) {
-        return new Capacity(min, max, groupSize, required, canFail, type, cloudAccount, clusterInfo);
+        return new Capacity(min, max, groupSize, required, canFail, type, cloudAccount, cloudResourceTags, clusterInfo);
     }
 
     @Override
@@ -107,7 +117,7 @@ public final class Capacity {
     }
 
     public static Capacity from(ClusterResources min, ClusterResources max, IntRange groupSize) {
-        return from(min, max, groupSize, false, true, Optional.empty(), ClusterInfo.empty());
+        return from(min, max, groupSize, false, true, Optional.empty(), CloudResourceTags.empty(), ClusterInfo.empty());
     }
 
     public static Capacity from(ClusterResources resources, boolean required, boolean canFail) {
@@ -120,7 +130,13 @@ public final class Capacity {
 
     public static Capacity from(ClusterResources min, ClusterResources max, IntRange groupSize, boolean required, boolean canFail,
                                 Optional<CloudAccount> cloudAccount, ClusterInfo clusterInfo) {
-        return new Capacity(min, max, groupSize, required, canFail, NodeType.tenant, cloudAccount, clusterInfo);
+        return from(min, max, groupSize, required, canFail, cloudAccount, CloudResourceTags.empty(), clusterInfo);
+    }
+
+    public static Capacity from(ClusterResources min, ClusterResources max, IntRange groupSize, boolean required, boolean canFail,
+                                Optional<CloudAccount> cloudAccount, CloudResourceTags cloudResourceTags,
+                                ClusterInfo clusterInfo) {
+        return new Capacity(min, max, groupSize, required, canFail, NodeType.tenant, cloudAccount, cloudResourceTags, clusterInfo);
     }
 
     /** Creates this from a node type */
@@ -129,7 +145,7 @@ public final class Capacity {
     }
 
     private static Capacity from(ClusterResources resources, boolean required, boolean canFail, NodeType type, Duration hostTTL) {
-        return new Capacity(resources, resources, IntRange.empty(), required, canFail, type, Optional.empty(), new ClusterInfo.Builder().hostTTL(hostTTL).build());
+        return new Capacity(resources, resources, IntRange.empty(), required, canFail, type, Optional.empty(), CloudResourceTags.empty(), new ClusterInfo.Builder().hostTTL(hostTTL).build());
     }
 
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -1,0 +1,88 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable key-value tags to apply to cloud resources in custom enclave deployments.
+ * These tags are propagated to the underlying cloud provider (AWS, GCP, Azure) and
+ * applied to infrastructure resources provisioned for the enclave.
+ *
+ * @author gjoranv
+ */
+public class CloudResourceTags {
+
+    private static final CloudResourceTags EMPTY = new CloudResourceTags(Map.of());
+
+    private static final int MAX_KEY_LENGTH = 128;
+    private static final int MAX_VALUE_LENGTH = 256;
+    private static final int MAX_TAGS = 50;
+
+    private final Map<String, String> tags;
+
+    private CloudResourceTags(Map<String, String> tags) {
+        this.tags = Map.copyOf(tags);
+    }
+
+    /** Returns the tags as an unmodifiable map. */
+    public Map<String, String> asMap() { return tags; }
+
+    public boolean isEmpty() { return tags.isEmpty(); }
+
+    public int size() { return tags.size(); }
+
+    /**
+     * Returns a new instance with the given tags merged into this.
+     * Tags from {@code other} take precedence on key conflicts.
+     */
+    public CloudResourceTags mergedWith(CloudResourceTags other) {
+        if (other.isEmpty()) return this;
+        if (this.isEmpty()) return other;
+        var merged = new LinkedHashMap<>(this.tags);
+        merged.putAll(other.tags);
+        return from(merged);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return tags.equals(((CloudResourceTags) o).tags);
+    }
+
+    @Override
+    public int hashCode() { return tags.hashCode(); }
+
+    @Override
+    public String toString() { return tags.toString(); }
+
+    public static CloudResourceTags empty() { return EMPTY; }
+
+    /** Creates a new instance from the given map, validating keys and values. */
+    public static CloudResourceTags from(Map<String, String> tags) {
+        if (tags.isEmpty()) return EMPTY;
+        validate(tags);
+        return new CloudResourceTags(tags);
+    }
+
+    private static void validate(Map<String, String> tags) {
+        if (tags.size() > MAX_TAGS)
+            throw new IllegalArgumentException("Too many cloud resource tags (" + tags.size() +
+                                               "): maximum is " + MAX_TAGS);
+        tags.forEach((key, value) -> {
+            Objects.requireNonNull(key, "Tag key cannot be null");
+            Objects.requireNonNull(value, "Tag value cannot be null");
+            if (key.isEmpty())
+                throw new IllegalArgumentException("Tag key cannot be empty");
+            if (key.length() > MAX_KEY_LENGTH)
+                throw new IllegalArgumentException("Tag key exceeds " + MAX_KEY_LENGTH +
+                                                   " characters: '" + key + "'");
+            if (value.length() > MAX_VALUE_LENGTH)
+                throw new IllegalArgumentException("Tag value exceeds " + MAX_VALUE_LENGTH +
+                                                   " characters for key '" + key + "'");
+        });
+    }
+
+}

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -1,0 +1,127 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author gjoranv
+ */
+class CloudResourceTagsTest {
+
+    @Test
+    void empty_tags() {
+        CloudResourceTags tags = CloudResourceTags.empty();
+        assertTrue(tags.isEmpty());
+        assertEquals(0, tags.size());
+        assertEquals(Map.of(), tags.asMap());
+    }
+
+    @Test
+    void from_empty_map_returns_empty() {
+        assertEquals(CloudResourceTags.empty(), CloudResourceTags.from(Map.of()));
+    }
+
+    @Test
+    void basic_construction() {
+        var tags = CloudResourceTags.from(Map.of("env", "prod", "team", "search"));
+        assertFalse(tags.isEmpty());
+        assertEquals(2, tags.size());
+        assertEquals("prod", tags.asMap().get("env"));
+        assertEquals("search", tags.asMap().get("team"));
+    }
+
+    @Test
+    void map_is_unmodifiable() {
+        var tags = CloudResourceTags.from(Map.of("key", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> tags.asMap().put("new", "entry"));
+    }
+
+    @Test
+    void equals_and_hashcode() {
+        var tags1 = CloudResourceTags.from(Map.of("a", "1", "b", "2"));
+        var tags2 = CloudResourceTags.from(Map.of("b", "2", "a", "1"));
+        assertEquals(tags1, tags2);
+        assertEquals(tags1.hashCode(), tags2.hashCode());
+
+        var tags3 = CloudResourceTags.from(Map.of("a", "1", "b", "3"));
+        assertNotEquals(tags1, tags3);
+    }
+
+    @Test
+    void merge_with_empty() {
+        var tags = CloudResourceTags.from(Map.of("a", "1"));
+        assertEquals(tags, tags.mergedWith(CloudResourceTags.empty()));
+        assertEquals(tags, CloudResourceTags.empty().mergedWith(tags));
+    }
+
+    @Test
+    void merge_combines_tags() {
+        var base = CloudResourceTags.from(Map.of("a", "1", "b", "2"));
+        var overlay = CloudResourceTags.from(Map.of("b", "override", "c", "3"));
+        var merged = base.mergedWith(overlay);
+
+        assertEquals(3, merged.size());
+        assertEquals("1", merged.asMap().get("a"));
+        assertEquals("override", merged.asMap().get("b"));
+        assertEquals("3", merged.asMap().get("c"));
+    }
+
+    @Test
+    void empty_key_rejected() {
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("", "value")));
+    }
+
+    @Test
+    void key_exceeding_max_length_rejected() {
+        String longKey = "k".repeat(129);
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of(longKey, "value")));
+    }
+
+    @Test
+    void value_exceeding_max_length_rejected() {
+        String longValue = "v".repeat(257);
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", longValue)));
+    }
+
+    @Test
+    void too_many_tags_rejected() {
+        Map<String, String> tooMany = IntStream.rangeClosed(1, 51)
+                                               .boxed()
+                                               .collect(toMap(i -> "key" + i, i -> "val" + i));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(tooMany));
+    }
+
+    @Test
+    void max_allowed_tags_accepted() {
+        Map<String, String> maxTags = IntStream.rangeClosed(1, 50)
+                                               .boxed()
+                                               .collect(toMap(i -> "key" + i, i -> "val" + i));
+        var tags = CloudResourceTags.from(maxTags);
+        assertEquals(50, tags.size());
+    }
+
+    @Test
+    void empty_value_is_allowed() {
+        var tags = CloudResourceTags.from(Map.of("key", ""));
+        assertEquals("", tags.asMap().get("key"));
+    }
+
+    @Test
+    void to_string() {
+        var tags = CloudResourceTags.from(Map.of("env", "prod"));
+        assertTrue(tags.toString().contains("env"));
+        assertTrue(tags.toString().contains("prod"));
+    }
+
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -22,6 +22,7 @@ import com.yahoo.config.model.api.TenantVault;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.config.provision.CloudAccount;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DataplaneToken;
 import com.yahoo.config.provision.DockerImage;
@@ -286,6 +287,7 @@ public class ModelContextImpl implements ModelContext {
         private final List<TenantSecretStore> tenantSecretStores;
         private final List<X509Certificate> operatorCertificates;
         private final Optional<CloudAccount> cloudAccount;
+        private final CloudResourceTags cloudResourceTags;
         private final List<DataplaneToken> dataplaneTokens;
 
         public Properties(ApplicationId applicationId,
@@ -302,6 +304,7 @@ public class ModelContextImpl implements ModelContext {
                           List<TenantSecretStore> tenantSecretStores,
                           List<X509Certificate> operatorCertificates,
                           Optional<CloudAccount> cloudAccount,
+                          CloudResourceTags cloudResourceTags,
                           List<DataplaneToken> dataplaneTokens) {
             this.featureFlags = new FeatureFlags(flagSource, applicationId, modelVersion);
             this.applicationId = applicationId;
@@ -324,6 +327,7 @@ public class ModelContextImpl implements ModelContext {
             this.tenantSecretStores = tenantSecretStores;
             this.operatorCertificates = operatorCertificates;
             this.cloudAccount = cloudAccount;
+            this.cloudResourceTags = cloudResourceTags;
             this.dataplaneTokens = dataplaneTokens;
         }
 
@@ -345,6 +349,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public List<TenantSecretStore> tenantSecretStores() { return tenantSecretStores; }
         @Override public List<X509Certificate> operatorCertificates() { return operatorCertificates; }
         @Override public Optional<CloudAccount> cloudAccount() { return cloudAccount; }
+        @Override public CloudResourceTags cloudResourceTags() { return cloudResourceTags; }
         @Override public List<DataplaneToken> dataplaneTokens() { return dataplaneTokens; }
         @Override public boolean allowDisableMtls() { return flag(PermanentFlags.ALLOW_DISABLE_MTLS).value(); }
         @Override public List<String> tlsCiphersOverride() { return flag(PermanentFlags.TLS_CIPHERS_OVERRIDE).value(); }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -14,6 +14,7 @@ import com.yahoo.config.model.api.OnnxModelCost;
 import com.yahoo.config.model.api.Provisioned;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
@@ -164,6 +165,7 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                                                zkClient.readTenantSecretStores(),
                                                zkClient.readOperatorCertificates(),
                                                zkClient.readCloudAccount(),
+                                               CloudResourceTags.empty(), // TODO: Read from ZK when persistence is wired
                                                zkClient.readDataplaneTokens());
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -223,6 +223,7 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
                                                params.tenantSecretStores(),
                                                params.operatorCertificates(),
                                                params.cloudAccount(),
+                                               params.cloudResourceTags(),
                                                params.dataplaneTokens());
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
@@ -10,6 +10,7 @@ import com.yahoo.config.model.api.TenantVault;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.config.provision.CloudAccount;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.DataplaneToken;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.TenantName;
@@ -21,6 +22,7 @@ import com.yahoo.slime.SlimeUtils;
 import com.yahoo.vespa.config.server.TimeoutBudget;
 import com.yahoo.vespa.config.server.http.SessionHandler;
 import com.yahoo.vespa.config.server.tenant.CloudAccountSerializer;
+import com.yahoo.vespa.config.server.tenant.CloudResourceTagsSerializer;
 import com.yahoo.vespa.config.server.tenant.ContainerEndpointSerializer;
 import com.yahoo.vespa.config.server.tenant.DataplaneTokenSerializer;
 import com.yahoo.vespa.config.server.tenant.EndpointCertificateMetadataSerializer;
@@ -60,6 +62,7 @@ public final class PrepareParams {
     static final String WAIT_FOR_RESOURCES_IN_PREPARE = "waitForResourcesInPrepare";
     static final String OPERATOR_CERTIFICATES = "operatorCertificates";
     static final String CLOUD_ACCOUNT = "cloudAccount";
+    static final String CLOUD_RESOURCE_TAGS = "cloudResourceTags";
     static final String DATAPLANE_TOKENS = "dataplaneTokens";
 
     private final ApplicationId applicationId;
@@ -82,6 +85,7 @@ public final class PrepareParams {
     private final List<TenantSecretStore> tenantSecretStores;
     private final List<X509Certificate> operatorCertificates;
     private final Optional<CloudAccount> cloudAccount;
+    private final CloudResourceTags cloudResourceTags;
     private final List<DataplaneToken> dataplaneTokens;
 
     private PrepareParams(ApplicationId applicationId,
@@ -104,6 +108,7 @@ public final class PrepareParams {
                           boolean waitForResourcesInPrepare,
                           List<X509Certificate> operatorCertificates,
                           Optional<CloudAccount> cloudAccount,
+                          CloudResourceTags cloudResourceTags,
                           List<DataplaneToken> dataplaneTokens) {
         this.timeoutBudget = timeoutBudget;
         this.applicationId = Objects.requireNonNull(applicationId);
@@ -125,6 +130,7 @@ public final class PrepareParams {
         this.waitForResourcesInPrepare = waitForResourcesInPrepare;
         this.operatorCertificates = operatorCertificates;
         this.cloudAccount = Objects.requireNonNull(cloudAccount);
+        this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
         this.dataplaneTokens = dataplaneTokens;
     }
 
@@ -150,6 +156,7 @@ public final class PrepareParams {
         private List<TenantSecretStore> tenantSecretStores = List.of();
         private List<X509Certificate> operatorCertificates = List.of();
         private Optional<CloudAccount> cloudAccount = Optional.empty();
+        private CloudResourceTags cloudResourceTags = CloudResourceTags.empty();
         private List<DataplaneToken> dataplaneTokens = List.of();
 
         public Builder() { }
@@ -318,6 +325,11 @@ public final class PrepareParams {
             return this;
         }
 
+        public Builder cloudResourceTags(CloudResourceTags cloudResourceTags) {
+            this.cloudResourceTags = cloudResourceTags != null ? cloudResourceTags : CloudResourceTags.empty();
+            return this;
+        }
+
         public Builder dataplaneTokens(List<DataplaneToken> dataplaneTokens) {
             this.dataplaneTokens = List.copyOf(dataplaneTokens);
             return this;
@@ -344,6 +356,7 @@ public final class PrepareParams {
                                      waitForResourcesInPrepare,
                                      operatorCertificates,
                                      cloudAccount,
+                                     cloudResourceTags,
                                      dataplaneTokens);
         }
 
@@ -396,6 +409,7 @@ public final class PrepareParams {
                 .waitForResourcesInPrepare(booleanValue(params, WAIT_FOR_RESOURCES_IN_PREPARE))
                 .operatorCertificates(deserialize(params.field(OPERATOR_CERTIFICATES), PrepareParams::readOperatorCertificates, List.of()))
                 .cloudAccount(deserialize(params.field(CLOUD_ACCOUNT), CloudAccountSerializer::fromSlime, null))
+                .cloudResourceTags(deserialize(params.field(CLOUD_RESOURCE_TAGS), CloudResourceTagsSerializer::fromSlime, CloudResourceTags.empty()))
                 .dataplaneTokens(deserialize(params.field(DATAPLANE_TOKENS), DataplaneTokenSerializer::fromSlime, List.of()))
                 .build();
     }
@@ -521,6 +535,10 @@ public final class PrepareParams {
 
     public Optional<CloudAccount> cloudAccount() {
         return cloudAccount;
+    }
+
+    public CloudResourceTags cloudResourceTags() {
+        return cloudResourceTags;
     }
 
     public List<DataplaneToken> dataplaneTokens() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/CloudResourceTagsSerializer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/CloudResourceTagsSerializer.java
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server.tenant;
+
+import com.yahoo.config.provision.CloudResourceTags;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Inspector;
+import com.yahoo.slime.Slime;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Serialization of {@link CloudResourceTags} to/from Slime.
+ *
+ * @author gjoranv
+ */
+public class CloudResourceTagsSerializer {
+
+    private CloudResourceTagsSerializer() {}
+
+    public static CloudResourceTags fromSlime(Inspector object) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        object.traverse((String key, Inspector value) -> tags.put(key, value.asString()));
+        return tags.isEmpty() ? CloudResourceTags.empty() : CloudResourceTags.from(tags);
+    }
+
+    public static void toSlime(CloudResourceTags tags, Cursor object) {
+        tags.asMap().forEach(object::setString);
+    }
+
+}

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
@@ -16,6 +16,7 @@ import com.yahoo.config.model.application.provider.MockFileRegistry;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.vespa.config.server.deploy.ModelContextImpl;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import org.junit.Test;
@@ -73,6 +74,7 @@ public class ModelContextImplTest {
                         List.of(),
                         List.of(),
                         Optional.empty(),
+                        CloudResourceTags.empty(),
                         List.of()),
                 Optional.empty(),
                 OnnxModelCost.disabled(),

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
@@ -9,6 +9,7 @@ import com.yahoo.config.model.api.TenantSecretStore;
 import com.yahoo.config.model.api.TenantVault;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.CloudAccount;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.security.X509CertificateUtils;
@@ -229,6 +230,27 @@ public class PrepareParamsTest {
         String json = "{\"cloudAccount\": {\"id\": \"012345678912\"}}";
         PrepareParams params = PrepareParams.fromJson(json.getBytes(StandardCharsets.UTF_8), TenantName.defaultName(), Duration.ZERO);
         assertEquals(CloudAccount.from("012345678912"), params.cloudAccount().get());
+    }
+
+    @Test
+    public void testCloudResourceTags() {
+        String json = "{\"cloudResourceTags\": {\"env\": \"prod\", \"team\": \"search\"}}";
+        PrepareParams params = PrepareParams.fromJson(json.getBytes(StandardCharsets.UTF_8), TenantName.defaultName(), Duration.ZERO);
+        assertEquals(CloudResourceTags.from(java.util.Map.of("env", "prod", "team", "search")), params.cloudResourceTags());
+    }
+
+    @Test
+    public void testCloudResourceTagsEmpty() {
+        String json = "{}";
+        PrepareParams params = PrepareParams.fromJson(json.getBytes(StandardCharsets.UTF_8), TenantName.defaultName(), Duration.ZERO);
+        assertTrue(params.cloudResourceTags().isEmpty());
+    }
+
+    @Test
+    public void testCloudResourceTagsEmptyObject() {
+        String json = "{\"cloudResourceTags\": {}}";
+        PrepareParams params = PrepareParams.fromJson(json.getBytes(StandardCharsets.UTF_8), TenantName.defaultName(), Duration.ZERO);
+        assertTrue(params.cloudResourceTags().isEmpty());
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/CloudResourceTagsSerializerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/CloudResourceTagsSerializerTest.java
@@ -1,0 +1,52 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server.tenant;
+
+import com.yahoo.config.provision.CloudResourceTags;
+import com.yahoo.slime.Slime;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author gjoranv
+ */
+public class CloudResourceTagsSerializerTest {
+
+    @Test
+    public void roundTrip() {
+        var tags = CloudResourceTags.from(Map.of("env", "prod", "team", "search", "cost-center", "42"));
+        var slime = new Slime();
+        CloudResourceTagsSerializer.toSlime(tags, slime.setObject());
+        var deserialized = CloudResourceTagsSerializer.fromSlime(slime.get());
+        assertEquals(tags, deserialized);
+    }
+
+    @Test
+    public void emptyRoundTrip() {
+        var slime = new Slime();
+        CloudResourceTagsSerializer.toSlime(CloudResourceTags.empty(), slime.setObject());
+        var deserialized = CloudResourceTagsSerializer.fromSlime(slime.get());
+        assertTrue(deserialized.isEmpty());
+    }
+
+    @Test
+    public void fromEmptyInspector() {
+        var slime = new Slime();
+        slime.setObject();
+        var deserialized = CloudResourceTagsSerializer.fromSlime(slime.get());
+        assertTrue(deserialized.isEmpty());
+    }
+
+    @Test
+    public void emptyValuePreserved() {
+        var tags = CloudResourceTags.from(Map.of("marker", ""));
+        var slime = new Slime();
+        CloudResourceTagsSerializer.toSlime(tags, slime.setObject());
+        var deserialized = CloudResourceTagsSerializer.fromSlime(slime.get());
+        assertEquals("", deserialized.asMap().get("marker"));
+    }
+
+}


### PR DESCRIPTION
Adds a `<resource-tags>` element to `deployment.xml` that lets enclave tenants attach custom key-value tags to provisioned cloud resources (VMs, disks, NICs) for cost tracking and resource management.

## Changes

- New `CloudResourceTags` immutable value class in `config-provisioning` with merge, template resolution, and JSON serialization
- `deployment.rnc` schema and `DeploymentSpecXmlReader` support for `<resource-tags>` at top-level `<deployment>` and `<instance>` levels
- Instance-level tags merge with top-level; instance wins on key conflict
- Tag values support template variables (`${environment}`, `${application}`, `${instance}`, `${tenant}`, `${region}`) resolved at deployment time; unknown variables fail deployment
- Validation uses GCP rules as lowest common denominator: keys and values `[a-z0-9_-]`, max 63 chars, max 20 tags, no empty values; `vai-` prefix and system tag names rejected; only allowed when `cloud-account` is set
- Tags propagate through `DeploymentSpec` / `DeploymentInstanceSpec` → `PrepareParams` → ZooKeeper session → `ModelContext.Properties` → `Capacity` → `HostProvisionRequest`
- Unit tests covering parsing, merging, validation, template resolution, and reserved namespace rejection