### PR TITLE
Remove unused use-vespa-node-ctl and tls-capabilities-enforcement-mode flags

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -309,15 +309,6 @@ public class Flags {
             "Takes effect at next deployment of the application",
             INSTANCE_ID);
 
-    public static final UnboundBooleanFlag USE_VESPA_NODE_CTL = defineFeatureFlag(
-            "use-vespa-node-ctl", true,
-            List.of("hmusum"), "2025-08-12", "2026-06-01",
-            "Whether to use vespa-node-ctl to start, stop, restart, suspend and resume services " +
-            "or do this directly from host-admin.",
-            "Takes effect at next tick",
-            HOSTNAME
-    );
-
     public static final UnboundBooleanFlag RESTART_ON_DEPLOY_MAINTAINER = defineFeatureFlag(
             "restart-on-deploy-maintainer", false,
             List.of("glebashnik"), "2026-04-07", "2026-10-07",

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -597,13 +597,6 @@ public class PermanentFlags {
             "Whether to sync companies to HubSpot. Use this to block sync for specific companies",
             "Takes effect immediately");
 
-    public static final UnboundStringFlag TLS_CAPABILITIES_ENFORCEMENT_MODE = defineStringFlag(
-            "tls-capabilities-enforcement-mode", "disable",
-            "Configure Vespa TLS capability enforcement mode",
-            "Takes effect on restart of Docker container",
-            INSTANCE_ID,HOSTNAME,NODE_TYPE,TENANT_ID,VESPA_VERSION
-    );
-
     public static final UnboundDoubleFlag FEED_CONCURRENCY = defineDoubleFlag(
             "feed-concurrency", 0.5,
             "How much concurrency should be allowed for feed",


### PR DESCRIPTION
## Summary

- Remove `Flags.USE_VESPA_NODE_CTL` and `PermanentFlags.TLS_CAPABILITIES_ENFORCEMENT_MODE`. Neither flag has any callers in this repository, so the definitions are dead code.