### PR TITLE
upgrade io.projectreactor:reactor-core to 3.8.5

### DIFF
--- a/container-disc/src/main/java/org/jspecify/annotations/package-info.java
+++ b/container-disc/src/main/java/org/jspecify/annotations/package-info.java
@@ -1,0 +1,6 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Exports packages from io.modelcontextprotocol.sdk:mcp - https://github.com/modelcontextprotocol/java-sdk
+@ExportPackage
+package org.jspecify.annotations;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -153,6 +153,7 @@
         <protobuf.vespa.version>3.25.5</protobuf.vespa.version>
         <questdb.vespa.version>7.4.2</questdb.vespa.version>
         <re2j.vespa.version>1.8</re2j.vespa.version>
+        <reactor-core.vespa.version>3.8.5</reactor-core.vespa.version>
         <spifly.vespa.version>1.3.7</spifly.vespa.version>
         <snappy.vespa.version>1.1.10.8</snappy.vespa.version>
         <snakeyaml.vespa.version>2.4</snakeyaml.vespa.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -859,6 +859,11 @@
                 <version>${dropwizard.metrics.vespa.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${reactor-core.vespa.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
                 <version>${netty.vespa.version}</version>

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -85,7 +85,7 @@ io.netty:netty-transport-native-epoll:${netty.vespa.version}:linux-x86_64
 io.netty:netty-transport-native-unix-common:${netty.vespa.version}
 io.netty:netty-transport:${netty.vespa.version}
 io.perfmark:perfmark-api:0.27.0
-io.projectreactor:reactor-core:3.7.0
+io.projectreactor:reactor-core:${reactor-core.vespa.version}
 io.prometheus:simpleclient:${prometheus.client.vespa.version}
 io.prometheus:simpleclient_common:${prometheus.client.vespa.version}
 io.prometheus:simpleclient_tracer_common:${prometheus.client.vespa.version}
@@ -193,6 +193,7 @@ org.jetbrains.kotlin:kotlin-stdlib:${kotlin.vespa.version}
 org.jetbrains.kotlin:kotlin-stdlib:2.1.10
 org.jetbrains:annotations:17.0.0
 org.json:json:${org.json.vespa.version}
+org.jspecify:jspecify:1.0.0
 org.junit.jupiter:junit-jupiter-api:${junit.vespa.tenant.version}
 org.junit.jupiter:junit-jupiter-api:${junit.vespa.version}
 org.junit.jupiter:junit-jupiter-engine:${junit.vespa.tenant.version}


### PR DESCRIPTION
now requires org.jspecify:jspecify; note we must
export the org.jspecify.annotations package as well.

Note 1:
probably requires a PR in the other repo to sync the version.

Note 2: 
This package is a dependency via io.modelcontextprotocol.sdk:mcp in container-disc.
mcp-sdk.vespa.version is 0.11.2, but there seem to exist many newer versions:
https://central.sonatype.com/artifact/io.modelcontextprotocol.sdk/mcp/versions