### PR TITLE
fix: Write permissions dummyKeyring. Warning for user with old permissions

### DIFF
--- a/client/go/internal/cli/auth/secrets.go
+++ b/client/go/internal/cli/auth/secrets.go
@@ -3,6 +3,7 @@
 package auth
 
 import (
+	"errors"
 	"os"
 
 	"github.com/zalando/go-keyring"
@@ -58,7 +59,7 @@ func (k *dummyKeyring) Set(namespace, key, value string) error {
 		return err
 	}
 	err = os.Remove(fn)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	err = os.WriteFile(fn, []byte(value), 0o400)

--- a/client/go/internal/cli/auth/secrets.go
+++ b/client/go/internal/cli/auth/secrets.go
@@ -57,7 +57,7 @@ func (k *dummyKeyring) Set(namespace, key, value string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(fn, []byte(value), 0o400)
+	return os.WriteFile(fn, []byte(value), 0o600)
 }
 
 // Get gets a value for the given namespace and key.

--- a/client/go/internal/cli/auth/secrets.go
+++ b/client/go/internal/cli/auth/secrets.go
@@ -57,14 +57,13 @@ func (k *dummyKeyring) Set(namespace, key, value string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(fn, []byte(value), 0o600); err != nil {
-		if !os.IsPermission(err) {
-			return err
-		}
-		if chmodErr := os.Chmod(fn, 0o600); chmodErr != nil {
-			return err
-		}
-		return os.WriteFile(fn, []byte(value), 0o600)
+	err = os.Remove(fn)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(fn, []byte(value), 0o400)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/client/go/internal/cli/auth/secrets.go
+++ b/client/go/internal/cli/auth/secrets.go
@@ -57,7 +57,16 @@ func (k *dummyKeyring) Set(namespace, key, value string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(fn, []byte(value), 0o600)
+	if err := os.WriteFile(fn, []byte(value), 0o600); err != nil {
+		if !os.IsPermission(err) {
+			return err
+		}
+		if chmodErr := os.Chmod(fn, 0o600); chmodErr != nil {
+			return err
+		}
+		return os.WriteFile(fn, []byte(value), 0o600)
+	}
+	return nil
 }
 
 // Get gets a value for the given namespace and key.

--- a/client/go/internal/cli/auth/secrets_test.go
+++ b/client/go/internal/cli/auth/secrets_test.go
@@ -16,4 +16,8 @@ func TestDummyKeyringSaveOverwrite(t *testing.T) {
 	assert.Nil(t, err)
 	err = k.Set("test", "user", "password2")
 	assert.Nil(t, err)
+
+	value, err := k.Get("test", "user")
+	assert.Nil(t, err)
+	assert.Equal(t, "password2", value)
 }

--- a/client/go/internal/cli/auth/secrets_test.go
+++ b/client/go/internal/cli/auth/secrets_test.go
@@ -1,0 +1,19 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDummyKeyringSaveOverwrite(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	k := NewKeyringWithOptions(true)
+
+	err := k.Set("test", "user", "password1")
+	assert.Nil(t, err)
+	err = k.Set("test", "user", "password2")
+	assert.Nil(t, err)
+}

--- a/client/go/internal/cli/cmd/login.go
+++ b/client/go/internal/cli/cmd/login.go
@@ -97,11 +97,14 @@ func doLogin(cli *CLI, cmd *cobra.Command, useFileStorage bool) error {
 	secretsStore := auth.NewKeyringWithOptions(useFileStorage)
 	err = secretsStore.Set(auth.SecretsNamespace, system.Name, res.RefreshToken)
 	if err != nil {
-		// log the error but move on
-		cli.printWarning("Could not store the refresh token locally. You may need to login again once your access token expires (30 minutes).")
-		if !useFileStorage {
-			cli.printWarning("To persist the refresh token using file storage (unencrypted), use --file-storage flag")
-			cli.printWarning("Note: Storing the refresh token unencrypted directly on your file system means someone with access to this file can get unauthorized access to your application for the life of the refresh token (24 hours)")
+		if os.IsPermission(err) {
+			cli.printWarning(fmt.Sprintf("Could not store refresh token locally because the keyring.vespa-cli.public has wrong file permissions. Delete it and try again: %v", err))
+		} else {
+			cli.printWarning("Could not store the refresh token locally. You may need to login again once your access token expires (30 minutes).")
+			if !useFileStorage {
+				cli.printWarning("To persist the refresh token using file storage (unencrypted), use --file-storage flag")
+				cli.printWarning("Note: Storing the refresh token unencrypted directly on your file system means someone with access to this file can get unauthorized access to your application for the life of the refresh token (24 hours)")
+			}
 		}
 	}
 

--- a/client/go/internal/cli/cmd/login.go
+++ b/client/go/internal/cli/cmd/login.go
@@ -97,8 +97,8 @@ func doLogin(cli *CLI, cmd *cobra.Command, useFileStorage bool) error {
 	secretsStore := auth.NewKeyringWithOptions(useFileStorage)
 	err = secretsStore.Set(auth.SecretsNamespace, system.Name, res.RefreshToken)
 	if err != nil {
-		if os.IsPermission(err) {
-			cli.printWarning(fmt.Sprintf("Could not store refresh token locally because the keyring.vespa-cli.public has wrong file permissions. Delete it and try again: %v", err))
+		if useFileStorage && os.IsPermission(err) {
+			cli.printWarning(fmt.Sprintf("Could not store refresh token locally because ~/.vespa/keyring.%s.%s has wrong file permissions. Delete it and try again: %v", auth.SecretsNamespace, system.Name, err))
 		} else {
 			cli.printWarning("Could not store the refresh token locally. You may need to login again once your access token expires (30 minutes).")
 			if !useFileStorage {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The only problem was really the file writing permission. If a user has already created the keyring.vespa-cli.public it will have 0o400 permissions and they will be asked to manually delete it.