### PR TITLE
Avoid reading from docstore for visit with the field set '[id]'

### DIFF
--- a/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
+++ b/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
@@ -173,7 +173,7 @@ struct UnitDR : DocumentRetrieverBaseForTest {
     }
 };
 
-uint32_t  UnitDR::get_full_document_calls = 0;
+uint32_t UnitDR::get_full_document_calls = 0;
 
 Document::UP make_doc(DocumentId docid) {
     return Document::make_without_repo(*DataType::DOCUMENT, docid);

--- a/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
+++ b/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
@@ -109,6 +109,7 @@ IncludedVersions allV() {
 
 struct UnitDR : DocumentRetrieverBaseForTest {
     static DocumentIdT _docidCnt;
+    static uint32_t    get_full_document_calls;
 
     document::DocumentTypeRepo repo;
     document::Document::UP     document;
@@ -118,6 +119,7 @@ struct UnitDR : DocumentRetrieverBaseForTest {
     DocumentIdT                docid;
     DocumentIdT                docIdLimit;
     DocTypeName                doc_type_name;
+    bool                       enable_populate_document_metadata_docid;
 
     UnitDR();
     UnitDR(Document::UP d, Timestamp t, Bucket b, bool r);
@@ -128,6 +130,7 @@ struct UnitDR : DocumentRetrieverBaseForTest {
         return repo;
     }
     const DocTypeName& get_doc_type_name() const noexcept override { return doc_type_name; }
+    bool can_populate_document_metadata_docid() const noexcept override { return enable_populate_document_metadata_docid; }
     void getBucketMetadata(const Bucket &b, DocumentMetadata::Vector &result, bool populate_docid) const override
     {
         if (b == bucket) {
@@ -145,6 +148,9 @@ struct UnitDR : DocumentRetrieverBaseForTest {
         return DocumentMetadata();
     }
     document::Document::UP getFullDocument(DocumentIdT lid) const override {
+        if (lid == docid) {
+            ++get_full_document_calls;
+        }
         return Document::UP((lid == docid) ? document->clone() : nullptr);
     }
 
@@ -161,8 +167,13 @@ struct UnitDR : DocumentRetrieverBaseForTest {
         return res;
     }
 
-    static void reset() { _docidCnt = 2; }
+    static void reset() {
+        _docidCnt = 2;
+        get_full_document_calls = 0;
+    }
 };
+
+uint32_t  UnitDR::get_full_document_calls = 0;
 
 Document::UP make_doc(DocumentId docid) {
     return Document::make_without_repo(*DataType::DOCUMENT, docid);
@@ -171,19 +182,22 @@ Document::UP make_doc(DocumentId docid) {
 UnitDR::UnitDR()
     : repo(), document(make_doc(DocumentId())), timestamp(0),
       bucket(), removed(false), docid(0), docIdLimit(std::numeric_limits<uint32_t>::max()),
-      doc_type_name(document->getType().getName())
+      doc_type_name(document->getType().getName()),
+      enable_populate_document_metadata_docid(false)
 {}
 
 UnitDR::UnitDR(Document::UP d, Timestamp t, Bucket b, bool r)
     : repo(), document(std::move(d)), timestamp(t), bucket(b), removed(r), docid(++_docidCnt),
       docIdLimit(std::numeric_limits<uint32_t>::max()),
-      doc_type_name(document->getType().getName())
+      doc_type_name(document->getType().getName()),
+      enable_populate_document_metadata_docid(false)
 {}
 
 UnitDR::UnitDR(const DocumentType &dt, Document::UP d, Timestamp t, Bucket b, bool r)
     : repo(dt), document(std::move(d)), timestamp(t), bucket(b), removed(r), docid(++_docidCnt),
       docIdLimit(std::numeric_limits<uint32_t>::max()),
-      doc_type_name(document->getType().getName())
+      doc_type_name(document->getType().getName()),
+      enable_populate_document_metadata_docid(false)
 {
     EXPECT_EQ(doc_type_name.getName(), dt.getName());
 }
@@ -277,6 +291,9 @@ struct PairDR : DocumentRetrieverBaseForTest {
         return first->getDocumentTypeRepo();
     }
     const DocTypeName& get_doc_type_name() const noexcept override { return first->get_doc_type_name(); }
+    bool can_populate_document_metadata_docid() const noexcept override {
+        return first->can_populate_document_metadata_docid() && second->can_populate_document_metadata_docid();
+    }
     void getBucketMetadata(const Bucket &b, DocumentMetadata::Vector &result, bool populate_docid) const override {
         first->getBucketMetadata(b, result, populate_docid);
         second->getBucketMetadata(b, result, populate_docid);
@@ -327,6 +344,20 @@ rem(const DocumentId &id, Timestamp t, Bucket b) {
 IDocumentRetriever::SP
 rem(const std::string &id, Timestamp t, Bucket b) {
     return rem(DocumentId(id), t, b);
+}
+
+IDocumentRetriever::SP
+doc_with_docid(const std::string &id, Timestamp t, Bucket b, bool enable_populate_document_metadata_docid) {
+    auto dr = std::make_shared<UnitDR>(make_doc(DocumentId(id)), t, b, false);
+    dr->enable_populate_document_metadata_docid = enable_populate_document_metadata_docid;
+    return dr;
+}
+
+IDocumentRetriever::SP
+rem_with_docid(const std::string &id, Timestamp t, Bucket b, bool enable_populate_document_metadata_docid) {
+    auto dr = std::make_shared<UnitDR>(make_doc(DocumentId(id)), t, b, true);
+    dr->enable_populate_document_metadata_docid = enable_populate_document_metadata_docid;
+    return dr;
 }
 
 IDocumentRetriever::SP cat(IDocumentRetriever::SP first, IDocumentRetriever::SP second) {
@@ -432,7 +463,7 @@ void checkEntry(const IterateResult &res, size_t idx, const DocumentId &id, cons
     SCOPED_TRACE("idx=" + std::to_string(idx));
     ASSERT_LT(idx, res.getEntries().size());
     auto expect = DocEntry::create(timestamp, DocumentMetaEnum::REMOVE_ENTRY, id);
-    EXPECT_TRUE(equal(*expect, *res.getEntries()[idx]));
+    EXPECT_TRUE(equal(*expect, *res.getEntries()[idx])) << "expected " << expect->toString() << ", got " << res.getEntries()[idx]->toString();
     EXPECT_EQ(getSize(id), res.getEntries()[idx]->getSize());
     EXPECT_GT(getSize(id), 0u);
 }
@@ -514,6 +545,34 @@ TEST(DocumentIteratorTest, require_that_normal_documents_can_be_iterated)
     checkEntry(res, 0, *make_doc(DocumentId("id:ns:document::1")), Timestamp(2));
     checkEntry(res, 1, *make_doc(DocumentId("id:ns:document::2")), Timestamp(3));
     checkEntry(res, 2, *make_doc(DocumentId("id:ns:document::3")), Timestamp(4));
+}
+
+void visit_docid_only(bool enable_populate_document_metadata_docid, uint32_t exp_get_full_document_calls)
+{
+    UnitDR::reset();
+    DocumentIterator itr(bucket(5), std::make_shared<document::DocIdOnly>(), selectAll(), newestV(), -1, false);
+    itr.add(doc_with_docid("id:ns:document::1", Timestamp(2), bucket(5), enable_populate_document_metadata_docid));
+    itr.add(cat(doc_with_docid("id:ns:document::2", Timestamp(3), bucket(5), enable_populate_document_metadata_docid),
+                doc_with_docid("id:ns:document::3", Timestamp(4), bucket(5), enable_populate_document_metadata_docid)));
+    itr.add(rem_with_docid("id:ns:document::4", Timestamp(5), bucket(5), enable_populate_document_metadata_docid));
+    IterateResult res = itr.iterate(largeNum);
+    EXPECT_TRUE(res.isCompleted());
+    EXPECT_EQ(4u, res.getEntries().size());
+    checkEntry(res, 0, *make_doc(DocumentId("id:ns:document::1")), Timestamp(2));
+    checkEntry(res, 1, *make_doc(DocumentId("id:ns:document::2")), Timestamp(3));
+    checkEntry(res, 2, *make_doc(DocumentId("id:ns:document::3")), Timestamp(4));
+    checkEntry(res, 3, DocumentId("id:ns:document::4"), Timestamp(5));
+    EXPECT_EQ(exp_get_full_document_calls, UnitDR::get_full_document_calls);
+}
+
+TEST(DocumentIteratorTest, iterate_docid_only_getting_full_docs)
+{
+    visit_docid_only(false, 4);
+}
+
+TEST(DocumentIteratorTest, iterate_docid_only_skipping_full_docs)
+{
+    visit_docid_only(true, 0);
 }
 
 void verifyIterateIgnoringStopSignal(DocumentIterator & itr) {

--- a/searchcore/src/tests/proton/documentdb/bucketmover_common.h
+++ b/searchcore/src/tests/proton/documentdb/bucketmover_common.h
@@ -92,6 +92,8 @@ struct MyDocumentRetriever : public DocumentRetrieverBaseForTest {
     const DocumentTypeRepo &getDocumentTypeRepo() const override { return *_repo; }
     const DocTypeName& get_doc_type_name() const noexcept override { return _doc_type_name; }
 
+    bool can_populate_document_metadata_docid() const noexcept override { return false; }
+
     void getBucketMetadata(const storage::spi::Bucket &, DocumentMetadata::Vector &, bool) const override {}
 
     DocumentMetadata getDocumentMetadata(const DocumentId &) const override { return {}; }

--- a/searchcore/src/tests/proton/documentdb/lid_space_common.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_common.cpp
@@ -192,6 +192,8 @@ MyDocumentRetriever::getDocumentTypeRepo() const {
 
 const DocTypeName& MyDocumentRetriever::get_doc_type_name() const noexcept { return doc_type_name; }
 
+bool MyDocumentRetriever::can_populate_document_metadata_docid() const noexcept { return false; }
+
 void
 MyDocumentRetriever::getBucketMetadata(const storage::spi::Bucket&, DocumentMetadata::Vector&, bool) const {
     abort();

--- a/searchcore/src/tests/proton/documentdb/lid_space_common.h
+++ b/searchcore/src/tests/proton/documentdb/lid_space_common.h
@@ -132,6 +132,7 @@ struct MyDocumentRetriever : public DocumentRetrieverBaseForTest {
     ~MyDocumentRetriever();
     const document::DocumentTypeRepo& getDocumentTypeRepo() const override;
     const DocTypeName& get_doc_type_name() const noexcept override;
+    bool can_populate_document_metadata_docid() const noexcept override;
     void getBucketMetadata(const storage::spi::Bucket&, DocumentMetadata::Vector&, bool populate_docid) const override;
     DocumentMetadata getDocumentMetadata(const DocumentId&) const override;
     Document::UP getFullDocument(DocumentIdT lid) const override;

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller_test.cpp
@@ -153,6 +153,7 @@ struct MyDocumentRetriever : public DocumentRetrieverBaseForTest
 
     const document::DocumentTypeRepo & getDocumentTypeRepo() const override { abort(); }
     const DocTypeName& get_doc_type_name() const noexcept override { return _doc_type_name; }
+    bool can_populate_document_metadata_docid() const noexcept override { return false; }
     void getBucketMetadata(const storage::spi::Bucket &, DocumentMetadata::Vector &, bool) const override { abort(); }
     DocumentMetadata getDocumentMetadata(const DocumentId &) const override { return {}; }
     Document::UP getFullDocument(DocumentIdT lid) const override { return _subDB.getDocument(lid); }

--- a/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
@@ -120,6 +120,7 @@ struct MyDocumentRetriever : DocumentRetrieverBaseForTest {
         return repo;
     }
     const DocTypeName& get_doc_type_name() const noexcept override { return doc_type_name; }
+    bool can_populate_document_metadata_docid() const noexcept override { return false; }
     void getBucketMetadata(const storage::spi::Bucket &, search::DocumentMetadata::Vector &v, bool) const override {
         if (document != nullptr) {
             v.push_back(getDocumentMetadata(document->getId()));

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/commit_and_wait_document_retriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/commit_and_wait_document_retriever.cpp
@@ -27,6 +27,10 @@ CommitAndWaitDocumentRetriever::getBucketMetadata(const Bucket &bucket, search::
     return _retriever->getBucketMetadata(bucket, result, populate_docid);
 }
 
+bool CommitAndWaitDocumentRetriever::can_populate_document_metadata_docid() const noexcept {
+    return _retriever->can_populate_document_metadata_docid();
+}
+
 search::DocumentMetadata
 CommitAndWaitDocumentRetriever::getDocumentMetadata(const document::DocumentId &id) const {
     return _retriever->getDocumentMetadata(id);

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/commit_and_wait_document_retriever.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/commit_and_wait_document_retriever.h
@@ -24,6 +24,7 @@ public:
     const document::DocumentTypeRepo &getDocumentTypeRepo() const override;
     const DocTypeName& get_doc_type_name() const noexcept override;
     void getBucketMetadata(const Bucket &bucket, search::DocumentMetadata::Vector &result, bool populate_docid) const override;
+    bool can_populate_document_metadata_docid() const noexcept override;
     search::DocumentMetadata getDocumentMetadata(const document::DocumentId &id) const override;
     DocumentUP getFullDocument(search::DocumentIdT lid) const override;
     DocumentUP getPartialDocument(search::DocumentIdT lid, const document::DocumentId & docId, const document::FieldSet & fieldSet) const override;

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.cpp
@@ -313,7 +313,7 @@ DocumentIterator::fetchCompleteSource(const DocTypeName & doc_type_name,
                 list.push_back(DocEntry::create(Timestamp(meta.timestamp), DocumentMetaEnum::REMOVE_ENTRY, docid));
             } else {
                 auto doc = std::make_unique<Document>(repo, *document_type, docid);
-                list.push_back(createDocEntry(Timestamp(meta.timestamp), meta.removed, std::move(doc), _defaultSerializedSize));
+                list.push_back(createDocEntry(Timestamp(meta.timestamp), false, std::move(doc), _defaultSerializedSize));
             }
         }
     } else {

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.cpp
@@ -6,6 +6,8 @@
 #include <vespa/searchcore/proton/common/cachedselect.h>
 #include <vespa/searchcore/proton/common/doctypename.h>
 #include <vespa/searchcore/proton/common/selectcontext.h>
+#include <vespa/document/datatype/documenttype.h>
+#include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/select/gid_filter.h>
 #include <vespa/document/select/node.h>
 #include <vespa/document/fieldvalue/document.h>
@@ -89,6 +91,7 @@ DocumentIterator::DocumentIterator(const storage::spi::Bucket &bucket,
       _defaultSerializedSize((readConsistency == ReadConsistency::WEAK) ? defaultSerializedSize : -1),
       _readConsistency(readConsistency),
       _metaOnly(_fields->getType() == document::FieldSet::Type::NONE),
+      _use_populated_docids(_fields->getType() == document::FieldSet::Type::DOCID),
       _ignoreMaxBytes((readConsistency == ReadConsistency::WEAK) && ignoreMaxBytes),
       _fetchedData(false),
       _sources(),
@@ -140,17 +143,19 @@ namespace {
 class Matcher {
 public:
     Matcher(const IDocumentRetriever &source, bool metaOnly, const std::string &selection) :
-        _dscTrue(true),
+        _document_selection_always_true(true),
         _metaOnly(metaOnly),
+        _needs_document(false),
         _willAlwaysFail(false),
         _docidLimit(source.getDocIdLimit())
     {
         if (!(_metaOnly || selection.empty())) {
             LOG(spam, "ParseSelect: %s", selection.c_str());
             _cachedSelect = source.parseSelect(selection);
-            _dscTrue = _cachedSelect->is_always_true();
+            _needs_document = _cachedSelect->needs_document();
+            _document_selection_always_true = _cachedSelect->is_always_true();
             if (_cachedSelect->is_always_false() || _cachedSelect->is_always_invalid()) {
-                assert(!_dscTrue);
+                assert(!_document_selection_always_true);
                 LOG(debug, "Nothing will ever match cs.allFalse = '%d', cs.allInvalid = '%d'",
                     _cachedSelect->is_always_false(), _cachedSelect->is_always_invalid());
                 _willAlwaysFail = true;
@@ -162,7 +167,7 @@ public:
                 _selectCxt->getAttributeGuards();
             }
         } else {
-            _dscTrue = true;
+            _document_selection_always_true = true;
         }
     }
     
@@ -173,12 +178,13 @@ public:
     }
 
     [[nodiscard]] bool willAlwaysFail() const noexcept { return _willAlwaysFail; }
+    [[nodiscard]] bool needs_document() const noexcept { return _needs_document; }
 
     [[nodiscard]] bool match(const search::DocumentMetadata & meta) const {
         if (meta.lid >= _docidLimit) {
             return false;
         }
-        if (_dscTrue || _metaOnly) {
+        if (_document_selection_always_true || _metaOnly) {
             return true;
         }
         if (!_gidFilter.gid_might_match_selection(meta.gid)) {
@@ -190,7 +196,7 @@ public:
         return _selectSession->contains_pre_doc(*_selectCxt);
     }
     [[nodiscard]] bool match(const search::DocumentMetadata & meta, const Document * doc) const {
-        if (_dscTrue || _metaOnly) {
+        if (_document_selection_always_true || _metaOnly) {
             return true;
         }
         assert(_selectCxt);
@@ -199,8 +205,9 @@ public:
         return (doc && (doc->getId().getGlobalId() == meta.gid) && _selectSession->contains_doc(*_selectCxt));
     }
 private:
-    bool                           _dscTrue;
+    bool                           _document_selection_always_true;
     bool                           _metaOnly;
+    bool                           _needs_document;
     bool                           _willAlwaysFail;
     uint32_t                       _docidLimit;
     CachedSelect::SP               _cachedSelect;
@@ -233,7 +240,7 @@ public:
             if (doc && _fields) {
                 document::FieldSet::stripFields(*doc, *_fields);
             }
-            _list.push_back(createDocEntry(storage::spi::Timestamp(meta.timestamp), meta.removed, std::move(doc), _defaultSerializedSize));
+            _list.push_back(createDocEntry(Timestamp(meta.timestamp), meta.removed, std::move(doc), _defaultSerializedSize));
         }
     }
 
@@ -260,7 +267,8 @@ DocumentIterator::fetchCompleteSource(const DocTypeName & doc_type_name,
 {
     IDocumentRetriever::ReadGuard sourceReadGuard(source.getReadGuard());
     search::DocumentMetadata::Vector metadata;
-    source.getBucketMetadata(_bucket, metadata, false);
+    bool populate_document_metadata_docids = _use_populated_docids && source.can_populate_document_metadata_docid();
+    source.getBucketMetadata(_bucket, metadata, populate_document_metadata_docids);
     if (metadata.empty()) {
         return;
     }
@@ -290,7 +298,23 @@ DocumentIterator::fetchCompleteSource(const DocTypeName & doc_type_name,
         for (uint32_t lid : lidsToFetch) {
             const search::DocumentMetadata & meta = metadata[lidIndexMap[lid]];
             assert(lid == meta.lid);
-            list.push_back(createDocEntry(storage::spi::Timestamp(meta.timestamp), meta.removed, doc_type_name.getName(), meta.gid));
+            list.push_back(createDocEntry(Timestamp(meta.timestamp), meta.removed, doc_type_name.getName(), meta.gid));
+        }
+    } else if (populate_document_metadata_docids && !matcher.needs_document()) {
+        auto& repo = source.getDocumentTypeRepo();
+        auto document_type = repo.getDocumentType(doc_type_name.getName());
+        assert(document_type != nullptr);
+        for (uint32_t lid : lidsToFetch) {
+            const search::DocumentMetadata & meta = metadata[lidIndexMap[lid]];
+            assert(lid == meta.lid);
+            DocumentId docid(meta.docid);
+            assert(docid.getGlobalId() == meta.gid);
+            if (meta.removed) {
+                list.push_back(DocEntry::create(Timestamp(meta.timestamp), DocumentMetaEnum::REMOVE_ENTRY, docid));
+            } else {
+                auto doc = std::make_unique<Document>(repo, *document_type, docid);
+                list.push_back(createDocEntry(Timestamp(meta.timestamp), meta.removed, std::move(doc), _defaultSerializedSize));
+            }
         }
     } else {
         MatchVisitor visitor(matcher, metadata, lidIndexMap, _fields.get(), list, _defaultSerializedSize);

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.h
@@ -28,6 +28,7 @@ private:
     const ssize_t                         _defaultSerializedSize;
     const ReadConsistency                 _readConsistency;
     const bool                            _metaOnly;
+    const bool                            _use_populated_docids;
     const bool                            _ignoreMaxBytes;
     bool                                  _fetchedData;
     std::vector<DocTypeNameAndRetriever>  _sources;

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/i_document_retriever.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/i_document_retriever.h
@@ -36,6 +36,7 @@ public:
 
     virtual const document::DocumentTypeRepo & getDocumentTypeRepo() const = 0;
     virtual const DocTypeName& get_doc_type_name() const noexcept = 0;
+    virtual bool can_populate_document_metadata_docid() const noexcept = 0;
     virtual void getBucketMetadata(const storage::spi::Bucket &bucket, search::DocumentMetadata::Vector &result, bool populate_docid) const = 0;
     virtual search::DocumentMetadata getDocumentMetadata(const document::DocumentId &id) const = 0;
     /**

--- a/searchcore/src/vespa/searchcore/proton/server/documentretrieverbase.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretrieverbase.cpp
@@ -17,6 +17,7 @@ DocumentRetrieverBase::DocumentRetrieverBase(const DocTypeName &docTypeName, con
       _docTypeName(docTypeName),
       _repo(repo),
       _meta_store(meta_store),
+      _can_populate_document_metadata_docid(_meta_store.can_populate_document_metadata_docid()),
       _selectCache(256u),
       _lock(),
       _emptyDoc(),
@@ -27,6 +28,10 @@ DocumentRetrieverBase::DocumentRetrieverBase(const DocTypeName &docTypeName, con
 }
 
 DocumentRetrieverBase::~DocumentRetrieverBase() = default;
+
+bool DocumentRetrieverBase::can_populate_document_metadata_docid() const noexcept {
+    return _can_populate_document_metadata_docid;
+}
 
 void
 DocumentRetrieverBase::getBucketMetadata(const storage::spi::Bucket &bucket,

--- a/searchcore/src/vespa/searchcore/proton/server/documentretrieverbase.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretrieverbase.h
@@ -16,6 +16,7 @@ class DocumentRetrieverBase : public IDocumentRetriever
     const DocTypeName                &_docTypeName;
     const document::DocumentTypeRepo &_repo;
     const IDocumentMetaStoreContext  &_meta_store;
+    const bool                        _can_populate_document_metadata_docid;
 
     using SelectCache = vespalib::lrucache_map<vespalib::LruParam<std::string, CachedSelect::SP>>;
 
@@ -38,6 +39,7 @@ public:
 
     const document::DocumentTypeRepo &getDocumentTypeRepo() const override { return _repo; }
     const DocTypeName& get_doc_type_name() const noexcept override { return _docTypeName; }
+    virtual bool can_populate_document_metadata_docid() const noexcept override;
     void getBucketMetadata(const storage::spi::Bucket &bucket, search::DocumentMetadata::Vector &result, bool populate_docid) const override;
     search::DocumentMetadata getDocumentMetadata(const document::DocumentId &id) const override;
     CachedSelect::SP parseSelect(const std::string &selection) const override;


### PR DESCRIPTION
if document meta store contains document ids.

@boeker and @vekterli : please review
