### PR TITLE
Use atomic variable for docid reference. The write thread might

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -61,6 +61,7 @@ using vespalib::GenerationHeldBase;
 using vespalib::IllegalStateException;
 using vespalib::MemoryUsage;
 using vespalib::btree::BTreeNoLeafData;
+using vespalib::datastore::EntryRef;
 using vespalib::make_string;
 
 namespace proton {
@@ -642,7 +643,8 @@ DocumentMetaStore::remove(DocId lid, uint64_t prepare_serial_num)
     }
     RawDocumentMetadata meta = removeInternal(lid, prepare_serial_num);
     if (_store_full_document_id) {
-        _docid_store.remove(meta._docid_ref);
+        _docid_store.remove(meta.get_relaxed_docid_ref());
+        _metadataStore[lid].set_docid_ref(EntryRef());
     }
     _bucketDB->takeGuard()->remove(meta.getGid(), meta.getBucketId().stripUnused(),
                                    meta.getTimestamp(), meta.getDocSize(), _subDbType);
@@ -728,7 +730,7 @@ DocumentMetaStore::removeBatch(const std::vector<DocId> &lidsToRemove, const uin
         assert(validLid(lid));
         removed.emplace_back(lid, _metadataStore[lid]);
         if (_store_full_document_id) {
-            _docid_store.remove(removed.back().second._docid_ref);
+            _docid_store.remove(removed.back().second.get_relaxed_docid_ref());
         }
     }
     remove_batch_internal_btree(removed);
@@ -843,7 +845,7 @@ DocumentMetaStore::get_docid_string(const GlobalId &gid) const
         return {};
     }
     const RawDocumentMetadata &raw = getRawMetadata(lid);
-    auto span = _docid_store.get(raw.get_docid_ref());
+    auto span = _docid_store.get(raw.acquire_docid_ref());
     return {span.data(), span.size()};
 }
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -61,7 +61,8 @@ private:
     using OperationListenerSP = std::shared_ptr<documentmetastore::OperationListener>;
     using BucketDBOwnerSP = std::shared_ptr<bucketdb::BucketDBOwner>;
     using TypeMapper = vespalib::datastore::ArrayStoreDynamicTypeMapper<char>;
-    using DocumentIdStore = vespalib::datastore::ArrayStore<char, RawDocumentMetadata::DocumentIdEntryRef, TypeMapper>;
+    using DocumentIdEntryRef = vespalib::datastore::EntryRefT<19>;
+    using DocumentIdStore = vespalib::datastore::ArrayStore<char, DocumentIdEntryRef, TypeMapper>;
 
     static constexpr float array_store_alloc_grow_factor = 0.2;
     static constexpr double array_store_grow_factor = 1.03;

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/raw_document_metadata.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/raw_document_metadata.h
@@ -5,7 +5,7 @@
 #include <vespa/document/base/globalid.h>
 #include <vespa/document/bucket/bucketid.h>
 #include <vespa/persistence/spi/types.h>
-#include <vespa/vespalib/datastore/entryref.h>
+#include <vespa/vespalib/datastore/atomic_entry_ref.h>
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -20,9 +20,10 @@ struct RawDocumentMetadata
     using GlobalId = document::GlobalId;
     using BucketId = document::BucketId;
     using Timestamp = storage::spi::Timestamp;
-    using DocumentIdEntryRef = vespalib::datastore::EntryRefT<19>;
+    using EntryRef = vespalib::datastore::EntryRef;
+    using AtomicEntryRef = vespalib::datastore::AtomicEntryRef;
     GlobalId              _gid;
-    DocumentIdEntryRef    _docid_ref;
+    AtomicEntryRef        _docid_ref;
     std::atomic<uint32_t> _bucket_used_bits_and_doc_size;
     std::atomic<uint64_t> _timestamp;
 
@@ -73,8 +74,9 @@ struct RawDocumentMetadata
     GlobalId &getGid() { return _gid; }
     void setGid(const GlobalId &rhs) { _gid = rhs; }
 
-    DocumentIdEntryRef get_docid_ref() const { return _docid_ref; }
-    void set_docid_ref(DocumentIdEntryRef ref) { _docid_ref = ref; }
+    [[nodiscard]] EntryRef acquire_docid_ref() const noexcept { return _docid_ref.load_acquire(); }
+    [[nodiscard]] EntryRef get_relaxed_docid_ref() const noexcept { return _docid_ref.load_relaxed(); }
+    void set_docid_ref(EntryRef ref) noexcept { _docid_ref.store_release(ref); }
 
     uint8_t getBucketUsedBits() const { return _bucket_used_bits_and_doc_size.load(std::memory_order_relaxed) & 0xffu; }
 


### PR DESCRIPTION
change the docid reference (due to array store compaction) while a read thread tries to read the same docid reference.

@boeker : please review
