### PR TITLE
Scope stale host registry check to current tenant

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -836,8 +836,11 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             SessionRepository sessionRepository = tenant.getSessionRepository();
             HostRegistry hostRegistry = tenantApplications.hostRegistry();
 
-            // Phase A: Optimistic (lock-free) comparison of ApplicationId sets
-            Set<ApplicationId> registryApps = hostRegistry.getApplicationIds();
+            // Phase A: Optimistic (lock-free) comparison of ApplicationId sets.
+            // hostRegistry is global (hosts for all apps for all tenants), so scope to the current tenant.
+            Set<ApplicationId> registryApps = hostRegistry.getApplicationIds().stream()
+                    .filter(app -> app.tenant().equals(tenant.getName()))
+                    .collect(Collectors.toSet());
             Set<ApplicationId> activeApps = Set.copyOf(tenantApplications.activeApplications());
 
             Set<ApplicationId> inRegistryOnly = new HashSet<>(registryApps);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -72,7 +72,7 @@ public class TenantApplications implements RequestHandler, HostValidator {
     private final TenantName tenant;
     private final ConfigActivationListener configActivationListener;
     private final ConfigResponseFactory responseFactory;
-    private final HostRegistry hostRegistry;
+    private final HostRegistry hostRegistry; // global host registry, hosts for all apps for all tenants
     private final ApplicationMapper applicationMapper = new ApplicationMapper();
     private final MetricUpdater tenantMetricUpdater;
     private final Clock clock;


### PR DESCRIPTION
## Summary
- `HostRegistry` is a process-wide registry (hosts for all apps across all tenants), but `ApplicationRepository.removeStaleHostRegistryEntries()` was comparing its full snapshot against only the current tenant's active apps inside the per-tenant loop.
- Consequence: `inRegistryOnly = registryApps - activeApps` always included apps belonging to *other* tenants, producing spurious `"Host registry has hosts … but application is not active (tenant …)"` log lines.
- Fix: filter `registryApps` by `tenant.getName()` before the diff so all three phases reason only about the tenant currently being processed.
- Also adds a clarifying comment on `TenantApplications.hostRegistry` noting it is the global registry.