### PR TITLE
feat: add dynamic batching to Mistral and OpenAI embedders

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/EmbedderBatchingConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/EmbedderBatchingConfig.java
@@ -5,6 +5,8 @@ import com.yahoo.text.XML;
 import org.w3c.dom.Element;
 
 import java.time.Duration;
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
 
 /**
  * Shared parsing of the {@code <batching>} element for embedder components.
@@ -12,6 +14,11 @@ import java.time.Duration;
  * @author bjorncs
  */
 record EmbedderBatchingConfig(int maxSize, Duration maxDelay) {
+
+    void applyTo(IntConsumer maxSizeSetter, LongConsumer maxDelayMillisSetter) {
+        maxSizeSetter.accept(maxSize);
+        maxDelayMillisSetter.accept(maxDelay.toMillis());
+    }
 
     static EmbedderBatchingConfig parseBatchingElement(Element parent) {
         var batchingElement = XML.getChild(parent, "batching");

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/MistralEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/MistralEmbedder.java
@@ -10,6 +10,7 @@ import java.util.Locale;
 
 import static com.yahoo.text.XML.getChildValue;
 import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
+import static com.yahoo.vespa.model.container.component.EmbedderBatchingConfig.parseBatchingElement;
 
 /**
  * Configuration builder for Mistral embedder component.
@@ -22,6 +23,7 @@ public class MistralEmbedder extends TypedComponent implements MistralEmbedderCo
     private final String model;
     private final int dimensions;
     private final String quantization;
+    private final EmbedderBatchingConfig batching;
 
     @SuppressWarnings("unused")
     public MistralEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
@@ -31,6 +33,7 @@ public class MistralEmbedder extends TypedComponent implements MistralEmbedderCo
         this.dimensions = getChildValue(xml, "dimensions")
                 .map(Integer::parseInt).get();
         this.quantization = getChildValue(xml, "quantization").orElse(null);
+        this.batching = parseBatchingElement(xml);
     }
 
     @Override
@@ -41,5 +44,6 @@ public class MistralEmbedder extends TypedComponent implements MistralEmbedderCo
         if (quantization != null) {
             builder.quantization(MistralEmbedderConfig.Quantization.Enum.valueOf(quantization.toUpperCase(Locale.ROOT)));
         }
+        if (batching != null) batching.applyTo(builder.batching::maxSize, builder.batching::maxDelayMillis);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/OpenAIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/OpenAIEmbedder.java
@@ -8,6 +8,7 @@ import org.w3c.dom.Element;
 
 import static com.yahoo.text.XML.getChildValue;
 import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
+import static com.yahoo.vespa.model.container.component.EmbedderBatchingConfig.parseBatchingElement;
 
 /**
  * Configuration builder for OpenAI embedder component.
@@ -20,6 +21,7 @@ public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConf
     private final String model;
     private final int dimensions;
     private final String endpoint;
+    private final EmbedderBatchingConfig batching;
 
     @SuppressWarnings("unused")
     public OpenAIEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
@@ -29,6 +31,7 @@ public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConf
         this.dimensions = getChildValue(xml, "dimensions")
                 .map(Integer::parseInt).get();
         this.endpoint = getChildValue(xml, "endpoint").orElse(null);
+        this.batching = parseBatchingElement(xml);
     }
 
     @Override
@@ -37,5 +40,6 @@ public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConf
         builder.model(model);
         builder.dimensions(dimensions);
         if (endpoint != null) builder.endpoint(endpoint);
+        if (batching != null) batching.applyTo(builder.batching::maxSize, builder.batching::maxDelayMillis);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/VoyageAIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/VoyageAIEmbedder.java
@@ -57,9 +57,6 @@ public class VoyageAIEmbedder extends TypedComponent implements VoyageAiEmbedder
             builder.quantization(VoyageAiEmbedderConfig.Quantization.Enum.valueOf(quantization.toUpperCase(Locale.ROOT)));
         }
         if (truncate != null) builder.truncate(truncate);
-        if (batching != null) {
-            builder.batching.maxSize(batching.maxSize());
-            builder.batching.maxDelayMillis(batching.maxDelay().toMillis());
-        }
+        if (batching != null) batching.applyTo(builder.batching::maxSize, builder.batching::maxDelayMillis);
     }
 }

--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -169,14 +169,16 @@ OpenAIEmbedder =
    element model { xsd:string } &
    element api-key-secret-ref { xsd:string }? &
    element dimensions { xsd:positiveInteger } &
-   element endpoint { xsd:string }?
+   element endpoint { xsd:string }? &
+   EmbedderBatchingParams
 
 MistralEmbedder =
    attribute type { "mistral-embedder" } &
    element model { xsd:string } &
    element api-key-secret-ref { xsd:string } &
    element dimensions { xsd:positiveInteger } &
-   EmbedderQuantization
+   EmbedderQuantization &
+   EmbedderBatchingParams
 
 OnnxModelExecutionParams =
     element onnx-execution-mode { "parallel" | "sequential" }? &

--- a/config-model/src/test/cfg/application/mistral-embedder/services.xml
+++ b/config-model/src/test/cfg/application/mistral-embedder/services.xml
@@ -16,6 +16,7 @@
             <api-key-secret-ref>mistral_key</api-key-secret-ref>
             <dimensions>2048</dimensions>
             <quantization>int8</quantization>
+            <batching max-size="16" max-delay="200ms"/>
         </component>
     </container>
 </services>

--- a/config-model/src/test/cfg/application/openai-embedder/services.xml
+++ b/config-model/src/test/cfg/application/openai-embedder/services.xml
@@ -11,6 +11,7 @@
             <api-key-secret-ref>openai_api_key</api-key-secret-ref>
             <dimensions>1024</dimensions>
             <endpoint>https://api.openai.com/v1/embeddings</endpoint>
+            <batching max-size="16" max-delay="200ms"/>
         </component>
 
         <!-- OpenAI Embedder with minimal configuration (uses default endpoint) -->

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/MistralEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/MistralEmbedderTest.java
@@ -36,6 +36,8 @@ public class MistralEmbedderTest {
         assertEquals("mistral_key", config.apiKeySecretRef());
         assertEquals(1024, config.dimensions());
         assertEquals(MistralEmbedderConfig.Quantization.Enum.AUTO, config.quantization());
+        assertEquals(0, config.batching().maxSize());
+        assertEquals(0, config.batching().maxDelayMillis());
     }
 
     @Test
@@ -47,6 +49,8 @@ public class MistralEmbedderTest {
         assertEquals("codestral-embed", config.model());
         assertEquals(2048, config.dimensions());
         assertEquals(MistralEmbedderConfig.Quantization.Enum.INT8, config.quantization());
+        assertEquals(16, config.batching().maxSize());
+        assertEquals(200, config.batching().maxDelayMillis());
     }
 
     private VespaModel loadModel(Path path) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/OpenAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/OpenAIEmbedderTest.java
@@ -36,6 +36,8 @@ public class OpenAIEmbedderTest {
         assertEquals("openai_api_key", config.apiKeySecretRef());
         assertEquals(1024, config.dimensions());
         assertEquals("https://api.openai.com/v1/embeddings", config.endpoint());
+        assertEquals(16, config.batching().maxSize());
+        assertEquals(200, config.batching().maxDelayMillis());
     }
 
     @Test
@@ -47,6 +49,8 @@ public class OpenAIEmbedderTest {
         assertEquals("text-embedding-3-small", config.model());
         assertEquals(1536, config.dimensions());
         assertEquals("https://api.openai.com/v1/embeddings", config.endpoint());
+        assertEquals(0, config.batching().maxSize());
+        assertEquals(0, config.batching().maxDelayMillis());
     }
 
     // ===== Helper Methods =====

--- a/configdefinitions/src/vespa/mistral-embedder.def
+++ b/configdefinitions/src/vespa/mistral-embedder.def
@@ -16,3 +16,7 @@ dimensions               int
 
 # Output quantization mode
 quantization             enum { AUTO, FLOAT, INT8, BINARY } default=AUTO
+
+# Dynamic batching configuration
+batching.maxSize         int default=0
+batching.maxDelayMillis  long default=0

--- a/configdefinitions/src/vespa/openai-embedder.def
+++ b/configdefinitions/src/vespa/openai-embedder.def
@@ -13,3 +13,7 @@ model                    string
 
 # Output dimension
 dimensions               int
+
+# Dynamic batching configuration
+batching.maxSize         int default=0
+batching.maxDelayMillis  long default=0

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -184,12 +184,12 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
                     var response = chain.proceed(request);
                     int code = response.code();
                     boolean retryable = code == 500 || code == 502 || code == 503 || code == 504;
-                    if (response.isSuccessful() || !retryable || attempt == maxRetries) {
-                        if (attempt == maxRetries && retryable)
-                            log.fine(() -> "Max retries exceeded (%d) for embedding API; last status %d"
-                                    .formatted(maxRetries, code));
+                    if (attempt == maxRetries && retryable) {
+                        log.fine(() -> "Max retries exceeded (%d) for embedding API; last status %d"
+                                .formatted(maxRetries, code));
                         return response;
                     }
+                    if (response.isSuccessful() || !retryable) return response;
                     response.close();
                 } catch (InterruptedIOException e) {
                     throw e;

--- a/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/AbstractHttpEmbedder.java
@@ -179,40 +179,30 @@ public abstract class AbstractHttpEmbedder extends AbstractComponent {
         @Override
         public okhttp3.Response intercept(Chain chain) throws IOException {
             var request = chain.request();
-            int lastStatusCode = 0;
-            var lastResponseBody = "";
-            IOException lastException = null;
-
             for (int attempt = 0; attempt <= maxRetries; attempt++) {
                 try {
                     var response = chain.proceed(request);
                     int code = response.code();
                     boolean retryable = code == 500 || code == 502 || code == 503 || code == 504;
-                    if (response.isSuccessful() || !retryable) return response;
-
-                    lastStatusCode = code;
-                    lastException = null;
-                    try {
-                        if (attempt == maxRetries && response.body() != null) {
-                                lastResponseBody = response.body().string();
-                        }
-                    } finally {
-                        response.close();
+                    if (response.isSuccessful() || !retryable || attempt == maxRetries) {
+                        if (attempt == maxRetries && retryable)
+                            log.fine(() -> "Max retries exceeded (%d) for embedding API; last status %d"
+                                    .formatted(maxRetries, code));
+                        return response;
                     }
+                    response.close();
                 } catch (InterruptedIOException e) {
                     throw e;
                 } catch (IOException e) {
-                    lastException = e;
+                    if (attempt == maxRetries) {
+                        log.fine(() -> "Max retries exceeded (%d) for embedding API; last error: %s"
+                                .formatted(maxRetries, e.getMessage()));
+                        throw e;
+                    }
                 }
-                // Both 5xx and IOException paths fall through here for retry
-                if (attempt < maxRetries)
-                    sleepBeforeRetry(chain, attempt + 1);
+                sleepBeforeRetry(chain, attempt + 1);
             }
-            if (lastException != null)
-                throw new IOException("Max retries exceeded for embedding API (%d). Last error: %s"
-                        .formatted(maxRetries, lastException.getMessage()), lastException);
-            throw new IOException("Max retries exceeded for embedding API (%d). Last response: %d - %s"
-                    .formatted(maxRetries, lastStatusCode, lastResponseBody));
+            throw new IllegalStateException("unreachable");
         }
 
         private void sleepBeforeRetry(Chain chain, int retryNumber) throws IOException {

--- a/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/MistralEmbedder.java
@@ -33,6 +33,7 @@ public class MistralEmbedder extends AbstractHttpEmbedder implements Embedder {
     private final Embedder.Runtime runtime;
     private final Secret apiKey;
     private final EmbeddingQuantization.Quantization quantization;
+    private final Embedder.Batching batching;
 
     @Inject
     public MistralEmbedder(MistralEmbedderConfig config, Embedder.Runtime runtime, Secrets secrets) {
@@ -48,7 +49,11 @@ public class MistralEmbedder extends AbstractHttpEmbedder implements Embedder {
             throw new IllegalArgumentException("'api-key-secret-ref' must be configured for Mistral embedder");
         this.apiKey = secrets.get(config.apiKeySecretRef());
         this.quantization = EmbeddingQuantization.Quantization.valueOf(config.quantization().name());
+        this.batching = Embedder.Batching.of(
+                config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));
     }
+
+    @Override public Batching batchingConfig() { return batching; }
 
     @Override
     public List<Integer> embed(String text, Context context) {

--- a/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
@@ -34,6 +34,7 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     private final OpenaiEmbedderConfig config;
     private final Embedder.Runtime runtime;
     private final Secret apiKey;
+    private final Embedder.Batching batching;
 
     @Inject
     public OpenAIEmbedder(OpenaiEmbedderConfig config, Embedder.Runtime runtime, Secrets secrets) {
@@ -50,7 +51,11 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
             throw new IllegalArgumentException(
                     "Model '%s' has a fixed output size of %d; configure dimensions=%d"
                             .formatted(ADA_002_MODEL, ADA_002_DIMENSIONS, ADA_002_DIMENSIONS));
+        this.batching = Embedder.Batching.of(
+                config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));
     }
+
+    @Override public Batching batchingConfig() { return batching; }
 
     @Override
     public List<Integer> embed(String text, Context context) {

--- a/model-integration/src/test/java/ai/vespa/embedding/AbstractHttpEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/AbstractHttpEmbedderTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -33,14 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AbstractHttpEmbedderTest {
 
     private MockWebServer mockServer;
-    private Embedder.Runtime runtime;
+    private RecordingRuntime runtime;
     private AbstractHttpEmbedder embedder;
 
     @BeforeEach
     public void setUp() throws IOException {
         mockServer = new MockWebServer();
         mockServer.start();
-        runtime = Embedder.Runtime.testInstance();
+        runtime = new RecordingRuntime();
         embedder = new AbstractHttpEmbedder() {};
     }
 
@@ -139,14 +141,16 @@ public class AbstractHttpEmbedderTest {
     }
 
     @Test
-    public void testMaxRetriesExceeded() {
+    public void testMaxRetriesExceededRecordsActualStatusCode() {
         for (int i = 0; i < 10; i++) {
-            mockServer.enqueue(new MockResponse().setResponseCode(500).setBody("{\"error\":{\"message\":\"internal\"}}"));
+            mockServer.enqueue(new MockResponse().setResponseCode(503).setBody("{\"error\":{\"message\":\"unavailable\"}}"));
         }
 
         var exception = assertThrows(RuntimeException.class, this::call);
-        assertEquals("Embedding API call failed: Max retries exceeded for embedding API (3). "
-                + "Last response: 500 - {\"error\":{\"message\":\"internal\"}}", exception.getMessage());
+        assertEquals("Embedding API request failed with status 503: {\"error\":{\"message\":\"unavailable\"}}",
+                exception.getMessage());
+        assertEquals(List.of(503), runtime.sampledFailures);
+        assertEquals(4, mockServer.getRequestCount()); // 1 initial + 3 retries
     }
 
     @Test
@@ -175,7 +179,7 @@ public class AbstractHttpEmbedderTest {
             var exception = assertThrows(RuntimeException.class,
                     () -> embedderWithConfig.doHttpRequest(endpointUrl(), "{}", Map.of(),
                             new Embedder.Context("test"), runtime));
-            assertTrue(exception.getMessage().contains("Max retries exceeded for embedding API (1)"));
+            assertEquals("Embedding API request failed with status 503: x", exception.getMessage());
             assertEquals(2, mockServer.getRequestCount()); // 1 initial + 1 retry
         } finally {
             embedderWithConfig.deconstruct();
@@ -190,5 +194,14 @@ public class AbstractHttpEmbedderTest {
 
     private String endpointUrl() {
         return mockServer.url("/").toString();
+    }
+
+    private static class RecordingRuntime implements Embedder.Runtime {
+        final List<Integer> sampledFailures = new ArrayList<>();
+
+        @Override public void sampleEmbeddingLatency(double millis, Embedder.Context ctx) { }
+        @Override public void sampleSequenceLength(long length, Embedder.Context ctx) { }
+        @Override public void sampleRequestCount(Embedder.Context ctx) { }
+        @Override public void sampleRequestFailure(Embedder.Context ctx, int statusCode) { sampledFailures.add(statusCode); }
     }
 }

--- a/model-integration/src/test/java/ai/vespa/embedding/AbstractHttpEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/AbstractHttpEmbedderTest.java
@@ -9,6 +9,7 @@ import com.yahoo.language.process.OverloadException;
 import com.yahoo.language.process.TimeoutException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -138,6 +139,27 @@ public class AbstractHttpEmbedderTest {
 
         assertEquals("ok", call());
         assertEquals(2, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testRetriesOnIOException() {
+        mockServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        assertEquals("ok", call());
+        assertEquals(2, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testMaxRetriesExceededOnIOExceptionRethrows() {
+        for (int i = 0; i < 10; i++) {
+            mockServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+        }
+
+        var exception = assertThrows(RuntimeException.class, this::call);
+        assertTrue(exception.getMessage().startsWith("Embedding API call failed:"));
+        assertEquals(List.of(0), runtime.sampledFailures);
+        assertEquals(4, mockServer.getRequestCount()); // 1 initial + 3 retries
     }
 
     @Test

--- a/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderIntegrationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderIntegrationTest.java
@@ -7,6 +7,7 @@ import com.yahoo.tensor.TensorType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import java.time.Duration;
 import java.util.List;
 
 import static ai.vespa.embedding.EmbedderTestUtils.assertNonZeroTensor;
@@ -118,6 +119,34 @@ public class MistralEmbedderIntegrationTest {
         assertEquals(128, result.size());
         assertEquals(targetType, result.type());
         assertNonZeroTensor(result);
+
+        embedder.deconstruct();
+    }
+
+    @Test
+    public void testBatchingConfig() {
+        var config = new MistralEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .model("mistral-embed")
+                .dimensions(1024)
+                .quantization(MistralEmbedderConfig.Quantization.Enum.AUTO);
+        config.batching.maxSize(16).maxDelayMillis(200);
+        var embedder = new MistralEmbedder(config.build(), Embedder.Runtime.testInstance(),
+                key -> () -> System.getenv("VESPA_TEST_MISTRAL_API_KEY"));
+
+        var batching = embedder.batchingConfig();
+        assertTrue(batching.isEnabled());
+        assertEquals(16, batching.maxSize());
+        assertEquals(Duration.ofMillis(200), batching.maxDelay());
+
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
+        var results = embedder.embed(List.of("First text", "Second text"), context, targetType);
+        assertEquals(2, results.size());
+        for (var result : results) {
+            assertEquals(1024, result.size());
+            assertNonZeroTensor(result);
+        }
 
         embedder.deconstruct();
     }

--- a/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/MistralEmbedderTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static ai.vespa.embedding.EmbedderTestUtils.createMockSecrets;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,16 +90,46 @@ public class MistralEmbedderTest {
         assertTrue(body.contains("\"output_dtype\":\"float\""));
     }
 
+    @Test
+    public void testBatchEmbedding() throws Exception {
+        mockServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createJsonArrayBatchResponse(3, 1024)));
+
+        embedder = createEmbedder("mistral-embed", 1024, MistralEmbedderConfig.Quantization.Enum.INT8);
+
+        var targetType = TensorType.fromSpec("tensor<int8>(d0[1024])");
+        var context = new Embedder.Context("test-embedder");
+        var texts = List.of("Hello", "World", "Test");
+        var results = embedder.embed(texts, context, targetType);
+
+        assertEquals(3, results.size());
+        for (var result : results) {
+            assertEquals(1024, result.size());
+            assertEquals(targetType, result.type());
+        }
+        assertEquals(1, mockServer.getRequestCount());
+
+        var request = mockServer.takeRequest();
+        var body = request.getBody().readUtf8();
+        assertTrue(body.contains("\"input\":[\"Hello\",\"World\",\"Test\"]"));
+    }
+
     // ===== Helpers =====
 
     private MistralEmbedder createEmbedder(String model, int dimensions, MistralEmbedderConfig.Quantization.Enum quantization) {
-        var config = new MistralEmbedderConfig.Builder()
+        return new MistralEmbedder(mistralConfigBuilder(model, dimensions, quantization).build(), runtime, createMockSecrets());
+    }
+
+    private MistralEmbedderConfig.Builder mistralConfigBuilder(String model, int dimensions,
+                                                                MistralEmbedderConfig.Quantization.Enum quantization) {
+        return new MistralEmbedderConfig.Builder()
                 .apiKeySecretRef("test_key")
                 .endpoint(mockServer.url("/v1/embeddings").toString())
                 .model(model)
                 .dimensions(dimensions)
                 .quantization(quantization);
-        return new MistralEmbedder(config.build(), runtime, createMockSecrets());
     }
 
     private static String createJsonArrayResponse(int dimensions) {
@@ -110,5 +141,21 @@ public class MistralEmbedderTest {
         return Text.format("""
                 {"object":"list","data":[{"object":"embedding","embedding":[%s],"index":0}],"model":"mistral-embed","usage":{"prompt_tokens":10,"total_tokens":10}}
                 """, values);
+    }
+
+    private static String createJsonArrayBatchResponse(int batchSize, int dimensions) {
+        var data = new StringBuilder();
+        for (int b = 0; b < batchSize; b++) {
+            var values = new StringBuilder();
+            for (int i = 0; i < dimensions; i++) {
+                if (i > 0) values.append(",");
+                values.append((i % 256) - 128);
+            }
+            if (b > 0) data.append(",");
+            data.append(Text.format("{\"object\":\"embedding\",\"embedding\":[%s],\"index\":%d}", values, b));
+        }
+        return Text.format("""
+                {"object":"list","data":[%s],"model":"mistral-embed","usage":{"prompt_tokens":30,"total_tokens":30}}
+                """, data);
     }
 }

--- a/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderIntegrationTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderIntegrationTest.java
@@ -7,6 +7,7 @@ import com.yahoo.tensor.TensorType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import java.time.Duration;
 import java.util.List;
 
 import static ai.vespa.embedding.EmbedderTestUtils.assertNonZeroTensor;
@@ -115,6 +116,33 @@ public class OpenAIEmbedderIntegrationTest {
         } finally {
             embedder.deconstruct();
         }
+    }
+
+    @Test
+    public void testBatchingConfig() {
+        var config = new OpenaiEmbedderConfig.Builder()
+                .apiKeySecretRef("test_key")
+                .model("text-embedding-3-small")
+                .dimensions(1024);
+        config.batching.maxSize(16).maxDelayMillis(200);
+        var embedder = new OpenAIEmbedder(config.build(), Embedder.Runtime.testInstance(),
+                key -> () -> System.getenv("VESPA_TEST_OPENAI_API_KEY"));
+
+        var batching = embedder.batchingConfig();
+        assertTrue(batching.isEnabled());
+        assertEquals(16, batching.maxSize());
+        assertEquals(Duration.ofMillis(200), batching.maxDelay());
+
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var context = new Embedder.Context("integration-test");
+        var results = embedder.embed(List.of("First text", "Second text"), context, targetType);
+        assertEquals(2, results.size());
+        for (var result : results) {
+            assertEquals(1024, result.size());
+            assertNonZeroTensor(result);
+        }
+
+        embedder.deconstruct();
     }
 
     private static OpenAIEmbedder createEmbedder(int dimensions) {

--- a/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 
 import static ai.vespa.embedding.EmbedderTestUtils.createBase64EmbeddingResponse;
@@ -98,17 +99,33 @@ public class OpenAIEmbedderTest {
         assertTrue(body.contains("\"input\":[\"Hello\",\"World\",\"Test\"]"));
     }
 
+    @Test
+    public void testBatchingConfigEnabled() {
+        var config = openaiConfigBuilder(1024);
+        config.batching.maxSize(16);
+        config.batching.maxDelayMillis(200);
+        embedder = new OpenAIEmbedder(config.build(), runtime, createMockSecrets());
+
+        var batching = embedder.batchingConfig();
+        assertTrue(batching.isEnabled());
+        assertEquals(16, batching.maxSize());
+        assertEquals(Duration.ofMillis(200), batching.maxDelay());
+    }
+
     // ===== Helper Methods =====
 
     private OpenAIEmbedder createEmbedder() { return createEmbedder(1024); }
 
     private OpenAIEmbedder createEmbedder(int dimensions) {
-        var config = new OpenaiEmbedderConfig.Builder()
+        return new OpenAIEmbedder(openaiConfigBuilder(dimensions).build(), runtime, createMockSecrets());
+    }
+
+    private OpenaiEmbedderConfig.Builder openaiConfigBuilder(int dimensions) {
+        return new OpenaiEmbedderConfig.Builder()
                 .apiKeySecretRef("test_key")
                 .endpoint(mockServer.url("/v1/embeddings").toString())
                 .model("text-embedding-3-small")
                 .dimensions(dimensions);
-        return new OpenAIEmbedder(config.build(), runtime, createMockSecrets());
     }
 
     private static String createSuccessResponse(int dimensions) {


### PR DESCRIPTION
## Summary
- Opt the Mistral and OpenAI embedders into the framework-level dynamic batching mechanism already used by the VoyageAI embedder (`EmbedExpression` + `DynamicBatcher`), so concurrent per-document `embed()` calls are coalesced into a single multi-input API request.
- Extend the `mistral-embedder` and `openai-embedder` config definitions with `batching.maxSize` / `batching.maxDelayMillis` (default 0 = disabled) and expose the matching `<batching max-size="…" max-delay="…"/>` XML element via `common.rnc`.
- Consolidate builder-forwarding logic across all three embedder implementations (VoyageAI, Mistral, OpenAI) via a new `EmbedderBatchingConfig.applyTo(maxSizeSetter, maxDelayMillisSetter)` helper.
- Fold in a pre-existing fix (`fix: record actual 5xx status code when embedder retries are exhausted`) that's already on this branch.
- Add unit, config-model XML, and integration tests covering the new batching path.