### PR TITLE
Handle hex tensor decoding across compatible value types

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
@@ -44,9 +44,10 @@ public class TensorReader {
         if (buffer.current() == JsonToken.VALUE_STRING
             && builder instanceof IndexedTensor.BoundBuilder indexedBuilder)
         {
-            double[] decoded = decodeHexString(buffer.currentText(), builder.type().valueType());
-            if (decoded.length == 0)
+            if (buffer.currentText().isEmpty())
                 throw new IllegalArgumentException("Bad string input for tensor with type " + builder.type());
+            double[] decoded = decodeHexStringWithTypeConversion(buffer.currentText(), builder.type().valueType(),
+                                                                  denseValueCount(indexedBuilder.type()));
             for (int i = 0; i < decoded.length; i++) {
                 indexedBuilder.cellByDirectIndex(i, decoded[i]);
             }
@@ -140,9 +141,10 @@ public class TensorReader {
             throw new IllegalArgumentException("The 'values' field can only be used with dense tensors. " +
                                                "Use 'cells' or 'blocks' instead");
         if (buffer.current() == JsonToken.VALUE_STRING) {
-            double[] decoded = decodeHexString(buffer.currentText(), builder.type().valueType());
-            if (decoded.length == 0)
+            if (buffer.currentText().isEmpty())
                 throw new IllegalArgumentException("The 'values' string does not contain any values");
+            double[] decoded = decodeHexStringWithTypeConversion(buffer.currentText(), builder.type().valueType(),
+                                                                  denseValueCount(indexedBuilder.type()));
             for (int i = 0; i < decoded.length; i++) {
                 indexedBuilder.cellByDirectIndex(i, decoded[i]);
             }
@@ -252,7 +254,7 @@ public class TensorReader {
         int index = 0;
         double[] values = new double[size];
         if (buffer.current() == JsonToken.VALUE_STRING) {
-            values = decodeHexString(buffer.currentText(), type.valueType());
+            values = decodeHexStringWithTypeConversion(buffer.currentText(), type.valueType(), size);
             index = values.length;
         } else {
             expectArrayStart(buffer.current());
@@ -285,6 +287,55 @@ public class TensorReader {
         if (type.dimensions().size() != 1)
             throw new IllegalArgumentException("Expected a tensor with a single dimension but got '" + type + "'");
         return new TensorAddress.Builder(type).add(type.dimensions().get(0).name(), label).build();
+    }
+
+    private static int denseValueCount(TensorType type) {
+        long valueCount = 1;
+        for (var dimension : type.dimensions()) {
+            valueCount *= dimension.size().orElseThrow(() ->
+                    new IllegalArgumentException("Hex values can only be used with bound dimensions in " + type));
+        }
+        return Math.toIntExact(valueCount);
+    }
+
+    private static double[] decodeHexStringWithTypeConversion(String input,
+                                                               TensorType.Value targetValueType,
+                                                               int expectedValueCount) {
+        int expectedHexDigits = expectedHexDigitCount(expectedValueCount, targetValueType);
+        if (input.length() == expectedHexDigits) {
+            return decodeHexString(input, targetValueType);
+        }
+
+        if (expectedValueCount > 0 && input.length() % expectedValueCount == 0) {
+            TensorType.Value sourceValueType = inferHexValueType(input.length() / expectedValueCount);
+            if (sourceValueType != null) {
+                return decodeHexString(input, sourceValueType);
+            }
+        }
+
+        throw new IllegalArgumentException("Expected " + expectedHexDigits + " hex digits for " +
+                                           expectedValueCount + " " + targetValueType +
+                                           " values, but got " + input.length());
+    }
+
+    private static int expectedHexDigitCount(int expectedValueCount, TensorType.Value valueType) {
+        int hexDigitsPerCell = switch (valueType) {
+            case INT8 -> 2;
+            case BFLOAT16 -> 4;
+            case FLOAT -> 8;
+            case DOUBLE -> 16;
+        };
+        return expectedValueCount * hexDigitsPerCell;
+    }
+
+    private static TensorType.Value inferHexValueType(int hexDigitsPerCell) {
+        return switch (hexDigitsPerCell) {
+            case 2 -> TensorType.Value.INT8;
+            case 4 -> TensorType.Value.BFLOAT16;
+            case 8 -> TensorType.Value.FLOAT;
+            case 16 -> TensorType.Value.DOUBLE;
+            default -> null;
+        };
     }
 
 }

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -178,8 +178,8 @@ public class JsonReaderTestCase {
                     new TensorDataType(TensorType.fromSpec("tensor<int8>(x[2],y[3])"))));
             x.addField(new Field("dense_float_tensor",
                     new TensorDataType(TensorType.fromSpec("tensor<float>(y[3])"))));
-                x.addField(new Field("dense_bfloat16_tensor",
-                  new TensorDataType(TensorType.fromSpec("tensor<bfloat16>(x[1])"))));
+            x.addField(new Field("dense_bfloat16_tensor",
+                    new TensorDataType(TensorType.fromSpec("tensor<bfloat16>(x[1])"))));
             x.addField(new Field("dense_unbound_tensor",
                     new TensorDataType(new TensorType.Builder().indexed("x").indexed("y").build())));
             x.addField(new Field("mixed_tensor",

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -178,6 +178,8 @@ public class JsonReaderTestCase {
                     new TensorDataType(TensorType.fromSpec("tensor<int8>(x[2],y[3])"))));
             x.addField(new Field("dense_float_tensor",
                     new TensorDataType(TensorType.fromSpec("tensor<float>(y[3])"))));
+                x.addField(new Field("dense_bfloat16_tensor",
+                  new TensorDataType(TensorType.fromSpec("tensor<bfloat16>(x[1])"))));
             x.addField(new Field("dense_unbound_tensor",
                     new TensorDataType(new TensorType.Builder().indexed("x").indexed("y").build())));
             x.addField(new Field("mixed_tensor",
@@ -2013,6 +2015,18 @@ public class JsonReaderTestCase {
                                    createPutWithTensor("""
                                                        "42280000be0000007f800000"
                                                        """, "dense_float_tensor"), "dense_float_tensor");
+        expected = Tensor.from("tensor<bfloat16>(x[1]):[1.0]");
+        tensor = assertTensorField(expected,
+                                   createPutWithTensor("""
+                                                       {
+                                                         "values": "3F800000"
+                                                       }""", "dense_bfloat16_tensor"), "dense_bfloat16_tensor");
+        assertTrue(tensor instanceof IndexedTensor); // this matters for performance
+        tensor = assertTensorField(expected,
+                                   createPutWithTensor("""
+                                                       "3F800000"
+                                                       """, "dense_bfloat16_tensor"), "dense_bfloat16_tensor");
+        assertTrue(tensor instanceof IndexedTensor); // this matters for performance
         try {
             assertTensorField(expected,
                               createPutWithTensor("""
@@ -2050,6 +2064,17 @@ public class JsonReaderTestCase {
                              "blocks":{"foo":"400040404080", "bar":"40A040C040E0"}
                            }
                     """;
+        put = createPutWithTensor(inputJson(mixedJson), "mixed_bfloat16_tensor");
+        tensor = assertTensorField(expected, put, "mixed_bfloat16_tensor");
+
+        mixedJson = """
+                           {
+                             "blocks":[
+                               {"address":{"x":"foo"},"values":"400000004040000040800000"},
+                               {"address":{"x":"bar"},"values":"40A0000040C0000040E00000"}
+                             ]
+                           }
+                           """;
         put = createPutWithTensor(inputJson(mixedJson), "mixed_bfloat16_tensor");
         tensor = assertTensorField(expected, put, "mixed_bfloat16_tensor");
     }

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -340,9 +340,10 @@ public class JsonFormat {
         if ( ! (builder instanceof IndexedTensor.BoundBuilder indexedBuilder))
             throw new IllegalArgumentException("An array of values can only be used with a dense tensor. Use a map instead");
         if (values.type() == Type.STRING) {
-            double[] decoded = decodeHexString(values.asString(), builder.type().valueType());
-            if (decoded.length == 0)
+            if (values.asString().isEmpty())
                 throw new IllegalArgumentException("The values string does not contain any values");
+            double[] decoded = decodeHexStringToExpectedValueCount(values.asString(), builder.type().valueType(),
+                                                                    denseValueCount(indexedBuilder.type()));
             for (int i = 0; i < decoded.length; i++) {
                 indexedBuilder.cellByDirectIndex(i, decoded[i]);
             }
@@ -421,6 +422,37 @@ public class JsonFormat {
         return (byte)d;
     }
 
+    private static int denseValueCount(TensorType type) {
+        long valueCount = 1;
+        for (var dimension : type.dimensions()) {
+            if (dimension.size().isEmpty()) {
+                throw new IllegalArgumentException("Hex values can only be used with bound dimensions in " + type);
+            }
+            valueCount *= dimension.size().get();
+        }
+        return Math.toIntExact(valueCount);
+    }
+
+    private static int expectedHexDigitCount(int expectedValueCount, TensorType.Value valueType) {
+        int hexDigitsPerCell = switch (valueType) {
+            case INT8 -> 2;
+            case BFLOAT16 -> 4;
+            case FLOAT -> 8;
+            case DOUBLE -> 16;
+        };
+        return expectedValueCount * hexDigitsPerCell;
+    }
+
+    private static TensorType.Value inferHexValueType(int hexDigitsPerCell) {
+        return switch (hexDigitsPerCell) {
+            case 2 -> TensorType.Value.INT8;
+            case 4 -> TensorType.Value.BFLOAT16;
+            case 8 -> TensorType.Value.FLOAT;
+            case 16 -> TensorType.Value.DOUBLE;
+            default -> null;
+        };
+    }
+
     private static double[] decodeHexStringAsBytes(String input) {
         int l = input.length() / 2;
         double[] result = new double[l];
@@ -488,6 +520,29 @@ public class JsonFormat {
         };
     }
 
+    /**
+     * Decodes hex encoded values, inferring an alternate source cell type when the input length does not match
+     * the target type but still matches the expected number of values.
+     */
+    private static double[] decodeHexStringToExpectedValueCount(String input, TensorType.Value targetValueType,
+                                                                 int expectedValueCount) {
+        int expectedHexDigits = expectedHexDigitCount(expectedValueCount, targetValueType);
+        if (input.length() == expectedHexDigits) {
+            return decodeHexString(input, targetValueType);
+        }
+
+        if (expectedValueCount > 0 && input.length() % expectedValueCount == 0) {
+            TensorType.Value sourceValueType = inferHexValueType(input.length() / expectedValueCount);
+            if (sourceValueType != null) {
+                return decodeHexString(input, sourceValueType);
+            }
+        }
+
+        throw new IllegalArgumentException("Expected " + expectedHexDigits + " hex digits for " +
+                                           expectedValueCount + " " + targetValueType +
+                                           " values, but got " + input.length());
+    }
+
     private static void decodeMaybeNestedValuesInBlock(Inspector arrayField, double[] target, MutableInteger index) {
         if (arrayField.entries() == 0) {
             throw new IllegalArgumentException("The block value array does not contain any values");
@@ -506,11 +561,12 @@ public class JsonFormat {
         if (valuesField.type() == Type.ARRAY) {
             decodeMaybeNestedValuesInBlock(valuesField, values, new MutableInteger(0));
         } else if (valuesField.type() == Type.STRING) {
-            double[] decoded = decodeHexString(valuesField.asString(), mixedBuilder.type().valueType());
-            if (decoded.length == 0) {
+            if (valuesField.asString().isEmpty()) {
                 throw new IllegalArgumentException("The block value string does not contain any values");
             }
-            System.arraycopy(decoded, 0, values, 0, decoded.length);
+            double[] decoded = decodeHexStringToExpectedValueCount(valuesField.asString(), mixedBuilder.type().valueType(),
+                                                                   values.length);
+            System.arraycopy(decoded, 0, values, 0, values.length);
         } else {
             throw new IllegalArgumentException("Expected a block to contain an array of values");
         }

--- a/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
@@ -515,6 +515,34 @@ public class JsonFormatTestCase {
     }
 
     @Test
+    public void testFloatHexCanBeDecodedAsBFloat16DenseValues() {
+        var type = TensorType.fromSpec("tensor<bfloat16>(x[1])");
+        var expected = Tensor.from("tensor<bfloat16>(x[1]):[1.0]");
+
+        String wrappedJson = "{\"values\":\"3F800000\"}";
+        Tensor decoded = JsonFormat.decode(type, wrappedJson.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, decoded);
+
+        String directJson = "\"3F800000\"";
+        decoded = JsonFormat.decode(type, directJson.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, decoded);
+    }
+
+    @Test
+    public void testFloatHexCanBeDecodedAsBFloat16BlockValues() {
+        var type = TensorType.fromSpec("tensor<bfloat16>(x{},y[1])");
+        var expected = Tensor.from("tensor<bfloat16>(x{},y[1]):{{x:foo,y:0}:1.0}");
+
+        String mixedJson = "{\"blocks\":[{\"address\":{\"x\":\"foo\"},\"values\":\"3F800000\"}]}";
+        Tensor decoded = JsonFormat.decode(type, mixedJson.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, decoded);
+
+        String shortJson = "{\"blocks\":{\"foo\":\"3F800000\"}}";
+        decoded = JsonFormat.decode(type, shortJson.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, decoded);
+    }
+
+    @Test
     public void testFloatVectorInHexForm() {
         var builder = Tensor.Builder.of(TensorType.fromSpec("tensor<float>(x[3],y[4])"));
         builder.cell().label("x", 0).label("y", 0).value(42.0);


### PR DESCRIPTION
### Why
Hex-encoded tensor input currently depends on field cell type in a brittle way. Feeding float-encoded hex to a `tensor<bfloat16>(...)` field can fail with an out-of-bounds error in JSON tensor parsing.

### What
- Added expected-size-aware hex decoding in tensor JSON parsing.
- When hex length matches the expected number of values but a different supported cell width, decode using inferred source type and let normal numeric assignment convert to target field type.
- Applied this in both:
  - `vespajlib` JSON tensor decoding (`JsonFormat`)
  - document feed JSON reader (`TensorReader`)
- Kept empty-string behavior intact with existing error messages.

### Tests
- `mvn -pl vespajlib -Dtest=JsonFormatTestCase test`
- `mvn -pl document -Dtest=JsonReaderTestCase test`
- `mvn -pl document -am -Dtest=JsonReaderTestCase -Dsurefire.failIfNoSpecifiedTests=false test`

### Regression coverage added
- float-hex -> bfloat16 decoding for dense values
- float-hex -> bfloat16 decoding for mixed block values
- document JSON reader coverage for both direct dense and mixed block hex forms

Fixes #35611
