### PR TITLE
Fix bugs in vdslib

### DIFF
--- a/vdslib/src/vespa/vdslib/container/CMakeLists.txt
+++ b/vdslib/src/vespa/vdslib/container/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(vdslib_container OBJECT
     SOURCES
-    dummycppfile.cpp
     parameters.cpp
     searchresult.cpp
     documentsummary.cpp

--- a/vdslib/src/vespa/vdslib/container/dummycppfile.cpp
+++ b/vdslib/src/vespa/vdslib/container/dummycppfile.cpp
@@ -1,4 +1,0 @@
-// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
- // This file exist because make make can't install headers from a directory
- // without having a cpp file to build..

--- a/vdslib/src/vespa/vdslib/container/parameters.cpp
+++ b/vdslib/src/vespa/vdslib/container/parameters.cpp
@@ -87,7 +87,7 @@ Parameters::operator==(const Parameters &other) const
         return false;
     }
 
-    for (ParametersMap::const_iterator a(_parameters.begin()), b(other._parameters.begin()), am(_parameters.begin()); (a != am); ++a, ++b) {
+    for (ParametersMap::const_iterator a(_parameters.begin()), b(other._parameters.begin()), am(_parameters.end()); (a != am); ++a, ++b) {
         if ((a->first != b->first)) {
             return false;
         }

--- a/vdslib/src/vespa/vdslib/distribution/distribution.cpp
+++ b/vdslib/src/vespa/vdslib/distribution/distribution.cpp
@@ -278,7 +278,8 @@ namespace {
         }
         tmpResults.emplace_back(scoredNode);
     }
-}
+
+} // namespace <unnamed>
 
 void
 Distribution::getIdealGroups(const document::BucketId& bucket, const ClusterState& clusterState, const Group& parent,

--- a/vdslib/src/vespa/vdslib/state/clusterstate.cpp
+++ b/vdslib/src/vespa/vdslib/state/clusterstate.cpp
@@ -89,7 +89,7 @@ ClusterState::ClusterState(std::string_view serialized)
         } else {
             lastAbsolutePath = key;
         }
-        
+
         if (key.empty() || ! parse(key, value, nodeData) ) {
             LOG(debug, "Unknown key %s in systemstate. Ignoring it, assuming it's "
                        "a new feature from a newer version than ourself: %s",
@@ -343,8 +343,8 @@ ClusterState::removeExtraElements(const NodeType & type)
 {
     // Simplify the system state by removing the last indexes if the nodes
     // are down.
-    for (int32_t index = _nodeCount[type]; index >= 0; --index) {
-        Node node(type, index - 1);
+    for (int32_t index = _nodeCount[type]; index-- > 0; ) {
+        Node node(type, index);
         const auto it = _nodeStates.find(node);
         if (it == _nodeStates.end()) break;
         if (it->second.getState() != State::DOWN) break;
@@ -411,7 +411,7 @@ template<typename T>
 std::string getNumberSpec(const std::vector<T>& numbers) {
     std::ostringstream ost;
     bool first = true;
-    uint32_t firstInRange = numbers.size() == 0 ? 0 : numbers[0];;
+    uint32_t firstInRange = numbers.size() == 0 ? 0 : numbers[0];
     uint32_t lastInRange = firstInRange;
     for (uint32_t i=1; i<=numbers.size(); ++i) {
         if (i < numbers.size() && numbers[i] == lastInRange + 1) {


### PR DESCRIPTION
parameters.cpp: operator== had am initialized to begin() instead of end(), so the loop body never executed and equal-sized maps always compared equal.

clusterstate.cpp: removeExtraElements used index-1 with an index>=0 guard, which was awkward and error-prone at the boundary; replaced with the idiomatic index-- > 0 post-decrement form.

Also removes dummycppfile.cpp (only existed to satisfy old make-based builds that required a .cpp source to install headers; not needed with CMake), plus minor cleanup: trailing whitespace, double semicolon, namespace comment.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
