### PR TITLE
Fix refresh token storage: fall back to file when keyring fails

### DIFF
--- a/client/go/internal/cli/auth/REFRESH_TOKEN_STORAGE.md
+++ b/client/go/internal/cli/auth/REFRESH_TOKEN_STORAGE.md
@@ -1,0 +1,112 @@
+# refresh token storage
+
+how the vespa CLI stores and retrieves OAuth2 refresh tokens, and the
+fallback mechanism for systems where the OS keyring is unavailable.
+
+## overview
+
+the vespa CLI uses a two-token OAuth2 flow:
+
+- **access token** — short-lived (30 min), stored in `~/.vespa/auth.json`
+- **refresh token** — long-lived (24 hours), stored in the system keyring or a local file
+
+when the access token expires, the CLI uses the refresh token to obtain a
+new one without requiring the user to re-authenticate in the browser.
+
+## storage backends
+
+the CLI has two `SecretStore` implementations for persisting the refresh token:
+
+| backend | type | storage location | when used |
+|---|---|---|---|
+| system keyring | `realKeyring` | macOS Keychain, GNOME Keyring, Windows Credential Manager | default (primary) |
+| file storage | `dummyKeyring` | `~/.vespa/keyring.<namespace>.<key>` (mode 0o400) | fallback, or `--file-storage` / `VESPA_CLI_DUMMY_KEYRING=1` |
+
+## fallback keyring
+
+`NewKeyring()` returns a `fallbackKeyring` that composes both backends:
+
+```
+┌─────────────────────────────────────────┐
+│           fallbackKeyring               │
+│                                         │
+│  Set(k, v):                             │
+│    try realKeyring.Set(k, v)            │
+│    if err → dummyKeyring.Set(k, v)      │
+│                                         │
+│  Get(k):                                │
+│    try realKeyring.Get(k)               │
+│    if err or empty → dummyKeyring.Get(k)│
+│                                         │
+│  Delete(k):                             │
+│    realKeyring.Delete(k)                │
+│    dummyKeyring.Delete(k)               │
+│    fail only if both fail               │
+└─────────────────────────────────────────┘
+```
+
+this means:
+
+- on systems with a working keyring, behavior is unchanged
+- on systems where the keyring fails (unsigned binaries, SSH, Docker, CI),
+  the token is transparently stored in `~/.vespa/` files
+- the refresh path (`AccessToken()` in `auth0.go`) finds the token
+  regardless of which backend stored it
+
+## explicit overrides
+
+users can bypass the fallback and force file-only storage:
+
+- **`--file-storage` flag** on `vespa auth login` — uses `dummyKeyring` directly
+- **`VESPA_CLI_DUMMY_KEYRING=1`** environment variable — makes all
+  `NewKeyring()` and `NewKeyringWithOptions(false)` calls return `dummyKeyring`
+
+both skip the system keyring entirely, which avoids the keyring failure
+latency on systems known to lack keyring support.
+
+## token lifecycle
+
+```
+vespa auth login
+  │
+  ├─ browser OAuth2 device flow → access token + refresh token
+  │
+  ├─ store refresh token:
+  │    NewKeyringWithOptions(useFileStorage).Set("vespa-cli", system, refreshToken)
+  │    └─ without --file-storage: fallbackKeyring tries keyring, then file
+  │    └─ with --file-storage: dummyKeyring writes file directly
+  │
+  └─ store access token + expiry → ~/.vespa/auth.json
+
+(later, any vespa command)
+  │
+  ├─ read access token from ~/.vespa/auth.json
+  ├─ if expired (within 5 min of expiry):
+  │    NewKeyring().Get("vespa-cli", system)  → retrieve refresh token
+  │    └─ fallbackKeyring: tries keyring, then file
+  │    POST refresh token to OAuth token endpoint → new access token
+  │    update ~/.vespa/auth.json
+  └─ use access token in Authorization header
+```
+
+## file permissions
+
+the file-based token (`~/.vespa/keyring.vespa-cli.<system>`) is created
+with mode `0o400` (owner read-only). before overwriting, the existing file
+is removed first — `os.WriteFile` cannot truncate a read-only file, so
+`os.Remove` is called before each write.
+
+the `~/.vespa/` directory is created with mode `0o700` (owner only).
+
+## security considerations
+
+the file-based token is stored unencrypted. anyone with read access to
+`~/.vespa/keyring.vespa-cli.*` can use the refresh token to generate new
+access tokens for its remaining lifetime (up to 24 hours). this is
+comparable to SSH private keys or cloud CLI credentials stored in
+`~/.config/`.
+
+the system keyring provides better protection (encrypted at rest, access
+gated by OS authentication), which is why it remains the primary backend.
+file storage is a fallback for environments where the keyring is not
+available.

