### PR TITLE
Ensure that bucket DB updater test uses sufficient node set size

### DIFF
--- a/storage/src/tests/distributor/top_level_bucket_db_updater_test.cpp
+++ b/storage/src/tests/distributor/top_level_bucket_db_updater_test.cpp
@@ -1761,9 +1761,11 @@ TEST_F(TopLevelBucketDBUpdaterTest, pending_cluster_state_merge) {
                       "0:1,2,4,5|1:2,3,4,6|2:1,3,5,6"));
 
     // New node came up
-    EXPECT_EQ("4:0,1|2:0,1|6:1,2,3|1:0,2,3|5:2,0,3|3:2,1,3|",
+    EXPECT_EQ("4:0,1|2:0,1|6:1,2,3|1:3,0,2|5:2,0,3|3:2,3,1|",
               merge_bucket_lists(
+                      lib::ClusterState("distributor:1 storage:3"),
                       "0:1,2,4,5|1:2,3,4,6|2:1,3,5,6",
+                      lib::ClusterState("distributor:1 storage:4"),
                       "3:1,3,5,6"));
 
     // Node came up with some buckets removed and some added

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -89,6 +89,7 @@ public:
      * request bucket info commands. Only used for debug logging.
      */
     void setNodeReplied(uint16_t nodeIdx) {
+        assert(nodeIdx < _requestedNodes.size());
         _requestedNodes[nodeIdx] = true;
     }
 


### PR DESCRIPTION
@toregge please review.

Must assign a cluster state with the correct number of nodes prior to setting reply states for these nodes.
