### PR TITLE
Add DocumentMetaStoreConfig class with setting for storing full document ids

### DIFF
--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -40,6 +40,9 @@ numsummarythreads int default=16 restart
 ## Hence it must always be followed by a manual restart when enabled.
 validate_and_sanitize_docstore enum {NO, YES} default = NO
 
+## Store the full document ids in memory and not just the internal global ids.
+store_full_document_ids enum {NO, YES} default = NO
+
 ## Maximum number of concurrent flushes outstanding.
 flush.maxconcurrent int default=2 restart
 

--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -41,7 +41,7 @@ numsummarythreads int default=16 restart
 validate_and_sanitize_docstore enum {NO, YES} default = NO
 
 ## Store the full document ids in memory and not just the internal global ids.
-store_full_document_ids enum {NO, YES} default = NO
+store_full_document_ids bool default=false
 
 ## Maximum number of concurrent flushes outstanding.
 flush.maxconcurrent int default=2 restart

--- a/searchcore/src/apps/tests/persistenceconformance_test.cpp
+++ b/searchcore/src/apps/tests/persistenceconformance_test.cpp
@@ -163,9 +163,9 @@ public:
                         search::LogDocumentStore::Config(),
                         ThreadingServiceConfig::make(),
                         AllocConfig::makeDefault(),
+                        DocumentMetaStoreConfig::make(),
                         "client",
-                        docTypeName.getName(),
-                        DocumentMetaStoreConfig::make());
+                        docTypeName.getName());
     }
 };
 

--- a/searchcore/src/apps/tests/persistenceconformance_test.cpp
+++ b/searchcore/src/apps/tests/persistenceconformance_test.cpp
@@ -164,7 +164,8 @@ public:
                         ThreadingServiceConfig::make(),
                         AllocConfig::makeDefault(),
                         "client",
-                        docTypeName.getName());
+                        docTypeName.getName(),
+                        DocumentMetaStoreConfig::make());
     }
 };
 

--- a/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
+++ b/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
@@ -99,7 +99,8 @@ struct DBConfigFixture {
              ThreadingServiceConfig::make(),
              AllocConfig::makeDefault(),
              configId,
-             docTypeName);
+             docTypeName,
+             DocumentMetaStoreConfig::make());
     }
 };
 

--- a/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
+++ b/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
@@ -98,9 +98,9 @@ struct DBConfigFixture {
              search::LogDocumentStore::Config(),
              ThreadingServiceConfig::make(),
              AllocConfig::makeDefault(),
+             DocumentMetaStoreConfig::make(),
              configId,
-             docTypeName,
-             DocumentMetaStoreConfig::make());
+             docTypeName);
     }
 };
 

