### PR TITLE
Add index properties for ANN timeout and time budget

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -154,13 +154,30 @@ Matcher::create_match_tools_factory(const search::engine::Request& request, ISea
                                              : _stats.softDoomFactor())
                         : 0.95;
     vespalib::duration    safeLeft = std::chrono::duration_cast<vespalib::duration>(request.getTimeLeft() * factor);
-    vespalib::steady_time safeDoom(_now_ref.load(std::memory_order_relaxed) + safeLeft);
+    vespalib::steady_time now(_now_ref.load(std::memory_order_relaxed));
+    vespalib::steady_time safeDoom(now + safeLeft);
     if (softTimeoutEnabled) {
         LOG(debug, "Soft-timeout computed factor=%1.3f, used factor=%1.3f, userSupplied=%d, softTimeout=%" PRId64,
             _stats.softDoomFactor(), factor, hasFactorOverride, vespalib::count_ns(safeLeft));
     }
+    bool                  ann_timeout_enabled = softTimeoutEnabled && anntimeout::Enabled::lookup(rankProperties);
+    double                ann_timeout_factor = ann_timeout_enabled ? anntimeout::Factor::lookup(rankProperties) : 1.0;
+    vespalib::duration    ann_left = std::chrono::duration_cast<vespalib::duration>(safeLeft * ann_timeout_factor);
+    vespalib::steady_time ann_timeout(now + ann_left);
+    if (ann_timeout_enabled) {
+        LOG(debug, "ANN timeout: enabled=%d, factor=%1.3f, left=%" PRId64, ann_timeout_enabled, ann_timeout_factor,
+            vespalib::count_ns(ann_left));
+    }
+    bool               ann_timebudget_specified = AnnTimeBudget::is_present(rankProperties);
+    vespalib::duration ann_timebudget =
+        ann_timebudget_specified
+            ? std::chrono::duration_cast<vespalib::duration>(1ms * AnnTimeBudget::lookup(rankProperties))
+            : vespalib::duration::max();
+    if (ann_timebudget_specified) {
+        LOG(debug, "ANN timebudget=%" PRId64, vespalib::count_ns(ann_timebudget));
+    }
     vespalib::Doom           doom(_now_ref, safeDoom, request.getTimeOfDoom(), hasFactorOverride);
-    AnnDeadlineConfiguration ann_deadline_config(safeDoom);
+    AnnDeadlineConfiguration ann_deadline_config(ann_timebudget, ann_timeout_enabled, ann_timeout);
     const auto&              queryTree = request.getSerializedQueryTree();
     return std::make_unique<MatchToolsFactory>(_queryLimiter, doom, ann_deadline_config, searchContext, attrContext,
                                                request.trace(), queryTree, request.location, _viewResolver, metaStore,

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
@@ -520,6 +520,46 @@ bool SortBlueprintsByCost::check(const Properties& props, bool fallback) {
     return lookupBool(props, NAME, fallback);
 }
 
+const std::string AnnTimeBudget::NAME("vespa.matching.anntimebudget");
+const uint32_t    AnnTimeBudget::DEFAULT_VALUE(std::numeric_limits<uint32_t>::max());
+
+uint32_t AnnTimeBudget::lookup(const Properties& props) {
+    return lookupUint32(props, NAME, DEFAULT_VALUE);
+}
+
+uint32_t AnnTimeBudget::lookup(const Properties& props, uint32_t default_value) {
+    return lookupUint32(props, NAME, default_value);
+}
+
+bool AnnTimeBudget::is_present(const Properties& props) {
+    return props.lookup(NAME).found();
+}
+
+namespace anntimeout {
+
+const std::string Enabled::NAME("vespa.matching.anntimeout.enable");
+const bool        Enabled::DEFAULT_VALUE(false);
+
+bool Enabled::lookup(const Properties& props) {
+    return lookupBool(props, NAME, DEFAULT_VALUE);
+}
+
+bool Enabled::lookup(const Properties& props, bool default_value) {
+    return lookupBool(props, NAME, default_value);
+}
+
+const std::string Factor::NAME("vespa.matching.anntimeout.factor");
+const double      Factor::DEFAULT_VALUE(0.9);
+
+double Factor::lookup(const Properties& props) {
+    return lookupDouble(props, NAME, DEFAULT_VALUE);
+}
+double Factor::lookup(const Properties& props, double default_value) {
+    return lookupDouble(props, NAME, default_value);
+}
+
+} // namespace anntimeout
+
 } // namespace matching
 
 namespace softtimeout {

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.h
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.h
@@ -471,6 +471,43 @@ struct SortBlueprintsByCost {
     static bool check(const Properties& props) { return check(props, DEFAULT_VALUE); }
     static bool check(const Properties& props, bool fallback);
 };
+
+/**
+ * Specifies a time budget for ANN in milliseconds.
+ */
+struct AnnTimeBudget {
+    static const std::string NAME;
+    static const uint32_t    DEFAULT_VALUE;
+    static uint32_t lookup(const Properties& props);
+    static uint32_t lookup(const Properties& props, uint32_t default_value);
+    static bool is_present(const Properties& props);
+};
+
+namespace anntimeout {
+/**
+ * Enables or disables the ANN timeout.
+ * Default is off.
+ * TODO: Make on the default once controllable from the outside.
+ */
+struct Enabled {
+    static const std::string NAME;
+    static const bool        DEFAULT_VALUE;
+    static bool lookup(const Properties& props);
+    static bool lookup(const Properties& props, bool default_value);
+};
+
+/**
+ * Specifies the ANN timeout as a factor of the soft-timeout used by the backend.
+ */
+struct Factor {
+    static const std::string NAME;
+    static const double      DEFAULT_VALUE;
+    static double lookup(const Properties& props);
+    static double lookup(const Properties& props, double default_value);
+};
+
+} // namespace anntimeout
+
 } // namespace matching
 
 namespace softtimeout {


### PR DESCRIPTION
The timeout defaults to "off" for now and no time budget is set by default. Hence, this should not change the current behavior. Will set the timeout to "on" by default once everything else (query parameter etc.) is in place.