### PR TITLE
Add flag for legacy query stack format

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1432,6 +1432,7 @@
       "public boolean useLegacyWandQueryParsing()",
       "public boolean useSimpleAnnotations()",
       "public boolean sendProtobufQuerytree()",
+      "public boolean sendOldQueryStack()",
       "public boolean forwardAllLogLevels()",
       "public long zookeeperPreAllocSize()",
       "public int maxContentNodeMaintenanceOpConcurrency()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -77,7 +77,7 @@ public interface ModelContext {
      *   default method with the `removeAfter` set beyond the Vespa version to be released.
      *
      * 3)
-     *  - Remove the default method in FeatureFlags once the oldest config model in use are beyond the `removeAfter` 
+     *  - Remove the default method in FeatureFlags once the oldest config model in use are beyond the `removeAfter`
      */
     interface FeatureFlags {
         @ModelFeatureFlag(owners = {"hakonhall"}) default boolean useNonPublicEndpointForTest() { return false; }
@@ -114,7 +114,8 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"arnej"}) default double clusterControllerNodeMemory() { return 0.0; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean useLegacyWandQueryParsing() { return true; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean useSimpleAnnotations() { return true; }
-        @ModelFeatureFlag(owners = {"arnej"}) default boolean sendProtobufQuerytree() { return true; }
+        @ModelFeatureFlag(owners = {"arnej"}, removeAfter = "8.687") default boolean sendProtobufQuerytree() { return true; }
+        @ModelFeatureFlag(owners = {"arnej"}) default boolean sendOldQueryStack() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean forwardAllLogLevels() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxContentNodeMaintenanceOpConcurrency() { return -1; }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -248,6 +248,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean useLegacyWandQueryParsing() { return flag(Flags.USE_LEGACY_WAND_QUERY_PARSING).value(); }
         @Override public boolean useSimpleAnnotations() { return flag(Flags.USE_SIMPLE_ANNOTATIONS).value(); }
         @Override public boolean sendProtobufQuerytree() { return true; }
+        @Override public boolean sendOldQueryStack() { return flag(Flags.SEND_OLD_QUERY_STACK).value(); }
         @Override public boolean forwardAllLogLevels() { return flag(PermanentFlags.FORWARD_ALL_LOG_LEVELS).value(); }
         @Override public long zookeeperPreAllocSize() { return flag(PermanentFlags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(PermanentFlags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }

--- a/container-disc/src/main/resources/configdefinitions/container.qr-searchers.def
+++ b/container-disc/src/main/resources/configdefinitions/container.qr-searchers.def
@@ -82,5 +82,8 @@ parserSettings.keepSegmentAnds bool default=false
 ## keep ideographic comma and full stop (default: replace with space)
 parserSettings.keepIdeographicPunctuation bool default=false
 
-## send query tree as protobuf in addition to legacy format
+## send query tree as protobuf (ignored, always true)
 sendProtobufQuerytree bool default=true
+
+## send query stack in legacy format in addition to protobuf format
+sendOldQueryStack bool default=false

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -321,7 +321,7 @@ public class Flags {
     public static final UnboundBooleanFlag APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG = defineFeatureFlag(
             "apply-on-restart-for-application-metadata-config", false,
             List.of("glebashnik"), "2026-02-13", "2026-08-13",
-            "Whether to set applyOnRestart flag on ApplicationMetadataConfig. " + 
+            "Whether to set applyOnRestart flag on ApplicationMetadataConfig. " +
                     "This might fix deferring config changes until container restart.",
             "Takes effect at redeployment",
             INSTANCE_ID
@@ -347,6 +347,13 @@ public class Flags {
             "Whether to skip autoscaling when config server upgrades or downgrades.",
             "Takes effect immediately",
             HOSTNAME);
+    public static final UnboundBooleanFlag SEND_OLD_QUERY_STACK = defineFeatureFlag(
+            "send-old-query-stack", false,
+            List.of("arnej"), "2026-05-07", "2026-09-01",
+            "If true, send the old query stack format in addition to protobuf serialization.",
+            "Takes effect at redeployment",
+            TENANT_ID, APPLICATION, INSTANCE_ID);
+
 
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,


### PR DESCRIPTION
The query tree is now always sent in protobuf format: sendProtobufQuerytree is hardcoded to true in ModelContextImpl and marked removeAfter="8.687" for future cleanup. The new send-old-query-stack flag (default false) re-enables sending the old query stack wire format alongside protobuf when needed, serving as a per-tenant/application rollback mechanism if backends are found to have trouble with protobuf-only input.

Note: actually checking the flag will be a separate PR
