### PR TITLE
Remove restart for internal redeployment when local LLM config is unchanged

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
@@ -24,7 +24,7 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
  * configs for this cluster.
  *
  * @author Lester Solbakken
- * @author glabashnik
+ * @author glebashnik
  */
 public class RestartOnDeployForLocalLLMValidator implements ChangeValidator {
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
@@ -1,25 +1,30 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
+import ai.vespa.llm.clients.LlmLocalClientConfig;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.INFO;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 /**
  * If using local LLMs, this validator will make sure that restartOnDeploy is set for
  * configs for this cluster.
  *
- * @author lesters
+ * @author Lester Solbakken
+ * @author glabashnik
  */
 public class RestartOnDeployForLocalLLMValidator implements ChangeValidator {
 
@@ -29,26 +34,86 @@ public class RestartOnDeployForLocalLLMValidator implements ChangeValidator {
 
     @Override
     public void validate(ChangeContext context) {
-        var previousClustersWithLocalLLM = findClustersWithLocalLLMs(context.previousModel());
-        var nextClustersWithLocalLLM = findClustersWithLocalLLMs(context.model());
+        Set<ClusterSpec.Id> previousClustersWithLocalLLM = findClustersWithLocalLLMs(context.previousModel());
+        Set<ClusterSpec.Id> nextClustersWithLocalLLM = findClustersWithLocalLLMs(context.model());
 
-        // Only restart services if we use a local LLM in both the next and previous generation
-        for (var clusterId : intersect(previousClustersWithLocalLLM, nextClustersWithLocalLLM)) {
+        // For clusters with local LLM in both generations: always restart on external redeploy,
+        // but only restart on internal redeploy if the local LLM config changed.
+        for (ClusterSpec.Id clusterId : intersect(previousClustersWithLocalLLM, nextClustersWithLocalLLM)) {
+            ApplicationContainerCluster previousCluster = context.previousModel().getContainerClusters().get(
+                    clusterId.value());
+            ApplicationContainerCluster nextCluster = context.model().getContainerClusters().get(clusterId.value());
+            boolean llmConfigChanged = localLLMConfigChanged(
+                    context.previousModel(), previousCluster,
+                    context.model(), nextCluster
+            );
+
             String message = Text.format("Need to restart services in %s due to use of local LLM", clusterId);
             context.require(new VespaRestartAction(
                     clusterId,
                     message,
-                    context.model().getContainerClusters().get(clusterId.value()).getContainers()
-                            .stream().map(AbstractService::getServiceInfo).toList(),
-                    VespaRestartAction.ConfigChange.DEFER_UNTIL_RESTART));
+                    nextCluster.getContainers().stream().map(AbstractService::getServiceInfo).toList(),
+                    !llmConfigChanged,
+                    VespaRestartAction.ConfigChange.DEFER_UNTIL_RESTART
+            ));
             log.log(INFO, message);
         }
     }
 
+    private boolean localLLMConfigChanged(VespaModel previousModel, ApplicationContainerCluster previousCluster,
+                                          VespaModel nextModel, ApplicationContainerCluster nextCluster) {
+        Map<String, Component<?, ?>> previousLLMs = findLocalLLMComponents(previousCluster);
+        Map<String, Component<?, ?>> nextLLMs = findLocalLLMComponents(nextCluster);
+
+        if (!previousLLMs.keySet().equals(nextLLMs.keySet())) {
+            return true;
+        }
+
+        for (String id : nextLLMs.keySet()) {
+            LlmLocalClientConfig previousConfig = previousModel.getConfig(
+                    LlmLocalClientConfig.class, previousLLMs.get(id).getConfigId());
+            LlmLocalClientConfig nextConfig = nextModel.getConfig(
+                    LlmLocalClientConfig.class, nextLLMs.get(id).getConfigId());
+
+            if (configChanged(previousConfig, nextConfig)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Custom field-by-field comparison is needed because LlmLocalClientConfig.equals() delegates to
+     * LeafNode.equals(), which compares the resolved Path value. For model references that have not yet
+     * been resolved (e.g. during deployment validation), the resolved value is null regardless of the
+     * configured path, so two components with different model paths would incorrectly appear equal.
+     * ModelReference.equals() compares the configured path directly and is correct for unresolved refs.
+     */
+    private boolean configChanged(LlmLocalClientConfig previous, LlmLocalClientConfig next) {
+        return !previous.modelReference().equals(next.modelReference())
+                || previous.parallelRequests() != next.parallelRequests()
+                || previous.maxQueueSize() != next.maxQueueSize()
+                || previous.maxQueueWait() != next.maxQueueWait()
+                || previous.maxEnqueueWait() != next.maxEnqueueWait()
+                || previous.useGpu() != next.useGpu()
+                || previous.gpuLayers() != next.gpuLayers()
+                || previous.threads() != next.threads()
+                || previous.contextSize() != next.contextSize()
+                || previous.maxTokens() != next.maxTokens()
+                || previous.maxPromptTokens() != next.maxPromptTokens()
+                || previous.contextOverflowPolicy() != next.contextOverflowPolicy()
+                || previous.seed() != next.seed();
+    }
+
+    private Map<String, Component<?, ?>> findLocalLLMComponents(ApplicationContainerCluster cluster) {
+        return cluster.getAllComponents().stream()
+                .filter(c -> c.getClassId().getName().equals(LOCAL_LLM_COMPONENT))
+                .collect(toUnmodifiableMap(c -> c.getComponentId().stringValue(), c -> c));
+    }
+
     private Set<ClusterSpec.Id> findClustersWithLocalLLMs(VespaModel model) {
         return model.getContainerClusters().values().stream()
-                .filter(cluster -> cluster.getAllComponents().stream()
-                    .anyMatch(component -> component.getClassId().getName().equals(LOCAL_LLM_COMPONENT)))
+                .filter(cluster -> !findLocalLLMComponents(cluster).isEmpty())
                 .map(ApplicationContainerCluster::id)
                 .collect(toUnmodifiableSet());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidator.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.model.application.validation.change;
 import ai.vespa.llm.clients.LlmLocalClientConfig;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.text.Text;
+import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -83,26 +84,13 @@ public class RestartOnDeployForLocalLLMValidator implements ChangeValidator {
     }
 
     /**
-     * Custom field-by-field comparison is needed because LlmLocalClientConfig.equals() delegates to
-     * LeafNode.equals(), which compares the resolved Path value. For model references that have not yet
-     * been resolved (e.g. during deployment validation), the resolved value is null regardless of the
-     * configured path, so two components with different model paths would incorrectly appear equal.
-     * ModelReference.equals() compares the configured path directly and is correct for unresolved refs.
+     * Compares configs via their serialized payload. ConfigPayload serializes ModelNode using
+     * ModelNode.getValue(), which returns the configured reference string rather than the resolved
+     * Path — correctly detecting model path changes even before model references are resolved.
      */
     private boolean configChanged(LlmLocalClientConfig previous, LlmLocalClientConfig next) {
-        return !previous.modelReference().equals(next.modelReference())
-                || previous.parallelRequests() != next.parallelRequests()
-                || previous.maxQueueSize() != next.maxQueueSize()
-                || previous.maxQueueWait() != next.maxQueueWait()
-                || previous.maxEnqueueWait() != next.maxEnqueueWait()
-                || previous.useGpu() != next.useGpu()
-                || previous.gpuLayers() != next.gpuLayers()
-                || previous.threads() != next.threads()
-                || previous.contextSize() != next.contextSize()
-                || previous.maxTokens() != next.maxTokens()
-                || previous.maxPromptTokens() != next.maxPromptTokens()
-                || previous.contextOverflowPolicy() != next.contextOverflowPolicy()
-                || previous.seed() != next.seed();
+        return !ConfigPayload.fromInstance(previous).toString(true)
+                .equals(ConfigPayload.fromInstance(next).toString(true));
     }
 
     private Map<String, Component<?, ?>> findLocalLLMComponents(ApplicationContainerCluster cluster) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidatorTest.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestDeployState;
-import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
@@ -14,10 +13,12 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author lesters
+ * @author Lester Solbakken
+ * @author glabashnik
  */
 public class RestartOnDeployForLocalLLMValidatorTest {
 
@@ -26,38 +27,68 @@ public class RestartOnDeployForLocalLLMValidatorTest {
     @Test
     void validate_no_restart_on_deploy() {
         VespaModel current = createModel();
-        VespaModel next = createModel(withComponent(LOCAL_LLM_COMPONENT));
+        VespaModel next = createModel(withLocalLLMComponent("models/model.gguf", 1));
         List<ConfigChangeAction> result = validateModel(current, next);
         assertEquals(0, result.size());
     }
 
     @Test
-    void validate_restart_on_deploy() {
-        VespaModel current = createModel(withComponent(LOCAL_LLM_COMPONENT));
-        VespaModel next = createModel(withComponent(LOCAL_LLM_COMPONENT));
+    void validate_restart_on_deploy_llm_config_unchanged() {
+        VespaModel current = createModel(withLocalLLMComponent("models/model.gguf", 1));
+        VespaModel next = createModel(withLocalLLMComponent("models/model.gguf", 1));
         List<ConfigChangeAction> result = validateModel(current, next);
         assertEquals(1, result.size());
         assertTrue(result.get(0).validationId().isEmpty());
-        assertEquals("Need to restart services in cluster 'cluster1' due to use of local LLM", result.get(0).getMessage());
+        assertEquals(
+                "Need to restart services in cluster 'cluster1' due to use of local LLM", result.get(0).getMessage());
+        assertTrue(
+                result.get(0).ignoreForInternalRedeploy(),
+                "Restart must be ignored for internal redeployment when LLM config is unchanged"
+        );
+    }
+
+    @Test
+    void validate_restart_on_deploy_llm_config_changed() {
+        VespaModel current = createModel(withLocalLLMComponent("models/model.gguf", 1));
+        VespaModel next = createModel(withLocalLLMComponent("models/model.gguf", 2));
+        List<ConfigChangeAction> result = validateModel(current, next);
+        assertEquals(1, result.size());
+        assertFalse(
+                result.get(0).ignoreForInternalRedeploy(),
+                "Restart must not be ignored for internal redeployment when LLM config changed"
+        );
+    }
+
+    @Test
+    void validate_restart_on_deploy_model_path_changed() {
+        VespaModel current = createModel(withLocalLLMComponent("models/model-a.gguf", 1));
+        VespaModel next = createModel(withLocalLLMComponent("models/model-b.gguf", 1));
+        List<ConfigChangeAction> result = validateModel(current, next);
+        assertEquals(1, result.size());
+        assertFalse(result.get(0).ignoreForInternalRedeploy(), "Restart must not be ignored when model path changed");
     }
 
     private static List<ConfigChangeAction> validateModel(VespaModel current, VespaModel next) {
-        return ValidationTester.validateChanges(new RestartOnDeployForLocalLLMValidator(),
-                                                next,
-                                                deployStateBuilder().previousModel(current).build());
+        return ValidationTester.validateChanges(
+                new RestartOnDeployForLocalLLMValidator(),
+                next,
+                deployStateBuilder().previousModel(current).build()
+        );
     }
 
     private static VespaModel createModel(String component) {
-        var xml = Text.format("""
-                <services version='1.0'>
-                  <container id='cluster1' version='1.0'>
-                    <http>
-                      <server id='server1' port='8080'/>
-                    </http>
-                    %s
-                  </container>
-                </services>
-                """, component);
+        var xml = Text.format(
+                """
+                        <services version='1.0'>
+                          <container id='cluster1' version='1.0'>
+                            <http>
+                              <server id='server1' port='8080'/>
+                            </http>
+                            %s
+                          </container>
+                        </services>
+                        """, component
+        );
         DeployState.Builder builder = deployStateBuilder();
         return new VespaModelCreatorWithMockPkg(null, xml).create(builder);
     }
@@ -66,16 +97,21 @@ public class RestartOnDeployForLocalLLMValidatorTest {
         return createModel("");
     }
 
-    private static String withComponent(String componentClass) {
-        return Text.format("<component id='llm' class='%s' />", componentClass);
+    private static String withLocalLLMComponent(String modelPath, int parallelRequests) {
+        return Text.format(
+                """
+                        <component id='llm' class='%s'>
+                          <config name="ai.vespa.llm.clients.llm-local-client">
+                            <model path="%s"/>
+                            <parallelRequests>%d</parallelRequests>
+                          </config>
+                        </component>""", RestartOnDeployForLocalLLMValidatorTest.LOCAL_LLM_COMPONENT, modelPath,
+                parallelRequests
+        );
     }
 
     private static DeployState.Builder deployStateBuilder() {
         return TestDeployState.createBuilder();
-    }
-
-    private static void assertStartsWith(String expected, List<ConfigChangeAction> result) {
-        assertTrue(result.get(0).getMessage().startsWith(expected));
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForLocalLLMValidatorTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Lester Solbakken
- * @author glabashnik
+ * @author glebashnik
  */
 public class RestartOnDeployForLocalLLMValidatorTest {
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Previous logic always triggered restart when local LLM component is present in previous and next config generation.
This resulted in hourly restarts triggered by internal redeployment.
This changes the restart on deploy logic to not trigger restart for internal redeployment when local LLM component config is unchanged.