### PR TITLE
Add Hugging Face TEI remote embedder component

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.model.container.component.ColBertEmbedder;
 import com.yahoo.vespa.model.container.component.SpladeEmbedder;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.HuggingFaceEmbedder;
+import com.yahoo.vespa.model.container.component.HuggingFaceTEIEmbedder;
 import com.yahoo.vespa.model.container.component.HuggingFaceTokenizer;
 import com.yahoo.vespa.model.container.component.VoyageAIEmbedder;
 import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuilder;
@@ -50,6 +51,7 @@ public class DomComponentBuilder extends VespaDomBuilder.DomConfigProducerBuilde
             var type = spec.getAttribute("type");
             return switch (type) {
                 case "hugging-face-embedder" -> new HuggingFaceEmbedder((ApplicationContainerCluster)ancestor, spec, state);
+                case "hugging-face-tei-embedder" -> new HuggingFaceTEIEmbedder((ApplicationContainerCluster)ancestor, spec, state);
                 case "hugging-face-tokenizer" -> new HuggingFaceTokenizer(spec, state);
                 case "colbert-embedder" -> new ColBertEmbedder((ApplicationContainerCluster)ancestor, spec, state);
                 case "bert-embedder" -> new BertEmbedder((ApplicationContainerCluster)ancestor, spec, state);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/HuggingFaceTEIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/HuggingFaceTEIEmbedder.java
@@ -1,0 +1,88 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.component;
+
+import ai.vespa.embedding.config.HuggingFaceTeiEmbedderConfig;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import org.w3c.dom.Element;
+
+import java.util.Locale;
+
+import static com.yahoo.text.XML.getChildValue;
+import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
+import static com.yahoo.vespa.model.container.component.EmbedderBatchingConfig.parseBatchingElement;
+
+/**
+ * Parses XML configuration from services.xml and produces HuggingFaceTeiEmbedderConfig.
+ */
+public class HuggingFaceTEIEmbedder extends TypedComponent implements HuggingFaceTeiEmbedderConfig.Producer {
+
+    private final String endpoint;
+    private final String apiKeySecretRef;
+    private final Integer dimensions;
+    private final Boolean normalize;
+    private final Boolean truncate;
+    private final String truncationDirection;
+    private final String promptName;
+    private final String queryPromptName;
+    private final String documentPromptName;
+    private final Integer maxRetries;
+    private final Integer timeout;
+    private final EmbedderBatchingConfig batching;
+
+    @SuppressWarnings("unused")
+    public HuggingFaceTEIEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
+        super("ai.vespa.embedding.HuggingFaceTEIEmbedder", INTEGRATION_BUNDLE_NAME, xml);
+
+        endpoint = getChildValue(xml, "endpoint").orElse(null);
+        apiKeySecretRef = getChildValue(xml, "api-key-secret-ref").orElse(null);
+        dimensions = getChildValue(xml, "dimensions").map(Integer::parseInt).orElse(null);
+        normalize = getChildValue(xml, "normalize").map(Boolean::parseBoolean).orElse(null);
+        truncate = getChildValue(xml, "truncate").map(Boolean::parseBoolean).orElse(null);
+        truncationDirection = getChildValue(xml, "truncation-direction").orElse(null);
+        promptName = getChildValue(xml, "prompt-name").orElse(null);
+        queryPromptName = getChildValue(xml, "query-prompt-name").orElse(null);
+        documentPromptName = getChildValue(xml, "document-prompt-name").orElse(null);
+        maxRetries = getChildValue(xml, "max-retries").map(Integer::parseInt).orElse(null);
+        timeout = getChildValue(xml, "timeout").map(Integer::parseInt).orElse(null);
+        batching = parseBatchingElement(xml);
+
+        validateConfig();
+    }
+
+    private void validateConfig() {
+        if (dimensions != null && dimensions < 0)
+            throw new IllegalArgumentException("dimensions must be non-negative, got: " + dimensions);
+        if (maxRetries != null && maxRetries < 0)
+            throw new IllegalArgumentException("max-retries must be non-negative, got: " + maxRetries);
+        if (timeout != null && timeout <= 0)
+            throw new IllegalArgumentException("timeout must be positive, got: " + timeout);
+        if (truncationDirection != null) {
+            var value = truncationDirection.toUpperCase(Locale.ROOT);
+            if (!value.equals("LEFT") && !value.equals("RIGHT"))
+                throw new IllegalArgumentException("truncation-direction must be one of [left, right], got: " + truncationDirection);
+        }
+    }
+
+    @Override
+    public void getConfig(HuggingFaceTeiEmbedderConfig.Builder builder) {
+        if (endpoint != null) builder.endpoint(endpoint);
+        if (apiKeySecretRef != null) builder.apiKeySecretRef(apiKeySecretRef);
+        if (dimensions != null) builder.dimensions(dimensions);
+        if (normalize != null) builder.normalize(normalize);
+        if (truncate != null) builder.truncate(truncate);
+        if (truncationDirection != null) {
+            builder.truncationDirection(HuggingFaceTeiEmbedderConfig.TruncationDirection.Enum
+                    .valueOf(truncationDirection.toUpperCase(Locale.ROOT)));
+        }
+        if (promptName != null) builder.promptName(promptName);
+        if (queryPromptName != null) builder.queryPromptName(queryPromptName);
+        if (documentPromptName != null) builder.documentPromptName(documentPromptName);
+        if (maxRetries != null) builder.maxRetries(maxRetries);
+        if (timeout != null) builder.timeout(timeout);
+        if (batching != null) {
+            builder.batching.maxSize(batching.maxSize());
+            builder.batching.maxDelayMillis(batching.maxDelay().toMillis());
+        }
+    }
+}

