### PR TITLE
Always return a non-empty az

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
@@ -46,7 +46,7 @@ public final class ClusterSpec {
         this.zoneEndpoint = Objects.requireNonNull(zoneEndpoint);
         this.stateful = stateful;
         this.sidecars = sidecars;
-        this.availabilityZones = availabilityZones;
+        this.availabilityZones = availabilityZones.isEmpty() ? List.of(AzName.unspecified()) : availabilityZones;
         this.profile = profile;
     }
 
@@ -85,7 +85,7 @@ public final class ClusterSpec {
 
     /**
      * Returns the availability zones this cluster should run across.
-     * An empty list means the zone-default placement.
+     * This may contain the single unspecified AzName, but is never empty.
      */
     public List<AzName> availabilityZones() { return availabilityZones; }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
@@ -110,9 +110,7 @@ public class AllocatedHostsSerializer {
             if (!sidecars.isEmpty())
                 sidecarsToSlime(sidecars, object.setArray(sidecarsKey));
 
-            var availabilityZones = membership.cluster().availabilityZones();
-            if (!availabilityZones.isEmpty())
-                availabilityZonesToSlime(availabilityZones, object.setArray(availabilityZonesKey));
+            availabilityZonesToSlime(membership.cluster().availabilityZones(), object.setArray(availabilityZonesKey));
         });
         toSlime(host.realResources(), object.setObject(realResourcesKey));
         toSlime(host.advertisedResources(), object.setObject(advertisedResourcesKey));


### PR DESCRIPTION
Avoid any ambiguity between empty AZ list and List.of(AzName.unspecified())

@hakonhall or @evgiz 