--- a/searchcore/src/tests/proton/server/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/CMakeLists.txt
@@ -5,6 +5,7 @@ vespa_add_executable(searchcore_proton_server_gtest_test_app TEST
     gtest_runner.cpp
     ddbstate_test.cpp
     document_db_initialization_status_test.cpp
+    document_meta_store_config_test.cpp
     documentretriever_test.cpp
     feeddebugger_test.cpp
     feedstates_test.cpp

--- a/searchcore/src/tests/proton/server/document_meta_store_config_test.cpp
+++ b/searchcore/src/tests/proton/server/document_meta_store_config_test.cpp
@@ -1,0 +1,71 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/config-proton.h>
+#include <vespa/searchcore/proton/server/document_meta_store_config.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using proton::DocumentMetaStoreConfig;
+using ProtonConfig = vespa::config::search::core::ProtonConfig;
+using ProtonConfigBuilder = vespa::config::search::core::ProtonConfigBuilder;
+
+class DocumentMetaStoreConfigTest : public ::testing::Test {
+public:
+    DocumentMetaStoreConfigTest();
+    ~DocumentMetaStoreConfigTest() override;
+
+    static ProtonConfig make_proton_config() {
+        ProtonConfigBuilder builder;
+        return builder;
+    }
+
+    static ProtonConfig make_proton_config(bool store_full_document_ids) {
+        ProtonConfigBuilder builder;
+        builder.storeFullDocumentIds = store_full_document_ids;
+        return builder;
+    }
+
+    static DocumentMetaStoreConfig make_config() {
+        return DocumentMetaStoreConfig::make(make_proton_config());
+    }
+
+    static DocumentMetaStoreConfig make_config(bool store_full_document_ids) {
+        return DocumentMetaStoreConfig::make(make_proton_config(store_full_document_ids));
+    }
+protected:
+    DocumentMetaStoreConfig config_false;
+    DocumentMetaStoreConfig config_true;
+};
+
+DocumentMetaStoreConfigTest::DocumentMetaStoreConfigTest()
+    : config_false(make_config(false)),
+      config_true(make_config(true)) {
+}
+
+DocumentMetaStoreConfigTest::~DocumentMetaStoreConfigTest() = default;
+
+TEST_F(DocumentMetaStoreConfigTest, require_that_store_full_document_ids_default_is_false) {
+    EXPECT_EQ(false, DocumentMetaStoreConfig::make().store_full_document_ids());
+    EXPECT_EQ(false, make_config().store_full_document_ids()); // From default ProtonConfig
+}
+
+TEST_F(DocumentMetaStoreConfigTest, require_that_store_full_document_ids_report_works) {
+    EXPECT_EQ(true, make_config(true).store_full_document_ids());
+    EXPECT_EQ(false, make_config(false).store_full_document_ids());
+}
+
+TEST_F(DocumentMetaStoreConfigTest, require_that_updating_works) {
+    auto config = make_config();
+
+    EXPECT_EQ(false, config.store_full_document_ids());
+    config.update(config_true);
+    EXPECT_EQ(true, config.store_full_document_ids());
+    config.update(config_false);
+    EXPECT_EQ(false, config.store_full_document_ids());
+}
+
+TEST_F(DocumentMetaStoreConfigTest, require_that_comparison_works) {
+    EXPECT_EQ(config_false, make_config(false));
+    EXPECT_NE(config_true, make_config(false));
+    EXPECT_EQ(config_true, make_config(true));
+    EXPECT_NE(config_false, make_config(true));
+}

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -185,9 +185,9 @@ std::shared_ptr<DocumentDBConfig> make_document_db_config(std::shared_ptr<Docume
             search::LogDocumentStore::Config(),
             proton::ThreadingServiceConfig::make(),
             proton::AllocConfig::makeDefault(),
+            proton::DocumentMetaStoreConfig::make(),
             "client",
-            doc_type_name.getName(),
-            proton::DocumentMetaStoreConfig::make());
+            doc_type_name.getName());
 }
 
 void

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -186,7 +186,8 @@ std::shared_ptr<DocumentDBConfig> make_document_db_config(std::shared_ptr<Docume
             proton::ThreadingServiceConfig::make(),
             proton::AllocConfig::makeDefault(),
             "client",
-            doc_type_name.getName());
+            doc_type_name.getName(),
+            proton::DocumentMetaStoreConfig::make());
 }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -22,6 +22,7 @@ vespa_add_library(searchcore_server STATIC
     document_db_initialization_status.cpp
     document_db_maintenance_config.cpp
     document_db_reconfig.cpp
+    document_meta_store_config.cpp
     document_meta_store_read_guards.cpp
     document_scan_iterator.cpp
     document_subdb_collection_explorer.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.cpp
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "document_meta_store_config.h"
+#include <vespa/config-proton.h>
+
+namespace proton {
+
+DocumentMetaStoreConfig::DocumentMetaStoreConfig(bool store_full_document_ids)
+    : _store_full_document_ids(store_full_document_ids) {
+}
+
+DocumentMetaStoreConfig DocumentMetaStoreConfig::make(const ProtonConfig& cfg) {
+    return { cfg.storeFullDocumentIds == vespa::config::search::core::ProtonConfig::StoreFullDocumentIds::YES };
+}
+
+DocumentMetaStoreConfig DocumentMetaStoreConfig::make() {
+    return { false };
+}
+
+void DocumentMetaStoreConfig::update(const DocumentMetaStoreConfig& cfg) {
+    _store_full_document_ids = cfg._store_full_document_ids;
+}
+
+bool DocumentMetaStoreConfig::operator==(const DocumentMetaStoreConfig& rhs) const {
+    return _store_full_document_ids == rhs._store_full_document_ids;
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.cpp
@@ -10,7 +10,7 @@ DocumentMetaStoreConfig::DocumentMetaStoreConfig(bool store_full_document_ids)
 }
 
 DocumentMetaStoreConfig DocumentMetaStoreConfig::make(const ProtonConfig& cfg) {
-    return { cfg.storeFullDocumentIds == vespa::config::search::core::ProtonConfig::StoreFullDocumentIds::YES };
+    return { cfg.storeFullDocumentIds };
 }
 
 DocumentMetaStoreConfig DocumentMetaStoreConfig::make() {

--- a/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.h
@@ -1,0 +1,30 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/config-proton.h>
+
+namespace vespa::config::search::core::internal { class InternalProtonType; }
+namespace proton {
+
+/**
+ * Config for the DocumentMetaStore used by StoreOnlyDocSubDB.
+ */
+class DocumentMetaStoreConfig {
+public:
+    using ProtonConfig = const vespa::config::search::core::internal::InternalProtonType;
+
+private:
+    bool _store_full_document_ids;
+
+private:
+    DocumentMetaStoreConfig(bool store_full_document_ids);
+
+public:
+    static DocumentMetaStoreConfig make(const ProtonConfig& cfg);
+    static DocumentMetaStoreConfig make();
+    void update(const DocumentMetaStoreConfig& cfg);
+    bool store_full_document_ids() const { return _store_full_document_ids; }
+    bool operator==(const DocumentMetaStoreConfig& rhs) const;
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -46,6 +46,8 @@
 #include <vespa/searchcorespi/index/warmupconfig.h>
 #include <vespa/searchlib/util/disk_space_calculator.h>
 
+#include "vespa/config-proton.h"
+
 LOG_SETUP(".proton.server.documentdb");
 
 using vespa::config::search::AttributesConfig;

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.cpp
@@ -72,9 +72,9 @@ DocumentDBConfig::DocumentDBConfig(
                const search::LogDocumentStore::Config & storeConfig,
                const ThreadingServiceConfig & threading_service_config,
                const AllocConfig & alloc_config,
+               const DocumentMetaStoreConfig& document_meta_store_config,
                const std::string &configId,
-               const std::string &docTypeName,
-               const DocumentMetaStoreConfig& document_meta_store_config) noexcept
+               const std::string &docTypeName) noexcept
     : _configId(configId),
       _docTypeName(docTypeName),
       _generation(generation),
@@ -95,9 +95,9 @@ DocumentDBConfig::DocumentDBConfig(
       _storeConfig(storeConfig),
       _threading_service_config(threading_service_config),
       _alloc_config(alloc_config),
+      _document_meta_store_config(document_meta_store_config),
       _orig(),
-      _delayedAttributeAspects(false),
-      _document_meta_store_config(document_meta_store_config)
+      _delayedAttributeAspects(false)
 { }
 
 
@@ -239,9 +239,9 @@ DocumentDBConfig::makeReplayConfig(const SP & orig)
                 o._storeConfig,
                 o._threading_service_config,
                 o._alloc_config,
+                o._document_meta_store_config,
                 o._configId,
-                o._docTypeName,
-                o._document_meta_store_config);
+                o._docTypeName);
     ret->_orig = orig;
     return ret;
 }
@@ -283,9 +283,9 @@ DocumentDBConfig::newFromAttributesConfig(const AttributesConfigSP &attributes) 
             _storeConfig,
             _threading_service_config,
             _alloc_config,
+            _document_meta_store_config,
             _configId,
-            _docTypeName,
-            _document_meta_store_config);
+            _docTypeName);
 }
 
 DocumentDBConfig::SP
