### PR TITLE
streamingvisitors: fix typos and remove dead code

### DIFF
--- a/streamingvisitors/src/tests/tokens_converter/tokens_converter_test.cpp
+++ b/streamingvisitors/src/tests/tokens_converter/tokens_converter_test.cpp
@@ -29,7 +29,7 @@ class TokensConverterTest : public testing::Test {
 protected:
     TokensConverterTest();
     ~TokensConverterTest() override;
-    ;
+
     std::string convert(const StringFieldValue& fv, bool exact_match, Normalizing normalize_mode);
 };
 

--- a/streamingvisitors/src/vespa/vsm/common/document.cpp
+++ b/streamingvisitors/src/vespa/vsm/common/document.cpp
@@ -11,16 +11,6 @@ using search::TimeT;
 
 namespace vsm {
 
-vespalib::asciistream& operator<<(vespalib::asciistream& os, const FieldRef& f) {
-    const char* s = f.data();
-    os << f.size();
-    if (s) {
-        os << s; // Better hope it's null terminated!
-    }
-    os << " : ";
-    return os;
-}
-
 vespalib::asciistream& operator<<(vespalib::asciistream& os, const StringFieldIdTMap& f) {
     std::map<std::string, FieldIdT> ordered(f._map.begin(), f._map.end());
     for (const auto& elem : ordered) {

--- a/streamingvisitors/src/vespa/vsm/common/storagedocument.cpp
+++ b/streamingvisitors/src/vespa/vsm/common/storagedocument.cpp
@@ -21,7 +21,7 @@ StorageDocument::~StorageDocument() = default;
 
 namespace {
 FieldPath                    _emptyFieldPath;
-StorageDocument::SubDocument _empySubDocument(nullptr, _emptyFieldPath.getFullRange());
+StorageDocument::SubDocument _emptySubDocument(nullptr, _emptyFieldPath.getFullRange());
 } // namespace
 
 const StorageDocument::SubDocument& StorageDocument::getComplexField(FieldIdT fId) const {
@@ -39,7 +39,7 @@ const StorageDocument::SubDocument& StorageDocument::getComplexField(FieldIdT fI
             }
         } else {
             LOG(debug, "Failed getting field fId %d.", fId);
-            return _empySubDocument;
+            return _emptySubDocument;
         }
     }
     return _cachedFields[fId];


### PR DESCRIPTION
Removes unused operator<<(asciistream&, FieldRef) from document.cpp — the function had an unsafe assumption (relied on null-termination of FieldRef data, as noted by its own "Better hope it's null terminated!" comment) and had no callers.

Also fixes two typos spotted during the reformat work:
- _empySubDocument → _emptySubDocument in storagedocument.cpp
- stray extra semicolon removed from TokensConverterTest class definition