--- a/client/go/internal/cli/auth/secrets.go
+++ b/client/go/internal/cli/auth/secrets.go
@@ -9,8 +9,12 @@ import (
 )
 
 type (
-	realKeyring  struct{}
-	dummyKeyring struct{}
+	realKeyring     struct{}
+	dummyKeyring    struct{}
+	fallbackKeyring struct {
+		primary   SecretStore
+		secondary SecretStore
+	}
 )
 
 func NewKeyring() SecretStore {
@@ -21,7 +25,10 @@ func NewKeyringWithOptions(useDummy bool) SecretStore {
 	if useDummy || os.Getenv("VESPA_CLI_DUMMY_KEYRING") != "" {
 		return &dummyKeyring{}
 	}
-	return &realKeyring{}
+	return &fallbackKeyring{
+		primary:   &realKeyring{},
+		secondary: &dummyKeyring{},
+	}
 }
 
 // Set sets the given key/value pair with the given namespace.
@@ -57,6 +64,9 @@ func (k *dummyKeyring) Set(namespace, key, value string) error {
 	if err != nil {
 		return err
 	}
+	// Remove any existing file first. The file is created with mode 0o400
+	// (read-only), so os.WriteFile cannot truncate it on subsequent writes.
+	_ = os.Remove(fn)
 	return os.WriteFile(fn, []byte(value), 0o400)
 }
 
@@ -77,4 +87,31 @@ func (k *dummyKeyring) Delete(namespace, key string) error {
 		return err
 	}
 	return os.Remove(fn)
+}
+
+// Set tries the primary store and falls back to the secondary on failure.
+func (k *fallbackKeyring) Set(namespace, key, value string) error {
+	if err := k.primary.Set(namespace, key, value); err != nil {
+		return k.secondary.Set(namespace, key, value)
+	}
+	return nil
+}
+
+// Get tries the primary store and falls back to the secondary on failure.
+func (k *fallbackKeyring) Get(namespace, key string) (string, error) {
+	val, err := k.primary.Get(namespace, key)
+	if err == nil && val != "" {
+		return val, nil
+	}
+	return k.secondary.Get(namespace, key)
+}
+
+// Delete tries to delete from both stores, returning an error only if both fail.
+func (k *fallbackKeyring) Delete(namespace, key string) error {
+	err1 := k.primary.Delete(namespace, key)
+	err2 := k.secondary.Delete(namespace, key)
+	if err1 != nil && err2 != nil {
+		return err1
+	}
+	return nil
 }

--- a/client/go/internal/cli/auth/secrets_test.go
+++ b/client/go/internal/cli/auth/secrets_test.go
@@ -1,0 +1,110 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDummyKeyringOverwritesReadOnlyFile(t *testing.T) {
+	// Simulate the bug: dummyKeyring.Set creates a 0o400 file, then a
+	// second Set must succeed despite the file being read-only.
+	dir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", dir)
+	defer os.Setenv("HOME", origHome)
+
+	k := &dummyKeyring{}
+	require.NoError(t, k.Set("ns", "key", "first"))
+
+	fn := filepath.Join(dir, ".vespa", "keyring.ns.key")
+	info, err := os.Stat(fn)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o400), info.Mode().Perm())
+
+	// Second write must not fail even though the file is read-only
+	require.NoError(t, k.Set("ns", "key", "second"))
+
+	val, err := k.Get("ns", "key")
+	require.NoError(t, err)
+	assert.Equal(t, "second", val)
+}
+
+func TestFallbackKeyringSet(t *testing.T) {
+	k := &fallbackKeyring{
+		primary:   &failingStore{},
+		secondary: &dummyTestStore{data: map[string]string{}},
+	}
+	// Primary fails, so the value should end up in secondary
+	require.NoError(t, k.Set("ns", "key", "value"))
+	val, err := k.Get("ns", "key")
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+}
+
+func TestFallbackKeyringGetPrimaryFirst(t *testing.T) {
+	primary := &dummyTestStore{data: map[string]string{"ns/key": "from-primary"}}
+	secondary := &dummyTestStore{data: map[string]string{"ns/key": "from-secondary"}}
+	k := &fallbackKeyring{primary: primary, secondary: secondary}
+
+	val, err := k.Get("ns", "key")
+	require.NoError(t, err)
+	assert.Equal(t, "from-primary", val)
+}
+
+func TestFallbackKeyringGetFallsBack(t *testing.T) {
+	k := &fallbackKeyring{
+		primary:   &failingStore{},
+		secondary: &dummyTestStore{data: map[string]string{"ns/key": "from-file"}},
+	}
+	val, err := k.Get("ns", "key")
+	require.NoError(t, err)
+	assert.Equal(t, "from-file", val)
+}
+
+func TestFallbackKeyringDeleteBoth(t *testing.T) {
+	primary := &dummyTestStore{data: map[string]string{"ns/key": "a"}}
+	secondary := &dummyTestStore{data: map[string]string{"ns/key": "b"}}
+	k := &fallbackKeyring{primary: primary, secondary: secondary}
+
+	require.NoError(t, k.Delete("ns", "key"))
+	_, ok := primary.data["ns/key"]
+	assert.False(t, ok)
+	_, ok = secondary.data["ns/key"]
+	assert.False(t, ok)
+}
+
+// --- test helpers ---
+
+type failingStore struct{}
+
+func (f *failingStore) Set(_, _, _ string) error     { return os.ErrPermission }
+func (f *failingStore) Get(_, _ string) (string, error) { return "", os.ErrNotExist }
+func (f *failingStore) Delete(_, _ string) error      { return os.ErrNotExist }
+
+type dummyTestStore struct {
+	data map[string]string
+}
+
+func (d *dummyTestStore) Set(namespace, key, value string) error {
+	d.data[namespace+"/"+key] = value
+	return nil
+}
+
+func (d *dummyTestStore) Get(namespace, key string) (string, error) {
+	v, ok := d.data[namespace+"/"+key]
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	return v, nil
+}
+
+func (d *dummyTestStore) Delete(namespace, key string) error {
+	delete(d.data, namespace+"/"+key)
+	return nil
+}