@@ -323,9 +323,9 @@ DocumentDBConfig::makeDelayedAttributeAspectConfig(const SP &newCfg, const Docum
                    n._storeConfig,
                    n._threading_service_config,
                    n._alloc_config,
+                   n._document_meta_store_config,
                    n._configId,
-                   n._docTypeName,
-                   n._document_meta_store_config);
+                   n._docTypeName);
     result->_delayedAttributeAspects = true;
     return result;
 }

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.cpp
@@ -49,7 +49,8 @@ DocumentDBConfig::ComparisonResult::ComparisonResult()
       storeChanged(false),
       visibilityDelayChanged(false),
       flushChanged(false),
-      alloc_config_changed(false)
+      alloc_config_changed(false),
+      document_meta_store_config_changed(false)
 { }
 
 DocumentDBConfig::DocumentDBConfig(
@@ -72,7 +73,8 @@ DocumentDBConfig::DocumentDBConfig(
                const ThreadingServiceConfig & threading_service_config,
                const AllocConfig & alloc_config,
                const std::string &configId,
-               const std::string &docTypeName) noexcept
+               const std::string &docTypeName,
+               const DocumentMetaStoreConfig& document_meta_store_config) noexcept
     : _configId(configId),
       _docTypeName(docTypeName),
       _generation(generation),
