### PR TITLE
Add `fields` to select queries

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5921,6 +5921,8 @@
       "public void setWhereString(java.lang.String)",
       "public java.lang.String getWhereString()",
       "public void setGroupingString(java.lang.String)",
+      "public void setFieldsString(java.lang.String)",
+      "public java.lang.String getFieldsString()",
       "public void setGroupingExpressionString(java.lang.String)",
       "public java.lang.String getGroupingExpressionString()",
       "public java.lang.String getGroupingString()",
@@ -5947,6 +5949,7 @@
     "methods" : [
       "public void <init>(com.yahoo.search.query.parser.ParserEnvironment)",
       "public com.yahoo.search.query.QueryTree parse(com.yahoo.search.query.parser.Parsable)",
+      "public java.util.Set getSelectSummaryFields()",
       "public java.util.List getGroupingSteps(java.lang.String)"
     ],
     "fields" : [ ]

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5932,7 +5932,8 @@
     "fields" : [
       "public static final java.lang.String SELECT",
       "public static final java.lang.String WHERE",
-      "public static final java.lang.String GROUPING"
+      "public static final java.lang.String GROUPING",
+      "public static final java.lang.String FIELDS"
     ]
   },
   "com.yahoo.search.query.SelectParser" : {

--- a/container-search/src/main/java/com/yahoo/search/query/Select.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Select.java
@@ -27,6 +27,7 @@ public class Select implements Cloneable {
     public static final String SELECT = "select";
     public static final String WHERE = "where";
     public static final String GROUPING = "grouping";
+    public static final String FIELDS = "fields";
 
     private final Query parent;
     private final List<GroupingRequest> groupingRequests;
@@ -41,6 +42,7 @@ public class Select implements Cloneable {
         argumentType.setBuiltin(true);
         argumentType.addField(new FieldDescription(WHERE, "string"));
         argumentType.addField(new FieldDescription(GROUPING, "string"));
+        argumentType.addField(new FieldDescription(FIELDS, "string"));
         argumentType.freeze();
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/Select.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Select.java
@@ -14,6 +14,7 @@ import com.yahoo.slime.Inspector;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.slime.Type;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -122,6 +123,10 @@ public class Select implements Cloneable {
             return;
         }
         Inspector inspector = SlimeUtils.jsonToSlime(this.fields).get();
+        if (inspector.field("error_message").valid()) {
+            throw new IllegalInputException("Illegal 'select.fields': " + inspector.field("error_message").asString() +
+                                            " at: '" + new String(inspector.field("offending_input").asData(), StandardCharsets.UTF_8) + "'");
+        }
         if (inspector.type() != Type.ARRAY) {
             throw new IllegalInputException("'select.fields' must be a JSON array of field names");
         }

--- a/container-search/src/main/java/com/yahoo/search/query/Select.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Select.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query;
 
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.Query;
 import com.yahoo.search.grouping.GroupingRequest;
 import com.yahoo.search.query.parser.ParserEnvironment;
@@ -8,6 +9,10 @@ import com.yahoo.search.query.parser.ParserFactory;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileType;
 import com.yahoo.search.yql.VespaGroupingStep;
+import com.yahoo.slime.ArrayTraverser;
+import com.yahoo.slime.Inspector;
+import com.yahoo.slime.SlimeUtils;
+import com.yahoo.slime.Type;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +40,7 @@ public class Select implements Cloneable {
     private String where;
     private String grouping;
     private String groupingExpressionString;
+    private String fields = "";
 
     static {
         argumentType = new QueryProfileType(SELECT);
@@ -54,15 +60,16 @@ public class Select implements Cloneable {
     }
 
     public Select(String where, String grouping, Query query) {
-        this(where, grouping, null, query, List.of());
+        this(where, grouping, null, query, List.of(), "");
     }
 
-    private Select(String where, String grouping, String groupingExpressionString, Query query, List<GroupingRequest> groupingRequests) {
+    private Select(String where, String grouping, String groupingExpressionString, Query query, List<GroupingRequest> groupingRequests, String fields) {
         this.where = Objects.requireNonNull(where, "A Select must have a where string (possibly the empty string)");
         this.grouping = Objects.requireNonNull(grouping, "A Select must have a select string (possibly the empty string)");
         this.groupingExpressionString = groupingExpressionString;
         this.parent = Objects.requireNonNull(query, "A Select must have a parent query");
         this.groupingRequests = deepCopy(groupingRequests, this);
+        this.fields = Objects.requireNonNullElse(fields, "");
     }
 
     private static List<GroupingRequest> deepCopy(List<GroupingRequest> groupingRequests, Select parentOfCopy) {
@@ -107,6 +114,32 @@ public class Select implements Cloneable {
     }
 
     /**
+     * Sets the summary fields to fetch as a JSON array string of field names, e.g. {@code ["id", "title"]}.
+     */
+    public void setFieldsString(String fieldsJson) {
+        this.fields = Objects.requireNonNullElse(fieldsJson, "");
+        if (this.fields.isEmpty()) {
+            return;
+        }
+        Inspector inspector = SlimeUtils.jsonToSlime(this.fields).get();
+        if (inspector.type() != Type.ARRAY) {
+            throw new IllegalInputException("'select.fields' must be a JSON array of field names");
+        }
+        var summaryFields = parent.getPresentation().getSummaryFields();
+        inspector.traverse((ArrayTraverser) (idx, element) -> {
+            if (element.type() != Type.STRING) {
+                throw new IllegalInputException("'select.fields' element at index " + idx + " is not a string");
+            }
+            summaryFields.add(element.asString());
+        });
+    }
+
+    /** Returns the fields JSON string previously assigned, or an empty string if none */
+    public String getFieldsString() {
+        return fields;
+    }
+
+    /**
      * Sets the grouping expression string directly.
      * This will not be parsed by this but will be accessed later by GroupingQueryParser.
      */
@@ -132,11 +165,11 @@ public class Select implements Cloneable {
 
     @Override
     public Object clone() {
-        return new Select(where, grouping, groupingExpressionString, parent, groupingRequests);
+        return new Select(where, grouping, groupingExpressionString, parent, groupingRequests, fields);
     }
 
     public Select cloneFor(Query parent)  {
-        return new Select(where, grouping, groupingExpressionString, parent, groupingRequests);
+        return new Select(where, grouping, groupingExpressionString, parent, groupingRequests, fields);
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -8,6 +8,7 @@ import com.yahoo.prelude.query.StringInItem;
 import com.yahoo.prelude.query.TrueItem;
 import com.yahoo.processing.IllegalInputException;
 import com.yahoo.collections.LazyMap;
+import com.yahoo.collections.LazySet;
 import com.yahoo.geo.DistanceParser;
 import com.yahoo.geo.ParsedDegree;
 import com.yahoo.language.Language;
@@ -179,6 +180,7 @@ public class SelectParser implements Parser {
     private final IndexFacts indexFacts;
     private final Map<Integer, TaggableItem> identifiedItems = LazyMap.newHashMap();
     private final List<ConnectedItem> connectedItems = new ArrayList<>();
+    private final Set<String> selectSummaryFields = LazySet.newHashSet();
     private final Normalizer normalizer;
     private final Segmenter segmenter;
     private final Detector detector;
@@ -235,9 +237,32 @@ public class SelectParser implements Parser {
         indexFactsSession = indexFacts.newSession(query.getSources(), query.getRestrict());
         connectedItems.clear();
         identifiedItems.clear();
+        selectSummaryFields.clear();
         this.query = query;
 
+        populateSelectSummaryFields(query.getSelect().getFieldsString());
         return buildTree();
+    }
+
+    private void populateSelectSummaryFields(String fieldsJson) {
+        if (fieldsJson == null || fieldsJson.isEmpty()) {
+            return;
+        }
+        Inspector inspector = SlimeUtils.jsonToSlime(fieldsJson).get();
+        if (inspector.type() != ARRAY) {
+            throw new IllegalInputException("'select.fields' must be a JSON array of field names");
+        }
+        inspector.traverse((ArrayTraverser) (idx, element) -> {
+            if (element.type() != STRING) {
+                throw new IllegalInputException("'select.fields' element at index " + idx + " is not a string");
+            }
+            selectSummaryFields.add(element.asString());
+        });
+    }
+
+    /** The summary fields parsed from the most recent {@code select.fields} JSON array. */
+    public Set<String> getSelectSummaryFields() {
+        return selectSummaryFields;
     }
 
     private QueryTree buildTree() {

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -249,6 +249,10 @@ public class SelectParser implements Parser {
             return;
         }
         Inspector inspector = SlimeUtils.jsonToSlime(fieldsJson).get();
+        if (inspector.field("error_message").valid()) {
+            throw new IllegalInputException("Illegal 'select.fields': " + inspector.field("error_message").asString() +
+                                            " at: '" + new String(inspector.field("offending_input").asData(), StandardCharsets.UTF_8) + "'");
+        }
         if (inspector.type() != ARRAY) {
             throw new IllegalInputException("'select.fields' must be a JSON array of field names");
         }

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -28,14 +28,11 @@ import com.yahoo.search.query.ranking.SecondPhase;
 import com.yahoo.search.query.ranking.SoftTimeout;
 import com.yahoo.search.query.ranking.Significance;
 import com.yahoo.search.query.ranking.WeakAnd;
-import com.yahoo.slime.ArrayTraverser;
-import com.yahoo.slime.SlimeUtils;
 import com.yahoo.tensor.Tensor;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.StringJoiner;
 
 /**
  * Maps between the query model and text properties.
@@ -138,7 +135,7 @@ public class QueryProperties extends Properties {
         map.put(CompoundName.fromComponents(Select.SELECT), GetterSetter.of(query -> query.getSelect().getGroupingExpressionString(), (query, value) -> query.getSelect().setGroupingExpressionString(asString(value, ""))));
         map.put(CompoundName.fromComponents(Select.SELECT, Select.WHERE), GetterSetter.of(query -> query.getSelect().getWhereString(), (query, value) -> query.getSelect().setWhereString(asString(value, ""))));
         map.put(CompoundName.fromComponents(Select.SELECT, Select.GROUPING), GetterSetter.of(query -> query.getSelect().getGroupingString(), (query, value) -> query.getSelect().setGroupingString(asString(value, ""))));
-        map.put(CompoundName.fromComponents(Select.SELECT, Select.FIELDS), GetterSetter.of(query -> query.getPresentation().getSummaryFields(), (query, value) -> setSelectFields(query, asString(value, ""))));
+        map.put(CompoundName.fromComponents(Select.SELECT, Select.FIELDS), GetterSetter.of(query -> query.getSelect().getFieldsString(), (query, value) -> query.getSelect().setFieldsString(asString(value, ""))));
         map.put(CompoundName.fromComponents(Trace.TRACE, Trace.LEVEL), GetterSetter.of(query -> query.getTrace().getLevel(), (query, value) -> query.getTrace().setLevel(asInteger(value, 0))));
         map.put(CompoundName.fromComponents(Trace.TRACE, Trace.PROFILE), GetterSetter.of(query -> query.getTrace().getProfile(), (query, value) -> query.getTrace().setProfile(asBoolean(value, false))));
         map.put(CompoundName.fromComponents(Trace.TRACE, Trace.EXPLAIN_LEVEL), GetterSetter.of(query -> query.getTrace().getExplainLevel(), (query, value) -> query.getTrace().setExplainLevel(asInteger(value, 0))));
@@ -285,16 +282,6 @@ public class QueryProperties extends Properties {
         FieldDescription field = type.getField(key);
         if (field == null) return value; // ditto
         return field.getType().convertFrom(value, new ConversionContext(key, profileRegistry, embedders, context, this));
-    }
-
-    private static void setSelectFields(Query query, String fieldsJson) {
-        if (fieldsJson.isEmpty()) {
-            return;
-        }
-        var inspector = SlimeUtils.jsonToSlime(fieldsJson).get();
-        StringJoiner joiner = new StringJoiner(",");
-        inspector.traverse((ArrayTraverser) (idx, element) -> joiner.add(element.asString()));
-        query.getPresentation().setSummaryFields(joiner.toString());
     }
 
     private void throwIllegalParameter(String key, String namespace) {

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -28,11 +28,14 @@ import com.yahoo.search.query.ranking.SecondPhase;
 import com.yahoo.search.query.ranking.SoftTimeout;
 import com.yahoo.search.query.ranking.Significance;
 import com.yahoo.search.query.ranking.WeakAnd;
+import com.yahoo.slime.ArrayTraverser;
+import com.yahoo.slime.SlimeUtils;
 import com.yahoo.tensor.Tensor;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * Maps between the query model and text properties.
@@ -135,6 +138,7 @@ public class QueryProperties extends Properties {
         map.put(CompoundName.fromComponents(Select.SELECT), GetterSetter.of(query -> query.getSelect().getGroupingExpressionString(), (query, value) -> query.getSelect().setGroupingExpressionString(asString(value, ""))));
         map.put(CompoundName.fromComponents(Select.SELECT, Select.WHERE), GetterSetter.of(query -> query.getSelect().getWhereString(), (query, value) -> query.getSelect().setWhereString(asString(value, ""))));
         map.put(CompoundName.fromComponents(Select.SELECT, Select.GROUPING), GetterSetter.of(query -> query.getSelect().getGroupingString(), (query, value) -> query.getSelect().setGroupingString(asString(value, ""))));
+        map.put(CompoundName.fromComponents(Select.SELECT, Select.FIELDS), GetterSetter.of(query -> query.getPresentation().getSummaryFields(), (query, value) -> setSelectFields(query, asString(value, ""))));
         map.put(CompoundName.fromComponents(Trace.TRACE, Trace.LEVEL), GetterSetter.of(query -> query.getTrace().getLevel(), (query, value) -> query.getTrace().setLevel(asInteger(value, 0))));
         map.put(CompoundName.fromComponents(Trace.TRACE, Trace.PROFILE), GetterSetter.of(query -> query.getTrace().getProfile(), (query, value) -> query.getTrace().setProfile(asBoolean(value, false))));
         map.put(CompoundName.fromComponents(Trace.TRACE, Trace.EXPLAIN_LEVEL), GetterSetter.of(query -> query.getTrace().getExplainLevel(), (query, value) -> query.getTrace().setExplainLevel(asInteger(value, 0))));
@@ -281,6 +285,16 @@ public class QueryProperties extends Properties {
         FieldDescription field = type.getField(key);
         if (field == null) return value; // ditto
         return field.getType().convertFrom(value, new ConversionContext(key, profileRegistry, embedders, context, this));
+    }
+
+    private static void setSelectFields(Query query, String fieldsJson) {
+        if (fieldsJson.isEmpty()) {
+            return;
+        }
+        var inspector = SlimeUtils.jsonToSlime(fieldsJson).get();
+        StringJoiner joiner = new StringJoiner(",");
+        inspector.traverse((ArrayTraverser) (idx, element) -> joiner.add(element.asString()));
+        query.getPresentation().setSummaryFields(joiner.toString());
     }
 
     private void throwIllegalParameter(String key, String namespace) {

--- a/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import static com.yahoo.jdisc.http.HttpRequest.Method.GET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -407,6 +408,20 @@ public class JSONSearchHandlerTestCase {
 
         String expected = "{\"root\":{\"id\":\"toplevel\",\"relevance\":1.0,\"fields\":{\"totalCount\":0},\"children\":[{\"id\":\"Query\",\"relevance\":1.0,\"fields\":{\"query\":\"select * from sources * where field contains \\\"term\\\" | all(output(count()))\"}}]}}";
         assertEquals(expected, result);
+    }
+
+    @Test
+    void testSelectFieldsSetsSummaryFields() {
+        var query = new com.yahoo.search.Query();
+        query.properties().set("select.fields", "[\"id\", \"title\", \"body\"]");
+        assertEquals(Set.of("id", "title", "body"), query.getPresentation().getSummaryFields());
+    }
+
+    @Test
+    void testSelectFieldsEmptyArray() {
+        var query = new com.yahoo.search.Query();
+        query.properties().set("select.fields", "[]");
+        assertTrue(query.getPresentation().getSummaryFields().isEmpty());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.handler;
 
-import com.yahoo.json.Jackson;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -12,7 +11,9 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.RequestHandlerTestDriver;
 import com.yahoo.container.protect.Error;
 import com.yahoo.io.IOUtils;
+import com.yahoo.json.Jackson;
 import com.yahoo.net.HostName;
+import com.yahoo.search.Query;
 import com.yahoo.search.searchchain.config.test.SearchChainConfigurerTestCase;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.SlimeUtils;
@@ -413,21 +414,21 @@ public class JSONSearchHandlerTestCase {
 
     @Test
     void testSelectFieldsSetsSummaryFields() {
-        var query = new com.yahoo.search.Query();
+        var query = new Query();
         query.properties().set("select.fields", "[\"id\", \"title\", \"body\"]");
         assertEquals(Set.of("id", "title", "body"), query.getPresentation().getSummaryFields());
     }
 
     @Test
     void testSelectFieldsEmptyArray() {
-        var query = new com.yahoo.search.Query();
+        var query = new Query();
         query.properties().set("select.fields", "[]");
         assertTrue(query.getPresentation().getSummaryFields().isEmpty());
     }
 
     @Test
     void testSelectFieldsMalformedJsonReportsParseError() {
-        var query = new com.yahoo.search.Query();
+        var query = new Query();
         var thrown = assertThrows(RuntimeException.class,
                 () -> query.properties().set("select.fields", "[\"id\", "));
         assertTrue(rootCauseMessage(thrown).contains("select.fields"),
@@ -436,7 +437,7 @@ public class JSONSearchHandlerTestCase {
 
     @Test
     void testSelectFieldsNonStringElementRejected() {
-        var query = new com.yahoo.search.Query();
+        var query = new Query();
         var thrown = assertThrows(RuntimeException.class,
                 () -> query.properties().set("select.fields", "[\"id\", 42]"));
         assertTrue(rootCauseMessage(thrown).contains("not a string"),
@@ -445,7 +446,7 @@ public class JSONSearchHandlerTestCase {
 
     @Test
     void testSelectFieldsNotArrayRejected() {
-        var query = new com.yahoo.search.Query();
+        var query = new Query();
         var thrown = assertThrows(RuntimeException.class,
                 () -> query.properties().set("select.fields", "{\"id\": 1}"));
         assertTrue(rootCauseMessage(thrown).contains("JSON array"),

--- a/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -422,6 +423,41 @@ public class JSONSearchHandlerTestCase {
         var query = new com.yahoo.search.Query();
         query.properties().set("select.fields", "[]");
         assertTrue(query.getPresentation().getSummaryFields().isEmpty());
+    }
+
+    @Test
+    void testSelectFieldsMalformedJsonReportsParseError() {
+        var query = new com.yahoo.search.Query();
+        var thrown = assertThrows(RuntimeException.class,
+                () -> query.properties().set("select.fields", "[\"id\", "));
+        assertTrue(rootCauseMessage(thrown).contains("select.fields"),
+                "error should reference 'select.fields': " + rootCauseMessage(thrown));
+    }
+
+    @Test
+    void testSelectFieldsNonStringElementRejected() {
+        var query = new com.yahoo.search.Query();
+        var thrown = assertThrows(RuntimeException.class,
+                () -> query.properties().set("select.fields", "[\"id\", 42]"));
+        assertTrue(rootCauseMessage(thrown).contains("not a string"),
+                "error should mention non-string element: " + rootCauseMessage(thrown));
+    }
+
+    @Test
+    void testSelectFieldsNotArrayRejected() {
+        var query = new com.yahoo.search.Query();
+        var thrown = assertThrows(RuntimeException.class,
+                () -> query.properties().set("select.fields", "{\"id\": 1}"));
+        assertTrue(rootCauseMessage(thrown).contains("JSON array"),
+                "error should mention JSON array: " + rootCauseMessage(thrown));
+    }
+
+    private static String rootCauseMessage(Throwable t) {
+        Throwable cause = t;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() == null ? "" : cause.getMessage();
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
@@ -14,6 +14,8 @@ import com.yahoo.slime.SlimeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -336,6 +338,22 @@ public class YqlJsonQueryFeatureParityTest {
         assertGroupingParity(
                 "all(group(predefined(price, bucket[1, 2>, bucket[3, 4>)))",
                 "[ { 'all' : { 'group' : { 'predefined' : [ 'price', { 'bucket' : [1, 2] }, { 'bucket' : [3, 4] } ] } } } ]");
+    }
+
+    @Test
+    void testSelectFields() {
+        // YQL: select id, title from sources * where title contains 'madonna'
+        var yqlQuery = new Query();
+        yqlParser.parse(new Parsable().setQuery("select id, title from sources * where title contains 'madonna'"));
+        yqlQuery.getPresentation().getSummaryFields().addAll(yqlParser.getYqlSummaryFields());
+
+        // JSON: { "select": { "fields": ["id", "title"], "where": ... } }
+        var jsonQuery = new Query();
+        jsonQuery.properties().set("select.fields", "[\"id\", \"title\"]");
+
+        assertEquals(yqlQuery.getPresentation().getSummaryFields(), jsonQuery.getPresentation().getSummaryFields(),
+                "YQL field selection and JSON select.fields should produce the same summary fields");
+        assertEquals(Set.of("id", "title"), jsonQuery.getPresentation().getSummaryFields());
     }
 
     /** Asserts parity using a where-clause; automatically wraps the YQL in {@code select * from sources * where ...} */

--- a/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/YqlJsonQueryFeatureParityTest.java
@@ -343,17 +343,16 @@ public class YqlJsonQueryFeatureParityTest {
     @Test
     void testSelectFields() {
         // YQL: select id, title from sources * where title contains 'madonna'
-        var yqlQuery = new Query();
         yqlParser.parse(new Parsable().setQuery("select id, title from sources * where title contains 'madonna'"));
-        yqlQuery.getPresentation().getSummaryFields().addAll(yqlParser.getYqlSummaryFields());
 
-        // JSON: { "select": { "fields": ["id", "title"], "where": ... } }
-        var jsonQuery = new Query();
-        jsonQuery.properties().set("select.fields", "[\"id\", \"title\"]");
+        // JSON: { "select": { "fields": ["id", "title"], "where": { "contains": ["title", "madonna"] } } }
+        var select = new Select("{ \"contains\": [\"title\", \"madonna\"] }", "", new Query());
+        select.setFieldsString("[\"id\", \"title\"]");
+        selectParser.parse(new Parsable().setSelect(select));
 
-        assertEquals(yqlQuery.getPresentation().getSummaryFields(), jsonQuery.getPresentation().getSummaryFields(),
-                "YQL field selection and JSON select.fields should produce the same summary fields");
-        assertEquals(Set.of("id", "title"), jsonQuery.getPresentation().getSummaryFields());
+        assertEquals(yqlParser.getYqlSummaryFields(), selectParser.getSelectSummaryFields(),
+                "YqlParser.getYqlSummaryFields() and SelectParser.getSelectSummaryFields() should match");
+        assertEquals(Set.of("id", "title"), selectParser.getSelectSummaryFields());
     }
 
     /** Asserts parity using a where-clause; automatically wraps the YQL in {@code select * from sources * where ...} */


### PR DESCRIPTION
Let users specify fields to return, like:
```json
{
  "select": {
    "fields": ["id", "title"],
    "where": true
  }
}
```

- AI has been used to write some of the code in this PR. 🤖 