### PR TITLE
refactor: use temporary file for MinimalMain bundle index

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/utils/BundleIndexer.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/utils/BundleIndexer.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.utils;
 
-import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.text.Text;
 import org.apache.felix.bundlerepository.DataModelHelper;
 import org.apache.felix.bundlerepository.Resource;
@@ -12,7 +11,6 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -40,16 +38,7 @@ class BundleIndexer {
         this.denyListPattern = denyListPattern;
     }
 
-    Path createIndexIfMissing(List<String> additionalDirectories, String mainBundleSymbolicName) throws IOException {
-        return createIndexIfMissing(additionalDirectories, getIndexPath(mainBundleSymbolicName));
-    }
-
-    Path createIndexIfMissing(List<String> additionalDirectories, Path indexPath) throws IOException {
-        if (Files.exists(indexPath)) return indexPath;
-        return createIndex(additionalDirectories, indexPath);
-    }
-
-    private Path createIndex(List<String> additionalDirectories, Path indexPath) throws IOException {
+    Path createIndex(List<String> additionalDirectories, Path indexPath) throws IOException {
         var resources = scanBundles(additionalDirectories);
         writeIndex(resources, indexPath);
         log.log(Level.FINE, () -> Text.format("Created index with %d bundles", resources.size()));
@@ -97,19 +86,9 @@ class BundleIndexer {
     }
 
     private void writeIndex(List<Resource> resources, Path indexPath) throws IOException {
-        var tempFile = Files.createTempFile(indexPath.getParent(), ".bundle-index-", ".tmp");
-        try {
-            try (var writer = new OutputStreamWriter(Files.newOutputStream(tempFile), StandardCharsets.UTF_8)) {
-                dataModelHelper.writeRepository(dataModelHelper.repository(resources.toArray(Resource[]::new)), writer);
-            }
-            Files.move(tempFile, indexPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
-            Files.deleteIfExists(tempFile);
-            throw new IOException("Failed to write repository index: " + e.getMessage(), e);
+        try (var writer = new OutputStreamWriter(Files.newOutputStream(indexPath), StandardCharsets.UTF_8)) {
+            dataModelHelper.writeRepository(dataModelHelper.repository(resources.toArray(Resource[]::new)), writer);
         }
     }
 
-    private static Path getIndexPath(String mainBundleSymbolicName) {
-        return Path.of(Defaults.getDefaults().underVespaHome("tmp/bundle-index-" + mainBundleSymbolicName + ".xml"));
-    }
 }

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/utils/MinimalMain.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/utils/MinimalMain.java
@@ -25,8 +25,8 @@ import java.util.regex.Pattern;
  * This is useful for building CLI tools that utilize existing bundles, removing the need for building self-contained fat jars.
  *
  * <p>This utility uses automatic bundle dependency resolution. It scans available bundles in {@code $VESPA_HOME/lib/jars}
- * and additional directories specified in {@code bundle.additionalLocations}, creates an index (stored per main bundle symbolic name),
- * and automatically resolves and installs all required dependencies for the main bundle.
+ * and additional directories specified in {@code bundle.additionalLocations}, creates a fresh index in a temporary file
+ * on every invocation (deleted on JVM exit), and automatically resolves and installs all required dependencies for the main bundle.
  *
  * <p>System properties:
  * <ul>
@@ -122,7 +122,9 @@ public class MinimalMain {
         try {
             var denylistPattern = createDenylistPattern();
             var bundleIndexer = new BundleIndexer(Path.of(Defaults.getDefaults().underVespaHome("lib/jars")), denylistPattern);
-            var indexPath = bundleIndexer.createIndexIfMissing(additionalDirectories, mainBundleSymbolicName);
+            var indexPath = Files.createTempFile("bundle-index-" + mainBundleSymbolicName + "-", ".xml");
+            indexPath.toFile().deleteOnExit();
+            bundleIndexer.createIndex(additionalDirectories, indexPath);
             return new BundleResolver(framework.bundleContext(), indexPath).resolve(mainBundleSymbolicName);
         } catch (Exception e) {
             throw new LauncherException("Failed to resolve bundle dependencies: " + e.getMessage(), 1, e);

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/utils/MinimalMainBundleResolutionTest.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/utils/MinimalMainBundleResolutionTest.java
@@ -28,7 +28,6 @@ class MinimalMainBundleResolutionTest {
 
     @Test
     void testBundleIndexingAndResolution(@TempDir Path tempDir) throws Exception {
-        // Create a temporary bundles directory with test JAR files
         var bundlesDir = tempDir.resolve("bundles");
         Files.createDirectories(bundlesDir);
 
@@ -44,23 +43,19 @@ class MinimalMainBundleResolutionTest {
                     "com.test.main",
                     "com.test.dependency");
 
-        // Create a blacklisted bundle
         createBundle(bundlesDir.resolve("vespajlib.jar"),
                     "test.bundle.blacklisted",
                     "1.0.0",
                     "com.test.blacklisted",
                     null);
 
-        // Create index from bundles with blacklist pattern to exclude vespajlib.jar
         var indexPath = tempDir.resolve("bundle-index.xml");
         var blacklistPattern = Pattern.compile("vespajlib\\.jar");
         var bundleIndexer = new BundleIndexer(bundlesDir, blacklistPattern);
-        var createdIndexPath = bundleIndexer.createIndexIfMissing(List.of(), indexPath);
+        var createdIndexPath = bundleIndexer.createIndex(List.of(), indexPath);
 
-        // Verify index was created
         assertTrue(Files.exists(createdIndexPath), "Index file should be created");
 
-        // Create a Felix framework to get BundleContext
         var felixCacheDir = tempDir.resolve("felix-cache");
         Files.createDirectories(felixCacheDir);
         var framework = new FelixFramework(
@@ -73,11 +68,9 @@ class MinimalMainBundleResolutionTest {
             var resolver = new BundleResolver(framework.bundleContext(), indexPath);
             var resolved = resolver.resolve("test.bundle.main");
 
-            // Verify resolution results
             assertNotNull(resolved, "Resolved bundles should not be null");
             assertEquals(2, resolved.size(), "Should resolve exactly 2 bundles (main + dependency)");
 
-            // Verify both required bundles are in the resolved list
             var hasDependency = resolved.stream().anyMatch(path -> path.contains("bundle-dependency.jar"));
             var hasMain = resolved.stream().anyMatch(path -> path.contains("bundle-main.jar"));
             assertTrue(hasDependency, "Dependency bundle should be in resolved list");


### PR DESCRIPTION
## Summary
- Always regenerate the OSGi bundle index in a JVM-managed temp file (`Files.createTempFile` + `deleteOnExit`) instead of caching it under `$VESPA_HOME/tmp/bundle-index-<name>.xml`.
- Removes a correctness hazard where a stale cached index pointed the resolver at outdated bundles after the contents of `lib/jars` (or `bundle.additionalLocations`) changed.
- Drops the `createIndexIfMissing` overloads and the per-symbolic-name index path helper in `BundleIndexer`; the indexer now only writes to a caller-supplied path.
- Simplifies `writeIndex` — destination is now a fresh per-invocation temp file, so the sibling-temp-then-atomic-move dance is no longer earning its keep.