### PR TITLE
Add utilities for fast mapping of random numbers into a range

### DIFF
--- a/vespalib/src/tests/util/CMakeLists.txt
+++ b/vespalib/src/tests/util/CMakeLists.txt
@@ -15,6 +15,7 @@ vespa_add_executable(vespalib_util_gtest_runner_test_app TEST
     crypto_test.cpp
     defer_test.cpp
     eventbarrier.cpp
+    fast_range_test.cpp
     file_area_freelist_test.cpp
     generation_hold_list_test.cpp
     generationhandler_test.cpp

--- a/vespalib/src/tests/util/fast_range_test.cpp
+++ b/vespalib/src/tests/util/fast_range_test.cpp
@@ -1,0 +1,36 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/fast_range.h>
+#include <vespa/vespalib/util/xoshiro.h>
+#include <gtest/gtest.h>
+#include <concepts>
+#include <random>
+
+using namespace ::testing;
+
+namespace vespalib {
+
+namespace {
+
+template <std::integral T>
+void do_test_fast_range() {
+    Xoshiro256PlusPlusPrng gen(std::random_device{}());
+    for (size_t i = 0; i < 10'000; ++i) {
+        const T max_incl = static_cast<T>(gen());
+        const T mapped   = map_random_to_range(static_cast<T>(gen()), max_incl);
+
+        ASSERT_TRUE(mapped <= max_incl) << mapped << " for range [0, " << max_incl << "]";
+    }
+}
+
+} // namespace
+
+TEST(FastRangeTest, can_map_u32_values) {
+    do_test_fast_range<uint32_t>();
+}
+
+TEST(FastRangeTest, can_map_u64_values) {
+    do_test_fast_range<uint64_t>();
+}
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/fast_range.h
+++ b/vespalib/src/vespa/vespalib/util/fast_range.h
@@ -1,0 +1,45 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+
+namespace vespalib {
+
+/**
+ * Fast and fair mapping of _statistically random_ u32 and u64 values into an
+ * arbitrary range via the Lemire reduction method(tm). For random variables
+ * this is a fast alternative to (non-power of 2) modulo calculations which
+ * only uses one multiplication and a bit-shift.
+ *
+ * Note that the output of this mapping is _not at all_ equal to the modulo
+ * operation, and trying to use it as a direct substitution will inevitably
+ * end in tears. This also means it can't be used for hash tables that use
+ * identity (aka. no-op, aka. "I'm sure it will be fine, yolo") hashing of
+ * integers, as all sufficiently low numbers will end up in the same bucket!
+ *
+ * See https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+ */
+
+// Returns an unspecified (but fair) mapping of the random u32 variable `x` into the u32 range [0, `n`]
+[[nodiscard]] constexpr uint32_t map_random_to_range(const uint32_t x, const uint32_t n) noexcept {
+    return (static_cast<uint64_t>(x) * static_cast<uint64_t>(n)) >> 32;
+}
+
+// Returns an unspecified (but fair) mapping of the random u64 variable `x` into the u64 range [0, `n`]
+[[nodiscard]] constexpr uint64_t map_random_to_range(const uint64_t x, const uint64_t n) noexcept {
+    // The compiler understands this pattern well enough that it will use the
+    // native instruction and/or register for extracting the top 64 bits of the
+    // multiplication, making this no more costly than a normal multiplication.
+    //
+    // On x64, this will do a regular (unsigned) MUL (which places high bits in
+    // RDX and low bits in RAX) and just use the RDX register result verbatim.
+    //
+    // On AArch64 it will directly generate an UMULH (multiply, return high bits)
+    // instruction.
+    //
+    // Godbolt example: https://godbolt.org/z/G75Gzj1o4
+    return (static_cast<__uint128_t>(x) * n) >> 64;
+}
+
+} // namespace vespalib


### PR DESCRIPTION
@havardpe please review. As discussed yesterday~ 👀

This adds a fast and fair mapping of _statistically random_ u32 and u64 values into an arbitrary range via the Lemire reduction method(tm). For random variables this is a fast alternative to (non-power of 2) modulo calculations which only uses a single multiplication and a bit-shift.

Note that the output of this mapping is _not at all_ equal to the modulo operation, and trying to use it as a direct substitution will inevitably end in tears. This also means it can't be used for hash tables that use identity (aka. no-op, aka. "I'm sure it will be fine, yolo") hashing of integers, as all sufficiently low numbers will end up in the same bucket!

On the other hand, this algorithm is particularly well suited for generating random numbers in a range very quickly, or for mapping good quality hashes to non-2^n buckets.

This is adapted from https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/

Benchmarking numbers from Daniel Lemire's blogpost indicate that this is 4x faster than modulo on a Skylake-tier system.
