### PR TITLE
Fix spelling of "metadata" in DocumentIdSaver

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
@@ -18,22 +18,22 @@ namespace {
  */
 class WriteDocumentId {
     using DocumentIdStore = DocumentIdSaver::DocumentIdStore;
-    using MetaDataView = DocumentMetaStoreSaver::MetadataView;
+    using MetadataView = DocumentMetaStoreSaver::MetadataView;
     search::BufferWriter&  _writer;
-    MetaDataView           _meta_data_view;
+    MetadataView           _metadata_view;
     const DocumentIdStore& _docid_store;
 public:
-    WriteDocumentId(search::BufferWriter &writer, MetaDataView meta_data_view, const DocumentIdStore &docid_store)
+    WriteDocumentId(search::BufferWriter &writer, MetadataView metadata_view, const DocumentIdStore &docid_store)
         : _writer(writer),
-          _meta_data_view(meta_data_view),
+          _metadata_view(metadata_view),
           _docid_store(docid_store) {
     }
 
     void operator()(documentmetastore::GidToLidMapKey key) {
         auto lid = key.get_lid();
-        assert(lid < _meta_data_view.size());
-        const RawDocumentMetadata& meta_data = _meta_data_view[lid];
-        auto docid_ref = meta_data.acquire_docid_ref();
+        assert(lid < _metadata_view.size());
+        const RawDocumentMetadata& metadata = _metadata_view[lid];
+        auto docid_ref = metadata.acquire_docid_ref();
         assert(docid_ref.valid());
         auto span = _docid_store.get(docid_ref);
         size_t size = span.size();
@@ -43,9 +43,9 @@ public:
 };
 }
 
-DocumentIdSaver::DocumentIdSaver(const GidIterator &gid_iterator, MetaDataView meta_data_view, const DocumentIdSaver::DocumentIdStore& docid_store)
+DocumentIdSaver::DocumentIdSaver(const GidIterator &gid_iterator, MetadataView metadata_view, const DocumentIdSaver::DocumentIdStore& docid_store)
     : _gid_iterator(gid_iterator),
-      _meta_data_view(meta_data_view),
+      _metadata_view(metadata_view),
       _docid_store(docid_store) {
 }
 
@@ -53,7 +53,7 @@ DocumentIdSaver::~DocumentIdSaver() {
 }
 
 void DocumentIdSaver::save(search::BufferWriter& writer) const {
-    _gid_iterator.foreach_key(WriteDocumentId(writer, _meta_data_view, _docid_store));
+    _gid_iterator.foreach_key(WriteDocumentId(writer, _metadata_view, _docid_store));
     writer.flush();
 }
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.h
@@ -23,17 +23,17 @@ public:
         vespalib::btree::BTreeNoLeafData,
         vespalib::btree::NoAggregated,
         const KeyComp &>;
-    using MetaDataView = std::span<const RawDocumentMetadata>;
+    using MetadataView = std::span<const RawDocumentMetadata>;
     using TypeMapper = vespalib::datastore::ArrayStoreDynamicTypeMapper<char>;
     using DocumentIdEntryRef = vespalib::datastore::EntryRefT<19>;
     using DocumentIdStore = vespalib::datastore::ArrayStore<char, DocumentIdEntryRef, TypeMapper>;
-    DocumentIdSaver(const GidIterator &gidIterator, MetaDataView metaDataView, const DocumentIdStore& docid_store);
+    DocumentIdSaver(const GidIterator &gid_iterator, MetadataView metadata_view, const DocumentIdStore& docid_store);
     ~DocumentIdSaver();
     void save(search::BufferWriter& writer) const;
 
 private:
     GidIterator            _gid_iterator;
-    MetaDataView           _meta_data_view;
+    MetadataView           _metadata_view;
     const DocumentIdStore& _docid_store;
 };
 


### PR DESCRIPTION
Changes "meta data" to "metadata".