@@ -94,7 +96,8 @@ DocumentDBConfig::DocumentDBConfig(
       _threading_service_config(threading_service_config),
       _alloc_config(alloc_config),
       _orig(),
-      _delayedAttributeAspects(false)
+      _delayedAttributeAspects(false),
+      _document_meta_store_config(document_meta_store_config)
 { }
 
 
@@ -122,7 +125,8 @@ DocumentDBConfig::operator==(const DocumentDBConfig & rhs) const
            equals<DocumentDBMaintenanceConfig>(_maintenance.get(), rhs._maintenance.get()) &&
            (_storeConfig == rhs._storeConfig) &&
            (_threading_service_config == rhs._threading_service_config) &&
-           (_alloc_config == rhs._alloc_config);
+           (_alloc_config == rhs._alloc_config) &&
+           (_document_meta_store_config == rhs._document_meta_store_config);
 }
 
 
@@ -148,6 +152,7 @@ DocumentDBConfig::compare(const DocumentDBConfig &rhs) const
     retval.visibilityDelayChanged = (_maintenance->getVisibilityDelay() != rhs._maintenance->getVisibilityDelay());
     retval.flushChanged = !equals<DocumentDBMaintenanceConfig>(_maintenance.get(), rhs._maintenance.get(), [](const auto &l, const auto &r) { return l.getFlushConfig() == r.getFlushConfig(); });
     retval.alloc_config_changed = (_alloc_config != rhs._alloc_config);
+    retval.document_meta_store_config_changed = (_document_meta_store_config != rhs._document_meta_store_config);
     return retval;
 }
 
@@ -235,7 +240,8 @@ DocumentDBConfig::makeReplayConfig(const SP & orig)
                 o._threading_service_config,
                 o._alloc_config,
                 o._configId,
-                o._docTypeName);
+                o._docTypeName,
+                o._document_meta_store_config);
     ret->_orig = orig;
     return ret;
 }
@@ -278,7 +284,8 @@ DocumentDBConfig::newFromAttributesConfig(const AttributesConfigSP &attributes) 
             _threading_service_config,
             _alloc_config,
             _configId,
-            _docTypeName);
+            _docTypeName,
+            _document_meta_store_config);
 }
 
 DocumentDBConfig::SP
@@ -317,7 +324,8 @@ DocumentDBConfig::makeDelayedAttributeAspectConfig(const SP &newCfg, const Docum
                    n._threading_service_config,
                    n._alloc_config,
                    n._configId,
-                   n._docTypeName);
+                   n._docTypeName,
+                   n._document_meta_store_config);
     result->_delayedAttributeAspects = true;
     return result;
 }

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "document_db_maintenance_config.h"
+#include "document_meta_store_config.h"
 #include "threading_service_config.h"
 #include <vespa/searchcore/proton/common/alloc_config.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
@@ -56,6 +57,7 @@ public:
         bool visibilityDelayChanged;
         bool flushChanged;
         bool alloc_config_changed;
+        bool document_meta_store_config_changed;
 
         ComparisonResult();
         ComparisonResult &setRankProfilesChanged(bool val) { rankProfilesChanged = val; return *this; }
@@ -89,6 +91,7 @@ public:
             return *this;
         }
         ComparisonResult &set_alloc_config_changed(bool val) { alloc_config_changed = val; return *this; }
+        ComparisonResult &set_document_meta_store_config_changed(bool val) { document_meta_store_config_changed = val; return *this; }
     };
 
     using SP = std::shared_ptr<DocumentDBConfig>;
@@ -133,6 +136,7 @@ private:
     const AllocConfig                         _alloc_config;
     SP                                        _orig;
     bool                                      _delayedAttributeAspects;
