### PR TITLE
Check vector sizes in `NumericFunctionNode::handle`

### DIFF
--- a/searchlib/src/vespa/searchlib/expression/numericfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/numericfunctionnode.cpp
@@ -72,12 +72,16 @@ template <typename T> void NumericFunctionNode::VectorHandler<T>::handle(const R
         const size_t            oldRSize(result.size());
         if (argSize > oldRSize) {
             result.resize(argSize);
-            for (size_t i(oldRSize); i < argSize; i++) {
-                result[i] = result[i % oldRSize];
+            if (oldRSize > 0) {
+                for (size_t i(oldRSize); i < argSize; i++) {
+                    result[i] = result[i % oldRSize];
+                }
             }
         }
-        for (size_t i(0), m(result.size()), isize(argSize); i < m; i++) {
-            function().executeIterative(av.get(i % isize), result[i]);
+        if (argSize > 0) {
+            for (size_t i(0), m(result.size()), isize(argSize); i < m; i++) {
+                function().executeIterative(av.get(i % isize), result[i]);
+            }
         }
     } else {
         for (size_t i(0), m(result.size()); i < m; i++) {


### PR DESCRIPTION
When `argSize > oldSize`, the result vector is resized to `argSize`, then existing values are repeated to fill the vector:

```
arg:    [1, 2, 3, 4, 5, 6]
result: [1, 2]

=> result = [1, 2, 1, 2, 1, 2]
 ```

such that result and arg get the same size.

The same pattern was also used when `argSize < oldSize`, but flipped where
values were read from `arg` using modulo indexing.

The bug occurred when `result` or `arg` was empty. When `result` is empty, `i % oldSize`
caused a division-by-zero error. When `arg` is empty, `i % argSize` caused a division-by-zero error.

The fix is to skip the loops where the respective size is 0.

Result: if either `result` or `arg` is empty, the non-empty vector is
preserved unchanged.

@arnej27959 please review
@toregge fyi
@bjorncs fyi