### PR TITLE
Discover additional flag definitions via ServiceLoader SPI

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/FlagDefinitions.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FlagDefinitions.java
@@ -1,0 +1,30 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+/**
+ * Service Provider Interface that allows additional flag definitions, defined outside the
+ * {@code flags} bundle, to be registered with {@link Flags} and {@link PermanentFlags}.
+ *
+ * <p>Implementations are discovered via {@link java.util.ServiceLoader} when {@link Flags}
+ * is class-initialized, and {@link #register()} is invoked at most once per {@link Flags}
+ * class initialization (i.e. once per classloader that loads this class). Implementations
+ * are expected to register their flags by calling {@code Flags.defineXxxFlag(...)} (typically
+ * by forcing class-initialization of the classes that hold the flag fields).</p>
+ *
+ * <p>To register an implementation, declare it as a service in
+ * {@code META-INF/services/com.yahoo.vespa.flags.FlagDefinitions}.</p>
+ *
+ * @author hakonhall
+ */
+public interface FlagDefinitions {
+
+    /**
+     * Register additional flag definitions.
+     *
+     * <p>Called from the static initializer of {@link Flags}, after the static flag map
+     * has been initialized — at most once per {@link Flags} class initialization.
+     * Implementations should call {@code Flags.defineXxxFlag(...)} (directly or
+     * transitively) for every flag they own.</p>
+     */
+    void register();
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -12,7 +12,9 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import static com.yahoo.vespa.flags.Dimension.APPLICATION;
@@ -51,6 +53,8 @@ import static com.yahoo.vespa.flags.Dimension.VESPA_VERSION;
 public class Flags {
 
     private static volatile TreeMap<FlagId, FlagDefinition> flags = new TreeMap<>();
+
+    private static final AtomicBoolean spiLoaded = new AtomicBoolean(false);
 
     public static final UnboundBooleanFlag GCP_ENCLAVE_V2 = defineFeatureFlag(
             "gcp-enclave-v2", false,
@@ -368,20 +372,38 @@ public class Flags {
     public static final UnboundBooleanFlag APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG = defineFeatureFlag(
             "apply-on-restart-for-application-metadata-config", false,
             List.of("glebashnik"), "2026-02-13", "2026-08-13",
-            "Whether to set applyOnRestart flag on ApplicationMetadataConfig. " + 
+            "Whether to set applyOnRestart flag on ApplicationMetadataConfig. " +
                     "This might fix deferring config changes until container restart.",
             "Takes effect at redeployment",
             INSTANCE_ID
     );
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    static {
+        // Discover and register flag definitions provided outside the flags bundle.
+        // Runs after the static flag map and all in-class flag fields above are initialized.
+        loadFlagDefinitionsSpi();
+    }
+
+    /**
+     * Load {@link FlagDefinitions} implementations via {@link ServiceLoader} and invoke
+     * {@link FlagDefinitions#register()} at most once per {@link Flags} class
+     * initialization (i.e. once per classloader that loads this class). The
+     * {@link AtomicBoolean} guard makes any subsequent invocation a no-op.
+     */
+    static void loadFlagDefinitionsSpi() {
+        if (spiLoaded.compareAndSet(false, true)) {
+            ServiceLoader.load(FlagDefinitions.class).forEach(FlagDefinitions::register);
+        }
+    }
+
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,
                                                        String modificationEffect, Dimension... dimensions) {
         return define(UnboundBooleanFlag::new, flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static UnboundStringFlag defineStringFlag(String flagId, String defaultValue, List<String> owners,
                                                      String createdAt, String expiresAt, String description,
                                                      String modificationEffect, Dimension... dimensions) {
@@ -391,7 +413,7 @@ public class Flags {
                                 dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static UnboundStringFlag defineStringFlag(String flagId, String defaultValue, List<String> owners,
                                                      String createdAt, String expiresAt, String description,
                                                      String modificationEffect, Predicate<String> validator,
@@ -400,28 +422,28 @@ public class Flags {
                       flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static UnboundIntFlag defineIntFlag(String flagId, int defaultValue, List<String> owners,
                                                String createdAt, String expiresAt, String description,
                                                String modificationEffect, Dimension... dimensions) {
         return define(UnboundIntFlag::new, flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static UnboundLongFlag defineLongFlag(String flagId, long defaultValue, List<String> owners,
                                                  String createdAt, String expiresAt, String description,
                                                  String modificationEffect, Dimension... dimensions) {
         return define(UnboundLongFlag::new, flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static UnboundDoubleFlag defineDoubleFlag(String flagId, double defaultValue, List<String> owners,
                                                      String createdAt, String expiresAt, String description,
                                                      String modificationEffect, Dimension... dimensions) {
         return define(UnboundDoubleFlag::new, flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static <T> UnboundJacksonFlag<T> defineJacksonFlag(String flagId, T defaultValue, Class<T> jacksonClass, List<String> owners,
                                                               String createdAt, String expiresAt, String description,
                                                               String modificationEffect, Predicate<T> validator, Dimension... dimensions) {
@@ -429,7 +451,7 @@ public class Flags {
                       flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static <T> UnboundListFlag<T> defineListFlag(String flagId, List<T> defaultValue, Class<T> elementClass,
                                                         List<String> owners, String createdAt, String expiresAt,
                                                         String description, String modificationEffect, Dimension... dimensions) {
@@ -437,7 +459,7 @@ public class Flags {
                 flagId, defaultValue, owners, createdAt, expiresAt, description, modificationEffect, dimensions);
     }
 
-    /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
+    /** WARNING: public for testing and for {@link FlagDefinitions} SPI implementations: All flags should be defined in {@link Flags}, {@link PermanentFlags}, or in a {@link FlagDefinitions} SPI implementation. */
     public static <T> UnboundListFlag<T> defineListFlag(String flagId, List<T> defaultValue, Class<T> elementClass,
                                                         List<String> owners, String createdAt, String expiresAt,
                                                         String description, String modificationEffect,

--- a/flags/src/test/java/com/yahoo/vespa/flags/FlagDefinitionsSpiTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/FlagDefinitionsSpiTest.java
@@ -1,0 +1,55 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link Flags} discovers and invokes {@link FlagDefinitions} implementations
+ * via {@link ServiceLoader} during its static initializer, and that the resulting flags are
+ * visible through the public registry.
+ *
+ * @see TestFlagDefinitions
+ */
+class FlagDefinitionsSpiTest {
+
+    @Test
+    void serviceLoader_finds_test_spi_implementation() {
+        long count = ServiceLoader.load(FlagDefinitions.class).stream()
+                .filter(provider -> provider.type().equals(TestFlagDefinitions.class))
+                .count();
+        assertEquals(1, count, "TestFlagDefinitions should be discoverable via ServiceLoader");
+    }
+
+    @Test
+    void spi_registered_feature_flag_is_visible_in_flags_registry() {
+        Optional<FlagDefinition> definition = Flags.getFlag(new FlagId(TestFlagDefinitions.SPI_TEST_FLAG_ID));
+        assertTrue(definition.isPresent(),
+                   "Flag registered by FlagDefinitions SPI implementation should be present in Flags");
+    }
+
+    @Test
+    void spi_registered_string_flag_is_visible_in_flags_registry() {
+        Optional<FlagDefinition> definition = Flags.getFlag(new FlagId(TestFlagDefinitions.SPI_TEST_STRING_FLAG_ID));
+        assertTrue(definition.isPresent(),
+                   "String flag registered by FlagDefinitions SPI implementation should be present in Flags");
+    }
+
+    @Test
+    void permanentFlags_static_init_does_not_double_register() {
+        // PermanentFlags field initializers delegate to Flags.defineXxxFlag(...), which forces
+        // Flags.<clinit> to complete (including SPI loading) before PermanentFlags is fully
+        // initialized. The AtomicBoolean guard inside Flags makes any subsequent invocation
+        // of loadFlagDefinitionsSpi() a no-op, so SPI flags are not re-registered.
+        String firstFlagId = PermanentFlags.SHARED_HOST.id().toString();
+        assertEquals("shared-host", firstFlagId);
+
+        // SPI flags remain present after PermanentFlags has been initialized.
+        assertTrue(Flags.getFlag(new FlagId(TestFlagDefinitions.SPI_TEST_FLAG_ID)).isPresent());
+    }
+}

--- a/flags/src/test/java/com/yahoo/vespa/flags/FlagsReplacerSpiRegressionTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/FlagsReplacerSpiRegressionTest.java
@@ -1,0 +1,45 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for {@link Flags.Replacer}: flags registered via the
+ * {@link FlagDefinitions} SPI must be saved on open and restored on close, exactly like
+ * flags defined directly in {@link Flags} or {@link PermanentFlags}.
+ */
+class FlagsReplacerSpiRegressionTest {
+
+    @Test
+    void replacer_saves_and_restores_spi_registered_flags() {
+        FlagId spiFlag = new FlagId(TestFlagDefinitions.SPI_TEST_FLAG_ID);
+
+        // Sanity: SPI flag is in the registry before any Replacer is opened.
+        assertTrue(Flags.getFlag(spiFlag).isPresent(),
+                   "SPI flag should be registered by the time test bodies run");
+
+        try (Flags.Replacer replacer = Flags.clearFlagsForTesting()) {
+            assertFalse(Flags.getFlag(spiFlag).isPresent(),
+                        "Replacer should clear SPI flags from the active map");
+        }
+
+        // After close: the originally-saved map is restored, including SPI flags.
+        assertTrue(Flags.getFlag(spiFlag).isPresent(),
+                   "SPI flag should be restored when the Replacer is closed");
+    }
+
+    @Test
+    void replacer_can_keep_spi_registered_flags() {
+        FlagId spiFlag = new FlagId(TestFlagDefinitions.SPI_TEST_FLAG_ID);
+
+        try (Flags.Replacer replacer = Flags.clearFlagsForTesting(spiFlag)) {
+            assertTrue(Flags.getFlag(spiFlag).isPresent(),
+                       "Replacer keep-list should retain SPI flags as well");
+        }
+
+        assertTrue(Flags.getFlag(spiFlag).isPresent());
+    }
+}

--- a/flags/src/test/java/com/yahoo/vespa/flags/TestFlagDefinitions.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/TestFlagDefinitions.java
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags;
+
+import java.util.List;
+
+/**
+ * Test-only {@link FlagDefinitions} implementation registered via
+ * {@code META-INF/services/com.yahoo.vespa.flags.FlagDefinitions} on the test classpath.
+ *
+ * <p>Exercises the SPI loaded from {@link Flags}'s static initializer.</p>
+ */
+public class TestFlagDefinitions implements FlagDefinitions {
+
+    public static final String SPI_TEST_FLAG_ID = "spi-test-flag";
+    public static final String SPI_TEST_STRING_FLAG_ID = "spi-test-permanent-flag";
+
+    @Override
+    public void register() {
+        Flags.defineFeatureFlag(
+                SPI_TEST_FLAG_ID, false,
+                List.of("spi-test"), "1970-01-01", "2100-01-01",
+                "Flag registered by the test SPI implementation",
+                "Takes effect immediately");
+
+        Flags.defineStringFlag(
+                SPI_TEST_STRING_FLAG_ID, "default",
+                List.of("spi-test"), "1970-01-01", "2100-01-01",
+                "String flag registered by the test SPI implementation",
+                "Takes effect immediately");
+    }
+}

--- a/flags/src/test/resources/META-INF/services/com.yahoo.vespa.flags.FlagDefinitions
+++ b/flags/src/test/resources/META-INF/services/com.yahoo.vespa.flags.FlagDefinitions
@@ -1,0 +1,1 @@
+com.yahoo.vespa.flags.TestFlagDefinitions


### PR DESCRIPTION
## What

Add a `FlagDefinitions` service-provider interface (single `register()`
method). `Flags.<clinit>` and `PermanentFlags.<clinit>` discover
implementations via `java.util.ServiceLoader` and invoke `register()`
once per JVM, after the static flag map is initialized. Existing flag
definitions are untouched.

## Why

- Lets other bundles on the classpath contribute flag definitions without
  modifying this one.
- Keeps consumer-specific metadata (owners, expiry dates, rollout notes)
  out of this generic bundle.
- Purely additive: no new compile-time or runtime edge from this bundle
  to any other artifact, and no behavior change for flags currently
  defined here.
