### PR TITLE
Collect timing-related ANN information in trace and make tracedoctor print it

### DIFF
--- a/client/go/internal/vespa/tracedoctor/ann.go
+++ b/client/go/internal/vespa/tracedoctor/ann.go
@@ -47,6 +47,18 @@ func (n annNode) makeRows(tab *table) {
 	if top_k_hits := n.root.Field("top_k_hits"); top_k_hits.Valid() {
 		tab.str("found hits").str(fmt.Sprintf("%d", top_k_hits.AsLong())).commit()
 	}
+	if time_allocated := n.root.Field("time_allocated"); time_allocated.Valid() {
+		tab.str("time_allocated").str(fmt.Sprintf("%.3f ms", time_allocated.AsDouble())).commit()
+	}
+	if time_used := n.root.Field("time_used"); time_used.Valid() {
+		tab.str("time_used").str(fmt.Sprintf("%.3f ms", time_used.AsDouble())).commit()
+	}
+	if terminated_early := n.root.Field("terminated_early"); terminated_early.Valid() {
+		tab.str("terminated_early").str(fmt.Sprintf("%t", terminated_early.AsBool())).commit()
+	}
+	if timeout_hit := n.root.Field("timeout_hit"); timeout_hit.Valid() {
+		tab.str("timeout_hit").str(fmt.Sprintf("%t", timeout_hit.AsBool())).commit()
+	}
 }
 
 func (p protonTrace) findAnnNodes() []annNode {

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -84,6 +84,10 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec&  
       _low_hit_ratio(false),
       _pending_index_search(false),
       _matching_phase(MatchingPhase::FIRST_PHASE),
+      _ann_time_allocated(vespalib::duration::zero()),
+      _ann_time_used(vespalib::duration::zero()),
+      _ann_terminated_early(false),
+      _ann_timeout_hit(false),
       _nni_stats(),
       _stats() {
     _distance_heap.set_distance_threshold(_hnsw_params.distance_threshold);
@@ -150,9 +154,16 @@ bool NearestNeighborBlueprint::pending_index_search() const {
     return _pending_index_search;
 }
 
-void NearestNeighborBlueprint::perform_index_search(const vespalib::Deadline& doom) {
+void NearestNeighborBlueprint::perform_index_search(const vespalib::Deadline& deadline) {
     if (_pending_index_search) {
-        perform_top_k(_attr_tensor.nearest_neighbor_index(), doom);
+        _ann_time_allocated = deadline.time_left();
+
+        vespalib::Timer timer;
+        perform_top_k(_attr_tensor.nearest_neighbor_index(), deadline);
+        _ann_time_used = timer.elapsed();
+
+        _ann_terminated_early = deadline.was_missed();
+        _ann_timeout_hit = _ann_terminated_early && deadline.type() == vespalib::Deadline::TIMEOUT;
         _pending_index_search = false;
     }
 }
@@ -242,6 +253,10 @@ void NearestNeighborBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) co
         visitor.visitBool("filter_first_heuristic_used", _low_hit_ratio);
     }
     if (_algorithm == Algorithm::INDEX_TOP_K || _algorithm == Algorithm::INDEX_TOP_K_WITH_FILTER) {
+        visitor.visitFloat("time_allocated", vespalib::count_ns(_ann_time_allocated) / 1000000.0);
+        visitor.visitFloat("time_used", vespalib::count_ns(_ann_time_used) / 1000000.0);
+        visitor.visitBool("terminated_early", _ann_terminated_early);
+        visitor.visitBool("timeout_hit", _ann_timeout_hit);
         visitor.visitInt("distances_computed", _nni_stats.distances_computed());
         visitor.visitInt("nodes_visited", _nni_stats.nodes_visited());
         visitor.visitInt("top_k_hits", _found_hits.size());

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -62,6 +62,10 @@ private:
     bool                                                        _low_hit_ratio;
     bool                                                        _pending_index_search;
     MatchingPhase                                               _matching_phase;
+    vespalib::duration                                          _ann_time_allocated;
+    vespalib::duration                                          _ann_time_used;
+    bool                                                        _ann_terminated_early;
+    bool                                                        _ann_timeout_hit;
     search::tensor::NearestNeighborIndex::Stats                 _nni_stats;
     std::shared_ptr<QueryEvalStats>                             _stats;
 


### PR DESCRIPTION
Includes the time allocated for the search (time until deadline), the time it actually used, whether it terminated early (because it reached the deadline), and whether it timed out (because it reached the deadline and that deadline was a timeout.)