--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -82,7 +82,7 @@ ComponentDefinition =
 
 TypedComponentDefinition =
    attribute id { xsd:Name } &
-   (HuggingFaceEmbedder | HuggingFaceTokenizer | BertBaseEmbedder | ColBertEmbedder | SpladeEmbedder | VoyageAIEmbedder ) &
+    (HuggingFaceEmbedder | HuggingFaceTEIEmbedder | HuggingFaceTokenizer | BertBaseEmbedder | ColBertEmbedder | SpladeEmbedder | VoyageAIEmbedder ) &
    GenericConfig* &
    Component*
 
@@ -163,6 +163,21 @@ VoyageAIEmbedder =
    element endpoint { xsd:string }? &
    element truncate { xsd:boolean }? &
    EmbedderBatchingParams
+
+HuggingFaceTEIEmbedder =
+    attribute type { "hugging-face-tei-embedder" } &
+    element endpoint { xsd:string }? &
+    element api-key-secret-ref { xsd:string }? &
+    element dimensions { xsd:nonNegativeInteger }? &
+    element normalize { xsd:boolean }? &
+    element truncate { xsd:boolean }? &
+    element truncation-direction { "left" | "right" }? &
+    element prompt-name { xsd:string }? &
+    element query-prompt-name { xsd:string }? &
+    element document-prompt-name { xsd:string }? &
+    element max-retries { xsd:nonNegativeInteger }? &
+    element timeout { xsd:positiveInteger }? &
+    EmbedderBatchingParams
 
 OnnxModelExecutionParams =
     element onnx-execution-mode { "parallel" | "sequential" }? &

