### PR TITLE
Basic functionality of storing and retrieving full document ids from DocumentMetaStore

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -367,6 +367,27 @@ TEST(DocumentMetaStore, gids_can_be_cleared)
     EXPECT_TRUE(!dms.remove(2, 0u)); // outside range
 }
 
+TEST(DocumentMetaStoreTest, full_docids_can_be_inserted_and_retrieved)
+{
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms.constructFreeList();
+    // put()
+    assertPut(bucketId1, time1, 1, docid1, dms);
+    assertPut(bucketId2, time2, 2, docid2, dms);
+
+    // get_docid_string()
+    EXPECT_EQ(docid1.toString(), dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+
+    // already inserted
+    assertPut(bucketId1, time1, 1, docid1, dms);
+    assertPut(bucketId2, time2, 2, docid2, dms);
+
+    // get_docid_string()
+    EXPECT_EQ(docid1.toString(), dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+}
+
 TEST(DocumentMetaStore, generation_handling_is_working)
 {
     auto dms = std::make_shared<DocumentMetaStore>(createBucketDB());

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -1796,6 +1796,35 @@ TEST(DocumentMetaStoreTest, move_works)
     EXPECT_EQ(1u, lid);
 }
 
+TEST(DocumentMetaStoreTest, getting_full_document_id_works_after_move)
+{
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms.constructFreeList();
+
+    assertPut(bucketId1, time1, 1u, docid1, dms);
+    assertPut(bucketId2, time2, 2u, docid2, dms);
+    EXPECT_EQ(docid1.toString(), dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+    EXPECT_TRUE(dms.remove(1u, 0u));
+    dms.commit();
+    EXPECT_EQ("", dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+    dms.removes_complete({ 1u });
+    EXPECT_EQ("", dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+    dms.move(2u, 1u, 0u);
+    dms.commit();
+    EXPECT_EQ("", dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+    dms.removes_complete({ 2u });
+    // Make sure that the lid of gid2 is 1, i.e., that the lid was moved
+    uint32_t lid = 0;
+    EXPECT_TRUE(dms.getLid(gid2, lid));
+    EXPECT_EQ(1u, lid);
+    EXPECT_EQ("", dms.get_docid_string(gid1));
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+}
+
 void
 assertLidSpace(uint32_t numDocs,
                uint32_t committedDocIdLimit,

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -388,6 +388,29 @@ TEST(DocumentMetaStoreTest, full_docids_can_be_inserted_and_retrieved)
     EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
 }
 
+TEST(DocumentMetaStoreTest, full_docids_are_removed)
+{
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms.constructFreeList();
+
+    // Add document and get gid
+    addDoc(dms, docid1, bucketId1, time1);
+    EXPECT_EQ(docid1.toString(), dms.get_docid_string(gid1));
+    // Remove and check that full string is also removed
+    EXPECT_TRUE(dms.remove(1, 0u));
+    dms.commit();
+    EXPECT_EQ("", dms.get_docid_string(gid1));
+    dms.removes_complete({ 1 });
+
+    // With reused lid
+    addDoc(dms, docid2, bucketId2, time2);
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+    EXPECT_TRUE(dms.remove(1, 0u));
+    dms.commit();
+    EXPECT_EQ("", dms.get_docid_string(gid2));
+    dms.removes_complete({ 1 });
+}
+
 TEST(DocumentMetaStore, generation_handling_is_working)
 {
     auto dms = std::make_shared<DocumentMetaStore>(createBucketDB());

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -472,6 +472,27 @@ TEST(DocumentMetaStoreTest, can_store_bucket_id_and_timestamp)
     }
 }
 
+TEST(DocumentMetaStoreTest, can_store_full_document_id)
+{
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    uint32_t numLids = 1000;
+
+    dms.constructFreeList();
+    for (uint32_t lid = 1; lid <= numLids; ++lid) {
+        const auto docid = createDocId(lid);
+        auto& gid = docid.getGlobalId();
+        BucketId bucketId(gid.convertToBucketId());
+        bucketId.setUsedBits(numBucketBits);
+        uint32_t addLid = addDoc(dms, docid, bucketId, Timestamp(lid + timestampBias));
+        EXPECT_EQ(lid, addLid);
+    }
+    for (uint32_t lid = 1; lid <= numLids; ++lid) {
+        const auto docid = createDocId(lid);
+        auto& gid = docid.getGlobalId();
+        EXPECT_EQ(docid.toString(), dms.get_docid_string(gid));
+    }
+}
+
 TEST(DocumentMetaStoreTest, gids_can_be_saved_and_loaded)
 {
     DocumentMetaStore dms1(createBucketDB());

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -2050,6 +2050,31 @@ TEST(DocumentMetaStoreTest, multiple_lids_can_be_removed_with_removeBatch)
     dms.removes_complete({1, 3});
 }
 
+TEST(DocumentMetaStoreTest, removeBatch_removes_full_document_ids)
+{
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms.constructFreeList();
+    addLid(dms, 1);
+    addLid(dms, 2);
+    addLid(dms, 3);
+    addLid(dms, 4);
+
+    dms.removeBatch({1, 3}, 5);
+    dms.commit();
+
+    DocumentId id1, id2, id3, id4;
+    id1 = createDocId(1);
+    id2 = createDocId(2);
+    id3 = createDocId(3);
+    id4 = createDocId(4);
+
+    EXPECT_EQ("", dms.get_docid_string(id1.getGlobalId()));
+    EXPECT_EQ(id2.toString(), dms.get_docid_string(id2.getGlobalId()));
+    EXPECT_EQ("", dms.get_docid_string(id3.getGlobalId()));
+    EXPECT_EQ(id4.toString(), dms.get_docid_string(id4.getGlobalId()));
+    dms.removes_complete({1, 3});
+}
+
 TEST(DocumentMetaStoreTest, serialize_for_sort)
 {
     DocumentMetaStore dms(createBucketDB());

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -435,6 +435,31 @@ TEST(DocumentMetaStore, generation_handling_is_working)
     EXPECT_EQ(3u, gh.getCurrentGeneration());
 }
 
+TEST(DocumentMetaStore, generation_handling_is_working_for_full_document_ids)
+{
+    auto dms = std::make_shared<DocumentMetaStore>(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms->constructFreeList();
+
+    assertPut(bucketId1, time1, 1u, docid1, *dms);
+    EXPECT_EQ(docid1.toString(), dms->get_docid_string(gid1));
+    vespalib::MemoryUsage memory_usage;
+    {
+        AttributeGuard g1(dms);
+        auto str_view = dms->get_docid_string(gid1);
+        EXPECT_EQ(docid1.toString(), str_view);
+        dms->remove(1u, 0u);
+        EXPECT_EQ("", dms->get_docid_string(gid1));
+        dms->incGeneration();
+        memory_usage = dms->get_docid_memory_usage();
+        dms->reclaim_unused_memory(); // Nothing to reclaim yet
+        EXPECT_EQ(docid1.toString(), str_view); // Check that str_view still contains the docid
+        EXPECT_EQ(memory_usage, dms->get_docid_memory_usage());
+    }
+    dms->reclaim_unused_memory(); // Reclaim now
+    EXPECT_NE(memory_usage, dms->get_docid_memory_usage());
+    dms->removes_complete({ 1 });
+}
+
 TEST(DocumentMetaStoreTest, lid_and_gid_space_is_reused)
 {
     auto dms = std::make_shared<DocumentMetaStore>(createBucketDB());

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -724,6 +724,9 @@ DocumentMetaStore::removeBatch(const std::vector<DocId> &lidsToRemove, const uin
 
         assert(validLid(lid));
         removed.emplace_back(lid, _metaDataStore[lid]);
+        if (_store_full_document_id) {
+            _docid_store.remove(removed.back().second._docid_ref);
+        }
     }
     remove_batch_internal_btree(removed);
     _lidAlloc.unregister_lids(lidsToRemove);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -638,6 +638,9 @@ DocumentMetaStore::remove(DocId lid, uint64_t prepare_serial_num)
         return false;
     }
     RawDocumentMetaData meta = removeInternal(lid, prepare_serial_num);
+    if (_store_full_document_id) {
+        _docid_store.remove(meta._docid_ref);
+    }
     _bucketDB->takeGuard()->remove(meta.getGid(), meta.getBucketId().stripUnused(),
                                    meta.getTimestamp(), meta.getDocSize(), _subDbType);
     _changesSinceCommit++;

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -267,6 +267,7 @@ DocumentMetaStore::before_inc_generation(generation_t current_gen)
 {
     _gidToLidMap.getAllocator().freeze();
     _gidToLidMap.getAllocator().assign_generation(current_gen);
+    _docid_store.assign_generation(current_gen);
     getGenerationHolder().assign_generation(current_gen);
     updateStat(CommitParam::UpdateStats::SKIP);
 }
@@ -275,6 +276,7 @@ void
 DocumentMetaStore::reclaim_memory(generation_t oldest_used_gen)
 {
     _gidToLidMap.getAllocator().reclaim_memory(oldest_used_gen);
+    _docid_store.reclaim_memory(oldest_used_gen);
     _lidAlloc.reclaim_memory(oldest_used_gen);
     getGenerationHolder().reclaim(oldest_used_gen);
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -561,6 +561,10 @@ DocumentMetaStore::put(const DocumentId& docid, const BucketId &bucketId, Timest
             assert(freeLid == lid);
             (void) freeLid;
         }
+        if (_store_full_document_id) {
+            const auto ref = _docid_store.add(docid.getScheme().toString());
+            metaData.set_docid_ref(ref);
+        }
         insert(GidToLidMapKey(lid, find_key.get_gid_key()), metaData);
         res.setLid(lid);
         res.markSuccess();

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -826,6 +826,18 @@ DocumentMetaStore::getMetaData(const BucketId &bucketId,
     }
 }
 
+std::string_view
+DocumentMetaStore::get_docid_string(const GlobalId &gid) const
+{
+    DocId lid = 0;
+    if (!getLid(gid, lid) || !validLid(lid)) {
+        return {};
+    }
+    const RawDocumentMetaData &raw = getRawMetaData(lid);
+    auto span = _docid_store.get(raw.get_docid_ref());
+    return {span.data(), span.size()};
+}
+
 LidUsageStats
 DocumentMetaStore::getLidUsageStats() const
 {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -297,6 +297,7 @@ public:
                           search::common::sortspec::MissingPolicy policy,
                           std::string_view missing_value) const override;
 
+    vespalib::MemoryUsage get_docid_memory_usage() const { return _docid_store.getMemoryUsage(); };
     static vespalib::datastore::ArrayStoreConfig make_default_docid_array_store_config();
 };
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -217,6 +217,7 @@ public:
     bool getLid(const GlobalId & gid, DocId &lid) const override;
     search::DocumentMetaData getMetaData(const GlobalId &gid) const override;
     void getMetaData(const BucketId &bucketId, search::DocumentMetaData::Vector &result) const override;
+    std::string_view get_docid_string(const GlobalId &gid) const;
     DocId   getNumUsedLids() const override { return _lidAlloc.getNumUsedLids(); }
     DocId getNumActiveLids() const override { return _lidAlloc.getNumActiveLids(); }
     search::LidUsageStats getLidUsageStats() const override;

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/raw_document_meta_data.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/raw_document_meta_data.h
@@ -72,6 +72,10 @@ struct RawDocumentMetaData
     const GlobalId &getGid() const { return _gid; }
     GlobalId &getGid() { return _gid; }
     void setGid(const GlobalId &rhs) { _gid = rhs; }
+
+    DocumentIdEntryRef get_docid_ref() const { return _docid_ref; }
+    void set_docid_ref(DocumentIdEntryRef ref) { _docid_ref = ref; }
+
     uint8_t getBucketUsedBits() const { return _bucket_used_bits_and_doc_size.load(std::memory_order_relaxed) & 0xffu; }
 
     BucketId getBucketId() const {


### PR DESCRIPTION
Generation handling still missing. And so is storing on and loading from disk.