+    const DocumentMetaStoreConfig             _document_meta_store_config;
 
 
     template <typename T>
@@ -171,7 +175,8 @@ public:
                      const ThreadingServiceConfig & threading_service_config,
                      const AllocConfig & alloc_config,
                      const std::string &configId,
-                     const std::string &docTypeName) noexcept;
+                     const std::string &docTypeName,
+                     const DocumentMetaStoreConfig& document_meta_store_config) noexcept;
 
     DocumentDBConfig(const DocumentDBConfig &cfg) noexcept;
     DocumentDBConfig & operator=(const DocumentDBConfig &cfg) = delete;
@@ -212,6 +217,7 @@ public:
     bool getDelayedAttributeAspects() const { return _delayedAttributeAspects; }
     const ThreadingServiceConfig& get_threading_service_config() const { return _threading_service_config; }
     const AllocConfig& get_alloc_config() const { return _alloc_config; }
+    const DocumentMetaStoreConfig& get_document_meta_store_config() const { return _document_meta_store_config; }
 
     bool operator==(const DocumentDBConfig &rhs) const;
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.h
@@ -134,9 +134,9 @@ private:
     search::LogDocumentStore::Config          _storeConfig;
     const ThreadingServiceConfig              _threading_service_config;
     const AllocConfig                         _alloc_config;
+    const DocumentMetaStoreConfig             _document_meta_store_config;
     SP                                        _orig;
     bool                                      _delayedAttributeAspects;
-    const DocumentMetaStoreConfig             _document_meta_store_config;
 
 
     template <typename T>
@@ -174,9 +174,9 @@ public:
                      const search::LogDocumentStore::Config & storeConfig,
                      const ThreadingServiceConfig & threading_service_config,
                      const AllocConfig & alloc_config,
+                     const DocumentMetaStoreConfig& document_meta_store_config,
                      const std::string &configId,
