### PR TITLE
Move three flags to PermanentFlags

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -224,7 +224,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public double feedNiceness() { return flag(PermanentFlags.FEED_NICENESS).value(); }
         @Override public int mbusNetworkThreads() { return flag(Flags.MBUS_NUM_NETWORK_THREADS).value(); }
         @Override public List<String> allowedAthenzProxyIdentities() { return flag(PermanentFlags.ALLOWED_ATHENZ_PROXY_IDENTITIES).value(); }
-        @Override public int maxActivationInhibitedOutOfSyncGroups() { return flag(Flags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS).value(); }
+        @Override public int maxActivationInhibitedOutOfSyncGroups() { return flag(PermanentFlags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS).value(); }
         @Override public double resourceLimitDisk() { return flag(PermanentFlags.RESOURCE_LIMIT_DISK).value(); }
         @Override public double resourceLimitMemory() { return flag(PermanentFlags.RESOURCE_LIMIT_MEMORY).value(); }
         @Override public double resourceLimitAddressSpace() { return flag(PermanentFlags.RESOURCE_LIMIT_ADDRESS_SPACE).value(); }
@@ -250,7 +250,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean sendProtobufQuerytree() { return true; }
         @Override public boolean forwardAllLogLevels() { return flag(PermanentFlags.FORWARD_ALL_LOG_LEVELS).value(); }
         @Override public long zookeeperPreAllocSize() { return flag(PermanentFlags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
-        @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(Flags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }
+        @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(PermanentFlags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }
         @Override public Object sidecarsForTest() { return flag(Flags.SIDECARS_FOR_TEST).value(); }
         @Override public boolean useTriton() { return flag(Flags.USE_TRITON).value(); }
         @Override public ModelContext.FeatureFlag<Boolean> useTritonFlag() { return flag(Flags.USE_TRITON); }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -137,21 +137,6 @@ public class Flags {
             "Takes effect at redeployment",
             INSTANCE_ID);
 
-    public static final UnboundIntFlag MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS = defineIntFlag(
-            "max-activation-inhibited-out-of-sync-groups", 0,
-            List.of("vekterli"), "2021-02-19", "2026-10-01",
-            "Allows replicas in up to N content groups to not be activated " +
-            "for query visibility if they are out of sync with a majority of other replicas",
-            "Takes effect at redeployment",
-            INSTANCE_ID);
-
-    public static final UnboundStringFlag CORE_ENCRYPTION_PUBLIC_KEY_ID = defineStringFlag(
-            "core-encryption-public-key-id", "",
-            List.of("vekterli"), "2022-11-03", "2027-05-01",
-            "Specifies which public key to use for core dump encryption.",
-            "Takes effect on the next tick.",
-            NODE_TYPE, HOSTNAME);
-
     public static final UnboundListFlag<String> ZONAL_WEIGHTED_ENDPOINT_RECORDS = defineListFlag(
             "zonal-weighted-endpoint-records", List.of(), String.class,
             List.of("hmusum"), "2023-12-15", "2026-06-01",
@@ -290,15 +275,6 @@ public class Flags {
             "Only allow adding specific email domains as user to tenant",
             "Takes effect immediately",
             TENANT_ID);
-
-    public static final UnboundIntFlag MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY = defineIntFlag(
-            "max-content-node-maintenance-op-concurrency", -1,
-            List.of("vekterli"), "2025-03-07", "2026-10-01",
-            "Sets the maximum concurrency for maintenance-related operations on content nodes. " +
-            "Only intended as a manual emergency brake feature if a system is suddenly incapable of handling " +
-            "regular maintenance pressure.",
-            "Takes effect immediately",
-            INSTANCE_ID);
 
     public static final UnboundJacksonFlag<Sidecars> SIDECARS_FOR_TEST = defineJacksonFlag(
             "sidecars-for-test", Sidecars.DEFAULT, Sidecars.class,

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -712,6 +712,27 @@ public class PermanentFlags {
             TENANT_ID, APPLICATION, INSTANCE_ID, HOSTNAME, CLUSTER_TYPE
     );
 
+    public static final UnboundIntFlag MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS = defineIntFlag(
+            "max-activation-inhibited-out-of-sync-groups", 0,
+            "Allows replicas in up to N content groups to not be activated " +
+            "for query visibility if they are out of sync with a majority of other replicas",
+            "Takes effect at redeployment",
+            INSTANCE_ID);
+
+    public static final UnboundStringFlag CORE_ENCRYPTION_PUBLIC_KEY_ID = defineStringFlag(
+            "core-encryption-public-key-id", "",
+            "Specifies which public key to use for core dump encryption.",
+            "Takes effect on the next tick.",
+            NODE_TYPE, HOSTNAME);
+
+    public static final UnboundIntFlag MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY = defineIntFlag(
+            "max-content-node-maintenance-op-concurrency", -1,
+            "Sets the maximum concurrency for maintenance-related operations on content nodes. " +
+            "Only intended as a manual emergency brake feature if a system is suddenly incapable of handling " +
+            "regular maintenance pressure.",
+            "Takes effect immediately",
+            INSTANCE_ID);
+
     private PermanentFlags() {}
 
     private static UnboundBooleanFlag defineFeatureFlag(


### PR DESCRIPTION
## Summary
- Move `MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS`, `CORE_ENCRYPTION_PUBLIC_KEY_ID`, and `MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY` from `Flags` to `PermanentFlags`
- Update references in `ModelContextImpl` accordingly

## Test plan
- [x] Compiles cleanly

---
*Generated by Claude Code*