### PR TITLE
vespalib: prevent GCC 15 from turning heap-adjust branches branchless

### DIFF
--- a/vespalib/src/vespa/vespalib/util/left_right_heap.hpp
+++ b/vespalib/src/vespa/vespalib/util/left_right_heap.hpp
@@ -26,6 +26,8 @@ template <typename T, typename C> void right_heap_insert(T* heap, size_t pos, T 
     *(heap - pos) = std::move(value);
 }
 
+#pragma GCC push_options
+#pragma GCC optimize("no-if-conversion", "no-if-conversion2")
 template <typename T, typename C> void left_heap_adjust(T* heap, size_t len, T value, C cmp) {
     size_t pos = 0;
     size_t child2 = 2;
@@ -61,6 +63,7 @@ template <typename T, typename C> void right_heap_adjust(T* heap, size_t len, T 
     }
     right_heap_insert<T, C>(heap, pos, std::move(value), cmp);
 }
+#pragma GCC pop_options
 
 template <typename T, typename C> void left_heap_remove(T* heap, size_t len, T value, C cmp) {
     *(heap + len) = std::move(*heap);

--- a/vespalib/src/vespa/vespalib/util/left_right_heap.hpp
+++ b/vespalib/src/vespa/vespalib/util/left_right_heap.hpp
@@ -26,6 +26,8 @@ template <typename T, typename C> void right_heap_insert(T* heap, size_t pos, T 
     *(heap - pos) = std::move(value);
 }
 
+// prevent GCC 15 from turning heap-adjust branches branchless;
+// we got much better performance from GCC 14 on this code.
 #pragma GCC push_options
 #pragma GCC optimize("no-if-conversion", "no-if-conversion2")
 template <typename T, typename C> void left_heap_adjust(T* heap, size_t len, T value, C cmp) {


### PR DESCRIPTION
Wrap left_heap_adjust and right_heap_adjust in
  #pragma GCC optimize("no-if-conversion", "no-if-conversion2")
so the tight inner-loop `if (cmp(...)) --child2;` stays as a real conditional branch instead of being rewritten into branchless code.

Why: GCC 15's if-conversion passes aggressively eliminate this branch, but in practice the comparison outcome is very well predicted by the CPU's branch predictor. The branchless form replaces a predicted-taken no-op with an unconditional data dependency on every iteration, which measured slower than leaving the branch in place. Keeping the branch lets the hardware do what it is already good at.

Scope is limited to the two adjust functions (the hot path for heap pop/replace); other routines in the header are unchanged.
