### PR TITLE
Raise CBOR MaxNestedLevels to 1000 in vespa CLI

### DIFF
--- a/client/go/internal/ioutil/ioutil.go
+++ b/client/go/internal/ioutil/ioutil.go
@@ -24,7 +24,8 @@ var cborDecMode cbor.DecMode
 func init() {
 	var err error
 	cborDecMode, err = cbor.DecOptions{
-		DefaultMapType: reflect.TypeOf(map[string]interface{}(nil)),
+		DefaultMapType:  reflect.TypeOf(map[string]interface{}(nil)),
+		MaxNestedLevels: 1000,
 	}.DecMode()
 	if err != nil {
 		panic("failed to initialize CBOR decoder mode: " + err.Error())

--- a/client/go/internal/ioutil/ioutil_test.go
+++ b/client/go/internal/ioutil/ioutil_test.go
@@ -55,6 +55,21 @@ func TestCBORToJSONNoHTMLEscaping(t *testing.T) {
 	assert.Contains(t, gotCompact, `tensor<int8>(x[128])`)
 }
 
+func TestCBORToJSONDeepNesting(t *testing.T) {
+	// Build a nested map deeper than the fxamacker/cbor default MaxNestedLevels of 32.
+	const depth = 100
+	var v interface{} = "leaf"
+	for i := 0; i < depth; i++ {
+		v = map[string]interface{}{"n": v}
+	}
+	data, err := cbor.Marshal(v)
+	assert.Nil(t, err)
+
+	got, err := CBORToJSON(data)
+	assert.Nil(t, err)
+	assert.Contains(t, got, `"leaf"`)
+}
+
 func TestPathExists(t *testing.T) {
 	assert.Equal(t, true, Exists("ioutil.go"))
 	assert.Equal(t, false, Exists("nosuchthing.go"))


### PR DESCRIPTION
## Summary
- The vespa CLI prefers CBOR for query responses (\`Accept: application/cbor, application/json;q=0.9\` in \`client/go/internal/cli/cmd/query.go\`).
- The CBOR decoder in \`client/go/internal/ioutil/ioutil.go\` was constructed without setting \`MaxNestedLevels\`, so it used the fxamacker/cbor default of **32**. Responses with deeper nesting (e.g. deep grouping results, large traces) failed to decode with \`cbor: exceeded max nested level 32\`, surfacing to the user as \`failed to decode CBOR response\`.
- Set \`MaxNestedLevels: 1000\`, which should comfortably cover any real Vespa response while staying well under the library's max of 65535.

## Test plan
- [x] \`go build ./...\` in \`client/go\`
- [x] \`go test ./internal/ioutil/... ./internal/cli/cmd/...\`
- [x] New \`TestCBORToJSONDeepNesting\` builds a 100-level nested map and verifies it decodes (would fail under the previous default of 32)