--- a/config-model/src/test/cfg/application/huggingface-tei-embedder/services.xml
+++ b/config-model/src/test/cfg/application/huggingface-tei-embedder/services.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+    <container id="container" version="1.0">
+        <search />
+        <document-api />
+
+        <component id="hf-tei-full" type="hugging-face-tei-embedder">
+            <endpoint>http://tei.local:8080/embed</endpoint>
+            <api-key-secret-ref>hf_tei_api_key</api-key-secret-ref>
+            <dimensions>768</dimensions>
+            <normalize>true</normalize>
+            <truncate>true</truncate>
+            <truncation-direction>left</truncation-direction>
+            <prompt-name>default_prompt</prompt-name>
+            <query-prompt-name>query_prompt</query-prompt-name>
+            <document-prompt-name>document_prompt</document-prompt-name>
+            <max-retries>5</max-retries>
+            <timeout>45000</timeout>
+            <batching max-size="32" max-delay="50ms"/>
+        </component>
+
+        <component id="hf-tei-minimal" type="hugging-face-tei-embedder"/>
+    </container>
+</services>

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HuggingFaceTEIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HuggingFaceTEIEmbedderTest.java
@@ -1,0 +1,124 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.xml;
+
+import ai.vespa.embedding.config.HuggingFaceTeiEmbedderConfig;
+import com.yahoo.component.ComponentId;
+import com.yahoo.path.Path;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.HuggingFaceTEIEmbedder;
+import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
+import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HuggingFaceTEIEmbedderTest {
+
+    @Test
+    void testHuggingFaceTEIEmbedderWithFullConfiguration() throws Exception {
+        VespaModel model = loadModel(Path.fromString("src/test/cfg/application/huggingface-tei-embedder/"));
+        ApplicationContainerCluster cluster = model.getContainerClusters().get("container");
+
+        Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId("hf-tei-full"));
+        assertNotNull(component, "HuggingFace TEI embedder component should be present");
+        assertInstanceOf(HuggingFaceTEIEmbedder.class, component, "Component should be HuggingFaceTEIEmbedder");
+
+        HuggingFaceTeiEmbedderConfig config = getEmbedderConfig(cluster, "hf-tei-full");
+
+        assertEquals("http://tei.local:8080/embed", config.endpoint());
+        assertEquals("hf_tei_api_key", config.apiKeySecretRef());
+        assertEquals(768, config.dimensions());
+        assertTrue(config.normalize());
+        assertTrue(config.truncate());
+        assertEquals(HuggingFaceTeiEmbedderConfig.TruncationDirection.Enum.LEFT, config.truncationDirection());
+        assertEquals("default_prompt", config.promptName());
+        assertEquals("query_prompt", config.queryPromptName());
+        assertEquals("document_prompt", config.documentPromptName());
+        assertEquals(5, config.maxRetries());
+        assertEquals(45000, config.timeout());
+        assertEquals(32, config.batching().maxSize());
+        assertEquals(50, config.batching().maxDelayMillis());
+    }
+
+    @Test
+    void testHuggingFaceTEIEmbedderWithMinimalConfiguration() throws Exception {
+        VespaModel model = loadModel(Path.fromString("src/test/cfg/application/huggingface-tei-embedder/"));
+        ApplicationContainerCluster cluster = model.getContainerClusters().get("container");
+
+        HuggingFaceTeiEmbedderConfig config = getEmbedderConfig(cluster, "hf-tei-minimal");
+
+        assertEquals("http://localhost:8080/embed", config.endpoint());
+        assertEquals("", config.apiKeySecretRef());
+        assertEquals(0, config.dimensions());
+        assertTrue(config.normalize());
+        assertEquals(false, config.truncate());
+        assertEquals(HuggingFaceTeiEmbedderConfig.TruncationDirection.Enum.RIGHT, config.truncationDirection());
+        assertEquals("", config.promptName());
+        assertEquals("", config.queryPromptName());
+        assertEquals("", config.documentPromptName());
+        assertEquals(3, config.maxRetries());
+        assertEquals(60000, config.timeout());
+        assertEquals(0, config.batching().maxSize());
+        assertEquals(0, config.batching().maxDelayMillis());
+    }
+
+    @Test
+    void testInvalidTruncationDirectionFailsValidation() {
+        String servicesXml = """
+                <?xml version="1.0" encoding="utf-8" ?>
+                <services version="1.0">
+                    <container id="container" version="1.0">
+                        <component id="hf-tei" type="hugging-face-tei-embedder">
+                            <truncation-direction>middle</truncation-direction>
+                        </component>
+                    </container>
+                </services>
+                """;
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> buildModelFromXml(servicesXml));
+        assertTrue(exception.getMessage().contains("truncation-direction"));
+    }
+
+    @Test
+    void testNegativeDimensionsFailsValidation() {
+        String servicesXml = """
+                <?xml version="1.0" encoding="utf-8" ?>
+                <services version="1.0">
+                    <container id="container" version="1.0">
+                        <component id="hf-tei" type="hugging-face-tei-embedder">
+                            <dimensions>-1</dimensions>
+                        </component>
+                    </container>
+                </services>
+                """;
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> buildModelFromXml(servicesXml));
+        assertTrue(exception.getMessage().contains("dimensions"));
+    }
+
+    private VespaModel loadModel(Path path) throws Exception {
+        return new VespaModelCreatorWithFilePkg(path.toFile()).create();
+    }
+
+    private VespaModel buildModelFromXml(String servicesXml) throws Exception {
+        String hosts = "<hosts><host name='localhost'><alias>node1</alias></host></hosts>";
+        return new VespaModelCreatorWithMockPkg(hosts, servicesXml).create();
+    }
+
+    private HuggingFaceTeiEmbedderConfig getEmbedderConfig(ApplicationContainerCluster cluster, String componentId) {
+        Component<?, ?> component = cluster.getComponentsMap().get(new ComponentId(componentId));
+        assertNotNull(component, "Component " + componentId + " should exist");
+        assertInstanceOf(HuggingFaceTEIEmbedder.class, component, "Component should be HuggingFaceTEIEmbedder");
+
+        HuggingFaceTEIEmbedder embedder = (HuggingFaceTEIEmbedder) component;
+        HuggingFaceTeiEmbedderConfig.Builder builder = new HuggingFaceTeiEmbedderConfig.Builder();
+        embedder.getConfig(builder);
+        return builder.build();
+    }
+}

--- a/configdefinitions/src/vespa/hugging-face-tei-embedder.def
+++ b/configdefinitions/src/vespa/hugging-face-tei-embedder.def
@@ -1,0 +1,40 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package=ai.vespa.embedding.config
+
+# Hugging Face Text Embeddings Inference endpoint URL.
+endpoint string default="http://localhost:8080/embed"
+
+# Optional secret reference in Vespa's secret store containing Bearer token.
+apiKeySecretRef string default=""
+
+# Optional output dimension to request from the endpoint. 0 means infer from tensor type.
+dimensions int default=0
+
+# Whether to normalize embeddings server-side.
+normalize bool default=true
+
+# Truncate input if it exceeds the model token limit.
+truncate bool default=false
+
+# Truncation direction when truncation is enabled.
+truncationDirection enum { LEFT, RIGHT } default=RIGHT
+
+# Optional prompt name configured in sentence-transformers prompts.
+promptName string default=""
+
+# Optional prompt name for query destination.
+queryPromptName string default=""
+
+# Optional prompt name for document destination.
+documentPromptName string default=""
+
+# Maximum retry attempts on transient server errors.
+maxRetries int default=3
+
+# HTTP client timeout in milliseconds for read/write operations.
+timeout int default=60000
+
+# Dynamic batching configuration.
+batching.maxSize int default=0
+batching.maxDelayMillis long default=0

