### PR TITLE
Revert "Update commons-logging to 1.3.6"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -79,7 +79,7 @@
         <commons-digester.vespa.version>3.2</commons-digester.vespa.version>
         <commons-io.vespa.version>2.16.1</commons-io.vespa.version>
         <commons-lang3.vespa.version>3.18.0</commons-lang3.vespa.version>
-        <commons-logging.vespa.version>1.3.6</commons-logging.vespa.version>  <!-- Bindings exported by jdisc through jcl-over-slf4j. -->
+        <commons-logging.vespa.version>1.3.3</commons-logging.vespa.version>  <!-- Bindings exported by jdisc through jcl-over-slf4j. -->
         <commons.math3.vespa.version>3.6.1</commons.math3.vespa.version>
         <commons-compress.vespa.version>1.27.0</commons-compress.vespa.version>
         <commons-cli.vespa.version>1.11.0</commons-cli.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#36504

Broke stuff in internal repo