### PR TITLE
Rename Zone.getVirtualId() to id()

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneApi.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneApi.java
@@ -13,30 +13,8 @@ public interface ZoneApi {
 
     SystemName getSystemName();
 
-    /**
-     * Returns the ID of the zone.
-     *
-     * WARNING: The ID of a controller zone is equal to the ID of a prod zone in the same region.
-     * @see #getVirtualId()
-     */
-    ZoneId getId();
-
-    /** Returns the SYSTEM.ENVIRONMENT.REGION string. */
-    default String getFullName() {
-        return getSystemName().value() + "." + getEnvironment().value() + "." + getRegionName().value();
-    }
-
-    /**
-     * Returns {@link #getId()} for all zones except the controller zone.  Unlike {@link #getId()},
-     * the virtual ID of a controller is distinct from all other zones.
-     */
-    default ZoneId getVirtualId() {
-        return getId();
-    }
-
-    default Environment getEnvironment() { return getId().environment(); }
-
-    default RegionName getRegionName() { return getId().region(); }
+    /** Returns a unique ID across all config server zones (including the controller zone) within the system. */
+    default ZoneId id() { return legacyId(); }
 
     CloudName getCloudName();
 
@@ -45,5 +23,23 @@ public interface ZoneApi {
 
     /** Returns the availability zone within the cloud, e.g. 'use1-az2' in AWS */
     default String getCloudNativeAvailabilityZone() { throw new UnsupportedOperationException(); }
+
+    /**
+     * Returns the legacy ID of the zone.  It is "legacy" because a controller and prod config server gets the same ID.</p>
+     *
+     * @see #id()
+     */
+    ZoneId legacyId();
+
+    /** Returns the SYSTEM.ENVIRONMENT.REGION string. WARNING: Uses {@link #legacyId()} by default. */
+    default String getFullName() {
+        return getSystemName().value() + "." + getEnvironment().value() + "." + getRegionName().value();
+    }
+
+    /** WARNING: Uses {@link #legacyId()} by default. */
+    default Environment getEnvironment() { return legacyId().environment(); }
+
+    /** WARNING: Uses {@link #legacyId()} by default. */
+    default RegionName getRegionName() { return legacyId().region(); }
 
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneId.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneId.java
@@ -22,9 +22,9 @@ public class ZoneId {
      *
      * <p>The controller may also be associated with a real zone, i.e. with a region defining the location like
      * aws-us-east-1a.  Because such a zone ID is different for different systems, and may clash with a prod zone in the
-     * same region and system, the virtual zone ID is often used.</p>
+     * same region and system, the controller zone ID returned here (see {@link ZoneApi#id()}) is often used instead.</p>
      */
-    public static ZoneId ofVirtualControllerZone() { return CONTROLLER; }
+    public static ZoneId ofControllerZone() { return CONTROLLER; }
 
     private final Environment environment;
     private final RegionName region;

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneList.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/ZoneList.java
@@ -7,7 +7,6 @@ import com.yahoo.config.provision.RegionName;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Provides filters for and access to a list of ZoneIds.
@@ -51,7 +50,7 @@ public interface ZoneList extends ZoneFilter {
 
     /** Returns the ZoneIds of all zones in this list. */
     default List<ZoneId> ids() {
-        return zones().stream().map(ZoneApi::getVirtualId).toList();
+        return zones().stream().map(ZoneApi::id).toList();
     }
 
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Dimension.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Dimension.java
@@ -107,8 +107,8 @@ public enum Dimension {
     VESPA_VERSION("vespa-version"),
 
     /**
-     * Virtual zone ID from com.yahoo.config.provision.zone.ZoneId::value of the form environment.region,
-     * see com.yahoo.config.provision.zone.ZoneApi::getVirtualId.  <em>Eager resolution</em>, see {@link #CLOUD}.
+     * Zone ID from com.yahoo.config.provision.zone.ZoneId::value of the form environment.region,
+     * see com.yahoo.config.provision.zone.ZoneApi::id.  <em>Eager resolution</em>, see {@link #CLOUD}.
      */
     ZONE_ID("zone");
 

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flag.java
@@ -85,7 +85,7 @@ public interface Flag<T, F extends Flag<T, F>> {
     /** Sets the zone and environment dimensions. */
     default F with(Zone zone) { return with(Dimension.ZONE_ID, zone.systemLocalValue()) .with(Dimension.ENVIRONMENT, zone.environment().value()); }
     /** Sets the zone and environment dimensions. */
-    default F with(ZoneApi zoneApi) { return with(zoneApi.getVirtualId()); }
+    default F with(ZoneApi zoneApi) { return with(zoneApi.id()); }
 
     /** Sets the tenant, application, and instance dimensions. */
     default F withApplicationId(Optional<ApplicationId> applicationId) { return applicationId.map(this::with).orElse(self()); }


### PR DESCRIPTION
Changes to ZoneApi:
 - `getVirtualId()` → `id()`
 - `getId()` → `legacyId()`

`id()` is unique when including the controller zone, `legacyId()` is not.