### PR TITLE
Implement simple, scalar Fast Walsh-Hadamard transform

### DIFF
--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -103,6 +103,7 @@ vespa_define_module(
     src/tests/io/mapped_file_input
     src/tests/latch
     src/tests/left_right_heap
+    src/tests/quant
     src/tests/memory
     src/tests/memorydatastore
     src/tests/metrics

--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_quant_test_app TEST
+    SOURCES
+    hadamard_test.cpp
+    DEPENDS
+    vespalib
+    GTest::gtest
+    GTest::gmock
+)
+vespa_add_test(NAME vespalib_quant_test_app COMMAND vespalib_quant_test_app)

--- a/vespalib/src/tests/quant/hadamard_test.cpp
+++ b/vespalib/src/tests/quant/hadamard_test.cpp
@@ -1,0 +1,137 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/quant/hadamard.h>
+#include <vespa/vespalib/util/fast_range.h>
+#include <vespa/vespalib/util/xoshiro.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cmath>
+#include <vector>
+
+using namespace ::testing;
+
+namespace vespalib::quant {
+
+MATCHER_P(IsSquareRootNormalizedBy, dimensions, "") {
+    // Pointwise() matches on a 2-tuple <actual, expected>, i.e. lhs and rhs container args.
+    const float actual   = std::get<0>(arg);
+    const float expected = std::get<1>(arg) / std::sqrt(dimensions);
+    return ExplainMatchResult(FloatEq(expected), actual, result_listener);
+}
+
+// To minimize floating point hassle, use int vectors as much as possible.
+// However, the normalization step still requires floating point.
+void check_hadamard(const std::vector<int>& in, const std::vector<int>& expected) {
+    const size_t n = in.size();
+    ASSERT_TRUE(n == 0 || std::has_single_bit(n));
+    ASSERT_EQ(n, expected.size());
+
+    std::vector v = in;
+    // Non-normalized Hadamard transforms:
+    std::vector<int> tmp(n);
+    int* res = hadamard(v.data(), tmp.data(), n);
+    ASSERT_THAT(std::span<const int>(res, n), ElementsAreArray(expected)) << "out-of-place FWHT";
+
+    v = in;
+    hadamard<int>(v.data(), v.size());
+    ASSERT_THAT(v, ElementsAreArray(expected)) << "in-place FWHT";
+
+    // Post-normalized Hadamard transforms:
+    std::vector<float> v_f(in.begin(), in.end());
+    hadamard_normalized<float>(v_f.data(), v_f.size());
+    ASSERT_THAT(v_f, Pointwise(IsSquareRootNormalizedBy(n), expected)) << "normalized in-place FWHT";
+
+    v_f.assign(in.begin(), in.end());
+    std::vector<float> tmp_f(n);
+    float* res_f = hadamard_normalized(v_f.data(), tmp_f.data(), v_f.size());
+    ASSERT_THAT(std::span<const float>(res_f, n),
+                Pointwise(IsSquareRootNormalizedBy(n), expected)) << "normalized out-of-place FWHT";
+}
+
+TEST(FastWHTransformTest, zero_and_one_point_transforms_are_no_ops) {
+    // 0-point WHT
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({}, {}));
+    // 1-point WHT
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({7}, {7}));
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({-21}, {-21}));
+}
+
+TEST(FastWHTransformTest, two_point_transforms_have_expected_output) {
+    // Example calculations from the "The Walsh Hadamard Transform - Basics and Applications"
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({0, 0}, {0, 0}));
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({1, 0}, {1, 1}));
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({0, 1}, {1, -1}));
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({1, 1}, {2, 0}));
+}
+
+struct MyRandGen {
+    Xoshiro256PlusPlusPrng rng;
+    MyRandGen();
+    // Returns random number in [-100, 100]
+    [[nodiscard]] int operator()() noexcept {
+        return 100 - static_cast<int>(next_random_in_range<uint8_t>(rng, 0, 201));
+    }
+};
+// Avoid failed inlining warnings
+MyRandGen::MyRandGen() : rng(std::random_device{}()) {}
+
+// clang-format off: destroys semantic indenting
+
+TEST(FastWHTransformTest, four_point_transforms_have_expected_output) {
+    MyRandGen gen;
+    for (size_t i = 0; i < 1'000; ++i) {
+        const int a = gen(), b = gen(), c = gen(), d = gen();
+        ASSERT_NO_FATAL_FAILURE(check_hadamard({a, b, c, d}, {a + b + c + d,
+                                                              a - b + c - d,
+                                                              a + b - c - d,
+                                                              a - b - c + d}));
+    }
+}
+
+TEST(FastWHTransformTest, wiki_example_has_expected_output) {
+    // Example from https://en.wikipedia.org/wiki/Fast_Walsh%E2%80%93Hadamard_transform:
+    // [1, 0, 1, 0, 0, 1, 1, 0] => [4, 2, 0, -2, 0, 2, 0, 2]
+    ASSERT_NO_FATAL_FAILURE(check_hadamard({1, 0, 1,  0, 0, 1, 1, 0},
+                                           {4, 2, 0, -2, 0, 2, 0, 2}));
+}
+
+TEST(FastWHTransformTest, eight_point_transforms_have_expected_output) {
+    MyRandGen gen;
+    for (size_t i = 0; i < 1'000; ++i) {
+        const int a = gen(), b = gen(), c = gen(), d = gen(),
+                  e = gen(), f = gen(), g = gen(), h = gen();
+        ASSERT_NO_FATAL_FAILURE(check_hadamard({a, b, c, d, e, f, g, h},
+                                               {a + b + c + d + e + f + g + h,
+                                                a - b + c - d + e - f + g - h,
+                                                a + b - c - d + e + f - g - h,
+                                                a - b - c + d + e - f - g + h,
+                                                a + b + c + d - e - f - g - h,
+                                                a - b + c - d - e + f - g + h,
+                                                a + b - c - d - e - f + g + h,
+                                                a - b - c + d - e + f + g - h}));
+    }
+}
+
+// ... from here we "inductively" assume that > 8 point transforms are also correct :D
+
+TEST(FastWHTransformTest, can_explicitly_post_normalize_vector) {
+    std::vector v = {3.f, 5.f, 7.f, 11.f};
+    post_hadamard_normalize(v.data(), v.size());
+    auto scaled = [s = 1.f / std::sqrt(v.size())](float f) noexcept { return f * s; };
+    EXPECT_THAT(v, ElementsAre(FloatEq(scaled(3)), FloatEq(scaled(5)),
+                               FloatEq(scaled(7)), FloatEq(scaled(11))));
+}
+
+TEST(FastWHTransformTest, normalized_hadamard_is_self_inverse) {
+    const std::vector orig = {3.f, 5.f, 7.f, 11.f};
+    std::vector v = orig;
+    hadamard_normalized(v.data(), v.size());
+    hadamard_normalized(v.data(), v.size());
+    EXPECT_THAT(v, Pointwise(FloatEq(), orig));
+}
+
+// clang-format on
+
+} // namespace vespalib::quant
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/quant/hadamard.h
+++ b/vespalib/src/vespa/vespalib/quant/hadamard.h
@@ -1,0 +1,158 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <concepts>
+#include <span>
+
+namespace vespalib::quant {
+
+// The quotes and examples here are adapted from
+// "The Walsh Hadamard Transform - Basics and Applications" (2021)
+// by Sean O'Connor (in public domain).
+
+// Normalize a Walsh-Hadamard-transformed vector so that its magnitude is
+// the same as prior to the transformation.
+template <std::floating_point T>
+void post_hadamard_normalize(T* v, const size_t n) {
+    // Normalization is just dividing all elements by the square root of the size
+    const T sqrt_recip = T{1} / std::sqrt(n);
+    for (size_t i = 0; i < n; ++i) {
+        v[i] *= sqrt_recip;
+    }
+}
+
+/**
+ * Fast _out-of-place_ Walsh-Hadamard Transform (not normalized).
+ *
+ * Preconditions:
+ *   - the input array and the temporary array must not alias.
+ *   - the input size must be a power of two
+ *   - the temporary array must be at least as large as the input array
+ *
+ * Note that this function alternates between writing to _both_ arrays, and
+ * returns a pointer to the array that actually ended up receiving the final
+ * result. This is either the input or the temporary array.
+ *
+ * The temporary array does not have to be value-initialized prior to calling
+ * this function.
+ */
+template <typename T>
+[[nodiscard]] T* hadamard(T* v, T* tmp, const size_t n) noexcept {
+    if (n == 0) [[unlikely]] {
+        return v;
+    }
+    const size_t stages = std::bit_width(n) - 1;
+    assert(std::has_single_bit(n));
+    /*
+     * "Given an array of data that is some integer power of 2 in length, you
+     *  can step through the array data pairwise. The sum of each pair of array
+     *  elements is placed sequentially in the lower half of the temporary
+     *  array (the same size as the data array), and the difference of the pair
+     *  of elements is placed sequentially in the upper half of the temporary
+     *  array. Alike terms end up being grouped sequentially in the temporary
+     *  array. You then swap the data array and temporary array and repeat the
+     *  process. Stopping when there are no more alike terms to add and
+     *  subtract, that is to say when all the output terms are unique patterns
+     *  of addition and subtraction. That happens after log2(n) stages, where
+     *  n is the length of the original data array."
+     *
+     *  Example of 4-point out-of-place WHT:
+     *          2-point      4-point
+     * | a |    | a+b |    | a+b+c+d |
+     * | b | -> | c+d | -> | a-b+c-d |
+     * | c |    | a-b |    | a+b-c-d |
+     * | d |    | c-d |    | a-b-c+d |
+     */
+    T* in = v;
+    T* out = tmp;
+    for (size_t i = 0; i < stages; ++i) {
+        // Each stage processes elements pairwise, shoveling additions into the lower
+        // half (lo + ...) and subtractions into the top half (hi + ...) sequentially.
+        for (size_t j = 0, lo = 0, hi = n/2; j < n; j += 2, ++lo, ++hi) {
+            T a = in[j];
+            T b = in[j + 1];
+            out[lo] = a + b;
+            out[hi] = a - b;
+        }
+        std::swap(in, out);
+    }
+    return in; // since we swapped in/out before exiting the loop the last time
+}
+
+/**
+ * Fast _out-of-place_ Walsh-Hadamard Transform, with post-normalization.
+ *
+ * See `hadamard(v, tmp, n)` for pre/post-conditions.
+ */
+template <typename T>
+[[nodiscard]] T* hadamard_normalized(T* v, T* tmp, const size_t n) noexcept {
+    T* res = hadamard(v, tmp, n);
+    post_hadamard_normalize(res, n);
+    return res;
+}
+
+/**
+ * Fast _in-place_ Walsh-Hadamard Transform (not normalized).
+ *
+ * Precondition: input vector must have a power of 2 length.
+ */
+template <typename T>
+void hadamard(T* v, const size_t n) noexcept {
+    /*
+     * "The in-place algorithm requires you to keep track of where alike terms
+     *  are. Noting that alike terms that have been added and subtracted and
+     *  put back in place are no longer alike. The indexing requirements then
+     *  involve pairwise blocks of data. The block size increasing at each stage
+     *  of the calculation."
+     *
+     * Example of 8-point in-place WHT:
+     * "Alike terms have the same number in brackets. In the first stage the
+     *  block size is 1, the second stage 2, the third stage 4. You go through
+     *  blocks pairwise, adding and subtracting alike terms".
+     *
+     *             2-point       4-point              8-point
+     * |a (1)|    |a+b (1)|    |a+b+c+d (1)|    |a+b+c+d+e+f+g+h (1)|
+     * |b (1)|    |a-b (2)|    |a-b+c-d (2)|    |a-b+c-d+e-f+g-h (2)|
+     * |c (1)|    |c+d (1)|    |a+b-c-d (3)|    |a+b-c-d+e+f-g-h (3)|
+     * |d (1)| -> |c-d (2)| -> |a-b-c+d (4)| -> |a-b-c+d+e-f-g+h (4)|
+     * |e (1)|    |e+f (1)|    |e+f+g+h (1)|    |a+b+c+d-e-f-g-h (5)|
+     * |f (1)|    |e-f (2)|    |e-f+g-h (2)|    |a-b+c-d-e+f-g+h (6)|
+     * |g (1)|    |g+h (1)|    |e+f-g-h (3)|    |a+b-c-d-e-f+g+h (7)|
+     * |h (1)|    |g-h (2)|    |e-f-g+h (4)|    |a-b-c+d-e+f+g-h (8)|
+     */
+    assert(n == 0 || std::has_single_bit(n));
+    // Gap to next alike term (block size); doubles per iteration
+    for (size_t h = 1; h < n; h += h) {
+        size_t i = 0;
+        while (i < n) {
+            const size_t j = i + h; // Current block extent
+            while (i < j) {
+                T a = v[i];
+                T b = v[i + h]; // Alike term in _next_ block
+                v[i]     = a + b;
+                v[i + h] = a - b;
+                ++i;
+            }
+            // We process blocks in pairs, so skip past the second block that
+            // we've already wrangled in the above loop.
+            i += h;
+        }
+    }
+}
+
+/**
+ * Fast _in-place_ Walsh-Hadamard Transform, with post-normalization.
+ *
+ * See `hadamard(v, n)` for pre/post-conditions.
+ */
+template <typename T>
+void hadamard_normalized(T* v, const size_t n) noexcept {
+    hadamard(v, n);
+    post_hadamard_normalize(v, n);
+}
+
+} // namespace vespalib::quant


### PR DESCRIPTION
@havardpe please review. Adding this under a new `vespalib/quant/` subdirectory (and corresponding `vespalib::quant` namespace).
@arnej27959 FYI

The fast Walsh-Hadamard transform (FWHT) is commonly used to implement _O(n lg n)_ rotations of hyperdimensional vectors, effectively transforming each vector coordinate from an unknown and arbitrary distribution into an expected Gaussian distribution. This property can be used for some rather clever things 👀.

The Hadamard transform is self-inverse when the result is normalized with a scaling factor, allowing for easily undoing the transform (i.e. rotation).

This commit adds in-place and out-of-place scalar (i.e. non-vectorized) implementations of the fast Walsh-Hadamard transform, both with and without post-normalization of input vectors.

Tests are added for {0,1,2,4,8}-point transforms, which should hopefully be sufficient to assume correctness for N > 8.

Side note: this does not implement _(pseudo-)randomized_ rotations (the transform is entirely deterministic). This will come later.