### PR TITLE
vespalib: add [[unlikely]] hint in left_heap_adjust

### DIFF
--- a/vespalib/src/vespa/vespalib/util/left_right_heap.hpp
+++ b/vespalib/src/vespa/vespalib/util/left_right_heap.hpp
@@ -36,7 +36,8 @@ template <typename T, typename C> void left_heap_adjust(T* heap, size_t len, T v
     size_t pos = 0;
     size_t child2 = 2;
     while (child2 < len) {
-        if (cmp(*(heap + child2 - 1), *(heap + child2))) {
+        // the cmp() is a "less" operation, but ("equal" or "greater") is more likely:
+        if (cmp(*(heap + child2 - 1), *(heap + child2))) [[unlikely]] {
             --child2;
         }
         *(heap + pos) = std::move(*(heap + child2));


### PR DESCRIPTION
In the heap-adjust inner loop, cmp() is a "less" comparator. When descending the heap the right child tends not to be less than the left child, so the branch that decrements child2 is taken infrequently. Marking it [[unlikely]] lets the compiler lay out the hot path without the detour.
