### PR TITLE
Add Spec builder for nested iterator benchmark trees

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/CMakeLists.txt
@@ -1,12 +1,14 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_executable(searchlib_iterator_benchmark_test_app TEST
     SOURCES
-    intermediate_blueprint_factory.cpp
     attribute_ctx_builder.cpp
     benchmark_blueprint_factory.cpp
+    benchmark_spec.cpp
     common.cpp
     disk_index_builder.cpp
+    intermediate_blueprint_factory.cpp
     iterator_benchmark_test.cpp
+
     DEPENDS
     vespa_searchlib
     searchlib_test

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
@@ -1,1 +1,7 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 #include "benchmark_spec.h"
+
+namespace search::queryeval::test {
+
+}

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
@@ -1,0 +1,1 @@
+#include "benchmark_spec.h"

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
@@ -3,9 +3,12 @@
 #include "benchmark_spec.h"
 
 #include <vespa/searchlib/queryeval/intermediate_blueprints.h>
+#include <vespa/vespalib/util/overload.h>
 
 #include <ostream>
 #include <sstream>
+
+using vespalib::overload;
 
 namespace search::queryeval::test {
 
@@ -25,7 +28,7 @@ std::ostream& operator<<(std::ostream& os, const Spec& s) {
         os << "]";
     };
 
-    std::visit(overloaded{
+    std::visit(overload{
         [&](const TermSpec& t) {
             os << "Term(field=" << t.field.to_string() << ", r=" << t.hit_ratio << ")";
         },
@@ -55,7 +58,7 @@ SpecBlueprintFactory::~SpecBlueprintFactory() {
 }
 
 void SpecBlueprintFactory::collect_leaves(const Spec& spec, uint32_t num_docs, FactoryList& out) {
-    std::visit(overloaded{
+    std::visit(overload{
         [&](const TermSpec& t) {
             out.push_back(make_blueprint_factory(
                 t.field, QueryOperator::Term, num_docs,
@@ -75,7 +78,7 @@ void SpecBlueprintFactory::collect_leaves(const Spec& spec, uint32_t num_docs, F
 
 std::unique_ptr<Blueprint> SpecBlueprintFactory::build_tree(const Spec& spec, FactoryList& leaves, size_t& leaf_idx,
                                                  uint32_t docid_limit) {
-    return std::visit(overloaded{
+    return std::visit(overload{
         [&](const TermSpec&) -> std::unique_ptr<Blueprint> {
             return leaves[leaf_idx++]->make_blueprint();
         },

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
@@ -4,4 +4,8 @@
 
 namespace search::queryeval::test {
 
+Spec term(FieldConfig field, double hit_ratio) {
+    return Spec{TermSpec{std::move(field), hit_ratio}};
+}
+
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
@@ -2,10 +2,46 @@
 
 #include "benchmark_spec.h"
 
+#include <ostream>
+#include <sstream>
+
 namespace search::queryeval::test {
 
 Spec term(FieldConfig field, double hit_ratio) {
     return Spec{TermSpec{std::move(field), hit_ratio}};
+}
+
+template <typename... Fs>
+struct overloaded : Fs... { using Fs::operator()...; };
+
+template <typename... Fs> overloaded(Fs...) -> overloaded<Fs...>;
+
+std::ostream& operator<<(std::ostream& os, const Spec& s) {
+    auto print_intermediate = [&](const char* name, const std::vector<Spec>& children) {
+        os << name << "[";
+        for (size_t i = 0; i < children.size(); ++i) {
+            if (i) {
+                os << ", ";
+            }
+            os << children[i];
+        }
+        os << "]";
+    };
+
+    std::visit(overloaded{
+        [&](const TermSpec& t) {
+            os << "Term(field=" << t.field.to_string() << ", r=" << t.hit_ratio << ")";
+        },
+        [&](const AndSpec& a) { print_intermediate("And", a.children); },
+        [&](const OrSpec& o)  { print_intermediate("Or",  o.children); },
+    }, s.node);
+    return os;
+}
+
+std::string to_string(const Spec& s) {
+    std::stringstream os;
+    os << s;
+    return os.str();
 }
 
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.cpp
@@ -2,6 +2,8 @@
 
 #include "benchmark_spec.h"
 
+#include <vespa/searchlib/queryeval/intermediate_blueprints.h>
+
 #include <ostream>
 #include <sstream>
 
@@ -10,11 +12,6 @@ namespace search::queryeval::test {
 Spec term(FieldConfig field, double hit_ratio) {
     return Spec{TermSpec{std::move(field), hit_ratio}};
 }
-
-template <typename... Fs>
-struct overloaded : Fs... { using Fs::operator()...; };
-
-template <typename... Fs> overloaded(Fs...) -> overloaded<Fs...>;
 
 std::ostream& operator<<(std::ostream& os, const Spec& s) {
     auto print_intermediate = [&](const char* name, const std::vector<Spec>& children) {
@@ -42,6 +39,74 @@ std::string to_string(const Spec& s) {
     std::stringstream os;
     os << s;
     return os.str();
+}
+
+SpecBlueprintFactory::SpecBlueprintFactory(Spec spec, uint32_t num_docs)
+        : _spec(std::move(spec)),
+          _num_docs(num_docs),
+          _leaf_factories()
+{
+    collect_leaves(_spec, _num_docs, _leaf_factories);
+}
+
+
+SpecBlueprintFactory::~SpecBlueprintFactory() {
+
+}
+
+void SpecBlueprintFactory::collect_leaves(const Spec& spec, uint32_t num_docs, FactoryList& out) {
+    std::visit(overloaded{
+        [&](const TermSpec& t) {
+            out.push_back(make_blueprint_factory(
+                t.field, QueryOperator::Term, num_docs,
+                /*default_values_per_document*/ 0,
+                t.hit_ratio,
+                /*children*/ 1,
+                /*disjunct_children*/ false));
+        },
+        [&](const AndSpec& a) {
+            for (const auto& c : a.children) { collect_leaves(c, num_docs, out); }
+        },
+        [&](const OrSpec& o) {
+            for (const auto& c : o.children) { collect_leaves(c, num_docs, out); }
+        },
+    }, spec.node);
+}
+
+std::unique_ptr<Blueprint> SpecBlueprintFactory::build_tree(const Spec& spec, FactoryList& leaves, size_t& leaf_idx,
+                                                 uint32_t docid_limit) {
+    return std::visit(overloaded{
+        [&](const TermSpec&) -> std::unique_ptr<Blueprint> {
+            return leaves[leaf_idx++]->make_blueprint();
+        },
+        [&](const AndSpec& a) -> std::unique_ptr<Blueprint> {
+            auto bp = std::make_unique<AndBlueprint>();
+            for (const auto& c : a.children) {
+                bp->addChild(build_tree(c, leaves, leaf_idx, docid_limit));
+            }
+            bp->setDocIdLimit(docid_limit);
+            bp->update_flow_stats(docid_limit);
+            return bp;
+        },
+        [&](const OrSpec& o) -> std::unique_ptr<Blueprint> {
+            auto bp = std::make_unique<OrBlueprint>();
+            for (const auto& c : o.children) {
+                bp->addChild(build_tree(c, leaves, leaf_idx, docid_limit));
+            }
+            bp->setDocIdLimit(docid_limit);
+            bp->update_flow_stats(docid_limit);
+            return bp;
+        },
+    }, spec.node);
+}
+
+std::unique_ptr<Blueprint> SpecBlueprintFactory::make_blueprint() {
+    size_t leaf_idx = 0;
+    return build_tree(_spec, _leaf_factories, leaf_idx, _num_docs + 1);
+}
+
+std::string SpecBlueprintFactory::get_name(Blueprint&) const {
+    return to_string(_spec);
 }
 
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -8,10 +8,15 @@
 
 #include "common.h"
 
+#include <concepts>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
 namespace search::queryeval::test {
+
+// ----------------- Node specs ------------------------
 
 struct Spec;
 
@@ -31,5 +36,28 @@ struct OrSpec {
 struct Spec {
     std::variant<TermSpec, AndSpec, OrSpec> node;
 };
+
+// ----------------- Builders ------------------------
+
+Spec term(FieldConfig field, double hit_ratio);
+
+template <typename NodeSpec, typename... Specs>
+    requires (std::same_as<std::remove_cvref_t<Specs>, Spec> && ...)
+Spec make_intermediate(Specs&&... children) {
+    std::vector<Spec> v;
+    v.reserve(sizeof...(children));
+    (v.push_back(std::forward<Specs>(children)), ...);
+    return Spec{NodeSpec{std::move(v)}};
+}
+
+template <typename... Specs>
+Spec and_(Specs&&... children) {
+    return make_intermediate<AndSpec>(std::forward<Specs>(children)...);
+}
+
+template <typename... Specs>
+Spec or_(Specs&&... children) {
+    return make_intermediate<OrSpec>(std::forward<Specs>(children)...);
+}
 
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -6,6 +6,7 @@
  * Building trees.
  */
 
+#include "benchmark_blueprint_factory.h"
 #include "common.h"
 
 #include <concepts>
@@ -37,6 +38,11 @@ struct Spec {
     std::variant<TermSpec, AndSpec, OrSpec> node;
 };
 
+template <typename... Fs>
+struct overloaded : Fs... { using Fs::operator()...; };
+
+template <typename... Fs> overloaded(Fs...) -> overloaded<Fs...>;
+
 // ----------------- Builders ------------------------
 
 Spec term(FieldConfig field, double hit_ratio);
@@ -61,5 +67,30 @@ Spec or_(Specs&&... children) {
 }
 
 std::string to_string(const Spec& s);
+
+// ----------------- Factory ------------------------
+
+class SpecBlueprintFactory : public BenchmarkBlueprintFactory {
+public:
+    using FactoryList = std::vector<std::unique_ptr<BenchmarkBlueprintFactory>>;
+
+private:
+
+    Spec _spec;
+    uint32_t _num_docs;
+    FactoryList _leaf_factories;
+
+public:
+    SpecBlueprintFactory(Spec spec, uint32_t num_docs);
+    ~SpecBlueprintFactory() override;
+
+    std::unique_ptr<Blueprint> make_blueprint() override;
+    std::string get_name(Blueprint& blueprint) const override;
+
+private:
+    static void collect_leaves(const Spec& spec, uint32_t num_docs, FactoryList& out);
+    static std::unique_ptr<Blueprint> build_tree(const Spec& spec, FactoryList& leaves, size_t& leaf_idx,
+                                                 uint32_t docid_limit);
+};
 
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -6,3 +6,30 @@
  * Building trees.
  */
 
+#include "common.h"
+
+#include <variant>
+#include <vector>
+
+namespace search::queryeval::test {
+
+struct Spec;
+
+struct TermSpec {
+    FieldConfig field;
+    double hit_ratio;
+};
+
+struct AndSpec {
+    std::vector<Spec> children;
+};
+
+struct OrSpec {
+    std::vector<Spec> children;
+};
+
+struct Spec {
+    std::variant<TermSpec, AndSpec, OrSpec> node;
+};
+
+}

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -75,9 +75,8 @@ public:
     using FactoryList = std::vector<std::unique_ptr<BenchmarkBlueprintFactory>>;
 
 private:
-
-    Spec _spec;
-    uint32_t _num_docs;
+    Spec        _spec;
+    uint32_t    _num_docs;
     FactoryList _leaf_factories;
 
 public:

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -60,4 +60,6 @@ Spec or_(Specs&&... children) {
     return make_intermediate<OrSpec>(std::forward<Specs>(children)...);
 }
 
+std::string to_string(const Spec& s);
+
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -38,11 +38,6 @@ struct Spec {
     std::variant<TermSpec, AndSpec, OrSpec> node;
 };
 
-template <typename... Fs>
-struct overloaded : Fs... { using Fs::operator()...; };
-
-template <typename... Fs> overloaded(Fs...) -> overloaded<Fs...>;
-
 // ----------------- Builders ------------------------
 
 Spec term(FieldConfig field, double hit_ratio);

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_spec.h
@@ -1,0 +1,8 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+/*
+ * Building trees.
+ */
+

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1100,12 +1100,26 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
     }
 }
 
-TEST(IteratorBenchmark, print_test) {
+TEST(IteratorBenchmark, spec_factory_test) {
     auto tree = and_(
-        or_(term(int32_fs, 0.1), term(int32_fs, 0.2)),
-        term(str_fs, 0.1),
-        term(str_fs, 0.5));
-    std::println("{}", to_string(tree));
+        term(int32_fs, 0.01),
+        or_(term(str_fs, 0.1), term(str_fs, 0.3)));
+
+    SpecBlueprintFactory factory(std::move(tree), num_docs);
+
+    auto res = benchmark_search(factory,
+                                num_docs + 1,
+                                /*strict*/ true,
+                                /*force_strict*/ false,
+                                /*unpack_iterator*/ false,
+                                /*filter_hit_ratio*/ 1.0,
+                                PlanningAlgo::Cost);
+
+    std::cout << factory.get_name(/*unused*/ *factory.make_blueprint()) << "\n";
+    std::cout << "time_ms=" << res.time_ms
+              << " seeks=" << res.seeks
+              << " hits=" << res.hits
+              << " actual_cost=" << res.actual_cost << "\n";
 }
 
 int main(int argc, char **argv) {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1,16 +1,20 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "intermediate_blueprint_factory.h"
 #include "benchmark_blueprint_factory.h"
+#include "benchmark_spec.h"
 #include "common.h"
+#include "intermediate_blueprint_factory.h"
+
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/benchmark_timer.h>
 #include <vespa/vespalib/util/stringfmt.h>
+
 #include <cmath>
 #include <iomanip>
 #include <numeric>
+#include <print>
 #include <vector>
 
 using namespace search::attribute;
@@ -1094,6 +1098,14 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
         auto calculate_at = [&](double in_flow) { return std::make_pair(time_ms(*btree, in_flow), time_ms(*array, in_flow)); };
         fprintf(stderr, "btree/array crossover@%5.3f: %8.6f\n", hit_ratio, find_crossover("TIME", "btree", "array", calculate_at, 0.0001));
     }
+}
+
+TEST(IteratorBenchmark, print_test) {
+    auto tree = and_(
+        or_(term(int32_fs, 0.1), term(int32_fs, 0.2)),
+        term(str_fs, 0.1),
+        term(str_fs, 0.5));
+    std::println("{}", to_string(tree));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Working towards making test cases in `iterator_benchmark` more composable.

Can now write blueprint trees with several levels of intermediate nodes. Example:

```c++
auto tree = and_(
        term(int32_fs, 0.01),
        or_(term(str_fs, 0.1), term(str_fs, 0.3)));
```

Adds `SpecBlueprintFactory` which creates a blueprint tree from a `Spec` tree.

Only added `and`, `or` and `term` to keep this PR simple.

Future work includes:
- adding more intermediate node types,
- porting existing benchmarks to use this tree structure, and
- make a builder that folds `num_docs`, strictness, planning algorithms, and filter ratios into one configuration object.

@havardpe plal when you have time
@arnej27959 please review