### PR TITLE
Fix typos in identifiers, comments, and an error message; normalize n…

### DIFF
--- a/config/src/apps/vespa-configproxy-cmd/methods.cpp
+++ b/config/src/apps/vespa-configproxy-cmd/methods.cpp
@@ -41,4 +41,4 @@ void dump() {
     std::cerr << std::endl;
 }
 
-}; // namespace methods
+} // namespace methods

--- a/config/src/apps/vespa-configproxy-cmd/methods.h
+++ b/config/src/apps/vespa-configproxy-cmd/methods.h
@@ -14,4 +14,4 @@ namespace methods {
 const Method find(const std::string& name);
 void dump();
 
-}; // namespace methods
+} // namespace methods

--- a/searchcore/src/tests/proton/attribute/attribute_aspect_delayer/attribute_aspect_delayer_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_aspect_delayer/attribute_aspect_delayer_test.cpp
@@ -13,7 +13,7 @@
 #include <string>
 
 #include <vespa/log/log.h>
-LOG_SETUP("attibute_aspect_delayer_test");
+LOG_SETUP("attribute_aspect_delayer_test");
 
 using search::attribute::Config;
 using vespa::config::search::AttributesConfig;

--- a/searchcore/src/tests/proton/attribute/attributes_state_explorer/attributes_state_explorer_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attributes_state_explorer/attributes_state_explorer_test.cpp
@@ -172,7 +172,7 @@ TEST_F(AttributesStateExplorerTest, require_that_imported_attribute_shows_memory
     EXPECT_LT(0, slime[cache_memory_usage]["used"].asLong());
 }
 
