### PR TITLE
fast_addr_map: do not unroll address comparison loop [MERGEOK]

### DIFF
--- a/eval/src/vespa/eval/eval/fast_addr_map.h
+++ b/eval/src/vespa/eval/eval/fast_addr_map.h
@@ -87,6 +87,9 @@ public:
                 return false;
             }
             auto a_key = label_view.get_addr(a.tag.idx);
+#if !defined(__clang__) && defined(__GNUC__)
+#pragma GCC unroll 0
+#endif
             for (size_t i = 0; i < a_key.size(); ++i) {
                 if (a_key[i] != self(b.key[i])) {
                     return false;


### PR DESCRIPTION
Sparse tensors typically have 1 dimension, so the address comparison loop in Equal::operator() runs only once in the common case. GCC's default unrolling of this short, bounded loop produces larger code with no benefit in the hot path of sparse hash lookups. Disable it with #pragma GCC unroll 0, guarded to gcc only (clang does not accept this pragma).
