### PR TITLE
Add parity tests for range open bounds and equals with array index, f…

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -793,14 +793,16 @@ public class SelectParser implements Parser {
     private Item buildSameElementWithElementFilter(EqualsParams params) {
         int elementIndex = YqlParser.convertToElementId(params.index.asLong());
         var value = params.value;
-        Item valueItem = switch (value.type()) {
-            case BOOL -> new BoolItem(value.asBool(), "");
-            case LONG -> new IntItem(value.asLong(), "");
-            case DOUBLE -> new IntItem(new Limit(value.asDouble(), true), new Limit(value.asDouble(), true), "");
-            case STRING -> new WordItem(value.asString(), "");
+        // Convert value to string — sameElement only supports string children (consistent with YqlParser).
+        String stringValue = switch (value.type()) {
+            case BOOL -> String.valueOf(value.asBool());
+            case LONG -> String.valueOf(value.asLong());
+            case DOUBLE -> String.valueOf(value.asDouble());
+            case STRING -> value.asString();
             default -> throw new IllegalArgumentException("'value' in 'equals' should be a boolean, integer, double, " +
                                                           "or string but was " + value.type());
         };
+        Item valueItem = new WordItem(stringValue, "", true);
 
         SameElementItem sameElement = new SameElementItem(params.field.asString());
         sameElement.setElementFilter(List.of(elementIndex));

--- a/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
@@ -63,6 +63,12 @@ public class YqlJsonQueryFeatureParityTest {
     }
 
     @Test
+    void testEqualsWithArrayIndex() {
+        assertWhereParity("my_numbers[2] = 42",
+                "{ 'equals' : { 'field' : 'my_numbers', 'index' : 2, 'value' : 42 } }");
+    }
+
+    @Test
     void testNot() {
         assertWhereParity("!(title contains 'madonna')",
                 "{ 'not' : { 'contains' : ['title', 'madonna'] } }");
@@ -78,6 +84,16 @@ public class YqlJsonQueryFeatureParityTest {
     void testRange() {
         assertWhereParity("range(price, 0L, 500L)",
                 "{ 'range' : ['price', { '>=': 0, '<=': 500 }] }");
+    }
+
+    @Test
+    void testRangeOpenBounds() {
+        assertWhereParity("price > 0L",
+                "{ 'range' : ['price', { '>': 0 }] }");
+        assertWhereParity("price < 500L",
+                "{ 'range' : ['price', { '<': 500 }] }");
+        assertWhereParity("price > 0L and price < 500L",
+                "{ 'and' : [ { 'range' : ['price', { '>': 0 }] }, { 'range' : ['price', { '<': 500 }] } ] }");
     }
 
     @Test
@@ -279,6 +295,9 @@ public class YqlJsonQueryFeatureParityTest {
         var string = new Index("string");
         string.setString(true);
         sd.addIndex(string);
+        var myNumbers = new Index("my_numbers");
+        myNumbers.setInteger(true);
+        sd.addIndex(myNumbers);
         return new IndexFacts(new IndexModel(sd));
     }
 


### PR DESCRIPTION
…ix SelectParser element filter value type

`buildSameElementWithElementFilter` now makes the values into strings like YQL does instead of making `BoolItem` and `IntItem` directly.

Adds party test for equals with an array index and range bounds.
