### PR TITLE
Add toggle for enabling "pseudo row-column" distribution mode

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -102,6 +102,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
 
     public enum DistributionMode { LEGACY, STRICT, LOOSE }
     private DistributionMode distributionMode;
+    private boolean usePseudoRowColumnDistribution = false;
 
     public static class Builder {
 
@@ -248,6 +249,10 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
                     } else {
                         throw new IllegalArgumentException("Distribution type " + attr + " not supported.");
                     }
+                }
+                Boolean pseudoRowCol = distribution.childAsBoolean("pseudo-row-column-mode");
+                if (pseudoRowCol != null) {
+                    c.usePseudoRowColumnDistribution = pseudoRowCol;
                 }
             }
             ModelElement merges = tuning.child("merges");
@@ -527,6 +532,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
         if (search.usesHierarchicDistribution()) {
             builder.active_per_leaf_group(true);
         }
+        builder.relative_node_order_scoring(usePseudoRowColumnDistribution);
     }
 
     int getNodeCount() {
@@ -700,6 +706,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
         clusterBuilder.ready_copies(config.ready_copies());
         clusterBuilder.redundancy(config.redundancy());
         clusterBuilder.initial_redundancy(config.initial_redundancy());
+        clusterBuilder.relative_node_order_scoring(config.relative_node_order_scoring());
 
         for (StorDistributionConfig.Group group : config.group()) {
             DistributionConfig.Cluster.Group.Builder groupBuilder = new DistributionConfig.Cluster.Group.Builder();

--- a/config-model/src/main/resources/schema/content.rnc
+++ b/config-model/src/main/resources/schema/content.rnc
@@ -13,8 +13,13 @@ MinRedundancy = element min-redundancy {
     xsd:integer { minInclusive = "1" maxInclusive = "65534" }
 }
 
+PseudoRowColumnMode = element pseudo-row-column-mode {
+    xsd:boolean
+}
+
 DistributionType = element distribution {
-    attribute type { string "strict" | string "loose" | string "legacy" }
+    attribute type { string "strict" | string "loose" | string "legacy" }? &
+    PseudoRowColumnMode?
 }
 
 BucketSplitting = element bucket-splitting {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -126,6 +126,7 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(15, distributionConfig.cluster("storage").initial_redundancy());
         assertEquals(15, distributionConfig.cluster("storage").redundancy());
         assertEquals(4, distributionConfig.cluster("storage").group().size());
+        assertFalse(distributionConfig.cluster("storage").relative_node_order_scoring());
         assertEquals(1, distributionConfig.cluster().size());
 
         StorDistributionConfig.Builder storBuilder = new StorDistributionConfig.Builder();
@@ -134,6 +135,7 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(15, storConfig.initial_redundancy());
         assertEquals(15, storConfig.redundancy());
         assertEquals(3, storConfig.ready_copies());
+        assertFalse(storConfig.relative_node_order_scoring());
 
         ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
         cc.getSearch().getConfig(protonBuilder);
@@ -206,6 +208,7 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(3, distributionConfig.cluster("storage").ready_copies());
         assertEquals(4, distributionConfig.cluster("storage").initial_redundancy());
         assertEquals(5, distributionConfig.cluster("storage").redundancy());
+        assertFalse(distributionConfig.cluster("storage").relative_node_order_scoring());
 
         StorDistributionConfig.Builder storBuilder = new StorDistributionConfig.Builder();
         cc.getConfig(storBuilder);
@@ -213,12 +216,41 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(4, storConfig.initial_redundancy());
         assertEquals(5, storConfig.redundancy());
         assertEquals(3, storConfig.ready_copies());
+        assertFalse(storConfig.relative_node_order_scoring());
 
         ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
         cc.getSearch().getConfig(protonBuilder);
         ProtonConfig protonConfig = new ProtonConfig(protonBuilder);
         assertEquals(3, protonConfig.distribution().searchablecopies());
         assertEquals(5, protonConfig.distribution().redundancy());
+    }
+
+    @Test
+    void pseudo_row_column_distribution_setting_is_propagated_to_distribution_config() {
+        ContentCluster cc = parse("""
+              <content version="1.0" id="storage">
+                <documents/>
+                <redundancy>1</redundancy>
+                <group>
+                  <node hostalias='mockhost' distribution-key='0'/>
+                </group>
+                <tuning>
+                  <distribution>
+                    <pseudo-row-column-mode>true</pseudo-row-column-mode>
+                  </distribution>
+                </tuning>
+              </content>
+            """);
+
+        var storBuilder = new StorDistributionConfig.Builder();
+        cc.getConfig(storBuilder);
+        var storConfig = new StorDistributionConfig(storBuilder);
+        assertTrue(storConfig.relative_node_order_scoring());
+
+        var distributionBuilder = new DistributionConfig.Builder();
+        cc.getConfig(distributionBuilder);
+        var distributionConfig = distributionBuilder.build();
+        assertTrue(distributionConfig.cluster("storage").relative_node_order_scoring());
     }
 
     @Test


### PR DESCRIPTION
@hmusum please review
@toregge FYI

Enabling this mode requires touching two distinct configs (`stor-distribution` and `distribution`), where the latter is derived directly from the former. This means we need at least some minimal wiring to be able to system test this, since config overrides will not be propagated as expected.

Note: This is not considered a documented public API, and is therefore subject to change at any time.
