### PR TITLE
chore(query-builder): move to smaller container image

### DIFF
--- a/client/js/app/.dockerignore
+++ b/client/js/app/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+.husky
+.vscode
+.idea
+.DS_Store
+node_modules
+dist
+dist-ssr
+*.local
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+Dockerfile
+.dockerignore
+README.md

--- a/client/js/app/Dockerfile
+++ b/client/js/app/Dockerfile
@@ -1,10 +1,20 @@
-FROM  node:lts-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114
+# syntax=docker/dockerfile:1
 
-COPY . /app
+# Build stage: install deps and produce static assets.
+FROM node:lts-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114 AS builder
 
 WORKDIR /app
 
-RUN yarn install && \
-  yarn build
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --non-interactive
 
-CMD [ "yarn", "preview", "--host" ]
+COPY . .
+RUN yarn build
+
+# Runtime stage: tiny nginx serving the built SPA.
+FROM nginx:1.27-alpine-slim
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 3000

--- a/client/js/app/nginx.conf
+++ b/client/js/app/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen 3000;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /assets/ {
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## What
- Convert `client/js/app/Dockerfile` to a multi-stage build: a Node builder
  produces the Vite static bundle, `nginx:alpine-slim` serves it.
- Extract nginx config to `client/js/app/nginx.conf` with SPA fallback for
  BrowserRouter and a proper 404 for missing `/assets/*`.
- Add `client/js/app/.dockerignore` so `node_modules`, `dist`, `.git`, logs
  and editor files never enter the build context.

## Why
- The previous image shipped Node.js + full `node_modules` + sources and ran
  `vite preview`. Measured size of `ghcr.io/vespa-engine/vespa/query-builder:dev-latest`:
  **996 MB on-disk / ~424 MB pull**.
- The new image contains only static assets behind nginx:
  **~18 MB on-disk / ~8 MB pull**.
- Faster pulls and a smaller attack surface for a dev-only tool image.

## How to test
- `cd client/js/app && podman build -t query-builder:test .`
- `podman run --rm -p 3000:3000 query-builder:test`
- Verify: `/` loads, a deep-link like `/foo` serves the SPA, and a missing
  asset like `/assets/nope.js` returns 404.

## References
- Built and consumed by `.github/workflows/query-builder-container.yml`
  (port 3000 preserved).
