### PR TITLE
[codex] Propose generative retrieval interfaces for semantic IDs

### DIFF
--- a/linguistics/src/main/java/com/yahoo/language/process/DiscreteSequence.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/DiscreteSequence.java
@@ -1,0 +1,41 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.language.process;
+
+import com.yahoo.api.annotations.Beta;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A discrete sequence produced by quantization or sequence generation.
+ *
+ * @author gdonovan
+ */
+@Beta
+public record DiscreteSequence(List<Integer> tokenIds, List<String> tokenStrings) {
+
+    public DiscreteSequence {
+        tokenIds = List.copyOf(Objects.requireNonNull(tokenIds));
+        tokenStrings = List.copyOf(Objects.requireNonNull(tokenStrings));
+        if (!tokenStrings.isEmpty() && tokenStrings.size() != tokenIds.size()) {
+            throw new IllegalArgumentException("tokenStrings must be empty or have the same size as tokenIds");
+        }
+    }
+
+    public static DiscreteSequence of(List<Integer> tokenIds) {
+        return new DiscreteSequence(tokenIds, List.of());
+    }
+
+    public boolean hasTokenStrings() {
+        return !tokenStrings.isEmpty();
+    }
+
+    public String asText(String delimiter) {
+        Objects.requireNonNull(delimiter);
+        if (hasTokenStrings()) {
+            return String.join(delimiter, tokenStrings);
+        }
+        return tokenIds.stream().map(String::valueOf).collect(Collectors.joining(delimiter));
+    }
+}

