### PR TITLE
disable non-strict or flow short-curcuiting

### DIFF
--- a/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
@@ -199,9 +199,9 @@ TEST(IntermediateBlueprintsTest, test_Or_propagates_updated_histestimate) {
         EXPECT_FALSE(child.strict());
     }
     EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo &>(bp->getChild(0)).hit_rate);
-    EXPECT_NEAR(0.5, dynamic_cast<const RememberExecuteInfo &>(bp->getChild(1)).hit_rate, 1e-6);
-    EXPECT_NEAR(0.5*3.0/5.0, dynamic_cast<const RememberExecuteInfo &>(bp->getChild(2)).hit_rate, 1e-6);
-    EXPECT_NEAR(0.5*3.0*42.0/(5.0*50.0), dynamic_cast<const RememberExecuteInfo &>(bp->getChild(3)).hit_rate, 1e-6);
+    EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo &>(bp->getChild(1)).hit_rate);
+    EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo &>(bp->getChild(2)).hit_rate);
+    EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo &>(bp->getChild(3)).hit_rate);
     //--- execute info when strict:
     optimize(bp, true);
     bp->fetchPostings(ExecuteInfo::FULL);

--- a/searchlib/src/tests/queryeval/flow/queryeval_flow_test.cpp
+++ b/searchlib/src/tests/queryeval/flow/queryeval_flow_test.cpp
@@ -214,9 +214,9 @@ TEST(FlowTest, partial_and_flow) {
 TEST(FlowTest, full_or_flow) {
     verify_flow(OrFlow(false), {0.4, 0.7, 0.2},
                 {{1.0, 0.0, false},
-                 {0.6, 1.0-0.6, false},
-                 {0.6*0.3, 1.0-0.6*0.3, false},
-                 {0.6*0.3*0.8, 1.0-0.6*0.3*0.8, false}});
+                 {1.0, 1.0-0.6, false},
+                 {1.0, 1.0-0.6*0.3, false},
+                 {1.0, 1.0-0.6*0.3*0.8, false}});
     verify_flow(OrFlow(true), {0.4, 0.7, 0.2},
                 {{1.0, 0.0, true},
                  {1.0, 1.0-0.6, true},
@@ -228,9 +228,9 @@ TEST(FlowTest, partial_or_flow) {
     for (double in: {1.0, 0.5, 0.25}) {
         verify_flow(OrFlow(in), {0.4, 0.7, 0.2},
                     {{in, 0.0, false},
-                     {in*0.6, 1.0-0.6, false},
-                     {in*0.6*0.3, 1.0-0.6*0.3, false},
-                     {in*0.6*0.3*0.8, 1.0-0.6*0.3*0.8, false}});
+                     {in, 1.0-0.6, false},
+                     {in, 1.0-0.6*0.3, false},
+                     {in, 1.0-0.6*0.3*0.8, false}});
     }
 }
 
@@ -313,7 +313,7 @@ TEST(FlowTest, flow_cost) {
     std::vector<FlowStats> data = {{0.4, 1.1, 0.6}, {0.7, 1.2, 0.5}, {0.2, 1.3, 0.4}};
     EXPECT_DOUBLE_EQ(dual_ordered_cost_of<AndFlow>(data, false, false), 1.1 + 0.4*1.2 + 0.4*0.7*1.3);
     EXPECT_DOUBLE_EQ(dual_ordered_cost_of<AndFlow>(data, true, false), 0.6 + 0.4*1.2 + 0.4*0.7*1.3);
-    EXPECT_DOUBLE_EQ(dual_ordered_cost_of<OrFlow>(data, false, false), 1.1 + 0.6*1.2 + 0.6*0.3*1.3);
+    EXPECT_DOUBLE_EQ(dual_ordered_cost_of<OrFlow>(data, false, false), 1.1 + 1.2 + 1.3);
     EXPECT_DOUBLE_EQ(dual_ordered_cost_of<OrFlow>(data, true, false), 0.6 + 0.5 + 0.4);
     EXPECT_DOUBLE_EQ(dual_ordered_cost_of<AndNotFlow>(data, false, false), 1.1 + 0.4*1.2 + 0.4*0.3*1.3);
     EXPECT_DOUBLE_EQ(dual_ordered_cost_of<AndNotFlow>(data, true, false), 0.6 + 0.4*1.2 + 0.4*0.3*1.3);

--- a/searchlib/src/vespa/searchlib/queryeval/flow.h
+++ b/searchlib/src/vespa/searchlib/queryeval/flow.h
@@ -326,11 +326,7 @@ private:
     bool _strict;
 public:
     OrFlow(InFlow flow) noexcept : _flow(flow.rate()), _strict(flow.strict()) {}
-    void add(double est) noexcept {
-        if (!_strict) {
-            _flow *= (1.0 - est);
-        }
-    }
+    void add(double) noexcept {}
     double flow() const noexcept { return _flow; }
     bool strict() const noexcept { return _strict; }
     void update_cost(double &total_cost, double child_cost) noexcept {


### PR DESCRIPTION
- we still preserve sort order for optimal short-curcuiting
- this affects cost estimation and fetch postings execute info

@johansolbakken for your experiments
@arnej27959 please review