### PR TITLE
Use rate() for handled.requests

### DIFF
--- a/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
@@ -106,7 +106,7 @@ public class Vespa9VespaMetricSet {
 
         addMetric(metrics, ContainerMetrics.APPLICATION_GENERATION.baseName());
 
-        addMetric(metrics, ContainerMetrics.HANDLED_REQUESTS.count());
+        addMetric(metrics, ContainerMetrics.HANDLED_REQUESTS.rate());
         addMetric(metrics, ContainerMetrics.HANDLED_LATENCY, EnumSet.of(sum, count, max));
         addMetric(metrics, ContainerMetrics.JDISC_HTTP_LATENCY, EnumSet.of(max, sum, count, ninety_five_percentile, ninety_nine_percentile));
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Rationale: count() makes sense when it is used together with sum(), to produce an average. Using count()/"reporting interval" can be used as a proxy, but that is easy to miss when setting up dashboards for the metrics