### PR TITLE
Separate application of global filter and ANN searches into separate steps

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -21,6 +21,7 @@
 #include <vespa/vespalib/util/thread_bundle.h>
 #include <vespa/searchlib/query/proto_tree_converter.h>
 #include <vespa/searchlib/query/tree/querytreecreator.h>
+#include <queue>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.matching.query");
@@ -358,7 +359,25 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
         trace->addEvent(5, "Handle global filter in query execution plan");
     }
     blueprint.set_global_filter(*global_filter, estimated_hit_ratio);
+    perform_ann_searches(blueprint);
     return true;
+}
+
+void
+Query::perform_ann_searches(Blueprint& blueprint)
+{
+    std::queue<search::queryeval::NearestNeighborBlueprint*> ann_blueprints;
+    blueprint.each_node_post_order([&ann_blueprints](Blueprint& bp) {
+        if (auto nearest_neighbor = bp.asNearestNeighbor()) {
+            if (nearest_neighbor->pending_index_search()) {
+                ann_blueprints.push(nearest_neighbor);
+            }
+        }
+    });
+    while (!ann_blueprints.empty()) {
+        ann_blueprints.front()->perform_index_search();
+        ann_blueprints.pop();
+    }
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -128,6 +128,8 @@ public:
                                      double global_filter_lower_limit, double global_filter_upper_limit,
                                      vespalib::ThreadBundle &thread_bundle, search::engine::Trace* trace, bool use_lazy_filter = false);
 
+    static void perform_ann_searches(Blueprint& blueprint);
+
     void freeze();
     void set_matching_phase(search::queryeval::MatchingPhase matching_phase) const noexcept;
 

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1639,6 +1639,36 @@ TEST(TensorAttributeTest, NN_blueprint_handles_strong_filter_triggering_exact_se
     EXPECT_EQ(NNBA::EXACT_FALLBACK, bp->get_algorithm());
 }
 
+TEST(TensorAttributeTest, NN_blueprint_updates_pending_index_search_after_filter_change)
+{
+    NearestNeighborBlueprintFixture f;
+    auto bp = f.make_blueprint(true, 0.2);
+
+    auto weak_bv = search::BitVector::create(1,11);
+    weak_bv->setBit(1);
+    weak_bv->setBit(3);
+    weak_bv->setBit(5);
+    weak_bv->setBit(7);
+    weak_bv->setBit(9);
+    weak_bv->invalidateCachedCount();
+    auto weak_filter = GlobalFilter::create(std::move(weak_bv));
+
+    auto strong_bv= search::BitVector::create(1,11);
+    strong_bv->setBit(3);
+    strong_bv->invalidateCachedCount();
+    auto strong_filter = GlobalFilter::create(std::move(strong_bv));
+
+    EXPECT_FALSE(bp->pending_index_search());
+    bp->set_global_filter(*weak_filter, 0.6);
+    EXPECT_TRUE(bp->pending_index_search());
+    bp->set_global_filter(*strong_filter, 0.6);
+    EXPECT_FALSE(bp->pending_index_search());
+    bp->set_global_filter(*weak_filter, 0.6);
+    EXPECT_TRUE(bp->pending_index_search());
+    bp->perform_index_search();
+    EXPECT_FALSE(bp->pending_index_search());
+}
+
 TEST(TensorAttributeTest, NN_blueprint_wants_global_filter_when_having_index)
 {
     NearestNeighborBlueprintFixture f;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1550,7 +1550,11 @@ TEST(TensorAttributeTest, NN_blueprint_handles_empty_filter_for_post_filtering)
     NearestNeighborBlueprintFixture f;
     auto bp = f.make_blueprint();
     auto empty_filter = GlobalFilter::create();
+    EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*empty_filter, 0.6);
+    EXPECT_TRUE(bp->pending_index_search());
+    bp->perform_index_search();
+    EXPECT_FALSE(bp->pending_index_search());
     // targetHits is adjusted based on the estimated hit ratio of the query.
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(5u, bp->get_adjusted_target_hits());
@@ -1563,7 +1567,11 @@ TEST(TensorAttributeTest, NN_blueprint_adjustment_of_targetHits_is_bound_for_pos
     NearestNeighborBlueprintFixture f;
     auto bp = f.make_blueprint(true, 0.05, 3.5);
     auto empty_filter = GlobalFilter::create();
+    EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*empty_filter, 0.2);
+    EXPECT_TRUE(bp->pending_index_search());
+    bp->perform_index_search();
+    EXPECT_FALSE(bp->pending_index_search());
     // targetHits is adjusted based on the estimated hit ratio of the query,
     // but bound by target-hits-max-adjustment-factor
     EXPECT_EQ(3u, bp->get_target_hits());
@@ -1580,7 +1588,11 @@ TEST(TensorAttributeTest, NN_blueprint_handles_strong_filter_for_pre_filtering)
     filter->setBit(3);
     filter->invalidateCachedCount();
     auto strong_filter = GlobalFilter::create(std::move(filter));
+    EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*strong_filter, 0.25);
+    EXPECT_TRUE(bp->pending_index_search());
+    bp->perform_index_search();
+    EXPECT_FALSE(bp->pending_index_search());
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(3u, bp->get_adjusted_target_hits());
     EXPECT_EQ(1u, bp->getState().estimate().estHits);
@@ -1599,7 +1611,11 @@ TEST(TensorAttributeTest, NN_blueprint_handles_weak_filter_for_pre_filtering)
     filter->setBit(9);
     filter->invalidateCachedCount();
     auto weak_filter = GlobalFilter::create(std::move(filter));
