### PR TITLE
Return empty response for getting logs if node has reccently been dep…

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
@@ -35,22 +35,22 @@ public class LogRetriever {
     /**
      * Fetches logs from the log server for a given application.
      * An empty response will be returned if we are unable to fetch logs and
-     * the deployment is less than 5 minutes old OR we get UnknownHostException
+     * the deployment is less than 10 minutes old OR we get an exception related to DNS or
+     * communication with the node
      */
     @SuppressWarnings("deprecation")
     public HttpResponse getLogs(HttpURL logServerUri, Optional<Instant> deployTime) {
         HttpGet get = new HttpGet(logServerUri.asURI());
         try {
             return new ProxyResponse(httpClient.execute(get));
-        } catch (NoRouteToHostException | UnknownHostException | SocketTimeoutException e) {
-            // Application has been deleted or a real DNS issue or host not up yet, either way it's not
-            // an internal server error and client should just retry
-            log.log(INFO, "Communication with host " + logServerUri.asURI().getHost() + " failed when getting logs (" +
-                    e.getClass().getName() + ", returning empty response");
-            return new EmptyResponse();
         } catch (IOException ioe) {
-            if (deployTime.isPresent() && Instant.now().isBefore(deployTime.get().plus(Duration.ofMinutes(5))))
+            if (deployTime.isPresent() && Instant.now().isBefore(deployTime.get().plus(Duration.ofMinutes(10)))) {
+                // Application has been deleted or a real DNS issue or host not up yet, either way it's not
+                // an internal server error and client should just retry
+                log.log(INFO, "Communication with host " + logServerUri.asURI().getHost() + " failed when getting logs (" +
+                        ioe.getClass().getName() + ", returning empty response");
                 return new EmptyResponse();
+            }
 
             return new HttpErrorResponse(500, HttpErrorResponse.ErrorCode.INTERNAL_SERVER_ERROR.name(),
                                          "Failed to retrieve logs from log server (" + ioe.getClass().getName() + "): " + ioe.getMessage());


### PR DESCRIPTION
…loyed

Consider all io exceptions and don't return 500 internal server error unless there has been at least 10 minutes since last deployment. We are still getting a lot of noise related to this