### PR TITLE
Refactor wire IObjectStore into GetSecondPhaseWork in MatchLoopCommunicator

### DIFF
--- a/searchcore/src/tests/proton/matching/match_loop_communicator/match_loop_communicator_test.cpp
+++ b/searchcore/src/tests/proton/matching/match_loop_communicator/match_loop_communicator_test.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/searchcore/proton/matching/match_loop_communicator.h>
 #include <vespa/searchlib/features/first_phase_rank_lookup.h>
+#include <vespa/searchlib/fef/objectstore.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/test/nexus.h>
 #include <algorithm>
@@ -15,6 +16,7 @@ using Hit = MatchLoopCommunicator::Hit;
 using Hits = MatchLoopCommunicator::Hits;
 using TaggedHit = MatchLoopCommunicator::TaggedHit;
 using TaggedHits = MatchLoopCommunicator::TaggedHits;
+using ObjectStore = search::fef::ObjectStore;
 using search::features::FirstPhaseRankLookup;
 using search::queryeval::SortedHitSequence;
 using vespalib::test::Nexus;
@@ -304,10 +306,14 @@ TEST(MatchLoopCommunicatorTest, require_that_first_phase_rank_lookup_is_populate
 {
     constexpr size_t num_threads = 1;
     constexpr size_t thread_id = 0;
-    FirstPhaseRankLookup l1;
-    FirstPhaseRankLookup l2;
-    MatchLoopCommunicator f1(num_threads, 3, {}, &l1, do_nothing);
-    MatchLoopCommunicator f2(num_threads, 3, std::make_unique<EveryOdd>(), &l2, do_nothing);
+    ObjectStore s1;
+    ObjectStore s2;
+    FirstPhaseRankLookup::make_shared_state(s1);
+    FirstPhaseRankLookup::make_shared_state(s2);
+    MatchLoopCommunicator f1(num_threads, 3, {}, &s1, do_nothing);
+    MatchLoopCommunicator f2(num_threads, 3, std::make_unique<EveryOdd>(), &s2, do_nothing);
+    const auto& l1 = *FirstPhaseRankLookup::get_shared_state(s1);
+    const auto& l2 = *FirstPhaseRankLookup::get_shared_state(s2);
     auto hits_in = hit_vec({{21, 5}, {22, 4}, {23, 3}, {24, 2}, {25, 1}});
     auto res1 = second_phase(f1, hits_in, thread_id, 10);
     auto res2 = second_phase(f2, hits_in, thread_id, 10);

--- a/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.cpp
@@ -13,11 +13,11 @@ MatchLoopCommunicator::MatchLoopCommunicator(size_t threads, size_t topN)
     : MatchLoopCommunicator(threads, topN, {}, nullptr, []() noexcept {})
 {}
 
-MatchLoopCommunicator::MatchLoopCommunicator(size_t threads, size_t topN, std::unique_ptr<IDiversifier> diversifier, FirstPhaseRankLookup* first_phase_rank_lookup, std::function<void()> before_second_phase)
+MatchLoopCommunicator::MatchLoopCommunicator(size_t threads, size_t topN, std::unique_ptr<IDiversifier> diversifier, IObjectStore* object_store, std::function<void()> before_second_phase)
     : _best_scores(),
       _best_dropped(),
       _estimate_match_frequency(threads),
-      _get_second_phase_work(threads, topN, _best_scores, _best_dropped, std::move(diversifier), first_phase_rank_lookup, std::move(before_second_phase)),
+      _get_second_phase_work(threads, topN, _best_scores, _best_dropped, std::move(diversifier), object_store, std::move(before_second_phase)),
       _complete_second_phase(threads, topN, _best_scores, _best_dropped)
 {}
 
@@ -81,13 +81,13 @@ public:
 
 }
 
-MatchLoopCommunicator::GetSecondPhaseWork::GetSecondPhaseWork(size_t n, size_t topN_in, Range &best_scores_in, BestDropped &best_dropped_in, std::unique_ptr<IDiversifier> diversifier, FirstPhaseRankLookup* first_phase_rank_lookup, std::function<void()> before_second_phase)
+MatchLoopCommunicator::GetSecondPhaseWork::GetSecondPhaseWork(size_t n, size_t topN_in, Range &best_scores_in, BestDropped &best_dropped_in, std::unique_ptr<IDiversifier> diversifier, IObjectStore* object_store, std::function<void()> before_second_phase)
     : vespalib::Rendezvous<SortedHitSequence, TaggedHits, true>(n),
       topN(topN_in),
       best_scores(best_scores_in),
       best_dropped(best_dropped_in),
       _diversifier(std::move(diversifier)),
-      _first_phase_rank_lookup(first_phase_rank_lookup),
+      _object_store(object_store),
       _before_second_phase(std::move(before_second_phase))
 {}
 
@@ -153,8 +153,13 @@ MatchLoopCommunicator::GetSecondPhaseWork::mingle()
             queue.push(i);
         }
     }
