### PR TITLE
Add max-document-size element under <document-api> in services.xml

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -111,7 +111,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean forwardAllLogLevels() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxContentNodeMaintenanceOpConcurrency() { return -1; }
-        @ModelFeatureFlag(owners = {"glebashnik"}) default int maxDocumentOperationRequestSizeMib() { return 2048; }
+        @ModelFeatureFlag(owners = {"glebashnik"}) default int maxDocumentOperationRequestSizeMib() { return 128; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default Object sidecarsForTest() { return null; }
         @ModelFeatureFlag(owners = {"bjorncs"}) default boolean useTriton() { return false; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean ignoreConnectivityChecksAtStartup() { return false; }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/MaxDocumentSizeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/MaxDocumentSizeValidator.java
@@ -1,0 +1,50 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation;
+
+import com.yahoo.vespa.model.application.validation.Validation.Context;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.content.cluster.ContentCluster;
+
+import java.util.OptionalInt;
+import java.util.logging.Level;
+
+/**
+ * Validates that the {@code <max-document-size>} configured under {@code <document-api>} is not
+ * larger than the smallest {@code max-document-size} configured on any content cluster — otherwise
+ * the document API would accept requests the content cluster will reject.
+ *
+ * <p>Currently issues a deploy WARNING. TODO: tighten to a hard failure once usage is understood.
+ *
+ * @author hmusum
+ */
+public class MaxDocumentSizeValidator implements Validator {
+
+    @Override
+    public void validate(Context context) {
+        OptionalInt smallestContentMax = smallestContentClusterMaxDocumentSizeMib(context);
+        if (smallestContentMax.isEmpty()) return;
+
+        for (var entry : context.model().getContainerClusters().entrySet()) {
+            String clusterId = entry.getKey();
+            ApplicationContainerCluster cluster = entry.getValue();
+            int containerMax = cluster.getMaxDocumentOperationRequestSizeMib();
+            if (containerMax > smallestContentMax.getAsInt()) {
+                context.deployState().getDeployLogger().log(Level.WARNING,
+                        "max-document-size in <document-api> for container cluster '" + clusterId +
+                        "' is " + containerMax + " MiB, which is larger than the smallest content cluster " +
+                        "max-document-size of " + smallestContentMax.getAsInt() + " MiB. " +
+                        "Documents larger than the content cluster limit will be rejected. " +
+                        "This will become a hard failure in a future release.");
+            }
+        }
+    }
+
+    private static OptionalInt smallestContentClusterMaxDocumentSizeMib(Context context) {
+        return context.model().getContentClusters().values().stream()
+                .map(ContentCluster::getDistributorNodes)
+                .filter(d -> d != null)
+                .mapToInt(d -> d.getMaxDocumentOperationSizeMib())
+                .filter(v -> v > 0)
+                .min();
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -121,6 +121,7 @@ public class Validation {
         new TenantSecretValidator().validate(execution);
         new HnswValidator().validate(execution);
         new EmbedExpressionValidator().validate(execution);
+        new MaxDocumentSizeValidator().validate(execution);
     }
 
     private static void validateFirstTimeDeployment(Execution execution) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -104,7 +104,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     private int zookeeperSessionTimeoutSeconds = 30;
     private final int transport_events_before_wakeup;
     private final int transport_connections_per_target;
-    private final int maxDocumentOperationRequestSizeMib;
+    private int maxDocumentOperationRequestSizeMib;
 
     /** The heap size % of total memory available to the JVM process. */
     private final int heapSizePercentageOfAvailableMemory;
@@ -220,6 +220,11 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     }
 
     public void setMemoryPercentage(Integer memoryPercentage) { this.memoryPercentage = memoryPercentage; }
+
+    /** Overrides the feature-flag-derived default for the document API max request size. */
+    public void setMaxDocumentOperationRequestSizeMib(int mib) { this.maxDocumentOperationRequestSizeMib = mib; }
+
+    public int getMaxDocumentOperationRequestSizeMib() { return maxDocumentOperationRequestSizeMib; }
 
     public void setInferenceMemory(long bytes) { this.inferenceMemoryBytes = Optional.of(bytes); }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1375,6 +1375,8 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         if (documentApiElement == null) return ContainerDocumentApi.createDummyApi(cluster);
 
         ContainerDocumentApi.HandlerOptions documentApiOptions = DocumentApiOptionsBuilder.build(documentApiElement);
+        DocumentApiOptionsBuilder.parseMaxDocumentSizeMib(documentApiElement, deployState.getDeployLogger())
+                .ifPresent(cluster::setMaxDocumentOperationRequestSizeMib);
         Element ignoreUndefinedFields = XML.getChild(documentApiElement, "ignore-undefined-fields");
         return new ContainerDocumentApi(deployState, cluster, documentApiOptions,
                                         "true".equals(XML.getValue(ignoreUndefinedFields)), portBindingOverride(deployState, context, cluster));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/DocumentApiOptionsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/DocumentApiOptionsBuilder.java
@@ -1,14 +1,19 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.xml;
 
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.text.XML;
+import com.yahoo.vespa.model.builder.xml.dom.BinaryUnit;
 import com.yahoo.vespa.model.clients.ContainerDocumentApi;
 import org.w3c.dom.Element;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
 
 /**
  * @author Einar M R Rosenvinge
@@ -19,6 +24,28 @@ public class DocumentApiOptionsBuilder {
 
     public static ContainerDocumentApi.HandlerOptions build(Element spec) {
         return new ContainerDocumentApi.HandlerOptions(getBindings(spec), XML.getChild(spec, "http-client-api"));
+    }
+
+    /**
+     * Parses the optional {@code <max-document-size>} child of {@code <document-api>} and returns
+     * its value in MiB. The value uses the same syntax as the content cluster's
+     * {@code max-document-size} (e.g. {@code 100Mb}).
+     */
+    public static OptionalInt parseMaxDocumentSizeMib(Element spec, DeployLogger deployLogger) {
+        if (spec == null) return OptionalInt.empty();
+        Element maxSize = XML.getChild(spec, "max-document-size");
+        if (maxSize == null) return OptionalInt.empty();
+        String configuredValue = XML.getValue(maxSize);
+        if (configuredValue == null || configuredValue.isEmpty()) return OptionalInt.empty();
+        // The configured value has units, but the config expects it in MiB, extract the value and convert
+        int maxDocumentSize = (int) (BinaryUnit.valueOf(configuredValue) / 1024 / 1024);
+        if (maxDocumentSize < 1 || maxDocumentSize > 2048)
+            throw new IllegalArgumentException("Invalid max-document-size value '" + configuredValue + "': Value must be between 1 MiB and 2048 MiB");
+        if (maxDocumentSize > 128)
+            deployLogger.log(WARNING, "max-document-size value is set to '" + configuredValue +
+                    "', setting this above 128 MiB is strongly discouraged, as it may cause major performance issues. " +
+                    "See https://docs.vespa.ai/en/reference/services/container.html#document-api");
+        return OptionalInt.of(maxDocumentSize);
     }
 
     private static List<String> getBindings(Element spec) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -169,6 +169,9 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
         return parent.getName();
     }
 
+    /** Returns the configured {@code max-document-size} in MiB, or 0 if not set. */
+    public int getMaxDocumentOperationSizeMib() { return maxDocumentOperationSizeMib; }
+
     private static int maxDocumentSizeInMib(ModelElement clusterElement, DeployLogger deployLogger) {
         var tuning = clusterElement.child("tuning");
         if (tuning == null) return 0;

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -295,6 +295,7 @@ DocumentApi = element document-api {
    element route { text }? &
    element maxpendingdocs { xsd:positiveInteger }? &
    element maxpendingbytes { xsd:positiveInteger }? &
+   element max-document-size { xsd:string }? &
    element retrydelay { xsd:double { minInclusive = "0.0" } }? &
    element timeout { xsd:double { minInclusive = "0.0" } }? &
    element tracelevel { xsd:positiveInteger }? &

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/MaxDocumentSizeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/MaxDocumentSizeValidatorTest.java
@@ -1,0 +1,84 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.config.model.test.MockApplicationPackage;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.test.utils.ApplicationPackageUtils;
+import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author hmusum
+ */
+public class MaxDocumentSizeValidatorTest {
+
+    @Test
+    void warns_when_document_api_exceeds_smallest_content_cluster_max() {
+        var logger = new CapturingLogger();
+        buildModel(logger, "200Mb", "100Mb");
+        assertTrue(logger.warnings.stream().anyMatch(m -> m.contains("is 200 MiB") && m.contains("100 MiB")),
+                () -> "Expected mismatch warning, got: " + logger.warnings);
+    }
+
+    @Test
+    void no_warning_when_document_api_at_or_below_content_max() {
+        var logger = new CapturingLogger();
+        buildModel(logger, "100Mb", "100Mb");
+        assertFalse(logger.warnings.stream().anyMatch(m -> m.contains("max-document-size in <document-api>")),
+                () -> "Expected no mismatch warning, got: " + logger.warnings);
+    }
+
+    @Test
+    void no_warning_when_content_cluster_has_no_explicit_max() {
+        var logger = new CapturingLogger();
+        buildModel(logger, "200Mb", null);
+        assertFalse(logger.warnings.stream().anyMatch(m -> m.contains("max-document-size in <document-api>")),
+                () -> "Expected no mismatch warning when content cluster has no explicit max, got: " + logger.warnings);
+    }
+
+    private static VespaModel buildModel(DeployLogger logger, String containerMax, String contentMax) {
+        String tuning = (contentMax == null) ? "" :
+                "      <tuning><max-document-size>" + contentMax + "</max-document-size></tuning>";
+        String services =
+                "<?xml version='1.0' encoding='UTF-8' ?>" +
+                "<services version='1.0'>" +
+                "  <admin version='2.0'><adminserver hostalias='node1'/></admin>" +
+                "  <container id='default' version='1.0'>" +
+                "    <document-api>" +
+                "      <max-document-size>" + containerMax + "</max-document-size>" +
+                "    </document-api>" +
+                "    <nodes><node hostalias='node1'/></nodes>" +
+                "  </container>" +
+                "  <content id='storage' version='1.0'>" +
+                "    <redundancy>1</redundancy>" +
+                "    <documents><document mode='index' type='type1'/></documents>" +
+                "    <group><node distribution-key='0' hostalias='node1'/></group>" +
+                tuning +
+                "  </content>" +
+                "</services>";
+        var sds = ApplicationPackageUtils.generateSchemas("type1");
+        var pkg = new MockApplicationPackage.Builder().withServices(services).withSchemas(sds).build();
+        var deployStateBuilder = new DeployState.Builder()
+                .applicationPackage(pkg)
+                .properties(new TestProperties())
+                .deployLogger(logger);
+        return new VespaModelCreatorWithMockPkg(pkg).create(deployStateBuilder);
+    }
+
+    private static class CapturingLogger implements DeployLogger {
+        final List<String> warnings = new ArrayList<>();
+        @Override public void log(Level level, String message) {
+            if (level.intValue() >= Level.WARNING.intValue()) warnings.add(message);
+        }
+    }
+}

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
@@ -6,6 +6,7 @@ import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.document.config.DocumentmanagerConfig;
+import com.yahoo.document.restapi.DocumentOperationExecutorConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.component.Handler;
@@ -22,6 +23,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -121,6 +123,52 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
                 ContainerThreadpoolConfig.class, "cluster1/component/com.yahoo.vespa.http.server.FeedHandler/threadpool@feedapi-handler");
         assertEquals(4, config.relativeMaxThreads());
         assertEquals(4, config.relativeMinThreads());
+    }
+
+    @Test
+    void max_document_size_is_parsed() {
+        Element elem = DomBuilderTest.parse(
+                "<container id='cluster1' version='1.0'>",
+                "  <document-api>",
+                "    <max-document-size>100Mb</max-document-size>",
+                "  </document-api>",
+                nodesXml,
+                "</container>");
+        ContainerModel model = createModel(root, elem).get(0);
+
+        var builder = new DocumentOperationExecutorConfig.Builder();
+        ((com.yahoo.vespa.model.container.ApplicationContainerCluster) model.getCluster()).getConfig(builder);
+        assertEquals(100, builder.build().maxDocumentOperationRequestSizeMib());
+    }
+
+    @Test
+    void max_document_size_above_2048_is_rejected() {
+        Element elem = DomBuilderTest.parse(
+                "<container id='cluster1' version='1.0'>",
+                "  <document-api>",
+                "    <max-document-size>3gb</max-document-size>",
+                "  </document-api>",
+                nodesXml,
+                "</container>");
+        var ex = assertThrows(IllegalArgumentException.class, () -> createModel(root, elem));
+        assertTrue(ex.getMessage().contains("Invalid max-document-size value '3gb'"),
+                () -> "Unexpected message: " + ex.getMessage());
+    }
+
+    @Test
+    void max_document_size_omitted_keeps_feature_flag_default() {
+        Element elem = DomBuilderTest.parse(
+                "<container id='cluster1' version='1.0'>",
+                "  <document-api />",
+                nodesXml,
+                "</container>");
+        ContainerModel model = createModel(root, elem).get(0);
+
+        var builder = new DocumentOperationExecutorConfig.Builder();
+        ((com.yahoo.vespa.model.container.ApplicationContainerCluster) model.getCluster()).getConfig(builder);
+        // Feature-flag default in tests; just assert it was not overridden to our test value.
+        assertFalse(builder.build().maxDocumentOperationRequestSizeMib() == 100,
+                "Expected feature-flag default, not the value tested above");
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
@@ -166,9 +166,8 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
 
         var builder = new DocumentOperationExecutorConfig.Builder();
         ((com.yahoo.vespa.model.container.ApplicationContainerCluster) model.getCluster()).getConfig(builder);
-        // Feature-flag default in tests; just assert it was not overridden to our test value.
-        assertFalse(builder.build().maxDocumentOperationRequestSizeMib() == 100,
-                "Expected feature-flag default, not the value tested above");
+        assertEquals(128, builder.build().maxDocumentOperationRequestSizeMib(),
+                "Expected omitted max-document-size to keep the feature-flag default");
     }
 
     @Test

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -308,7 +308,7 @@ public class Flags {
             INSTANCE_ID);
 
     public static final UnboundIntFlag MAX_DOCUMENT_OPERATION_REQUEST_SIZE_MIB = defineIntFlag(
-            "max-document-operation-request-size-mib", 2048,
+            "max-document-operation-request-size-mib", 128,
             List.of("glebashnik"), "2025-09-04", "2026-06-01",
             "Sets the maximum size in MiB of a document operation request (POST or PUT). " +
             "This is the size of a serialized request, which can be several times larger than " +


### PR DESCRIPTION
## Summary
- New optional `<max-document-size>` element under `<document-api>` in `services.xml`, with the same syntax as the content cluster's `max-document-size` (e.g. `100Mb`). Parsed via `BinaryUnit`, range-checked to 1–2048 MiB.
- When set, overrides `maxDocumentOperationRequestSizeMib` which was previously only sourced from a feature flag — applies to all document types in the container cluster.
- New `MaxDocumentSizeValidator` warns when the document-api value exceeds the smallest content-cluster `max-document-size`. Marked with TODO to tighten to a hard failure later.

## Benefits
- Operators can now reject oversize document API requests at the container layer instead of only after they reach the content cluster.
- Mirrors existing content-cluster `max-document-size` syntax and validation, so the error/warning text and bounds are consistent.
- No behavior change when the element is absent — the feature-flag-derived default is preserved.