### PR TITLE
Add cluster-scoped resolver to CloudResourceTags

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -39,10 +39,9 @@ public class CloudResourceTags {
     /** Key prefixes reserved by the platform. */
     private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "bastion_");
 
-    private static final List<String> DEPLOYMENT_PLACEHOLDERS = List.of(
-            "${tenant}", "${application}", "${instance}", "${environment}", "${region}");
-
-    private static final List<String> CLUSTER_PLACEHOLDERS = List.of("${clustername}", "${clustertype}");
+    private static final List<String> PLACEHOLDERS = List.of(
+            "${tenant}", "${application}", "${instance}", "${environment}", "${region}",
+            "${clustername}", "${clustertype}");
 
     private final Map<String, String> tags;
 
@@ -64,8 +63,7 @@ public class CloudResourceTags {
     public void validatePlaceholders() {
         for (var entry : tags.entrySet()) {
             String remaining = entry.getValue();
-            for (String p : DEPLOYMENT_PLACEHOLDERS) remaining = remaining.replace(p, "");
-            for (String p : CLUSTER_PLACEHOLDERS) remaining = remaining.replace(p, "");
+            for (String p : PLACEHOLDERS) remaining = remaining.replace(p, "");
             if (remaining.contains("${"))
                 throw new IllegalArgumentException("Unknown template variable in resource tag value for key '" +
                                                    entry.getKey() + "': " + entry.getValue());
@@ -73,35 +71,21 @@ public class CloudResourceTags {
     }
 
     /**
-     * Returns a new instance with deployment-context placeholders
-     * ({@code ${tenant}}, {@code ${application}}, etc.) substituted.
-     * Cluster-scoped placeholders ({@code ${clustername}}, {@code ${clustertype}}) are not affected.
+     * Returns a new instance with all template variables substituted.
+     * Throws if any {@code ${...}} placeholders remain after substitution.
      */
-    public CloudResourceTags resolveDeployment(String tenant, String application, String instance,
-                                               String environment, String region) {
-        if (tags.isEmpty()) return this;
-        Map<String, String> resolved = new LinkedHashMap<>();
-        for (var entry : tags.entrySet()) {
-            resolved.put(entry.getKey(), entry.getValue()
-                    .replace("${tenant}", tenant.toLowerCase(Locale.ROOT))
-                    .replace("${application}", application.toLowerCase(Locale.ROOT))
-                    .replace("${instance}", instance.toLowerCase(Locale.ROOT))
-                    .replace("${environment}", environment)
-                    .replace("${region}", region));
-        }
-        return from(resolved);
-    }
-
-    /**
-     * Returns a new instance with {@code ${clustername}} and {@code ${clustertype}} substituted.
-     * Throws if any {@code ${...}} placeholders remain after substitution. Call
-     * {@link #resolveDeployment} first to resolve deployment-context placeholders.
-     */
-    public CloudResourceTags resolveCluster(ClusterSpec.Id clusterId, ClusterSpec.Type clusterType) {
+    public CloudResourceTags resolve(String tenant, String application, String instance,
+                                     String environment, String region,
+                                     ClusterSpec.Id clusterId, ClusterSpec.Type clusterType) {
         if (tags.isEmpty()) return this;
         Map<String, String> resolved = new LinkedHashMap<>();
         for (var entry : tags.entrySet()) {
             String value = entry.getValue()
+                    .replace("${tenant}", tenant.toLowerCase(Locale.ROOT))
+                    .replace("${application}", application.toLowerCase(Locale.ROOT))
+                    .replace("${instance}", instance.toLowerCase(Locale.ROOT))
+                    .replace("${environment}", environment)
+                    .replace("${region}", region)
                     .replace("${clustername}", clusterId.value().toLowerCase(Locale.ROOT))
                     .replace("${clustertype}", clusterType.name());
             if (value.contains("${"))
@@ -110,11 +94,6 @@ public class CloudResourceTags {
             resolved.put(entry.getKey(), value);
         }
         return from(resolved);
-    }
-
-    /** Returns true if any tag value contains cluster-scoped placeholders. */
-    public boolean containsClusterPlaceholders() {
-        return tags.values().stream().anyMatch(v -> CLUSTER_PLACEHOLDERS.stream().anyMatch(v::contains));
     }
 
     /**

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -74,18 +74,17 @@ public class CloudResourceTags {
      * Returns a new instance with all template variables substituted.
      * Throws if any {@code ${...}} placeholders remain after substitution.
      */
-    public CloudResourceTags resolve(String tenant, String application, String instance,
-                                     String environment, String region,
+    public CloudResourceTags resolve(ApplicationId application, Environment environment, RegionName region,
                                      ClusterSpec.Id clusterId, ClusterSpec.Type clusterType) {
         if (tags.isEmpty()) return this;
         Map<String, String> resolved = new LinkedHashMap<>();
         for (var entry : tags.entrySet()) {
             String value = entry.getValue()
-                    .replace("${tenant}", tenant.toLowerCase(Locale.ROOT))
-                    .replace("${application}", application.toLowerCase(Locale.ROOT))
-                    .replace("${instance}", instance.toLowerCase(Locale.ROOT))
-                    .replace("${environment}", environment)
-                    .replace("${region}", region)
+                    .replace("${tenant}", application.tenant().value().toLowerCase(Locale.ROOT))
+                    .replace("${application}", application.application().value().toLowerCase(Locale.ROOT))
+                    .replace("${instance}", application.instance().value().toLowerCase(Locale.ROOT))
+                    .replace("${environment}", environment.value())
+                    .replace("${region}", region.value())
                     .replace("${clustername}", clusterId.value().toLowerCase(Locale.ROOT))
                     .replace("${clustertype}", clusterType.name());
             if (value.contains("${"))

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -3,6 +3,7 @@ package com.yahoo.config.provision;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -38,6 +39,11 @@ public class CloudResourceTags {
     /** Key prefixes reserved by the platform. */
     private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "bastion_");
 
+    private static final List<String> DEPLOYMENT_PLACEHOLDERS = List.of(
+            "${tenant}", "${application}", "${instance}", "${environment}", "${region}");
+
+    private static final List<String> CLUSTER_PLACEHOLDERS = List.of("${clustername}", "${clustertype}");
+
     private final Map<String, String> tags;
 
     private CloudResourceTags(Map<String, String> tags) {
@@ -50,6 +56,66 @@ public class CloudResourceTags {
     public boolean isEmpty() { return tags.isEmpty(); }
 
     public int size() { return tags.size(); }
+
+    /**
+     * Validates that all {@code ${...}} placeholders in tag values are recognized.
+     * Throws on any unknown placeholder. Does not resolve anything.
+     */
+    public void validatePlaceholders() {
+        for (var entry : tags.entrySet()) {
+            String remaining = entry.getValue();
+            for (String p : DEPLOYMENT_PLACEHOLDERS) remaining = remaining.replace(p, "");
+            for (String p : CLUSTER_PLACEHOLDERS) remaining = remaining.replace(p, "");
+            if (remaining.contains("${"))
+                throw new IllegalArgumentException("Unknown template variable in resource tag value for key '" +
+                                                   entry.getKey() + "': " + entry.getValue());
+        }
+    }
+
+    /**
+     * Returns a new instance with deployment-context placeholders
+     * ({@code ${tenant}}, {@code ${application}}, etc.) substituted.
+     * Cluster-scoped placeholders ({@code ${clustername}}, {@code ${clustertype}}) are not affected.
+     */
+    public CloudResourceTags resolveDeployment(String tenant, String application, String instance,
+                                               String environment, String region) {
+        if (tags.isEmpty()) return this;
+        Map<String, String> resolved = new LinkedHashMap<>();
+        for (var entry : tags.entrySet()) {
+            resolved.put(entry.getKey(), entry.getValue()
+                    .replace("${tenant}", tenant.toLowerCase(Locale.ROOT))
+                    .replace("${application}", application.toLowerCase(Locale.ROOT))
+                    .replace("${instance}", instance.toLowerCase(Locale.ROOT))
+                    .replace("${environment}", environment)
+                    .replace("${region}", region));
+        }
+        return from(resolved);
+    }
+
+    /**
+     * Returns a new instance with {@code ${clustername}} and {@code ${clustertype}} substituted.
+     * Throws if any {@code ${...}} placeholders remain after substitution. Call
+     * {@link #resolveDeployment} first to resolve deployment-context placeholders.
+     */
+    public CloudResourceTags resolveCluster(ClusterSpec.Id clusterId, ClusterSpec.Type clusterType) {
+        if (tags.isEmpty()) return this;
+        Map<String, String> resolved = new LinkedHashMap<>();
+        for (var entry : tags.entrySet()) {
+            String value = entry.getValue()
+                    .replace("${clustername}", clusterId.value().toLowerCase(Locale.ROOT))
+                    .replace("${clustertype}", clusterType.name());
+            if (value.contains("${"))
+                throw new IllegalArgumentException("Unresolved template variable in resource tag value for key '" +
+                                                   entry.getKey() + "': " + value);
+            resolved.put(entry.getKey(), value);
+        }
+        return from(resolved);
+    }
+
+    /** Returns true if any tag value contains cluster-scoped placeholders. */
+    public boolean containsClusterPlaceholders() {
+        return tags.values().stream().anyMatch(v -> CLUSTER_PLACEHOLDERS.stream().anyMatch(v::contains));
+    }
 
     /**
      * Returns a new instance with the given tags merged into this.

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -189,6 +189,10 @@ class CloudResourceTagsTest {
         assertEquals(3, tags.size());
     }
 
+    private static final ApplicationId testApp = ApplicationId.from("Tenant1", "App1", "Default");
+    private static final Environment testEnv = Environment.prod;
+    private static final RegionName testRegion = RegionName.from("aws-us-east-1c");
+
     @Test
     void resolve_substitutes_all_placeholders() {
         var tags = CloudResourceTags.from(Map.of(
@@ -198,7 +202,7 @@ class CloudResourceTagsTest {
                 "cluster", "${clustername}",
                 "type", "${clustertype}",
                 "combined", "${environment}-${clustername}-${clustertype}"));
-        var resolved = tags.resolve("Tenant1", "App1", "Default", "prod", "aws-us-east-1c",
+        var resolved = tags.resolve(testApp, testEnv, testRegion,
                                     ClusterSpec.Id.from("my-search"), ClusterSpec.Type.content);
         assertEquals("prod", resolved.asMap().get("env"));
         assertEquals("aws-us-east-1c", resolved.asMap().get("loc"));
@@ -211,14 +215,14 @@ class CloudResourceTagsTest {
     @Test
     void resolve_lowercases_tenant_application_instance_and_cluster_id() {
         var tags = CloudResourceTags.from(Map.of("tag", "${tenant}-${clustername}"));
-        var resolved = tags.resolve("MyTenant", "MyApp", "MyInst", "prod", "r",
+        var resolved = tags.resolve(testApp, testEnv, testRegion,
                                     ClusterSpec.Id.from("MyCluster"), ClusterSpec.Type.container);
-        assertEquals("mytenant-mycluster", resolved.asMap().get("tag"));
+        assertEquals("tenant1-mycluster", resolved.asMap().get("tag"));
     }
 
     @Test
     void resolve_on_empty_returns_empty() {
-        var resolved = CloudResourceTags.empty().resolve("t", "a", "i", "prod", "r",
+        var resolved = CloudResourceTags.empty().resolve(testApp, testEnv, testRegion,
                                                          ClusterSpec.Id.from("c"), ClusterSpec.Type.admin);
         assertTrue(resolved.isEmpty());
     }
@@ -226,7 +230,7 @@ class CloudResourceTagsTest {
     @Test
     void resolve_on_tags_without_placeholders() {
         var tags = CloudResourceTags.from(Map.of("env", "prod"));
-        var resolved = tags.resolve("t", "a", "i", "e", "r",
+        var resolved = tags.resolve(testApp, testEnv, testRegion,
                                     ClusterSpec.Id.from("c"), ClusterSpec.Type.content);
         assertEquals("prod", resolved.asMap().get("env"));
     }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -190,6 +190,97 @@ class CloudResourceTagsTest {
     }
 
     @Test
+    void resolve_deployment_substitutes_placeholders() {
+        var tags = CloudResourceTags.from(Map.of(
+                "env", "${environment}",
+                "loc", "${region}",
+                "team", "${tenant}-${application}-${instance}"));
+        var resolved = tags.resolveDeployment("Tenant1", "App1", "Default", "prod", "aws-us-east-1c");
+        assertEquals("prod", resolved.asMap().get("env"));
+        assertEquals("aws-us-east-1c", resolved.asMap().get("loc"));
+        assertEquals("tenant1-app1-default", resolved.asMap().get("team"));
+    }
+
+    @Test
+    void resolve_deployment_passes_through_cluster_placeholders() {
+        var tags = CloudResourceTags.from(Map.of(
+                "tag", "${environment}-${clustertype}"));
+        var resolved = tags.resolveDeployment("t", "a", "i", "prod", "r");
+        assertEquals("prod-${clustertype}", resolved.asMap().get("tag"));
+    }
+
+    @Test
+    void resolve_deployment_on_empty_returns_empty() {
+        var resolved = CloudResourceTags.empty().resolveDeployment("t", "a", "i", "prod", "r");
+        assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void validate_placeholders_accepts_all_known() {
+        var tags = CloudResourceTags.from(Map.of(
+                "a", "${tenant}-${application}-${instance}",
+                "b", "${environment}-${region}",
+                "c", "${clustername}-${clustertype}"));
+        tags.validatePlaceholders();
+    }
+
+    @Test
+    void validate_placeholders_rejects_unknown() {
+        var tags = CloudResourceTags.from(Map.of("bad", "${unknown}"));
+        var e = assertThrows(IllegalArgumentException.class, tags::validatePlaceholders);
+        assertTrue(e.getMessage().contains("Unknown template variable"));
+    }
+
+    @Test
+    void resolve_cluster_substitutes_placeholders() {
+        var tags = CloudResourceTags.from(Map.of(
+                "cluster", "${clustername}",
+                "type", "${clustertype}",
+                "combined", "${clustername}-${clustertype}"));
+        var resolved = tags.resolveCluster(ClusterSpec.Id.from("my-search"), ClusterSpec.Type.content);
+        assertEquals("my-search", resolved.asMap().get("cluster"));
+        assertEquals("content", resolved.asMap().get("type"));
+        assertEquals("my-search-content", resolved.asMap().get("combined"));
+    }
+
+    @Test
+    void resolve_cluster_lowercases_cluster_id() {
+        var tags = CloudResourceTags.from(Map.of("cluster", "${clustername}"));
+        var resolved = tags.resolveCluster(ClusterSpec.Id.from("MyCluster"), ClusterSpec.Type.container);
+        assertEquals("mycluster", resolved.asMap().get("cluster"));
+    }
+
+    @Test
+    void resolve_cluster_leaves_other_placeholders_untouched_and_throws() {
+        var tags = CloudResourceTags.from(Map.of("tag", "${environment}-${clustername}"));
+        var e = assertThrows(IllegalArgumentException.class,
+                             () -> tags.resolveCluster(ClusterSpec.Id.from("search"), ClusterSpec.Type.content));
+        assertTrue(e.getMessage().contains("Unresolved template variable"));
+    }
+
+    @Test
+    void resolve_cluster_on_empty_tags_returns_empty() {
+        var resolved = CloudResourceTags.empty().resolveCluster(ClusterSpec.Id.from("x"), ClusterSpec.Type.admin);
+        assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void resolve_cluster_on_tags_without_placeholders() {
+        var tags = CloudResourceTags.from(Map.of("env", "prod"));
+        var resolved = tags.resolveCluster(ClusterSpec.Id.from("search"), ClusterSpec.Type.content);
+        assertEquals("prod", resolved.asMap().get("env"));
+    }
+
+    @Test
+    void contains_cluster_placeholders() {
+        assertFalse(CloudResourceTags.empty().containsClusterPlaceholders());
+        assertFalse(CloudResourceTags.from(Map.of("env", "prod")).containsClusterPlaceholders());
+        assertTrue(CloudResourceTags.from(Map.of("cluster", "${clustername}")).containsClusterPlaceholders());
+        assertTrue(CloudResourceTags.from(Map.of("type", "${clustertype}")).containsClusterPlaceholders());
+        assertTrue(CloudResourceTags.from(Map.of("tag", "prefix-${clustername}")).containsClusterPlaceholders());
+    }
+
+    @Test
     void to_string() {
         var tags = CloudResourceTags.from(Map.of("env", "prod"));
         assertTrue(tags.toString().contains("env"));

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -190,29 +190,45 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void resolve_deployment_substitutes_placeholders() {
+    void resolve_substitutes_all_placeholders() {
         var tags = CloudResourceTags.from(Map.of(
                 "env", "${environment}",
                 "loc", "${region}",
-                "team", "${tenant}-${application}-${instance}"));
-        var resolved = tags.resolveDeployment("Tenant1", "App1", "Default", "prod", "aws-us-east-1c");
+                "team", "${tenant}-${application}-${instance}",
+                "cluster", "${clustername}",
+                "type", "${clustertype}",
+                "combined", "${environment}-${clustername}-${clustertype}"));
+        var resolved = tags.resolve("Tenant1", "App1", "Default", "prod", "aws-us-east-1c",
+                                    ClusterSpec.Id.from("my-search"), ClusterSpec.Type.content);
         assertEquals("prod", resolved.asMap().get("env"));
         assertEquals("aws-us-east-1c", resolved.asMap().get("loc"));
         assertEquals("tenant1-app1-default", resolved.asMap().get("team"));
+        assertEquals("my-search", resolved.asMap().get("cluster"));
+        assertEquals("content", resolved.asMap().get("type"));
+        assertEquals("prod-my-search-content", resolved.asMap().get("combined"));
     }
 
     @Test
-    void resolve_deployment_passes_through_cluster_placeholders() {
-        var tags = CloudResourceTags.from(Map.of(
-                "tag", "${environment}-${clustertype}"));
-        var resolved = tags.resolveDeployment("t", "a", "i", "prod", "r");
-        assertEquals("prod-${clustertype}", resolved.asMap().get("tag"));
+    void resolve_lowercases_tenant_application_instance_and_cluster_id() {
+        var tags = CloudResourceTags.from(Map.of("tag", "${tenant}-${clustername}"));
+        var resolved = tags.resolve("MyTenant", "MyApp", "MyInst", "prod", "r",
+                                    ClusterSpec.Id.from("MyCluster"), ClusterSpec.Type.container);
+        assertEquals("mytenant-mycluster", resolved.asMap().get("tag"));
     }
 
     @Test
-    void resolve_deployment_on_empty_returns_empty() {
-        var resolved = CloudResourceTags.empty().resolveDeployment("t", "a", "i", "prod", "r");
+    void resolve_on_empty_returns_empty() {
+        var resolved = CloudResourceTags.empty().resolve("t", "a", "i", "prod", "r",
+                                                         ClusterSpec.Id.from("c"), ClusterSpec.Type.admin);
         assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void resolve_on_tags_without_placeholders() {
+        var tags = CloudResourceTags.from(Map.of("env", "prod"));
+        var resolved = tags.resolve("t", "a", "i", "e", "r",
+                                    ClusterSpec.Id.from("c"), ClusterSpec.Type.content);
+        assertEquals("prod", resolved.asMap().get("env"));
     }
 
     @Test
@@ -229,55 +245,6 @@ class CloudResourceTagsTest {
         var tags = CloudResourceTags.from(Map.of("bad", "${unknown}"));
         var e = assertThrows(IllegalArgumentException.class, tags::validatePlaceholders);
         assertTrue(e.getMessage().contains("Unknown template variable"));
-    }
-
-    @Test
-    void resolve_cluster_substitutes_placeholders() {
-        var tags = CloudResourceTags.from(Map.of(
-                "cluster", "${clustername}",
-                "type", "${clustertype}",
-                "combined", "${clustername}-${clustertype}"));
-        var resolved = tags.resolveCluster(ClusterSpec.Id.from("my-search"), ClusterSpec.Type.content);
-        assertEquals("my-search", resolved.asMap().get("cluster"));
-        assertEquals("content", resolved.asMap().get("type"));
-        assertEquals("my-search-content", resolved.asMap().get("combined"));
-    }
-
-    @Test
-    void resolve_cluster_lowercases_cluster_id() {
-        var tags = CloudResourceTags.from(Map.of("cluster", "${clustername}"));
-        var resolved = tags.resolveCluster(ClusterSpec.Id.from("MyCluster"), ClusterSpec.Type.container);
-        assertEquals("mycluster", resolved.asMap().get("cluster"));
-    }
-
-    @Test
-    void resolve_cluster_leaves_other_placeholders_untouched_and_throws() {
-        var tags = CloudResourceTags.from(Map.of("tag", "${environment}-${clustername}"));
-        var e = assertThrows(IllegalArgumentException.class,
-                             () -> tags.resolveCluster(ClusterSpec.Id.from("search"), ClusterSpec.Type.content));
-        assertTrue(e.getMessage().contains("Unresolved template variable"));
-    }
-
-    @Test
-    void resolve_cluster_on_empty_tags_returns_empty() {
-        var resolved = CloudResourceTags.empty().resolveCluster(ClusterSpec.Id.from("x"), ClusterSpec.Type.admin);
-        assertTrue(resolved.isEmpty());
-    }
-
-    @Test
-    void resolve_cluster_on_tags_without_placeholders() {
-        var tags = CloudResourceTags.from(Map.of("env", "prod"));
-        var resolved = tags.resolveCluster(ClusterSpec.Id.from("search"), ClusterSpec.Type.content);
-        assertEquals("prod", resolved.asMap().get("env"));
-    }
-
-    @Test
-    void contains_cluster_placeholders() {
-        assertFalse(CloudResourceTags.empty().containsClusterPlaceholders());
-        assertFalse(CloudResourceTags.from(Map.of("env", "prod")).containsClusterPlaceholders());
-        assertTrue(CloudResourceTags.from(Map.of("cluster", "${clustername}")).containsClusterPlaceholders());
-        assertTrue(CloudResourceTags.from(Map.of("type", "${clustertype}")).containsClusterPlaceholders());
-        assertTrue(CloudResourceTags.from(Map.of("tag", "prefix-${clustername}")).containsClusterPlaceholders());
     }
 
     @Test


### PR DESCRIPTION
Adds `resolveCluster(ClusterSpec.Id, ClusterSpec.Type)` to `CloudResourceTags` for resolving `${clustername}` and `${clustertype}` template variables in cloud resource tag values.

These placeholders are cluster-scoped (unlike the existing five deployment-context variables) and are resolved per host at apply time in the cloud repo, where cluster allocation context is available.

- `resolveCluster()`: substitutes the two placeholders, lowercases the cluster ID for GCP label compatibility, throws on remaining unresolved placeholders
- `containsClusterPlaceholders()`: quick check to skip unnecessary cluster lookups when tags have no cluster placeholders