### PR TITLE
Propagate SubjectAlternativeNames from CSR when signing certificate

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/X509CertificateBuilder.java
+++ b/security-utils/src/main/java/com/yahoo/security/X509CertificateBuilder.java
@@ -77,14 +77,16 @@ public class X509CertificateBuilder {
             PublicKey publicKey = new JcaPKCS10CertificationRequest(bcCsr)
                     .setProvider(BouncyCastleProviderHolder.getInstance())
                     .getPublicKey();
-            return new X509CertificateBuilder(caIssuer,
-                                              new X500Principal(bcCsr.getSubject().getEncoded()),
-                                              notBefore,
-                                              notAfter,
-                                              publicKey,
-                                              caPrivateKey,
-                                              signingAlgorithm,
-                                              serialNumber);
+            var builder = new X509CertificateBuilder(caIssuer,
+                                                      new X500Principal(bcCsr.getSubject().getEncoded()),
+                                                      notBefore,
+                                                      notAfter,
+                                                      publicKey,
+                                                      caPrivateKey,
+                                                      signingAlgorithm,
+                                                      serialNumber);
+            csr.getSubjectAlternativeNames().forEach(builder::addSubjectAlternativeName);
+            return builder;
         } catch (GeneralSecurityException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {


### PR DESCRIPTION
X509CertificateBuilder.fromCsr() was silently dropping all SANs present in the CSR, so issued certificates never contained them. Since modern TLS clients rely on SANs for hostname verification (CN is deprecated per RFC 2818), any cert issued this way would fail peer-auth checks that match on DNS or IP SANs.
