### PR TITLE
Use only four bytes for document-id length in file

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -1971,7 +1971,7 @@ TEST(DocumentMetaStoreTest, full_document_ids_are_considered_in_estimated_save_b
     dms.commit(CommitParam::UpdateStats::FORCE);
 
     uint64_t expected_save_bytes_size = DocumentMetaStore::minHeaderLen + 3 * DocumentMetaStore::entry_size(true) +
-                                        DocumentMetaStore::minHeaderLen + 3 * sizeof(size_t) +
+                                        DocumentMetaStore::minHeaderLen + 3 * sizeof(uint32_t) +
                                         createDocId(1).toString().length() + replaced_docid.length() +
                                         createDocId(4).toString().length();
     EXPECT_EQ(expected_save_bytes_size, dms.getEstimatedSaveByteSize());

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
@@ -35,8 +35,10 @@ public:
         const RawDocumentMetadata& metadata = _metadata_view[lid];
         auto                       docid_ref = metadata.acquire_docid_ref();
         assert(docid_ref.valid());
-        auto     span = _docid_store.get(docid_ref);
-        uint32_t size = span.size(); // Document ids have a maximum length of 0x10000, so 4 bytes are enough
+        auto span = _docid_store.get(docid_ref);
+        assert(span.size() <= std::numeric_limits<uint32_t>::max()); // Document ids have a maximum length of 0x10000,
+                                                                     // so 4 bytes are enough
+        uint32_t size = span.size();
         _writer.write(&size, sizeof(size));
         _writer.write(span.data(), size);
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
@@ -35,8 +35,8 @@ public:
         const RawDocumentMetadata& metadata = _metadata_view[lid];
         auto                       docid_ref = metadata.acquire_docid_ref();
         assert(docid_ref.valid());
-        auto   span = _docid_store.get(docid_ref);
-        size_t size = span.size();
+        auto     span = _docid_store.get(docid_ref);
+        uint32_t size = span.size(); // Document ids have a maximum length of 0x10000, so 4 bytes are enough
         _writer.write(&size, sizeof(size));
         _writer.write(span.data(), size);
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -137,17 +137,17 @@ Reader::~Reader() = default;
  **/
 class DocIdReader {
 private:
-    FileWithHeader     _docid_file;
-    FileReader<size_t> _length_reader;
-    FileReader<char>   _char_reader;
-    std::vector<char>  _docid_buffer;
+    FileWithHeader       _docid_file;
+    FileReader<uint32_t> _length_reader;
+    FileReader<char>     _char_reader;
+    std::vector<char>    _docid_buffer;
 
 public:
     explicit DocIdReader(std::unique_ptr<FastOS_FileInterface> docid_file);
     ~DocIdReader();
 
     std::span<const char> get_next_docid() {
-        size_t length = _length_reader.readHostOrder();
+        uint32_t length = _length_reader.readHostOrder();
         _docid_buffer.reserve(length);
         _char_reader.readNHostOrder(_docid_buffer.data(), length);
         return {_docid_buffer.data(), length};
@@ -1098,7 +1098,7 @@ uint64_t DocumentMetaStore::getEstimatedSaveByteSize() const {
     uint32_t numDocs = getNumUsedLids();
     uint64_t estimate = minHeaderLen + numDocs * entry_size(_trackDocumentSizes);
     if (_store_full_document_id) {
-        estimate += minHeaderLen + numDocs * sizeof(size_t) + get_docid_bytes_stats();
+        estimate += minHeaderLen + numDocs * sizeof(uint32_t) + get_docid_bytes_stats();
     }
     return estimate;
 }


### PR DESCRIPTION
Use four instead of eight bytes when storing document ids from `DocumentMetaStore` in a file. Document ids cannot be longer than `0x10000` (as per the Java code). I added an assertion for `std::numeric_limits<uint32_t>::max()` since I did not want to hardcode that limit here.