### PR TITLE
Improve vespa prod deploy --wait UX

### DIFF
--- a/client/go/internal/cli/cmd/prod.go
+++ b/client/go/internal/cli/cmd/prod.go
@@ -173,16 +173,17 @@ $ vespa prod deploy`,
 			if err != nil {
 				return fmt.Errorf("could not deploy application: %w", err)
 			}
-			cli.printSuccess(fmt.Sprintf("Deployed '%s' with build number %s", color.CyanString(pkg.Path), color.CyanString(strconv.FormatInt(build, 10))))
+			cli.printSuccess(fmt.Sprintf("Submitted '%s' with build number %s", color.CyanString(pkg.Path), color.CyanString(strconv.FormatInt(build, 10))))
 			log.Printf("See %s for deployment progress\n", color.CyanString(fmt.Sprintf("%s/tenant/%s/application/%s/prod/deployment",
 				deployment.Target.Deployment().System.ConsoleURL, deployment.Target.Deployment().Application.Tenant, deployment.Target.Deployment().Application.Application)))
 			if options.waitSecs > 0 {
-				skipped, err := vespa.AwaitBuild(target, build, time.Duration(options.waitSecs)*time.Second, cli.Stderr)
+				log.Printf("Waiting up to %s for build pipeline to complete...\n", (time.Duration(options.waitSecs) * time.Second).String())
+				skipped, skipReason, err := vespa.AwaitBuild(target, build, time.Duration(options.waitSecs)*time.Second, cli.Stderr)
 				if err != nil {
 					return err
 				}
 				if skipped {
-					cli.printSuccess(fmt.Sprintf("Build %d completed", build))
+					cli.printSuccess(fmt.Sprintf("Build %d skipped: %s", build, skipReason))
 				} else {
 					cli.printSuccess(fmt.Sprintf("Build %d deployed to production", build))
 				}

--- a/client/go/internal/cli/cmd/prod_test.go
+++ b/client/go/internal/cli/cmd/prod_test.go
@@ -177,7 +177,7 @@ func TestProdDeployWithoutCertificate(t *testing.T) {
 	require.Nil(t, os.WriteFile(filepath.Join(pkgDir, "security", "clients.pem"), []byte{}, 0o644))
 	httpClient.NextResponseString(200, `{"build": 42}`)
 	assert.Nil(t, cli.Run("prod", "deploy", pkgDir))
-	assert.Contains(t, stdout.String(), "Success: Deployed '"+pkgDir+"' with build number 42")
+	assert.Contains(t, stdout.String(), "Success: Submitted '"+pkgDir+"' with build number 42")
 	assert.Contains(t, stdout.String(), "See https://console.vespa-cloud.com/tenant/t1/application/a1/prod/deployment for deployment progress")
 }
 
@@ -213,12 +213,12 @@ func prodDeploy(pkgDir string, t *testing.T) {
 	cli.Environment["VESPA_CLI_API_KEY_FILE"] = filepath.Join(cli.config.homeDir, "t1.api-key.pem")
 	httpClient.NextResponseString(200, `{"build": 42}`)
 	assert.Nil(t, cli.Run("prod", "deploy", "--add-cert"))
-	assert.Contains(t, stdout.String(), "Success: Deployed '.' with build number 42")
+	assert.Contains(t, stdout.String(), "Success: Submitted '.' with build number 42")
 	assert.Contains(t, stdout.String(), "See https://console.vespa-cloud.com/tenant/t1/application/a1/prod/deployment for deployment progress")
 	stdout.Reset()
 	httpClient.NextResponseString(200, `{"build": 43}`)
 	assert.Nil(t, cli.Run("prod", "submit", "--add-cert")) // old variant also works
-	assert.Contains(t, stdout.String(), "Success: Deployed '.' with build number 43")
+	assert.Contains(t, stdout.String(), "Success: Submitted '.' with build number 43")
 	assert.Contains(t, stdout.String(), "See https://console.vespa-cloud.com/tenant/t1/application/a1/prod/deployment for deployment progress")
 }
 
@@ -239,7 +239,7 @@ func TestProdDeployWithJava(t *testing.T) {
 	cli.Environment["VESPA_CLI_API_KEY_FILE"] = filepath.Join(cli.config.homeDir, "t1.api-key.pem")
 	assert.Nil(t, cli.Run("prod", "deploy", "--add-cert", pkgDir))
 	assert.Equal(t, "", stderr.String())
-	assert.Contains(t, stdout.String(), "Success: Deployed '"+pkgDir+"/target/application' with build number 42")
+	assert.Contains(t, stdout.String(), "Success: Submitted '"+pkgDir+"/target/application' with build number 42")
 	assert.Contains(t, stdout.String(), "See https://console.vespa-cloud.com/tenant/t1/application/a1/prod/deployment for deployment progress")
 }
 
@@ -287,10 +287,15 @@ func TestProdDeployWithWait(t *testing.T) {
 
 	// Deployed successfully
 	stdout.Reset()
+	stderr.Reset()
 	httpClient.NextResponseString(200, `{"build": 42}`)
-	httpClient.NextResponseString(200, `{"deployed": true, "jobs": []}`)
+	httpClient.NextResponseString(200, `{"deployed": false, "status": "deploying", "jobs": [{"jobName":"system-test","runStatus":"running","runId":1,"instance":"default"}]}`)
+	httpClient.NextResponseString(200, `{"deployed": true, "status": "done", "jobs": [{"jobName":"system-test","runStatus":"success","runId":1,"instance":"default"}]}`)
 	assert.Nil(t, cli.Run("prod", "deploy", "--wait", "5", "--add-cert"))
-	assert.Contains(t, stdout.String(), "Success: Deployed '.' with build number 42")
+	assert.Contains(t, stdout.String(), "Success: Submitted '.' with build number 42")
+	assert.Contains(t, stdout.String(), "Waiting up to 5s for build pipeline to complete...")
+	assert.Contains(t, stderr.String(), "system-test: running")
+	assert.Contains(t, stderr.String(), "system-test: success")
 	assert.Contains(t, stdout.String(), "Success: Build 42 deployed to production")
 
 	// Skipped due to no changes
@@ -298,7 +303,7 @@ func TestProdDeployWithWait(t *testing.T) {
 	httpClient.NextResponseString(200, `{"build": 43}`)
 	httpClient.NextResponseString(200, `{"skipReason": "no changes detected"}`)
 	assert.Nil(t, cli.Run("prod", "deploy", "--wait", "5", "--add-cert"))
-	assert.Contains(t, stdout.String(), "Success: Build 43 completed")
+	assert.Contains(t, stdout.String(), "Success: Build 43 skipped: no changes detected")
 
 	// Job failure
 	stdout.Reset()
@@ -330,5 +335,5 @@ func TestProdDeployWarnsOnInstance(t *testing.T) {
 	cli.Environment["VESPA_CLI_API_KEY_FILE"] = filepath.Join(cli.config.homeDir, "t1.api-key.pem")
 	assert.Nil(t, cli.Run("prod", "deploy", "--add-cert", pkgDir))
 	assert.Contains(t, stderr.String(), "Warning: Instance is set in config but will be ignored for production deployments")
-	assert.Contains(t, stdout.String(), "Success: Deployed")
+	assert.Contains(t, stdout.String(), "Success: Submitted")
 }

--- a/client/go/internal/vespa/target_cloud.go
+++ b/client/go/internal/vespa/target_cloud.go
@@ -449,20 +449,22 @@ func streamBuildJobLogs(target Target, job buildStatusJob, timeout time.Duration
 
 // AwaitBuild waits for a production build to deploy by polling the build-status endpoint
 // and streaming per-job run logs. Returns skipped=true if the build was skipped due to no
-// changes. logWriter may be nil to suppress log output.
-func AwaitBuild(target Target, buildID int64, timeout time.Duration, logWriter io.Writer) (skipped bool, _ error) {
+// changes or being manually cancelled. logWriter may be nil to suppress log output.
+func AwaitBuild(target Target, buildID int64, timeout time.Duration, logWriter io.Writer) (skipped bool, skipReason string, _ error) {
 	if !target.IsCloud() {
-		return false, fmt.Errorf("AwaitBuild is only supported for cloud targets")
+		return false, "", fmt.Errorf("AwaitBuild is only supported for cloud targets")
 	}
 	d := target.Deployment()
 	buildStatusURL := d.System.BuildStatusURL(d, buildID)
 	req, err := http.NewRequest("GET", buildStatusURL, nil)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	sw := io.Writer(&syncWriter{w: logWriter})
 	var isSkipped bool
+	var observedSkipReason string
 	retryInterval := 2 * time.Second
+	lastStatus := map[string]string{}
 	statusFunc := func(status int, response []byte) (bool, error) {
 		if ok, err := isOK(status); !ok {
 			return ok, err
@@ -471,8 +473,17 @@ func AwaitBuild(target Target, buildID int64, timeout time.Duration, logWriter i
 		if err := json.Unmarshal(response, &resp); err != nil {
 			return false, err
 		}
+		for _, job := range resp.Jobs {
+			if lastStatus[job.JobName] != job.RunStatus {
+				lastStatus[job.JobName] = job.RunStatus
+				if logWriter != nil {
+					fmt.Fprintf(sw, "[%s] %s: %s\n", time.Now().Format("15:04:05"), job.JobName, job.RunStatus)
+				}
+			}
+		}
 		if resp.SkipReason != "" {
 			isSkipped = true
+			observedSkipReason = resp.SkipReason
 			return true, nil
 		}
 		if !resp.HasFailed {
@@ -504,9 +515,9 @@ func AwaitBuild(target Target, buildID int64, timeout time.Duration, logWriter i
 	}
 	_, mainErr := deployRequest(target, statusFunc, func() *http.Request { return req }, timeout, retryInterval)
 	if mainErr != nil {
-		return false, mainErr
+		return false, "", mainErr
 	}
-	return isSkipped, nil
+	return isSkipped, observedSkipReason, nil
 }
 
 func (t *cloudTarget) discoverPrivateServices(timeout time.Duration) (map[string]*PrivateServiceInfo, error) {

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -483,9 +483,10 @@ func TestAwaitBuild(t *testing.T) {
 		Status: 200,
 		Body:   []byte(`{"deployed": true, "status": "done", "jobs": []}`),
 	})
-	skipped, err := AwaitBuild(target, 42, time.Second, nil)
+	skipped, skipReason, err := AwaitBuild(target, 42, time.Second, nil)
 	assert.Nil(t, err)
 	assert.False(t, skipped)
+	assert.Equal(t, "", skipReason)
 
 	// Skipped due to no changes
 	client.NextResponse(mock.HTTPResponse{
@@ -493,9 +494,10 @@ func TestAwaitBuild(t *testing.T) {
 		Status: 200,
 		Body:   []byte(`{"skipReason": "no changes detected"}`),
 	})
-	skipped, err = AwaitBuild(target, 42, time.Second, nil)
+	skipped, skipReason, err = AwaitBuild(target, 42, time.Second, nil)
 	assert.Nil(t, err)
 	assert.True(t, skipped)
+	assert.Equal(t, "no changes detected", skipReason)
 
 	// Build failed (no jobs with runs)
 	client.NextResponse(mock.HTTPResponse{
@@ -503,7 +505,7 @@ func TestAwaitBuild(t *testing.T) {
 		Status: 200,
 		Body:   []byte(`{"hasFailed": true, "jobs": []}`),
 	})
-	_, err = AwaitBuild(target, 42, time.Second, nil)
+	_, _, err = AwaitBuild(target, 42, time.Second, nil)
 	require.NotNil(t, err)
 	assert.True(t, errors.Is(err, ErrDeployment))
 
@@ -518,7 +520,7 @@ func TestAwaitBuild(t *testing.T) {
 		Status: 200,
 		Body:   []byte(`{"active": false, "status": "deploymentFailed"}`),
 	})
-	_, err = AwaitBuild(target, 42, time.Second, nil)
+	_, _, err = AwaitBuild(target, 42, time.Second, nil)
 	require.NotNil(t, err)
 	assert.True(t, errors.Is(err, ErrDeployment))
 	assert.Contains(t, err.Error(), "production-aws-us-east-1c")
@@ -534,7 +536,7 @@ func TestAwaitBuild(t *testing.T) {
 		Status: 200,
 		Body:   []byte(`{"active": false, "status": "testFailure"}`),
 	})
-	_, err = AwaitBuild(target, 42, time.Second, nil)
+	_, _, err = AwaitBuild(target, 42, time.Second, nil)
 	require.NotNil(t, err)
 	assert.True(t, errors.Is(err, ErrDeployment))
 	assert.Contains(t, err.Error(), "system-test.aws-us-east-1c")
@@ -545,7 +547,7 @@ func TestAwaitBuild(t *testing.T) {
 		Status: 200,
 		Body:   []byte(`{"deployed": false, "status": "deploying"}`),
 	})
-	_, err = AwaitBuild(target, 42, time.Millisecond, nil)
+	_, _, err = AwaitBuild(target, 42, time.Millisecond, nil)
 	assert.True(t, errors.Is(err, ErrWaitTimeout))
 }
 


### PR DESCRIPTION
## Summary

Align `vespa prod deploy --wait` output with `vespa deploy --wait` and pyvespa's `wait_for_prod_deployment`. Before this change the command printed `Success: Deployed ...` immediately after submission and then went silent for the entire pipeline duration — users thought the CLI had hung or exited prematurely.

Four tightly related changes:

1. Rename the initial message `Success: Deployed` → `Success: Submitted`. The build is only submitted at that point; the terminal `Success: Build N deployed to production` message is unchanged.
2. Print a `Waiting up to Ns for build pipeline to complete...` banner before `AwaitBuild` starts polling, matching `vespa deploy`'s `Waiting up to 5m0s for deployment to converge...`.
3. Stream per-job status changes during polling as `[hh:mm:ss] jobName: runStatus` lines, mirroring pyvespa.
4. Surface `skipReason` from the build-status response in the final line: `Build N skipped: <reason>` instead of the opaque `Build N completed`. `AwaitBuild`'s return signature is extended from `(bool, error)` to `(bool, string, error)` to pass the reason through.

## Before / after

Before:
```
$ vespa prod deploy --wait 1800
Success: Deployed '.' with build number N
See https://console.vespa-cloud.com/... for deployment progress
Success: Build N completed
```

After, full pipeline run:
```
$ vespa prod deploy --wait 1800
Success: Submitted '.' with build number N
See https://console.vespa-cloud.com/... for deployment progress
Waiting up to 30m0s for build pipeline to complete...
[15:00:22] system-test: running
[15:00:22] staging-test: running
[15:01:19] system-test: success
[15:01:47] staging-test: success
Success: Build N deployed to production
```

After, skipped submission:
```
$ vespa prod deploy --wait 1800
Success: Submitted '.' with build number N
See https://console.vespa-cloud.com/... for deployment progress
Waiting up to 30m0s for build pipeline to complete...
Success: Build N skipped: no-changes
```

## Test plan

- `go build ./...`, `go test ./...`, `gofmt -l .` — all clean.
- New assertions in `prod_test.go` cover the new wording, the waiting banner, streamed per-job lines, and the skip-reason message.
- `TestAwaitBuild` in `target_test.go` updated for the extended return signature.
- Verified end-to-end on a live Vespa Cloud deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)