### PR TITLE
Add EntryRef to RawDocumentMetaData and ArrayStore to DocumentMetaStore

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -282,7 +282,7 @@ putDoc(DocumentMetaStore &dms, const DocumentId& docid, uint32_t lid, Timestamp 
 }
 
 TEST(DocumentMetaStoreTest, control_meta_data_sizeof) {
-    EXPECT_EQ(24u, sizeof(RawDocumentMetaData));
+    EXPECT_EQ(32u, sizeof(RawDocumentMetaData));
     EXPECT_EQ(40u, sizeof(search::DocumentMetaData));
 }
  TEST(DocumentMetaStoreTest, removed_documents_are_bucketized_to_bucket_0)

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -26,6 +26,7 @@
 #include <vespa/vespalib/btree/btreenodeallocator.hpp>
 #include <vespa/vespalib/btree/btreenodestore.hpp>
 #include <vespa/vespalib/btree/btreeroot.hpp>
+#include <vespa/vespalib/datastore/array_store.hpp>
 #include <vespa/vespalib/datastore/buffer_type.hpp>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/rcuvector.hpp>
@@ -61,7 +62,6 @@ using vespalib::btree::BTreeNoLeafData;
 using vespalib::make_string;
 
 namespace proton {
-
 namespace documentmetastore {
 
 std::string DOCID_LIMIT("docIdLimit");
@@ -454,6 +454,7 @@ DocumentMetaStore::DocumentMetaStore(BucketDBOwnerSP bucketDB,
                                      SubDbType subDbType)
     : DocumentMetaStoreAttribute(name),
       _metaDataStore(grow, getGenerationHolder()),
+      _docid_store(make_default_docid_array_store_config(), {}),
       _gidToLidMap(),
       _gid_to_lid_map_write_itr(vespalib::datastore::EntryRef(), _gidToLidMap.getAllocator()),
       _gid_to_lid_map_write_itr_prepare_serial_num(0u),
@@ -1180,6 +1181,17 @@ DocumentMetaStore::make_sort_blob_writer(bool ascending, const search::common::B
     } else {
         return std::make_unique<DocumentMetaStoreSortBlobWriter<false>>(*this);
     }
+}
+
+vespalib::datastore::ArrayStoreConfig
+DocumentMetaStore::make_default_docid_array_store_config()
+{
+    return DocumentIdStore::optimizedConfigForHugePage(193,
+                                                       vespalib::alloc::MemoryAllocator::HUGEPAGE_SIZE,
+                                                       vespalib::alloc::MemoryAllocator::PAGE_SIZE,
+                                                       vespalib::datastore::ArrayStoreConfig::default_max_buffer_size,
+                                                       512_Ki,
+                                                       0.3).enable_free_lists(true);
 }
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -27,6 +27,7 @@
 #include <vespa/vespalib/btree/btreenodestore.hpp>
 #include <vespa/vespalib/btree/btreeroot.hpp>
 #include <vespa/vespalib/datastore/array_store.hpp>
+#include <vespa/vespalib/datastore/dynamic_array_buffer_type.h>
 #include <vespa/vespalib/datastore/buffer_type.hpp>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/rcuvector.hpp>
@@ -454,7 +455,7 @@ DocumentMetaStore::DocumentMetaStore(BucketDBOwnerSP bucketDB,
                                      SubDbType subDbType)
     : DocumentMetaStoreAttribute(name),
       _metaDataStore(grow, getGenerationHolder()),
-      _docid_store(make_default_docid_array_store_config(), {}),
+      _docid_store(make_default_docid_array_store_config(), get_memory_allocator(), TypeMapper(array_store_max_type_id, array_store_grow_factor, array_store_max_buffer_size)),
       _gidToLidMap(),
       _gid_to_lid_map_write_itr(vespalib::datastore::EntryRef(), _gidToLidMap.getAllocator()),
       _gid_to_lid_map_write_itr_prepare_serial_num(0u),
@@ -1186,12 +1187,13 @@ DocumentMetaStore::make_sort_blob_writer(bool ascending, const search::common::B
 vespalib::datastore::ArrayStoreConfig
 DocumentMetaStore::make_default_docid_array_store_config()
 {
-    return DocumentIdStore::optimizedConfigForHugePage(193,
+    return DocumentIdStore::optimizedConfigForHugePage(array_store_max_type_id,
+                                                       TypeMapper(array_store_max_type_id, array_store_grow_factor, array_store_max_buffer_size),
                                                        vespalib::alloc::MemoryAllocator::HUGEPAGE_SIZE,
                                                        vespalib::alloc::MemoryAllocator::PAGE_SIZE,
-                                                       vespalib::datastore::ArrayStoreConfig::default_max_buffer_size,
-                                                       512_Ki,
-                                                       0.3).enable_free_lists(true);
+                                                       array_store_max_buffer_size,
+                                                       8_Ki,
+                                                       array_store_alloc_grow_factor);
 }
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -63,6 +63,7 @@ using vespalib::btree::BTreeNoLeafData;
 using vespalib::make_string;
 
 namespace proton {
+
 namespace documentmetastore {
 
 std::string DOCID_LIMIT("docIdLimit");

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -11,6 +11,7 @@
 #include <vespa/searchlib/docstore/ibucketizer.h>
 #include <vespa/searchcommon/common/growstrategy.h>
 #include <vespa/vespalib/datastore/array_store.h>
+#include <vespa/vespalib/datastore/array_store_dynamic_type_mapper.h>
 #include <vespa/vespalib/util/rcuvector.h>
 
 namespace proton::bucketdb {
@@ -59,7 +60,13 @@ private:
     using KeyComp = documentmetastore::LidGidKeyComparator;
     using OperationListenerSP = std::shared_ptr<documentmetastore::OperationListener>;
     using BucketDBOwnerSP = std::shared_ptr<bucketdb::BucketDBOwner>;
-    using DocumentIdStore = vespalib::datastore::ArrayStore<char, RawDocumentMetaData::DocumentIdEntryRef>;
+    using TypeMapper = vespalib::datastore::ArrayStoreDynamicTypeMapper<char>;
+    using DocumentIdStore = vespalib::datastore::ArrayStore<char, RawDocumentMetaData::DocumentIdEntryRef, TypeMapper>;
+
+    static constexpr float array_store_alloc_grow_factor = 0.2;
+    static constexpr double array_store_grow_factor = 1.03;
+    static constexpr uint32_t array_store_max_type_id = 400;
+    static constexpr size_t array_store_max_buffer_size = vespalib::datastore::ArrayStoreConfig::default_max_buffer_size;
 
     // Lids are stored as keys in the tree, sorted by their gid
     // counterpart.  The LidGidKeyComparator class maps from lids -> metadata by

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -10,6 +10,7 @@
 #include <vespa/searchcore/proton/common/subdbtype.h>
 #include <vespa/searchlib/docstore/ibucketizer.h>
 #include <vespa/searchcommon/common/growstrategy.h>
+#include <vespa/vespalib/datastore/array_store.h>
 #include <vespa/vespalib/util/rcuvector.h>
 
 namespace proton::bucketdb {
@@ -58,6 +59,7 @@ private:
     using KeyComp = documentmetastore::LidGidKeyComparator;
     using OperationListenerSP = std::shared_ptr<documentmetastore::OperationListener>;
     using BucketDBOwnerSP = std::shared_ptr<bucketdb::BucketDBOwner>;
+    using DocumentIdStore = vespalib::datastore::ArrayStore<char, RawDocumentMetaData::DocumentIdEntryRef>;
 
     // Lids are stored as keys in the tree, sorted by their gid
     // counterpart.  The LidGidKeyComparator class maps from lids -> metadata by
@@ -67,6 +69,7 @@ private:
     using LidAndRawDocumentMetaData = std::pair<uint32_t, RawDocumentMetaData>;
 
     MetaDataStore       _metaDataStore;
+    DocumentIdStore     _docid_store;
     TreeType            _gidToLidMap;
     Iterator            _gid_to_lid_map_write_itr; // Iterator used for all updates of _gidToLidMap
     SerialNum           _gid_to_lid_map_write_itr_prepare_serial_num;
@@ -285,6 +288,8 @@ public:
     make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
                           search::common::sortspec::MissingPolicy policy,
                           std::string_view missing_value) const override;
+
+    static vespalib::datastore::ArrayStoreConfig make_default_docid_array_store_config();
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/raw_document_meta_data.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/raw_document_meta_data.h
@@ -5,6 +5,7 @@
 #include <vespa/document/base/globalid.h>
 #include <vespa/document/bucket/bucketid.h>
 #include <vespa/persistence/spi/types.h>
+#include <vespa/vespalib/datastore/entryref.h>
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -19,7 +20,9 @@ struct RawDocumentMetaData
     using GlobalId = document::GlobalId;
     using BucketId = document::BucketId;
     using Timestamp = storage::spi::Timestamp;
-    GlobalId  _gid;
+    using DocumentIdEntryRef = vespalib::datastore::EntryRefT<19>;
+    GlobalId              _gid;
+    DocumentIdEntryRef    _docid_ref;
     std::atomic<uint32_t> _bucket_used_bits_and_doc_size;
     std::atomic<uint64_t> _timestamp;
 
@@ -27,12 +30,14 @@ struct RawDocumentMetaData
 
     RawDocumentMetaData() noexcept
         : _gid(),
+          _docid_ref(),
           _bucket_used_bits_and_doc_size(BucketId::minNumBits),
           _timestamp(0)
     { }
 
     RawDocumentMetaData(const GlobalId &gid, const BucketId &bucketId, const Timestamp &timestamp, uint32_t docSize) noexcept
         : _gid(gid),
+          _docid_ref(),
           _bucket_used_bits_and_doc_size(bucketId.getUsedBits() | (capped_doc_size(docSize) << 8)),
           _timestamp(timestamp)
     {
@@ -45,6 +50,7 @@ struct RawDocumentMetaData
 
     RawDocumentMetaData(const RawDocumentMetaData& rhs)
         : _gid(rhs._gid),
+          _docid_ref(rhs._docid_ref),
           _bucket_used_bits_and_doc_size(rhs._bucket_used_bits_and_doc_size.load(std::memory_order_relaxed)),
           _timestamp(rhs._timestamp.load(std::memory_order_relaxed))
     {
@@ -52,6 +58,7 @@ struct RawDocumentMetaData
 
     RawDocumentMetaData& operator=(const RawDocumentMetaData& rhs) {
         _gid = rhs._gid;
+        _docid_ref = rhs._docid_ref;
         _bucket_used_bits_and_doc_size.store(rhs._bucket_used_bits_and_doc_size.load(std::memory_order_relaxed), std::memory_order_relaxed);
         _timestamp.store(rhs._timestamp.load(std::memory_order_relaxed), std::memory_order_relaxed);
         return *this;


### PR DESCRIPTION
Adding the EntryRef makes the `RawDocumentMetaData` grow by 8 bytes due to alignment even though the EntryRef is just 4 bytes.

@toregge How does one properly configure an ArrayStore?

Edit: Plan is to use the 4 bytes we have to use from alignment to store a more precise document size later on.