### PR TITLE
fix: set firstBitCalculated, not firstBitIndex, to false after first bit

### DIFF
--- a/storage/src/vespa/storage/tools/generatedistributionbits.cpp
+++ b/storage/src/vespa/storage/tools/generatedistributionbits.cpp
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
             if (firstBitIndex == -1) {
                 firstBitIndex = bitIndex;
             } else {
-                firstBitIndex = false;
+                firstBitCalculated = false;
             }
         }
         bool printedStart = false;


### PR DESCRIPTION
In the distribution-bits calculation loop, firstBitCalculated is a bool flag that controls whether the startAtNodeCount threshold is applied when skipping node counts. It should be set to false once we have processed the first bit index so that subsequent bits don't skip small node counts.

The previous code mistakenly assigned false to firstBitIndex (an int32_t), zeroing it out instead of clearing the flag, which would corrupt the bit-index tracking and produce incorrect skip decisions for all subsequent iterations.
