### PR TITLE
Support running under OpenShift arbitrary UIDs (restricted-v2 SCC)

### DIFF
--- a/client/go/internal/vespa/find_user.go
+++ b/client/go/internal/vespa/find_user.go
@@ -39,6 +39,8 @@ func FindVespaUser() string {
 		u, err := user.Current()
 		if err == nil {
 			uName = u.Username
+		} else {
+			uName = strconv.Itoa(os.Getuid())
 		}
 	}
 	if uName != "" {

--- a/client/go/internal/vespa/switch_user.go
+++ b/client/go/internal/vespa/switch_user.go
@@ -17,6 +17,9 @@ import (
 const ENV_CHECK = envvars.VESPA_ALREADY_SWITCHED_USER_TO
 
 func CheckCorrectUser() {
+	if os.Getenv("VESPA_SKIP_USER_CHECK") != "" {
+		return
+	}
 	vespaUser := FindVespaUser()
 	currentName := ""
 	currentUser, err1 := user.Current()
@@ -24,6 +27,7 @@ func CheckCorrectUser() {
 		currentName = currentUser.Username
 	} else {
 		trace.Trace("user.Current() failed:", err1)
+		currentName = fmt.Sprintf("%d", os.Getuid())
 	}
 	if currentName == vespaUser {
 		// all OK
@@ -36,9 +40,17 @@ func CheckCorrectUser() {
 		wantName = wantUser.Username
 	} else {
 		trace.Trace("user.Lookup", vespaUser, "failed:", err2)
+		if os.Getuid() != 0 {
+			trace.Warning("target user not found and not root; proceeding as current user")
+			return
+		}
 	}
 	if currentName == wantName {
 		// somewhat OK
+		return
+	}
+	if os.Getuid() != 0 {
+		trace.Warning("not running as VESPA_USER", vespaUser, "but cannot switch (not root); proceeding")
 		return
 	}
 	trace.Warning("not running as the VESPA_USER:", vespaUser)
@@ -68,14 +80,25 @@ func MaybeSwitchUser(action string) error {
 	wantUser, err := user.Lookup(vespaUser)
 	if err != nil {
 		trace.Trace("user.Lookup", vespaUser, "failed:", err)
+		if os.Getuid() != 0 {
+			trace.Trace("not root, proceeding as current user")
+			return nil
+		}
 		return err
 	}
 	currUser, err := user.Current()
 	if err != nil {
 		trace.Trace("user.Current() failed:", err)
+		if os.Getuid() != 0 {
+			return nil
+		}
 		return err
 	}
 	if wantUser.Username != currUser.Username {
+		if os.Getuid() != 0 {
+			trace.Trace("not root, cannot switch user; proceeding as", currUser.Username)
+			return nil
+		}
 		trace.Trace("want to switch user from:", currUser.Username)
 		trace.Trace("want to switch user to:", wantUser.Username)
 		alreadyTried := os.Getenv(ENV_CHECK)

--- a/configd/src/apps/su/main.cpp
+++ b/configd/src/apps/su/main.cpp
@@ -19,6 +19,18 @@ int main(int argc, char** argv) {
     if (username == nullptr) {
         username = "vespa";
     }
+
+    uid_t oldu = getuid();
+
+    // Non-root cannot switch user/group, so just exec directly.
+    // This also supports OpenShift arbitrary UIDs (restricted-v2 SCC)
+    // where the container user may not exist in /etc/passwd.
+    if (oldu != 0) {
+        execvp(argv[1], &argv[1]);
+        perror("FATAL error: execvp failed");
+        return 1;
+    }
+
     struct passwd* p = getpwnam(username);
     if (p == nullptr) {
         fprintf(stderr, "FATAL error: user '%s' missing in passwd file\n", username);
@@ -45,7 +57,6 @@ int main(int argc, char** argv) {
 #endif
 
     gid_t oldg = getgid();
-    uid_t oldu = getuid();
 
     if (g != oldg && setgid(g) != 0) {
         perror("FATAL error: could not change group id");

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -468,7 +468,11 @@ getent group %{_vespa_group} >/dev/null || groupadd -r %{_vespa_group}
 getent passwd %{_vespa_user} >/dev/null || \
     useradd -r %{?_vespa_user_uid:-u %{_vespa_user_uid}} -g %{_vespa_group} --home-dir %{_prefix} -s /sbin/nologin \
     -c "Create owner of all Vespa data files" %{_vespa_user}
+usermod -a -G root %{_vespa_user} 2>/dev/null || true
 %endif
+if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
+    chmod g+w /etc/passwd 2>/dev/null || true
+fi
 %if 0%{?el8} || 0%{?el9}
 # TODO Hardcoded toolset version, should be detected in a better way.
 mkdir -p /opt/rh
@@ -555,7 +559,7 @@ fi
 %exclude %{_prefix}/conf/configserver-app/config-models.xml
 %dir %{_prefix}/conf/logd
 %dir %{_prefix}/conf/vespa
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/zookeeper/conf
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/zookeeper/conf
 %dir %{_prefix}/etc
 %{_prefix}/etc/systemd
 %{_prefix}/etc/vespa
@@ -586,39 +590,39 @@ fi
 %exclude %{_prefix}/libexec/vespa/find-pid
 %exclude %{_prefix}/libexec/vespa/standalone-container.sh
 %exclude %{_prefix}/libexec/vespa/vespa-curl-wrapper
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/logs
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/logs/vespa
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/logs/vespa/access
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/logs/vespa/configserver
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/logs/vespa/search
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/logs
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/logs/vespa
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/logs/vespa/access
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/logs/vespa/configserver
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/logs/vespa/search
 %{_prefix}/man
 %{_prefix}/sbin
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/secure
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/crash
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/config_server
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/config_server/serverdb
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/config_server/serverdb/tenants
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/download
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/filedistribution
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/index
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/logcontrol
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/search
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/tmp
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/jdisc_container
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/run
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp/vespa
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/application
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/bundlecache
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/bundlecache/configserver
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/cache
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/cache/config
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/zookeeper
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/zookeeper/version-2
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/secure
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/crash
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/config_server
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/config_server/serverdb
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/config_server/serverdb/tenants
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/download
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/filedistribution
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/index
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/logcontrol
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/search
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/db/vespa/tmp
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/jdisc_container
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/run
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/tmp
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/tmp/vespa
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/vespa
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/vespa/application
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/vespa/bundlecache
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/vespa/bundlecache/configserver
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/vespa/cache
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/vespa/cache/config
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/zookeeper
+%dir %attr(0775,%{_vespa_user},root) %{_prefix}/var/zookeeper/version-2
 %config(noreplace) %{_prefix}/conf/logd/logd.cfg
 %if %{_create_vespa_service}
 %attr(644,root,root) /usr/lib/systemd/system/vespa.service

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -108,8 +108,10 @@ FixDataDirectory() {
         echo "Creating data directory '$1'"
         mkdir -p "$1" || exit 1
     fi
-    chown "${VESPA_USER}" "$1"
-    chmod 755 "$1"
+    if [ "$(id -u)" = "0" ]; then
+        chown "${VESPA_USER}" "$1"
+    fi
+    chmod 755 "$1" 2>/dev/null || true
 }
 
 StartCommand() {
@@ -262,10 +264,12 @@ Main() {
         Fail "Service must math the regex '$service_regex'"
     fi
 
-    if ! getent passwd "$user" &> /dev/null; then
-        Fail "Bad user ($user): not found in passwd"
-    elif test "$(id -un)" != "$user"; then
-        Fail "${0##*/} must be started by $user"
+    if getent passwd "$user" &> /dev/null; then
+        if test "$(id -un 2>/dev/null)" != "$user"; then
+            if [ "$(id -u)" != "$(id -u "$user" 2>/dev/null)" ]; then
+                Fail "${0##*/} must be started by $user"
+            fi
+        fi
     fi
 
     case "$command" in

--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -81,6 +81,8 @@ populate_environment () {
         consider_fallback VESPA_USER "vespa"
     elif id nobody >/dev/null 2>&1 ; then
         consider_fallback VESPA_USER "nobody"
+    else
+        consider_fallback VESPA_USER "$(id -un 2>/dev/null || echo $(id -u))"
     fi
 }
 

--- a/vespabase/src/rhel-prestart.sh
+++ b/vespabase/src/rhel-prestart.sh
@@ -98,23 +98,14 @@ fixdir () {
         exit 1
     fi
     mkdir -p "$4"
-    if ! $IS_ROOT; then
-        local stat="$(stat -c "%U %G" $4)"
-        local user=${stat% *}
-        local group=${stat#* }
-        if [ "$1" != "$user" ]; then
-            echo "Wrong owner for ${VESPA_HOME}/$4, expected $1, was $user"
-            exit 1
-        fi
-        if [ "$2" != "$group" ]; then
-            echo "Wrong group for ${VESPA_HOME}/$4, expected $2, was $group"
-            exit 1
-        fi
-    else
+    if $IS_ROOT; then
         chown $1 "$4"
         chgrp $2 "$4"
+    elif ! [ -w "$4" ]; then
+        echo "Directory ${VESPA_HOME}/$4 is not writable by current user (UID $(id -u))"
+        exit 1
     fi
-    chmod $3 "$4"
+    chmod $3 "$4" 2>/dev/null || true
 }
 
 # BEGIN directory fixups
@@ -149,8 +140,9 @@ fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/cache
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/cache/config
 
 if $IS_ROOT; then
-    chown -hR ${VESPA_USER} logs/vespa
-    chown -hR ${VESPA_USER} var/db/vespa
+    chown -hR ${VESPA_USER}:root logs/vespa
+    chown -hR ${VESPA_USER}:root var/db/vespa
+    chmod -R g+w logs/vespa var/db/vespa 2>/dev/null || true
 fi
 
 # END directory fixups

--- a/vespabase/src/vespa-configserver.service.in
+++ b/vespabase/src/vespa-configserver.service.in
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=forking
-User=vespa
+User=@VESPA_USER@
 PIDFile=@CMAKE_INSTALL_PREFIX@/var/run/configserver.pid
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/vespa-start-configserver
 ExecStop=@CMAKE_INSTALL_PREFIX@/bin/vespa-stop-configserver

--- a/vespabase/src/vespa.service.in
+++ b/vespabase/src/vespa.service.in
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=forking
-User=vespa
+User=@VESPA_USER@
 PIDFile=@CMAKE_INSTALL_PREFIX@/var/run/sentinel.pid
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/vespa-start-services
 ExecStop=@CMAKE_INSTALL_PREFIX@/bin/vespa-stop-services


### PR DESCRIPTION
## Summary

- Make Vespa compatible with OpenShift 4.20's default `restricted-v2` Security Context Constraint (SCC), which runs containers with arbitrary UIDs and GID 0 (root group)
- All writable directories are now group-owned by root (GID 0) with group-write permissions, following the [OpenShift image creation guidelines](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images)
- User-switching and ownership validation code paths gracefully handle non-root execution with arbitrary UIDs

## Background: OpenShift SCCs and the root group

OpenShift uses [Security Context Constraints (SCCs)](https://docs.openshift.com/container-platform/4.20/authentication/managing-security-context-constraints.html) to control what pods can do at runtime. The default `restricted-v2` SCC enforces:

- **Arbitrary UID assignment**: Containers run as a random UID from a [namespace-specific range](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images) (e.g. `1000660000`+), not the UID specified in the Dockerfile
- **GID 0 (root group)**: The arbitrary UID is always a member of the root group (GID 0). This is [by design](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images) — the root *group* is used as the access mechanism for arbitrary UIDs, while the root *user* (UID 0) remains prohibited
- **No privilege escalation**: `setuid()`/`setgid()` are blocked; `CAP_SETUID` and `CAP_SETGID` are dropped

As stated in the [OpenShift documentation](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images):

> *"The directories and files that are read from or written to by processes in the image should be owned by the root group and be read/writable by that group. Files to be executed should also have group execute permissions [...] because the container user is always a member of the root group, the container user can read and write these files."*

### Why root group ownership is safe

Using GID 0 as the group owner does **not** grant root privileges. It simply allows any UID assigned to the root group (which OpenShift always does) to read/write the directories. The actual user remains unprivileged — it cannot escalate to UID 0, bind privileged ports, or perform any root-level operations.

## Changes

### RPM spec (`dist/vespa.spec`)
- All writable directory `%attr` directives changed from `(-,vespa,vespa)` to `(0775,vespa,root)` — GID 0 with group-write
- `vespa` user added to root group via `usermod -a -G root`
- `/etc/passwd` made group-writable to support runtime UID injection

### Startup scripts
- **`rhel-prestart.sh`**: Replaced strict user/group name ownership checks with writability checks (`[ -w "$4" ]`). Non-root processes can no longer fail startup due to ownership mismatch
- **`common-env.sh`**: Added fallback to numeric UID when neither `vespa` nor `nobody` user exists in `/etc/passwd`
- **`standalone-container.sh`**: `chown` is now conditional on running as root; user validation relaxed for arbitrary UIDs

### User switching
- **`vespa-run-as-vespa-user` (C++)**: Detects non-root execution and skips `setuid()`/`setgid()`/`setgroups()`, proceeding with `execvp()` directly
- **Go user code (`find_user.go`, `switch_user.go`)**: Falls back to numeric UID string when `user.Current()` fails; `CheckCorrectUser()` and `MaybeSwitchUser()` proceed with warnings instead of exiting when non-root. Added `VESPA_SKIP_USER_CHECK` env var for explicit bypass

### Systemd services
- Replaced hardcoded `User=vespa` with `User=@VESPA_USER@` CMake template variable in both service files

## Companion PR

The corresponding container image changes are in [vespa-engine/docker-image](https://github.com/vespa-engine/docker-image) (Dockerfiles and entrypoint script).

## Test plan

- [ ] Build RPMs and verify directory permissions are `0775` with `root` group
- [ ] Run container image with `--user=$(id -u):0` to simulate OpenShift arbitrary UID
- [ ] Verify `vespa-start-configserver` and `vespa-start-services` succeed under arbitrary UID
- [ ] Verify `rhel-prestart.sh` passes writability checks without root
- [ ] Verify `vespa-run-as-vespa-user` executes commands without attempting `setuid`
- [ ] Confirm no regression when running as the `vespa` user (UID 1000) in standard Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)