### PR TITLE
TurboQuant native distance path and HNSW persistence support (WIP quality tuning)

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/document/Attribute.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/Attribute.java
@@ -41,7 +41,7 @@ import java.util.Set;
  */
 public final class Attribute implements Cloneable, Serializable {
 
-    public enum DistanceMetric { EUCLIDEAN, ANGULAR, GEODEGREES, INNERPRODUCT, HAMMING, PRENORMALIZED_ANGULAR, DOTPRODUCT }
+    public enum DistanceMetric { EUCLIDEAN, ANGULAR, GEODEGREES, INNERPRODUCT, HAMMING, PRENORMALIZED_ANGULAR, DOTPRODUCT, TURBOQUANT }
 
     // Remember to change hashCode and equals when you add new fields
 

--- a/config-model/src/test/java/com/yahoo/schema/AttributeSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/AttributeSettingsTestCase.java
@@ -348,6 +348,7 @@ public class AttributeSettingsTestCase extends AbstractSchemaTestCase {
         // TODO Vespa 9: Remove 'innerproduct' as alias for 'prenormalized-angular'.
         assertDerivedDistanceMetric(AttributesConfig.Attribute.Distancemetric.INNERPRODUCT, "innerproduct");
         assertDerivedDistanceMetric(AttributesConfig.Attribute.Distancemetric.PRENORMALIZED_ANGULAR, "prenormalized-angular");
+        assertDerivedDistanceMetric(AttributesConfig.Attribute.Distancemetric.TURBOQUANT, "turboquant");
     }
 
     private void assertDerivedDistanceMetric(AttributesConfig.Attribute.Distancemetric.Enum expDistanceMetric,

--- a/configdefinitions/src/vespa/attributes.def
+++ b/configdefinitions/src/vespa/attributes.def
@@ -37,7 +37,7 @@ attribute[].maxuncommittedmemory long default=130000
 
 # The distance metric to use for nearest neighbor search.
 # Is only used when the attribute is a 1-dimensional indexed tensor.
-attribute[].distancemetric enum { EUCLIDEAN, ANGULAR, GEODEGREES, INNERPRODUCT, HAMMING, PRENORMALIZED_ANGULAR, DOTPRODUCT } default=EUCLIDEAN
+attribute[].distancemetric enum { EUCLIDEAN, ANGULAR, GEODEGREES, INNERPRODUCT, HAMMING, PRENORMALIZED_ANGULAR, DOTPRODUCT, TURBOQUANT } default=EUCLIDEAN
 
 # Configuration parameters for a hnsw index used together with a 1-dimensional indexed tensor for approximate nearest neighbor search.
 attribute[].index.hnsw.enabled bool default=false

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/FixedKeywordBodies.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/FixedKeywordBodies.java
@@ -188,6 +188,8 @@ public class FixedKeywordBodies {
         CompletionUtils.constructBasic("euclidean"),
         CompletionUtils.constructBasic("angular"),
         CompletionUtils.constructBasic("dotproduct"),
+        CompletionUtils.constructBasic("innerproduct"),
+        CompletionUtils.constructBasic("turboquant"),
         CompletionUtils.constructBasic("prenormalized-angular"),
         CompletionUtils.constructBasic("geodegrees"),
         CompletionUtils.constructBasic("hamming")

--- a/integration/tmgrammar/grammar/vespa-schema.tmLanguage.json
+++ b/integration/tmgrammar/grammar/vespa-schema.tmLanguage.json
@@ -770,7 +770,7 @@
       ]
     },
     "enum-value-inline": {
-      "match": "(?<![a-zA-Z0-9_-])(match|rank|rank-type|sorting|bolding|stemming|summary-to|distance-metric|normalizing|function|locale|strength|order)(:\\s*)(token|word|exact|text|gram|prefix|substring|suffix|cased|uncased|literal|identity|tags|source|bolding|full|static|dynamic|tokens|matched-elements-only|angular|dotproduct|euclidean|prenormalized-angular|hamming|geodegrees|best|shortest|multiple|none|primary|secondary|tertiary|quaternary|identical|lowercase|raw|ascending|descending|always|on-demand|never|normal|contextual)(?![a-zA-Z0-9_-])",
+      "match": "(?<![a-zA-Z0-9_-])(match|rank|rank-type|sorting|bolding|stemming|summary-to|distance-metric|normalizing|function|locale|strength|order)(:\\s*)(token|word|exact|text|gram|prefix|substring|suffix|cased|uncased|literal|identity|tags|source|bolding|full|static|dynamic|tokens|matched-elements-only|angular|dotproduct|euclidean|innerproduct|prenormalized-angular|hamming|geodegrees|turboquant|best|shortest|multiple|none|primary|secondary|tertiary|quaternary|identical|lowercase|raw|ascending|descending|always|on-demand|never|normal|contextual)(?![a-zA-Z0-9_-])",
       "captures": {
         "1": {
           "name": "keyword.control.vespa"
@@ -818,7 +818,7 @@
         },
         {
           "name": "variable.other.enummember.vespa",
-          "match": "\\b(token|word|exact|text|gram|prefix|substring|suffix|cased|uncased|literal|identity|tags|source|bolding|full|static|dynamic|tokens|matched-elements-only|angular|dotproduct|euclidean|prenormalized-angular|hamming|geodegrees|best|shortest|multiple|none|primary|secondary|tertiary|quaternary|identical|lowercase|raw|ascending|descending|always|on-demand|never|normal|contextual)\\b"
+          "match": "\\b(token|word|exact|text|gram|prefix|substring|suffix|cased|uncased|literal|identity|tags|source|bolding|full|static|dynamic|tokens|matched-elements-only|angular|dotproduct|euclidean|innerproduct|prenormalized-angular|hamming|geodegrees|turboquant|best|shortest|multiple|none|primary|secondary|tertiary|quaternary|identical|lowercase|raw|ascending|descending|always|on-demand|never|normal|contextual)\\b"
         },
         {
           "include": "#schema-keywords"
@@ -878,7 +878,7 @@
         },
         {
           "name": "variable.other.enummember.vespa",
-          "match": "\\b(token|word|exact|text|gram|prefix|substring|suffix|cased|uncased|literal|identity|tags|source|bolding|full|static|dynamic|tokens|matched-elements-only|angular|dotproduct|euclidean|prenormalized-angular|hamming|geodegrees|best|shortest|multiple|none|primary|secondary|tertiary|quaternary|identical|lowercase|raw|ascending|descending|always|on-demand|never|normal|contextual)\\b"
+          "match": "\\b(token|word|exact|text|gram|prefix|substring|suffix|cased|uncased|literal|identity|tags|source|bolding|full|static|dynamic|tokens|matched-elements-only|angular|dotproduct|euclidean|innerproduct|prenormalized-angular|hamming|geodegrees|turboquant|best|shortest|multiple|none|primary|secondary|tertiary|quaternary|identical|lowercase|raw|ascending|descending|always|on-demand|never|normal|contextual)\\b"
         },
         {
           "include": "#schema-keywords"

--- a/searchlib/src/tests/attribute/attribute_header/attribute_header_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_header/attribute_header_test.cpp
@@ -79,6 +79,7 @@ TEST(AttributeHeaderTest, can_be_added_to_and_extracted_from_generic_header)
     verify_roundtrip_serialization(HnswIPO({16, 100, DistanceMetric::InnerProduct}));
     verify_roundtrip_serialization(HnswIPO({16, 100, DistanceMetric::PrenormalizedAngular}));
     verify_roundtrip_serialization(HnswIPO({16, 100, DistanceMetric::Hamming}));
+    verify_roundtrip_serialization(HnswIPO({16, 100, DistanceMetric::TurboQuant}));
     verify_roundtrip_serialization(HnswIPO());
 }
 

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -274,6 +274,7 @@ TEST(AttributeManagerTest, require_that_config_can_be_converted)
         expect_distance_metric(AttributesConfig::Attribute::Distancemetric::INNERPRODUCT, DistanceMetric::InnerProduct);
         expect_distance_metric(AttributesConfig::Attribute::Distancemetric::PRENORMALIZED_ANGULAR, DistanceMetric::PrenormalizedAngular);
         expect_distance_metric(AttributesConfig::Attribute::Distancemetric::DOTPRODUCT, DistanceMetric::Dotproduct);
+        expect_distance_metric(AttributesConfig::Attribute::Distancemetric::TURBOQUANT, DistanceMetric::TurboQuant);
     }
     { // hnsw index default params (enabled)
         CACA a;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -408,6 +408,8 @@ const std::string test_dir = "test_data/";
 const std::string attr_name = test_dir + "my_attr";
 
 const std::string hnsw_max_squared_norm = "hnsw.max_squared_norm";
+const std::string hnsw_turbo_quant_version = "hnsw.turbo_quant.version";
+const std::string hnsw_turbo_quant_levels = "hnsw.turbo_quant.levels";
 
 struct FixtureTraits {
     bool use_dense_tensor_attribute = false;
@@ -416,6 +418,7 @@ struct FixtureTraits {
     bool use_mock_index = false;
     bool use_mmap_file_allocator = false;
     bool use_mips_distance = false;
+    bool use_turbo_quant_distance = false;
 
     FixtureTraits dense() && {
         use_dense_tensor_attribute = true;
@@ -454,6 +457,14 @@ struct FixtureTraits {
         enable_hnsw_index = true;
         use_mock_index = false;
         use_mips_distance = true;
+        return *this;
+    }
+
+    FixtureTraits turbo_quant_hnsw() && {
+        use_dense_tensor_attribute = true;
+        enable_hnsw_index = true;
+        use_mock_index = false;
+        use_turbo_quant_distance = true;
         return *this;
     }
 
@@ -718,7 +729,12 @@ Fixture::Fixture(const std::string &typeSpec, FixtureTraits traits)
       _mmap_allocator_base_dir("mmap-file-allocator-factory-dir")
 {
     if (traits.enable_hnsw_index) {
-        auto dm = traits.use_mips_distance ? DistanceMetric::Dotproduct : DistanceMetric::Euclidean;
+        auto dm = DistanceMetric::Euclidean;
+        if (traits.use_turbo_quant_distance) {
+            dm = DistanceMetric::TurboQuant;
+        } else if (traits.use_mips_distance) {
+            dm = DistanceMetric::Dotproduct;
+        }
         _cfg.set_distance_metric(dm);
         _cfg.set_hnsw_index_params(HnswIndexParams(4, 20, dm));
     }
@@ -1459,6 +1475,11 @@ public:
     DenseTensorAttributeMipsIndex() : Fixture(vec_2d_spec, FixtureTraits().mips_hnsw()) {}
 };
 
+class DenseTensorAttributeTurboQuantIndex : public Fixture {
+public:
+    DenseTensorAttributeTurboQuantIndex() : Fixture(vec_2d_spec, FixtureTraits().turbo_quant_hnsw()) {}
+};
+
 TEST(TensorAttributeTest, Nearest_neighbor_index_with_mips_distance_metrics_stores_square_of_max_distance)
 {
     DenseTensorAttributeMipsIndex f;
@@ -1467,6 +1488,23 @@ TEST(TensorAttributeTest, Nearest_neighbor_index_with_mips_distance_metrics_stor
     auto header = f.get_file_header();
     EXPECT_TRUE(header.hasTag(hnsw_max_squared_norm));
     EXPECT_EQ(130.0, header.getTag(hnsw_max_squared_norm).asFloat());
+    EXPECT_TRUE(f.load());
+    auto& norm_store = dynamic_cast<MipsDistanceFunctionFactoryBase&>(f.hnsw_index().distance_function_factory()).get_max_squared_norm_store();
+    EXPECT_EQ(130.0, norm_store.get_max());
+}
+
+TEST(TensorAttributeTest, Nearest_neighbor_index_with_turboquant_distance_metric_stores_square_of_max_distance)
+{
+    DenseTensorAttributeTurboQuantIndex f;
+    f.set_example_tensors();
+    EXPECT_TRUE(f.save());
+    auto header = f.get_file_header();
+    EXPECT_TRUE(header.hasTag(hnsw_max_squared_norm));
+    EXPECT_EQ(130.0, header.getTag(hnsw_max_squared_norm).asFloat());
+    EXPECT_TRUE(header.hasTag(hnsw_turbo_quant_version));
+    EXPECT_EQ(1, header.getTag(hnsw_turbo_quant_version).asInteger());
+    EXPECT_TRUE(header.hasTag(hnsw_turbo_quant_levels));
+    EXPECT_EQ(4, header.getTag(hnsw_turbo_quant_levels).asInteger());
     EXPECT_TRUE(f.load());
     auto& norm_store = dynamic_cast<MipsDistanceFunctionFactoryBase&>(f.hnsw_index().distance_function_factory()).get_max_squared_norm_store();
     EXPECT_EQ(130.0, norm_store.get_max());

--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/tensor/distance_functions.h>
 #include <vespa/searchlib/tensor/distance_function_factory.h>
 #include <vespa/searchlib/tensor/mips_distance_transform.h>
+#include <vespa/searchlib/tensor/turbo_quant_distance.h>
 #include <vespa/vespalib/util/benchmark_timer.h>
 #include <vespa/vespalib/util/classname.h>
 
@@ -86,6 +87,9 @@ void benchmark(size_t iterations, size_t elems, const std::string & dist_functio
     if (dist_functions.find("mips") != npos) {
         benchmark<T>(iterations, elems, MipsDistanceFunctionFactory<T>());
     }
+    if (dist_functions.find("turboquant") != npos) {
+        benchmark<T>(iterations, elems, TurboQuantDistanceFunctionFactory<T>());
+    }
 }
 
 void
@@ -108,7 +112,7 @@ int
 main(int argc, char *argv[]) {
     size_t num_iterations = 10000000;
     size_t num_elems = 1024;
-    std::string dist_functions = "angular euclid prenorm mips";
+    std::string dist_functions = "angular euclid prenorm mips turboquant";
     std::string data_types = "double float32 bfloat16 float8";
     if (argc > 1) { num_iterations = atol(argv[1]); }
     if (argc > 2) { num_elems = atol(argv[2]); }

--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
@@ -5,8 +5,10 @@
 #include <vespa/searchlib/tensor/distance_functions.h>
 #include <vespa/searchlib/tensor/distance_function_factory.h>
 #include <vespa/searchlib/tensor/mips_distance_transform.h>
+#include <vespa/searchlib/tensor/turbo_quant_distance.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <numbers>
+#include <random>
 #include <vector>
 
 #include <vespa/log/log.h>
@@ -762,6 +764,106 @@ TEST(DistanceFunctionsTest, dotproduct_can_reference_insertion_vector)
     expect_reference_insertion_vector<double>(0.0, DistanceMetric::Dotproduct, CellType::DOUBLE);
     expect_reference_insertion_vector<Int8Float>(0.0, DistanceMetric::Dotproduct, CellType::INT8);
     expect_reference_insertion_vector<BFloat16>(0.0, DistanceMetric::Dotproduct, CellType::BFLOAT16);
+}
+
+TEST(DistanceFunctionsTest, turboquant_uses_dedicated_factory_type)
+{
+    auto dotproduct_factory = make_distance_function_factory(DistanceMetric::Dotproduct, CellType::FLOAT);
+    auto turboquant_factory = make_distance_function_factory(DistanceMetric::TurboQuant, CellType::FLOAT);
+    EXPECT_NE(nullptr, dynamic_cast<MipsDistanceFunctionFactory<float>*>(dotproduct_factory.get()));
+    EXPECT_NE(nullptr, dynamic_cast<TurboQuantDistanceFunctionFactory<float>*>(turboquant_factory.get()));
+    EXPECT_EQ(nullptr, dynamic_cast<TurboQuantDistanceFunctionFactory<float>*>(dotproduct_factory.get()));
+}
+
+TEST(DistanceFunctionsTest, turboquant_can_reference_insertion_vector)
+{
+    auto check_ref = [](CellType cell_type) {
+        std::vector<double> lhs{0.0, 1.0};
+        std::vector<double> rhs{0.0, 1.0};
+        auto factory = make_distance_function_factory(DistanceMetric::TurboQuant, cell_type);
+        auto func = factory->for_insertion_vector(t(lhs));
+        const double before = func->calc(t(rhs));
+        lhs[0] = 1.0;
+        lhs[1] = 0.0;
+        const double after = func->calc(t(rhs));
+        EXPECT_NE(before, after);
+    };
+    check_ref(CellType::FLOAT);
+    check_ref(CellType::DOUBLE);
+}
+
+TEST(DistanceFunctionsTest, turboquant_prefers_identical_vector_over_dissimilar_vector)
+{
+    std::vector<float> query{1.0f, 2.0f, 3.0f, 4.0f};
+    std::vector<float> same{1.0f, 2.0f, 3.0f, 4.0f};
+    std::vector<float> dissimilar{-4.0f, 3.0f, -2.0f, 1.0f};
+
+    auto factory = make_distance_function_factory(DistanceMetric::TurboQuant, CellType::FLOAT);
+    auto df = factory->for_query_vector(t(query));
+    const double same_distance = df->calc(t(same));
+    const double dissimilar_distance = df->calc(t(dissimilar));
+
+    EXPECT_LT(same_distance, dissimilar_distance);
+    EXPECT_GT(df->to_rawscore(same_distance), df->to_rawscore(dissimilar_distance));
+}
+
+TEST(DistanceFunctionsTest, turboquant_topk_overlap_with_exact_dotproduct_is_reasonable)
+{
+    constexpr size_t dims = 128;
+    constexpr size_t docs = 200;
+    constexpr size_t k = 10;
+
+    std::mt19937 rng(7);
+    std::uniform_real_distribution<float> dist(-3.0f, 3.0f);
+
+    std::vector<float> query(dims);
+    for (auto& value : query) {
+        value = dist(rng);
+    }
+    std::vector<std::vector<float>> vectors;
+    vectors.reserve(docs);
+    for (size_t i = 0; i < docs; ++i) {
+        std::vector<float> v(dims);
+        for (auto& value : v) {
+            value = dist(rng);
+        }
+        vectors.push_back(std::move(v));
+    }
+
+    auto turbo_factory = make_distance_function_factory(DistanceMetric::TurboQuant, CellType::FLOAT);
+    auto turbo_df = turbo_factory->for_query_vector(t(query));
+
+    auto exact_dot = [&query](const std::vector<float>& v) {
+        double sum = 0.0;
+        for (size_t i = 0; i < query.size(); ++i) {
+            sum += static_cast<double>(query[i]) * static_cast<double>(v[i]);
+        }
+        return sum;
+    };
+
+    std::vector<std::pair<double, uint32_t>> exact;
+    std::vector<std::pair<double, uint32_t>> approx;
+    exact.reserve(docs);
+    approx.reserve(docs);
+    for (uint32_t i = 0; i < docs; ++i) {
+        const auto& v = vectors[i];
+        exact.emplace_back(exact_dot(v), i);
+        approx.emplace_back(turbo_df->to_rawscore(turbo_df->calc(t(v))), i);
+    }
+    auto greater = [](const auto& lhs, const auto& rhs) { return lhs.first > rhs.first; };
+    std::partial_sort(exact.begin(), exact.begin() + k, exact.end(), greater);
+    std::partial_sort(approx.begin(), approx.begin() + k, approx.end(), greater);
+
+    size_t overlap = 0;
+    for (size_t i = 0; i < k; ++i) {
+        for (size_t j = 0; j < k; ++j) {
+            if (exact[i].second == approx[j].second) {
+                ++overlap;
+                break;
+            }
+        }
+    }
+    EXPECT_GE(overlap, 5u);
 }
 
 TEST(DistanceFunctionsTest, hamming_can_reference_insertion_vector)

--- a/searchlib/src/vespa/searchcommon/attribute/distance_metric.h
+++ b/searchlib/src/vespa/searchcommon/attribute/distance_metric.h
@@ -6,6 +6,6 @@
 
 namespace search::attribute {
 
-enum class DistanceMetric : uint8_t { Euclidean, Angular, GeoDegrees, InnerProduct, Hamming, PrenormalizedAngular, Dotproduct };
+enum class DistanceMetric : uint8_t { Euclidean, Angular, GeoDegrees, InnerProduct, Hamming, PrenormalizedAngular, Dotproduct, TurboQuant };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -139,6 +139,9 @@ ConfigConverter::convert(const AttributesConfig::Attribute & cfg)
         case CfgDm::DOTPRODUCT:
             dm = DistanceMetric::Dotproduct;
             break;
+        case CfgDm::TURBOQUANT:
+            dm = DistanceMetric::TurboQuant;
+            break;
     }
     retval.set_distance_metric(dm);
     if (cfg.index.hnsw.enabled) {

--- a/searchlib/src/vespa/searchlib/attribute/distance_metric_utils.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/distance_metric_utils.cpp
@@ -14,6 +14,7 @@ const std::string innerproduct = "innerproduct";
 const std::string prenormalized_angular = "prenormalized_angular";
 const std::string dotproduct = "dotproduct";
 const std::string hamming = "hamming";
+const std::string turboquant = "turboquant";
 
 }
 
@@ -28,6 +29,7 @@ DistanceMetricUtils::to_string(DistanceMetric metric)
         case DistanceMetric::Hamming: return hamming;
         case DistanceMetric::PrenormalizedAngular: return prenormalized_angular;
         case DistanceMetric::Dotproduct: return dotproduct;
+        case DistanceMetric::TurboQuant: return turboquant;
     }
     throw vespalib::IllegalArgumentException("Unknown distance metric " + std::to_string(static_cast<int>(metric)));
 }
@@ -49,6 +51,8 @@ DistanceMetricUtils::to_distance_metric(const std::string& metric)
         return DistanceMetric::Dotproduct;
     } else if (metric == hamming) {
         return DistanceMetric::Hamming;
+    } else if (metric == turboquant) {
+        return DistanceMetric::TurboQuant;
     } else {
         throw vespalib::IllegalStateException("Unknown distance metric '" + metric + "'");
     }

--- a/searchlib/src/vespa/searchlib/tensor/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/tensor/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_library(searchlib_tensor OBJECT
     SOURCES
     angular_distance.cpp
     mips_distance_transform.cpp
+    turbo_quant_distance.cpp
     bitvector_visited_tracker.cpp
     bound_distance_function.cpp
     default_nearest_neighbor_index_factory.cpp

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
@@ -3,6 +3,7 @@
 #include "distance_function_factory.h"
 #include "distance_functions.h"
 #include "mips_distance_transform.h"
+#include "turbo_quant_distance.h"
 
 using search::attribute::DistanceMetric;
 using vespalib::eval::CellType;
@@ -46,6 +47,14 @@ make_distance_function_factory(DistanceMetric variant, CellType cell_type)
                 case CellType::BFLOAT16: return std::make_unique<MipsDistanceFunctionFactory<vespalib::BFloat16>>(true);
                 case CellType::FLOAT:    return std::make_unique<MipsDistanceFunctionFactory<float>>(true);
                 default:                 return std::make_unique<MipsDistanceFunctionFactory<float>>();
+            }
+        case DistanceMetric::TurboQuant:
+            switch (cell_type) {
+                case CellType::DOUBLE:   return std::make_unique<TurboQuantDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:     return std::make_unique<TurboQuantDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::BFLOAT16: return std::make_unique<TurboQuantDistanceFunctionFactory<vespalib::BFloat16>>(true);
+                case CellType::FLOAT:    return std::make_unique<TurboQuantDistanceFunctionFactory<float>>(true);
+                default:                 return std::make_unique<TurboQuantDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::GeoDegrees:
             return std::make_unique<GeoDistanceFunctionFactory>();

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_factory.h
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_factory.h
@@ -6,6 +6,8 @@
 #include "bound_distance_function.h"
 #include <vespa/searchcommon/attribute/distance_metric.h>
 
+namespace vespalib { class GenericHeader; }
+
 namespace search::tensor {
 
 /**
@@ -19,6 +21,8 @@ struct DistanceFunctionFactory {
     virtual ~DistanceFunctionFactory() = default;
     virtual BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const = 0;
     virtual BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const = 0;
+    virtual void save_state(vespalib::GenericHeader&) const {}
+    virtual void load_state(const vespalib::GenericHeader&) {}
     using UP = std::unique_ptr<DistanceFunctionFactory>;
 };
 

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -6,7 +6,6 @@
 #include "hnsw_index_explorer.h"
 #include "hnsw_index_loader.hpp"
 #include "hnsw_index_saver.h"
-#include "mips_distance_transform.h"
 #include "random_level_generator.h"
 #include "vector_bundle.h"
 #include <vespa/searchlib/attribute/address_space_components.h>
@@ -41,29 +40,6 @@ constexpr float alloc_grow_factor = 0.3;
 constexpr size_t max_level_array_size = 16;
 constexpr size_t max_link_array_size = 193;
 constexpr vespalib::duration MAX_COUNT_DURATION(1000ms);
-
-const std::string hnsw_max_squared_norm = "hnsw.max_squared_norm";
-
-void save_mips_max_distance(GenericHeader& header, DistanceFunctionFactory& dff) {
-    auto* mips_dff = dynamic_cast<MipsDistanceFunctionFactoryBase*>(&dff);
-    if (mips_dff != nullptr) {
-        auto& norm_store = mips_dff->get_max_squared_norm_store();
-        header.putTag(GenericHeader::Tag(hnsw_max_squared_norm, norm_store.get_max()));
-    }
-}
-
-void load_mips_max_distance(const GenericHeader& header, DistanceFunctionFactory& dff) {
-    auto* mips_dff = dynamic_cast<MipsDistanceFunctionFactoryBase*>(&dff);
-    if (mips_dff != nullptr) {
-        auto& norm_store = mips_dff->get_max_squared_norm_store();
-        if (header.hasTag(hnsw_max_squared_norm)) {
-            auto& tag = header.getTag(hnsw_max_squared_norm);
-            if (tag.getType() == GenericHeader::Tag::Type::TYPE_FLOAT) {
-                (void) norm_store.get_max(tag.asFloat());
-            }
-        }
-    }
-}
 
 bool has_link_to(std::span<const uint32_t> links, uint32_t id) {
     for (uint32_t link : links) {
@@ -1090,7 +1066,7 @@ template <HnswIndexType type>
 std::unique_ptr<NearestNeighborIndexSaver>
 HnswIndex<type>::make_saver(GenericHeader& header) const
 {
-    save_mips_max_distance(header, distance_function_factory());
+    distance_function_factory().save_state(header);
     return std::make_unique<HnswIndexSaver<type>>(_graph);
 }
 
@@ -1099,7 +1075,7 @@ std::unique_ptr<NearestNeighborIndexLoader>
 HnswIndex<type>::make_loader(FastOS_FileInterface& file, const vespalib::GenericHeader& header)
 {
     assert(get_entry_nodeid() == 0); // cannot load after index has data
-    load_mips_max_distance(header, distance_function_factory());
+    distance_function_factory().load_state(header);
     _graph.set_last_flush_duration(FileHeaderContext::get_flush_duration(header));
     using ReaderType = FileReader<uint32_t>;
     using LoaderType = HnswIndexLoader<ReaderType, type>;

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
@@ -11,6 +11,29 @@ namespace hwaccelerated = vespalib::hwaccelerated;
 
 namespace search::tensor {
 
+namespace {
+
+const std::string hnsw_max_squared_norm = "hnsw.max_squared_norm";
+
+}
+
+void
+MipsDistanceFunctionFactoryBase::save_state(vespalib::GenericHeader& header) const
+{
+    header.putTag(vespalib::GenericHeader::Tag(hnsw_max_squared_norm, _sq_norm_store->get_max()));
+}
+
+void
+MipsDistanceFunctionFactoryBase::load_state(const vespalib::GenericHeader& header)
+{
+    if (header.hasTag(hnsw_max_squared_norm)) {
+        const auto& tag = header.getTag(hnsw_max_squared_norm);
+        if (tag.getType() == vespalib::GenericHeader::Tag::Type::TYPE_FLOAT) {
+            (void) _sq_norm_store->get_max(tag.asFloat());
+        }
+    }
+}
+
 template <typename VectorStoreType, bool extra_dim>
 class BoundMipsDistanceFunction final : public BoundDistanceFunction {
     using FloatType = VectorStoreType::FloatType;

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
@@ -5,6 +5,7 @@
 #include "distance_function.h"
 #include "distance_function_factory.h"
 #include <vespa/eval/eval/typed_cells.h>
+#include <vespa/vespalib/data/fileheader.h>
 #include <mutex>
 #include <memory>
 
@@ -47,6 +48,8 @@ public:
     }
     ~MipsDistanceFunctionFactoryBase() override = default;
     MaximumSquaredNormStore& get_max_squared_norm_store() noexcept { return *_sq_norm_store; }
+    void save_state(vespalib::GenericHeader& header) const override;
+    void load_state(const vespalib::GenericHeader& header) override;
 };
 
 /**

--- a/searchlib/src/vespa/searchlib/tensor/turbo_quant_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/turbo_quant_distance.cpp
@@ -1,0 +1,225 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "turbo_quant_distance.h"
+#include "temporary_vector_store.h"
+#include <vespa/vespalib/hwaccelerated/functions.h>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numbers>
+#include <string>
+
+using vespalib::eval::Int8Float;
+namespace hwaccelerated = vespalib::hwaccelerated;
+
+namespace search::tensor {
+
+namespace {
+
+const std::string hnsw_turbo_quant_version = "hnsw.turbo_quant.version";
+const std::string hnsw_turbo_quant_levels = "hnsw.turbo_quant.levels";
+constexpr uint32_t turbo_quant_state_version = 1;
+
+constexpr double k_qjl_scale = 1.2533141373155002512; // sqrt(pi/2)
+constexpr double k_eps = 1e-12;
+
+inline int
+residual_sign(double value) noexcept
+{
+    if (value > 0.0) {
+        return 1;
+    }
+    if (value < 0.0) {
+        return -1;
+    }
+    return 0;
+}
+
+inline double
+dequantize_normalized(double value, uint32_t levels) noexcept
+{
+    if (levels <= 4) {
+        // 2-bit base quantization centroids (TurboQuant-like low-bit stage).
+        if (value < -0.9815) return -1.510;
+        if (value < 0.0) return -0.453;
+        if (value < 0.9815) return 0.453;
+        return 1.510;
+    }
+    // 3-bit base quantization fallback using simple uniform bins.
+    if (value < -2.0) return -2.5;
+    if (value < -1.25) return -1.5;
+    if (value < -0.75) return -1.0;
+    if (value < -0.25) return -0.5;
+    if (value < 0.25) return 0.5;
+    if (value < 0.75) return 1.0;
+    if (value < 1.25) return 1.5;
+    return 2.5;
+}
+
+template <typename FloatType>
+double
+vector_scale(std::span<const FloatType> vector) noexcept
+{
+    if (vector.empty()) {
+        return 1.0;
+    }
+    double norm_sq = 0.0;
+    for (auto value : vector) {
+        double v = value;
+        norm_sq += (v * v);
+    }
+    if (norm_sq <= k_eps) {
+        return 1.0;
+    }
+    return std::sqrt(norm_sq / static_cast<double>(vector.size()));
+}
+
+} // namespace
+
+template <typename VectorStoreType>
+class BoundTurboQuantDistance final : public BoundDistanceFunction {
+    using FloatType = typename VectorStoreType::FloatType;
+    mutable VectorStoreType _tmp_space;
+    std::span<const FloatType> _lhs;
+    MaximumSquaredNormStore* _sq_norm_store;
+    bool _update_norm_store;
+    uint32_t _mse_levels;
+
+public:
+    BoundTurboQuantDistance(TypedCells lhs, MaximumSquaredNormStore& sq_norm_store, bool update_norm_store, uint32_t mse_levels)
+        : _tmp_space(lhs.size),
+          _lhs(_tmp_space.storeLhs(lhs)),
+          _sq_norm_store(&sq_norm_store),
+          _update_norm_store(update_norm_store),
+          _mse_levels(mse_levels)
+    {
+        const auto* data = _lhs.data();
+        double lhs_sq_norm = hwaccelerated::dot_product(cast(data), cast(data), _lhs.size());
+        if (_update_norm_store) {
+            (void) _sq_norm_store->get_max(lhs_sq_norm);
+        } else {
+            (void) _sq_norm_store->get_max();
+        }
+    }
+
+    double calc(TypedCells rhs) const noexcept override {
+        auto rhs_vec = _tmp_space.convertRhs(rhs);
+        const size_t sz = _lhs.size();
+        if (sz == 0u) {
+            return 0.0;
+        }
+
+        const double lhs_scale = vector_scale(_lhs);
+        const double rhs_scale = vector_scale(rhs_vec);
+        const double lhs_inv_scale = 1.0 / std::max(lhs_scale, k_eps);
+        const double rhs_inv_scale = 1.0 / std::max(rhs_scale, k_eps);
+
+        double quantized_dot = 0.0;
+        double lhs_residual_norm_sq = 0.0;
+        double rhs_residual_norm_sq = 0.0;
+        int residual_sign_dot = 0;
+
+        for (size_t i = 0; i < sz; ++i) {
+            const double lhs_val = _lhs[i];
+            const double rhs_val = rhs_vec[i];
+
+            const double lhs_q = dequantize_normalized(lhs_val * lhs_inv_scale, _mse_levels) * lhs_scale;
+            const double rhs_q = dequantize_normalized(rhs_val * rhs_inv_scale, _mse_levels) * rhs_scale;
+
+            quantized_dot += (lhs_q * rhs_q);
+
+            const double lhs_residual = lhs_val - lhs_q;
+            const double rhs_residual = rhs_val - rhs_q;
+            lhs_residual_norm_sq += lhs_residual * lhs_residual;
+            rhs_residual_norm_sq += rhs_residual * rhs_residual;
+            residual_sign_dot += residual_sign(lhs_residual) * residual_sign(rhs_residual);
+        }
+
+        double correction = 0.0;
+        if ((lhs_residual_norm_sq > k_eps) && (rhs_residual_norm_sq > k_eps)) {
+            const double residual_product_norm = std::sqrt(lhs_residual_norm_sq * rhs_residual_norm_sq);
+            correction = (k_qjl_scale / static_cast<double>(sz)) * residual_product_norm * static_cast<double>(residual_sign_dot);
+        }
+        const double estimated_inner_product = quantized_dot + correction;
+        return -estimated_inner_product;
+    }
+
+    double convert_threshold(double threshold) const noexcept override {
+        return threshold;
+    }
+
+    double to_rawscore(double distance) const noexcept override {
+        return -distance;
+    }
+
+    double to_distance(double rawscore) const noexcept override {
+        return -rawscore;
+    }
+
+    double min_rawscore() const noexcept override {
+        return std::numeric_limits<double>::lowest();
+    }
+
+    double calc_with_limit(TypedCells rhs, double) const noexcept override {
+        return calc(rhs);
+    }
+};
+
+template class BoundTurboQuantDistance<TemporaryVectorStore<Int8Float>>;
+template class BoundTurboQuantDistance<TemporaryVectorStore<vespalib::BFloat16>>;
+template class BoundTurboQuantDistance<TemporaryVectorStore<float>>;
+template class BoundTurboQuantDistance<TemporaryVectorStore<double>>;
+template class BoundTurboQuantDistance<ReferenceVectorStore<Int8Float>>;
+template class BoundTurboQuantDistance<ReferenceVectorStore<vespalib::BFloat16>>;
+template class BoundTurboQuantDistance<ReferenceVectorStore<float>>;
+template class BoundTurboQuantDistance<ReferenceVectorStore<double>>;
+
+template <typename FloatType>
+BoundDistanceFunction::UP
+TurboQuantDistanceFunctionFactory<FloatType>::for_query_vector(TypedCells lhs) const {
+    using DFT = BoundTurboQuantDistance<TemporaryVectorStore<FloatType>>;
+    return std::make_unique<DFT>(lhs, *_sq_norm_store, false, _mse_levels);
+}
+
+template <typename FloatType>
+BoundDistanceFunction::UP
+TurboQuantDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) const {
+    if (_reference_insertion_vector) {
+        using DFT = BoundTurboQuantDistance<ReferenceVectorStore<FloatType>>;
+        return std::make_unique<DFT>(lhs, *_sq_norm_store, true, _mse_levels);
+    }
+    using DFT = BoundTurboQuantDistance<TemporaryVectorStore<FloatType>>;
+    return std::make_unique<DFT>(lhs, *_sq_norm_store, true, _mse_levels);
+}
+
+template <typename FloatType>
+void
+TurboQuantDistanceFunctionFactory<FloatType>::save_state(vespalib::GenericHeader& header) const
+{
+    MipsDistanceFunctionFactoryBase::save_state(header);
+    header.putTag(vespalib::GenericHeader::Tag(hnsw_turbo_quant_version, static_cast<uint32_t>(turbo_quant_state_version)));
+    header.putTag(vespalib::GenericHeader::Tag(hnsw_turbo_quant_levels, _mse_levels));
+}
+
+template <typename FloatType>
+void
+TurboQuantDistanceFunctionFactory<FloatType>::load_state(const vespalib::GenericHeader& header)
+{
+    MipsDistanceFunctionFactoryBase::load_state(header);
+    if (header.hasTag(hnsw_turbo_quant_levels)) {
+        const auto& tag = header.getTag(hnsw_turbo_quant_levels);
+        if (tag.getType() == vespalib::GenericHeader::Tag::Type::TYPE_INTEGER) {
+            auto levels = static_cast<uint32_t>(tag.asInteger());
+            if ((levels == 4u) || (levels == 8u)) {
+                _mse_levels = levels;
+            }
+        }
+    }
+}
+
+template class TurboQuantDistanceFunctionFactory<Int8Float>;
+template class TurboQuantDistanceFunctionFactory<vespalib::BFloat16>;
+template class TurboQuantDistanceFunctionFactory<float>;
+template class TurboQuantDistanceFunctionFactory<double>;
+
+}

--- a/searchlib/src/vespa/searchlib/tensor/turbo_quant_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/turbo_quant_distance.h
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "mips_distance_transform.h"
+
+namespace search::tensor {
+
+/**
+ * Factory for TurboQuant distance functions.
+ *
+ * This implements a native quantized distance approximation that combines
+ * low-bit quantized inner product with a residual-sign correction term.
+ */
+template <typename FloatType>
+class TurboQuantDistanceFunctionFactory : public MipsDistanceFunctionFactoryBase {
+public:
+    using TypedCells = DistanceFunctionFactory::TypedCells;
+
+    TurboQuantDistanceFunctionFactory() noexcept : TurboQuantDistanceFunctionFactory(false) {}
+    TurboQuantDistanceFunctionFactory(bool reference_insertion_vector) noexcept
+        : _reference_insertion_vector(reference_insertion_vector),
+          _mse_levels(4)
+    {
+    }
+    ~TurboQuantDistanceFunctionFactory() override = default;
+
+    BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
+    BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
+    void save_state(vespalib::GenericHeader& header) const override;
+    void load_state(const vespalib::GenericHeader& header) override;
+
+    uint32_t mse_levels() const noexcept { return _mse_levels; }
+
+private:
+    bool _reference_insertion_vector;
+    uint32_t _mse_levels;
+};
+
+}

--- a/streamingvisitors/src/tests/nearest_neighbor_field_searcher/nearest_neighbor_field_searcher_test.cpp
+++ b/streamingvisitors/src/tests/nearest_neighbor_field_searcher/nearest_neighbor_field_searcher_test.cpp
@@ -179,6 +179,7 @@ TEST_F(NearestNeighborSearcherTest, distance_metric_from_string)
     EXPECT_EQ(DistanceMetric::GeoDegrees,   NNFS::distance_metric_from_string("GEODEGREES"));
     EXPECT_EQ(DistanceMetric::InnerProduct, NNFS::distance_metric_from_string("INNERPRODUCT"));
     EXPECT_EQ(DistanceMetric::Hamming,      NNFS::distance_metric_from_string("HAMMING"));
+    EXPECT_EQ(DistanceMetric::TurboQuant,   NNFS::distance_metric_from_string("TURBOQUANT"));
     EXPECT_EQ(DistanceMetric::Euclidean,    NNFS::distance_metric_from_string("not_available"));
 }
 


### PR DESCRIPTION
I hereby state that this submission is released according to the license in the root of this project's source tree, and that I have the proper authorization to make this contribution on behalf of the owner of its copyright.

Tracks #36327

Summary of changes introduced
A dedicated TurboQuant distance path (no DotProduct fallback).
TurboQuant-aware HNSW saving/loading of internal state hooks.
Improvements in schema/tooling as well as additional TurboQuant-specific tests.

Validation
All distance functions: validation passed.
HNSW Index: all validation passed.
Stress test for HNSW index (using SIFT dataset): passed.
Latency / memory checks performed.

**Limitations of the current implementation**
Recall metric is yet to meet the desired level (recall@10 ~ 0.26 on SIFT subset). 
Therefore, this PR can be considered integration/stability ready, however requires some more quality tuning before closing #36327.