### PR TITLE
Add ENN to `iterator_benchmark`

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/CMakeLists.txt
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/CMakeLists.txt
@@ -8,6 +8,7 @@ vespa_add_executable(searchlib_iterator_benchmark_test_app TEST
     disk_index_builder.cpp
     intermediate_blueprint_factory.cpp
     iterator_benchmark_test.cpp
+    leaf_blueprint_factory.cpp
 
     DEPENDS
     vespa_searchlib

--- a/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.cpp
@@ -10,6 +10,7 @@
 #include <vespa/searchlib/fef/matchdatalayout.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/fake_requestcontext.h>
+#include <vespa/searchlib/tensor/tensor_attribute.h>
 
 using namespace search::attribute;
 using namespace search::attribute::test;
@@ -128,6 +129,24 @@ void AttributeContextBuilder::add(const search::attribute::Config& cfg, std::str
                                   uint32_t num_docs, const HitSpecs& hit_specs, bool disjunct_terms) {
     auto attr = make_attribute(cfg, field_name, num_docs, hit_specs, disjunct_terms);
     _ctx->add(std::move(attr));
+}
+
+AttributeVector::SP
+AttributeContextBuilder::add_tensor(const search::attribute::Config& cfg, std::string_view field_name,
+                                    uint32_t num_docs, std::function<vespalib::eval::Value::UP(uint32_t docid)> gen) {
+    auto attr = AttributeFactory::createAttribute(field_name, cfg);
+    attr->addReservedDoc();
+    attr->addDocs(num_docs);
+    auto& real = dynamic_cast<search::tensor::TensorAttribute&>(*attr);
+    for (uint32_t docid = 1; docid <= num_docs; ++docid) {
+        auto v = gen(docid);
+        if (v) {
+            real.setTensor(docid, *v);
+        }
+    }
+    attr->commit(CommitParam::UpdateStats::FORCE);
+    _ctx->add(attr);
+    return attr;
 }
 
 std::unique_ptr<BenchmarkSearchable> AttributeContextBuilder::build() {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.h
@@ -4,11 +4,13 @@
 
 #include "benchmark_searchable.h"
 #include "common.h"
-
+#include <vespa/eval/eval/value.h>
 #include <vespa/searchcommon/attribute/config.h>
+#include <vespa/searchlib/attribute/attrvector.h>
 #include <vespa/searchlib/test/mock_attribute_context.h>
 
 #include <memory>
+#include <functional>
 
 namespace search::queryeval::test {
 
@@ -23,6 +25,12 @@ public:
     AttributeContextBuilder();
     void add(const search::attribute::Config& cfg, std::string_view field_name, uint32_t num_docs,
              const HitSpecs& hit_specs, bool disjunct_terms);
+
+    AttributeVector::SP add_tensor(const search::attribute::Config& cfg,
+                                   std::string_view field_name,
+                                   uint32_t num_docs,
+                                   std::function<vespalib::eval::Value::UP(uint32_t docid)> gen);
+
     std::unique_ptr<BenchmarkSearchable> build();
 };
 

--- a/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.h
@@ -4,13 +4,14 @@
 
 #include "benchmark_searchable.h"
 #include "common.h"
+
 #include <vespa/eval/eval/value.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/attribute/attrvector.h>
 #include <vespa/searchlib/test/mock_attribute_context.h>
 
-#include <memory>
 #include <functional>
+#include <memory>
 
 namespace search::queryeval::test {
 
@@ -26,10 +27,8 @@ public:
     void add(const search::attribute::Config& cfg, std::string_view field_name, uint32_t num_docs,
              const HitSpecs& hit_specs, bool disjunct_terms);
 
-    AttributeVector::SP add_tensor(const search::attribute::Config& cfg,
-                                   std::string_view field_name,
-                                   uint32_t num_docs,
-                                   std::function<vespalib::eval::Value::UP(uint32_t docid)> gen);
+    AttributeVector::SP add_tensor(const search::attribute::Config& cfg, std::string_view field_name,
+                                   uint32_t num_docs, std::function<vespalib::eval::Value::UP(uint32_t docid)> gen);
 
     std::unique_ptr<BenchmarkSearchable> build();
 };

--- a/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.cpp
@@ -2,7 +2,13 @@
 
 #include "blueprint_factory_builder.h"
 
+#include "leaf_blueprint_factory.h"
+
 namespace search::queryeval::test {
+
+FactoryPtr enn(uint32_t target_hits) {
+    return std::make_unique<EnnBlueprintFactory>(target_hits);
+}
 
 FactoryPtr term(FieldConfig field, uint32_t num_docs, uint32_t default_values_per_document, double hit_ratio) {
     return make_blueprint_factory(field, QueryOperator::Term, num_docs, default_values_per_document, hit_ratio, 1,

--- a/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.cpp
@@ -6,8 +6,8 @@
 
 namespace search::queryeval::test {
 
-FactoryPtr enn(AttributeVector::SP attr, Value::UP query, uint32_t target_hits) {
-    return std::make_unique<EnnBlueprintFactory>(attr, std::move(query), target_hits);
+FactoryPtr enn(const EnnConfig& cfg) {
+    return std::make_unique<EnnBlueprintFactory>(cfg);
 }
 
 FactoryPtr term(FieldConfig field, uint32_t num_docs, uint32_t default_values_per_document, double hit_ratio) {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.cpp
@@ -6,8 +6,8 @@
 
 namespace search::queryeval::test {
 
-FactoryPtr enn(uint32_t target_hits) {
-    return std::make_unique<EnnBlueprintFactory>(target_hits);
+FactoryPtr enn(AttributeVector::SP attr, Value::UP query, uint32_t target_hits) {
+    return std::make_unique<EnnBlueprintFactory>(attr, std::move(query), target_hits);
 }
 
 FactoryPtr term(FieldConfig field, uint32_t num_docs, uint32_t default_values_per_document, double hit_ratio) {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.h
@@ -9,6 +9,8 @@
 #include "benchmark_blueprint_factory.h"
 #include "common.h"
 #include "intermediate_blueprint_factory.h"
+#include "leaf_blueprint_factory.h"
+
 #include <vespa/eval/eval/value.h>
 
 namespace search::queryeval::test {
@@ -17,7 +19,7 @@ using vespalib::eval::Value;
 
 using FactoryPtr = std::shared_ptr<BenchmarkBlueprintFactory>;
 
-FactoryPtr enn(AttributeVector::SP attr, Value::UP query, uint32_t target_hits);
+FactoryPtr enn(const EnnConfig& cfg = {});
 
 FactoryPtr term(FieldConfig field, uint32_t num_docs, uint32_t default_values_per_document, double hit_ratio);
 

--- a/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.h
@@ -9,12 +9,15 @@
 #include "benchmark_blueprint_factory.h"
 #include "common.h"
 #include "intermediate_blueprint_factory.h"
+#include <vespa/eval/eval/value.h>
 
 namespace search::queryeval::test {
 
+using vespalib::eval::Value;
+
 using FactoryPtr = std::shared_ptr<BenchmarkBlueprintFactory>;
 
-FactoryPtr enn(uint32_t target_hits);
+FactoryPtr enn(AttributeVector::SP attr, Value::UP query, uint32_t target_hits);
 
 FactoryPtr term(FieldConfig field, uint32_t num_docs, uint32_t default_values_per_document, double hit_ratio);
 

--- a/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/blueprint_factory_builder.h
@@ -14,6 +14,8 @@ namespace search::queryeval::test {
 
 using FactoryPtr = std::shared_ptr<BenchmarkBlueprintFactory>;
 
+FactoryPtr enn(uint32_t target_hits);
+
 FactoryPtr term(FieldConfig field, uint32_t num_docs, uint32_t default_values_per_document, double hit_ratio);
 
 template <class... Cs> FactoryPtr and_(Cs&&... cs) {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1,10 +1,15 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "attribute_ctx_builder.h"
 #include "benchmark_blueprint_factory.h"
 #include "blueprint_factory_builder.h"
 #include "common.h"
 #include "intermediate_blueprint_factory.h"
 
+#include <vespa/eval/eval/simple_value.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/value_type.h>
+#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/vespalib/gtest/gtest.h>
@@ -711,7 +716,7 @@ struct BlueprintFactorySetup {
         return std::shared_ptr<BenchmarkBlueprintFactory>(make_factory(num_docs, op_hit_ratio));
     }
     std::string to_string() const {
-        return "field=" + field_cfg.to_string() + ", query=" + test::to_string(query_op) +
+        return "field=" + field_cfg.to_string() + ", query=" + queryeval::test::to_string(query_op) +
                ", children=" + std::to_string(children);
     }
 };
@@ -1021,7 +1026,22 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
 }
 
 TEST(IteratorBenchmark, spec_factory_test) {
-    auto tree = and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3), enn(100));
+    using vespalib::eval::SimpleValue;
+    using vespalib::eval::TensorSpec;
+    using vespalib::eval::ValueType;
+    search::attribute::Config tensor_cfg(BasicType::TENSOR);
+    tensor_cfg.setTensorType(ValueType::from_spec("tensor<float>(x[2])"));
+    tensor_cfg.set_distance_metric(DistanceMetric::Euclidean);
+
+    AttributeContextBuilder builder;
+    auto                    attr = builder.add_tensor(tensor_cfg, "nn", num_docs, [](uint32_t docid) {
+        return SimpleValue::from_spec(
+            TensorSpec("tensor<float>(x[2])").add({{"x", 0}}, double(docid)).add({{"x", 1}}, 0.0));
+    });
+    auto query = SimpleValue::from_spec(TensorSpec("tensor<float>(x[2])").add({{"x", 0}}, 0.0).add({{"x", 1}}, 0.0));
+
+    auto tree =
+        and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3), enn(attr, std::move(query), 100));
 
     auto res = benchmark_search(*tree, num_docs + 1,
                                 /*strict*/ true,

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1024,35 +1024,31 @@ TEST(IteratorBenchmark, analyze_AND_plan_variants_ENN) {
     auto enn_factory = enn({.num_docs = num_docs, .target_hits = 100});
     auto term_hit_ratios = gen_ratios(0.01, 10.0, 7);
 
-    auto run_plan = [&](const std::string& tag, FactoryPtr root, double term_hit_ratio, PlanningAlgo algo) {
+    auto run_plan = [&](const std::string& tag, FactoryPtr root, double term_hit_ratio) {
         auto res = benchmark_search(*root, num_docs + 1, /*strict*/ true, /*force_strict*/ false,
-                                    /*unpack_iterator*/ false, /*filter_hit_ratio*/ 1.0, algo);
-        std::println("  {:>22} | term_hr={:>8.5f} | hits={:>8} | seeks={:>8} | time_ms={:>8.3f} | plan={}", tag,
-                     term_hit_ratio, res.hits, res.seeks, res.time_ms, res.blueprint_name);
+                                    /*unpack_iterator*/ false, /*filter_hit_ratio*/ 1.0, PlanningAlgo::Order);
+        std::println("  {:>16} | term_hr={:>8.5f} | hits={:>8} | time_ms={:>8.3f} | plan={}", tag, term_hit_ratio,
+                     res.hits, res.time_ms, res.blueprint_name);
         return res.time_ms;
     };
 
     std::println("Plan variants for AND(term{{int32_fs}}, ENN{{num_docs={},target_hits=100,dim=2}})", num_docs);
-    std::println("Singles + 2 child orderings × {{Order, CostForceStrict}}.");
+    std::println("term-alone, enn-alone are baselines. AND rows force build order via PlanningAlgo::Order.");
 
     double max_penalty = 0.0;
     for (double hr : term_hit_ratios) {
         auto term_factory = term(int32_fs, num_docs, 0, hr);
 
         std::println("----- term_hit_ratio={} -----", hr);
-        run_plan("term-alone", term_factory, hr, PlanningAlgo::Order);
-        run_plan("enn-alone", enn_factory, hr, PlanningAlgo::Order);
-        double t_te_o = run_plan("AND[term,enn] ordr", and_(term_factory, enn_factory), hr, PlanningAlgo::Order);
-        double t_te_f =
-            run_plan("AND[term,enn] forc", and_(term_factory, enn_factory), hr, PlanningAlgo::CostForceStrict);
-        double t_et_o = run_plan("AND[enn,term] ordr", and_(enn_factory, term_factory), hr, PlanningAlgo::Order);
-        double t_et_f =
-            run_plan("AND[enn,term] forc", and_(enn_factory, term_factory), hr, PlanningAlgo::CostForceStrict);
+        run_plan("term-alone", term_factory, hr);
+        run_plan("enn-alone", enn_factory, hr);
+        double t_term_first = run_plan("AND[term,enn]", and_(term_factory, enn_factory), hr);
+        double t_enn_first  = run_plan("AND[enn,term]", and_(enn_factory, term_factory), hr);
 
-        double best = std::min({t_te_o, t_te_f, t_et_o, t_et_f});
-        double worst = std::max({t_te_o, t_te_f, t_et_o, t_et_f});
+        double best    = std::min(t_term_first, t_enn_first);
+        double worst   = std::max(t_term_first, t_enn_first);
         double penalty = (best > 0) ? (worst / best) : 0.0;
-        max_penalty = std::max(max_penalty, penalty);
+        max_penalty    = std::max(max_penalty, penalty);
         std::println("  worst/best ratio={:.4f}", penalty);
     }
     std::println("max worst-plan penalty={:.4f}", max_penalty);

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1024,29 +1024,33 @@ TEST(IteratorBenchmark, analyze_AND_plan_variants_ENN) {
     auto enn_factory = enn({.num_docs = num_docs, .target_hits = 100});
     auto term_hit_ratios = gen_ratios(0.01, 10.0, 7);
 
-    auto run_plan = [&](const std::string& tag, FactoryPtr root, double term_hit_ratio) {
+    auto run_plan = [&](const std::string& tag, FactoryPtr root, double term_hit_ratio, PlanningAlgo algo) {
         auto res = benchmark_search(*root, num_docs + 1, /*strict*/ true, /*force_strict*/ false,
-                                    /*unpack_iterator*/ false, /*filter_hit_ratio*/ 1.0, PlanningAlgo::Order);
-        std::println("  {:>14} | term_hr={:>8.5f} | hits={:>8} | seeks={:>8} | time_ms={:>8.3f} | plan={}", tag,
+                                    /*unpack_iterator*/ false, /*filter_hit_ratio*/ 1.0, algo);
+        std::println("  {:>22} | term_hr={:>8.5f} | hits={:>8} | seeks={:>8} | time_ms={:>8.3f} | plan={}", tag,
                      term_hit_ratio, res.hits, res.seeks, res.time_ms, res.blueprint_name);
         return res.time_ms;
     };
 
     std::println("Plan variants for AND(term{{int32_fs}}, ENN{{num_docs={},target_hits=100,dim=2}})", num_docs);
-    std::println("Single-child baselines + 2 AND child orderings, all forced via PlanningAlgo::Order.");
+    std::println("Singles + 2 child orderings × {{Order, CostForceStrict}}.");
 
     double max_penalty = 0.0;
     for (double hr : term_hit_ratios) {
         auto term_factory = term(int32_fs, num_docs, 0, hr);
 
         std::println("----- term_hit_ratio={} -----", hr);
-        run_plan("term-alone", term_factory, hr);
-        run_plan("enn-alone", enn_factory, hr);
-        double t_tf = run_plan("AND[term,enn]", and_(term_factory, enn_factory), hr);
-        double t_ef = run_plan("AND[enn,term]", and_(enn_factory, term_factory), hr);
+        run_plan("term-alone", term_factory, hr, PlanningAlgo::Order);
+        run_plan("enn-alone", enn_factory, hr, PlanningAlgo::Order);
+        double t_te_o = run_plan("AND[term,enn] ordr", and_(term_factory, enn_factory), hr, PlanningAlgo::Order);
+        double t_te_f =
+            run_plan("AND[term,enn] forc", and_(term_factory, enn_factory), hr, PlanningAlgo::CostForceStrict);
+        double t_et_o = run_plan("AND[enn,term] ordr", and_(enn_factory, term_factory), hr, PlanningAlgo::Order);
+        double t_et_f =
+            run_plan("AND[enn,term] forc", and_(enn_factory, term_factory), hr, PlanningAlgo::CostForceStrict);
 
-        double best = std::min(t_tf, t_ef);
-        double worst = std::max(t_tf, t_ef);
+        double best = std::min({t_te_o, t_te_f, t_et_o, t_et_f});
+        double worst = std::max({t_te_o, t_te_f, t_et_o, t_et_f});
         double penalty = (best > 0) ? (worst / best) : 0.0;
         max_penalty = std::max(max_penalty, penalty);
         std::println("  worst/best ratio={:.4f}", penalty);

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -30,7 +30,9 @@ using namespace vespalib;
 
 using search::fef::MatchData;
 using search::index::Schema;
-
+using vespalib::eval::SimpleValue;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::ValueType;
 using vespalib::make_string_short::fmt;
 
 const std::string field_name = "myfield";
@@ -1026,9 +1028,6 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
 }
 
 TEST(IteratorBenchmark, spec_factory_test) {
-    using vespalib::eval::SimpleValue;
-    using vespalib::eval::TensorSpec;
-    using vespalib::eval::ValueType;
     search::attribute::Config tensor_cfg(BasicType::TENSOR);
     tensor_cfg.setTensorType(ValueType::from_spec("tensor<float>(x[2])"));
     tensor_cfg.set_distance_metric(DistanceMetric::Euclidean);

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1021,7 +1021,7 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
 }
 
 TEST(IteratorBenchmark, spec_factory_test) {
-    auto tree = and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3));
+    auto tree = and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3), enn(100));
 
     auto res = benchmark_search(*tree, num_docs + 1,
                                 /*strict*/ true,

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1,15 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "attribute_ctx_builder.h"
 #include "benchmark_blueprint_factory.h"
 #include "blueprint_factory_builder.h"
 #include "common.h"
 #include "intermediate_blueprint_factory.h"
 
-#include <vespa/eval/eval/simple_value.h>
-#include <vespa/eval/eval/tensor_spec.h>
-#include <vespa/eval/eval/value_type.h>
-#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/vespalib/gtest/gtest.h>
@@ -30,9 +25,7 @@ using namespace vespalib;
 
 using search::fef::MatchData;
 using search::index::Schema;
-using vespalib::eval::SimpleValue;
-using vespalib::eval::TensorSpec;
-using vespalib::eval::ValueType;
+
 using vespalib::make_string_short::fmt;
 
 const std::string field_name = "myfield";
@@ -1028,19 +1021,8 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
 }
 
 TEST(IteratorBenchmark, spec_factory_test) {
-    search::attribute::Config tensor_cfg(BasicType::TENSOR);
-    tensor_cfg.setTensorType(ValueType::from_spec("tensor<float>(x[2])"));
-    tensor_cfg.set_distance_metric(DistanceMetric::Euclidean);
-
-    AttributeContextBuilder builder;
-    auto                    attr = builder.add_tensor(tensor_cfg, "nn", num_docs, [](uint32_t docid) {
-        return SimpleValue::from_spec(
-            TensorSpec("tensor<float>(x[2])").add({{"x", 0}}, double(docid)).add({{"x", 1}}, 0.0));
-    });
-    auto query = SimpleValue::from_spec(TensorSpec("tensor<float>(x[2])").add({{"x", 0}}, 0.0).add({{"x", 1}}, 0.0));
-
-    auto tree =
-        and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3), enn(attr, std::move(query), 100));
+    auto tree = and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3),
+                     enn({.num_docs = num_docs, .target_hits = 100}));
 
     auto res = benchmark_search(*tree, num_docs + 1,
                                 /*strict*/ true,

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1020,19 +1020,38 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
     }
 }
 
-TEST(IteratorBenchmark, spec_factory_test) {
-    auto tree = and_(term(int32_fs, num_docs, 0, 0.01), term(str_fs, num_docs, 0, 0.3),
-                     enn({.num_docs = num_docs, .target_hits = 100}));
+TEST(IteratorBenchmark, analyze_AND_plan_variants_ENN) {
+    auto enn_factory = enn({.num_docs = num_docs, .target_hits = 100});
+    auto term_hit_ratios = gen_ratios(0.01, 10.0, 7);
 
-    auto res = benchmark_search(*tree, num_docs + 1,
-                                /*strict*/ true,
-                                /*force_strict*/ false,
-                                /*unpack_iterator*/ false,
-                                /*filter_hit_ratio*/ 1.0, PlanningAlgo::Cost);
+    auto run_plan = [&](const std::string& tag, FactoryPtr root, double term_hit_ratio) {
+        auto res = benchmark_search(*root, num_docs + 1, /*strict*/ true, /*force_strict*/ false,
+                                    /*unpack_iterator*/ false, /*filter_hit_ratio*/ 1.0, PlanningAlgo::Order);
+        std::println("  {:>14} | term_hr={:>8.5f} | hits={:>8} | seeks={:>8} | time_ms={:>8.3f} | plan={}", tag,
+                     term_hit_ratio, res.hits, res.seeks, res.time_ms, res.blueprint_name);
+        return res.time_ms;
+    };
 
-    std::cout << tree->get_name(/*unused*/ *tree->make_blueprint()) << "\n";
-    std::cout << "time_ms=" << res.time_ms << " seeks=" << res.seeks << " hits=" << res.hits
-              << " actual_cost=" << res.actual_cost << "\n";
+    std::println("Plan variants for AND(term{{int32_fs}}, ENN{{num_docs={},target_hits=100,dim=2}})", num_docs);
+    std::println("Single-child baselines + 2 AND child orderings, all forced via PlanningAlgo::Order.");
+
+    double max_penalty = 0.0;
+    for (double hr : term_hit_ratios) {
+        auto term_factory = term(int32_fs, num_docs, 0, hr);
+
+        std::println("----- term_hit_ratio={} -----", hr);
+        run_plan("term-alone", term_factory, hr);
+        run_plan("enn-alone", enn_factory, hr);
+        double t_tf = run_plan("AND[term,enn]", and_(term_factory, enn_factory), hr);
+        double t_ef = run_plan("AND[enn,term]", and_(enn_factory, term_factory), hr);
+
+        double best = std::min(t_tf, t_ef);
+        double worst = std::max(t_tf, t_ef);
+        double penalty = (best > 0) ? (worst / best) : 0.0;
+        max_penalty = std::max(max_penalty, penalty);
+        std::println("  worst/best ratio={:.4f}", penalty);
+    }
+    std::println("max worst-plan penalty={:.4f}", max_penalty);
 }
 
 int main(int argc, char** argv) {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
@@ -1,0 +1,28 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "leaf_blueprint_factory.h"
+
+#include <vespa/searchlib/queryeval/nearest_neighbor_blueprint.h>
+
+namespace search::queryeval::test {
+
+// ---------------- EnnBlueprintFactory --------------------
+
+EnnBlueprintFactory::EnnBlueprintFactory(uint32_t target_hits)
+    : _target_hits(target_hits) {
+}
+
+EnnBlueprintFactory::~EnnBlueprintFactory() = default;
+
+std::unique_ptr<Blueprint> EnnBlueprintFactory::make_blueprint() {
+    FieldSpec field;
+    auto distance_calc = tensor::DistanceCalculator::make_with_validation();
+    auto enn = std::make_unique<NearestNeighborBlueprint>(field, distance_calc, _target_hits, false, {});
+    return std::move(enn);
+}
+
+std::string EnnBlueprintFactory::get_name(Blueprint& blueprint) const {
+    return get_class_name(blueprint);
+}
+
+}

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
@@ -8,17 +8,19 @@ namespace search::queryeval::test {
 
 // ---------------- EnnBlueprintFactory --------------------
 
-EnnBlueprintFactory::EnnBlueprintFactory(uint32_t target_hits)
-    : _target_hits(target_hits) {
+EnnBlueprintFactory::EnnBlueprintFactory(AttributeVector::SP attr, Value::UP query, uint32_t target_hits)
+    : _attr(attr),
+      _query(std::move(query)),
+      _target_hits(target_hits) {
 }
 
 EnnBlueprintFactory::~EnnBlueprintFactory() = default;
 
 std::unique_ptr<Blueprint> EnnBlueprintFactory::make_blueprint() {
-    FieldSpec field;
-    auto distance_calc = tensor::DistanceCalculator::make_with_validation();
-    auto enn = std::make_unique<NearestNeighborBlueprint>(field, distance_calc, _target_hits, false, {});
-    return std::move(enn);
+    auto calc = std::make_unique<tensor::DistanceCalculator>(
+              *_attr->asTensorAttribute(), *_query);
+    FieldSpec field("nn", 0, 0);
+    return std::make_unique<NearestNeighborBlueprint>(field, std::move(calc), _target_hits, false, NearestNeighborBlueprint::HnswParams{});
 }
 
 std::string EnnBlueprintFactory::get_name(Blueprint& blueprint) const {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
@@ -2,14 +2,52 @@
 
 #include "leaf_blueprint_factory.h"
 
+#include "attribute_ctx_builder.h"
+
+#include <vespa/eval/eval/simple_value.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/value_type.h>
+#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/queryeval/nearest_neighbor_blueprint.h>
+
+#include <format>
+#include <random>
+
+using search::attribute::BasicType;
+using search::attribute::Config;
+using vespalib::eval::SimpleValue;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::Value;
+using vespalib::eval::ValueType;
 
 namespace search::queryeval::test {
 
+namespace {
+
+Value::UP make_random_vec(const std::string& type_spec, uint32_t dim, std::mt19937& gen) {
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    TensorSpec                            spec(type_spec);
+    for (uint32_t i = 0; i < dim; i++) {
+        spec.add({{"x", i}}, dist(gen));
+    }
+    return SimpleValue::from_spec(spec);
+}
+
+} // namespace
+
 // ---------------- EnnBlueprintFactory --------------------
 
-EnnBlueprintFactory::EnnBlueprintFactory(AttributeVector::SP attr, Value::UP query, uint32_t target_hits)
-    : _attr(attr), _query(std::move(query)), _target_hits(target_hits) {
+EnnBlueprintFactory::EnnBlueprintFactory(const EnnConfig& cfg) : _attr(), _query(), _target_hits(cfg.target_hits) {
+    auto   type_spec = std::format("tensor<float>(x[{}])", cfg.dim);
+    Config tensor_cfg(BasicType::TENSOR);
+    tensor_cfg.setTensorType(ValueType::from_spec(type_spec));
+    tensor_cfg.set_distance_metric(cfg.distance_metric);
+
+    std::mt19937            gen(cfg.seed);
+    AttributeContextBuilder builder;
+    _attr = builder.add_tensor(tensor_cfg, "nn", cfg.num_docs,
+                               [&](uint32_t) { return make_random_vec(type_spec, cfg.dim, gen); });
+    _query = make_random_vec(type_spec, cfg.dim, gen);
 }
 
 EnnBlueprintFactory::~EnnBlueprintFactory() = default;

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
@@ -9,22 +9,20 @@ namespace search::queryeval::test {
 // ---------------- EnnBlueprintFactory --------------------
 
 EnnBlueprintFactory::EnnBlueprintFactory(AttributeVector::SP attr, Value::UP query, uint32_t target_hits)
-    : _attr(attr),
-      _query(std::move(query)),
-      _target_hits(target_hits) {
+    : _attr(attr), _query(std::move(query)), _target_hits(target_hits) {
 }
 
 EnnBlueprintFactory::~EnnBlueprintFactory() = default;
 
 std::unique_ptr<Blueprint> EnnBlueprintFactory::make_blueprint() {
-    auto calc = std::make_unique<tensor::DistanceCalculator>(
-              *_attr->asTensorAttribute(), *_query);
+    auto      calc = std::make_unique<tensor::DistanceCalculator>(*_attr->asTensorAttribute(), *_query);
     FieldSpec field("nn", 0, 0);
-    return std::make_unique<NearestNeighborBlueprint>(field, std::move(calc), _target_hits, false, NearestNeighborBlueprint::HnswParams{});
+    return std::make_unique<NearestNeighborBlueprint>(field, std::move(calc), _target_hits, false,
+                                                      NearestNeighborBlueprint::HnswParams{});
 }
 
 std::string EnnBlueprintFactory::get_name(Blueprint& blueprint) const {
     return get_class_name(blueprint);
 }
 
-}
+} // namespace search::queryeval::test

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.cpp
@@ -11,6 +11,7 @@
 #include <vespa/searchlib/queryeval/nearest_neighbor_blueprint.h>
 
 #include <format>
+#include <limits>
 #include <random>
 
 using search::attribute::BasicType;
@@ -55,8 +56,9 @@ EnnBlueprintFactory::~EnnBlueprintFactory() = default;
 std::unique_ptr<Blueprint> EnnBlueprintFactory::make_blueprint() {
     auto      calc = std::make_unique<tensor::DistanceCalculator>(*_attr->asTensorAttribute(), *_query);
     FieldSpec field("nn", 0, 0);
-    return std::make_unique<NearestNeighborBlueprint>(field, std::move(calc), _target_hits, false,
-                                                      NearestNeighborBlueprint::HnswParams{});
+    NearestNeighborBlueprint::HnswParams hnsw_params{};
+    hnsw_params.distance_threshold = std::numeric_limits<double>::max();
+    return std::make_unique<NearestNeighborBlueprint>(field, std::move(calc), _target_hits, false, hnsw_params);
 }
 
 std::string EnnBlueprintFactory::get_name(Blueprint& blueprint) const {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.h
@@ -2,26 +2,41 @@
 
 #pragma once
 
-#include "blueprint_factory_builder.h"
+#include "benchmark_blueprint_factory.h"
+
 #include <vespa/eval/eval/value.h>
+#include <vespa/searchcommon/attribute/distance_metric.h>
+#include <vespa/searchlib/attribute/attributevector.h>
 
 namespace search::queryeval::test {
 
-using vespalib::eval::Value;
+struct EnnConfig {
+    using DistanceMetric = search::attribute::DistanceMetric;
+
+    uint32_t       num_docs = 10'000;
+    uint32_t       dim = 2;
+    uint32_t       target_hits = 100;
+    DistanceMetric distance_metric = DistanceMetric::Euclidean;
+    uint32_t       seed = 42;
+};
 
 /**
  * Factory that creates an ENN blueprint.
  */
 class EnnBlueprintFactory : public BenchmarkBlueprintFactory {
-    AttributeVector::SP _attr;
-    Value::UP           _query;
-    uint32_t            _target_hits;
+public:
+    using Value = vespalib::eval::Value;
+
+private:
+    AttributeVector::SP       _attr;
+    vespalib::eval::Value::UP _query;
+    uint32_t                  _target_hits;
 
 public:
-    EnnBlueprintFactory(AttributeVector::SP attr, Value::UP query, uint32_t target_hits);
+    explicit EnnBlueprintFactory(const EnnConfig& cfg);
     ~EnnBlueprintFactory() override;
     std::unique_ptr<Blueprint> make_blueprint() override;
     std::string get_name(Blueprint& blueprint) const override;
 };
 
-}
+} // namespace search::queryeval::test

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.h
@@ -1,0 +1,23 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "blueprint_factory_builder.h"
+
+namespace search::queryeval::test {
+
+/**
+ * Factory that creates an ENN blueprint.
+ */
+class EnnBlueprintFactory : public BenchmarkBlueprintFactory {
+    uint32_t _target_hits;
+    // TODO: distance function, more?
+
+public:
+    explicit EnnBlueprintFactory(uint32_t target_hits);
+    ~EnnBlueprintFactory() override;
+    std::unique_ptr<Blueprint> make_blueprint() override;
+    std::string get_name(Blueprint& blueprint) const override;
+};
+
+}

--- a/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/leaf_blueprint_factory.h
@@ -3,18 +3,22 @@
 #pragma once
 
 #include "blueprint_factory_builder.h"
+#include <vespa/eval/eval/value.h>
 
 namespace search::queryeval::test {
+
+using vespalib::eval::Value;
 
 /**
  * Factory that creates an ENN blueprint.
  */
 class EnnBlueprintFactory : public BenchmarkBlueprintFactory {
-    uint32_t _target_hits;
-    // TODO: distance function, more?
+    AttributeVector::SP _attr;
+    Value::UP           _query;
+    uint32_t            _target_hits;
 
 public:
-    explicit EnnBlueprintFactory(uint32_t target_hits);
+    EnnBlueprintFactory(AttributeVector::SP attr, Value::UP query, uint32_t target_hits);
     ~EnnBlueprintFactory() override;
     std::unique_ptr<Blueprint> make_blueprint() override;
     std::string get_name(Blueprint& blueprint) const override;


### PR DESCRIPTION
With help from 🤖 

- Adds `AttributeContextBuilder::add_tensor` to support tensor data type.
- Adds `EnnBlueprintFactory` for making exact nearest neighbor blueprints.
- Adds `enn(...)` for adding enn to factory trees.
- Adds test case `analyze_AND_plan_variants_ENN` to use ENN in a test.