### PR TITLE
Renovate: Ignore byte-buddy versions with suffix -jdk5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,14 @@
     "local>vespa-engine/renovate-config"
   ],
   "prHourlyLimit": 20,
-  "prConcurrentLimit": 20
+  "prConcurrentLimit": 20,
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "net.bytebuddy:byte-buddy",
+        "net.bytebuddy:byte-buddy-agent"
+      ],
+      "ignoredVersions": ["/-jdk5$/"]
+    }
+  ]
 }


### PR DESCRIPTION
We want to use the plain version (for jdk8 and later)

