### PR TITLE
Include document ids in file-size estimate in DocumentMetaStore

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -1948,6 +1948,35 @@ TEST(DocumentMetaStoreTest, full_document_ids_are_saved) {
     std::filesystem::remove(std::filesystem::path("documentmetastore5.docids.dat"));
 }
 
+TEST(DocumentMetaStoreTest, full_document_ids_are_considered_in_estimated_save_byte_size) {
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms.constructFreeList();
+    addLid(dms, 1);
+    addLid(dms, 2);
+    addLid(dms, 3);
+    addLid(dms, 4);
+    addLid(dms, 5);
+
+    // Replace docid for lid 2 to make sure that this is reflected in the estimate
+    std::string replaced_docid = "this:is:not:what:you:expect:from:a:docid";
+    dms.update_docid_string(2, replaced_docid);
+
+    // Remove lid 3 to make sure that this is reflected in the estimate
+    removeLid(dms, 3);
+
+    // Remove lid 5 with removeBatch to make sure that this is reflected in the estimate
+    dms.removeBatch({5}, 6);
+
+    // Commit to update the stats used for estimate
+    dms.commit(CommitParam::UpdateStats::FORCE);
+
+    uint64_t expected_save_bytes_size = DocumentMetaStore::minHeaderLen + 3 * DocumentMetaStore::entry_size(true) +
+                                        DocumentMetaStore::minHeaderLen + 3 * sizeof(size_t) +
+                                        createDocId(1).toString().length() + replaced_docid.length() +
+                                        createDocId(4).toString().length();
+    EXPECT_EQ(expected_save_bytes_size, dms.getEstimatedSaveByteSize());
+}
+
 namespace {
 
 void assertLidGidFound(uint32_t lid, DocumentMetaStore& dms) {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -116,9 +116,7 @@ public:
         return _datFile.data_size() / DocumentMetaStore::entry_size(_version != NO_DOCUMENT_SIZE_TRACKING_VERSION);
     }
 
-    uint64_t size_on_disk() const noexcept {
-        return _datFile.size_on_disk() + DiskSpaceCalculator::directory_placeholder_size();
-    }
+    uint64_t size_on_disk() const noexcept { return _datFile.size_on_disk(); }
     std::chrono::steady_clock::duration flush_duration() const noexcept { return _datFile.flush_duration(); }
 };
 
@@ -155,9 +153,7 @@ public:
         return {_docid_buffer.data(), length};
     }
 
-    uint64_t size_on_disk() const noexcept {
-        return _docid_file.size_on_disk() + DiskSpaceCalculator::directory_placeholder_size();
-    }
+    uint64_t size_on_disk() const noexcept { return _docid_file.size_on_disk(); }
     std::chrono::steady_clock::duration flush_duration() const noexcept { return _docid_file.flush_duration(); }
 };
 
@@ -375,8 +371,14 @@ bool DocumentMetaStore::onLoad(vespalib::Executor*) {
 
     setNumDocs(_metadataStore.size());
     setCommittedDocIdLimit(_metadataStore.size());
-    set_size_on_disk(reader.size_on_disk());
-    set_last_flush_duration(reader.flush_duration());
+    uint64_t size_on_disk = DiskSpaceCalculator::directory_placeholder_size() + reader.size_on_disk();
+    std::chrono::steady_clock::duration flush_duration = reader.flush_duration();
+    if (docid_reader) {
+        size_on_disk += docid_reader->size_on_disk();
+        flush_duration += docid_reader->flush_duration();
+    }
+    set_size_on_disk(size_on_disk);
+    set_last_flush_duration(flush_duration);
 
     return true;
 }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -291,6 +291,7 @@ void DocumentMetaStore::onUpdateStat(CommitParam::UpdateStats updateStats) {
     // the free lists are not taken into account here
     updateStatistics(_metadataStore.size(), _metadataStore.size(), usage.allocatedBytes(), usage.usedBytes(),
                      usage.deadBytes(), usage.allocatedBytesOnHold());
+    update_docid_bytes_stats();
 }
 
 void DocumentMetaStore::before_inc_generation(Generation current_gen) {
@@ -389,6 +390,7 @@ bool DocumentMetaStore::onLoad(vespalib::Executor*) {
     }
     set_size_on_disk(size_on_disk);
     set_last_flush_duration(flush_duration);
+    update_docid_bytes_stats();
 
     return true;
 }
