### PR TITLE
Fix incorrect logic in TuneFileRandRead::operator!=

### DIFF
--- a/searchlib/src/vespa/searchlib/common/tunefileinfo.h
+++ b/searchlib/src/vespa/searchlib/common/tunefileinfo.h
@@ -101,7 +101,7 @@ public:
     }
 
     bool operator!=(const TuneFileRandRead& rhs) const noexcept {
-        return (_tuneControl != rhs._tuneControl) && (_mmapFlags == rhs._mmapFlags);
+        return (_tuneControl != rhs._tuneControl) || (_mmapFlags != rhs._mmapFlags);
     }
     TuneFileRandRead consider_force_memory_map(bool force_memory_map) const noexcept;
 };


### PR DESCRIPTION
The previous implementation returned
  (_tuneControl != rhs._tuneControl) && (_mmapFlags == rhs._mmapFlags)
which is not the negation of operator==. By De Morgan's law, the negation of (a == b) && (c == d) is (a != b) || (c != d), so both the combining operator and the second comparison were wrong.