### PR TITLE
add commons-compress dependency

### DIFF
--- a/cloud/tenant-cd-api/pom.xml
+++ b/cloud/tenant-cd-api/pom.xml
@@ -53,6 +53,28 @@
 
         <!-- compile -->
         <dependency>
+            <!-- Seems to be needed from somewhere -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.vespa.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <!-- avoid old versions from commons-compress -->
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${hosted-tenant-base-junit-version}</version>


### PR DESCRIPTION
after seeing error: Unable to resolve ...
missing requirement [tenant-cd-api [34](R 34.0)] osgi.wiring.package; (&(osgi.wiring.package=org.apache.commons.compress.compressors)(version>=1.28.0)(!(version>=2.0.0)))