### PR TITLE
Add quantization codebooks and centroid utilities

### DIFF
--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -204,6 +204,7 @@ vespa_define_module(
     src/vespa/vespalib/objects
     src/vespa/vespalib/portal
     src/vespa/vespalib/process
+    src/vespa/vespalib/quant
     src/vespa/vespalib/regex
     src/vespa/vespalib/stllike
     src/vespa/vespalib/test

--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_executable(vespalib_quant_test_app TEST
     SOURCES
+    centroid_test.cpp
     hadamard_test.cpp
     DEPENDS
     vespalib

--- a/vespalib/src/tests/quant/centroid_test.cpp
+++ b/vespalib/src/tests/quant/centroid_test.cpp
@@ -1,0 +1,51 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/quant/centroid.h>
+
+#include <array>
+
+using namespace ::testing;
+
+namespace vespalib::quant {
+
+// This use-case doesn't make sense at all, but let's ensure that the code generalizes.
+TEST(CentroidTest, single_centroid_choice_is_obvious) {
+    constexpr std::array<int, 1> my_silly_centroid = {5};
+
+    auto idx_of = [&](int v) noexcept { return closest_centroid_index<int>(v, my_silly_centroid); };
+    EXPECT_EQ(idx_of(-100000), 0);
+    EXPECT_EQ(idx_of(5), 0);
+    EXPECT_EQ(idx_of(100000), 0);
+}
+
+TEST(CentroidTest, choose_closest_of_two_centroids) {
+    constexpr std::array<int, 2> my_centroids = {-10, 10};
+
+    auto idx_of = [&](int v) noexcept { return closest_centroid_index<int>(v, my_centroids); };
+    EXPECT_EQ(idx_of(-100000), 0);
+    EXPECT_EQ(idx_of(-10), 0);
+    EXPECT_EQ(idx_of(-5), 0);
+    EXPECT_EQ(idx_of(-1), 0);
+    EXPECT_EQ(idx_of(0), 0); // Exact boundary "rounds down" since distance to the next centroid is not less
+    EXPECT_EQ(idx_of(1), 1);
+    EXPECT_EQ(idx_of(5), 1);
+    EXPECT_EQ(idx_of(10), 1);
+    EXPECT_EQ(idx_of(100000), 1);
+}
+
+TEST(CentroidTest, centroid_distance_can_be_non_uniform) {
+    constexpr std::array<float, 4> my_centroids = {1, 2, 8, 20};
+
+    auto idx_of = [&](float v) noexcept { return closest_centroid_index<float>(v, my_centroids); };
+    EXPECT_EQ(idx_of(1), 0);
+    EXPECT_EQ(idx_of(1.5), 0);
+    EXPECT_EQ(idx_of(1.51), 1);
+    EXPECT_EQ(idx_of(2), 1);
+    EXPECT_EQ(idx_of(5), 1);
+    EXPECT_EQ(idx_of(5.0001), 2);
+    EXPECT_EQ(idx_of(14), 2);
+    EXPECT_EQ(idx_of(14.0001), 3);
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/CMakeLists.txt
@@ -44,6 +44,7 @@ vespa_add_library(vespalib
     $<TARGET_OBJECTS:vespalib_vespalib_objects>
     $<TARGET_OBJECTS:vespalib_vespalib_portal>
     $<TARGET_OBJECTS:vespalib_vespalib_process>
+    $<TARGET_OBJECTS:vespalib_vespalib_quant>
     $<TARGET_OBJECTS:vespalib_vespalib_regex>
     $<TARGET_OBJECTS:vespalib_vespalib_stllike>
     $<TARGET_OBJECTS:vespalib_vespalib_test>

--- a/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_library(vespalib_vespalib_quant OBJECT
+    SOURCES
+    codebooks.cpp
+    DEPENDS
+)

--- a/vespalib/src/vespa/vespalib/quant/centroid.h
+++ b/vespalib/src/vespa/vespalib/quant/centroid.h
@@ -1,0 +1,37 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+
+namespace vespalib::quant {
+
+/*
+ * Finds the centroid whose value has the smallest absolute difference from `v`
+ * and returns its index in the `centroids` array. If `v` is at the exact boundary
+ * between two centroids (i.e. it's the same distance from both), the _first_
+ * centroid index will be returned.
+ *
+ * Preconditions:
+ *  - centroids.size() > 0
+ *  - `v` and all values in `centroids` are finite numbers
+ */
+template <typename T>
+[[nodiscard]] size_t closest_centroid_index(const T v, std::span<const T> centroids) noexcept {
+    size_t min_idx = 0;
+    T      min_dist = std::numeric_limits<T>::max();
+    for (size_t i = 0; i < centroids.size(); ++i) {
+        const T dist = std::abs(v - centroids[i]);
+        // The greater `n`, the less relative chance of observing a lower value, assuming randomized input.
+        if (dist < min_dist) [[unlikely]] {
+            min_idx = i;
+            min_dist = dist;
+        }
+    }
+    return min_idx;
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/codebooks.cpp
+++ b/vespalib/src/vespa/vespalib/quant/codebooks.cpp
@@ -1,0 +1,55 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "codebooks.h"
+
+namespace vespalib::quant::codebooks {
+
+// clang-format off: intentional array element indents
+
+/* Codebooks have been computed offline using an iterative Lloyd-Max algorithm
+ * implementation with a fixed iteration count of 1000.
+ *
+ * See lloyd_max.py in this directory, which was used for this computation.
+ *
+ * Our Lloyd-Max codebook results have been crosschecked with the centroids in:
+ *  - https://github.com/securefederatedai/openfederatedlearning/blob/develop/openfl/pipelines/eden_pipeline.py
+ *    (EDEN quantization)
+ *  - https://github.com/VectorDB-NTU/rabitq-turboquant-comparison/blob/main/accuracy/turbo_quant.py
+ *    (TurboQuant comparison by RaBitQ authors)
+ *
+ * MSE of our codebook centroids with the above is:
+ * 1 bit:
+ *   EDEN:   1.232595164407831e-32
+ *   RaBitQ: 1.9289412309414601e-13
+ * 2 bits:
+ *   EDEN:   1.3801577665466222e-17
+ *   RaBitQ: 8.902629970902564e-08
+ * 3 bits:
+ *   EDEN:   6.964738710623366e-16
+ *   RaBitQ: 3.869521778101932e-07
+ * 4 bits:
+ *   EDEN:   1.328846476913042e-13
+ *   RaBitQ: 4.591929788084447e-05
+ *
+ * We shall treat this as "close enough", noting that we're much closer to the EDEN
+ * centroids, which also are specified with much greater precision than the ones from
+ * the RaBitQ TurboQuant comparison.
+ */
+const float unit_norm_centroids_f32[4][16] = {
+    // 1 bit:
+    {-0.7978845608028653,  0.7978845608028653},
+    // 2 bits:
+    {-1.510417608499096,  -0.45278003463649225, 0.45278003463649225, 1.510417608499096},
+    // 3 bits:
+    {-2.1519457045369887, -1.3439092785050009, -0.7560052812058778, -0.2450941789442218,
+      0.2450941789442218 , 0.7560052812058778,  1.3439092785050009,  2.1519457045369887},
+    // 4 bits:
+    {-2.732589570995166,  -2.0690172265313915, -1.618046386021888,  -1.2562311973471827,
+     -0.9423404564869668, -0.6567591185324675, -0.3880482994902925, -0.12839502985114778,
+      0.12839502985114778, 0.3880482994902925,  0.6567591185324675,  0.9423404564869668,
+      1.2562311973471827,  1.618046386021888,   2.0690172265313915,  2.732589570995166}
+};
+
+// clang-format on
+
+} // namespace vespalib::quant::codebooks

--- a/vespalib/src/vespa/vespalib/quant/codebooks.h
+++ b/vespalib/src/vespa/vespalib/quant/codebooks.h
@@ -1,0 +1,26 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace vespalib::quant::codebooks {
+
+/*
+ * Precomputed codebooks that are optimal for minimizing Mean Squared Error (MSE)
+ * when quantizing a unit normal, i.e. N(0, 1), probability distribution into
+ * 2^B parts. B is here the number of bits used for quantization.
+ *
+ * The optimal quantized centroid for any input coordinate is the one that has the
+ * minimal absolute distance from the coordinate.
+ *
+ * The array at index 0 is for 1 bit quantization, index 1 for 2 bits and so on.
+ * This is a "full" centroid array that is symmetric around zero, i.e. the first
+ * half elements are negative, the second half is their positive mirror.
+ *
+ * For unit_norm_centroids[B-1], note that only the first 2^B entries are specified.
+ *
+ * Important: for a vector with `d` dimensions, these centroids must be scaled with
+ * 1/sqrt(d) to fit the expected distribution
+ */
+extern const float unit_norm_centroids_f32[4][16];
+
+} // namespace vespalib::quant::codebooks

--- a/vespalib/src/vespa/vespalib/quant/hadamard.h
+++ b/vespalib/src/vespa/vespalib/quant/hadamard.h
@@ -7,7 +7,6 @@
 #include <cassert>
 #include <cmath>
 #include <concepts>
-#include <span>
 
 namespace vespalib::quant {
 

--- a/vespalib/src/vespa/vespalib/quant/lloyd_max.py
+++ b/vespalib/src/vespa/vespalib/quant/lloyd_max.py
@@ -1,0 +1,45 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+import math
+import scipy
+
+
+def lloyd_max(f, a, b, m, iters=100):
+    """
+    A simple implementation of iterative Lloyd-Max for computing the centroids and
+    decision thresholds that minimizes mean squared error when quantizing the
+    probability distribution `f` into `m` parts.
+
+    :param f: Integratable function object that will be called as f(x) with x in [a, b).
+    :param a: Lower bound of function to quantize.
+    :param b: Upper bound of the function to quantize.
+    :param m: Number of centroids to compute, i.e. the quantization factor.
+    :param iters: Number of iterations to run the algorithm for.
+    :return: Tuple (centroids array, thresholds array) of sizes (m, m-1).
+    """
+    # Initial centroid guess: uniformly distributed over the range.
+    centroids = [a + ((i - 0.5) / m) * (b - a) for i in range(1, m + 1)]
+    thresholds = []
+    for i in range(iters):
+        # Decision thresholds are always at the half-way point between centroids.
+        thresholds = [0.5 * (centroids[q - 1] + centroids[q]) for q in range(1, m)]
+        for q in range(m):
+            lo = a if q == 0 else thresholds[q - 1]
+            hi = b if q == m - 1 else thresholds[q]
+            centroids[q] = scipy.integrate.quad(lambda x: x * f(x), lo, hi)[0] / scipy.integrate.quad(f, lo, hi)[0]
+    return centroids, thresholds
+
+
+def unit_norm(z):
+    return math.exp((-z ** 2) / 2) / math.sqrt(2 * math.pi)
+
+
+def compute_codebook_centroids(bits):
+    lm = lloyd_max(unit_norm, -20, 20, 2**bits, 1000)
+    return lm[0]
+
+
+if __name__ == "__main__":
+    for bits in range(1, 5):
+        print(f"{bits}-bit codebook:")
+        print(compute_codebook_centroids(bits))


### PR DESCRIPTION
@havardpe and/or @arnej27959 please review

This adds precomputed codebooks for quantizing a unit normal distribution using 1-4 bits (inclusive). The codebooks specify the centroids of the quantization ranges. I.e. the decision thresholds (quantization bin boundaries) lie at the halfway point between any two centroids.

The codebooks have been computed offline using a simple implementation of the iterative Lloyd-Max algorithm. This implementation is included in `lloyd_max.py` in case it'll come in handy later (requires SciPy for numerical integration).

Also add generic functionality for finding the closest centroid. This can/should be optimized much further.