-                     const std::string &docTypeName,
-                     const DocumentMetaStoreConfig& document_meta_store_config) noexcept;
+                     const std::string &docTypeName) noexcept;
 
     DocumentDBConfig(const DocumentDBConfig &cfg) noexcept;
     DocumentDBConfig & operator=(const DocumentDBConfig &cfg) = delete;

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -367,7 +367,8 @@ DocumentDBConfigManager::update(FNET_Transport & transport, const ConfigSnapshot
                                  ThreadingServiceConfig::make(_bootstrapConfig->getProtonConfig()),
                                  build_alloc_config(_bootstrapConfig->getHwInfo(), _bootstrapConfig->getProtonConfig(), _docTypeName),
                                  _configId,
-                                 _docTypeName);
+                                 _docTypeName,
+                                 DocumentMetaStoreConfig::make(_bootstrapConfig->getProtonConfig()));
     assert(newSnapshot->valid());
     {
         std::lock_guard<std::mutex> lock(_pendingConfigMutex);

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -366,9 +366,9 @@ DocumentDBConfigManager::update(FNET_Transport & transport, const ConfigSnapshot
                                  storeConfig,
                                  ThreadingServiceConfig::make(_bootstrapConfig->getProtonConfig()),
                                  build_alloc_config(_bootstrapConfig->getHwInfo(), _bootstrapConfig->getProtonConfig(), _docTypeName),
+                                 DocumentMetaStoreConfig::make(_bootstrapConfig->getProtonConfig()),
                                  _configId,
-                                 _docTypeName,
-                                 DocumentMetaStoreConfig::make(_bootstrapConfig->getProtonConfig()));
+                                 _docTypeName);
     assert(newSnapshot->valid());
     {
         std::lock_guard<std::mutex> lock(_pendingConfigMutex);

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -254,7 +254,8 @@ InitializerTask::SP
 StoreOnlyDocSubDB::
 createDocumentMetaStoreInitializer(const AllocStrategy& alloc_strategy,
                                    const search::TuneFileAttributes &tuneFile,
-                                   std::shared_ptr<DocumentMetaStoreInitializerResult::SP> result) const
+                                   std::shared_ptr<DocumentMetaStoreInitializerResult::SP> result,
+                                   bool store_full_document_ids) const
 {
     GrowStrategy grow = alloc_strategy.get_grow_strategy();
     // Amortize memory spike cost over N docs
@@ -266,7 +267,7 @@ createDocumentMetaStoreInitializer(const AllocStrategy& alloc_strategy,
     // initializers to get hold of document meta store instance in
     // their constructors.
     *result = std::make_shared<DocumentMetaStoreInitializerResult>
-              (std::make_shared<DocumentMetaStore>(_bucketDB, attrFileName, grow, _subDbType), tuneFile);
+              (std::make_shared<DocumentMetaStore>(_bucketDB, attrFileName, grow, store_full_document_ids, _subDbType), tuneFile);
     return std::make_shared<documentmetastore::DocumentMetaStoreInitializer>
         (baseDir, getSubDbName(), _docTypeName.toString(), (*result)->documentMetaStore());
 }
@@ -317,7 +318,8 @@ StoreOnlyDocSubDB::createInitializer(const DocumentDBConfig &configSnapshot, Ser
     AllocStrategy alloc_strategy = configSnapshot.get_alloc_config().make_alloc_strategy(_subDbType);
     auto dmsInitTask = createDocumentMetaStoreInitializer(alloc_strategy,
                                                           configSnapshot.getTuneFileDocumentDBSP()->_attr,
-                                                          result->writableResult().writableDocumentMetaStore());
+                                                          result->writableResult().writableDocumentMetaStore(),
+                                                          configSnapshot.get_document_meta_store_config().store_full_document_ids());
     result->addDocumentMetaStoreInitTask(dmsInitTask);
     auto summaryTask = createSummaryManagerInitializer(createStoreConfig(configSnapshot.getStoreConfig(), _subDbType),
                                                        alloc_strategy,

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -253,9 +253,9 @@ StoreOnlyDocSubDB::setupSummaryManager(SummaryManager::SP summaryManager)
 InitializerTask::SP
 StoreOnlyDocSubDB::
 createDocumentMetaStoreInitializer(const AllocStrategy& alloc_strategy,
+                                   bool store_full_document_ids,
                                    const search::TuneFileAttributes &tuneFile,
-                                   std::shared_ptr<DocumentMetaStoreInitializerResult::SP> result,
-                                   bool store_full_document_ids) const
+                                   std::shared_ptr<DocumentMetaStoreInitializerResult::SP> result) const
 {
     GrowStrategy grow = alloc_strategy.get_grow_strategy();
     // Amortize memory spike cost over N docs
@@ -317,9 +317,9 @@ StoreOnlyDocSubDB::createInitializer(const DocumentDBConfig &configSnapshot, Ser
                                                              _writeService.master());
     AllocStrategy alloc_strategy = configSnapshot.get_alloc_config().make_alloc_strategy(_subDbType);
     auto dmsInitTask = createDocumentMetaStoreInitializer(alloc_strategy,
+                                                          configSnapshot.get_document_meta_store_config().store_full_document_ids(),
                                                           configSnapshot.getTuneFileDocumentDBSP()->_attr,
-                                                          result->writableResult().writableDocumentMetaStore(),
-                                                          configSnapshot.get_document_meta_store_config().store_full_document_ids());
+                                                          result->writableResult().writableDocumentMetaStore());
     result->addDocumentMetaStoreInitTask(dmsInitTask);
     auto summaryTask = createSummaryManagerInitializer(createStoreConfig(configSnapshot.getStoreConfig(), _subDbType),
                                                        alloc_strategy,

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -174,7 +174,8 @@ protected:
     std::shared_ptr<initializer::InitializerTask>
     createDocumentMetaStoreInitializer(const AllocStrategy& alloc_strategy,
                                        const search::TuneFileAttributes &tuneFile,
-                                       std::shared_ptr<std::shared_ptr<DocumentMetaStoreInitializerResult>> result) const;
+                                       std::shared_ptr<std::shared_ptr<DocumentMetaStoreInitializerResult>> result,
+                                       bool store_full_document_ids) const;
 
     void setupDocumentMetaStore(const DocumentMetaStoreInitializerResult & dmsResult);
     void initFeedView(const DocumentDBConfig &configSnapshot);

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -173,9 +173,9 @@ protected:
 
     std::shared_ptr<initializer::InitializerTask>
     createDocumentMetaStoreInitializer(const AllocStrategy& alloc_strategy,
+                                       bool store_full_document_ids,
                                        const search::TuneFileAttributes &tuneFile,
-                                       std::shared_ptr<std::shared_ptr<DocumentMetaStoreInitializerResult>> result,
-                                       bool store_full_document_ids) const;
+                                       std::shared_ptr<std::shared_ptr<DocumentMetaStoreInitializerResult>> result) const;
 
     void setupDocumentMetaStore(const DocumentMetaStoreInitializerResult & dmsResult);
     void initFeedView(const DocumentDBConfig &configSnapshot);