-TEST_F(AttributesStateExplorerTest, require_that_bool_attibute_shows_bitvector) {
+TEST_F(AttributesStateExplorerTest, require_that_bool_attribute_shows_bitvector) {
     std::string bitvector("bitvector");
     add_bool_attribute("bool");
     auto slime = explore_attribute("bool");

--- a/searchcore/src/tests/proton/common/alloc_config/alloc_config_test.cpp
+++ b/searchcore/src/tests/proton/common/alloc_config/alloc_config_test.cpp
@@ -22,7 +22,7 @@ AllocStrategy make_alloc_strategy(uint32_t initial_docs) {
     return AllocStrategy(make_grow_strategy(initial_docs), baseline_compaction_strategy, 10000);
 }
 
-}; // namespace
+} // namespace
 
 TEST(AllocConfigTest, can_make_allocation_strategy_for_sub_dbs) {
     AllocConfig config(make_alloc_strategy(10000000), 5, 2);

--- a/searchcore/src/tests/proton/documentdb/buckethandler_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/buckethandler_test.cpp
@@ -130,15 +130,12 @@ BucketHandlerTest::BucketHandlerTest()
       _bucketInfo(),
       _genResult(std::make_shared<test::GenericResultHandler>()) {
     // bucket 2 & 3 & 4 & 7 in ready
-    _ready.insertDocs(_builder.createDocs(2, 1, 3)
-                          . // 2 docs
-                      createDocs(3, 3, 6)
-                          . // 3 docs
-                      createDocs(4, 6, 10)
-                          . // 4 docs
-                      createDocs(7, 10, 11)
-                          . // 1 doc
-                      getDocs());
+    _ready.insertDocs(_builder
+                          .createDocs(2, 1, 3)   // 2 docs
+                          .createDocs(3, 3, 6)   // 3 docs
+                          .createDocs(4, 6, 10)  // 4 docs
+                          .createDocs(7, 10, 11) // 1 doc
+                          .getDocs());
     // bucket 2 in removed
     _removed.insertDocs(_builder.clearDocs().createDocs(2, 16, 20). // 4 docs
                         getDocs());

--- a/searchcore/src/tests/proton/server/documentretriever_test.cpp
+++ b/searchcore/src/tests/proton/server/documentretriever_test.cpp
@@ -645,7 +645,7 @@ struct Lookup : public IFieldInfo {
     mutable unsigned _count;
 };
 
-TEST(DocumentRetrieverTest, require_that_fieldset_can_figure_out_their_attributeness_and_rember_it) {
+TEST(DocumentRetrieverTest, require_that_fieldset_can_figure_out_their_attributeness_and_remember_it) {
     Lookup               lookup;
     FieldSetAttributeDB  fsDB(lookup);
     document::Field      attr1("attr1", 1, *document::DataType::LONG);

--- a/searchcore/src/tests/proton/server/memory_flush_config_updater_test.cpp
+++ b/searchcore/src/tests/proton/server/memory_flush_config_updater_test.cpp
@@ -178,7 +178,7 @@ TEST(MemoryFlushConfigUpdaterTest,
 }
 
 TEST(MemoryFlushConfigUpdaterTest,
-     require_that_last_config_if_remembered_when_setting_new_disk_and_memory_usage_state) {
+     require_that_last_config_is_remembered_when_setting_new_disk_and_memory_usage_state) {
     Fixture f;
     f.updater.setConfig(getConfig(6, 3, 30));
     f.notifyDiskMemUsage(aboveLimit(), belowLimit());
@@ -242,5 +242,5 @@ TEST(MemoryFlushConfigUpdaterTest,
     f.set_node_retired_or_maintenance(true);
     f.assertStrategyDiskConfig("2nd notify", (0.8 - ((0.3 / 0.7) * (1 - DEFAULT_DISK_BLOAT))) / 0.8, 1.0);
     f.notifyDiskMemUsage(belowLimit(), belowLimit());
-    f.assertStrategyDiskConfig("erd notify", DEFAULT_DISK_BLOAT, DEFAULT_DISK_BLOAT);
+    f.assertStrategyDiskConfig("3rd notify", DEFAULT_DISK_BLOAT, DEFAULT_DISK_BLOAT);
 }

--- a/searchcore/src/tests/proton/server/memoryconfigstore_test.cpp
+++ b/searchcore/src/tests/proton/server/memoryconfigstore_test.cpp
@@ -85,7 +85,7 @@ TEST(MemoryConfigStoreTest, require_that_prune_removes_old_configs) {
 }
 
 TEST(MemoryConfigStoreTest,
-     require_that_MemoryConfigStores_preserves_state_of_MemoryConfigStore_between_instantiations) {
+     require_that_MemoryConfigStore_preserves_state_of_MemoryConfigStore_between_instantiations) {
     MemoryConfigStores config_stores;
     const std::string  name("foo");
     ConfigStore::UP    config_store = config_stores.getConfigStore(name);

--- a/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
@@ -192,7 +192,7 @@ TEST_F(ResourceUsageWriteFilterTest, check_that_enum_store_limit_can_be_reached)
               "attributeName: \"enumeratedName\", componentName: \"enum-store\", subdb: \"ready\"}");
 }
 
-TEST_F(ResourceUsageWriteFilterTest, Check_that_multivalue_limit_can_be_reached) {
+TEST_F(ResourceUsageWriteFilterTest, check_that_multivalue_limit_can_be_reached) {
     EXPECT_TRUE(_notifier.setConfig(Config(0.8, 0.8, 0.0, AttributeUsageFilterConfig(0.8))));
     MyAttributeStats stats;
     stats.triggerMultiValueLimit();
@@ -209,7 +209,7 @@ TEST_F(ResourceUsageWriteFilterTest, Check_that_multivalue_limit_can_be_reached)
               "attributeName: \"multiValueName\", componentName: \"multi-value\", subdb: \"ready\"}");
 }
 
-TEST_F(ResourceUsageWriteFilterTest, Check_that_source_selector_limit_can_be_reached) {
+TEST_F(ResourceUsageWriteFilterTest, check_that_source_selector_limit_can_be_reached) {
     EXPECT_TRUE(_notifier.setConfig(Config(0.8, 0.8, 0.0, AttributeUsageFilterConfig(0.8))));
     MyAttributeStats stats;
     stats.trigger_source_selector_limit();

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_distribution.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_distribution.cpp
@@ -139,4 +139,4 @@ void BmDistribution::commit_cluster_state_change() {
     }
 }
 
-}; // namespace search::bmcluster
+} // namespace search::bmcluster

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_distribution.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_distribution.h
@@ -36,4 +36,4 @@ public:
     void commit_cluster_state_change();
 };
 
-}; // namespace search::bmcluster
+} // namespace search::bmcluster

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_feed_operation.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_feed_operation.h
@@ -6,4 +6,4 @@ namespace search::bmcluster {
 
 enum class BmFeedOperation { PUT_OPERATION, UPDATE_OPERATION, GET_OPERATION, REMOVE_OPERATION };
 
-}
+} // namespace search::bmcluster

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.h
@@ -16,7 +16,7 @@ class DocumentTypeRepo;
 class DocumentType;
 class Field;
 
