### PR TITLE
Add global DataPond and populate it

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/data_pond.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/data_pond.h
@@ -129,7 +129,7 @@ class DataPond {
     std::vector<Record> _records;
 
 public:
-    const std::vector<Record>& records() { return _records; }
+    const std::vector<Record>& records() const { return _records; }
 
     Record& new_record() {
         _records.emplace_back();

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -1180,16 +1180,16 @@ static std::string smoke_test_filter = "--gtest_filter="
                                        ":IteratorBenchmark.analyze_AND_plan_variants_ENN";
 
 int main(int argc, char** argv) {
-    bool dump_pond = false;
+    bool opt_dump_pond = false;
     for (int i = 0; i < argc; i++) {
         std::string_view smoke_test{"--smoke-test"};
         if (smoke_test == argv[i]) {
             std::println(stderr, "Adding --smoke-test filter");
             argv[i] = smoke_test_filter.data();
         }
-        std::string_view dump_pond_{"--dump-pond"};
-        if (dump_pond_ == argv[i]) {
-            dump_pond = true;
+        std::string_view dump_pond_flag{"--dump-pond"};
+        if (dump_pond_flag == argv[i]) {
+            opt_dump_pond = true;
         }
     }
     ::testing::InitGoogleTest(&argc, argv);
@@ -1198,7 +1198,7 @@ int main(int argc, char** argv) {
         global_summary.calc_calibration();
         print_summary(global_summary);
     }
-    if (dump_pond) {
+    if (opt_dump_pond) {
         dump_pond(global_pond);
     }
     return res;

--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -596,6 +596,12 @@ void print_summary(const BenchmarkSummary& summary) {
     }
 }
 
+void dump_pond(const DataPond& pond) {
+    for (const auto& rec : pond.records()) {
+        std::println(stderr, "{}", rec.to_string());
+    }
+}
+
 struct BenchmarkCaseSetup {
     uint32_t              num_docs;
     BenchmarkCase         bcase;
@@ -671,6 +677,41 @@ struct BenchmarkSetup {
 
 BenchmarkSetup::~BenchmarkSetup() = default;
 
+BenchmarkSummary global_summary;
+DataPond         global_pond;
+
+std::string current_test_name() {
+    if (auto* info = ::testing::UnitTest::GetInstance()->current_test_info()) {
+        return info->name();
+    }
+    return "";
+}
+
+void add_to_pond(DataPond& pond, const BenchmarkCaseSetup& setup, const BenchmarkResult& res, double op_hit_ratio,
+                 uint32_t children, double filter_hit_ratio, PlanningAlgo algo) {
+    Record record;
+    record.set("actual_cost", res.actual_cost);
+    record.set("algo", to_string(algo));
+    record.set("blueprint_name", res.blueprint_name);
+    record.set("children", static_cast<int64_t>(children));
+    record.set("cost", res.flow.cost);
+    record.set("estimate", res.flow.estimate);
+    record.set("field_cfg", setup.bcase.field_cfg.to_string());
+    record.set("filter_hit_ratio", filter_hit_ratio);
+    record.set("force_strict", setup.bcase.force_strict);
+    record.set("group", current_test_name());
+    record.set("hits", static_cast<int64_t>(res.hits));
+    record.set("iterator_name", res.iterator_name);
+    record.set("op_hit_ratio", op_hit_ratio);
+    record.set("query_op", to_string(setup.bcase.query_op));
+    record.set("seeks", static_cast<int64_t>(res.seeks));
+    record.set("strict_context", setup.bcase.strict_context);
+    record.set("strict_cost", res.flow.strict_cost);
+    record.set("time_ms", res.time_ms);
+    record.set("unpack", setup.bcase.unpack_iterator);
+    pond.add(record);
+}
+
 BenchmarkCaseResult run_benchmark_case(const BenchmarkCaseSetup& setup) {
     BenchmarkCaseResult result;
     std::cout << "-------- run_benchmark_case: " << setup.bcase.to_string() << " --------" << std::endl;
@@ -688,6 +729,8 @@ BenchmarkCaseResult run_benchmark_case(const BenchmarkCaseSetup& setup) {
                     print_result(res, children, op_hit_ratio, InFlow(setup.bcase.strict_context, filter_hit_ratio),
                                  setup.num_docs);
                     result.add(res);
+                    add_to_pond(global_pond, setup, res, op_hit_ratio, children, filter_hit_ratio,
+                                PlanningAlgo::Cost);
                 }
             }
         }
@@ -695,8 +738,6 @@ BenchmarkCaseResult run_benchmark_case(const BenchmarkCaseSetup& setup) {
     print_result(result);
     return result;
 }
-
-BenchmarkSummary global_summary;
 
 void run_benchmarks(const BenchmarkSetup& setup, BenchmarkSummary& summary) {
     for (const auto& field_cfg : setup.field_cfgs) {
@@ -1139,11 +1180,16 @@ static std::string smoke_test_filter = "--gtest_filter="
                                        ":IteratorBenchmark.analyze_AND_plan_variants_ENN";
 
 int main(int argc, char** argv) {
+    bool dump_pond = false;
     for (int i = 0; i < argc; i++) {
         std::string_view smoke_test{"--smoke-test"};
         if (smoke_test == argv[i]) {
             std::println(stderr, "Adding --smoke-test filter");
             argv[i] = smoke_test_filter.data();
+        }
+        std::string_view dump_pond_{"--dump-pond"};
+        if (dump_pond_ == argv[i]) {
+            dump_pond = true;
         }
     }
     ::testing::InitGoogleTest(&argc, argv);
@@ -1151,6 +1197,9 @@ int main(int argc, char** argv) {
     if (!global_summary.empty()) {
         global_summary.calc_calibration();
         print_summary(global_summary);
+    }
+    if (dump_pond) {
+        dump_pond(global_pond);
     }
     return res;
 }


### PR DESCRIPTION
Only for `run_benchmark_case`.

Example:
```
Record{actual_cost: 0.019928115509676665, algo: 'cost', blueprint_name: 'OrBlueprint', children: 2, cost: 0.41596239840376015, estimate: 0.009951616507326566, field_cfg: 'int32(fs)', filter_hit_ratio: 1, force_strict: false, group: 'analyze_OR_strict', hits: 99765, iterator_name: 'StrictHeapOrSearch<()::FullUnpack, LeftArrayHeap, unsigned char>', op_hit_ratio: 0.01, query_op: 'Or', seeks: 99766, strict_context: true, strict_cost: 0.019928115509676665, time_ms: 0.778417, unpack: false}
```

@havardpe please review