### PR TITLE
bump build-dependencies version

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -33,7 +33,7 @@
 %define _defattr_is_vespa_vespa 0
 %define _command_cmake cmake
 %global _vespa_abseil_cpp_version 20250127.1
-%global _vespa_build_depencencies_version 1.11.0
+%global _vespa_build_depencencies_version 1.12.0
 %global _vespa_gtest_version 1.16.0
 %global _vespa_protobuf_version 6.34.1
 %global _vespa_openblas_version 0.3.27
@@ -115,6 +115,10 @@ Requires: zstd
 
 %if 0%{?el9}
 %global _centos_stream %(grep -qs '^NAME="CentOS Stream"' /etc/os-release && echo 1 || echo 0)
+%define _devtoolset_enable /opt/rh/gcc-toolset/enable
+%endif
+
+%if 0%{?el10}
 %define _devtoolset_enable /opt/rh/gcc-toolset/enable
 %endif
 


### PR DESCRIPTION
Note: triggers use of GCC 15 on el9 and el10 platforms.