--- a/client/go/internal/cli/cmd/login.go
+++ b/client/go/internal/cli/cmd/login.go
@@ -97,12 +97,7 @@ func doLogin(cli *CLI, cmd *cobra.Command, useFileStorage bool) error {
 	secretsStore := auth.NewKeyringWithOptions(useFileStorage)
 	err = secretsStore.Set(auth.SecretsNamespace, system.Name, res.RefreshToken)
 	if err != nil {
-		// log the error but move on
 		cli.printWarning("Could not store the refresh token locally. You may need to login again once your access token expires (30 minutes).")
-		if !useFileStorage {
-			cli.printWarning("To persist the refresh token using file storage (unencrypted), use --file-storage flag")
-			cli.printWarning("Note: Storing the refresh token unencrypted directly on your file system means someone with access to this file can get unauthorized access to your application for the life of the refresh token (24 hours)")
-		}
 	}
 
 	creds := auth0.Credentials{


### PR DESCRIPTION
## Summary

Fixes three issues that prevent the CLI refresh token from persisting on systems where the OS keyring is unavailable (macOS with unsigned binaries, SSH sessions, Docker/CI environments):

1. **`dummyKeyring.Set` cannot overwrite its own files** — files are created with mode `0o400` (read-only), so `os.WriteFile` fails with permission denied on subsequent logins
2. **Token refresh ignores `--file-storage`** — `AccessToken()` and `RemoveCredentials()` hardcode `auth.NewKeyring()` which always returns `realKeyring`, so the refresh path never reads from file storage even when the token was stored there
3. **Login warning cleanup** — the `--file-storage` suggestion in the login warning is no longer needed since the fallback handles this automatically

## Changes

- `secrets.go`: Add `os.Remove` before `os.WriteFile` in `dummyKeyring.Set` to handle existing read-only files
- `secrets.go`: Add `fallbackKeyring` composite type that tries system keyring first and falls back to file storage on failure. `NewKeyring()` now returns this instead of `realKeyring`
- `login.go`: Remove the now-unnecessary `--file-storage` suggestion from the login warning (the fallback makes it automatic)
- `secrets_test.go`: Add tests for read-only file overwrite and fallback keyring behavior

## Behavior

| Scenario | Before | After |
|---|---|---|
| System keyring works | Token in keyring | Token in keyring (no change) |
| System keyring fails, no `--file-storage` | Token lost, re-auth every 30 min | Token auto-saved to file |
| System keyring fails, with `--file-storage` | Token saved to file, but refresh reads from (empty) keyring | Token saved to file, refresh reads from file |
| Second login with file storage | `os.WriteFile` fails on read-only file | Old file removed, new file written |
| `VESPA_CLI_DUMMY_KEYRING=1` | File storage only | File storage only (no change) |

## Test plan

- [x] `secrets_test.go`: `TestDummyKeyringOverwritesReadOnlyFile` — verifies second `Set` succeeds on a `0o400` file
- [x] `secrets_test.go`: `TestFallbackKeyringSet` — verifies fallback to secondary when primary fails
- [x] `secrets_test.go`: `TestFallbackKeyringGetPrimaryFirst` — verifies primary is preferred when available
- [x] `secrets_test.go`: `TestFallbackKeyringGetFallsBack` — verifies secondary is used when primary fails
- [x] `secrets_test.go`: `TestFallbackKeyringDeleteBoth` — verifies both stores are cleaned up on delete