### PR TITLE
feat: visit uses jsonl from server when args json-lines and stream is used.

### DIFF
--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -448,7 +448,7 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 		} else {
 			reqHeader = make(http.Header)
 		}
-		reqHeader.Set("Accept", "application/jsonl")
+		reqHeader.Set("Accept", "application/json, application/jsonl")
 	}
 	request := &http.Request{
 		URL:    url,
@@ -549,25 +549,27 @@ func parseVisitOutputJSONL(r io.Reader, w io.Writer, warnWriter io.Writer) (*Ves
 	for {
 		var line jsonlLine
 		err := dec.Decode(&line)
+		// Stops when at end of file or if json is truncated
 		if err == io.EOF {
+			break
+		}
+		if err == io.ErrUnexpectedEOF {
+			done = false
 			break
 		}
 		if err != nil {
 			return &result, fmt.Errorf("error reading JSONL response: %s", err)
 		}
 		switch {
-		case line.Put != "" || line.Remove != "":
+		case line.Put != "":
 			id := line.Put
-			if id == "" {
-				id = line.Remove
-			}
 			type docOut struct {
 				ID     string          `json:"id"`
 				Fields json.RawMessage `json:"fields,omitempty"`
 			}
 			outBytes, err := json.Marshal(docOut{ID: id, Fields: line.Fields})
 			if err != nil {
-				continue
+				return &result, err
 			}
 			if _, err := w.Write(outBytes); err != nil {
 				return &result, fmt.Errorf("error writing document: %s", err)

--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -342,6 +342,7 @@ func runVisit(vArgs *visitArgs, service *vespa.Service) (res OperationResult) {
 	const maxRetryBackoffMs = 10_000.0 // Actually up to 15s, see below
 	backoffBaselineMs := baseRetryBackoffMs
 	var continuationToken string
+	consecutiveTruncations := 0
 	for {
 		var vvo *VespaVisitOutput
 		vvo, res = runOneVisit(vArgs, service, continuationToken)
@@ -370,9 +371,14 @@ func runVisit(vArgs *visitArgs, service *vespa.Service) (res OperationResult) {
 			continuationToken = vvo.Continuation
 		}
 		if vvo.Truncated {
+			consecutiveTruncations++
+			if consecutiveTruncations >= 5 {
+				return Failure("Response truncated 5 times in a row: aborting visit")
+			}
 			vArgs.cli.printWarning("Response truncated: retrying from last continuation token (may produce duplicates)")
 			continue
 		}
+		consecutiveTruncations = 0
 		if vvo.Continuation == "" {
 			break
 		}
@@ -458,7 +464,7 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 
 	if response.StatusCode == 200 {
 		if strings.Contains(response.Header.Get("Content-Type"), "application/jsonl") {
-			vvo, err := parseVisitOutputJSONL(response.Body, vArgs.cli.Stdout)
+			vvo, err := parseVisitOutputJSONL(response.Body, vArgs.cli.Stdout, vArgs.cli.Stderr)
 			if err != nil {
 				return nil, Failure("error reading JSONL response: " + err.Error())
 			}
@@ -509,7 +515,7 @@ type VespaVisitOutput struct {
 	DocumentCount int            `json:"documentCount"`
 	Continuation  string         `json:"continuation"`
 	ErrorMsg      string         `json:"message"`
-	Truncated     bool           // true when a JSONL response ended without a final newline
+	Truncated     bool           // true when JSONL response ended without a completion signal from the server
 }
 
 type jsonlLine struct {
@@ -536,22 +542,18 @@ func parseVisitOutput(r io.Reader) (*VespaVisitOutput, error) {
 	return &parsedJson, nil
 }
 
-func parseVisitOutputJSONL(r io.Reader, w io.Writer) (*VespaVisitOutput, error) {
+func parseVisitOutputJSONL(r io.Reader, w io.Writer, warnWriter io.Writer) (*VespaVisitOutput, error) {
 	dec := json.NewDecoder(r)
 	var result VespaVisitOutput
 	done := false
 	for {
-		var raw json.RawMessage
-		err := dec.Decode(&raw)
+		var line jsonlLine
+		err := dec.Decode(&line)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			return &result, fmt.Errorf("error reading JSONL response: %s", err)
-		}
-		var line jsonlLine
-		if err := json.Unmarshal(raw, &line); err != nil {
-			continue
 		}
 		switch {
 		case line.Put != "" || line.Remove != "":
@@ -567,13 +569,20 @@ func parseVisitOutputJSONL(r io.Reader, w io.Writer) (*VespaVisitOutput, error) 
 			if err != nil {
 				continue
 			}
-			w.Write(outBytes)
-			w.Write([]byte("\n"))
+			if _, err := w.Write(outBytes); err != nil {
+				return &result, fmt.Errorf("error writing document: %s", err)
+			}
+			if _, err := w.Write([]byte("\n")); err != nil {
+				return &result, fmt.Errorf("error writing document: %s", err)
+			}
 			result.DocumentCount++
 		case line.Continuation != nil:
 			result.Continuation = line.Continuation.Token
 			done = line.Continuation.Token == ""
 		case line.SessionStats != nil:
+			if line.SessionStats.DocumentCount != result.DocumentCount {
+				fmt.Fprintf(warnWriter, "WARNING: server reported %d documents but %d were received\n", line.SessionStats.DocumentCount, result.DocumentCount)
+			}
 			result.DocumentCount = line.SessionStats.DocumentCount
 		case line.Message != "":
 			result.ErrorMsg = line.Message

--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -366,8 +366,14 @@ func runVisit(vArgs *visitArgs, service *vespa.Service) (res OperationResult) {
 		vArgs.dumpDocuments(vvo.Documents)
 		vArgs.debugPrint(fmt.Sprintf("got %d documents", len(vvo.Documents)))
 		totalDocuments += len(vvo.Documents)
-		continuationToken = vvo.Continuation
-		if continuationToken == "" {
+		if vvo.Continuation != "" {
+			continuationToken = vvo.Continuation
+		}
+		if vvo.Truncated {
+			vArgs.cli.printWarning("Response truncated: retrying from last continuation token (may produce duplicates)")
+			continue
+		}
+		if vvo.Continuation == "" {
 			break
 		}
 	}
@@ -429,10 +435,19 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 	if urlParseError != nil {
 		return nil, Failure("Invalid request path: '" + urlPath + "': " + urlParseError.Error())
 	}
+	reqHeader := vArgs.header
+	if vArgs.stream && vArgs.jsonLines && !vArgs.makeFeed && reqHeader.Get("Accept") == "" {
+		if vArgs.header != nil {
+			reqHeader = vArgs.header.Clone()
+		} else {
+			reqHeader = make(http.Header)
+		}
+		reqHeader.Set("Accept", "application/jsonl")
+	}
 	request := &http.Request{
 		URL:    url,
 		Method: "GET",
-		Header: vArgs.header,
+		Header: reqHeader,
 	}
 	timeout := time.Duration(900) * time.Second
 	response, err := service.Do(request, timeout)
@@ -440,9 +455,17 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 		return nil, Failure("Request failed: " + err.Error())
 	}
 	defer response.Body.Close()
-	vvo, err := parseVisitOutput(response.Body)
-	switch {
-	case response.StatusCode == 200:
+
+	if response.StatusCode == 200 {
+		if strings.Contains(response.Header.Get("Content-Type"), "application/jsonl") {
+			vvo, err := parseVisitOutputJSONL(response.Body, vArgs.cli.Stdout)
+			if err != nil {
+				return nil, Failure("error reading JSONL response: " + err.Error())
+			}
+			totalDocCount += vvo.DocumentCount
+			return vvo, Success("visited " + vArgs.contentCluster)
+		}
+		vvo, err := parseVisitOutput(response.Body)
 		if err == nil {
 			totalDocCount += vvo.DocumentCount
 			if vvo.DocumentCount != len(vvo.Documents) {
@@ -452,9 +475,11 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 				return nil, Failure("Inconsistent contents from document API")
 			}
 			return vvo, Success("visited " + vArgs.contentCluster)
-		} else {
-			return nil, Failure("error reading response: " + err.Error())
 		}
+		return nil, Failure("error reading response: " + err.Error())
+	}
+	vvo, _ := parseVisitOutput(response.Body)
+	switch {
 	case response.StatusCode == 429:
 		return nil, Success("Transient overload")
 	case response.StatusCode/100 == 4:
@@ -484,6 +509,21 @@ type VespaVisitOutput struct {
 	DocumentCount int            `json:"documentCount"`
 	Continuation  string         `json:"continuation"`
 	ErrorMsg      string         `json:"message"`
+	Truncated     bool           // true when a JSONL response ended without a final newline
+}
+
+type jsonlLine struct {
+	Put          string          `json:"put,omitempty"`
+	Remove       string          `json:"remove,omitempty"`
+	Fields       json.RawMessage `json:"fields,omitempty"`
+	Continuation *struct {
+		Token           string  `json:"token,omitempty"`
+		PercentFinished float64 `json:"percentFinished"`
+	} `json:"continuation,omitempty"`
+	SessionStats *struct {
+		DocumentCount int `json:"documentCount"`
+	} `json:"sessionStats,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 func parseVisitOutput(r io.Reader) (*VespaVisitOutput, error) {
@@ -494,4 +534,51 @@ func parseVisitOutput(r io.Reader) (*VespaVisitOutput, error) {
 		return nil, fmt.Errorf("could not decode JSON, error: %s", err.Error())
 	}
 	return &parsedJson, nil
+}
+
+func parseVisitOutputJSONL(r io.Reader, w io.Writer) (*VespaVisitOutput, error) {
+	dec := json.NewDecoder(r)
+	var result VespaVisitOutput
+	done := false
+	for {
+		var raw json.RawMessage
+		err := dec.Decode(&raw)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return &result, fmt.Errorf("error reading JSONL response: %s", err)
+		}
+		var line jsonlLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			continue
+		}
+		switch {
+		case line.Put != "" || line.Remove != "":
+			id := line.Put
+			if id == "" {
+				id = line.Remove
+			}
+			type docOut struct {
+				ID     string          `json:"id"`
+				Fields json.RawMessage `json:"fields,omitempty"`
+			}
+			outBytes, err := json.Marshal(docOut{ID: id, Fields: line.Fields})
+			if err != nil {
+				continue
+			}
+			w.Write(outBytes)
+			w.Write([]byte("\n"))
+			result.DocumentCount++
+		case line.Continuation != nil:
+			result.Continuation = line.Continuation.Token
+			done = line.Continuation.Token == ""
+		case line.SessionStats != nil:
+			result.DocumentCount = line.SessionStats.DocumentCount
+		case line.Message != "":
+			result.ErrorMsg = line.Message
+		}
+	}
+	result.Truncated = !done
+	return &result, nil
 }

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -148,6 +148,112 @@ func TestVisitCommand(t *testing.T) {
 			document3+"\n")
 }
 
+const (
+	jsonlDoc1    = `{"put":"id:space:music::1","fields":{"title":"first"}}`
+	jsonlDoc2    = `{"put":"id:space:music::2","fields":{"title":"second"}}`
+	jsonlCont    = `{"continuation":{"token":"JSONL_TOKEN","percentFinished":50.0}}`
+	jsonlDone    = `{"continuation":{"percentFinished":100.0}}`
+	jsonlStats   = `{"sessionStats":{"documentCount":2}}`
+	jsonlOutDoc1 = `{"id":"id:space:music::1","fields":{"title":"first"}}`
+	jsonlOutDoc2 = `{"id":"id:space:music::2","fields":{"title":"second"}}`
+)
+
+func jsonlResponse(body string) mock.HTTPResponse {
+	return mock.HTTPResponse{
+		Status: 200,
+		Body:   []byte(body),
+		Header: http.Header{"Content-Type": []string{"application/jsonl; charset=UTF-8"}},
+	}
+}
+
+func TestRunOneVisitJSONL(t *testing.T) {
+	// Complete response: docs + stats + done signal
+	body := jsonlDoc1 + "\n" + jsonlDoc2 + "\n" + jsonlStats + "\n" + jsonlDone + "\n"
+	client := &mock.HTTPClient{}
+	mockServiceStatus(client, "container")
+	client.NextResponse(jsonlResponse(body))
+	cli, stdout, _ := newTestCLI(t)
+	cli.httpClient = client
+	service, err := documentService(cli, &Waiter{cli: cli})
+	assert.Nil(t, err)
+	vArgs := visitArgs{
+		contentCluster: "fooCC",
+		stream:         true,
+		jsonLines:      true,
+		chunkCount:     1000,
+		header:         make(http.Header),
+		cli:            cli,
+	}
+	vvo, res := runOneVisit(&vArgs, service, "")
+	assert.True(t, res.Success)
+	assert.Equal(t, "application/jsonl", client.LastRequest.Header.Get("Accept"))
+	assert.Equal(t, "", vvo.Continuation)
+	assert.False(t, vvo.Truncated)
+	assert.Equal(t, 2, vvo.DocumentCount)
+	assert.Equal(t, jsonlOutDoc1+"\n"+jsonlOutDoc2+"\n", stdout.String())
+}
+
+func TestVisitCommandJSONL(t *testing.T) {
+	// JSONL is a single streaming response — all docs in one body with done signal
+	body := jsonlDoc1 + "\n" + jsonlDoc2 + "\n" + jsonlDone + "\n"
+	client := &mock.HTTPClient{}
+	client.NextResponseString(200, handlersResponse)
+	client.NextResponse(jsonlResponse(body))
+	cli, stdout, stderr := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	assert.Nil(t, cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080"))
+	assert.Equal(t, jsonlOutDoc1+"\n"+jsonlOutDoc2+"\n", stdout.String())
+	assert.Equal(t, "", stderr.String())
+	assert.Equal(t, 2, len(client.Requests))
+	assert.Equal(t, "application/jsonl", client.LastRequest.Header.Get("Accept"))
+	assert.Equal(t, "cluster=fooCC&wantedDocumentCount=1000&bucketSpace=default&stream=true", client.LastRequest.URL.RawQuery)
+}
+
+func TestRunOneVisitJSONLUserAcceptHeader(t *testing.T) {
+	body := jsonlDoc1 + "\n" + jsonlStats + "\n" + jsonlDone + "\n"
+	client := &mock.HTTPClient{}
+	mockServiceStatus(client, "container")
+	client.NextResponse(jsonlResponse(body))
+	cli, _, _ := newTestCLI(t)
+	cli.httpClient = client
+	service, err := documentService(cli, &Waiter{cli: cli})
+	assert.Nil(t, err)
+	userHeader := make(http.Header)
+	userHeader.Set("Accept", "application/json")
+	vArgs := visitArgs{
+		contentCluster: "fooCC",
+		stream:         true,
+		jsonLines:      true,
+		chunkCount:     1000,
+		header:         userHeader,
+		cli:            cli,
+	}
+	_, res := runOneVisit(&vArgs, service, "")
+	assert.True(t, res.Success)
+	assert.Equal(t, "application/json", client.LastRequest.Header.Get("Accept"))
+}
+
+func TestVisitCommandJSONLTruncatedRetry(t *testing.T) {
+	// First response has no trailing newline — truncated
+	truncatedBody := jsonlDoc1 + "\n" + jsonlCont
+	completeBody := jsonlDoc2 + "\n" + jsonlDone + "\n"
+	client := &mock.HTTPClient{}
+	client.NextResponseString(200, handlersResponse)
+	client.NextResponse(jsonlResponse(truncatedBody))
+	client.NextResponse(jsonlResponse(completeBody))
+	cli, stdout, stderr := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	assert.Nil(t, cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080"))
+	assert.Contains(t, stdout.String(), jsonlOutDoc1+"\n")
+	assert.Contains(t, stdout.String(), jsonlOutDoc2+"\n")
+	assert.Contains(t, stderr.String(), "truncated")
+	// Retry request must use the continuation token extracted from the truncated response
+	assert.Equal(t, 3, len(client.Requests))
+	assert.Contains(t, client.Requests[2].URL.RawQuery, "continuation=JSONL_TOKEN")
+}
+
 func inRangeMillis(v time.Duration, lo int64, hi int64) bool {
 	return v.Milliseconds() >= lo && v.Milliseconds() <= hi
 }

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -254,6 +254,23 @@ func TestVisitCommandJSONLTruncatedRetry(t *testing.T) {
 	assert.Contains(t, client.Requests[2].URL.RawQuery, "continuation=JSONL_TOKEN")
 }
 
+func TestVisitCommandJSONLTruncatedAbort(t *testing.T) {
+	// Truncated 5 times in a row with no continuation token — should abort
+	truncatedNoToken := jsonlDoc1 + "\n" // no continuation line, no done signal
+	client := &mock.HTTPClient{}
+	client.NextResponseString(200, handlersResponse)
+	for range 5 {
+		client.NextResponse(jsonlResponse(truncatedNoToken))
+	}
+	cli, _, _ := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "truncated")
+	assert.Equal(t, 6, len(client.Requests)) // probe + 5 visit attempts
+}
+
 func inRangeMillis(v time.Duration, lo int64, hi int64) bool {
 	return v.Milliseconds() >= lo && v.Milliseconds() <= hi
 }

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -149,13 +149,14 @@ func TestVisitCommand(t *testing.T) {
 }
 
 const (
-	jsonlDoc1    = `{"put":"id:space:music::1","fields":{"title":"first"}}`
-	jsonlDoc2    = `{"put":"id:space:music::2","fields":{"title":"second"}}`
-	jsonlCont    = `{"continuation":{"token":"JSONL_TOKEN","percentFinished":50.0}}`
-	jsonlDone    = `{"continuation":{"percentFinished":100.0}}`
-	jsonlStats   = `{"sessionStats":{"documentCount":2}}`
-	jsonlOutDoc1 = `{"id":"id:space:music::1","fields":{"title":"first"}}`
-	jsonlOutDoc2 = `{"id":"id:space:music::2","fields":{"title":"second"}}`
+	jsonlDoc1      = `{"put":"id:space:music::1","fields":{"title":"first"}}`
+	jsonlDoc2      = `{"put":"id:space:music::2","fields":{"title":"second"}}`
+	jsonlRemoveDoc = `{"remove":"id:space:music::3","fields":{"title":"third"}}`
+	jsonlCont      = `{"continuation":{"token":"JSONL_TOKEN","percentFinished":50.0}}`
+	jsonlDone      = `{"continuation":{"percentFinished":100.0}}`
+	jsonlStats     = `{"sessionStats":{"documentCount":2}}`
+	jsonlOutDoc1   = `{"id":"id:space:music::1","fields":{"title":"first"}}`
+	jsonlOutDoc2   = `{"id":"id:space:music::2","fields":{"title":"second"}}`
 )
 
 func jsonlResponse(body string) mock.HTTPResponse {
@@ -186,7 +187,7 @@ func TestRunOneVisitJSONL(t *testing.T) {
 	}
 	vvo, res := runOneVisit(&vArgs, service, "")
 	assert.True(t, res.Success)
-	assert.Equal(t, "application/jsonl", client.LastRequest.Header.Get("Accept"))
+	assert.Equal(t, "application/json, application/jsonl", client.LastRequest.Header.Get("Accept"))
 	assert.Equal(t, "", vvo.Continuation)
 	assert.False(t, vvo.Truncated)
 	assert.Equal(t, 2, vvo.DocumentCount)
@@ -206,7 +207,7 @@ func TestVisitCommandJSONL(t *testing.T) {
 	assert.Equal(t, jsonlOutDoc1+"\n"+jsonlOutDoc2+"\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	assert.Equal(t, 2, len(client.Requests))
-	assert.Equal(t, "application/jsonl", client.LastRequest.Header.Get("Accept"))
+	assert.Equal(t, "application/json, application/jsonl", client.LastRequest.Header.Get("Accept"))
 	assert.Equal(t, "cluster=fooCC&wantedDocumentCount=1000&bucketSpace=default&stream=true", client.LastRequest.URL.RawQuery)
 }
 
@@ -269,6 +270,60 @@ func TestVisitCommandJSONLTruncatedAbort(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "truncated")
 	assert.Equal(t, 6, len(client.Requests)) // probe + 5 visit attempts
+}
+
+func TestTruncatedMidJSONLMaxRetries(t *testing.T) {
+	client := &mock.HTTPClient{}
+	client.NextResponseString(200, handlersResponse)
+	// Testing trunctaion with different substrings of document from idx = 1 to idx = 11
+	for i := range 5 {
+		truncation_idx := (i * 5) + 1
+		client.NextResponse(jsonlResponse(jsonlDoc1[0:truncation_idx]))
+	}
+	cli, _, _ := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "truncated")
+	assert.Equal(t, 6, len(client.Requests)) // probe + 5 visit attempts until it does not try retry any more
+}
+
+// Get truncated response 2 times and then the full response
+func TestTruncatedMidJSONLSomeRetries(t *testing.T) {
+	client := &mock.HTTPClient{}
+	client.NextResponseString(200, handlersResponse)
+	// Testing trunctaion with different substrings of document from idx = 1 to idx = 11
+	for i := range 2 {
+		truncation_idx := (i * 5) + 1
+		client.NextResponse(jsonlResponse(jsonlDoc1[0:truncation_idx]))
+	}
+	jsonlComplete := jsonlDoc1 + "\n" + jsonlDone
+	client.NextResponse(jsonlResponse(jsonlComplete))
+	cli, _, _ := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(client.Requests)) // probe + 3 visit attempts where the last one is a valid response
+}
+
+// All remove entreis should be ignored
+func TestRemoveIgnored(t *testing.T) {
+	client := &mock.HTTPClient{}
+	client.NextResponseString(200, handlersResponse)
+	// Testing trunctaion with different substrings of document from idx = 1 to idx = 11
+	response_doc := jsonlDoc1 + "\n" + jsonlDoc2 + "\n" + jsonlRemoveDoc + "\n" + jsonlDone + "\n"
+	client.NextResponse(jsonlResponse(response_doc))
+	cli, stdout, _ := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	assert.Nil(t, err)
+	// The remove content is ignored
+	assert.NotContains(t, stdout.String(), "third")
+	assert.NotContains(t, stdout.String(), "3")
+	assert.Equal(t, 2, len(client.Requests)) // probe + 1 visit
 }
 
 func inRangeMillis(v time.Duration, lo int64, hi int64) bool {

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"testing"
@@ -151,7 +152,7 @@ func TestVisitCommand(t *testing.T) {
 const (
 	jsonlDoc1      = `{"put":"id:space:music::1","fields":{"title":"first"}}`
 	jsonlDoc2      = `{"put":"id:space:music::2","fields":{"title":"second"}}`
-	jsonlRemoveDoc = `{"remove":"id:space:music::3","fields":{"title":"third"}}`
+	jsonlRemoveDoc = `{"remove":"id:space:music::3"}`
 	jsonlCont      = `{"continuation":{"token":"JSONL_TOKEN","percentFinished":50.0}}`
 	jsonlDone      = `{"continuation":{"percentFinished":100.0}}`
 	jsonlStats     = `{"sessionStats":{"documentCount":2}}`
@@ -235,6 +236,14 @@ func TestRunOneVisitJSONLUserAcceptHeader(t *testing.T) {
 	assert.Equal(t, "application/json", client.LastRequest.Header.Get("Accept"))
 }
 
+func SetUpCliAndRunVisit(t *testing.T, client *mock.HTTPClient) (stdout *bytes.Buffer, stderr *bytes.Buffer, err error) {
+	cli, stdout, stderr := newTestCLI(t)
+	cli.httpClient = client
+	cli.sleeper = func(d time.Duration) {}
+	err = cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	return stdout, stderr, err
+}
+
 func TestVisitCommandJSONLTruncatedRetry(t *testing.T) {
 	// First response has no trailing newline — truncated
 	truncatedBody := jsonlDoc1 + "\n" + jsonlCont
@@ -243,10 +252,8 @@ func TestVisitCommandJSONLTruncatedRetry(t *testing.T) {
 	client.NextResponseString(200, handlersResponse)
 	client.NextResponse(jsonlResponse(truncatedBody))
 	client.NextResponse(jsonlResponse(completeBody))
-	cli, stdout, stderr := newTestCLI(t)
-	cli.httpClient = client
-	cli.sleeper = func(d time.Duration) {}
-	assert.Nil(t, cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080"))
+	stdout, stderr, err := SetUpCliAndRunVisit(t, client)
+	assert.Nil(t, err)
 	assert.Contains(t, stdout.String(), jsonlOutDoc1+"\n")
 	assert.Contains(t, stdout.String(), jsonlOutDoc2+"\n")
 	assert.Contains(t, stderr.String(), "truncated")
@@ -263,10 +270,7 @@ func TestVisitCommandJSONLTruncatedAbort(t *testing.T) {
 	for range 5 {
 		client.NextResponse(jsonlResponse(truncatedNoToken))
 	}
-	cli, _, _ := newTestCLI(t)
-	cli.httpClient = client
-	cli.sleeper = func(d time.Duration) {}
-	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	_, _, err := SetUpCliAndRunVisit(t, client)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "truncated")
 	assert.Equal(t, 6, len(client.Requests)) // probe + 5 visit attempts
@@ -275,15 +279,12 @@ func TestVisitCommandJSONLTruncatedAbort(t *testing.T) {
 func TestTruncatedMidJSONLMaxRetries(t *testing.T) {
 	client := &mock.HTTPClient{}
 	client.NextResponseString(200, handlersResponse)
-	// Testing trunctaion with different substrings of document from idx = 1 to idx = 11
+	// Creating responses that truncate at different lengths
 	for i := range 5 {
-		truncation_idx := (i * 5) + 1
-		client.NextResponse(jsonlResponse(jsonlDoc1[0:truncation_idx]))
+		truncationIdx := (i * 5) + 1
+		client.NextResponse(jsonlResponse(jsonlDoc1[0:truncationIdx]))
 	}
-	cli, _, _ := newTestCLI(t)
-	cli.httpClient = client
-	cli.sleeper = func(d time.Duration) {}
-	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	_, _, err := SetUpCliAndRunVisit(t, client)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "truncated")
 	assert.Equal(t, 6, len(client.Requests)) // probe + 5 visit attempts until it does not try retry any more
@@ -293,36 +294,28 @@ func TestTruncatedMidJSONLMaxRetries(t *testing.T) {
 func TestTruncatedMidJSONLSomeRetries(t *testing.T) {
 	client := &mock.HTTPClient{}
 	client.NextResponseString(200, handlersResponse)
-	// Testing trunctaion with different substrings of document from idx = 1 to idx = 11
+	// Creating responses that truncate at different lengths
 	for i := range 2 {
-		truncation_idx := (i * 5) + 1
-		client.NextResponse(jsonlResponse(jsonlDoc1[0:truncation_idx]))
+		truncationIdx := (i * 5) + 1
+		client.NextResponse(jsonlResponse(jsonlDoc1[0:truncationIdx]))
 	}
-	jsonlComplete := jsonlDoc1 + "\n" + jsonlDone
+	jsonlComplete := jsonlDoc1 + "\n" + jsonlDone + "\n"
 	client.NextResponse(jsonlResponse(jsonlComplete))
-	cli, _, _ := newTestCLI(t)
-	cli.httpClient = client
-	cli.sleeper = func(d time.Duration) {}
-	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	_, _, err := SetUpCliAndRunVisit(t, client)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(client.Requests)) // probe + 3 visit attempts where the last one is a valid response
 }
 
-// All remove entreis should be ignored
-func TestRemoveIgnored(t *testing.T) {
+func TestRemoveEntriesAreIgnored(t *testing.T) {
 	client := &mock.HTTPClient{}
 	client.NextResponseString(200, handlersResponse)
-	// Testing trunctaion with different substrings of document from idx = 1 to idx = 11
-	response_doc := jsonlDoc1 + "\n" + jsonlDoc2 + "\n" + jsonlRemoveDoc + "\n" + jsonlDone + "\n"
-	client.NextResponse(jsonlResponse(response_doc))
-	cli, stdout, _ := newTestCLI(t)
-	cli.httpClient = client
-	cli.sleeper = func(d time.Duration) {}
-	err := cli.Run("visit", "--stream", "--json-lines", "--bucket-space", "default", "--content-cluster", "fooCC", "-t", "http://127.0.0.1:8080")
+	responseDoc := jsonlDoc1 + "\n" + jsonlDoc2 + "\n" + jsonlRemoveDoc + "\n" + jsonlDone + "\n"
+	client.NextResponse(jsonlResponse(responseDoc))
+	stdout, _, err := SetUpCliAndRunVisit(t, client)
 	assert.Nil(t, err)
 	// The remove content is ignored
-	assert.NotContains(t, stdout.String(), "third")
-	assert.NotContains(t, stdout.String(), "3")
+	assert.NotContains(t, stdout.String(), "remove")
+	assert.NotContains(t, stdout.String(), "id:space:music::3")
 	assert.Equal(t, 2, len(client.Requests)) // probe + 1 visit
 }
 
@@ -348,7 +341,7 @@ func assertVisitResults(arguments []string, t *testing.T, responses []responseCo
 	assert.Equal(t, "/document/v1/", client.LastRequest.URL.Path)
 	assert.Equal(t, "GET", client.LastRequest.Method)
 
-	assert.Equal(t, len(backoffs), 4)
+	assert.Equal(t, 4, len(backoffs))
 	assert.True(t, inRangeMillis(backoffs[0], 100, 300)) // 200ms +- 100ms
 	assert.True(t, inRangeMillis(backoffs[1], 150, 450)) // 300ms +- 150ms
 	assert.True(t, inRangeMillis(backoffs[2], 225, 675)) // 450ms +- 225ms


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.