### PR TITLE
chore: upgrade Jetty to 12.0.35

### DIFF
--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
@@ -103,6 +103,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -886,11 +887,13 @@ public class HttpServerIT {
                 .newGet("/status.html").addHeader("Host", "localhost").addHeader("Host", "vespa.ai").execute()
                 .expectStatusCode(is(OK));
 
-        // Verify metric was aggregated
-        verify(metricConsumer.mockitoMock())
+        // Two mismatched Host headers trigger both DUPLICATE_HOST_HEADERS and MISMATCHED_AUTHORITY violations.
+        verify(metricConsumer.mockitoMock(), times(2))
                 .add(eq(ContainerMetrics.JETTY_HTTP_COMPLIANCE_VIOLATION.baseName()), eq(1L), Mockito.any());
         verify(metricConsumer.mockitoMock())
                 .createContext(eq(Map.of("mode", "RFC7230_VESPA", "violation", "DUPLICATE_HOST_HEADERS")));
+        verify(metricConsumer.mockitoMock())
+                .createContext(eq(Map.of("mode", "RFC7230_VESPA", "violation", "MISMATCHED_AUTHORITY")));
 
         assertTrue(driver.close());
     }

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -109,7 +109,7 @@
         <io-perfmark.vespa.version>0.27.0</io-perfmark.vespa.version>
         <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.5</jaxb.runtime.vespa.version>
-        <jetty.vespa.version>12.0.34</jetty.vespa.version>
+        <jetty.vespa.version>12.0.35</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jieba.vespa.version>1.0.2</jieba.vespa.version>
         <jimfs.vespa.version>1.3.1</jimfs.vespa.version>


### PR DESCRIPTION
## Summary
- Bump `jetty.vespa.version` from 12.0.34 to 12.0.35 to pick up upstream bug fixes from the Jetty 12.0.x patch release.