### PR TITLE
Clearly mark C++ files generated by configgen as generated

### DIFF
--- a/configgen/src/main/java/com/yahoo/config/codegen/CppClassBuilder.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/CppClassBuilder.java
@@ -219,6 +219,9 @@ public class CppClassBuilder implements ClassBuilder {
         String namespacePrint = generateCppNameSpaceString(namespaceList);
         String className = getTypeName(root, false);
         w.write(""
+                + "// ------------   D O   N O T   E D I T !   ------------\n"
+                + "// This file is generated from a config definition file.\n"
+                + "\n"
                 + "/**\n"
                 + " * @class " + namespacePrint + "::" + className + "\n"
                 + " * @ingroup config\n"
@@ -567,6 +570,9 @@ public class CppClassBuilder implements ClassBuilder {
     }
 
     void writeBodyHeader(Writer w, CNode root, String subdir) throws IOException {
+        w.write("// ------------   D O   N O T   E D I T !   ------------\n");
+        w.write("// This file is generated from a config definition file.\n");
+        w.write("\n");
         if (subdir == null) {
             w.write("#include \"" + getFileName(root, "h") + "\"");
         } else {


### PR DESCRIPTION
Makes it a bit easier to notice that these source files are, in fact, generated and should not be edited. Adds the same warning we already have in Java files.
