### PR TITLE
Tag sentinel.totalRestarts with service dimension

### DIFF
--- a/configd/src/apps/sentinel/metrics.cpp
+++ b/configd/src/apps/sentinel/metrics.cpp
@@ -13,8 +13,9 @@ StartMetrics::StartMetrics()
     : metrics(SimpleMetricsManager::create(SimpleManagerConfig())),
       producer(metrics),
       currentlyRunningServices(0),
-      totalRestartsCounter(0),
+      totalRestartsByService(),
       startedTime(vespalib::steady_clock::now()),
+      service_dim(metrics->dimension("service")),
       sentinel_restarts(metrics->counter("sentinel.restarts", "how many times sentinel restarted a service")),
       sentinel_totalRestarts(metrics->gauge("sentinel.totalRestarts",
                                             "how many times sentinel restarted a service since sentinel start")),
@@ -33,18 +34,24 @@ void StartMetrics::maybeLog() {
     if (curTime - lastRestartTime > 2h) {
         reset();
     }
-    sentinel_totalRestarts.sample(totalRestartsCounter);
+    for (const auto& entry : totalRestartsByService) {
+        sentinel_totalRestarts.sample(entry.second.count, entry.second.point);
+    }
     sentinel_running.sample(currentlyRunningServices);
     sentinel_uptime.sample(vespalib::to_s(curTime - startedTime));
 }
 
-void StartMetrics::incRestartsCounter() {
-    ++totalRestartsCounter;
+void StartMetrics::incRestartsCounter(const std::string& serviceName) {
+    auto [it, inserted] = totalRestartsByService.try_emplace(serviceName);
+    if (inserted) {
+        it->second.point = metrics->pointBuilder().bind(service_dim, serviceName);
+    }
+    ++it->second.count;
     lastRestartTime = vespalib::steady_clock::now();
 }
 
 void StartMetrics::reset() {
-    totalRestartsCounter = 0;
+    totalRestartsByService.clear();
     lastRestartTime = vespalib::steady_clock::now();
 }
 

--- a/configd/src/apps/sentinel/metrics.h
+++ b/configd/src/apps/sentinel/metrics.h
@@ -4,29 +4,40 @@
 #include <vespa/vespalib/metrics/simple_metrics.h>
 #include <vespa/vespalib/util/time.h>
 
+#include <map>
+#include <string>
+
 namespace config::sentinel {
 
 using vespalib::metrics::Counter;
+using vespalib::metrics::Dimension;
 using vespalib::metrics::Gauge;
 using vespalib::metrics::MetricsManager;
+using vespalib::metrics::Point;
 
 struct StartMetrics {
-    std::shared_ptr<MetricsManager> metrics;
-    vespalib::metrics::Producer     producer;
-    unsigned long                   currentlyRunningServices;
-    unsigned long                   totalRestartsCounter;
-    vespalib::steady_time           startedTime;
-    Counter                         sentinel_restarts;
-    Gauge                           sentinel_totalRestarts;
-    Gauge                           sentinel_running;
-    Gauge                           sentinel_uptime;
-    vespalib::steady_time           lastRestartTime;
+    struct PerServiceRestarts {
+        Point         point{Point::empty};
+        unsigned long count{0};
+    };
+
+    std::shared_ptr<MetricsManager>              metrics;
+    vespalib::metrics::Producer                  producer;
+    unsigned long                                currentlyRunningServices;
+    std::map<std::string, PerServiceRestarts>    totalRestartsByService;
+    vespalib::steady_time                        startedTime;
+    const Dimension                              service_dim;
+    Counter                                      sentinel_restarts;
+    Gauge                                        sentinel_totalRestarts;
+    Gauge                                        sentinel_running;
+    Gauge                                        sentinel_uptime;
+    vespalib::steady_time                        lastRestartTime;
 
     StartMetrics();
     ~StartMetrics();
 
     void maybeLog();
-    void incRestartsCounter();
+    void incRestartsCounter(const std::string& serviceName);
     void reset();
 };
 

--- a/configd/src/apps/sentinel/service.cpp
+++ b/configd/src/apps/sentinel/service.cpp
@@ -311,7 +311,7 @@ void Service::youExited(int status) {
         // ### Implement some rate limiting here maybe?
         LOG(debug, "%s: Restarting.", name().c_str());
         setState(RESTARTING);
-        _metrics.incRestartsCounter();
+        _metrics.incRestartsCounter(name());
         _metrics.sentinel_restarts.add();
     }
 }


### PR DESCRIPTION
Track restart counts per service in StartMetrics and emit one sentinel.totalRestarts gauge sample per service, each tagged with a "service" dimension. The Point for each service is built once on first restart and cached alongside the count to avoid reconstructing it on every maybeLog() emission.