--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceTEIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceTEIEmbedder.java
@@ -1,0 +1,470 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.HuggingFaceTeiEmbedderConfig;
+import ai.vespa.secret.Secret;
+import ai.vespa.secret.Secrets;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.yahoo.api.annotations.Beta;
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.component.annotation.Inject;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.InvalidInputException;
+import com.yahoo.language.process.OverloadException;
+import com.yahoo.language.process.TimeoutException;
+import com.yahoo.tensor.IndexedTensor;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.text.Text;
+import okhttp3.ConnectionPool;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Embedder backed by Hugging Face Text Embeddings Inference API.
+ *
+ * @see <a href="https://huggingface.github.io/text-embeddings-inference/">Text Embeddings Inference</a>
+ */
+@Beta
+public class HuggingFaceTEIEmbedder extends AbstractComponent implements Embedder {
+
+    private static final Logger log = Logger.getLogger(HuggingFaceTEIEmbedder.class.getName());
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+
+    private static final String DEFAULT_ENDPOINT = "http://localhost:8080/embed";
+
+    private final HuggingFaceTeiEmbedderConfig config;
+    private final Embedder.Runtime runtime;
+    private final Embedder.Batching batching;
+    private final Optional<Secret> apiKey;
+    private final OkHttpClient httpClient;
+    private final String endpoint;
+
+    @Inject
+    public HuggingFaceTEIEmbedder(HuggingFaceTeiEmbedderConfig config, Embedder.Runtime runtime, Secrets secretStore) {
+        this.config = config;
+        this.runtime = runtime;
+        this.batching = Embedder.Batching.of(config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));
+        this.apiKey = resolveApiKey(config.apiKeySecretRef(), secretStore);
+        this.httpClient = createHttpClient(config);
+        this.endpoint = normalizeEndpoint(config.endpoint());
+
+        log.fine(() -> Text.format("HuggingFace TEI embedder initialized with endpoint: %s", endpoint));
+    }
+
+    @Override
+    public Batching batchingConfig() { return batching; }
+
+    @Override
+    public List<Integer> embed(String text, Context context) {
+        throw new UnsupportedOperationException(
+                "HuggingFace TEI embedder only supports embed() with TensorType. " +
+                "Use embed(String text, Context context, TensorType targetType) instead.");
+    }
+
+    @Override
+    public Tensor embed(String text, Context context, TensorType targetType) {
+        return invokeTEI(List.of(text), context, targetType).get(0);
+    }
+
+    @Override
+    public List<Tensor> embed(List<String> texts, Context context, TensorType targetType) {
+        return invokeTEI(texts, context, targetType);
+    }
+
+    private List<Tensor> invokeTEI(List<String> texts, Context context, TensorType targetType) {
+        if (texts.isEmpty()) return List.of();
+
+        validateTensorType(targetType);
+        var inputTexts = List.copyOf(texts);
+        var promptName = resolvePromptName(context);
+        var requestedDimensions = resolveRequestedDimensions(targetType);
+        var timeoutMs = calculateTimeoutMs(context);
+
+        var cacheKey = new CacheKey(context.getEmbedderId(), inputTexts, requestedDimensions, promptName,
+                                    config.normalize(), config.truncate(), config.truncationDirection().name());
+
+        var startTime = System.nanoTime();
+        var responseBody = context.computeCachedValueIfAbsent(cacheKey,
+                () -> doRequest(createJsonRequest(inputTexts, promptName, requestedDimensions), timeoutMs, context));
+
+        var embeddings = parseEmbeddings(responseBody);
+        if (embeddings.size() != inputTexts.size()) {
+            throw new RuntimeException(Text.format(
+                    "HuggingFace TEI returned %d embeddings for %d inputs.", embeddings.size(), inputTexts.size()));
+        }
+
+        var tensors = embeddings.stream()
+                .map(embedding -> toTensor(embedding, targetType, requestedDimensions))
+                .toList();
+
+        runtime.sampleEmbeddingLatency(Duration.ofNanos(System.nanoTime() - startTime).toMillis(), context);
+        return tensors;
+    }
+
+    private void validateTensorType(TensorType targetTensorType) {
+        if (targetTensorType.dimensions().size() != 1) {
+            throw new IllegalArgumentException(
+                    "Error in embedding to type '" + targetTensorType + "': should only have one dimension.");
+        }
+
+        var tensorDimension = targetTensorType.dimensions().get(0);
+        if (!tensorDimension.isIndexed()) {
+            throw new IllegalArgumentException(
+                    "Error in embedding to type '" + targetTensorType + "': dimension should be indexed.");
+        }
+
+        var valueType = targetTensorType.valueType();
+        if (valueType != TensorType.Value.FLOAT && valueType != TensorType.Value.BFLOAT16) {
+            throw new IllegalArgumentException(
+                    "HuggingFace TEI embedder only supports tensor<float> and tensor<bfloat16>, got " + targetTensorType + ".");
+        }
+
+        var configuredDimensions = config.dimensions();
+        var tensorDimensions = tensorDimension.size();
+
+        if (configuredDimensions < 0) {
+            throw new IllegalArgumentException("Configured dimensions must be non-negative, got: " + configuredDimensions);
+        }
+
+        if (configuredDimensions > 0 && tensorDimensions.isPresent() && tensorDimensions.get() != configuredDimensions) {
+            throw new IllegalArgumentException(Text.format(
+                    "Tensor dimension %d does not match configured dimension %d.",
+                    tensorDimensions.get(), configuredDimensions));
+        }
+    }
+
+    private Integer resolveRequestedDimensions(TensorType targetTensorType) {
+        if (config.dimensions() > 0) return config.dimensions();
+
+        Optional<Long> tensorDimension = targetTensorType.dimensions().get(0).size();
+        if (tensorDimension.isPresent()) {
+            return Math.toIntExact(tensorDimension.get());
+        }
+
+        return null;
+    }
+
+    private String resolvePromptName(Context context) {
+        if (context.getDestinationType() == Context.DestinationType.QUERY && !config.queryPromptName().isBlank()) {
+            return config.queryPromptName();
+        }
+        if (context.getDestinationType() == Context.DestinationType.DOCUMENT && !config.documentPromptName().isBlank()) {
+            return config.documentPromptName();
+        }
+        if (!config.promptName().isBlank()) {
+            return config.promptName();
+        }
+        return null;
+    }
+
+    private String createJsonRequest(List<String> texts, String promptName, Integer requestedDimensions) {
+        try {
+            ObjectNode root = objectMapper.createObjectNode();
+            if (texts.size() == 1) {
+                root.put("inputs", texts.get(0));
+            } else {
+                var array = root.putArray("inputs");
+                texts.forEach(array::add);
+            }
+            root.put("normalize", config.normalize());
+            root.put("truncate", config.truncate());
+            root.put("truncation_direction", toTeiTruncationDirection(config.truncationDirection()));
+            if (promptName != null && !promptName.isBlank()) {
+                root.put("prompt_name", promptName);
+            }
+            if (requestedDimensions != null) {
+                root.put("dimensions", requestedDimensions);
+            }
+
+            return objectMapper.writeValueAsString(root);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize HuggingFace TEI request", e);
+        }
+    }
+
+    private String doRequest(String jsonRequest, long timeoutMs, Context context) {
+        var builder = new Request.Builder()
+                .url(endpoint)
+                .header("Content-Type", "application/json")
+                .post(RequestBody.create(jsonRequest, JSON_MEDIA_TYPE));
+
+        apiKey.ifPresent(secret -> builder.header("Authorization", "Bearer " + secret.current()));
+
+        runtime.sampleRequestCount(context);
+
+        var call = httpClient.newCall(builder.build());
+        call.timeout().timeout(timeoutMs, TimeUnit.MILLISECONDS);
+
+        try (var response = call.execute()) {
+            var responseBody = response.body() != null ? response.body().string() : "";
+            log.fine(() -> "HuggingFace TEI response with code " + response.code() + ": " + responseBody);
+
+            if (response.isSuccessful()) return responseBody;
+
+            runtime.sampleRequestFailure(context, response.code());
+            var errorDetail = parseErrorDetail(responseBody).orElse(responseBody);
+
+            if (response.code() == 429) {
+                throw new OverloadException("HuggingFace TEI API overloaded (429)");
+            }
+            if (response.code() == 400 || response.code() == 413 || response.code() == 422) {
+                throw new InvalidInputException("HuggingFace TEI API bad request (" + response.code() + "): " + errorDetail);
+            }
+
+            throw new RuntimeException(
+                    "HuggingFace TEI API request failed with status " + response.code() + ": " + errorDetail);
+        } catch (InterruptedIOException e) {
+            runtime.sampleRequestFailure(context, 0);
+            throw new TimeoutException("HuggingFace TEI API call timed out after " + timeoutMs + "ms", e);
+        } catch (IOException e) {
+            runtime.sampleRequestFailure(context, 0);
+            throw new RuntimeException("HuggingFace TEI API call failed: " + e.getMessage(), e);
+        }
+    }
+
+    private List<List<Float>> parseEmbeddings(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            if (root.isArray()) {
+                return parseArrayResponse(root);
+            }
+
+            if (root.isObject() && root.has("data") && root.get("data").isArray()) {
+                return parseOpenAICompatibleResponse(root.get("data"));
+            }
+
+            throw new IllegalArgumentException("Unexpected HuggingFace TEI response format: " + root.getNodeType());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse HuggingFace TEI response", e);
+        }
+    }
+
+    private List<List<Float>> parseArrayResponse(JsonNode root) {
+        if (root.isEmpty()) return List.of();
+
+        if (root.get(0).isNumber()) {
+            return List.of(parseEmbeddingVector(root));
+        }
+
+        var embeddings = new ArrayList<List<Float>>(root.size());
+        for (var item : root) {
+            embeddings.add(parseEmbeddingVector(item));
+        }
+        return embeddings;
+    }
+
+    private List<List<Float>> parseOpenAICompatibleResponse(JsonNode dataArray) {
+        var embeddings = new ArrayList<List<Float>>(dataArray.size());
+        for (var item : dataArray) {
+            var embedding = item.get("embedding");
+            if (embedding == null) {
+                throw new IllegalArgumentException("Missing 'embedding' field in OpenAI-compatible response item");
+            }
+            if (embedding.isArray()) {
+                embeddings.add(parseEmbeddingVector(embedding));
+            } else if (embedding.isTextual()) {
+                embeddings.add(decodeBase64FloatVector(embedding.textValue()));
+            } else {
+                throw new IllegalArgumentException("Unsupported 'embedding' value in OpenAI-compatible response: " + embedding);
+            }
+        }
+        return embeddings;
+    }
+
+    private List<Float> parseEmbeddingVector(JsonNode vectorNode) {
+        if (!vectorNode.isArray()) {
+            throw new IllegalArgumentException("Expected embedding vector array, got: " + vectorNode.getNodeType());
+        }
+
+        var values = new ArrayList<Float>(vectorNode.size());
+        for (var value : vectorNode) {
+            if (!value.isNumber()) {
+                throw new IllegalArgumentException("Expected numeric embedding value, got: " + value);
+            }
+            values.add(value.floatValue());
+        }
+        return values;
+    }
+
+    private List<Float> decodeBase64FloatVector(String base64) {
+        var buffer = ByteBuffer.wrap(Base64.getDecoder().decode(base64)).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+        var values = new ArrayList<Float>(buffer.remaining());
+        while (buffer.hasRemaining()) {
+            values.add(buffer.get());
+        }
+        return values;
+    }
+
+    private Tensor toTensor(List<Float> embedding, TensorType targetType, Integer requestedDimensions) {
+        var dimension = targetType.dimensions().get(0);
+        long actualDimensions = embedding.size();
+        long expectedDimensions = requestedDimensions != null
+                ? requestedDimensions
+                : dimension.size().orElse(actualDimensions);
+
+        if (actualDimensions != expectedDimensions) {
+            throw new IllegalArgumentException(Text.format(
+                    "Expected embedding dimension %d, got %d.", expectedDimensions, actualDimensions));
+        }
+
+        var tensorType = new TensorType.Builder(targetType.valueType())
+                .indexed(dimension.name(), actualDimensions)
+                .build();
+
+        var tensorBuilder = IndexedTensor.Builder.of(tensorType);
+        for (int i = 0; i < embedding.size(); i++) {
+            tensorBuilder.cell(embedding.get(i), i);
+        }
+        return tensorBuilder.build();
+    }
+
+    private Optional<String> parseErrorDetail(String responseBody) {
+        try {
+            var error = objectMapper.readValue(responseBody, ErrorResponse.class);
+            if (error.error != null && !error.error.isBlank()) return Optional.of(error.error);
+            if (error.message != null && !error.message.isBlank()) return Optional.of(error.message);
+        } catch (IOException e) {
+            log.fine(() -> "Failed to parse TEI error response as JSON: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    private long calculateTimeoutMs(Context context) {
+        long remainingMs = context.getDeadline()
+                .map(d -> d.timeRemaining().toMillis())
+                .orElse((long) config.timeout());
+
+        if (remainingMs <= 0) {
+            throw new TimeoutException("Request deadline exceeded before HuggingFace TEI API call");
+        }
+        return remainingMs;
+    }
+
+    private static OkHttpClient createHttpClient(HuggingFaceTeiEmbedderConfig config) {
+        return new OkHttpClient.Builder()
+                .addInterceptor(new RetryInterceptor(config.maxRetries()))
+                .retryOnConnectionFailure(true)
+                .connectTimeout(Duration.ofSeconds(10))
+                .readTimeout(Duration.ofMillis(config.timeout()))
+                .writeTimeout(Duration.ofMillis(config.timeout()))
+                .connectionPool(new ConnectionPool(10, 1, TimeUnit.MINUTES))
+                .build();
+    }
+
+    private static Optional<Secret> resolveApiKey(String secretRef, Secrets secretStore) {
+        if (secretRef == null || secretRef.isBlank()) return Optional.empty();
+        Secret secret = secretStore.get(secretRef);
+        if (secret == null) {
+            throw new IllegalArgumentException("No secret found for api-key-secret-ref '" + secretRef + "'.");
+        }
+        return Optional.of(secret);
+    }
+
+    private static String normalizeEndpoint(String endpoint) {
+        String value = (endpoint == null || endpoint.isBlank()) ? DEFAULT_ENDPOINT : endpoint;
+        if (value.endsWith("/embed") || value.endsWith("/v1/embeddings")) {
+            return value;
+        }
+        if (value.endsWith("/")) {
+            return value + "embed";
+        }
+        return value + "/embed";
+    }
+
+    private static String toTeiTruncationDirection(HuggingFaceTeiEmbedderConfig.TruncationDirection.Enum direction) {
+        return switch (direction) {
+            case LEFT -> "Left";
+            case RIGHT -> "Right";
+        };
+    }
+
+    @Override
+    public void deconstruct() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+        super.deconstruct();
+    }
+
+    private static class RetryInterceptor implements Interceptor {
+        static final long RETRY_DELAY_MS = 100;
+        private final int maxRetries;
+
+        RetryInterceptor(int maxRetries) {
+            this.maxRetries = maxRetries;
+        }
+
+        @Override
+        public okhttp3.Response intercept(Chain chain) throws IOException {
+            var request = chain.request();
+            int lastStatusCode = 0;
+            String lastResponseBody = "";
+
+            for (int attempt = 0; attempt <= maxRetries; attempt++) {
+                try {
+                    var response = chain.proceed(request);
+
+                    int code = response.code();
+                    boolean shouldRetry = code == 500 || code == 502 || code == 503 || code == 504;
+                    if (response.isSuccessful() || !shouldRetry) return response;
+
+                    lastStatusCode = code;
+                    if (response.body() != null) {
+                        lastResponseBody = response.body().string();
+                    }
+                    response.close();
+
+                    if (attempt < maxRetries) {
+                        int retryNumber = attempt + 1;
+                        log.fine(() -> Text.format(
+                                "HuggingFace TEI API server error (%d). Retry %d of %d after %dms",
+                                code, retryNumber + 1, maxRetries, RETRY_DELAY_MS));
+                        Thread.sleep(RETRY_DELAY_MS);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Retry interrupted", e);
+                }
+            }
+
+            throw new IOException(Text.format(
+                    "Max retries exceeded for HuggingFace TEI API (%d). Last response: %d - %s",
+                    maxRetries, lastStatusCode, lastResponseBody));
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ErrorResponse(
+            @JsonProperty("error") String error,
+            @JsonProperty("error_type") String errorType,
+            @JsonProperty("message") String message) {}
+
+    private record CacheKey(String embedderId,
+                            List<String> texts,
+                            Integer dimensions,
+                            String promptName,
+                            boolean normalize,
+                            boolean truncate,
+                            String truncationDirection) {}
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceTEIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceTEIEmbedderTest.java
@@ -1,0 +1,197 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import ai.vespa.embedding.config.HuggingFaceTeiEmbedderConfig;
+import ai.vespa.secret.Secrets;
+import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.OverloadException;
+import com.yahoo.language.process.TimeoutException;
+import com.yahoo.tensor.IndexedTensor;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorType;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HuggingFaceTEIEmbedderTest {
+
+    private MockWebServer mockServer;
+    private HuggingFaceTEIEmbedder embedder;
+    private Embedder.Runtime runtime;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        runtime = Embedder.Runtime.testInstance();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (embedder != null) {
+            embedder.deconstruct();
+        }
+        mockServer.shutdown();
+    }
+
+    @Test
+    void testSuccessfulEmbedding() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("[[0.1,0.2,0.3,0.4]]"));
+
+        embedder = createEmbedder(builder -> builder.apiKeySecretRef("hf_key"));
+
+        TensorType targetType = TensorType.fromSpec("tensor<float>(x[4])");
+        Embedder.Context context = new Embedder.Context("schema.field").setEmbedderId("hf-tei");
+
+        Tensor result = embedder.embed("hello", context, targetType);
+
+        assertNotNull(result);
+        assertEquals(targetType, result.type());
+
+        IndexedTensor indexed = (IndexedTensor) result;
+        assertEquals(0.1f, indexed.getFloat(0), 1e-6);
+        assertEquals(0.4f, indexed.getFloat(3), 1e-6);
+
+        RecordedRequest request = mockServer.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals("/embed", request.getPath());
+        assertEquals("Bearer test-hf-token", request.getHeader("Authorization"));
+        String body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"inputs\":\"hello\""));
+        assertTrue(body.contains("\"dimensions\":4"));
+        assertTrue(body.contains("\"normalize\":true"));
+    }
+
+    @Test
+    void testBatchEmbeddingUsesSingleRequest() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("[[1.0,2.0],[3.0,4.0]]"));
+
+        embedder = createEmbedder();
+
+        TensorType targetType = TensorType.fromSpec("tensor<float>(x[2])");
+        Embedder.Context context = new Embedder.Context("schema.field").setEmbedderId("hf-tei");
+
+        var tensors = embedder.embed(List.of("first", "second"), context, targetType);
+
+        assertEquals(2, tensors.size());
+        assertEquals(1, mockServer.getRequestCount());
+
+        RecordedRequest request = mockServer.takeRequest();
+        String body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"inputs\":[\"first\",\"second\"]"));
+    }
+
+    @Test
+    void testPromptSelectionByDestinationType() throws Exception {
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("[[0.1,0.2]]"));
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("[[0.3,0.4]]"));
+
+        embedder = createEmbedder(builder -> {
+            builder.promptName("default_prompt");
+            builder.queryPromptName("query_prompt");
+            builder.documentPromptName("document_prompt");
+        });
+
+        TensorType targetType = TensorType.fromSpec("tensor<float>(x[2])");
+
+        embedder.embed("query text", new Embedder.Context("query(q)").setEmbedderId("hf-tei"), targetType);
+        embedder.embed("document text", new Embedder.Context("schema.field").setEmbedderId("hf-tei"), targetType);
+
+        RecordedRequest queryRequest = mockServer.takeRequest();
+        String queryBody = queryRequest.getBody().readUtf8();
+        assertTrue(queryBody.contains("\"prompt_name\":\"query_prompt\""));
+
+        RecordedRequest documentRequest = mockServer.takeRequest();
+        String documentBody = documentRequest.getBody().readUtf8();
+        assertTrue(documentBody.contains("\"prompt_name\":\"document_prompt\""));
+    }
+
+    @Test
+    void testThrowsOverloadExceptionOn429() {
+        mockServer.enqueue(new MockResponse().setResponseCode(429).setBody("{\"error\":\"Model is overloaded\"}"));
+
+        embedder = createEmbedder();
+
+        TensorType targetType = TensorType.fromSpec("tensor<float>(x[2])");
+        Embedder.Context context = new Embedder.Context("schema.field").setEmbedderId("hf-tei");
+
+        OverloadException exception = assertThrows(OverloadException.class,
+                () -> embedder.embed("test", context, targetType));
+
+        assertEquals("HuggingFace TEI API overloaded (429)", exception.getMessage());
+        assertEquals(1, mockServer.getRequestCount());
+    }
+
+    @Test
+    void testRejectsUnsupportedTensorType() {
+        embedder = createEmbedder();
+
+        TensorType targetType = TensorType.fromSpec("tensor<int8>(x[8])");
+        Embedder.Context context = new Embedder.Context("schema.field").setEmbedderId("hf-tei");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> embedder.embed("test", context, targetType));
+
+        assertTrue(exception.getMessage().contains("only supports tensor<float> and tensor<bfloat16>"));
+        assertEquals(0, mockServer.getRequestCount());
+    }
+
+    @Test
+    void testThrowsTimeoutExceptionOnSlowResponse() {
+        mockServer.enqueue(new MockResponse()
+                .setBodyDelay(1, TimeUnit.SECONDS)
+                .setResponseCode(200)
+                .setBody("[[0.1,0.2]]"));
+
+        embedder = createEmbedder(builder -> builder.timeout(100));
+
+        TensorType targetType = TensorType.fromSpec("tensor<float>(x[2])");
+        Embedder.Context context = new Embedder.Context("schema.field").setEmbedderId("hf-tei");
+
+        TimeoutException exception = assertThrows(TimeoutException.class,
+                () -> embedder.embed("test", context, targetType));
+
+        assertTrue(exception.getMessage().contains("timed out"));
+        assertEquals(1, mockServer.getRequestCount());
+    }
+
+    private HuggingFaceTEIEmbedder createEmbedder() {
+        return createEmbedder(builder -> { });
+    }
+
+    private HuggingFaceTEIEmbedder createEmbedder(Consumer<HuggingFaceTeiEmbedderConfig.Builder> customizer) {
+        HuggingFaceTeiEmbedderConfig.Builder builder = new HuggingFaceTeiEmbedderConfig.Builder()
+                .endpoint(mockServer.url("/embed").toString())
+                .timeout(5000);
+        customizer.accept(builder);
+        return new HuggingFaceTEIEmbedder(builder.build(), runtime, createSecrets());
+    }
+
+    private Secrets createSecrets() {
+        return key -> {
+            if ("hf_key".equals(key)) {
+                return () -> "test-hf-token";
+            }
+            return null;
+        };
+    }
+}


