### PR TITLE
ci: gate link-checker on run-link-check label

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,12 +8,15 @@ on:
   pull_request:
     branches:
       - master
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: "0 2 * * 1-5"
 
 jobs:
   test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-link-check')
     uses: vespa-engine/gh-actions/.github/workflows/jekyll-link-checker.yml@main
     secrets:
       github-app-id: ${{ secrets.LINK_CHECKER_APP_ID }}


### PR DESCRIPTION
## What
- Skip link-checker on PRs unless the `run-link-check` label is set.
- Add `labeled` to PR trigger types so applying the label starts the run.
- Drop the prior fork-only guard now that the label gates execution.

## Why
Avoid running the link checker on every PR; opt-in via label.