### PR TITLE
Add flag to toggle between UI versions

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -284,6 +284,13 @@ public class Flags {
             + "e.g. when running tests to avoid writing a large, sparse, mostly unused file",
             "Takes effect on restart of Docker container");
 
+    public static final UnboundBooleanFlag ENABLE_UI_VERSION_TOGGLE = defineFeatureFlag(
+            "enable-ui-version-toggle", false,
+            List.of("laura", "jille"), "2026-04-20", "2026-12-31",
+            "Enable a toggle to switch between the legacy and v2 Console UI",
+            "Takes effect immediately",
+            CONSOLE_USER_EMAIL);
+
     public static final UnboundBooleanFlag ENFORCE_EMAIL_DOMAIN_SSO = defineFeatureFlag(
             "enforce-email-domain-sso", false,
             List.of("eirik"), "2024-11-07", "2026-05-01",

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -287,7 +287,7 @@ public class Flags {
     public static final UnboundBooleanFlag ENABLE_UI_VERSION_TOGGLE = defineFeatureFlag(
             "enable-ui-version-toggle", false,
             List.of("laura", "jille"), "2026-04-20", "2026-12-31",
-            "Enable a toggle to switch between the legacy and v2 Console UI",
+            "Enable a toggle to switch between different versions of the Console UI",
             "Takes effect immediately",
             CONSOLE_USER_EMAIL);
 


### PR DESCRIPTION
This PR introduces a new feature flag to enable the redesign of the Application View in the Console.
The flag allows users to toggle between the legacy interface and the new v2 UI.

- Initial scope: access is restricted to developers for internal testing and feedback
- Future scope: the toggle will be rolled out to a wider audience once the v2 UI reaches stability

See [this](https://github.com/vespaai/yahoo-hosted-feature-flags/pull/1666) Pull Request for the implementation of the values.

##### Dropdown proof of concept
<img width="1198" height="308" alt="Screenshot 2026-04-20 at 13 16 58" src="https://github.com/user-attachments/assets/b5b2fc90-7113-430d-b6bf-c9aad0018632" />