### PR TITLE
chore: Fix toString for memoryGib in NodeResources

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -746,8 +746,8 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                                                              () -> createModelWithTesterNodes("<nodes count='2'/>"))));
 
         assertEquals("In container cluster 'default': tester resources must be absolute, but min and max resources differ: specification of dedicated " +
-                     "min 1 nodes with [vcpu: 0.0, memory: 1.0 Gb, disk: 0.0 Gb, bandwidth: 0.3 Gbps, architecture: any] " +
-                     "max 1 nodes with [vcpu: 0.0, memory: 2.0 Gb, disk: 0.0 Gb, bandwidth: 0.3 Gbps, architecture: any]",
+                     "min 1 nodes with [vcpu: 0.0, memory: 1.0 Gib, disk: 0.0 Gb, bandwidth: 0.3 Gbps, architecture: any] " +
+                     "max 1 nodes with [vcpu: 0.0, memory: 2.0 Gib, disk: 0.0 Gb, bandwidth: 0.3 Gbps, architecture: any]",
                      Exceptions.toMessageString(assertThrows(IllegalArgumentException.class,
                                                              () -> createModelWithTesterNodes("<nodes><resources memory='[1Gb, 2Gb]'/></nodes>"))));
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
@@ -408,7 +408,7 @@ public class NodeResources {
         appendDouble(sb, vcpu);
         sb.append(", memory: ");
         appendDouble(sb, memoryGiB);
-        sb.append(" Gb, disk: ");
+        sb.append(" GiB, disk: ");
         appendDouble(sb, diskGb);
         sb.append(" Gb");
         if (bandwidthGbps > 0) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
@@ -408,7 +408,7 @@ public class NodeResources {
         appendDouble(sb, vcpu);
         sb.append(", memory: ");
         appendDouble(sb, memoryGiB);
-        sb.append(" GiB, disk: ");
+        sb.append(" Gib, disk: ");
         appendDouble(sb, diskGb);
         sb.append(" Gb");
         if (bandwidthGbps > 0) {

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/NodeResourcesTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/NodeResourcesTest.java
@@ -25,11 +25,11 @@ class NodeResourcesTest {
 
     @Test
     void testToString() {
-        assertEquals("[vcpu: 1.0, memory: 10.0 Gb, disk: 100.0 Gb, architecture: any]",
+        assertEquals("[vcpu: 1.0, memory: 10.0 Gib, disk: 100.0 Gb, architecture: any]",
                                new NodeResources(1., 10., 100., 0).toString());
-        assertEquals("[vcpu: 0.3, memory: 3.3 Gb, disk: 33.3 Gb, bandwidth: 0.3 Gbps, architecture: any]",
+        assertEquals("[vcpu: 0.3, memory: 3.3 Gib, disk: 33.3 Gb, bandwidth: 0.3 Gbps, architecture: any]",
                                new NodeResources(1 / 3., 10 / 3., 100 / 3., 0.3).toString());
-        assertEquals("[vcpu: 0.7, memory: 9.0 Gb, disk: 66.7 Gb, bandwidth: 0.7 Gbps, architecture: any]",
+        assertEquals("[vcpu: 0.7, memory: 9.0 Gib, disk: 66.7 Gb, bandwidth: 0.7 Gbps, architecture: any]",
                                new NodeResources(2 / 3., 8.97, 200 / 3., 0.67).toString());
     }
 


### PR DESCRIPTION
This was showing up in logs for Vespa on K8s. Fixed to show the correct representation.