--- a/linguistics/src/main/java/com/yahoo/language/process/Quantizer.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/Quantizer.java
@@ -1,0 +1,94 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.language.process;
+
+import com.yahoo.api.annotations.Beta;
+import com.yahoo.tensor.Tensor;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Converts embeddings into discrete token sequences, such as semantic IDs.
+ *
+ * @author gdonovan
+ */
+@Beta
+public interface Quantizer {
+
+    /** ID of quantizer when none is explicitly given. */
+    String defaultQuantizerId = "default";
+
+    /** An instance of this which throws IllegalStateException if attempted used. */
+    Quantizer throwsOnUse = new FailingQuantizer();
+
+    /** Returns this quantizer instance as a map with the default quantizer name. */
+    default Map<String, Quantizer> asMap() {
+        return asMap(defaultQuantizerId);
+    }
+
+    /** Returns this quantizer instance as a map with the given name. */
+    default Map<String, Quantizer> asMap(String name) {
+        return Map.of(name, this);
+    }
+
+    DiscreteSequence quantize(Tensor embedding, Context context);
+
+    class Context extends InvocationContext<Context> {
+
+        public Context(String destination) {
+            super(destination);
+        }
+
+        public Context(String destination, Map<Object, Object> cache) {
+            super(destination, cache);
+        }
+
+        public Context(Context other) {
+            super(other);
+        }
+
+        public Context copy() {
+            return new Context(this);
+        }
+
+        /** Return the component id or 'unknown' if not set. */
+        public String getQuantizerId() { return getComponentId(); }
+
+        /** Sets the component id. */
+        public Context setQuantizerId(String componentId) {
+            return setComponentId(componentId);
+        }
+    }
+
+    class FailingQuantizer implements Quantizer {
+
+        private final String message;
+
+        public FailingQuantizer() {
+            this("No quantizer has been configured");
+        }
+
+        public FailingQuantizer(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public DiscreteSequence quantize(Tensor embedding, Context context) {
+            throw new IllegalStateException(message);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof FailingQuantizer;
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().getName().hashCode();
+        }
+
+        public static Function<String, Quantizer> factory() {
+            return FailingQuantizer::new;
+        }
+    }
+}

--- a/linguistics/src/main/java/com/yahoo/language/process/SequenceGenerator.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/SequenceGenerator.java
@@ -1,0 +1,133 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.language.process;
+
+import ai.vespa.llm.completion.Completion;
+import ai.vespa.llm.completion.Prompt;
+import com.yahoo.api.annotations.Beta;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Generates scored discrete token sequences from prompts.
+ *
+ * @author gdonovan
+ */
+@Beta
+public interface SequenceGenerator {
+
+    /** ID of generator when none is explicitly given. */
+    String defaultGeneratorId = "default";
+
+    /** An instance of this which throws IllegalStateException if attempted used. */
+    SequenceGenerator throwsOnUse = new FailingSequenceGenerator();
+
+    /** Returns this generator instance as a map with the default generator name. */
+    default Map<String, SequenceGenerator> asMap() {
+        return asMap(defaultGeneratorId);
+    }
+
+    /** Returns this generator instance as a map with the given name. */
+    default Map<String, SequenceGenerator> asMap(String name) {
+        return Map.of(name, this);
+    }
+
+    List<GeneratedSequence> generate(Prompt prompt, Context context, Options options);
+
+    record Options(int maxTokens, int beamWidth, int maxSequences, TokenConstraint constraint) {
+        public static final Options DEFAULT = new Options(16, 1, 1, TokenConstraint.none());
+
+        public Options {
+            if (maxTokens <= 0) throw new IllegalArgumentException("maxTokens must be positive");
+            if (beamWidth <= 0) throw new IllegalArgumentException("beamWidth must be positive");
+            if (maxSequences <= 0) throw new IllegalArgumentException("maxSequences must be positive");
+            constraint = Objects.requireNonNullElse(constraint, TokenConstraint.none());
+        }
+    }
+
+    record GeneratedSequence(DiscreteSequence sequence, double score, Completion.FinishReason finishReason) {
+        public GeneratedSequence {
+            sequence = Objects.requireNonNull(sequence);
+            finishReason = Objects.requireNonNull(finishReason);
+        }
+    }
+
+    @FunctionalInterface
+    interface TokenConstraint {
+
+        boolean isAllowed(List<Integer> prefix, int tokenId);
+
+        /**
+         * Returns whether the current prefix is a valid completed sequence.
+         * For constrained SID decoding this can be backed by a prefix trie.
+         */
+        default boolean isComplete(List<Integer> prefix) {
+            return true;
+        }
+
+        static TokenConstraint none() {
+            return (prefix, tokenId) -> true;
+        }
+    }
+
+    class Context extends InvocationContext<Context> {
+
+        public Context(String destination) {
+            super(destination);
+        }
+
+        public Context(String destination, Map<Object, Object> cache) {
+            super(destination, cache);
+        }
+
+        public Context(Context other) {
+            super(other);
+        }
+
+        public Context copy() {
+            return new Context(this);
+        }
+
+        /** Return the component id or 'unknown' if not set. */
+        public String getSequenceGeneratorId() { return getComponentId(); }
+
+        /** Sets the component id. */
+        public Context setSequenceGeneratorId(String componentId) {
+            return setComponentId(componentId);
+        }
+    }
+
+    class FailingSequenceGenerator implements SequenceGenerator {
+
+        private final String message;
+
+        public FailingSequenceGenerator() {
+            this("No sequence generator has been configured");
+        }
+
+        public FailingSequenceGenerator(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public List<GeneratedSequence> generate(Prompt prompt, Context context, Options options) {
+            throw new IllegalStateException(message);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof FailingSequenceGenerator;
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().getName().hashCode();
+        }
+
+        public static Function<String, SequenceGenerator> factory() {
+            return FailingSequenceGenerator::new;
+        }
+    }
+}

--- a/linguistics/src/test/java/com/yahoo/language/process/DiscreteSequenceTest.java
+++ b/linguistics/src/test/java/com/yahoo/language/process/DiscreteSequenceTest.java
@@ -1,0 +1,25 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.language.process;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DiscreteSequenceTest {
+
+    @Test
+    void renders_token_strings_when_present() {
+        var sequence = new DiscreteSequence(List.of(1, 2, 3), List.of("<cb0_1>", "<cb1_2>", "<cb2_3>"));
+
+        assertEquals("<cb0_1> <cb1_2> <cb2_3>", sequence.asText(" "));
+    }
+
+    @Test
+    void falls_back_to_numeric_tokens() {
+        var sequence = DiscreteSequence.of(List.of(1, 2, 3));
+
+        assertEquals("1,2,3", sequence.asText(","));
+    }
+}

--- a/proposals/semantic-id-generative-retrieval.md
+++ b/proposals/semantic-id-generative-retrieval.md
@@ -1,0 +1,246 @@
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+
+# Proposal: Structured Generative Retrieval and Semantic IDs
+
+Status: Draft
+
+## Motivation
+
+Vespa already has strong support for encoder-style model integration:
+
+- `Embedder`: one text input to one tensor or token sequence
+- `FieldGenerator`: indexing-time prompt to field value generation
+- `LanguageModel`: prompt to text completion
+
+This fits SPLADE and dense embedding well, but it does not fit a Semantic ID or GenSearch style flow where:
+
+1. Indexing quantizes an embedding into a discrete multi-level code.
+2. Query serving builds a structured prompt from user taste, recent actions, context, and query text.
+3. A generative model returns multiple scored SID candidates through beam search.
+4. Generation may be constrained by a prefix trie so every beam remains on a valid SID path.
+5. Generated SIDs are resolved to candidate documents, optionally with prefix backoff.
+
+The current model APIs do not represent that flow directly.
+
+## Why Current APIs Are Not Enough
+
+### `Embedder` is the wrong shape
+
+`Embedder` assumes `text -> tensor` or `text -> token ids`.
+
+That works for SPLADE because SPLADE is still one input string to one sparse tensor. A SID generator is different:
+
+- input is not just one text string
+- output is not one tensor
+- serving needs multiple scored sequences, not just one embedding
+- constrained decoding is part of generation
+
+Trying to force this into `Embedder` would overload it with behavior that is not embedding.
+
+### `FieldGenerator` is indexing-only
+
+`FieldGenerator` is useful for document processing, but it is tied to "generate a field value for a destination field". It is not a reusable query-time API for returning beams, token ids, or decoding constraints.
+
+### `LanguageModel` is too text-centric
+
+`LanguageModel` currently returns text completions only. It has no first-class support for:
+
+- structured prompt sections
+- returning token ids alongside text
+- beam search results
+- constrained decoding
+- SID-specific post-processing
+
+## Requirements From Semantic ID / GenSearch Workloads
+
+For the motivating workload described in `Semantic IDs and GenSearch.md`, Vespa needs to support:
+
+- `embedding -> SID` quantization at indexing time
+- structured prompts such as `user taste </s> recent actions </s> context </s> query`
+- multiple scored output sequences at serving time
+- optional constrained beam search using a prefix trie
+- application-level or future built-in `SID -> candidates` lookup
+
+The important design point is that these are additive capabilities. They should not weaken or complicate the existing encoder-style APIs.
+
+## Proposed Additions
+
+### 1. `StructuredPrompt`
+
+Add a prompt type that keeps ordered named sections while still being serializable to a flat string.
+
+This lets applications build prompts like:
+
+```java
+StructuredPrompt prompt = StructuredPrompt.builder()
+        .add("user-taste", userTaste)
+        .add("recent-actions", recentActions)
+        .add("context", context)
+        .add("query", query)
+        .separator(" </s> ")
+        .build();
+```
+
+This is useful even outside generative retrieval and can coexist with `StringPrompt`.
+
+### 2. `Quantizer`
+
+Add an indexing-time component contract for `Tensor -> DiscreteSequence`.
+
+This is the missing counterpart to `Embedder`. It separates:
+
+- encoder models that create embeddings
+- quantizers that convert embeddings into semantic IDs or other discrete paths
+
+Near term, this can be used from custom indexing components or processors. A future indexing expression could expose it more directly.
+
+### 3. `SequenceGenerator`
+
+Add a query-time contract for discrete generation:
+
+- prompt in
+- beams out
+- token ids included
+- optional decoding constraint
+
+This is the core missing runtime surface for SID generation.
+
+The proposed API is intentionally lower-level than retrieval. It stops at sequence generation and does not try to own result set semantics yet.
+
+### 4. Keep candidate lookup above the generator, initially
+
+The `SID -> document ids` lookup and prefix backoff logic should initially live one layer above `SequenceGenerator`, likely in a searcher or application component.
+
+That keeps the first API addition narrow:
+
+- `Quantizer` owns indexing-time discrete encoding
+- `SequenceGenerator` owns query-time sequence generation
+- lookup and retrieval policy remain composable
+
+If this becomes a broadly used serving pattern, Vespa can later add a higher-level `SequenceResolver` or `GenerativeRetriever`.
+
+## Example Flows
+
+### Indexing flow
+
+```java
+Tensor embedding = embedder.embed(text, embedContext, tensorType);
+DiscreteSequence sid = quantizer.quantize(embedding, new Quantizer.Context("listing.sid"));
+```
+
+Document fields can then store:
+
+- full SID tokens
+- prefix fields
+- optional rendered SID text
+
+### Query flow
+
+```java
+StructuredPrompt prompt = StructuredPrompt.builder()
+        .add("user-taste", userTaste)
+        .add("recent-actions", recentActions)
+        .add("context", context)
+        .add("query", query)
+        .separator(" </s> ")
+        .build();
+
+List<SequenceGenerator.GeneratedSequence> beams =
+        generator.generate(prompt,
+                           new SequenceGenerator.Context("query(sids)"),
+                           new SequenceGenerator.Options(8, 128, 128, trieConstraint));
+```
+
+The application or searcher then:
+
+1. resolves generated SID sequences
+2. applies exact match or prefix backoff policy
+3. turns those candidates into retrieval or ranking inputs
+
+## Proposed Configuration Surface
+
+The first implementation does not need new XML syntax. It can use the existing generic component mechanism:
+
+```xml
+<container version="1.0">
+    <component id="sid-quantizer"
+               class="ai.vespa.semanticid.ResidualQuantizer"
+               bundle="semanticid">
+        <config name="ai.vespa.semanticid.quantizer">
+            <codebook path="models/codebook.json"/>
+        </config>
+    </component>
+
+    <component id="sid-generator"
+               class="ai.vespa.semanticid.OnnxSequenceGenerator"
+               bundle="semanticid">
+        <config name="ai.vespa.semanticid.generator">
+            <model path="models/qwen-sid.onnx"/>
+            <tokenizer path="models/tokenizer.json"/>
+            <prefix-trie path="models/sid-prefix-trie.bin"/>
+        </config>
+    </component>
+</container>
+```
+
+If this proves broadly useful, Vespa can later add typed components similar to `splade-embedder`, for example:
+
+```xml
+<container version="1.0">
+    <component id="sid-quantizer" type="semantic-id-quantizer">
+        <codebook-model path="models/codebook.json"/>
+    </component>
+
+    <component id="sid-generator" type="sequence-generator">
+        <transformer-model path="models/qwen-sid.onnx"/>
+        <tokenizer-model path="models/tokenizer.json"/>
+        <prefix-trie path="models/sid-prefix-trie.bin"/>
+    </component>
+</container>
+```
+
+## Scope Of This PR
+
+This draft PR adds only proposal-level API sketches:
+
+- `StructuredPrompt`
+- `DiscreteSequence`
+- `Quantizer`
+- `SequenceGenerator`
+
+It does not:
+
+- add indexing language syntax
+- add query language syntax
+- add config-model typed components
+- add trie-aware decoding implementations
+- add searcher integration
+
+That is deliberate. The goal is to let the Vespa team review the API shape before plumbing it through runtime and config layers.
+
+## Design Principles
+
+- Keep encoder-style APIs simple and unchanged.
+- Add discrete generation as a parallel capability, not a special case of embedding.
+- Make structured prompts first-class, but still serializable to plain strings.
+- Separate generation from candidate resolution.
+- Allow constrained decoding without forcing it.
+
+## Open Questions
+
+1. Should `SequenceGenerator` live beside `LanguageModel`, or stay aligned with `Embedder` and `FieldGenerator` under `com.yahoo.language.process`?
+2. Should a future query syntax expose this directly, or should it remain a searcher-level capability?
+3. Should constrained decoding be modeled as a generic token constraint, or should there be a stronger trie-specific abstraction?
+4. When productized, should candidate lookup/backoff remain outside the generator, or become a first-class `GenerativeRetriever` component?
+5. Should a future indexing expression expose quantization directly, for example `quantize(quantizer-id)`?
+
+## Relation To SPLADE
+
+SPLADE should remain in the current embedder framework. It is still an encoder-style model: one string in, one sparse tensor out.
+
+Semantic ID generation is different enough that it deserves a separate API:
+
+- indexing side: `embedding -> discrete sequence`
+- query side: `structured prompt -> scored discrete sequences`
+
+That keeps both abstractions honest.

--- a/vespajlib/src/main/java/ai/vespa/llm/completion/StructuredPrompt.java
+++ b/vespajlib/src/main/java/ai/vespa/llm/completion/StructuredPrompt.java
@@ -1,0 +1,103 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.llm.completion;
+
+import com.yahoo.api.annotations.Beta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A prompt consisting of ordered named sections that can still be rendered as a flat string.
+ *
+ * @author gdonovan
+ */
+@Beta
+public class StructuredPrompt extends Prompt {
+
+    private final List<Section> sections;
+    private final String separator;
+
+    private StructuredPrompt(List<Section> sections, String separator) {
+        this.sections = List.copyOf(sections);
+        this.separator = Objects.requireNonNull(separator);
+        if (this.sections.isEmpty()) {
+            throw new IllegalArgumentException("StructuredPrompt requires at least one section");
+        }
+    }
+
+    public List<Section> sections() { return sections; }
+
+    public String separator() { return separator; }
+
+    @Override
+    public String asString() {
+        return sections.stream()
+                       .map(Section::text)
+                       .collect(Collectors.joining(separator));
+    }
+
+    @Override
+    public StructuredPrompt append(String text) {
+        Objects.requireNonNull(text);
+        var updated = new ArrayList<>(sections);
+        var lastSection = updated.remove(updated.size() - 1);
+        updated.add(lastSection.append(text));
+        return new StructuredPrompt(updated, separator);
+    }
+
+    /** Returns a new prompt with a new section appended at the end. */
+    public StructuredPrompt append(String name, String text) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(text);
+        var updated = new ArrayList<>(sections);
+        updated.add(new Section(name, text));
+        return new StructuredPrompt(updated, separator);
+    }
+
+    @Override
+    public String toString() {
+        return asString();
+    }
+
+    public static StructuredPrompt of(List<Section> sections) {
+        return new StructuredPrompt(sections, "\n");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public record Section(String name, String text) {
+
+        public Section {
+            name = Objects.requireNonNull(name);
+            text = Objects.requireNonNull(text);
+        }
+
+        private Section append(String suffix) {
+            return new Section(name, text + suffix);
+        }
+    }
+
+    public static class Builder {
+
+        private final List<Section> sections = new ArrayList<>();
+        private String separator = "\n";
+
+        public Builder add(String name, String text) {
+            sections.add(new Section(name, text));
+            return this;
+        }
+
+        public Builder separator(String separator) {
+            this.separator = Objects.requireNonNull(separator);
+            return this;
+        }
+
+        public StructuredPrompt build() {
+            return new StructuredPrompt(sections, separator);
+        }
+    }
+}

--- a/vespajlib/src/test/java/ai/vespa/llm/completion/StructuredPromptTest.java
+++ b/vespajlib/src/test/java/ai/vespa/llm/completion/StructuredPromptTest.java
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.llm.completion;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StructuredPromptTest {
+
+    @Test
+    void renders_sections_in_order() {
+        var prompt = StructuredPrompt.builder()
+                                     .add("user-taste", "bags")
+                                     .add("recent-actions", "view: <cb0_1>")
+                                     .add("query", "leather messenger bag")
+                                     .separator(" </s> ")
+                                     .build();
+
+        assertEquals("bags </s> view: <cb0_1> </s> leather messenger bag", prompt.asString());
+    }
+
+    @Test
+    void append_text_updates_last_section() {
+        var prompt = StructuredPrompt.builder()
+                                     .add("query", "leather")
+                                     .build()
+                                     .append(" messenger bag");
+
+        assertEquals("leather messenger bag", prompt.asString());
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a draft proposal and small API sketches for supporting Semantic ID and GenSearch style retrieval in Vespa without overloading the existing embedder APIs.

## What changed
- added `proposals/semantic-id-generative-retrieval.md` describing why `Embedder`, `FieldGenerator`, and `LanguageModel` do not fit this workload and proposing `StructuredPrompt`, `Quantizer`, and `SequenceGenerator` surfaces
- added `ai.vespa.llm.completion.StructuredPrompt` for ordered prompt sections that still serialize to a flat string
- added `com.yahoo.language.process.DiscreteSequence`, `Quantizer`, and `SequenceGenerator`
- added narrow unit tests for `StructuredPrompt` and `DiscreteSequence`

## Why
SPLADE fits the current embedder framework because it is still one string in and one sparse tensor out. Semantic ID generation needs different primitives:
- `embedding -> SID` quantization at indexing time
- structured user and query context at serving time
- multiple scored output sequences from beam search
- optional constrained decoding over valid SID paths

The goal here is to make the API shape reviewable before wiring this through config, indexing syntax, or query-time search integration.

## Impact
This is proposal-level only. It does not change existing runtime behavior.

## Validation
- `./bootstrap.sh java`
- `./mvnw -pl vespajlib,linguistics -am -Dtest=StructuredPromptTest,DiscreteSequenceTest -Dsurefire.failIfNoSpecifiedTests=false test`