@@ -479,6 +481,7 @@ DocumentMetaStore::DocumentMetaStore(BucketDBOwnerSP bucketDB, const std::string
       _docid_store(make_default_docid_array_store_config(), get_memory_allocator(),
                    TypeMapper(array_store_max_type_id, array_store_grow_factor, array_store_max_buffer_size)),
       _docid_bytes(0),
+      _docid_bytes_stats(0),
       _gidToLidMap(),
       _gid_to_lid_map_write_itr(EntryRef(), _gidToLidMap.getAllocator()),
       _gid_to_lid_map_write_itr_prepare_serial_num(0u),
@@ -1093,7 +1096,11 @@ GenerationGuard DocumentMetaStore::getGuard() const {
 
 uint64_t DocumentMetaStore::getEstimatedSaveByteSize() const {
     uint32_t numDocs = getNumUsedLids();
-    return minHeaderLen + numDocs * entry_size(_trackDocumentSizes);
+    uint64_t estimate = minHeaderLen + numDocs * entry_size(_trackDocumentSizes);
+    if (_store_full_document_id) {
+        estimate += minHeaderLen + numDocs * sizeof(size_t) + get_docid_bytes_stats();
+    }
+    return estimate;
 }
 
 uint32_t DocumentMetaStore::getVersion() const {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -214,6 +214,16 @@ void DocumentMetaStore::insert(GidToLidMapKey key, const RawDocumentMetadata& me
     updateCommittedDocIdLimit();
 }
 
+DocumentMetaStore::DocumentIdEntryRef DocumentMetaStore::add_docid_string(std::span<const char> docid) {
+    _docid_bytes += docid.size();
+    return _docid_store.add(docid);
+}
+
+void DocumentMetaStore::remove_docid_string(DocumentIdEntryRef ref) {
+    _docid_bytes -= _docid_store.get(ref).size();
+    _docid_store.remove(ref);
+}
+
 bool DocumentMetaStore::consider_compact_gid_to_lid_map() {
     if (_gidToLidMap.getAllocator().getNodeStore().has_held_buffers()) {
         return false;
@@ -320,7 +330,7 @@ DocumentMetaStore::DocId DocumentMetaStore::readNextDoc(documentmetastore::Reade
     meta.setDocSize(reader.getNextDocSize());
     meta.setTimestamp(reader.getNextTimestamp());
     if (docid_reader) {
-        const auto ref = _docid_store.add(docid_reader->get_next_docid());
+        const auto ref = add_docid_string(docid_reader->get_next_docid());
         meta.set_docid_ref(ref);
     }
     treeBuilder.insert(GidToLidMapKey(lid, meta.getGid()), BTreeNoLeafData());
@@ -468,6 +478,7 @@ DocumentMetaStore::DocumentMetaStore(BucketDBOwnerSP bucketDB, const std::string
       _metadataStore(grow, getGenerationHolder()),
       _docid_store(make_default_docid_array_store_config(), get_memory_allocator(),
                    TypeMapper(array_store_max_type_id, array_store_grow_factor, array_store_max_buffer_size)),
+      _docid_bytes(0),
       _gidToLidMap(),
       _gid_to_lid_map_write_itr(EntryRef(), _gidToLidMap.getAllocator()),
       _gid_to_lid_map_write_itr_prepare_serial_num(0u),
@@ -563,7 +574,7 @@ DocumentMetaStore::Result DocumentMetaStore::put(const DocumentId& docid, const 
             (void)freeLid;
         }
         if (_store_full_document_id) {
-            const auto ref = _docid_store.add(docid.getScheme().toString());
+            const auto ref = add_docid_string(docid.getScheme().toString());
             metadata.set_docid_ref(ref);
         }
         insert(GidToLidMapKey(lid, find_key.get_gid_key()), metadata);
@@ -606,12 +617,10 @@ bool DocumentMetaStore::update_docid_string(DocId lid, std::string_view docid) {
 
     if (_store_full_document_id) {
         auto&      metadata = _metadataStore[lid];
-        const auto new_ref = _docid_store.add(docid);
+        const auto new_ref = add_docid_string(docid);
         const auto old_ref = metadata.get_relaxed_docid_ref();
         metadata.set_docid_ref(new_ref);
-        if (old_ref.valid()) {
-            _docid_store.remove(old_ref);
-        }
+        remove_docid_string(old_ref);
     }
 
     return true;
@@ -642,7 +651,7 @@ bool DocumentMetaStore::remove(DocId lid, uint64_t prepare_serial_num) {
     }
     RawDocumentMetadata meta = removeInternal(lid, prepare_serial_num);
     if (_store_full_document_id) {
-        _docid_store.remove(meta.get_relaxed_docid_ref());
+        remove_docid_string(meta.get_relaxed_docid_ref());
         _metadataStore[lid].set_docid_ref(EntryRef());
     }
     _bucketDB->takeGuard()->remove(meta.getGid(), meta.getBucketId().stripUnused(), meta.getTimestamp(),
@@ -724,7 +733,7 @@ void DocumentMetaStore::removeBatch(const std::vector<DocId>& lidsToRemove, cons
         assert(validLid(lid));
         removed.emplace_back(lid, _metadataStore[lid]);
         if (_store_full_document_id) {
-            _docid_store.remove(removed.back().second.get_relaxed_docid_ref());
+            remove_docid_string(removed.back().second.get_relaxed_docid_ref());
             _metadataStore[lid].set_docid_ref(EntryRef());
         }
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -164,7 +164,8 @@ public:
     using Iterator = TreeType::Iterator;
     using ConstIterator = TreeType::ConstIterator;
     static constexpr size_t minHeaderLen = 0x1000;
-    static constexpr size_t min_entry_size = sizeof(uint32_t) + GlobalId::LENGTH + sizeof(uint8_t) + sizeof(Timestamp);
+    static constexpr size_t min_entry_size =
+        sizeof(uint32_t) + GlobalId::LENGTH + sizeof(uint8_t) + sizeof(Timestamp);
     static constexpr size_t entry_size(bool track_document_sizes) {
         return min_entry_size + (track_document_sizes ? 3 : 0);
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -83,6 +83,7 @@ private:
     MetadataStore                   _metadataStore;
     DocumentIdStore                 _docid_store;
     uint64_t                        _docid_bytes;
+    std::atomic<uint64_t>           _docid_bytes_stats; // Atomic mirror of _docid_bytes
     TreeType                        _gidToLidMap;
     Iterator                        _gid_to_lid_map_write_itr; // Iterator used for all updates of _gidToLidMap
     SerialNum                       _gid_to_lid_map_write_itr_prepare_serial_num;
@@ -112,6 +113,8 @@ private:
     void compact_docid_store();
     void onCommit() override;
     void onUpdateStat(CommitParam::UpdateStats updateStats) override;
+    void update_docid_bytes_stats() { _docid_bytes_stats.store(_docid_bytes, std::memory_order_relaxed); }
+    uint64_t get_docid_bytes_stats() const noexcept { return _docid_bytes_stats.load(std::memory_order_relaxed); }
 
     // Implements AttributeVector
     void before_inc_generation(vespalib::Generation current_gen) override;

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -82,6 +82,7 @@ private:
 
     MetadataStore                   _metadataStore;
     DocumentIdStore                 _docid_store;
+    uint64_t                        _docid_bytes;
     TreeType                        _gidToLidMap;
     Iterator                        _gid_to_lid_map_write_itr; // Iterator used for all updates of _gidToLidMap
     SerialNum                       _gid_to_lid_map_write_itr_prepare_serial_num;
@@ -101,6 +102,11 @@ private:
     void insert(documentmetastore::GidToLidMapKey key, const RawDocumentMetadata& metadata);
 
     const GlobalId& getRawGid(DocId lid) const { return getRawMetadata(lid).getGid(); }
+
+    // Add document id string to _docid_store and update _docid_bytes
+    DocumentIdEntryRef add_docid_string(std::span<const char> docid);
+    // Remove document id string from _docid_store and update _docid_bytes
+    void remove_docid_string(DocumentIdEntryRef ref);
 
     bool consider_compact_gid_to_lid_map();
     void compact_docid_store();


### PR DESCRIPTION
Includes a formatting fix as a free bonus. :)