### PR TITLE
Add --smoke-test flag

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1055,6 +1055,17 @@ TEST(IteratorBenchmark, analyze_AND_plan_variants_ENN) {
 }
 
 int main(int argc, char** argv) {
+    for (int i = 0; i < argc; i++) {
+        std::string_view smoke_test{"--smoke-test"};
+        if (smoke_test == argv[i]) {
+            std::println("Adding --smoke-test filter");
+            const char* smoke_test_filter = "--gtest_filter="
+                                            "IteratorBenchmark.analyze_term_search_in_attributes_strict"
+                                            ":IteratorBenchmark.analyze_OR_strict"
+                                            ":IteratorBenchmark.analyze_AND_plan_variants_ENN";
+            argv[i] = const_cast<char*>(smoke_test_filter);
+        }
+    }
     ::testing::InitGoogleTest(&argc, argv);
     int res = RUN_ALL_TESTS();
     if (!global_summary.empty()) {

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1054,16 +1054,17 @@ TEST(IteratorBenchmark, analyze_AND_plan_variants_ENN) {
     std::println("max worst-plan penalty={:.4f}", max_penalty);
 }
 
+static std::string smoke_test_filter = "--gtest_filter="
+                                       "IteratorBenchmark.analyze_term_search_in_attributes_strict"
+                                       ":IteratorBenchmark.analyze_OR_strict"
+                                       ":IteratorBenchmark.analyze_AND_plan_variants_ENN";
+
 int main(int argc, char** argv) {
     for (int i = 0; i < argc; i++) {
         std::string_view smoke_test{"--smoke-test"};
         if (smoke_test == argv[i]) {
-            std::println("Adding --smoke-test filter");
-            const char* smoke_test_filter = "--gtest_filter="
-                                            "IteratorBenchmark.analyze_term_search_in_attributes_strict"
-                                            ":IteratorBenchmark.analyze_OR_strict"
-                                            ":IteratorBenchmark.analyze_AND_plan_variants_ENN";
-            argv[i] = const_cast<char*>(smoke_test_filter);
+            std::println(stderr, "Adding --smoke-test filter");
+            argv[i] = smoke_test_filter.data();
         }
     }
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- Adds convenience flag `--smoke-test` for faster iteration speed that filters to a subset of semi-fast tests.

@havardpe please review