### PR TITLE
feat: add <prepend> config to OpenAI embedder

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/EmbedderPrependConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/EmbedderPrependConfig.java
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.component;
+
+import com.yahoo.text.XML;
+import org.w3c.dom.Element;
+
+import java.util.function.Consumer;
+
+/**
+ * Shared parsing of the {@code <prepend>} element for embedder components.
+ *
+ * @author bjorncs
+ */
+record EmbedderPrependConfig(String query, String document) {
+
+    void applyTo(Consumer<String> querySetter, Consumer<String> documentSetter) {
+        if (query != null) querySetter.accept(query);
+        if (document != null) documentSetter.accept(document);
+    }
+
+    static EmbedderPrependConfig parsePrependElement(Element parent) {
+        Element prepend = XML.getChild(parent, "prepend");
+        if (prepend == null) return null;
+        String query = XML.getChildValue(prepend, "query").orElse(null);
+        String document = XML.getChildValue(prepend, "document").orElse(null);
+        return new EmbedderPrependConfig(query, document);
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/HuggingFaceEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/HuggingFaceEmbedder.java
@@ -10,8 +10,8 @@ import org.w3c.dom.Element;
 import java.util.Set;
 
 import static com.yahoo.embedding.huggingface.HuggingFaceEmbedderConfig.PoolingStrategy;
-import static com.yahoo.text.XML.getChild;
 import static com.yahoo.text.XML.getChildValue;
+import static com.yahoo.vespa.model.container.component.EmbedderPrependConfig.parsePrependElement;
 import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
 import static com.yahoo.vespa.model.container.xml.ModelIdResolver.HF_TOKENIZER;
 import static com.yahoo.vespa.model.container.xml.ModelIdResolver.ONNX_MODEL;
@@ -32,10 +32,7 @@ public class HuggingFaceEmbedder extends OnnxEmbedder implements HuggingFaceEmbe
     private final String transformerOutput;
     private final Boolean normalize;
     private final String poolingStrategy;
-
-    private String prependQuery;
-
-    private String prependDocument;
+    private final EmbedderPrependConfig prepend;
 
     public HuggingFaceEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
         super("ai.vespa.embedding.HuggingFaceEmbedder", INTEGRATION_BUNDLE_NAME, xml, state);
@@ -49,11 +46,7 @@ public class HuggingFaceEmbedder extends OnnxEmbedder implements HuggingFaceEmbe
         transformerOutput = getChildValue(xml, "transformer-output").orElse(null);
         normalize = getChildValue(xml, "normalize").map(Boolean::parseBoolean).orElse(null);
         poolingStrategy = getChildValue(xml, "pooling-strategy").orElse(null);
-        Element prepend = getChild(xml, "prepend");
-        if (prepend != null) {
-            prependQuery = getChildValue(prepend, "query").orElse(null);
-            prependDocument = getChildValue(prepend, "document").orElse(null);
-        }
+        prepend = parsePrependElement(xml);
         model.registerOnnxModelCost(cluster, onnxModelOptions);
     }
 
@@ -67,7 +60,6 @@ public class HuggingFaceEmbedder extends OnnxEmbedder implements HuggingFaceEmbe
         if (transformerOutput != null) b.transformerOutput(transformerOutput);
         if (normalize != null) b.normalize(normalize);
         if (poolingStrategy != null) b.poolingStrategy(PoolingStrategy.Enum.valueOf(poolingStrategy));
-        if (prependQuery != null) b.prependQuery(prependQuery);
-        if (prependDocument != null) b.prependDocument(prependDocument);
+        if (prepend != null) prepend.applyTo(b::prependQuery, b::prependDocument);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/OpenAIEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/OpenAIEmbedder.java
@@ -9,6 +9,7 @@ import org.w3c.dom.Element;
 import static com.yahoo.text.XML.getChildValue;
 import static com.yahoo.vespa.model.container.ContainerModelEvaluation.INTEGRATION_BUNDLE_NAME;
 import static com.yahoo.vespa.model.container.component.EmbedderBatchingConfig.parseBatchingElement;
+import static com.yahoo.vespa.model.container.component.EmbedderPrependConfig.parsePrependElement;
 
 /**
  * Configuration builder for OpenAI embedder component.
@@ -22,6 +23,7 @@ public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConf
     private final int dimensions;
     private final String endpoint;
     private final EmbedderBatchingConfig batching;
+    private final EmbedderPrependConfig prepend;
 
     @SuppressWarnings("unused")
     public OpenAIEmbedder(ApplicationContainerCluster cluster, Element xml, DeployState state) {
@@ -32,6 +34,7 @@ public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConf
                 .map(Integer::parseInt).get();
         this.endpoint = getChildValue(xml, "endpoint").orElse(null);
         this.batching = parseBatchingElement(xml);
+        this.prepend = parsePrependElement(xml);
     }
 
     @Override
@@ -41,5 +44,6 @@ public class OpenAIEmbedder extends TypedComponent implements OpenaiEmbedderConf
         builder.dimensions(dimensions);
         if (endpoint != null) builder.endpoint(endpoint);
         if (batching != null) batching.applyTo(builder.batching::maxSize, builder.batching::maxDelayMillis);
+        if (prepend != null) prepend.applyTo(builder::prependQuery, builder::prependDocument);
     }
 }

--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -170,6 +170,7 @@ OpenAIEmbedder =
    element api-key-secret-ref { xsd:string }? &
    element dimensions { xsd:positiveInteger } &
    element endpoint { xsd:string }? &
+   PrependResources? &
    EmbedderBatchingParams
 
 MistralEmbedder =

--- a/config-model/src/test/cfg/application/openai-embedder/services.xml
+++ b/config-model/src/test/cfg/application/openai-embedder/services.xml
@@ -11,6 +11,10 @@
             <api-key-secret-ref>openai_api_key</api-key-secret-ref>
             <dimensions>1024</dimensions>
             <endpoint>https://api.openai.com/v1/embeddings</endpoint>
+            <prepend>
+                <query>query: </query>
+                <document>passage: </document>
+            </prepend>
             <batching max-size="16" max-delay="200ms"/>
         </component>
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/OpenAIEmbedderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/OpenAIEmbedderTest.java
@@ -36,6 +36,8 @@ public class OpenAIEmbedderTest {
         assertEquals("openai_api_key", config.apiKeySecretRef());
         assertEquals(1024, config.dimensions());
         assertEquals("https://api.openai.com/v1/embeddings", config.endpoint());
+        assertEquals("query: ", config.prependQuery());
+        assertEquals("passage: ", config.prependDocument());
         assertEquals(16, config.batching().maxSize());
         assertEquals(200, config.batching().maxDelayMillis());
     }
@@ -49,6 +51,8 @@ public class OpenAIEmbedderTest {
         assertEquals("text-embedding-3-small", config.model());
         assertEquals(1536, config.dimensions());
         assertEquals("https://api.openai.com/v1/embeddings", config.endpoint());
+        assertEquals("", config.prependQuery());
+        assertEquals("", config.prependDocument());
         assertEquals(0, config.batching().maxSize());
         assertEquals(0, config.batching().maxDelayMillis());
     }

--- a/configdefinitions/src/vespa/openai-embedder.def
+++ b/configdefinitions/src/vespa/openai-embedder.def
@@ -14,6 +14,12 @@ model                    string
 # Output dimension
 dimensions               int
 
+# Prefix to prepend to prompt (if in query context)
+prependQuery             string default=""
+
+# Prefix to prepend to prompt (if in document context)
+prependDocument          string default=""
+
 # Dynamic batching configuration
 batching.maxSize         int default=0
 batching.maxDelayMillis  long default=0

--- a/model-integration/src/main/java/ai/vespa/embedding/GgufEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/GgufEmbedder.java
@@ -30,8 +30,7 @@ public class GgufEmbedder extends AbstractComponent implements Embedder {
     private static final Logger log = Logger.getLogger(GgufEmbedder.class.getName());
     private final LlamaModel model;
     private final int maxPromptTokens;
-    private final String prependQuery;
-    private final String prependDocument;
+    private final TextPrepender prepender;
     private final boolean normalize;
 
     public static class Exception extends RuntimeException {
@@ -59,8 +58,7 @@ public class GgufEmbedder extends AbstractComponent implements Embedder {
     //  if (!log.isLoggable(Level.FINE)) modelParams.disableLog();
         model = new LlamaModel(modelParams);
         maxPromptTokens = config.maxPromptTokens();
-        prependQuery = config.prependQuery();
-        prependDocument = config.prependDocument();
+        prepender = new TextPrepender(config.prependQuery(), config.prependDocument());
         normalize = config.normalize();
     }
 
@@ -113,11 +111,7 @@ public class GgufEmbedder extends AbstractComponent implements Embedder {
      * Tokens are assumed to be independent and that the token sequence can be safely truncated at any position.
      */
     private String prependAndTruncatePrompt(String text, Context context) {
-        if (!prependQuery.isBlank() && context.getDestinationType() == Context.DestinationType.QUERY) {
-            text = prependQuery + text;
-        } else if (!prependDocument.isBlank()) {
-            text = prependDocument + text;
-        }
+        text = prepender.prepend(text, context);
         if (maxPromptTokens <= 0) return text;
         var tokens = model.encode(text);
         var maxTruncatedLength = maxPromptTokens - 2; // Reserve space for start and end token

--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
@@ -36,8 +36,7 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
     private final boolean normalize;
     private final HuggingFaceTokenizer tokenizer;
     private final OnnxEvaluator evaluator;
-    private final String prependQuery;
-    private final String prependDocument;
+    private final TextPrepender prepender;
 
     record ModelAnalysis(int numInputs,
                          String inputIdsName,
@@ -107,8 +106,7 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
         
         this.analysis = analyze(evaluator, embedderConfig);
         normalize = embedderConfig.normalize();
-        prependQuery = embedderConfig.prependQuery();
-        prependDocument = embedderConfig.prependDocument();
+        prepender = new TextPrepender(embedderConfig.prependQuery(), embedderConfig.prependDocument());
         var tokenizerPath = modelHelper.getModelPathResolvingIfNecessary(embedderConfig.tokenizerPathReference());
         var builder = new HuggingFaceTokenizer.Builder()
                 .addSpecialTokens(true)
@@ -156,7 +154,7 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
         if (!targetType.dimensions().get(0).isIndexed()) {
             throw new IllegalArgumentException("Error in embedding to type '" + targetType + "': dimension should be indexed.");
         }
-        var embeddingResult = lookupOrEvaluate(context, prependInstruction(text, context));
+        var embeddingResult = lookupOrEvaluate(context, prepender.prepend(text, context));
         IndexedTensor tokenEmbeddings = embeddingResult.output;
         if (targetType.valueType() == TensorType.Value.INT8) {
             return binaryQuantization(embeddingResult, targetType);
@@ -165,17 +163,6 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
             return normalize ? EmbeddingNormalizer.normalize(result, targetType) : result;
         }
     }
-
-    String prependInstruction(String text, Context context) {
-        if (prependQuery != null && !prependQuery.isEmpty() && context.getDestinationType() == Context.DestinationType.QUERY) {
-            return prependQuery + text;
-        }
-        if (prependDocument != null && !prependDocument.isEmpty()) {
-            return prependDocument + text;
-        }
-        return text;
-    }
-
 
     private HuggingFaceEmbedder.HFEmbeddingResult lookupOrEvaluate(Context context, String text) {
         var key = new HFEmbedderCacheKey(context.getEmbedderId(), text);

--- a/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OpenAIEmbedder.java
@@ -35,6 +35,7 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
     private final Embedder.Runtime runtime;
     private final Secret apiKey;
     private final Embedder.Batching batching;
+    private final TextPrepender prepender;
 
     @Inject
     public OpenAIEmbedder(OpenaiEmbedderConfig config, Embedder.Runtime runtime, Secrets secrets) {
@@ -53,6 +54,7 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
                             .formatted(ADA_002_MODEL, ADA_002_DIMENSIONS, ADA_002_DIMENSIONS));
         this.batching = Embedder.Batching.of(
                 config.batching().maxSize(), Duration.ofMillis(config.batching().maxDelayMillis()));
+        this.prepender = new TextPrepender(config.prependQuery(), config.prependDocument());
     }
 
     @Override public Batching batchingConfig() { return batching; }
@@ -73,9 +75,10 @@ public class OpenAIEmbedder extends AbstractHttpEmbedder implements Embedder {
         long startTime = System.nanoTime();
         EmbeddingQuantization.validateTensorType(targetType, config.dimensions(), EmbeddingQuantization.Quantization.FLOAT);
 
+        var prepended = prepender.prependAll(texts, context);
         record CacheKey(String embedderId, List<String> texts) {}
-        var cacheKey = new CacheKey(context.getEmbedderId(), texts);
-        var response = context.computeCachedValueIfAbsent(cacheKey, () -> sendRequest(texts, context));
+        var cacheKey = new CacheKey(context.getEmbedderId(), prepended);
+        var response = context.computeCachedValueIfAbsent(cacheKey, () -> sendRequest(prepended, context));
 
         if (response.usage != null) runtime.sampleSequenceLength(response.usage.totalTokens(), context);
         var tensors = toTensors(response, targetType);

--- a/model-integration/src/main/java/ai/vespa/embedding/TextPrepender.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/TextPrepender.java
@@ -1,0 +1,33 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import com.yahoo.language.process.Embedder;
+
+import java.util.List;
+
+/**
+ * Prepends a query- or document-specific prefix to embedder input text based on
+ * {@link com.yahoo.language.process.InvocationContext.DestinationType}.
+ *
+ * @author bjorncs
+ */
+public record TextPrepender(String prependQuery, String prependDocument) {
+
+    public String prepend(String text, Embedder.Context context) {
+        String prefix = prefixFor(context);
+        return prefix == null ? text : prefix + text;
+    }
+
+    /** Returns {@code texts} unchanged when no prefix applies — avoids allocation in the common case. */
+    public List<String> prependAll(List<String> texts, Embedder.Context context) {
+        String prefix = prefixFor(context);
+        if (prefix == null) return texts;
+        return texts.stream().map(t -> prefix + t).toList();
+    }
+
+    private String prefixFor(Embedder.Context context) {
+        String prefix = context.getDestinationType() == Embedder.Context.DestinationType.QUERY
+                ? prependQuery : prependDocument;
+        return (prefix == null || prefix.isBlank()) ? null : prefix;
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
@@ -171,18 +171,6 @@ public class HuggingFaceEmbedderTest {
     }
 
     @Test
-    public void testPrepend() {
-        var context = new Embedder.Context("schema.indexing");
-        String input = "This is a test";
-        var embedder = getNormalizePrefixdEmbedder();
-        var result = embedder.prependInstruction(input, context);
-        assertEquals("This is a document: This is a test",  result);
-        var queryContext = new Embedder.Context("query(qt)");
-        var queryResult = embedder.prependInstruction(input, queryContext);
-        assertEquals("Represent this text: This is a test",  queryResult);
-    }
-
-    @Test
     public void testSentenceEmbedder() {
         String input = "This is a test with lots of input text here";
         var context = new Embedder.Context("schema.indexing");

--- a/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OpenAIEmbedderTest.java
@@ -100,6 +100,54 @@ public class OpenAIEmbedderTest {
     }
 
     @Test
+    public void testPrependPrefixes() throws Exception {
+        var targetType = TensorType.fromSpec("tensor<float>(d0[1024])");
+        var texts = List.of("Hello", "World");
+
+        // Both prependQuery and prependDocument configured
+        var config = openaiConfigBuilder(1024)
+                .prependQuery("query: ")
+                .prependDocument("document: ");
+        embedder = new OpenAIEmbedder(config.build(), runtime, createMockSecrets());
+
+        // QUERY context — query prefix applied
+        mockServer.enqueue(new MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createBatchSuccessResponse(2, 1024)));
+        var queryContext = new Embedder.Context("query(embedding)");
+        embedder.embed(texts, queryContext, targetType);
+        var queryRequest = mockServer.takeRequest();
+        var queryBody = queryRequest.getBody().readUtf8();
+        assertTrue(queryBody.contains("\"input\":[\"query: Hello\",\"query: World\"]"),
+                "Expected query prefix in request body, got: " + queryBody);
+
+        // DOCUMENT context — document prefix applied
+        mockServer.enqueue(new MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createBatchSuccessResponse(2, 1024)));
+        var docContext = new Embedder.Context("test-embedder");
+        embedder.embed(texts, docContext, targetType);
+        var docRequest = mockServer.takeRequest();
+        var docBody = docRequest.getBody().readUtf8();
+        assertTrue(docBody.contains("\"input\":[\"document: Hello\",\"document: World\"]"),
+                "Expected document prefix in request body, got: " + docBody);
+
+        embedder.deconstruct();
+
+        // Only prependDocument configured — QUERY inputs must remain unmodified
+        var docOnlyConfig = openaiConfigBuilder(1024).prependDocument("document: ");
+        embedder = new OpenAIEmbedder(docOnlyConfig.build(), runtime, createMockSecrets());
+        mockServer.enqueue(new MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(createBatchSuccessResponse(2, 1024)));
+        embedder.embed(texts, queryContext, targetType);
+        var docOnlyQueryRequest = mockServer.takeRequest();
+        var docOnlyQueryBody = docOnlyQueryRequest.getBody().readUtf8();
+        assertTrue(docOnlyQueryBody.contains("\"input\":[\"Hello\",\"World\"]"),
+                "Expected no prefix for QUERY when only prependDocument is set, got: " + docOnlyQueryBody);
+    }
+
+    @Test
     public void testBatchingConfigEnabled() {
         var config = openaiConfigBuilder(1024);
         config.batching.maxSize(16);

--- a/model-integration/src/test/java/ai/vespa/embedding/TextPrependerTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/TextPrependerTest.java
@@ -1,0 +1,54 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import com.yahoo.language.process.Embedder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * @author bjorncs
+ */
+class TextPrependerTest {
+
+    private static final Embedder.Context QUERY = new Embedder.Context("query(qt)");
+    private static final Embedder.Context DOCUMENT = new Embedder.Context("schema.indexing");
+
+    @Test
+    void prependQuery_only_appliesToQueryContext_notDocument() {
+        var prepender = new TextPrepender("query: ", "");
+        assertEquals("query: hello", prepender.prepend("hello", QUERY));
+        assertEquals("hello", prepender.prepend("hello", DOCUMENT));
+    }
+
+    @Test
+    void prependDocument_only_appliesToDocumentContext_notQuery() {
+        var prepender = new TextPrepender("", "passage: ");
+        assertEquals("hello", prepender.prepend("hello", QUERY));
+        assertEquals("passage: hello", prepender.prepend("hello", DOCUMENT));
+    }
+
+    @Test
+    void both_configured_appliesIndependently() {
+        var prepender = new TextPrepender("query: ", "passage: ");
+        assertEquals("query: hello", prepender.prepend("hello", QUERY));
+        assertEquals("passage: hello", prepender.prepend("hello", DOCUMENT));
+    }
+
+    @Test
+    void prependAll_returnsSameListInstance_whenNoPrefixApplies() {
+        var texts = List.of("a", "b");
+        assertSame(texts, new TextPrepender("", "").prependAll(texts, QUERY));
+        assertSame(texts, new TextPrepender("", "passage: ").prependAll(texts, QUERY));
+    }
+
+    @Test
+    void prependAll_appliesPrefixToEveryElement() {
+        var prepender = new TextPrepender("query: ", "passage: ");
+        assertEquals(List.of("query: a", "query: b"), prepender.prependAll(List.of("a", "b"), QUERY));
+        assertEquals(List.of("passage: a", "passage: b"), prepender.prependAll(List.of("a", "b"), DOCUMENT));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `<prepend>` element to the OpenAI embedder for task-specific prefixes (`<query>`/`<document>`), matching existing support in HuggingFace and GGUF embedders.
- Extracts shared utilities to remove duplicated prepend logic:
  - `TextPrepender` (model-integration) — runtime prefix application, used by HuggingFace, GGUF, and OpenAI embedders.
  - `EmbedderPrependConfig` (config-model) — XML parsing of the `<prepend>` element, used by HuggingFace and OpenAI embedders.
- **Behavior change**: `TextPrepender` treats the two prefixes as strictly independent. Previously, HuggingFace and GGUF fell through to `prependDocument` when `prependQuery` was unset, leaking the document prefix into queries. Now a query context only ever sees `prependQuery`, and a document context only ever sees `prependDocument`.
- `OpenAIEmbedder.embed(List<String>, ...)` uses `TextPrepender.prependAll(...)`, which returns the input list unchanged when no prefix applies — no stream allocation in the unconfigured (common) case.
- Documentation update in `vespa-engine/documentation` is in a separate PR.