### PR TITLE
Remove no longer needed rosetta install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,18 +91,12 @@ for building Vespa, running unit tests and running system tests:
 brew install jenv mvnvm openjdk@17
 ```
 
-2. On ARM Macs (M1, M2 etc.), install intel compatibility since [grpc isn't properly maintained](https://github.com/grpc/grpc-java/issues/7690): 
-
-```sh
-softwareupdate --install-rosetta
-```
-
-3. For the system Java wrappers to find this JDK, symlink it with
+2. For the system Java wrappers to find this JDK, symlink it with
 ```sh
 sudo ln -sfn /opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
 ```
 
-4. Follow "Configure your shell" in https://www.jenv.be. Configuration is shell specific. For `zsh` use the below commands:
+3. Follow "Configure your shell" in https://www.jenv.be. Configuration is shell specific. For `zsh` use the below commands:
 ```sh
 echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.zshrc
 echo 'eval "$(jenv init -)"' >> ~/.zshrc
@@ -111,12 +105,12 @@ jenv enable-plugin export
 exec $SHELL -l
 ```
 
-5. Add JDK17 to jEnv
+4. Add JDK17 to jEnv
 ```sh
 jenv add $(/usr/libexec/java_home -v 17)
 ```
 
-6. Verify configuration with Maven by executing below command in the root of the source code.
+5. Verify configuration with Maven by executing below command in the root of the source code.
    Output should refer to the JDK and Maven version specified in the [.java-version](.java-version) and [mvnvm.properties](mvnvm.properties).
 ```sh
 mvn -v


### PR DESCRIPTION
https://github.com/grpc/grpc-java/issues/7690 was resolved with https://github.com/grpc/grpc-java/pull/12319 some time ago.

Verified the install/build/test steps on a M4 mac without the rosetta step.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
