### PR TITLE
Update httpclient5 to 5.6.1 and httpcore5 to 5.4.2

### DIFF
--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/Http2IT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/Http2IT.java
@@ -83,7 +83,7 @@ class Http2IT {
         var driver = createSslTestDriver(certificateFile, privateKeyFile, metricConsumer, connectionLog);
         var tlsStrategy = ClientTlsStrategyBuilder.create()
                 .setSslContext(driver.sslContext())
-                .build();
+                .buildAsync();
         try (var client = H2AsyncClientBuilder.create()
                 .setTlsStrategy(tlsStrategy)
                 .disableAutomaticRetries()

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/Utils.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/Utils.java
@@ -73,7 +73,7 @@ class Utils {
     static CloseableHttpAsyncClient createHttp2Client(JettyTestDriver driver) {
         TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
                 .setSslContext(driver.sslContext())
-                .build();
+                .buildAsync();
         var client = H2AsyncClientBuilder.create()
                 .disableAutomaticRetries()
                 .setTlsStrategy(tlsStrategy)

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -63,8 +63,8 @@
         <antlr4.vespa.version>4.13.2</antlr4.vespa.version>
         <apache.httpclient.vespa.version>4.5.14</apache.httpclient.vespa.version>
         <apache.httpcore.vespa.version>4.4.16</apache.httpcore.vespa.version>
-        <apache.httpclient5.vespa.version>5.4.4</apache.httpclient5.vespa.version>
-        <apache.httpcore5.vespa.version>5.3.4</apache.httpcore5.vespa.version>
+        <apache.httpclient5.vespa.version>5.6.1</apache.httpclient5.vespa.version>
+        <apache.httpcore5.vespa.version>5.4.2</apache.httpcore5.vespa.version>
         <apiguardian.vespa.version>1.1.2</apiguardian.vespa.version>
         <asm.vespa.version>9.9</asm.vespa.version>
         <assertj.vespa.version>3.27.7</assertj.vespa.version>

--- a/http-utils/src/main/java/ai/vespa/util/http/hc5/VespaAsyncHttpClientBuilder.java
+++ b/http-utils/src/main/java/ai/vespa/util/http/hc5/VespaAsyncHttpClientBuilder.java
@@ -52,12 +52,12 @@ public class VespaAsyncHttpClientBuilder {
                     .setSslContext(vespaTlsContext.sslContext().context())
                     .setTlsVersions(vespaTlsParameters.getProtocols())
                     .setCiphers(vespaTlsParameters.getCipherSuites())
-                    .build();
+                    .buildAsync();
             if (TransportSecurityUtils.getInsecureMixedMode() != MixedMode.PLAINTEXT_CLIENT_MIXED_SERVER) {
                 clientBuilder.setRoutePlanner(new HttpToHttpsRoutePlanner());
             }
         } else {
-            tlsStrategy = ClientTlsStrategyBuilder.create().build();
+            tlsStrategy = ClientTlsStrategyBuilder.create().buildAsync();
         }
         clientBuilder.disableConnectionState(); // Share connections between subsequent requests
         clientBuilder.disableCookieManagement();


### PR DESCRIPTION
Bump httpclient5 from 5.4.4 to 5.6.1 and httpcore5 from 5.3.4 to 5.4.2 (released together).