### PR TITLE
Preserve cloud resource tags on internal redeploy

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -325,7 +325,8 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                     .waitForResourcesInPrepare(waitForResourcesInPrepare)
                     .tenantVaults(session.getTenantVaults())
                     .tenantSecretStores(session.getTenantSecretStores())
-                    .dataplaneTokens(session.getDataplaneTokens());
+                    .dataplaneTokens(session.getDataplaneTokens())
+                    .cloudResourceTags(session.getCloudResourceTags());
             session.getDockerImageRepository().ifPresent(params::dockerImageRepository);
             session.getAthenzDomain().ifPresent(params::athenzDomain);
             session.getCloudAccount().ifPresent(params::cloudAccount);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -17,6 +17,7 @@ import com.yahoo.config.model.test.HostedConfigModelRegistry;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.CloudAccount;
+import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.Environment;
@@ -617,6 +618,22 @@ public class HostedDeployTest {
         assertTrue(deployment.isPresent());
         deployment.get().activate();
         assertEquals(cloudAccount, ((Deployment) deployment.get()).session().getCloudAccount().get());
+    }
+
+    @Test
+    public void testRedeployWithCloudResourceTags() {
+        CloudResourceTags tags = CloudResourceTags.from(Map.of("env", "prod", "team", "search"));
+        DeployTester tester = new DeployTester.Builder(temporaryFolder)
+                .hostedConfigserverConfig(Zone.defaultZone())
+                .modelFactory(createHostedModelFactory(Version.fromString("4.5.6"), clock))
+                .build();
+        tester.deployApp("src/test/apps/hosted/", new PrepareParams.Builder()
+                .vespaVersion("4.5.6")
+                .cloudResourceTags(tags));
+        Optional<com.yahoo.config.provision.Deployment> deployment = tester.redeployFromLocalActive(tester.applicationId());
+        assertTrue(deployment.isPresent());
+        deployment.get().activate();
+        assertEquals(tags, ((Deployment) deployment.get()).session().getCloudResourceTags());
     }
 
     @Test


### PR DESCRIPTION
This is a 1-line bug fix:

- Internal redeployments (periodic 1hr, bootstrap) built `PrepareParams` without reading `cloudResourceTags` from the session, while other session-persisted fields (`cloudAccount`, `tenantVaults`, `tenantSecretStores`, `dataplaneTokens`) were included.
- This caused `NodeRepositoryProvisioner` to overwrite `Application.cloudResourceTags` with empty on every internal redeploy, and the `CloudResourceTagMaintainer` would then strip all custom tags from enclave VMs and disks.
- Fix: add `.cloudResourceTags(session.getCloudResourceTags())` to `createPrepareParams`, matching the pattern of all other session-persisted fields.