+    EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*weak_filter, 0.6);
+    EXPECT_TRUE(bp->pending_index_search());
+    bp->perform_index_search();
+    EXPECT_FALSE(bp->pending_index_search());
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(3u, bp->get_adjusted_target_hits());
     EXPECT_EQ(3u, bp->getState().estimate().estHits);
@@ -1614,7 +1630,9 @@ TEST(TensorAttributeTest, NN_blueprint_handles_strong_filter_triggering_exact_se
     filter->setBit(3);
     filter->invalidateCachedCount();
     auto strong_filter = GlobalFilter::create(std::move(filter));
+    EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*strong_filter, 0.6);
+    EXPECT_FALSE(bp->pending_index_search());
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(3u, bp->get_adjusted_target_hits());
     EXPECT_EQ(1u, bp->getState().estimate().estHits);
@@ -1654,7 +1672,11 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
         auto bp = f.make_blueprint(true);
         bp->install_stats(*stats);
         auto inactive_filter = GlobalFilter::create();
+        EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*inactive_filter, 0.6);
+        EXPECT_TRUE(bp->pending_index_search());
+        bp->perform_index_search();
+        EXPECT_FALSE(bp->pending_index_search());
     }
     EXPECT_EQ(1, stats->approximate_nns_distances_computed());
     EXPECT_EQ(2, stats->approximate_nns_nodes_visited());
@@ -1671,7 +1693,11 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
         filter->setBit(9);
         filter->invalidateCachedCount();
         auto weak_filter = GlobalFilter::create(std::move(filter));
+        EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*weak_filter, 0.6);
+        EXPECT_TRUE(bp->pending_index_search());
+        bp->perform_index_search();
+        EXPECT_FALSE(bp->pending_index_search());
     }
     EXPECT_EQ(2, stats->approximate_nns_distances_computed());
     EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
@@ -1684,7 +1710,9 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
         filter->setBit(3);
         filter->invalidateCachedCount();
         auto strong_filter = GlobalFilter::create(std::move(filter));
+        EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*strong_filter, 0.6);
+        EXPECT_FALSE(bp->pending_index_search());
     }
     EXPECT_EQ(2, stats->approximate_nns_distances_computed());
     EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
@@ -1694,7 +1722,9 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats)
         auto bp = f.make_blueprint(false);
         bp->install_stats(*stats);
         auto inactive_filter = GlobalFilter::create();
+        EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*inactive_filter, 0.6);
+        EXPECT_FALSE(bp->pending_index_search());
     }
     EXPECT_EQ(2, stats->approximate_nns_distances_computed());
     EXPECT_EQ(4, stats->approximate_nns_nodes_visited());

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -79,6 +79,7 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
       _lazy_filter_hits(),
       _lazy_filter_hit_ratio(),
       _low_hit_ratio(false),
+      _pending_index_search(false),
       _doom(doom),
       _matching_phase(MatchingPhase::FIRST_PHASE),
       _nni_stats(),
@@ -135,7 +136,7 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
             est_hits = std::min(est_hits, _adjusted_target_hits);
             set_cost_tier(State::COST_TIER_NORMAL);
             setEstimate(HitEstimate(est_hits, false));
-            perform_top_k(nns_index);
+            _pending_index_search = true;
         }
     }
 }
@@ -143,6 +144,19 @@ NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, d
 void
 NearestNeighborBlueprint::set_lazy_filter(const GlobalFilter &lazy_filter) {
     _lazy_filter = lazy_filter.shared_from_this();
+}
+
+bool
+NearestNeighborBlueprint::pending_index_search() const {
+    return _pending_index_search;
+}
+
+void
+NearestNeighborBlueprint::perform_index_search() {
+    if (_pending_index_search) {
+        perform_top_k(_attr_tensor.nearest_neighbor_index());
+        _pending_index_search = false;
+    }
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -109,6 +109,8 @@ NearestNeighborBlueprint::want_global_filter(GlobalFilterLimits& limits) const
 void
 NearestNeighborBlueprint::set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio)
 {
+    _algorithm = Algorithm::EXACT;
+    _pending_index_search = false;
     _global_filter = global_filter.shared_from_this();
     _global_filter_set = true;
     auto nns_index = _attr_tensor.nearest_neighbor_index();

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -58,6 +58,7 @@ private:
     std::optional<uint32_t> _lazy_filter_hits;
     std::optional<double> _lazy_filter_hit_ratio;
     bool _low_hit_ratio;
+    bool _pending_index_search;
     const vespalib::Doom& _doom;
     MatchingPhase _matching_phase;
     search::tensor::NearestNeighborIndex::Stats _nni_stats;
@@ -80,8 +81,15 @@ public:
     uint32_t get_target_hits() const { return _target_hits; }
     uint32_t get_adjusted_target_hits() const { return _adjusted_target_hits; }
     bool want_global_filter(GlobalFilterLimits& limits) const override;
+    // Offers the GlobalFilter to the blueprint, which then decides whether to search the index or fall back to an exact search.
+    // After calling this method, pending_index_search() has to be called to check if the blueprint decided on an index search
+    // and perform_index_search() has to be called to perform the search.
     void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
     void set_lazy_filter(const GlobalFilter &lazy_filter) override;
+    // Whether the last call to want_global_filter() resulted in the decision to search the index.
+    bool pending_index_search() const;
+    // Perform the index search scheduled by the last call to set_global_filter().
+    void perform_index_search();
     Algorithm get_algorithm() const { return _algorithm; }
     double get_distance_threshold() const { return _hnsw_params.distance_threshold; }
     const HnswParams& get_hnsw_params() const { return _hnsw_params; }


### PR DESCRIPTION
Preparation for ANN timeout. Allows you to know how many ANN searches will actually be performed so that you can split the timeout.

Also makes it possible to have an own "Perform ANN search(es)" step in the trace after the "Handle global filter in query execution plan" step later on.