### PR TITLE
Sanitize DocumentStore automatically if needed to fill in missing document ids

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -560,6 +560,7 @@ TEST(DocumentMetaStoreTest, gids_can_be_saved_and_loaded) {
 
     DocumentMetaStore dms2(createBucketDB(), "documentmetastore2");
     EXPECT_TRUE(dms2.load());
+    EXPECT_FALSE(dms2.requires_document_ids_from_docstore());
     dms2.constructFreeList();
     EXPECT_EQ(numLids + 1, dms2.getNumDocs());
     EXPECT_EQ(numLids - 4, dms2.getNumUsedLids()); // 4 removed
@@ -613,6 +614,7 @@ TEST(DocumentMetaStoreTest, bucket_used_bits_are_lbounded_at_load_time) {
 
     DocumentMetaStore dms2(createBucketDB(), "documentmetastore2");
     ASSERT_TRUE(dms2.load());
+    EXPECT_FALSE(dms2.requires_document_ids_from_docstore());
     ASSERT_EQ(dms2.getNumDocs(), 2); // Incl. zero LID
 
     BucketId expected_bucket(storage::spi::BucketLimits::MinUsedBits, gid.convertToBucketId().getRawId());
@@ -1905,6 +1907,7 @@ TEST(DocumentMetaStoreTest, document_sizes_are_saved) {
 
     DocumentMetaStore dms3(createBucketDB(), "documentmetastore3");
     EXPECT_TRUE(dms3.load());
+    EXPECT_FALSE(dms3.requires_document_ids_from_docstore());
     dms3.constructFreeList();
     assertSize(dms3, 1, 100);
     assertSize(dms3, 2, 10000);
@@ -1912,6 +1915,7 @@ TEST(DocumentMetaStoreTest, document_sizes_are_saved) {
 
     DocumentMetaStore dms4(createBucketDB(), "documentmetastore4");
     EXPECT_TRUE(dms4.load());
+    EXPECT_FALSE(dms4.requires_document_ids_from_docstore());
     dms4.constructFreeList();
     assertSize(dms4, 1, 1);
     assertSize(dms4, 2, 1);
@@ -1936,6 +1940,7 @@ TEST(DocumentMetaStoreTest, full_document_ids_are_saved) {
                                         SubDbType::READY);
     EXPECT_TRUE(dms_loaded_docids.load());
     dms_loaded_docids.constructFreeList();
+    EXPECT_FALSE(dms_loaded_docids.requires_document_ids_from_docstore());
 
     auto d1 = createDocId(1);
     EXPECT_EQ(d1.toString(), dms_loaded_docids.get_docid_string(d1.getGlobalId()));
@@ -1975,6 +1980,28 @@ TEST(DocumentMetaStoreTest, full_document_ids_are_considered_in_estimated_save_b
                                         createDocId(1).toString().length() + replaced_docid.length() +
                                         createDocId(4).toString().length();
     EXPECT_EQ(expected_save_bytes_size, dms.getEstimatedSaveByteSize());
+}
+
+TEST(DocumentMetaStoreTest, dms_complains_about_missing_document_ids) {
+    // DocumentMetaStore not storing full document ids
+    DocumentMetaStore dms(createBucketDB(), "documentmetastore6", search::GrowStrategy(), false, SubDbType::READY);
+    dms.constructFreeList();
+    addLid(dms, 1);
+
+    TuneFileAttributes      tuneFileAttributes;
+    DummyFileHeaderContext  fileHeaderContext;
+    AttributeFileSaveTarget saveTarget(tuneFileAttributes, fileHeaderContext);
+    EXPECT_TRUE(dms.save(saveTarget, "documentmetastore6"));
+
+    // DocumentMetaStore storing full document ids
+    DocumentMetaStore dms_loaded(createBucketDB(), "documentmetastore6", search::GrowStrategy(), true,
+                                 SubDbType::READY);
+
+    // Cannot load document ids since there is no file with them
+    EXPECT_TRUE(dms_loaded.load());
+    EXPECT_TRUE(dms_loaded.requires_document_ids_from_docstore());
+
+    std::filesystem::remove(std::filesystem::path("documentmetastore6.dat"));
 }
 
 namespace {

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -357,6 +357,7 @@ bool DocumentMetaStore::onLoad(vespalib::Executor*) {
 
     // insert gids (already sorted)
     if (numElems > 0) {
+        _requires_document_ids_from_docstore = _store_full_document_id && !docid_reader;
         DocId                      lid = readNextDoc(reader, docid_reader.get(), treeBuilder);
         const RawDocumentMetadata* meta = &_metadataStore[lid];
         BucketId                   prevId(meta->getBucketId());
@@ -493,7 +494,8 @@ DocumentMetaStore::DocumentMetaStore(BucketDBOwnerSP bucketDB, const std::string
       _changesSinceCommit(0),
       _op_listener(),
       _should_compact_gid_to_lid_map(false),
-      _store_full_document_id(store_full_document_id) {
+      _store_full_document_id(store_full_document_id),
+      _requires_document_ids_from_docstore(false) {
     ensureSpace(0);                       // lid 0 is reserved
     setCommittedDocIdLimit(1u);           // lid 0 is reserved
     _gidToLidMap.getAllocator().freeze(); // create initial frozen tree

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -96,6 +96,7 @@ private:
     OperationListenerSP             _op_listener;
     bool                            _should_compact_gid_to_lid_map;
     bool                            _store_full_document_id;
+    bool                            _requires_document_ids_from_docstore;
 
     DocId getFreeLid();
     DocId peekFreeLid();
@@ -302,6 +303,14 @@ public:
     make_sort_blob_writer(bool ascending, const search::common::BlobConverter* converter,
                           search::common::sortspec::MissingPolicy policy,
                           std::string_view                        missing_value) const override;
+
+    /*
+     * Returns true if this DocumentMetaStore is supposed to store document id strings,
+     * has some documents, but misses their document ids.
+     * This signalizes that the docstore has to be validated after replay to fill in the missing document ids.
+     * This method continues to return true after the validation, which can be ignored.
+     */
+    bool requires_document_ids_from_docstore() const noexcept { return _requires_document_ids_from_docstore; }
 
     vespalib::MemoryUsage get_docid_memory_usage() const { return _docid_store.getMemoryUsage(); };
     vespalib::MemoryUsage get_gid_to_lid_map_memory_usage() const { return _gidToLidMap.getMemoryUsage(); };

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -613,7 +613,7 @@ void DocumentDB::onTransactionLogReplayDone() {
         // must signal that all existing buckets must be checked.
         notifyAllBucketsChanged();
     }
-    if (_validateAndSanitizeDocStore) {
+    if (_validateAndSanitizeDocStore || _subDBs.requires_doc_store_validation()) {
         LOG(info, "Validating documentdb %s", getName().c_str());
         SerialNum serialNum = _feedHandler->getSerialNum();
         sync(serialNum);

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
@@ -287,6 +287,15 @@ void DocumentSubDBCollection::validateDocStore(FeedHandler& feedHandler, SerialN
     }
 }
 
+bool DocumentSubDBCollection::requires_doc_store_validation() const {
+    for (auto subDb : _subDBs) {
+        if (subDb->requires_doc_store_validation()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 ResourceUsage DocumentSubDBCollection::get_resource_usage() const {
     ResourceUsage resource_usage;
     for (auto subDb : _subDBs) {

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
@@ -163,6 +163,11 @@ public:
     void close();
     void tearDownReferences(IDocumentDBReferenceResolver& resolver);
     void validateDocStore(FeedHandler& feedHandler, SerialNum serialNum);
+
+    /*
+     * Signalizes if one of the SubDBs requires a DocumentStore validation after replay.
+     */
+    bool requires_doc_store_validation() const;
     searchcorespi::common::ResourceUsage get_resource_usage() const;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/idocumentsubdb.h
@@ -144,6 +144,11 @@ public:
     virtual void validateDocStore(FeedHandler& op, SerialNum serialNum) const = 0;
     virtual PendingLidTrackerBase& getUncommittedLidsTracker() = 0;
     virtual searchcorespi::common::ResourceUsage get_resource_usage() const = 0;
+
+    /*
+     * Signalizes if a DocumentStore validation is needed after replay.
+     */
+    virtual bool requires_doc_store_validation() const = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -51,6 +51,7 @@ public:
 
     ~DocSubDB() override = default;
     void close() override {}
+    bool requires_doc_store_validation() const override { return false; }
 };
 
 /**
@@ -238,6 +239,9 @@ public:
     computeCompactionStrategy(vespalib::datastore::CompactionStrategy strategy) const;
     bool is_node_retired_or_maintenance() const { return _node_retired_or_maintenance; }
     searchcorespi::common::ResourceUsage get_resource_usage() const override;
+    bool requires_doc_store_validation() const override {
+        return _dms && _dms->requires_document_ids_from_docstore();
+    }
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_document_sub_db.h
@@ -85,6 +85,7 @@ struct DummyDocumentSubDb : public IDocumentSubDB {
 
     void tearDownReferences(IDocumentDBReferenceResolver&) override {}
     searchcorespi::common::ResourceUsage get_resource_usage() const override;
+    bool requires_doc_store_validation() const override { return false; }
 };
 
 } // namespace proton::test


### PR DESCRIPTION
Comes with a unit test for `DocumentMetaStore`. Not sure if I should add unit tests for the methods in `DocumentSubDBCollection` and `StoreOnlyDocSubDB`. 🤔 