### PR TITLE
Upgrade Jetty to 12.0.34

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -109,7 +109,7 @@
         <io-perfmark.vespa.version>0.27.0</io-perfmark.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.0.33</jetty.vespa.version>
+        <jetty.vespa.version>12.0.34</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>
         <jimfs.vespa.version>1.3.1</jimfs.vespa.version>


### PR DESCRIPTION
## Summary
- Bump `jetty.vespa.version` from 12.0.33 to 12.0.34
- Release notes: https://github.com/jetty/jetty.project/releases/tag/jetty-12.0.34