### PR TITLE
Rename reserved tag prefix vai- to vai_

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -36,7 +36,7 @@ public class CloudResourceTags {
             "applicationid", "athenz", "athenz-domain", "athenzservice", "fqdn", "name", "owner", "zone");
 
     /** Key prefixes reserved by the platform. */
-    private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai-", "corp_", "bastion_");
+    private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "bastion_");
 
     private final Map<String, String> tags;
 

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -139,7 +139,7 @@ class CloudResourceTagsTest {
 
     @Test
     void vai_prefix_rejected() {
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("vai-custom", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("vai_custom", "value")));
     }
 
     @Test


### PR DESCRIPTION
For consistency with the other reserved prefixes (corp_, bastion_).

This PR is self-contained.