### PR TITLE
std::unique_ptr::operator*() has nodiscard attribute on libc++ 22.

### DIFF
--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -584,7 +584,7 @@ public:
         verifyDoc(*_datastore->read(id, _repo), id);
     }
     void read(uint32_t id) {
-        *_datastore->read(id, _repo);
+        (void) *_datastore->read(id, _repo);
     }
     void verifyDoc(const Document & doc, uint32_t id) {
         EXPECT_TRUE(doc == *_inserted[id]);


### PR DESCRIPTION
@vekterli : please review
