### PR TITLE
Implement saving and loading of document ids in DocumentMetaStore

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -2056,6 +2056,34 @@ TEST(DocumentMetaStoreTest, document_sizes_are_saved)
     std::filesystem::remove(std::filesystem::path("documentmetastore4.dat"));
 }
 
+TEST(DocumentMetaStoreTest, full_document_ids_are_saved)
+{
+    DocumentMetaStore dms1(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms1.constructFreeList();
+    addLid(dms1, 1);
+    addLid(dms1, 2);
+    addLid(dms1, 3);
+
+    TuneFileAttributes tuneFileAttributes;
+    DummyFileHeaderContext fileHeaderContext;
+    AttributeFileSaveTarget saveTarget(tuneFileAttributes, fileHeaderContext);
+    EXPECT_TRUE(dms1.save(saveTarget, "documentmetastore5"));
+
+    DocumentMetaStore dms_loaded_docids(createBucketDB(), "documentmetastore5", search::GrowStrategy(), true, SubDbType::READY);
+    EXPECT_TRUE(dms_loaded_docids.load());
+    dms_loaded_docids.constructFreeList();
+
+    auto d1 = createDocId(1);
+    EXPECT_EQ(d1.toString(), dms_loaded_docids.get_docid_string(d1.getGlobalId()));
+    auto d2 = createDocId(2);
+    EXPECT_EQ(d2.toString(), dms_loaded_docids.get_docid_string(d2.getGlobalId()));
+    auto d3 = createDocId(3);
+    EXPECT_EQ(d3.toString(), dms_loaded_docids.get_docid_string(d3.getGlobalId()));
+
+    std::filesystem::remove(std::filesystem::path("documentmetastore5.dat"));
+    std::filesystem::remove(std::filesystem::path("documentmetastore5.docids.dat"));
+}
+
 namespace {
 
 void

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_library(searchcore_documentmetastore STATIC
     SOURCES
     document_meta_store_explorer.cpp
     document_meta_store_initializer_result.cpp
+    documentidsaver.cpp
     documentmetastore.cpp
     documentmetastoreattribute.cpp
     documentmetastorecontext.cpp

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
@@ -1,0 +1,60 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "documentidsaver.h"
+#include "documentmetastoresaver.h"
+#include <vespa/searchlib/util/bufferwriter.h>
+#include <vespa/vespalib/btree/btreenode.hpp>
+#include <vespa/vespalib/datastore/array_store.h>
+#include <vespa/vespalib/datastore/array_store.hpp>
+#include <vespa/vespalib/datastore/dynamic_array_buffer_type.h>
+#include <vespa/vespalib/datastore/dynamic_array_buffer_type.h>
+
+namespace proton {
+
+namespace {
+
+/*
+ * Functor class to write document id string for a single lid.
+ */
+class WriteDocumentId {
+    using DocumentIdStore = DocumentIdSaver::DocumentIdStore;
+    using MetaDataView = DocumentMetaStoreSaver::MetadataView;
+    search::BufferWriter&  _writer;
+    MetaDataView           _meta_data_view;
+    const DocumentIdStore& _docid_store;
+public:
+    WriteDocumentId(search::BufferWriter &writer, MetaDataView meta_data_view, const DocumentIdStore &docid_store)
+        : _writer(writer),
+          _meta_data_view(meta_data_view),
+          _docid_store(docid_store) {
+    }
+
+    void operator()(documentmetastore::GidToLidMapKey key) {
+        auto lid = key.get_lid();
+        assert(lid < _meta_data_view.size());
+        const RawDocumentMetadata& meta_data = _meta_data_view[lid];
+        auto docid_ref = meta_data.acquire_docid_ref();
+        assert(docid_ref.valid());
+        auto span = _docid_store.get(docid_ref);
+        size_t size = span.size();
+        _writer.write(&size, sizeof(size));
+        _writer.write(span.data(), size);
+    }
+};
+}
+
+DocumentIdSaver::DocumentIdSaver(const GidIterator &gid_iterator, MetaDataView meta_data_view, const DocumentIdSaver::DocumentIdStore& docid_store)
+    : _gid_iterator(gid_iterator),
+      _meta_data_view(meta_data_view),
+      _docid_store(docid_store) {
+}
+
+DocumentIdSaver::~DocumentIdSaver() {
+}
+
+void DocumentIdSaver::save(search::BufferWriter& writer) const {
+    _gid_iterator.foreach_key(WriteDocumentId(writer, _meta_data_view, _docid_store));
+    writer.flush();
+}
+
+}  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.h
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "lid_gid_key_comparator.h"
+#include "i_store.h"
+#include <vespa/vespalib/btree/btreeiterator.h>
+#include "raw_document_metadata.h"
+#include <vespa/searchlib/util/bufferwriter.h>
+#include <vespa/vespalib/datastore/array_store.h>
+#include <vespa/vespalib/datastore/array_store_dynamic_type_mapper.h>
+
+namespace proton {
+
+/**
+ * Implements saving document ids in binary format.
+ **/
+class DocumentIdSaver {
+public:
+    using KeyComp = documentmetastore::LidGidKeyComparator;
+    using GidIterator = vespalib::btree::BTreeConstIterator<
+        documentmetastore::GidToLidMapKey,
+        vespalib::btree::BTreeNoLeafData,
+        vespalib::btree::NoAggregated,
+        const KeyComp &>;
+    using MetaDataView = std::span<const RawDocumentMetadata>;
+    using TypeMapper = vespalib::datastore::ArrayStoreDynamicTypeMapper<char>;
+    using DocumentIdEntryRef = vespalib::datastore::EntryRefT<19>;
+    using DocumentIdStore = vespalib::datastore::ArrayStore<char, DocumentIdEntryRef, TypeMapper>;
+    DocumentIdSaver(const GidIterator &gidIterator, MetaDataView metaDataView, const DocumentIdStore& docid_store);
+    ~DocumentIdSaver();
+    void save(search::BufferWriter& writer) const;
+
+private:
+    GidIterator            _gid_iterator;
+    MetaDataView           _meta_data_view;
+    const DocumentIdStore& _docid_store;
+};
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "documentmetastore.h"
+#include "documentidsaver.h"
 #include "documentmetastoresaver.h"
 #include "operation_listener.h"
 #include "search_context.h"
@@ -287,10 +288,19 @@ std::unique_ptr<search::AttributeSaver>
 DocumentMetaStore::onInitSave(std::string_view fileName)
 {
     auto guard(getGuard());
+    auto gid_view = _gidToLidMap.getFrozenView();
+    auto metadata_view = make_metadata_view();
+    auto docid_saver = _store_full_document_id
+                     ? std::make_unique<DocumentIdSaver>(
+                        gid_view.begin(),
+                        metadata_view,
+                        _docid_store)
+                     : std::unique_ptr<DocumentIdSaver>();
     return std::make_unique<DocumentMetaStoreSaver>
         (std::move(guard), createAttributeHeader(fileName),
-         _gidToLidMap.getFrozenView().begin(),
-         make_metadata_view());
+         gid_view.begin(),
+         metadata_view,
+         std::move(docid_saver));
 }
 
 DocumentMetaStore::DocId

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -146,6 +146,42 @@ Reader::Reader(std::unique_ptr<FastOS_FileInterface> datFile)
 }
 Reader::~Reader() = default;
 
+/**
+ * Implements loading of document-id file saved by DocumentIdSaver.
+ **/
+class DocIdReader {
+private:
+    FileWithHeader     _docid_file;
+    FileReader<size_t> _length_reader;
+    FileReader<char>   _char_reader;
+
+public:
+    explicit DocIdReader(std::unique_ptr<FastOS_FileInterface> docid_file);
+    ~DocIdReader();
+
+    std::string get_next_docid() {
+        size_t length = _length_reader.readHostOrder();
+        std::string docid;
+        docid.reserve(length);
+        for (size_t i = 0; i < length; ++i) {
+            docid.push_back(_char_reader.readHostOrder());
+        }
+        return docid;
+    }
+
+    uint64_t size_on_disk() const noexcept {
+        return _docid_file.size_on_disk() + DiskSpaceCalculator::directory_placeholder_size();
+    }
+    std::chrono::steady_clock::duration flush_duration() const noexcept { return _docid_file.flush_duration(); }
+};
+
+DocIdReader::DocIdReader(std::unique_ptr<FastOS_FileInterface> docid_file)
+    : _docid_file(std::move(docid_file)),
+      _length_reader(&_docid_file.file()),
+      _char_reader(&_docid_file.file()) {
+}
+DocIdReader::~DocIdReader() = default;
+
 }
 
 namespace {
@@ -304,7 +340,7 @@ DocumentMetaStore::onInitSave(std::string_view fileName)
 }
 
 DocumentMetaStore::DocId
-DocumentMetaStore::readNextDoc(documentmetastore::Reader & reader, TreeType::Builder & treeBuilder)
+DocumentMetaStore::readNextDoc(documentmetastore::Reader & reader, documentmetastore::DocIdReader* docid_reader, TreeType::Builder & treeBuilder)
 {
     uint32_t lid(reader.getNextLid());
     assert(lid < reader.getDocIdLimit());
@@ -313,6 +349,11 @@ DocumentMetaStore::readNextDoc(documentmetastore::Reader & reader, TreeType::Bui
     meta.setBucketUsedBits(reader.getNextBucketUsedBits());
     meta.setDocSize(reader.getNextDocSize());
     meta.setTimestamp(reader.getNextTimestamp());
+    if (docid_reader) {
+        std::string docid = docid_reader->get_next_docid();
+        const auto ref = _docid_store.add(docid);
+        meta.set_docid_ref(ref);
+    }
     treeBuilder.insert(GidToLidMapKey(lid, meta.getGid()), BTreeNoLeafData());
     assert(!validLid(lid));
     _lidAlloc.registerLid(lid);
@@ -322,6 +363,11 @@ DocumentMetaStore::readNextDoc(documentmetastore::Reader & reader, TreeType::Bui
 bool
 DocumentMetaStore::onLoad(vespalib::Executor *)
 {
+    std::unique_ptr<documentmetastore::DocIdReader> docid_reader;
+    if (_store_full_document_id && LoadUtils::file_exists(*this, DocumentMetaStoreSaver::docid_file_suffix())) {
+        auto file = LoadUtils::openFile(*this, DocumentMetaStoreSaver::docid_file_suffix());
+        docid_reader = std::make_unique<documentmetastore::DocIdReader>(std::move(file));
+    }
     documentmetastore::Reader reader(LoadUtils::openDAT(*this));
     unload();
     size_t numElems = reader.getNumElems();
@@ -333,13 +379,13 @@ DocumentMetaStore::onLoad(vespalib::Executor *)
 
     // insert gids (already sorted)
     if (numElems > 0) {
-        DocId lid = readNextDoc(reader, treeBuilder);
+        DocId lid = readNextDoc(reader, docid_reader.get(), treeBuilder);
         const RawDocumentMetadata * meta = &_metadataStore[lid];
         BucketId prevId(meta->getBucketId());
         BucketState state;
         state.add(meta->getGid(), meta->getTimestamp(), meta->getDocSize(), _subDbType);
         for (size_t i = 1; i < numElems; ++i) {
-            lid = readNextDoc(reader, treeBuilder);
+            lid = readNextDoc(reader, docid_reader.get(), treeBuilder);
             meta = &_metadataStore[lid];
             BucketId bucketId = meta->getBucketId();
             if (prevId != bucketId) {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -21,6 +21,7 @@ namespace proton::bucketdb {
 }
 
 namespace proton::documentmetastore {
+    class DocIdReader;
     class OperationListener;
     class Reader;
 }
@@ -138,7 +139,7 @@ private:
         return getCurrentGeneration();
     }
 
-    VESPA_DLL_LOCAL DocId readNextDoc(documentmetastore::Reader & reader, TreeType::Builder & treeBuilder);
+    VESPA_DLL_LOCAL DocId readNextDoc(documentmetastore::Reader & reader, documentmetastore::DocIdReader* docid_reader, TreeType::Builder & treeBuilder);
 
     RawDocumentMetadata removeInternal(DocId lid, uint64_t cached_iterator_sequence_id);
     void remove_batch_internal_btree(std::vector<LidAndRawDocumentMetadata>& removed);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoresaver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoresaver.cpp
@@ -1,9 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "documentmetastoresaver.h"
-#include <vespa/searchlib/util/bufferwriter.h>
+#include "documentidsaver.h"
 #include "document_meta_store_versions.h"
 #include <vespa/searchlib/attribute/iattributesavetarget.h>
+#include <vespa/searchlib/util/bufferwriter.h>
 #include <vespa/vespalib/btree/btreenode.hpp>
 
 using vespalib::GenerationGuard;
@@ -68,13 +69,15 @@ public:
 
 DocumentMetaStoreSaver::
 DocumentMetaStoreSaver(GenerationGuard&& guard,
-                       const search::attribute::AttributeHeader& header,
+                       const search::attribute::AttributeHeader &header,
                        const GidIterator& gidIterator,
-                       MetadataView metadataView)
+                       MetadataView metadataView,
+                       std::unique_ptr<DocumentIdSaver> docid_saver)
     : AttributeSaver(std::move(guard), header),
       _gidIterator(gidIterator),
       _metadataView(metadataView),
-      _writeDocSize(true)
+      _writeDocSize(true),
+      _docid_saver(std::move(docid_saver))
 {
     if (header.getVersion() == documentmetastore::NO_DOCUMENT_SIZE_TRACKING_VERSION) {
         _writeDocSize = false;
@@ -88,6 +91,18 @@ DocumentMetaStoreSaver::~DocumentMetaStoreSaver() = default;
 bool
 DocumentMetaStoreSaver::onSave(IAttributeSaveTarget &saveTarget)
 {
+    if (_docid_saver) {
+        if (!saveTarget.setup_writer(docid_file_suffix(), "Binary data file for document id strings")) {
+            return false;
+        }
+
+        auto& docid_file_writer = saveTarget.get_writer(docid_file_suffix());
+        auto docid_writer = docid_file_writer.allocBufferWriter();
+        // Note: Implementation of save() is responsible to call BufferWriter::flush().
+        _docid_saver->save(*docid_writer);
+        docid_file_writer.close();
+        _docid_saver.reset();
+    }
     // write <lid,gid> pairs, sorted on gid
     std::unique_ptr<search::BufferWriter>
         datWriter(saveTarget.datWriter().allocBufferWriter());
@@ -96,5 +111,11 @@ DocumentMetaStoreSaver::onSave(IAttributeSaveTarget &saveTarget)
     return true;
 }
 
+
+std::string
+DocumentMetaStoreSaver::docid_file_suffix()
+{
+    return "docids.dat";
+}
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoresaver.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoresaver.h
@@ -6,8 +6,11 @@
 #include "i_store.h"
 #include <vespa/vespalib/btree/btreeiterator.h>
 #include <vespa/searchlib/attribute/attributesaver.h>
+#include <memory>
 
 namespace proton {
+
+class DocumentIdSaver;
 
 /*
  * Class holding the necessary context for saving a document meta
@@ -33,15 +36,19 @@ private:
     GidIterator _gidIterator; // iterator over frozen tree
     MetadataView _metadataView;
     bool _writeDocSize;
+    std::unique_ptr<DocumentIdSaver> _docid_saver;
 
     bool onSave(search::IAttributeSaveTarget &saveTarget) override;
 public:
     DocumentMetaStoreSaver(vespalib::GenerationGuard&& guard,
-                           const search::attribute::AttributeHeader& header,
-                           const GidIterator& gidIterator,
-                           MetadataView metadataView);
+                           const search::attribute::AttributeHeader &header,
+                           const GidIterator &gidIterator,
+                           MetadataView metadataView,
+                           std::unique_ptr<DocumentIdSaver> _docid_saver);
 
     ~DocumentMetaStoreSaver() override;
+
+    static std::string docid_file_suffix();
 };
 
 } // namespace proton


### PR DESCRIPTION
Not sure about this one. Looking back, saving and loading to the same file would have required much less code. Not sure if I should go back and do that instead.