### PR TITLE
Create http client once and close in deconstruct()

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,15 +55,14 @@ public class ConfigStateChecker extends AbstractComponent {
     private final ExecutorService responseHandlerExecutor =
             Executors.newSingleThreadExecutor(new DaemonThreadFactory("config-state-checker-response-handler-"));
     private final CloseableHttpAsyncClient client = createHttpClient();
-
-    public ConfigStateChecker() {
-        client.start();
-    }
+    private final AtomicBoolean clientStarted = new AtomicBoolean(false);
 
     /**
      * Fetch service config states for a list of services (in parallel).
      */
     public Map<ServiceInfo, ServiceConfigState> getServiceConfigStates(List<ServiceInfo> services, Duration timeout) {
+        startClientIfNotStarted();
+
         List<CompletableFuture<Void>> inprogressRequests = new ArrayList<>();
         ConcurrentMap<ServiceInfo, ServiceConfigState> temporaryResult = new ConcurrentHashMap<>();
         for (ServiceInfo service : services) {
@@ -127,6 +127,12 @@ public class ConfigStateChecker extends AbstractComponent {
         return responsePromise.thenApplyAsync(
                 response -> handleResponse(response, serviceName),
                 responseHandlerExecutor);
+    }
+
+    private void startClientIfNotStarted() {
+        if (clientStarted.compareAndSet(false, true)) {
+            client.start();
+        }
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigStateChecker.java
@@ -53,47 +53,46 @@ public class ConfigStateChecker extends AbstractComponent {
 
     private final ExecutorService responseHandlerExecutor =
             Executors.newSingleThreadExecutor(new DaemonThreadFactory("config-state-checker-response-handler-"));
+    private final CloseableHttpAsyncClient client = createHttpClient();
+
+    public ConfigStateChecker() {
+        client.start();
+    }
 
     /**
      * Fetch service config states for a list of services (in parallel).
      */
     public Map<ServiceInfo, ServiceConfigState> getServiceConfigStates(List<ServiceInfo> services, Duration timeout) {
-        try (CloseableHttpAsyncClient client = createHttpClient()) {
-            client.start();
-            List<CompletableFuture<Void>> inprogressRequests = new ArrayList<>();
-            ConcurrentMap<ServiceInfo, ServiceConfigState> temporaryResult = new ConcurrentHashMap<>();
-            for (ServiceInfo service : services) {
-                int statePort = getStatePort(service).orElse(0);
-                if (statePort <= 0) continue;
-                URI uri = URI.create("http://" + service.getHostName() + ":" + statePort);
-                String serviceName = service.getServiceName();
-                CompletableFuture<Void> inprogressRequest = getServiceConfigState(client, uri, serviceName, timeout)
-                        .handle((result, error) -> {
-                            if (result != null) {
-                                temporaryResult.put(service, result);
-                            } else {
-                                log.log(
-                                        FINE,
-                                        error,
-                                        () -> Text.format(
-                                                "Failed to retrieve service config state for '%s': %s",
-                                                service, error.getMessage()));
-                                temporaryResult.put(service, new ServiceConfigState(
-                                        serviceName,
-                                        -1L,
-                                        Optional.empty()));
-                            }
-                            return null;
-                        });
-                inprogressRequests.add(inprogressRequest);
-            }
-            CompletableFuture.allOf(inprogressRequests.toArray(CompletableFuture[]::new))
-                    .join();
-            return createMapOrderedByServiceList(services, temporaryResult);
-        } catch (IOException e) {
-            // Actual client implementation does not throw IOException on close()
-            throw new UncheckedIOException(e);
+        List<CompletableFuture<Void>> inprogressRequests = new ArrayList<>();
+        ConcurrentMap<ServiceInfo, ServiceConfigState> temporaryResult = new ConcurrentHashMap<>();
+        for (ServiceInfo service : services) {
+            int statePort = getStatePort(service).orElse(0);
+            if (statePort <= 0) continue;
+            URI uri = URI.create("http://" + service.getHostName() + ":" + statePort);
+            String serviceName = service.getServiceName();
+            CompletableFuture<Void> inprogressRequest = getServiceConfigState(client, uri, serviceName, timeout)
+                    .handle((result, error) -> {
+                        if (result != null) {
+                            temporaryResult.put(service, result);
+                        } else {
+                            log.log(
+                                    FINE,
+                                    error,
+                                    () -> Text.format(
+                                            "Failed to retrieve service config state for '%s': %s",
+                                            service, error.getMessage()));
+                            temporaryResult.put(service, new ServiceConfigState(
+                                    serviceName,
+                                    -1L,
+                                    Optional.empty()));
+                        }
+                        return null;
+                    });
+            inprogressRequests.add(inprogressRequest);
         }
+        CompletableFuture.allOf(inprogressRequests.toArray(CompletableFuture[]::new))
+                         .join();
+        return createMapOrderedByServiceList(services, temporaryResult);
     }
 
     /**
@@ -138,6 +137,13 @@ public class ConfigStateChecker extends AbstractComponent {
         } catch (InterruptedException e) {
             log.log(Level.WARNING, "Unable to shutdown executor", e);
         }
+
+        try {
+            client.close();
+        } catch (IOException e) {
+            log.log(Level.WARNING, "Unable to shutdown http client", e);
+        }
+
     }
 
     static ServiceConfigState handleResponse(SimpleHttpResponse response, String serviceName) throws UncheckedIOException {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ConfigStateCheckerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ConfigStateCheckerTest.java
@@ -12,6 +12,7 @@ import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.vespa.config.server.ServerCache;
 import com.yahoo.vespa.config.server.monitoring.MetricUpdater;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,6 +71,13 @@ public class ConfigStateCheckerTest {
         application = new Application(
                 mockModel, new ServerCache(), 3, new Version(0, 0, 0), MetricUpdater.createTestUpdater(), appId);
         checker = new ConfigStateChecker();
+    }
+
+    @After
+    public void tearDown() {
+        if (checker != null) {
+            checker.deconstruct();
+        }
     }
 
     @Test


### PR DESCRIPTION
* Seems like this client could live for the lifetime of the component, instead of being created for each invocation of getServiceConfigStates() Seeing some errors that are probably related to closing this client before network IO is finished, or related to shutdown