-}; // namespace document
+} // namespace document
 
 namespace storage::lib {
 class ClusterState;

--- a/searchcore/src/vespa/searchcore/bmcluster/i_bm_distribution.h
+++ b/searchcore/src/vespa/searchcore/bmcluster/i_bm_distribution.h
@@ -35,4 +35,4 @@ public:
     virtual storage::lib::ClusterStateBundle get_cluster_state_bundle() const = 0;
 };
 
-}; // namespace search::bmcluster
+} // namespace search::bmcluster

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/resource_usage_tracker.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/resource_usage_tracker.cpp
@@ -101,4 +101,4 @@ ResourceUsageTracker::remove_listener()
     _listener = nullptr;
 }
 
-};
+} // namespace proton

--- a/searchlib/src/tests/attribute/multi_value_read_view/multi_value_read_view_test.cpp
+++ b/searchlib/src/tests/attribute/multi_value_read_view/multi_value_read_view_test.cpp
@@ -376,7 +376,7 @@ TEST_P(MultiValueReadViewTest, test_imported_enumerated_array) {
     test_imported_attribute_vector(CollectionType::Type::ARRAY, true);
 };
 
-TEST_P(MultiValueReadViewTest, test_importe_weighted_set) {
+TEST_P(MultiValueReadViewTest, test_imported_weighted_set) {
     test_imported_attribute_vector(CollectionType::Type::WSET, false);
 };
 

--- a/searchlib/src/tests/diskindex/pagedict4/pagedict4_long_words_test.cpp
+++ b/searchlib/src/tests/diskindex/pagedict4/pagedict4_long_words_test.cpp
@@ -6,6 +6,7 @@
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <filesystem>
 

--- a/searchlib/src/tests/features/element_similarity_feature/element_similarity_feature_test.cpp
+++ b/searchlib/src/tests/features/element_similarity_feature/element_similarity_feature_test.cpp
@@ -242,7 +242,7 @@ TEST(ElementSimilarityFeatureTest, require_that_no_match_gives_zero_outputs) {
     EXPECT_EQ(0.0, f1.get_feature("x", indexFoo().element("y"), FIELD));
 }
 
-TEST(ElementSimilarityFeatureTest, require_that_minal_perfect_match_gives_max_outputs) {
+TEST(ElementSimilarityFeatureTest, require_that_minimal_perfect_match_gives_max_outputs) {
     RankFixture f1;
     EXPECT_EQ(1.0, f1.get_feature("x", indexFoo().element("x"), DEFAULT));
     EXPECT_EQ(1.0, f1.get_feature("x", indexFoo().element("x"), PROXIMITY));

--- a/searchlib/src/vespa/searchlib/common/bitvectorcache.cpp
+++ b/searchlib/src/vespa/searchlib/common/bitvectorcache.cpp
@@ -151,7 +151,7 @@ void BitVectorCache::populate(Key2Index& newKeys, CondensedBitVector& chunk, con
             } else {
                 LOG(error,
                     "Unable to to find a valid iterator for feature %" PRIu64
-                    " and %ld bits set at while populating bitvector %2d. This should in theory be impossible.",
+                    " (and %ld bits set) while populating bitvector %2d. This should in theory be impossible.",
                     e.first, m.bitCount(), index);
             }
             index++;

--- a/searchlib/src/vespa/searchlib/engine/monitorrequest.cpp
+++ b/searchlib/src/vespa/searchlib/engine/monitorrequest.cpp
@@ -6,4 +6,4 @@ namespace search::engine {
 
 MonitorRequest::MonitorRequest() = default;
 
-}
+} // namespace search::engine

--- a/searchlib/src/vespa/searchlib/features/weighted_set_parser.cpp
+++ b/searchlib/src/vespa/searchlib/features/weighted_set_parser.cpp
@@ -5,4 +5,8 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".features.weighted_set_parser");
 
-namespace search::features {}
+namespace search::features {
+
+// currently, class implementation is completely header-only.
+
+} // namespace search::features

--- a/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.cpp
@@ -35,7 +35,7 @@ public:
     }
 };
 
