### PR TITLE
Fix flaky latency metric due to clock race

### DIFF
--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
@@ -10,6 +10,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 
 import java.time.Duration;
@@ -51,13 +52,13 @@ class AccessLogRequestLog extends AbstractLifeCycle implements org.eclipse.jetty
             String peerAddress = Request.getRemoteAddr(request);
             int peerPort = Request.getRemotePort(request);
             long startTime = Request.getTimeStamp(request);
-            long endTime = System.currentTimeMillis();
+            long durationMillis = NanoTime.millisSince(request.getHeadersNanoTime());
             Integer statusCodeOverride = (Integer) request.getAttribute(JdiscDispatchingHandler.ACCESS_LOG_STATUS_CODE_OVERRIDE);
             builder.peerAddress(peerAddress)
                     .peerPort(peerPort)
                     .localPort(getLocalPort(request))
                     .timestamp(Instant.ofEpochMilli(startTime))
-                    .duration(Duration.ofMillis(Math.max(0, endTime - startTime)))
+                    .duration(Duration.ofMillis(durationMillis))
                     .responseSize(Response.getContentBytesWritten(response))
                     .requestSize(Request.getContentBytesRead(request))
                     .statusCode(statusCodeOverride != null ? statusCodeOverride : response.getStatus());

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLog.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/MetricAggregatingRequestLog.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.NanoTime;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +74,7 @@ class MetricAggregatingRequestLog implements RequestLog {
 
         Dimensions dimensions = Dimensions.of(request, status, monitoringHandlerPaths, searchHandlerPaths);
         StatusCodeMetric.of(status, dimensions).forEach(metric -> statistics.computeIfAbsent(metric, __ -> new LongAdder()).increment());
-        metric.set(MetricDefinitions.LATENCY, System.currentTimeMillis() - Request.getTimeStamp(request), metric.createContext(dimensions.asMap()));
+        metric.set(MetricDefinitions.LATENCY, NanoTime.millisSince(request.getHeadersNanoTime()), metric.createContext(dimensions.asMap()));
     }
 
     /** For testing */


### PR DESCRIPTION
## Summary
- Fix race condition in `MetricAggregatingRequestLog` where `System.currentTimeMillis()` is called twice (once in the outer expression, once inside `Request.getTimeStamp()`), and the millisecond clock can tick between the two calls, producing negative latency values.
- Use `NanoTime.millisSince(request.getHeadersNanoTime())` directly, which is monotonic and equivalent.