-    if (_first_phase_rank_lookup != nullptr) {
-        mingle(queue, RegisterFirstPhaseRank(*_first_phase_rank_lookup));
+    if (_object_store) {
+        auto* lookup = FirstPhaseRankLookup::get_mutable_shared_state(*_object_store);
+        if (lookup != nullptr) {
+            mingle(queue, RegisterFirstPhaseRank(*lookup));
+        } else {
+            mingle(queue, NoRegisterFirstPhaseRank());
+        }
     } else {
         mingle(queue, NoRegisterFirstPhaseRank());
     }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.cpp
@@ -88,8 +88,12 @@ MatchLoopCommunicator::GetSecondPhaseWork::GetSecondPhaseWork(size_t n, size_t t
       best_dropped(best_dropped_in),
       _diversifier(std::move(diversifier)),
       _object_store(object_store),
-      _before_second_phase(std::move(before_second_phase))
-{}
+      _first_phase_rank_lookup(nullptr),
+      _before_second_phase(std::move(before_second_phase)) {
+    if (_object_store) {
+        _first_phase_rank_lookup = FirstPhaseRankLookup::get_mutable_shared_state(*_object_store);
+    }
+}
 
 MatchLoopCommunicator::GetSecondPhaseWork::~GetSecondPhaseWork() = default;
 
@@ -153,13 +157,9 @@ MatchLoopCommunicator::GetSecondPhaseWork::mingle()
             queue.push(i);
         }
     }
