### PR TITLE
add nightly attribution workflow and ATTRIBUTIONS.md

### DIFF
--- a/.github/scripts/build-attribution.sh
+++ b/.github/scripts/build-attribution.sh
@@ -31,10 +31,6 @@ skipped=$(jq -s '
     | select(.license.name == "Requires Review" or (.component.groupId // "") == "")]
   | length
 ' "$@")
-if (( skipped > 0 )); then
-  echo "::notice::Skipped ${skipped} inventory entries with no identified license" >&2
-fi
-
 jq -s -r '
   [ .[] | (.response // [])[]
     | select(.license.name != "Requires Review" and (.component.groupId // "") != "")

--- a/.github/scripts/build-attribution.sh
+++ b/.github/scripts/build-attribution.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Build a deduplicated ATTRIBUTIONS.md from one or more inventory JSON files.
+#
+# Usage: build-attribution.sh <inventory.json> [<inventory.json> ...]
+# Output: markdown attribution document on stdout.
+#
+# Each input is expected in the wrapped shape produced by the
+# vespa-engine/gh-actions/mend-inventory action:
+#   { response: [ { component, license, copyrights, extraData, ... }, ... ],
+#     additionalData: { totalItems: N } }
+set -euo pipefail
+
+today=$(date -u +"%Y-%m-%d")
+
+cat <<EOF
+# Third-Party Software Attributions
+
+This file is auto-generated nightly and lists the open-source software
+dependencies of Vespa detected by scanning package manifests.
+
+For the hand-maintained list of vendored C/C++ libraries (Boost, OpenSSL,
+ICU, etc.), see [\`NOTICES\`](NOTICES).
+
+Last updated: $today
+EOF
+
+# Skip entries that don't have an identified license (the scanner couldn't
+# determine one, or the entry has no package identity to attribute).
+skipped=$(jq -s '
+  [.[] | (.response // [])[]
+    | select(.license.name == "Requires Review" or (.component.groupId // "") == "")]
+  | length
+' "$@")
+if (( skipped > 0 )); then
+  echo "::notice::Skipped ${skipped} inventory entries with no identified license" >&2
+fi
+
+jq -s -r '
+  [ .[] | (.response // [])[]
+    | select(.license.name != "Requires Review" and (.component.groupId // "") != "")
+  ]
+  | group_by([.component.groupId, .component.version, .license.name])
+  | map(.[0])
+  | sort_by([((.component.groupId // "") | ascii_downcase), (.component.version // "")])
+  | map(
+      [
+        "",
+        "---",
+        "",
+        ("## " + .component.groupId + " " + .component.version + " — " + .license.name),
+        ""
+      ]
+      + (if ((.extraData.homepage // "") | length) > 0
+          then ["- Homepage: <" + .extraData.homepage + ">"]
+          else [] end)
+      + ((.copyrights // []) | map("- " + .))
+      | join("\n")
+    )
+  | join("\n")
+' "$@"
+
+# Trailing newline so the file ends cleanly.
+echo

--- a/.github/workflows/attribution.yml
+++ b/.github/workflows/attribution.yml
@@ -1,0 +1,85 @@
+name: Update Third-Party Attributions
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *" # nightly 03:00 UTC
+  pull_request:
+    branches: [master]
+    paths:
+      - .github/workflows/attribution.yml
+      - .github/scripts/build-attribution.sh
+      - ATTRIBUTIONS.md
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  attribution:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fetch dependency inventory
+        uses: vespa-engine/gh-actions/mend-inventory@217825ab3497a98c67134a9e8bb30f04329e82fe # v1
+        with:
+          mend-project-name: GH_vespa_master
+          mend-project-uuid: dbdbea81-7f52-426c-974f-975c2848770d
+          mend-user: ${{ vars.MEND_ATTRIBUTION_USER_EMAIL }}
+          mend-api-key: ${{ secrets.MEND_ATTRIBUTION_USER_KEY }}
+          output-path: build/inventory.json
+
+      - name: Build ATTRIBUTIONS.md
+        run: |
+          ./.github/scripts/build-attribution.sh build/inventory.json > ATTRIBUTIONS.md
+          echo "Wrote $(wc -l < ATTRIBUTIONS.md) lines to ATTRIBUTIONS.md"
+
+      # Only uploaded on failure so the raw response is available for debugging
+      # without bloating the artifact list on every successful run.
+      - name: Upload raw inventory JSON (debug, on failure)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: inventory-debug
+          path: build/inventory.json
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Upload ATTRIBUTIONS.md
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: attributions
+          path: ATTRIBUTIONS.md
+          retention-days: 14
+
+      - name: Open PR if changed
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+
+          git add ATTRIBUTIONS.md
+          if git diff --cached --quiet; then
+            echo "ATTRIBUTIONS.md is up to date — nothing to do."
+            exit 0
+          fi
+
+          BRANCH="chore/update-attributions"
+          git checkout -B "$BRANCH"
+          git commit -m "chore: update third-party attributions"
+          git push --force --set-upstream origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "PR for $BRANCH already open — pushed update to existing PR."
+          else
+            gh pr create \
+              --base master \
+              --head "$BRANCH" \
+              --title "chore: update third-party attributions" \
+              --body "Auto-generated update of ATTRIBUTIONS.md."
+          fi

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,0 +1,1166 @@
+# Third-Party Software Attributions
+
+This file is auto-generated nightly and lists the open-source software
+dependencies of Vespa detected by scanning package manifests.
+
+For the hand-maintained list of vendored C/C++ libraries (Boost, OpenSSL,
+ICU, etc.), see [`NOTICES`](NOTICES).
+
+Last updated: 2026-05-07
+
+---
+
+## @shikijs/core 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## @shikijs/engine-javascript 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## @shikijs/engine-oniguruma 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## @shikijs/langs 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## @shikijs/themes 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## @shikijs/types 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## @shikijs/vscode-textmate 10.0.2 — MIT
+
+- Homepage: <https://github.com/shikijs/vscode-textmate#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## @types/hast 3.0.4 — MIT
+
+- Homepage: <https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/hast>
+- Copyright Microsoft Corporation
+
+---
+
+## @types/mdast 4.0.4 — MIT
+
+- Homepage: <https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mdast>
+- Copyright Microsoft Corporation
+
+---
+
+## @types/unist 3.0.3 — MIT
+
+- Homepage: <https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/unist>
+- Copyright Microsoft Corporation
+
+---
+
+## @ungap/structured-clone 1.3.1 — ISC
+
+- Homepage: <https://github.com/ungap/structured-clone#readme>
+- Copyright 2021 Andrea Giammarchi
+- @WebReflection
+
+---
+
+## addressable 2.9.0 — Apache 2.0
+
+- Homepage: <https://github.com/sporkmonger/addressable>
+- Copyright Bob Aman</dd>
+
+---
+
+## afm 0.2.2 — MIT
+
+- Homepage: <http://github.com/halfbyte/afm>
+- Copyright 2010 Jan Krutisch
+- Copyright 2009 Jan Krutisch
+
+---
+
+## Ascii85 1.1.0 — MIT
+
+- Homepage: <https://github.com/DataWraith/ascii85gem/>
+- Copyright 2009 Johannes Holzfuß
+
+---
+
+## async 1.5.2 — MIT
+
+- Homepage: <https://github.com/caolan/async#readme>
+- Copyright 2010-2017 Caolan McMahon
+- Copyright 2010-2014 Caolan McMahon
+
+---
+
+## async 2.6.5 — MIT
+
+- Homepage: <https://github.com/socketry/async>
+- Copyright, 2017-2023, by Samuel Williams.
+- Copyright, 2020-2022, by Bruno Sutic.
+
+---
+
+## balanced-match 1.0.2 — MIT
+
+- Homepage: <https://github.com/juliangruber/balanced-match>
+- Copyright 2013 Julian Gruber <julian@juliangruber.com>
+
+---
+
+## base64 0.3.0 — BSD 2
+
+- Homepage: <https://github.com/ruby/base64>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## benchmark 0.5.0 — BSD 2
+
+- Homepage: <https://github.com/ruby/benchmark>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## bigdecimal 4.1.2 — BSD 2
+
+- Homepage: <https://github.com/ruby/bigdecimal>
+
+---
+
+## bigdecimal 4.1.2 — Ruby
+
+- Homepage: <https://github.com/ruby/bigdecimal>
+
+---
+
+## brace-expansion 2.0.3 — MIT
+
+- Homepage: <https://github.com/juliangruber/brace-expansion>
+- Copyright 2013 Julian Gruber <julian@juliangruber.com>
+
+---
+
+## ccount 2.0.1 — MIT
+
+- Homepage: <https://github.com/wooorm/ccount#readme>
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## character-entities-html4 2.1.0 — MIT
+
+- Homepage: <https://github.com/wooorm/character-entities-html4#readme>
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## character-entities-legacy 3.0.0 — MIT
+
+- Homepage: <https://github.com/wooorm/character-entities-legacy#readme>
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## colorator 1.1.0 — MIT
+
+- Homepage: <https://github.com/octopress/colorator>
+- Copyright Parker Moore
+
+---
+
+## com.vladsch.flexmark 0.64.8 — BSD 2
+
+- Homepage: <https://github.com/vsch/flexmark-java>
+
+---
+
+## comma-separated-tokens 2.0.3 — MIT
+
+- Homepage: <https://github.com/wooorm/comma-separated-tokens#readme>
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## concurrent-ruby 1.2.2 — MIT
+
+- Homepage: <http://www.concurrent-ruby.com>
+- Copyright extensions on your users
+- It is Copyright © 2014
+- Copyright Jerry D'Antonio -- released under the MIT license
+
+---
+
+## concurrent-ruby 1.2.2 — Ruby
+
+- Homepage: <http://www.concurrent-ruby.com>
+- Copyright extensions on your users
+- It is Copyright © 2014
+- Copyright Jerry D'Antonio -- released under the MIT license
+
+---
+
+## console 1.23.7 — MIT
+
+- Homepage: <https://socketry.github.io/console/>
+- Copyright, 2019-2021, by Bryan Powell.
+- Copyright, 2019-2024, by Samuel Williams.
+
+---
+
+## csv 3.3.5 — BSD 2
+
+- Homepage: <https://github.com/ruby/csv>
+- Copyright 2007-2017 Yukihiro Matsumoto
+- Copyright 2017 pavel
+- Copyright 2005-2016 James Edward Gray II. All rights reserved
+- Copyright 2018 Kouhei Sutou
+- Copyright 2018 Vladislav
+- Copyright 2017-2018 Steven Daniels
+- Copyright 2017 Espartaco Palma
+- Copyright 2018 Tomohiro Ogoke
+- Copyright 2017 Marcus Stollsteimer
+- Copyright 2017 Olivier Lacan
+- Copyright 2017 SHIBATA Hiroshi
+- Copyright 2018 Mitsutaka Mimura
+
+---
+
+## dequal 2.0.3 — MIT
+
+- Homepage: <https://github.com/lukeed/dequal#readme>
+- Copyright Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+
+---
+
+## devlop 1.1.0 — MIT
+
+- Homepage: <https://github.com/wooorm/devlop#readme>
+- Copyright 2023 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## em-websocket 0.5.3 — MIT
+
+- Homepage: <http://github.com/igrigorik/em-websocket>
+- Copyright 2009-2014 Ilya Grigorik
+
+---
+
+## ethon 0.16.0 — MIT
+
+- Homepage: <https://github.com/typhoeus/ethon>
+- Copyright 2012-2016 Hans Hasselberg
+
+---
+
+## eventmachine 1.2.7 — GPL 2.0
+
+- Homepage: <http://rubyeventmachine.com>
+- Copyright 2006 by Francis Cianfrocca
+
+---
+
+## eventmachine 1.2.7 — Ruby
+
+- Homepage: <http://rubyeventmachine.com>
+- Copyright 2006 by Francis Cianfrocca
+
+---
+
+## ffi 1.15.5 — BSD 3
+
+- Homepage: <https://github.com/ffi/ffi/wiki>
+- Copyright 2008-2012 Ruby
+- Copyright 1996-2011 Anthony Green
+- Copyright 2008-2016 Ruby FFI project contributors
+- Copyright 2008-2013 Ruby FFI project contributors
+
+---
+
+## fiber-annotation 0.2.0 — MIT
+
+- Homepage: <https://github.com/ioquatix/fiber-annotation>
+- Copyright 2023, by Samuel Williams
+
+---
+
+## fiber-local 1.0.0 — MIT
+
+- Homepage: <https://github.com/socketry/fiber-local>
+
+---
+
+## forwardable-extended 2.6.0 — MIT
+
+- Homepage: <http://github.com/envygeeks/forwardable-extended>
+- Copyright 2015-2016 Jordon Bedwell
+
+---
+
+## github.com/Briandowns/spinner v1.23.2 — Apache 2.0
+
+- Homepage: <https://pkg.go.dev/github.com/Briandowns/spinner@v1.23.2>
+- Copyright 2022 Brian J. Downs
+
+---
+
+## github.com/clipperhouse/uax29/v2 v2.7.0 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/clipperhouse/uax29/v2@v2.7.0>
+- Copyright 2020 Matt Sherman
+
+---
+
+## github.com/CPUguy83/go-md2man/v2 v2.0.7 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/CPUguy83/go-md2man/v2@v2.0.7>
+- Copyright 2014 Brian Goff
+
+---
+
+## github.com/fatih/color v1.19.0 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/fatih/color@v1.19.0>
+- Copyright 2013 Fatih Arslan
+
+---
+
+## github.com/fxamacker/cbor/v2 v2.9.1 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/fxamacker/cbor/v2@v2.9.1>
+- Copyright 2019-2024 Faye Amacker
+- Copyright 2019 Faye Amacker
+
+---
+
+## github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 — BSD 3
+
+- Homepage: <https://pkg.go.dev/github.com/go-json-experiment/json@v0.0.0-20260214004413-d219187c3433>
+- Copyright 2020 The Go Authors
+
+---
+
+## github.com/godbus/dbus/v5 v5.2.2 — BSD 2
+
+- Homepage: <https://pkg.go.dev/github.com/godbus/dbus/v5@v5.2.2>
+- Copyright 2013 Georg Reinke <guelfey at gmail dot com>
+- Google
+
+---
+
+## github.com/Mattn/Go-colorable v0.1.14 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/Mattn/Go-colorable@v0.1.14>
+- Copyright 2016 Yasuhiro Matsumoto
+
+---
+
+## github.com/mattn/go-isatty v0.0.21 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/mattn/go-isatty@v0.0.21>
+- Copyright Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+---
+
+## github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c — BSD 2
+
+- Homepage: <https://pkg.go.dev/github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c>
+- Copyright 2014 Dave Cheney <dave@cheney.net>
+
+---
+
+## github.com/russross/blackFriday/v2 v2.1.0 — BSD 2
+
+- Homepage: <https://pkg.go.dev/github.com/russross/blackFriday/v2@v2.1.0>
+- Copyright 2011 Russ Ross
+
+---
+
+## github.com/Spf13/Cobra v1.10.2 — Apache 2.0
+
+- Homepage: <https://pkg.go.dev/github.com/Spf13/Cobra@v1.10.2>
+
+---
+
+## github.com/spf13/pFLAG v1.0.10 — BSD 3
+
+- Homepage: <https://pkg.go.dev/github.com/spf13/pFLAG@v1.0.10>
+- Copyright 2012 Alex Ogier
+- Copyright 2012 The Go Authors
+
+---
+
+## github.com/x448/float16 v0.8.4 — MIT
+
+- Homepage: <https://pkg.go.dev/github.com/x448/float16@v0.8.4>
+- Copyright 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+---
+
+## go.yaml.in/yaml/v3 v3.0.4 — Apache 2.0
+
+- Homepage: <https://pkg.go.dev/go.yaml.in/yaml/v3@v3.0.4>
+- Copyright 2011-2019 Canonical Ltd
+- Copyright 2011 when the project was ported over:
+- Copyright files of libyaml, and thus
+- Copyright 2006-2010 Kirill Simonov
+
+---
+
+## go.yaml.in/yaml/v3 v3.0.4 — MIT
+
+- Homepage: <https://pkg.go.dev/go.yaml.in/yaml/v3@v3.0.4>
+- Copyright 2011-2019 Canonical Ltd
+- Copyright 2011 when the project was ported over:
+- Copyright files of libyaml, and thus
+- Copyright 2006-2010 Kirill Simonov
+
+---
+
+## golang.org/x/sys v0.43.0 — Golang BSD + Patents
+
+- Homepage: <https://pkg.go.dev/golang.org/x/sys@v0.43.0>
+- Copyright 2009 The Go Authors
+
+---
+
+## golang.org/x/term v0.42.0 — Golang BSD + Patents
+
+- Homepage: <https://pkg.go.dev/golang.org/x/term@v0.42.0>
+- Copyright 2009 The Go Authors
+
+---
+
+## google-protobuf 3.25.8 — BSD 3
+
+- Homepage: <https://developers.google.com/protocol-buffers>
+
+---
+
+## gopkg.in/yAML.v3 v3.0.1 — Apache 2.0
+
+- Homepage: <https://pkg.go.dev/gopkg.in/yAML.v3@v3.0.1>
+- Copyright 2011-2019 Canonical Ltd
+- Copyright 2011 when the project was ported over:
+- Copyright files of libyaml, and thus
+- Copyright 2006-2010 Kirill Simonov
+- Copyright 2006-2011 Kirill Simonov
+
+---
+
+## gopkg.in/yAML.v3 v3.0.1 — MIT
+
+- Homepage: <https://pkg.go.dev/gopkg.in/yAML.v3@v3.0.1>
+- Copyright 2011-2019 Canonical Ltd
+- Copyright 2011 when the project was ported over:
+- Copyright files of libyaml, and thus
+- Copyright 2006-2010 Kirill Simonov
+- Copyright 2006-2011 Kirill Simonov
+
+---
+
+## gpt-4o generic — Proprietary
+
+- Homepage: <https://www.openai.com>
+
+---
+
+## gpt-4o-mini generic — Proprietary
+
+- Homepage: <https://www.openai.com>
+
+---
+
+## hasbin 1.2.3 — MIT
+
+- Homepage: <https://github.com/springernature/hasbin>
+- Copyright 2015 Nature Publishing Group
+- Copyright 2015 Springer Nature
+
+---
+
+## hashery 2.1.2 — BSD 2
+
+- Homepage: <http://rubyworks.github.com/hashery>
+- Copyright 2010 Rubyworks
+
+---
+
+## hast-util-to-html 9.0.5 — MIT
+
+- Homepage: <https://github.com/syntax-tree/hast-util-to-html#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## hast-util-whitespace 3.0.0 — MIT
+
+- Homepage: <https://github.com/syntax-tree/hast-util-whitespace#readme>
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## html-void-elements 3.0.0 — MIT
+
+- Homepage: <https://github.com/wooorm/html-void-elements#readme>
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## http_parser.rb 0.8.0 — MIT
+
+- Homepage: <https://github.com/tmm1/http_parser.rb>
+- Copyright 2010-2011 Aman Gupta <aman@tmm
+- Copyright 2009-2010 Marc
+
+---
+
+## i18n 1.14.1 — MIT
+
+- Homepage: <https://github.com/ruby-i18n/i18n>
+- Copyright 2008 The Ruby I18n team
+
+---
+
+## io-event 1.3.3 — MIT
+
+- Homepage: <https://github.com/socketry/io-event>
+- Copyright, 2021-2023, by Samuel Williams.
+
+---
+
+## javax.annotation 1.3.2 — CDDL 1.1
+
+- Homepage: <http://jcp.org/en/jsr/detail?id=250>
+- Copyright 2017 Oracle and/or its affiliates.
+
+---
+
+## jekyll 4.3.3 — MIT
+
+- Homepage: <https://jekyllrb.com>
+- Copyright 2008 Tom Preston-Werner and Jekyll contributors
+
+---
+
+## jekyll-feed 0.17.0 — MIT
+
+- Homepage: <https://github.com/jekyll/jekyll-feed>
+- Copyright 2015 Ben Balter and jekyll-feed contributors
+
+---
+
+## jekyll-redirect-from 0.16.0 — MIT
+
+- Homepage: <https://github.com/jekyll/jekyll-redirect-from>
+- Copyright 2013 Parker Moore and jekyll-redirect-from contributors
+
+---
+
+## jekyll-sass-converter 3.0.0 — MIT
+
+- Homepage: <https://github.com/jekyll/jekyll-sass-converter>
+
+---
+
+## jekyll-seo-tag 2.8.0 — MIT
+
+- Homepage: <https://github.com/jekyll/jekyll-seo-tag>
+- Copyright 2015 Ben Balter and the jekyll-seo-tag contributors
+
+---
+
+## jekyll-watch 2.2.1 — MIT
+
+- Homepage: <https://github.com/jekyll/jekyll-watch>
+- Copyright 2014 Parker Moore and the jekyll-watch contributors
+
+---
+
+## json 2.7.2 — Ruby
+
+- Homepage: <https://flori.github.io/json>
+
+---
+
+## kramdown 2.4.0 — GPL
+
+- Homepage: <http://kramdown.gettalong.org>
+- Copyright 2007 Michel Fortin
+- Copyright 2009-2013 Thomas Leitner <t
+
+---
+
+## kramdown 2.4.0 — MIT
+
+- Homepage: <http://kramdown.gettalong.org>
+- Copyright 2007 Michel Fortin
+- Copyright 2009-2013 Thomas Leitner <t
+
+---
+
+## kramdown-parser-gfm 1.1.0 — MIT
+
+- Homepage: <https://github.com/kramdown/parser-gfm>
+- Copyright 2019 Thomas Leitner <t_leitner@gmx.at>
+
+---
+
+## liquid 4.0.4 — MIT
+
+- Homepage: <http://www.liquidmarkup.org>
+- Copyright 2005-2006 Tobias Luetke
+
+---
+
+## listen 3.8.0 — MIT
+
+- Homepage: <https://github.com/guard/listen>
+- Copyright 2013 Thibaud Guillaume-Gentil
+
+---
+
+## logger 1.7.0 — BSD 2
+
+- Homepage: <https://github.com/ruby/logger>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## mdast-util-to-hast 13.2.1 — MIT
+
+- Homepage: <https://github.com/syntax-tree/mdast-util-to-hast#readme>
+- Copyright Titus Wormer
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## mercenary 0.4.0 — MIT
+
+- Homepage: <https://github.com/jekyll/mercenary>
+- Copyright 2013 Parker Moore and the mercenary contributors
+
+---
+
+## micromark-util-character 2.1.1 — MIT
+
+- Homepage: <https://github.com/micromark/micromark/tree/main#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## micromark-util-encode 2.0.1 — MIT
+
+- Homepage: <https://github.com/micromark/micromark/tree/main#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## micromark-util-sanitize-uri 2.0.1 — MIT
+
+- Homepage: <https://github.com/micromark/micromark/tree/main#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## micromark-util-symbol 2.0.1 — MIT
+
+- Homepage: <https://github.com/micromark/micromark/tree/main#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## micromark-util-types 2.0.2 — MIT
+
+- Homepage: <https://github.com/micromark/micromark/tree/main#readme>
+- Copyright Titus Wormer
+- Copyright 2020 Titus Wormer <tituswormer@gmail.com>
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## minima 2.5.1 — MIT
+
+- Homepage: <https://github.com/jekyll/minima>
+- Copyright 2016 Parker Moore and the minima contributors
+
+---
+
+## minimatch 5.1.9 — ISC
+
+- Homepage: <https://github.com/isaacs/minimatch#readme>
+
+---
+
+## mistral-embed 23.12 — Proprietary
+
+---
+
+## nokogiri 1.19.1 — MIT
+
+- Homepage: <https://nokogiri.org>
+- Copyright 2008-2023 Mike Dalessio
+- Copyright 1995-2017 Jean-loup Gailly and Mark Adler
+- Copyright 1998-2012 Daniel Veillard
+- Copyright 2001-2003 Thai Open Source Software Center Ltd
+- Copyright 2001-2002 SourceForge ISO-RELAX Project
+- Copyright 2001-2002 Thomas Broyer
+- Copyright 2001-2002 Daniel Veillard
+
+---
+
+## oniguruma-parser 0.12.2 — MIT
+
+- Homepage: <https://github.com/slevithan/oniguruma-parser#readme>
+- Copyright 2025-2026 Steven Levithan
+
+---
+
+## oniguruma-to-es 4.3.6 — MIT
+
+- Homepage: <https://github.com/slevithan/oniguruma-to-es#readme>
+- Copyright 2024-2026 Steven Levithan
+
+---
+
+## org.apache.zookeeper 3.9.5 — Apache 2.0
+
+- Homepage: <http://zookeeper.apache.org>
+- The Apache Software Foundation
+
+---
+
+## org.eclipse.lsp4j 0.23.1 — Eclipse 2.0
+
+- Homepage: <https://github.com/eclipse-lsp4j/lsp4j>
+- Copyright 2007 Eclipse Foundation, Inc. and its licensors
+
+---
+
+## org.jsoup 1.17.2 — MIT
+
+- Homepage: <https://jhy.io/>
+- Copyright 2009-2023 Jonathan Hedley <https
+- Jonathan Hedley
+
+---
+
+## pathutil 0.16.2 — MIT
+
+- Homepage: <http://github.com/envygeeks/pathutil>
+- Copyright 2015-2017 Jordon Bedwell
+
+---
+
+## pdf-reader 2.11.0 — MIT
+
+- Homepage: <https://github.com/yob/pdf-reader>
+- Copyright 2009 Peter Jones
+- Copyright 2009 James Healy
+
+---
+
+## property-information 7.1.0 — MIT
+
+- Homepage: <https://github.com/wooorm/property-information#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <mailto:tituswormer@gmail.com>
+- Copyright Facebook, Inc.
+
+---
+
+## public_suffix 7.0.5 — MIT
+
+- Homepage: <https://simonecarletti.com/code/publicsuffix-ruby>
+- Copyright 2009-2026 Simone Carletti
+- Copyright 2009-2026 Simone Carletti <weppos@weppos.net>
+
+---
+
+## public_suffix 7.0.5 — Mozilla
+
+- Homepage: <https://simonecarletti.com/code/publicsuffix-ruby>
+- Copyright 2009-2026 Simone Carletti
+- Copyright 2009-2026 Simone Carletti <weppos@weppos.net>
+
+---
+
+## racc 1.8.1 — BSD 2
+
+- Homepage: <https://github.com/ruby/racc>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## racc 1.8.1 — Ruby
+
+- Homepage: <https://github.com/ruby/racc>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## rainbow 3.1.1 — MIT
+
+- Homepage: <https://github.com/sickill/rainbow>
+- Copyright Marcin Kulik
+
+---
+
+## rake 13.2.1 — MIT
+
+- Homepage: <https://github.com/ruby/rake>
+- Copyright Jim Weirich
+
+---
+
+## rb-fsevent 0.11.2 — MIT
+
+- Homepage: <http://rubygems.org/gems/rb-fsevent>
+- Copyright 2010-2014 Thibaud Guillaume-Gentil
+
+---
+
+## rb-inotify 0.10.1 — MIT
+
+- Homepage: <https://github.com/guard/rb-inotify>
+- Copyright 2009, by "Natalie Weizenbaum" (https://github.com/nex3)
+
+---
+
+## react 19.1.0 — MIT
+
+- Homepage: <https://react.dev/>
+- Copyright Meta Platforms, Inc. and affiliates
+
+---
+
+## react-dom 19.1.0 — MIT
+
+- Homepage: <https://react.dev/>
+- Copyright Meta Platforms, Inc. and affiliates
+
+---
+
+## regex 6.1.0 — MIT
+
+- Homepage: <https://github.com/slevithan/regex#readme>
+- Copyright 2025 Steven Levithan
+
+---
+
+## regex-recursion 6.0.2 — MIT
+
+- Homepage: <https://github.com/slevithan/regex-recursion#readme>
+- Copyright 2025 Steven Levithan
+
+---
+
+## regex-utilities 2.3.0 — MIT
+
+- Homepage: <https://github.com/slevithan/regex-utilities#readme>
+- Copyright 2024 Steven Levithan
+
+---
+
+## rexml 3.4.2 — BSD 2
+
+- Homepage: <https://github.com/ruby/rexml>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## rouge 4.1.3 — BSD 2
+
+- Homepage: <http://rouge.jneen.net/>
+- Copyright 2012 Jeanine Adkisson
+- Copyright 2006-2012 by the respective authors
+
+---
+
+## rouge 4.1.3 — MIT
+
+- Homepage: <http://rouge.jneen.net/>
+- Copyright 2012 Jeanine Adkisson
+- Copyright 2006-2012 by the respective authors
+
+---
+
+## ruby-rc4 0.1.5 — MIT
+
+- Homepage: <http://www.caigenichols.com/>
+- Copyright 2010 Max Prokopiev, Alexandar Simic, Caige Nichols
+
+---
+
+## safe_yaml 1.0.5 — MIT
+
+- Homepage: <https://github.com/dtao/safe_yaml>
+- Copyright 2013 Dan Tao
+
+---
+
+## sass-embedded 1.67.0 — MIT
+
+- Homepage: <https://github.com/ntkme/sass-embedded-host-ruby>
+- Copyright (c) 2022, なつき
+
+---
+
+## scheduler 0.26.0 — MIT
+
+- Homepage: <https://react.dev/>
+- Copyright Meta Platforms, Inc. and affiliates
+
+---
+
+## semver 7.7.4 — ISC
+
+- Homepage: <https://github.com/npm/node-semver#readme>
+- Copyright Isaac Z. Schlueter and Contributors
+- Copyright Isaac Z
+
+---
+
+## shiki 3.23.0 — MIT
+
+- Homepage: <https://github.com/shikijs/shiki#readme>
+- Copyright 2021 Pine Wu
+- Copyright 2023 Anthony Fu <https://github.com/antfu>
+
+---
+
+## space-separated-tokens 2.0.2 — MIT
+
+- Homepage: <https://github.com/wooorm/space-separated-tokens#readme>
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## stringify-entities 4.0.4 — MIT
+
+- Homepage: <https://github.com/wooorm/stringify-entities#readme>
+- Copyright 2015 Titus Wormer <mailto:tituswormer@gmail.com>
+
+---
+
+## terminal-table 3.0.2 — MIT
+
+- Homepage: <https://github.com/tj/terminal-table>
+- Copyright 2008-2017 TJ Holowaychuk <tj@vision
+
+---
+
+## text-embedding-ada-002 002 — Proprietary
+
+- Homepage: <https://www.openai.com>
+
+---
+
+## timers 4.3.5 — MIT
+
+- Homepage: <https://github.com/socketry/timers>
+- Copyright, 2014-2022, by Samuel Williams.
+- Copyright, 2017-2020, by Olle Jonsson.
+- Copyright, 2015-2016, by Donovan Keme.
+- Copyright, 2012-2017, by Tony Arcieri.
+- Copyright, 2013-2015, by Utenmiki.
+
+---
+
+## trim-lines 3.0.1 — MIT
+
+- Homepage: <https://github.com/wooorm/trim-lines#readme>
+- Copyright 2015 Titus Wormer <mailto:tituswormer@gmail.com>
+
+---
+
+## ttfunk 1.7.0 — GPL 2.0
+
+- Homepage: <https://prawnpdf.org>
+
+---
+
+## ttfunk 1.7.0 — GPL 3.0
+
+- Homepage: <https://prawnpdf.org>
+
+---
+
+## typhoeus 1.4.1 — MIT
+
+- Homepage: <https://github.com/typhoeus/typhoeus>
+- Copyright 2011-2012 David Balatero
+- Copyright 2011 David Balatero
+- Copyright 2009-2010 Paul Dix
+- Copyright 2012-2016 Hans Hasselberg
+
+---
+
+## unicode-display_width 2.4.2 — MIT
+
+- Homepage: <https://github.com/janlelis/unicode-display_width>
+- Copyright 2011-2023 Jan Lelis
+- Copyright 2009 Run Paint Run Run
+- Copyright & Info
+
+---
+
+## unist-util-is 6.0.1 — MIT
+
+- Homepage: <https://github.com/syntax-tree/unist-util-is#readme>
+- Copyright Titus Wormer
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## unist-util-position 5.0.0 — MIT
+
+- Homepage: <https://github.com/syntax-tree/unist-util-position#readme>
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## unist-util-stringify-position 4.0.0 — MIT
+
+- Homepage: <https://github.com/syntax-tree/unist-util-stringify-position#readme>
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## unist-util-visit 5.1.0 — MIT
+
+- Homepage: <https://github.com/syntax-tree/unist-util-visit#readme>
+- Copyright Titus Wormer
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## unist-util-visit-parents 6.0.2 — MIT
+
+- Homepage: <https://github.com/syntax-tree/unist-util-visit-parents#readme>
+- Copyright Titus Wormer
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## vfile 6.0.3 — MIT
+
+- Homepage: <https://github.com/vfile/vfile#readme>
+- Copyright Titus Wormer
+- Copyright 2015 Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## vfile-message 4.0.3 — MIT
+
+- Homepage: <https://github.com/vfile/vfile-message#readme>
+- Copyright Titus Wormer
+- Copyright Titus Wormer <tituswormer@gmail.com>
+
+---
+
+## vscode-jsonrpc 8.2.0 — MIT
+
+- Homepage: <https://github.com/Microsoft/vscode-languageserver-node#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## vscode-languageclient 9.0.1 — MIT
+
+- Homepage: <https://github.com/Microsoft/vscode-languageserver-node#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## vscode-languageserver-protocol 3.17.5 — MIT
+
+- Homepage: <https://github.com/Microsoft/vscode-languageserver-node#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## vscode-languageserver-types 3.17.5 — MIT
+
+- Homepage: <https://github.com/Microsoft/vscode-languageserver-node#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## vscode-oniguruma 2.0.1 — MIT
+
+- Homepage: <https://github.com/microsoft/vscode-oniguruma#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## vscode-textmate 9.3.2 — MIT
+
+- Homepage: <https://github.com/microsoft/vscode-textmate#readme>
+- Copyright Microsoft Corporation
+
+---
+
+## webrick 1.8.2 — BSD 2
+
+- Homepage: <https://github.com/ruby/webrick>
+- Copyright 1993-2013 Yukihiro Matsumoto
+
+---
+
+## yell 2.2.2 — MIT
+
+- Homepage: <https://github.com/rudionrails/yell>
+- Copyright 2011 Rudolf Schmidt
+- Copyright 2011 Rudolf Schmidt, released under the MIT license
+
+---
+
+## zeitwerk 2.6.13 — MIT
+
+- Homepage: <https://github.com/fxn/zeitwerk>
+- Copyright 2019 Xavier Noria
+
+---
+
+## zwitch 2.0.4 — MIT
+
+- Homepage: <https://github.com/wooorm/zwitch#readme>
+- Copyright 2016 Titus Wormer <tituswormer@gmail.com>


### PR DESCRIPTION
Adds a workflow that fetches package-manifest dependency data for the Vespa project from our SCA scanner and writes an ATTRIBUTIONS.md at the repo root. Runs nightly and on manual dispatch; opens a chore PR when the file changes. The hand-maintained NOTICES file (vendored C/C++ libraries) stays as-is; the new file covers the manifest-detectable ecosystems (npm, Maven, Go, Ruby, ML models) that NOTICES does not.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
