### PR TITLE
Stop using sendProtobufQuerytree feature flag - always true now

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
@@ -51,7 +51,6 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains> implements
     private final Collection<String> schemasWithGlobalPhase;
     private final ApplicationPackage app;
     private final boolean useLegacyWandQueryParsing;
-    private final boolean sendProtobufQuerytree;
 
     private QueryProfiles queryProfiles;
     private SemanticRules semanticRules;
@@ -63,7 +62,6 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains> implements
         this.app = deployState.getApplicationPackage();
         this.owningCluster = cluster;
         this.useLegacyWandQueryParsing = deployState.featureFlags().useLegacyWandQueryParsing();
-        this.sendProtobufQuerytree = deployState.featureFlags().sendProtobufQuerytree();
 
         owningCluster.addComponent(Component.fromClassAndBundle(CompiledQueryProfileRegistry.class, SEARCH_AND_DOCPROC_BUNDLE));
         owningCluster.addComponent(Component.fromClassAndBundle(com.yahoo.search.schema.SchemaInfo.class, SEARCH_AND_DOCPROC_BUNDLE));
@@ -179,7 +177,7 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains> implements
                                    .keepSegmentAnds(true)
                                    .keepIdeographicPunctuation(true));
         }
-        builder.sendProtobufQuerytree(sendProtobufQuerytree);
+        builder.sendProtobufQuerytree(true);
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -247,7 +247,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public double clusterControllerNodeMemory() { return flag(PermanentFlags.CLUSTER_CONTROLLER_NODE_MEMORY).value(); }
         @Override public boolean useLegacyWandQueryParsing() { return flag(Flags.USE_LEGACY_WAND_QUERY_PARSING).value(); }
         @Override public boolean useSimpleAnnotations() { return flag(Flags.USE_SIMPLE_ANNOTATIONS).value(); }
-        @Override public boolean sendProtobufQuerytree() { return flag(Flags.SEND_PROTOBUF_QUERYTREE).value(); }
+        @Override public boolean sendProtobufQuerytree() { return true; }
         @Override public boolean forwardAllLogLevels() { return flag(PermanentFlags.FORWARD_ALL_LOG_LEVELS).value(); }
         @Override public long zookeeperPreAllocSize() { return flag(PermanentFlags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -103,7 +103,7 @@ public class ProtobufSerialization {
         GrowableByteBuffer scratchPad = threadLocalBuffer.get();
         var queryTree = query.getModel().getQueryTree();
         var context = new SerializationContext(contentShare);
-        boolean sendProtobuf = qrSearchersConfig.sendProtobufQuerytree();
+        boolean sendProtobuf = true;
         try {
             isProtobufAlsoSerialized.set(sendProtobuf);
             builder.setQueryTreeBlob(serializeQueryTree(queryTree, context, scratchPad));
@@ -262,7 +262,7 @@ public class ProtobufSerialization {
         var ranking = query.getRanking();
         var featureMap = ranking.getFeatures().asMap();
 
-        boolean sendProtobuf = qrSearchersConfig.sendProtobufQuerytree();
+        boolean sendProtobuf = true;
         var context = SerializationContext.ignored(); // Not necessary to track content share for docsum requests
         try {
             isProtobufAlsoSerialized.set(sendProtobuf);

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
@@ -87,11 +87,6 @@ public class StreamingBackend extends VespaBackend {
         this.route = Route.parse(storageClusterRouteSpec);
     }
 
-    private boolean sendProtobufQuerytree() {
-        var config = clusterParams.getQrSearchersConfig();
-        return config != null && config.sendProtobufQuerytree();
-    }
-
     public StreamingBackend(ClusterParams clusterParams, String searchClusterName, VespaDocumentAccess access, String storageClusterRouteSpec) {
         this(clusterParams, searchClusterName, new VespaVisitorFactory(access), storageClusterRouteSpec);
     }
@@ -165,7 +160,7 @@ public class StreamingBackend extends VespaBackend {
             partialSummaryHandler = new PartialSummaryHandler(db);
             partialSummaryHandler.wantToFill(query);
         }
-        var visitorContext = new Visitor.Context(getSearchClusterName(), schema, effectiveTraceLevel, partialSummaryHandler, sendProtobufQuerytree());
+        var visitorContext = new Visitor.Context(getSearchClusterName(), schema, effectiveTraceLevel, partialSummaryHandler);
         Visitor visitor = visitorFactory.createVisitor(query, route, visitorContext);
         try {
             visitor.doSearch();

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingVisitor.java
@@ -148,7 +148,7 @@ class StreamingVisitor extends VisitorDataHandler implements Visitor {
         }
 
         EncodedData ed = new EncodedData();
-        boolean sendProtobuf = context.sendProtobufQuerytree();
+        boolean sendProtobuf = true;
         ProtobufSerialization.setProtobufAlsoSerialized(sendProtobuf);
         try {
             encodeQueryData(query, 0, ed);

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
@@ -24,16 +24,12 @@ interface Visitor {
     record Context(String searchCluster,
                    String schema,
                    int traceLevelOverride,
-                   PartialSummaryHandler partialSummaryHandler,
-                   boolean sendProtobufQuerytree) {
+                   PartialSummaryHandler partialSummaryHandler) {
         Context(String searchCluster, String schema) {
             this(searchCluster, schema, 0);
         }
         Context(String searchCluster, String schema, int traceLevelOverride) {
             this(searchCluster, schema, traceLevelOverride, null);
-        }
-        Context(String searchCluster, String schema, int traceLevelOverride, PartialSummaryHandler partialSummaryHandler) {
-            this(searchCluster, schema, traceLevelOverride, partialSummaryHandler, false);
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -68,12 +68,12 @@ public class ProtobufSerializationTest {
     void testDocsumSerialization() {
         Query q = new Query("search/?query=test&hits=10&offset=3");
         var builder = ProtobufSerialization.createDocsumRequestBuilder(q, "server", "summary", Set.of("f1", "f2"),true, 0.5,
-                                                                       new QrSearchersConfig.Builder().sendProtobufQuerytree(false).build());
+                                                                       new QrSearchersConfig.Builder().sendProtobufQuerytree(true).build());
         builder.setTimeout(0);
         var hit = new FastHit(new GlobalId(IdString.createIdString("id:ns:type::id")).getRawId(), 0, OptionalInt.of(0), 0, 0);
         var bytes = ProtobufSerialization.serializeDocsumRequest(builder, List.of(hit));
 
-        assertEquals(56, bytes.length);
+        assertEquals(77, bytes.length);
     }
 
     private String contentsOf(ByteString property) {


### PR DESCRIPTION
The send-protobuf-querytree feature flag (added 2025-10-06, expiring 2026-04-30) has been at default-true in production and validated, so hardcode the behavior. The query tree is now always sent as protobuf in addition to the legacy stack-dump format, which is a prerequisite for eventually dropping the legacy format.

Replaces all flag-driven branches in ContainerSearch, ModelContextImpl, ProtobufSerialization, and the streaming visitor path with literal true. The expected docsum byte length in ProtobufSerializationTest grows from 56 to 77 to reflect the now-always-included protobuf querytree.
