### PR TITLE
add Java section

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,5 @@
+---
+Language: Cpp
 AccessModifierOffset: -4
 ColumnLimit: 118
 IndentWidth: 4
@@ -56,3 +58,11 @@ IncludeCategories:
 ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
+---
+Language: Java
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 118
+BreakAfterJavaFieldAnnotations: true
+SortJavaStaticImport: After
+---


### PR DESCRIPTION
By accident I ran clang-format on some java files and got lots of large changes, as it would use the C++ settings.  Add a minimal "standard" Java setup which is much closer to our existing code style; I will probably use this style for new Java code that I write.  Only impacts people likely to use clang-format.