### PR DESCRIPTION
## Why
Fixes #34211.

Issue #34211 asks for support/examples for using Hugging Face Text Embeddings Inference (TEI) as a remote embedding endpoint instead of local ONNX embedding.

## What
- Added a new embedder component type: hugging-face-tei-embedder.
- Added new config definition: hugging-face-tei-embedder.def.
- Added config-model producer and XML parsing for endpoint, auth secret ref, dimensions, prompt selection, truncation, retries, timeout, and batching.
- Wired new component type in DomComponentBuilder and services.xml schema validation.
- Implemented runtime embedder ai.vespa.embedding.HuggingFaceTEIEmbedder with:
  - TEI /embed request construction
  - response parsing to tensor<float> and tensor<bfloat16>
  - destination-aware prompt selection (query/document)
  - retry and timeout handling
  - overload and invalid-input error mapping
  - embed request caching and batching configuration
- Added tests:
  - model-integration: HuggingFaceTEIEmbedderTest (6 tests)
  - config-model: HuggingFaceTEIEmbedderTest (4 tests)

## Testing
- mvn -pl model-integration -am -Dtest=HuggingFaceTEIEmbedderTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl config-model -am -Dtest=HuggingFaceTEIEmbedderTest -Dsurefire.failIfNoSpecifiedTests=false test