-}; // namespace
+} // namespace
 
 EquivBlueprint::EquivBlueprint(FieldSpecBaseList fields, fef::MatchDataLayout subtree_mdl)
     : ComplexLeafBlueprint(std::move(fields)), _estimate(), _layout(std::move(subtree_mdl)), _terms(), _exactness() {

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_search.cpp
@@ -109,7 +109,7 @@ void SameElementSearch::doUnpack(uint32_t docid) {
     for (const auto& child : _children) {
         child->unpack(docid);
     }
-    // Need to filter descendants again due to FakeSearch and SimplePhraseSearch overwrititing filtered match data
+    // Need to filter descendants again due to FakeSearch and SimplePhraseSearch overwriting filtered match data
     filter_descendants_match_data(docid, _matchingElements);
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.cpp
@@ -106,7 +106,7 @@ SearchIterator::UP WeightedSetTermBlueprint::createLeafSearch(const fef::TermFie
     assert(tfmda.size() == 1);
     if ((_terms.size() == 1) && tfmda[0]->isNotNeeded()) {
         if (const LeafBlueprint* leaf = _terms[0]->asLeaf(); leaf != nullptr) {
-            // Always returnin a strict iterator independently of what was required,
+            // Always returning a strict iterator independently of what was required,
             // as that is what we do with all the children when there are more.
             return leaf->createLeafSearch(tfmda);
         }

--- a/searchsummary/src/vespa/juniper/query_item.h
+++ b/searchsummary/src/vespa/juniper/query_item.h
@@ -23,4 +23,4 @@ public:
     virtual ItemCreator get_creator() const = 0;
 };
 
-}; // namespace juniper
+} // namespace juniper

--- a/storage/src/vespa/storage/persistence/filestorage/mergestatus.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/mergestatus.cpp
@@ -144,4 +144,4 @@ MergeStatus::check_delayed_error(api::ReturnCode &return_code)
     }
 }
 
-};
+} // namespace storage

--- a/vespalib/src/tests/datastore/compact_buffer_candidates/compact_buffer_candidates_test.cpp
+++ b/vespalib/src/tests/datastore/compact_buffer_candidates/compact_buffer_candidates_test.cpp
@@ -12,7 +12,7 @@ constexpr double   default_ratio = 0.2 / 2;
 constexpr size_t   default_slack = 1000;
 constexpr double   default_active_buffers_ratio = 1.0;
 
-}; // namespace
+} // namespace
 
 class CompactBufferCandidatesTest : public ::testing::Test {
 public:

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_buffer_type.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_buffer_type.cpp
@@ -22,4 +22,4 @@ template class UniqueStoreBufferType<UniqueStoreEntry<uint32_t>>;
 template class UniqueStoreBufferType<UniqueStoreEntry<float>>;
 template class UniqueStoreBufferType<UniqueStoreEntry<double>>;
 
-}; // namespace vespalib::datastore
+} // namespace vespalib::datastore

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_string_allocator.h
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_string_allocator.h
@@ -22,7 +22,7 @@ namespace string_allocator {
 extern std::vector<size_t> array_sizes;
 uint32_t get_type_id(size_t string_len);
 
-}; // namespace string_allocator
+} // namespace string_allocator
 
 /*
  * Entry type for small strings. array_size is passed to constructors and


### PR DESCRIPTION
…amespace syntax

Correct misspellings scattered across searchlib and searchcore: test function names, a LOG_SETUP string, and inline comments. Typos in test names matter because they appear verbatim in test output and CI logs, making failures harder to search for.

Also fix `};` to `}` for namespace closing braces (the semicolon is legal C++ but unusual and inconsistent with the rest of the codebase), add missing namespace-name comments on closing braces, fix a garbled bitvectorcache error message ("to to find...at while" → "to find...(N bits set) while"), add a missing size_literals.h include, and reformat a builder method chain for readability.