-    if (_object_store) {
-        auto* lookup = FirstPhaseRankLookup::get_mutable_shared_state(*_object_store);
-        if (lookup != nullptr) {
-            mingle(queue, RegisterFirstPhaseRank(*lookup));
-        } else {
-            mingle(queue, NoRegisterFirstPhaseRank());
-        }
+
+    if (_first_phase_rank_lookup != nullptr) {
+        mingle(queue, RegisterFirstPhaseRank(*_first_phase_rank_lookup));
     } else {
         mingle(queue, NoRegisterFirstPhaseRank());
     }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.h
@@ -32,6 +32,7 @@ private:
         BestDropped &best_dropped;
         std::unique_ptr<IDiversifier> _diversifier;
         IObjectStore* _object_store;
+        FirstPhaseRankLookup* _first_phase_rank_lookup;
         std::function<void()> _before_second_phase;
         GetSecondPhaseWork(size_t n, size_t topN_in, Range &best_scores_in, BestDropped &best_dropped_in, std::unique_ptr<IDiversifier> diversifier, IObjectStore* object_store, std::function<void()> before_second_phase);
         ~GetSecondPhaseWork() override;

--- a/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_loop_communicator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "i_match_loop_communicator.h"
+#include <vespa/searchlib/fef/objectstore.h>
 #include <vespa/searchlib/queryeval/idiversifier.h>
 #include <vespa/vespalib/util/rendezvous.h>
 #include <functional>
@@ -14,8 +15,9 @@ namespace proton::matching {
 class MatchLoopCommunicator final : public IMatchLoopCommunicator
 {
 private:
-    using IDiversifier = search::queryeval::IDiversifier;
     using FirstPhaseRankLookup = search::features::FirstPhaseRankLookup;
+    using IDiversifier = search::queryeval::IDiversifier;
+    using IObjectStore = search::fef::IObjectStore;
     struct BestDropped {
         bool valid = false;
         search::feature_t score = 0.0;
@@ -29,9 +31,9 @@ private:
         Range &best_scores;
         BestDropped &best_dropped;
         std::unique_ptr<IDiversifier> _diversifier;
-        FirstPhaseRankLookup* _first_phase_rank_lookup;
+        IObjectStore* _object_store;
         std::function<void()> _before_second_phase;
-        GetSecondPhaseWork(size_t n, size_t topN_in, Range &best_scores_in, BestDropped &best_dropped_in, std::unique_ptr<IDiversifier> diversifier, FirstPhaseRankLookup* first_phase_rank_lookup, std::function<void()> before_second_phase);
+        GetSecondPhaseWork(size_t n, size_t topN_in, Range &best_scores_in, BestDropped &best_dropped_in, std::unique_ptr<IDiversifier> diversifier, IObjectStore* object_store, std::function<void()> before_second_phase);
         ~GetSecondPhaseWork() override;
         void mingle() override;
         template<typename Q, typename R>
@@ -67,7 +69,7 @@ private:
 
 public:
     MatchLoopCommunicator(size_t threads, size_t topN);
-    MatchLoopCommunicator(size_t threads, size_t topN, std::unique_ptr<IDiversifier>, FirstPhaseRankLookup* first_phase_rank_lookup, std::function<void()> before_second_phsae);
+    MatchLoopCommunicator(size_t threads, size_t topN, std::unique_ptr<IDiversifier>, IObjectStore* object_store, std::function<void()> before_second_phsae);
     ~MatchLoopCommunicator();
 
     double estimate_match_frequency(const Matches &matches) override;

--- a/searchcore/src/vespa/searchcore/proton/matching/match_master.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_master.cpp
@@ -91,7 +91,7 @@ MatchMaster::match(search::engine::Trace & trace,
      * later on when selecting documents for second phase ranking.
      */
     MatchLoopCommunicator communicator(threadBundle.size(), params.heapSize, mtf.createDiversifier(params.diversity_want_hits),
-                                       mtf.get_first_phase_rank_lookup(),
+                                       mtf.object_store(),
                                        [&mtf]() noexcept { mtf.query().set_matching_phase(MatchingPhase::SECOND_PHASE); });
     TimedMatchLoopCommunicator timedCommunicator(communicator);
     DocidRangeScheduler::UP scheduler = createScheduler(threadBundle.size(), numSearchPartitions, params.numDocs);

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -198,7 +198,7 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
       _featureOverrides(featureOverrides),
       _diversityParams(),
       _valid(false),
-      _first_phase_rank_lookup(nullptr),
+      _object_store(nullptr),
       _metaStore(metaStore),
       _needed_handles()
 {
@@ -238,7 +238,7 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
         _query.freeze();
         trace.addEvent(5, "Prepare shared state for multi-threaded rank executors");
         _rankSetup.prepareSharedState(_queryEnv, _queryEnv.getObjectStore());
-        _first_phase_rank_lookup = FirstPhaseRankLookup::get_mutable_shared_state(_queryEnv.getObjectStore());
+        _object_store = &_queryEnv.getObjectStore();
         _diversityParams = extractDiversityParams(_rankSetup, rankProperties);
         std::string attribute = DegradationAttribute::lookup(rankProperties, _rankSetup.getDegradationAttribute());
         DegradationParams degradationParams = extractDegradationParams(_rankSetup, attribute, rankProperties);

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -117,6 +117,7 @@ class MatchToolsFactory
 private:
     using IAttributeFunctor = search::attribute::IAttributeFunctor;
     using IAttributeContext = search::attribute::IAttributeContext;
+    using IObjectStore = search::fef::IObjectStore;
     using CreateBlueprintParams = search::queryeval::CreateBlueprintParams;
     using MatchDataLayout = search::fef::MatchDataLayout;
     using Properties = search::fef::Properties;
@@ -137,7 +138,7 @@ private:
     const Properties                 & _featureOverrides;
     DiversityParams                    _diversityParams;
     bool                               _valid;
-    FirstPhaseRankLookup*              _first_phase_rank_lookup;
+    IObjectStore*                      _object_store;
     const search::IDocumentMetaStore & _metaStore;
     HandleRecorder::HandleMap          _needed_handles;
 
@@ -197,7 +198,7 @@ public:
     static CreateBlueprintParams
     extract_create_blueprint_params(const RankSetup& rank_setup, const Properties& rank_properties,
                                     uint32_t active_docids, uint32_t docid_limit);
-    FirstPhaseRankLookup* get_first_phase_rank_lookup() const noexcept { return _first_phase_rank_lookup; }
+    IObjectStore* object_store() const noexcept { return _object_store; }
     const search::IDocumentMetaStore & metaStore() const noexcept { return _metaStore; }
     FieldIdToNameMapper getFieldIdToNameMapper() const {
         return FieldIdToNameMapper(_queryEnv.getIndexEnvironment());


### PR DESCRIPTION
Need to wire `firstPhaseMax` feature into `MatchLoopCommunicator::GetSecondPhaseWork::mingle()`. Tried to follow how `FirstPhaseRankLookup` is wired, but thought it would be cleaner to wire the `IObjectStore` down to the `mingle()` as a first step.

@arnej27959 please review