### PR TITLE
ci: add Extended PR Build trigger workflow

### DIFF
--- a/.github/workflows/extended-pr-build.yml
+++ b/.github/workflows/extended-pr-build.yml
@@ -2,7 +2,7 @@
 #
 # Extended PR Build.
 #
-# Runs an additional build on a labeled pull request that cannot be
+# Runs an additional build on a pull request that cannot be
 # executed on this repository's own runners. The build target is
 # configured through repository secrets so its identity does not appear
 # in this workflow's logs.

--- a/.github/workflows/extended-pr-build.yml
+++ b/.github/workflows/extended-pr-build.yml
@@ -1,0 +1,97 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#
+# Extended PR Build.
+#
+# Runs an additional build on a labeled pull request that cannot be
+# executed on this repository's own runners. The build target is
+# configured through repository secrets so its identity does not appear
+# in this workflow's logs.
+#
+# Trigger
+#   Every pull request — including drafts — on open, push, and reopen.
+#
+# Authorization
+#   - PRs from org members run automatically via the no-rules
+#     `extended-build-internal` environment.
+#   - PRs from external authors route through the `extended-build-external`
+#     environment, which requires reviewer approval before the build runs.
+#
+# Required configuration (one-time, repo or org scope)
+#
+#   Secrets:
+#     EXTENDED_BUILD_APP_ID         App ID of the GitHub App authorized to
+#                                   start the extended build.
+#     EXTENDED_BUILD_APP_PRIVATE_KEY PEM-encoded private key for that App.
+#     EXTENDED_BUILD_OWNER          Org/user that runs the extended build.
+#     EXTENDED_BUILD_REPO           Repository that runs the extended build.
+#
+#   Environments (Settings -> Environments):
+#     extended-build-internal       No protection rules.
+#     extended-build-external       Required reviewers: vespa-engine/vespa team.
+
+name: Extended PR Build
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: extended-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      env: ${{ steps.route.outputs.env }}
+    steps:
+      - name: Route by author association
+        id: route
+        env:
+          ASSOC: ${{ github.event.pull_request.author_association }}
+        run: |
+          case "${ASSOC}" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "env=extended-build-internal" >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "env=extended-build-external" >> "${GITHUB_OUTPUT}"
+              ;;
+          esac
+
+  dispatch:
+    needs: classify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.classify.outputs.env }}
+    steps:
+      - name: Mint dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.EXTENDED_BUILD_APP_ID }}
+          private-key: ${{ secrets.EXTENDED_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ secrets.EXTENDED_BUILD_OWNER }}
+          repositories: ${{ secrets.EXTENDED_BUILD_REPO }}
+
+      - name: Trigger extended build
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ secrets.EXTENDED_BUILD_OWNER }}
+          REPO: ${{ secrets.EXTENDED_BUILD_REPO }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          jq -nc \
+            --arg event "extended-build" \
+            --arg branch "${BRANCH}" \
+            --arg sha "${HEAD_SHA}" \
+            --arg pr "${PR_NUMBER}" \
+            --arg src "${SOURCE_REPO}" \
+            '{event_type: $event, client_payload: {branch: $branch, head_sha: $sha, pr_number: $pr, source_repo: $src}}' \
+          | gh api --method POST "repos/${OWNER}/${REPO}/dispatches" --input -
+          echo "Dispatched extended build for PR #${PR_NUMBER}."

--- a/.github/workflows/extended-pr-build.yml
+++ b/.github/workflows/extended-pr-build.yml
@@ -8,7 +8,10 @@
 # in this workflow's logs.
 #
 # Trigger
-#   Every pull request — including drafts — on open, push, and reopen.
+#   Fires whenever the code diff changes: on open, on synchronize (new
+#   commits pushed, force-pushed, rebased, or merged with the base branch),
+#   and on reopen. Does not fire for metadata-only events such as title
+#   edits or ready-for-review transitions.
 #
 # Authorization
 #   - PRs from org members run automatically via the no-rules

--- a/.github/workflows/extended-pr-build.yml
+++ b/.github/workflows/extended-pr-build.yml
@@ -87,7 +87,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           jq -nc \
             --arg event "extended-build" \

--- a/.github/workflows/extended-pr-build.yml
+++ b/.github/workflows/extended-pr-build.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Mint dispatch token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.EXTENDED_BUILD_APP_ID }}
           private-key: ${{ secrets.EXTENDED_BUILD_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/extended-pr-build.yml`: a GitHub Actions workflow that forwards every pull request event to a dispatch repository for an out-of-band build that cannot run on this repository's runners.
- Identity of the dispatch target is held in repository secrets so it does not appear in this workflow's public logs.
- PRs from org members run automatically through the no-rules `extended-build-internal` environment; PRs from external authors route through `extended-build-external`, which requires reviewer approval before the build is fired.
- One-time setup needed before the workflow becomes useful: a GitHub App, four repository secrets (`EXTENDED_BUILD_APP_ID`, `EXTENDED_BUILD_APP_PRIVATE_KEY`, `EXTENDED_BUILD_OWNER`, `EXTENDED_BUILD_REPO`), and the two environments configured in repo settings — all documented in the file's header.