### PR TITLE
Do not insert whitespace after prepend-text

### DIFF
--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
@@ -168,10 +168,10 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
 
     String prependInstruction(String text, Context context) {
         if (prependQuery != null && !prependQuery.isEmpty() && context.getDestinationType() == Context.DestinationType.QUERY) {
-            return prependQuery + " " + text;
+            return prependQuery + text;
         }
         if (prependDocument != null && !prependDocument.isEmpty()) {
-            return prependDocument + " " + text;
+            return prependDocument + text;
         }
         return text;
     }

--- a/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
@@ -256,8 +256,8 @@ public class HuggingFaceEmbedderTest {
         builder.tokenizerPath(ModelReference.valueOf(vocabPath));
         builder.transformerModel(ModelReference.valueOf(modelPath));
         builder.normalize(true);
-        builder.prependQuery("Represent this text:");
-        builder.prependDocument("This is a document:");
+        builder.prependQuery("Represent this text: ");
+        builder.prependDocument("This is a document: ");
         var onnxConfig = new OnnxEvaluatorConfig.Builder().build();
         var mockModelPathHelper = new MockModelPathHelper();
         HuggingFaceEmbedder huggingFaceEmbedder = new HuggingFaceEmbedder(OnnxRuntime.testInstance(), Embedder.Runtime.testInstance(), builder.build(), onnxConfig, mockModelPathHelper);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This will match [sentence-transformers](https://github.com/huggingface/sentence-transformers/blob/c500af50eb597aba2523024d98a842cde064c3fe/sentence_transformers/base/model.py#L541) behavior.

Will follow up with same fix to GgufEmbedder.