### PR TITLE
Add CallBack/MutatingCallBack type aliases to StorBucketDatabase

### DIFF
--- a/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
@@ -87,18 +87,16 @@ bool StorBucketDatabase::isConsistent(const WrappedEntry& entry) {
     return _impl->isConsistent(entry);
 }
 
-void StorBucketDatabase::for_each_chunked(std::function<Decision(uint64_t, const bucketdb::StorageBucketInfo&)> func,
-                                          const char* clientId, vespalib::duration yieldTime, uint32_t chunkSize) {
+void StorBucketDatabase::for_each_chunked(CallBack func, const char* clientId, vespalib::duration yieldTime,
+                                          uint32_t chunkSize) {
     _impl->for_each_chunked(std::move(func), clientId, yieldTime, chunkSize);
 }
 
-void StorBucketDatabase::for_each_mutable_unordered(
-    std::function<Decision(uint64_t, bucketdb::StorageBucketInfo&)> func, const char* clientId) {
+void StorBucketDatabase::for_each_mutable_unordered(MutatingCallBack func, const char* clientId) {
     _impl->for_each_mutable_unordered(std::move(func), clientId);
 }
 
-void StorBucketDatabase::for_each(std::function<Decision(uint64_t, const bucketdb::StorageBucketInfo&)> func,
-                                  const char*                                                           clientId) {
+void StorBucketDatabase::for_each(CallBack func, const char* clientId) {
     _impl->for_each(std::move(func), clientId);
 }
 

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.h
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.h
@@ -25,6 +25,8 @@ public:
     using WrappedEntry = BucketMap::WrappedEntry;
     using EntryMap = BucketMap::EntryMap;
     using BucketId = document::BucketId;
+    using CallBack = std::function<Decision(uint64_t, const Entry&)>;
+    using MutatingCallBack = std::function<Decision(uint64_t, Entry&)>;
 
     enum Flag { NONE = 0, CREATE_IF_NONEXISTING = 1 };
 
@@ -57,12 +59,12 @@ public:
      * thread between each such such to allow other threads to get a chance
      * at acquiring a bucket lock.
      */
-    void for_each_chunked(std::function<Decision(uint64_t, const Entry&)> func, const char* clientId,
-                          vespalib::duration yieldTime = 10us, uint32_t chunkSize = BucketMap::DEFAULT_CHUNK_SIZE);
+    void for_each_chunked(CallBack func, const char* clientId, vespalib::duration yieldTime = 10us,
+                          uint32_t chunkSize = BucketMap::DEFAULT_CHUNK_SIZE);
 
-    void for_each_mutable_unordered(std::function<Decision(uint64_t, Entry&)> func, const char* clientId);
+    void for_each_mutable_unordered(MutatingCallBack func, const char* clientId);
 
-    void for_each(std::function<Decision(uint64_t, const Entry&)> func, const char* clientId);
+    void for_each(CallBack func, const char* clientId);
 
     [[nodiscard]] std::unique_ptr<bucketdb::ReadGuard<Entry>> acquire_read_guard() const;
 


### PR DESCRIPTION
The three for_each* methods took verbose std::function<Decision(uint64_t, ...)> parameters inline, which caused the auto-formatter to produce awkward forced vertical alignment (e.g. extreme right-padding on clientId to align with the long type). Introducing named type aliases in the class definition shortens the signatures enough for the formatter to lay them out naturally, and makes the intent of each parameter clearer.

(As a bonus, now the declaration and definition of these functions actually match.)