--- a/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.cpp
@@ -47,9 +47,9 @@ DocumentDBConfigBuilder::DocumentDBConfigBuilder(int64_t generation,
       _store(),
       _threading_service_config(ThreadingServiceConfig::make()),
       _alloc_config(AllocConfig::makeDefault()),
+      _document_meta_store_config(DocumentMetaStoreConfig::make()),
       _configId(configId),
-      _docTypeName(docTypeName),
-      _document_meta_store_config(DocumentMetaStoreConfig::make())
+      _docTypeName(docTypeName)
 { }
 
 
@@ -72,9 +72,9 @@ DocumentDBConfigBuilder::DocumentDBConfigBuilder(const DocumentDBConfig &cfg)
       _store(cfg.getStoreConfig()),
       _threading_service_config(cfg.get_threading_service_config()),
       _alloc_config(cfg.get_alloc_config()),
+      _document_meta_store_config(cfg.get_document_meta_store_config()),
       _configId(cfg.getConfigId()),
-      _docTypeName(cfg.getDocTypeName()),
-      _document_meta_store_config(cfg.get_document_meta_store_config())
+      _docTypeName(cfg.getDocTypeName())
 {}
 
 DocumentDBConfigBuilder::~DocumentDBConfigBuilder() = default;
@@ -101,9 +101,9 @@ DocumentDBConfigBuilder::build()
             _store,
             _threading_service_config,
             _alloc_config,
+            _document_meta_store_config,
             _configId,
-            _docTypeName,
-            _document_meta_store_config);
+            _docTypeName);
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.cpp
@@ -48,7 +48,8 @@ DocumentDBConfigBuilder::DocumentDBConfigBuilder(int64_t generation,
       _threading_service_config(ThreadingServiceConfig::make()),
       _alloc_config(AllocConfig::makeDefault()),
       _configId(configId),
-      _docTypeName(docTypeName)
+      _docTypeName(docTypeName),
+      _document_meta_store_config(DocumentMetaStoreConfig::make())
 { }
 
 
@@ -72,7 +73,8 @@ DocumentDBConfigBuilder::DocumentDBConfigBuilder(const DocumentDBConfig &cfg)
       _threading_service_config(cfg.get_threading_service_config()),
       _alloc_config(cfg.get_alloc_config()),
       _configId(cfg.getConfigId()),
-      _docTypeName(cfg.getDocTypeName())
+      _docTypeName(cfg.getDocTypeName()),
+      _document_meta_store_config(cfg.get_document_meta_store_config())
 {}
 
 DocumentDBConfigBuilder::~DocumentDBConfigBuilder() = default;
@@ -100,7 +102,8 @@ DocumentDBConfigBuilder::build()
             _threading_service_config,
             _alloc_config,
             _configId,
-            _docTypeName);
+            _docTypeName,
+            _document_meta_store_config);
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.h
+++ b/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.h
@@ -34,6 +34,7 @@ private:
     const AllocConfig _alloc_config;
     std::string _configId;
     std::string _docTypeName;
+    const DocumentMetaStoreConfig _document_meta_store_config;
 
 public:
     DocumentDBConfigBuilder(int64_t generation,

--- a/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.h
+++ b/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.h
@@ -32,9 +32,9 @@ private:
     search::LogDocumentStore::Config _store;
     const ThreadingServiceConfig _threading_service_config;
     const AllocConfig _alloc_config;
+    const DocumentMetaStoreConfig _document_meta_store_config;
     std::string _configId;
     std::string _docTypeName;
-    const DocumentMetaStoreConfig _document_meta_store_config;
 
 public:
     DocumentDBConfigBuilder(int64_t generation,


### PR DESCRIPTION
@toregge Do you have a suggestion for a proper name for the setting? And an opinion on whether one should use an enum like this or a bool?

Also probably should add a test.