### PR TITLE
Add utility for quickly generating a random number in a range

### DIFF
--- a/vespalib/src/tests/util/fast_range_test.cpp
+++ b/vespalib/src/tests/util/fast_range_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/vespalib/util/fast_range.h>
 #include <vespa/vespalib/util/xoshiro.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <concepts>
 #include <random>
 
@@ -16,21 +17,45 @@ template <std::integral T>
 void do_test_fast_range() {
     Xoshiro256PlusPlusPrng gen(std::random_device{}());
     for (size_t i = 0; i < 10'000; ++i) {
-        const T max_incl = static_cast<T>(gen());
-        const T mapped   = map_random_to_range(static_cast<T>(gen()), max_incl);
+        const T max_excl = std::max(static_cast<T>(gen()), T{1});
+        const T mapped   = map_random_to_range(static_cast<T>(gen()), max_excl);
 
-        ASSERT_TRUE(mapped <= max_incl) << mapped << " for range [0, " << max_incl << "]";
+        ASSERT_LT(mapped, max_excl) << mapped << " for range [0, " << max_excl << ")";
+    }
+}
+
+template <std::unsigned_integral T>
+void do_test_next_random_in_range() {
+    Xoshiro256PlusPlusPrng gen(std::random_device{}());
+    for (size_t i = 0; i < 10'000; ++i) {
+        T from_incl = static_cast<T>(gen());
+        T to_excl   = static_cast<T>(gen());
+        if (from_incl > to_excl) {
+            std::swap(from_incl, to_excl);
+        } else if (from_incl == to_excl) {
+            continue; // we'll get them next time, for sure...!
+        }
+        T val = next_random_in_range<T>(gen, from_incl, to_excl);
+
+        ASSERT_GE(val, from_incl);
+        ASSERT_LT(val, to_excl);
     }
 }
 
 } // namespace
 
-TEST(FastRangeTest, can_map_u32_values) {
+TEST(FastRangeTest, can_map_integers_to_ranges) {
+    do_test_fast_range<uint8_t>();
+    do_test_fast_range<uint16_t>();
     do_test_fast_range<uint32_t>();
+    do_test_fast_range<uint64_t>();
 }
 
-TEST(FastRangeTest, can_map_u64_values) {
-    do_test_fast_range<uint64_t>();
+TEST(FastRangeTest, can_generate_randoms_in_numeric_ranges) {
+    do_test_next_random_in_range<uint8_t>();
+    do_test_next_random_in_range<uint16_t>();
+    do_test_next_random_in_range<uint32_t>();
+    do_test_next_random_in_range<uint64_t>();
 }
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/fast_range.h
+++ b/vespalib/src/vespa/vespalib/util/fast_range.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
+#include <random>
 
 namespace vespalib {
 
@@ -21,16 +23,22 @@ namespace vespalib {
  * See https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
  */
 
-// Returns an unspecified (but fair) mapping of the random u32 variable `x` into the u32 range [0, `n`]
-[[nodiscard]] constexpr uint32_t map_random_to_range(const uint32_t x, const uint32_t n) noexcept {
-    return (static_cast<uint64_t>(x) * static_cast<uint64_t>(n)) >> 32;
-}
+// Metafunction for widening an unsigned integer type to the next greater type.
+template <typename> struct Widened;
+template <> struct Widened<uint8_t>  { using type = uint16_t; };
+template <> struct Widened<uint16_t> { using type = uint32_t; };
+template <> struct Widened<uint32_t> { using type = uint64_t; };
+template <> struct Widened<uint64_t> { using type = __uint128_t; };
 
-// Returns an unspecified (but fair) mapping of the random u64 variable `x` into the u64 range [0, `n`]
-[[nodiscard]] constexpr uint64_t map_random_to_range(const uint64_t x, const uint64_t n) noexcept {
-    // The compiler understands this pattern well enough that it will use the
-    // native instruction and/or register for extracting the top 64 bits of the
-    // multiplication, making this no more costly than a normal multiplication.
+template <typename T> using Widen = Widened<T>::type;
+
+// Returns an unspecified (but fair) mapping of the random variable `x` into the range [0, `n`)
+template <std::unsigned_integral T>
+[[nodiscard]] constexpr T map_random_to_range(const T x, const T n) noexcept {
+    // For 128-bit multiplies, the compiler understands this pattern well enough
+    // that it will use the native instruction and/or register for extracting the
+    // top 64 bits of the multiplication, making this no more costly than a normal
+    // multiplication.
     //
     // On x64, this will do a regular (unsigned) MUL (which places high bits in
     // RDX and low bits in RAX) and just use the RDX register result verbatim.
@@ -39,7 +47,17 @@ namespace vespalib {
     // instruction.
     //
     // Godbolt example: https://godbolt.org/z/G75Gzj1o4
-    return (static_cast<__uint128_t>(x) * n) >> 64;
+    return (static_cast<Widen<T>>(x) * n) >> (sizeof(T) * 8);
+}
+
+// Returns a random number in the range [from_incl, to_excl) generated using the
+// supplied RNG instance `rng`.
+// Precondition: to_excl > from_incl
+template <std::unsigned_integral T, std::uniform_random_bit_generator Rng>
+[[nodiscard]] T next_random_in_range(Rng& rng, const T from_incl, const T to_excl) noexcept {
+    static_assert(Rng::min() == 0, "RNG output must cover entire value range");
+    static_assert(Rng::max() >= std::numeric_limits<T>::max(), "RNG output must cover entire value range");
+    return from_incl + map_random_to_range<T>(static_cast<T>(rng()), to_excl - from_incl);
 }
 
 } // namespace vespalib


### PR DESCRIPTION
@havardpe please review

This uses the (previously added) fast Lemire reduction method to quickly generate a uniformly distributed random number in a provided [from, to) range. It can use any RNG satisfying the uniform random bit generator concept, but is primarily intended to be used with the Xoshiro256++ generator.

Generalize the existing range mapping functionality so that it works with any unsigned integer type. Type widening is decoupled into its own metafunction.

Also correct a silly open vs. closed interval error in the comments.
