### PR TITLE
WIP: Add feature flags for metrics proxy heap size

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1443,6 +1443,8 @@
       "public double docprocHandlerThreadpool()",
       "public boolean applyOnRestartForApplicationMetadataConfig()",
       "public boolean scaleMetricsproxyHeapByNodeCount()",
+      "public java.util.OptionalInt metricsProxyHeapSizeInMib()",
+      "public java.util.OptionalInt metricsProxyAdminNodeHeapSizeInMib()",
       "public double autoscalerTargetWriteCpuPercentage(java.util.Optional)",
       "public double searchNodeReservedDiskSpaceFactor()"
     ],

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -26,6 +26,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -126,6 +127,8 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"johsol"}) default double docprocHandlerThreadpool() { return 1.0; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default boolean applyOnRestartForApplicationMetadataConfig() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean scaleMetricsproxyHeapByNodeCount() { return false; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default OptionalInt metricsProxyHeapSizeInMib() { return OptionalInt.empty(); }
+        @ModelFeatureFlag(owners = {"hmusum"}) default OptionalInt metricsProxyAdminNodeHeapSizeInMib() { return OptionalInt.empty(); }
         @ModelFeatureFlag(owners = {"hmusum"}) default double autoscalerTargetWriteCpuPercentage(Optional<String> clusterId) { return 0.95; }
         @ModelFeatureFlag(owners = {"toregge"}, removeAfter = "8.676") default double searchNodeReservedDiskSpaceFactor() { return 1.0; }
     }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.defaultHeapSizePercentageOfAvailableMemory;
@@ -79,6 +80,8 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private final Map<String, Integer> searchNodeInitializerThreads = new HashMap<>();
     private boolean useTriton = false;
     private boolean scaleMetricsproxyHeapByNodeCount = false;
+    private OptionalInt metricsProxyHeapSizeInMib = OptionalInt.empty();
+    private OptionalInt metricsProxyAdminNodeHeapSizeInMib = OptionalInt.empty();
     private boolean ignoreConnectivityChecksAtStartup = false;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
@@ -138,6 +141,8 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public boolean useTriton() { return useTriton; }
     @Override public ModelContext.FeatureFlag<Boolean> useTritonFlag() { return () -> useTriton; }
     @Override public boolean scaleMetricsproxyHeapByNodeCount() { return scaleMetricsproxyHeapByNodeCount; }
+    @Override public OptionalInt metricsProxyHeapSizeInMib() { return metricsProxyHeapSizeInMib; }
+    @Override public OptionalInt metricsProxyAdminNodeHeapSizeInMib() { return metricsProxyAdminNodeHeapSizeInMib; }
     @Override public boolean ignoreConnectivityChecksAtStartup() { return ignoreConnectivityChecksAtStartup; }
 
     public TestProperties maxUnCommittedMemory(int maxUnCommittedMemory) {
@@ -331,6 +336,16 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setScaleMetricsproxyHeapByNodeCount(boolean value) {
         this.scaleMetricsproxyHeapByNodeCount = value;
+        return this;
+    }
+
+    public TestProperties setMetricsProxyHeapSizeInMib(int value) {
+        this.metricsProxyHeapSizeInMib = OptionalInt.of(value);
+        return this;
+    }
+
+    public TestProperties setMetricsProxyAdminNodeHeapSizeInMib(int value) {
+        this.metricsProxyAdminNodeHeapSizeInMib = OptionalInt.of(value);
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.METRICS_PROXY_BUNDLE_NAME;
@@ -50,6 +51,8 @@ public class MetricsProxyContainer extends Container implements
     private final ApplicationId applicationId;
     private final Zone zone;
     private final boolean scaleHeapByNodeCount;
+    private final OptionalInt metricsProxyHeapSizeInMib;
+    private final OptionalInt metricsProxyAdminNodeHeapSizeInMib;
 
     public MetricsProxyContainer(MetricsProxyContainerCluster cluster, HostResource host, int index, DeployState deployState) {
         super(cluster, host.getHostname(), index, deployState);
@@ -59,6 +62,8 @@ public class MetricsProxyContainer extends Container implements
         this.applicationId = deployState.getApplicationPackage().getApplicationId();
         this.zone = deployState.zone();
         this.scaleHeapByNodeCount = deployState.featureFlags().scaleMetricsproxyHeapByNodeCount();
+        this.metricsProxyHeapSizeInMib = deployState.featureFlags().metricsProxyHeapSizeInMib();
+        this.metricsProxyAdminNodeHeapSizeInMib = deployState.featureFlags().metricsProxyAdminNodeHeapSizeInMib();
         setProp("clustertype", "admin");
         setProp("index", String.valueOf(index));
         addNodeSpecificComponents();
@@ -171,21 +176,22 @@ public class MetricsProxyContainer extends Container implements
     }
 
     private int calculateHeapSize(boolean adminCluster) {
-        int baseHeapSize = adminCluster ? 96 : 320;
-
-        if (!scaleHeapByNodeCount) {
-            return baseHeapSize;
+        int nodeCount = hostSystem().getHosts().size();
+        if (adminCluster) {
+            if (metricsProxyAdminNodeHeapSizeInMib.isPresent()) return metricsProxyAdminNodeHeapSizeInMib.getAsInt();
+            if (!scaleHeapByNodeCount) return 96;
+            // Increase in steps to avoid changes to heap size with small changes in node count.
+            var step = nodeCount / 50;
+            return Math.min(96 + (step * 50), 512);
         }
 
-        int nodeCount = hostSystem().getHosts().size();
-        int heapPerNode = adminCluster ? 1 : 2;
-        int maxHeapSize = adminCluster ? 512 : 1024;
-
+        if (metricsProxyHeapSizeInMib.isPresent()) return metricsProxyHeapSizeInMib.getAsInt();
+        if (!scaleHeapByNodeCount) return 320;
         // Increase in steps to avoid changes to heap size with small changes in node count.
         var step = nodeCount / 50;
-        int calculatedHeap = baseHeapSize + (step * heapPerNode * 50);
-        return Math.min(calculatedHeap, maxHeapSize);
+        return Math.min(320 + (step * 2 * 50), 1024);
     }
+
 
     private String getNodeRole() {
         String hostConfigId = getHost().getHost().getConfigId();

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
@@ -9,6 +9,7 @@ import ai.vespa.metricsproxy.service.VespaServicesConfig;
 import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
@@ -204,6 +205,52 @@ public class MetricsProxyContainerTest {
         int expectedHeap = 320 + (step * 2 * 50);
         assertEquals(expectedHeap, config.jvm().heapsize());
         assertEquals(expectedHeap, config.jvm().minHeapsize());
+    }
+
+    @Test
+    void heapSizeUsesExplicitFlagWhenSet() {
+        VespaModel model = getModel(hostedServicesWithContent(), self_hosted, new DeployState.Builder(),
+                                    1, new TestProperties().setMetricsProxyHeapSizeInMib(512));
+        QrStartConfig config = model.getConfig(QrStartConfig.class, CONTAINER_CONFIG_ID);
+        assertEquals(512, config.jvm().heapsize());
+        assertEquals(512, config.jvm().minHeapsize());
+    }
+
+    @Test
+    void adminHeapSizeUsesExplicitFlagWhenSet() {
+        VespaModel model = getModel(hostedServicesWithManyNodes(), hosted, new DeployState.Builder(),
+                                    7, new TestProperties().setMetricsProxyAdminNodeHeapSizeInMib(256));
+        boolean foundAdminNode = false;
+        for (var host : model.hostSystem().getHosts()) {
+            if (host.spec().membership().isPresent() &&
+                host.spec().membership().get().cluster().type() == ClusterSpec.Type.admin) {
+                QrStartConfig config = model.getConfig(QrStartConfig.class, CLUSTER_CONFIG_ID + "/" + host.getHostname());
+                assertEquals(256, config.jvm().heapsize());
+                assertEquals(256, config.jvm().minHeapsize());
+                foundAdminNode = true;
+            }
+        }
+        assertTrue(foundAdminNode, "Expected at least one admin cluster node");
+    }
+
+    @Test
+    void adminHeapSizeScalesWithNodeCountWhenFlagEnabled() {
+        int hostCount = 50;
+        VespaModel model = getModel(hostedServicesWithManyNodes(), hosted, new DeployState.Builder(),
+                                    hostCount, new TestProperties().setScaleMetricsproxyHeapByNodeCount(true));
+        int nodeCount = model.hostSystem().getHosts().size();
+        int step = nodeCount / 50;
+        int expectedHeap = 96 + (step * 50);
+        boolean foundAdminNode = false;
+        for (var host : model.hostSystem().getHosts()) {
+            if (host.spec().membership().isPresent() &&
+                host.spec().membership().get().cluster().type() == ClusterSpec.Type.admin) {
+                QrStartConfig config = model.getConfig(QrStartConfig.class, CLUSTER_CONFIG_ID + "/" + host.getHostname());
+                assertEquals(expectedHeap, config.jvm().heapsize());
+                foundAdminNode = true;
+            }
+        }
+        assertTrue(foundAdminNode, "Expected at least one admin cluster node");
     }
 
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -41,6 +41,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -254,6 +255,8 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean useTriton() { return flag(Flags.USE_TRITON).value(); }
         @Override public ModelContext.FeatureFlag<Boolean> useTritonFlag() { return flag(Flags.USE_TRITON); }
         @Override public boolean scaleMetricsproxyHeapByNodeCount() { return flag(Flags.SCALE_METRICSPROXY_HEAP_BY_NODE_COUNT).value(); }
+        @Override public OptionalInt metricsProxyHeapSizeInMib() { return toOptionalInt(flag(Flags.METRICS_PROXY_HEAP_SIZE_IN_MIB).value()); }
+        @Override public OptionalInt metricsProxyAdminNodeHeapSizeInMib() { return toOptionalInt(flag(Flags.METRICS_PROXY_ADMIN_HEAP_SIZE_IN_MIB).value()); }
         @Override public boolean ignoreConnectivityChecksAtStartup() { return flag(PermanentFlags.IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP).value(); }
         @Override public int searchCoreMaxOutstandingMoveOps() { return flag(Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS).value(); }
         @Override public double docprocHandlerThreadpool() { return flag(Flags.DOCPROC_HANDLER_THREADPOOL).value(); }
@@ -261,6 +264,10 @@ public class ModelContextImpl implements ModelContext {
         @Override public double autoscalerTargetWriteCpuPercentage(Optional<String> clusterId) {
             var flag = flag(Flags.AUTOSCALER_TARGET_WRITE_CPU_PERCENTAGE);
             return clusterId.map(id -> flag.withClusterId(ClusterSpec.Id.from(id)).value()).orElseGet(flag::value);
+        }
+
+        private static OptionalInt toOptionalInt(int value) {
+            return value > 0 ? OptionalInt.of(value) : OptionalInt.empty();
         }
     }
 

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -180,7 +180,8 @@ public class Flags {
     public static final UnboundBooleanFlag SCALE_METRICSPROXY_HEAP_BY_NODE_COUNT = defineFeatureFlag(
             "scale-metricsproxy-heap-by-node-count", false,
             List.of("hmusum"), "2026-02-15", "2026-08-15",
-            "Whether to scale metrics proxy container heap based on total number of nodes in the application",
+            "Whether to scale metrics proxy container heap based on total number of nodes in the application." +
+            " Will not have any effect if METRICS_PROXY_HEAP_SIZE_IN_MIB or METRICS_PROXY_ADMIN_HEAP_SIZE_IN_MIB is set",
             "Takes effect at redeployment",
             INSTANCE_ID);
 
@@ -373,6 +374,20 @@ public class Flags {
             "Takes effect at redeployment",
             INSTANCE_ID
     );
+
+    public static final UnboundIntFlag METRICS_PROXY_HEAP_SIZE_IN_MIB = defineIntFlag(
+            "metrics-proxy-heap-size-in-mib", 0,
+            List.of("hmusum"), "2026-04-29", "2026-06-01",
+            "Amount of memory (in MiB) to use for metrics proxy JVM heap on non-admin nodes. 0 means use the default.",
+            "Takes effect at redeployment",
+            TENANT_ID, APPLICATION, INSTANCE_ID);
+
+    public static final UnboundIntFlag METRICS_PROXY_ADMIN_HEAP_SIZE_IN_MIB = defineIntFlag(
+            "metrics-proxy-admin-heap-size-in-mib", 0,
+            List.of("hmusum"), "2026-04-29", "2026-06-01",
+            "Amount of memory (in MiB) to use for metrics proxy JVM heap on admin nodes. 0 means use the default.",
+            "Takes effect at redeployment",
+            TENANT_ID, APPLICATION, INSTANCE_ID);
 
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,


### PR DESCRIPTION
- METRICS_PROXY_HEAP_SIZE_IN_MIB: explicit heap override for non-admin nodes
- METRICS_PROXY_ADMIN_HEAP_SIZE_IN_MIB: explicit heap override for admin nodes
- Both use OptionalInt (0 = not set) to avoid magic value comparisons
- Explicit flag takes priority over scaleHeapByNodeCount scaling
- Scaling still applies as fallback when flags are not set
