### PR TITLE
Update commons-io to 2.21.0

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -77,7 +77,7 @@
         <commons-collections.vespa.version>3.2.2</commons-collections.vespa.version>
         <commons-csv.vespa.version>1.11.0</commons-csv.vespa.version>
         <commons-digester.vespa.version>3.2</commons-digester.vespa.version>
-        <commons-io.vespa.version>2.16.1</commons-io.vespa.version>
+        <commons-io.vespa.version>2.21.0</commons-io.vespa.version>
         <commons-lang3.vespa.version>3.18.0</commons-lang3.vespa.version>
         <commons-logging.vespa.version>1.3.3</commons-logging.vespa.version>  <!-- Bindings exported by jdisc through jcl-over-slf4j. -->
         <commons.math3.vespa.version>3.6.1</commons.math3.vespa.version>


### PR DESCRIPTION
Bump commons-io from 2.16.1 to 2.21.0.