### PR TITLE
Thomasht86/allow uppercase resourcetag values

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -26,8 +26,8 @@ public class CloudResourceTags {
     /** Keys must start with a lowercase letter (GCP requirement) and contain only [a-z0-9_-]. */
     private static final Pattern VALID_KEY_PATTERN = Pattern.compile("[a-z][a-z0-9_-]*");
 
-    /** Values may only contain lowercase alphanumeric characters, hyphens and underscores. */
-    private static final Pattern VALID_VALUE_PATTERN = Pattern.compile("[a-z0-9_-]+");
+    /** Values may contain alphanumeric characters (upper- or lowercase), hyphens and underscores. */
+    private static final Pattern VALID_VALUE_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
 
     /** Pattern for template variables, e.g. ${environment}, ${region}. */
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\$\\{[^}]+\\}");
@@ -152,7 +152,7 @@ public class CloudResourceTags {
             String strippedValue = TEMPLATE_VARIABLE.matcher(value).replaceAll("");
             if ( ! strippedValue.isEmpty() && ! VALID_VALUE_PATTERN.matcher(strippedValue).matches())
                 throw new IllegalArgumentException("Tag value contains invalid characters for key '" + key +
-                                                   "'. Only [a-z0-9_-] and template variables like ${environment} are allowed");
+                                                   "'. Only [A-Za-z0-9_-] and template variables like ${environment} are allowed");
             for (String reserved : RESERVED_TAG_NAMES) {
                 if (key.equals(reserved))
                     throw new IllegalArgumentException("Tag key '" + key + "' is reserved by the platform");

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -134,7 +134,17 @@ class CloudResourceTagsTest {
     @Test
     void value_with_invalid_characters_rejected() {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "My Value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "VALUE")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "value.with.dots")));
+    }
+
+    @Test
+    void value_uppercase_values_accepted() {
+        var tags = CloudResourceTags.from(Map.of(
+                "component", "ABCZ",
+                "mixed", "MyValue-1"
+        ));
+        assertEquals("ABCZ", tags.asMap().get("component"));
+        assertEquals("MyValue-1", tags.asMap().get("mixed"));
     }
 
     @Test
@@ -178,9 +188,13 @@ class CloudResourceTagsTest {
     @Test
     void template_variables_with_invalid_literal_parts_rejected() {
         assertThrows(IllegalArgumentException.class,
-                     () -> CloudResourceTags.from(Map.of("env", "UPPER${environment}")));
-        assertThrows(IllegalArgumentException.class,
                      () -> CloudResourceTags.from(Map.of("env", "${environment} space")));
+    }
+
+    @Test
+    void template_variables_mixed_with_uppercase_literals_accepted() {
+        var tags = CloudResourceTags.from(Map.of("env", "UPPER${environment}"));
+        assertEquals("UPPER${environment}", tags.asMap().get("env"));
     }
 
     @Test


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Customer has tag system with uppercase tag values which is difficult to change. 
GCP [disallows uppercase values](https://docs.cloud.google.com/resource-manager/docs/best-practices-labels#example_labels_table) so this needs cloud repo PR to handle that separately.  