### PR TITLE
Restore netty-codec dep management and add Netty 4.2 artifacts [ MERGEOK ]

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -865,7 +865,32 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-codec-base</artifactId>
+                <version>${netty.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-classes-quic</artifactId>
+                <version>${netty.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-compression</artifactId>
+                <version>${netty.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http3</artifactId>
+                <version>${netty.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-native-quic</artifactId>
                 <version>${netty.vespa.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Restore `netty-codec` to `<dependencyManagement>` in `parent/pom.xml`. Commit 5888447 removed it under the assumption it was renamed to `netty-codec-base` in Netty 4.2, but the artifact still exists (as an aggregator depending on `netty-codec-base`) and is pulled in transitively by AWS SDK v2's `netty-nio-client` and Azure SDK's `azure-core-http-netty`. Without dep management, those transitive declarations win and multiple `netty-codec` versions leak onto the classpath of downstream projects (e.g. vespaai/cloud's CI fails with `4.1.126.Final` and `4.1.118.Final` showing up).
- Add dep management for Netty 4.2-only artifacts that come in transitively via `reactor-netty 1.3.5`: `netty-codec-classes-quic`, `netty-codec-compression`, `netty-codec-http3`, `netty-codec-native-quic`. This lets downstream allow-lists reference `${netty.vespa.version}` instead of hardcoding `4.2.12.Final`.