### PR TITLE
use recursive lambda to constrain node types

### DIFF
--- a/streamingvisitors/src/vespa/searchvisitor/matching_elements_filler.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/matching_elements_filler.cpp
@@ -72,7 +72,7 @@ class Matcher {
         return matching_elements_field(field_id) != nullptr;
     };
     [[nodiscard]] bool has_matching_elements_field(QueryTerm& term) const;
-    [[nodiscard]] bool has_matching_elements_field_below_near(QueryNode& query_node) const;
+    [[nodiscard]] bool has_matching_elements_field(NearQueryNode& near) const;
     void select_multiterm_children(const MultiTerm& multi_term);
     void select_near_query_node(NearQueryNode& near);
     void select_query_term_node(QueryTerm& term);
@@ -138,21 +138,24 @@ bool Matcher::has_matching_elements_field(QueryTerm& term) const {
     return false;
 }
 
-bool Matcher::has_matching_elements_field_below_near(QueryNode& query_node) const {
-    if (as<SameElementQueryNode>(query_node) != nullptr) {
-        return false;
-    } else if (auto query_term = as<QueryTerm>(query_node)) {
-        return has_matching_elements_field(*query_term);
-    } else if (auto and_not = as<AndNotQueryNode>(query_node)) {
-        return has_matching_elements_field_below_near(*(*and_not)[0]);
-    } else if (auto intermediate = as<QueryConnector>(query_node)) {
-        for (size_t i = 0; i < intermediate->size(); ++i) {
-            if (has_matching_elements_field_below_near(*(*intermediate)[i])) {
-                return true;
+bool Matcher::has_matching_elements_field(NearQueryNode& near) const {
+    auto check = [&](auto&& self, QueryNode &query_node){
+        if (as<SameElementQueryNode>(query_node) != nullptr) {
+            return false;
+        } else if (auto query_term = as<QueryTerm>(query_node)) {
+            return has_matching_elements_field(*query_term);
+        } else if (auto and_not = as<AndNotQueryNode>(query_node)) {
+            return self(self, *(*and_not)[0]);
+        } else if (auto intermediate = as<QueryConnector>(query_node)) {
+            for (size_t i = 0; i < intermediate->size(); ++i) {
+                if (self(self, (*(*intermediate)[i]))) {
+                    return true;
+                }
             }
         }
-    }
-    return false;
+        return false;
+    };
+    return check(check, near);
 }
 
 void Matcher::select_multiterm_children(const MultiTerm& multi_term) {
@@ -172,7 +175,7 @@ void Matcher::select_multiterm_children(const MultiTerm& multi_term) {
 }
 
 void Matcher::select_near_query_node(NearQueryNode& near_query_node) {
-    if (has_matching_elements_field_below_near(near_query_node)) {
+    if (has_matching_elements_field(near_query_node)) {
         _near_query_nodes.emplace_back(&near_query_node);
     }
 }


### PR DESCRIPTION
auto-deducing self is available from c++23 so we need to pass it for now.

@toregge please review
@vekterli @arnej27959 FYI