### PR TITLE
Avoid conflict between variable PAGE_SIZE and macro PAGE_SIZE,

### DIFF
--- a/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
+++ b/vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
@@ -90,9 +90,9 @@ TEST_F(ProcessMemoryStatsTest, parse_statm) {
     asciistream      stream(view);
 
     ProcessMemoryStats stats = ProcessMemoryStats::parseStatm(stream);
-    EXPECT_EQ(3332000 * ProcessMemoryStats::PAGE_SIZE, stats.getVirt());
-    EXPECT_EQ((1917762 - 8060) * ProcessMemoryStats::PAGE_SIZE, stats.getAnonymousRss());
-    EXPECT_EQ(8060 * ProcessMemoryStats::PAGE_SIZE, stats.getMappedRss());
+    EXPECT_EQ(3332000 * ProcessMemoryStats::normal_page_size, stats.getVirt());
+    EXPECT_EQ((1917762 - 8060) * ProcessMemoryStats::normal_page_size, stats.getAnonymousRss());
+    EXPECT_EQ(8060 * ProcessMemoryStats::normal_page_size, stats.getMappedRss());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.cpp
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.cpp
@@ -18,7 +18,7 @@ LOG_SETUP(".vespalib.util.process_memory_stats");
 
 namespace vespalib {
 
-size_t ProcessMemoryStats::PAGE_SIZE = sysconf(_SC_PAGESIZE);
+size_t ProcessMemoryStats::normal_page_size = sysconf(_SC_PAGESIZE);
 
 /*
  * The statm line looks like this:
@@ -48,13 +48,13 @@ ProcessMemoryStats ProcessMemoryStats::parseStatm(asciistream& statm) {
 
         // we only get the total program size via statm (no distinction between anonymous and non-anonymous)
         // VmSize (in status) = size (in statm)
-        ret._virt = size * PAGE_SIZE;
+        ret._virt = size * normal_page_size;
 
         // RssAnon (in status) = resident - shared (in statm)
-        ret._anonymous_rss = (resident - shared) * PAGE_SIZE;
+        ret._anonymous_rss = (resident - shared) * normal_page_size;
 
         // RssFile + RssShmem (in status) = shared (in statm)
-        ret._mapped_rss = shared * PAGE_SIZE;
+        ret._mapped_rss = shared * normal_page_size;
 
     } catch (const IllegalArgumentException& e) {
         LOG(warning, "Error '%s' while reading statm line '%s'", e.what(), statm.c_str());

--- a/vespalib/src/vespa/vespalib/util/process_memory_stats.h
+++ b/vespalib/src/vespa/vespalib/util/process_memory_stats.h
@@ -19,7 +19,7 @@ class ProcessMemoryStats {
     static ProcessMemoryStats createStatsFromStatm();
 
 public:
-    static size_t PAGE_SIZE;
+    static size_t normal_page_size;
 
     ProcessMemoryStats();
     /**


### PR DESCRIPTION
just rename the variable to normal_page_size.

@vekterli : please review
@boeker : FYI
