### PR TITLE
Add DocumentDB-specific Proton setting for document-id attribute

### DIFF
--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -291,6 +291,8 @@ documentdb[].configid string
 documentdb[].visibilitydelay double default=0.0
 ## Whether this document type is globally distributed or not.
 documentdb[].global bool default=false
+## Whether the full document ids are stored in memory
+documentdb[].document_id_attribute bool default=false
 
 ## Minimum initial size for any per document tables.
 documentdb[].allocation.initialnumdocs long default=1024

--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -40,9 +40,6 @@ numsummarythreads int default=16 restart
 ## Hence it must always be followed by a manual restart when enabled.
 validate_and_sanitize_docstore enum {NO, YES} default = NO
 
-## Store the full document ids in memory and not just the internal global ids.
-store_full_document_ids bool default=false
-
 ## Maximum number of concurrent flushes outstanding.
 flush.maxconcurrent int default=2 restart
 

--- a/searchcore/src/tests/proton/server/document_meta_store_config_test.cpp
+++ b/searchcore/src/tests/proton/server/document_meta_store_config_test.cpp
@@ -13,21 +13,30 @@ public:
     DocumentMetaStoreConfigTest();
     ~DocumentMetaStoreConfigTest() override;
 
+    static ProtonConfig make_default_proton_config() {
+        ProtonConfigBuilder builder;
+        return builder;
+    }
+
     static ProtonConfig make_proton_config() {
         ProtonConfigBuilder builder;
+        // First DocumentDB: false
+        builder.documentdb.emplace_back(ProtonConfigBuilder::Documentdb());
+        builder.documentdb.back().documentIdAttribute = false;
+        // Second DocumentDB: true
+        builder.documentdb.emplace_back(ProtonConfigBuilder::Documentdb());
+        builder.documentdb.back().documentIdAttribute = true;
+        // Third DocumentDB: default
+        builder.documentdb.emplace_back(ProtonConfigBuilder::Documentdb());
         return builder;
     }
 
-    static ProtonConfig make_proton_config(bool store_full_document_ids) {
-        ProtonConfigBuilder builder;
-        builder.storeFullDocumentIds = store_full_document_ids;
-        return builder;
+    static DocumentMetaStoreConfig make_default_config() {
+        return DocumentMetaStoreConfig::make(make_default_proton_config(), 0);
     }
 
-    static DocumentMetaStoreConfig make_config() { return DocumentMetaStoreConfig::make(make_proton_config()); }
-
-    static DocumentMetaStoreConfig make_config(bool store_full_document_ids) {
-        return DocumentMetaStoreConfig::make(make_proton_config(store_full_document_ids));
+    static DocumentMetaStoreConfig make_config(bool document_id_attribute) {
+        return DocumentMetaStoreConfig::make(make_proton_config(), document_id_attribute);
     }
 
 protected:
@@ -42,23 +51,30 @@ DocumentMetaStoreConfigTest::DocumentMetaStoreConfigTest()
 DocumentMetaStoreConfigTest::~DocumentMetaStoreConfigTest() = default;
 
 TEST_F(DocumentMetaStoreConfigTest, require_that_store_full_document_ids_default_is_false) {
-    EXPECT_EQ(false, DocumentMetaStoreConfig::make().store_full_document_ids());
-    EXPECT_EQ(false, make_config().store_full_document_ids()); // From default ProtonConfig
+    // Without ProtonConfig
+    EXPECT_FALSE(DocumentMetaStoreConfig::make().store_full_document_ids());
+    // Default ProtonConfig
+    EXPECT_FALSE(DocumentMetaStoreConfig::make(make_default_proton_config(), 0).store_full_document_ids());
+    // Default from ProtonConfigBuilder::Documentdb()
+    EXPECT_FALSE(DocumentMetaStoreConfig::make(make_proton_config(), 2).store_full_document_ids());
+    // With present settings but invalid index
+    ASSERT_LE(make_proton_config().documentdb.size(), 3);
+    EXPECT_FALSE(DocumentMetaStoreConfig::make(make_proton_config(), 3).store_full_document_ids());
 }
 
 TEST_F(DocumentMetaStoreConfigTest, require_that_store_full_document_ids_report_works) {
-    EXPECT_EQ(true, make_config(true).store_full_document_ids());
-    EXPECT_EQ(false, make_config(false).store_full_document_ids());
+    EXPECT_TRUE(make_config(true).store_full_document_ids());
+    EXPECT_FALSE(make_config(false).store_full_document_ids());
 }
 
 TEST_F(DocumentMetaStoreConfigTest, require_that_updating_works) {
-    auto config = make_config();
+    auto config = make_default_config();
 
-    EXPECT_EQ(false, config.store_full_document_ids());
+    EXPECT_FALSE(config.store_full_document_ids());
     config.update(config_true);
-    EXPECT_EQ(true, config.store_full_document_ids());
+    EXPECT_TRUE(config.store_full_document_ids());
     config.update(config_false);
-    EXPECT_EQ(false, config.store_full_document_ids());
+    EXPECT_FALSE(config.store_full_document_ids());
 }
 
 TEST_F(DocumentMetaStoreConfigTest, require_that_comparison_works) {

--- a/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.cpp
@@ -10,8 +10,12 @@ DocumentMetaStoreConfig::DocumentMetaStoreConfig(bool store_full_document_ids)
     : _store_full_document_ids(store_full_document_ids) {
 }
 
-DocumentMetaStoreConfig DocumentMetaStoreConfig::make(const ProtonConfig& cfg) {
-    return {cfg.storeFullDocumentIds};
+DocumentMetaStoreConfig DocumentMetaStoreConfig::make(const ProtonConfig& cfg, uint32_t document_db_index) {
+    if (document_db_index < cfg.documentdb.size()) {
+        return {cfg.documentdb[document_db_index].documentIdAttribute};
+    }
+
+    return make();
 }
 
 DocumentMetaStoreConfig DocumentMetaStoreConfig::make() {

--- a/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_meta_store_config.h
@@ -3,6 +3,8 @@
 
 #include <vespa/config-proton.h>
 
+#include <cstdint>
+
 namespace vespa::config::search::core::internal {
 class InternalProtonType;
 }
@@ -22,7 +24,7 @@ private:
     DocumentMetaStoreConfig(bool store_full_document_ids);
 
 public:
-    static DocumentMetaStoreConfig make(const ProtonConfig& cfg);
+    static DocumentMetaStoreConfig make(const ProtonConfig& cfg, uint32_t document_db_index);
     static DocumentMetaStoreConfig make();
     void update(const DocumentMetaStoreConfig& cfg);
     bool store_full_document_ids() const { return _store_full_document_ids; }

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -84,20 +84,28 @@ std::shared_ptr<const Schema> DocumentDBConfigManager::buildSchema(const Attribu
 
 namespace {
 
-DocumentDBMaintenanceConfig::SP buildMaintenanceConfig(const BootstrapConfig::SP& bootstrapConfig,
-                                                       const std::string&         docTypeName) {
+// Use document type to find document db config in proton config
+uint32_t find_document_db_index(const BootstrapConfig::SP& bootstrapConfig, const std::string& doc_type_name) {
+    using DdbConfig = ProtonConfig::Documentdb;
+    ProtonConfig& proton(bootstrapConfig->getProtonConfig());
+
+    uint32_t index;
+    for (index = 0; index < proton.documentdb.size(); ++index) {
+        const DdbConfig& ddbConfig = proton.documentdb[index];
+        if (doc_type_name == ddbConfig.inputdoctypename)
+            break;
+    }
+
+    return index;
+}
+
+DocumentDBMaintenanceConfig::SP buildMaintenanceConfig(const BootstrapConfig::SP& bootstrapConfig, uint32_t index) {
     using DdbConfig = ProtonConfig::Documentdb;
     ProtonConfig& proton(bootstrapConfig->getProtonConfig());
 
     vespalib::duration visibilityDelay = vespalib::duration::zero();
     bool               isDocumentTypeGlobal = false;
-    // Use document type to find document db config in proton config
-    uint32_t index;
-    for (index = 0; index < proton.documentdb.size(); ++index) {
-        const DdbConfig& ddbConfig = proton.documentdb[index];
-        if (docTypeName == ddbConfig.inputdoctypename)
-            break;
-    }
+
     vespalib::duration pruneRemovedDocumentsAge = vespalib::from_s(proton.pruneremoveddocumentsage);
     vespalib::duration pruneRemovedDocumentsInterval = (proton.pruneremoveddocumentsinterval == 0)
                                                            ? (pruneRemovedDocumentsAge / 100)
@@ -317,8 +325,9 @@ void DocumentDBConfigManager::update(FNET_Transport& transport, const ConfigSnap
     JuniperrcConfigSP      newJuniperrcConfig = snapshot.getConfig<JuniperrcConfig>(_configId);
     ImportedFieldsConfigSP newImportedFieldsConfig = snapshot.getConfig<ImportedFieldsConfig>(_configId);
 
-    auto schema(buildSchema(*newAttributesConfig, *newIndexschemaConfig));
-    newMaintenanceConfig = buildMaintenanceConfig(_bootstrapConfig, _docTypeName);
+    auto     schema(buildSchema(*newAttributesConfig, *newIndexschemaConfig));
+    uint32_t document_db_index = find_document_db_index(_bootstrapConfig, _docTypeName);
+    newMaintenanceConfig = buildMaintenanceConfig(_bootstrapConfig, document_db_index);
     search::LogDocumentStore::Config storeConfig =
         buildStoreConfig(_bootstrapConfig->getProtonConfig(), _bootstrapConfig->getHwInfo());
     if (newMaintenanceConfig && oldMaintenanceConfig && (*newMaintenanceConfig == *oldMaintenanceConfig)) {
@@ -331,7 +340,8 @@ void DocumentDBConfigManager::update(FNET_Transport& transport, const ConfigSnap
         newImportedFieldsConfig, _bootstrapConfig->getTuneFileDocumentDBSP(), schema, newMaintenanceConfig,
         storeConfig, ThreadingServiceConfig::make(_bootstrapConfig->getProtonConfig()),
         build_alloc_config(_bootstrapConfig->getHwInfo(), _bootstrapConfig->getProtonConfig(), _docTypeName),
-        DocumentMetaStoreConfig::make(_bootstrapConfig->getProtonConfig()), _configId, _docTypeName);
+        DocumentMetaStoreConfig::make(_bootstrapConfig->getProtonConfig(), document_db_index), _configId,
+        _docTypeName);
     assert(newSnapshot->valid());
     {
         std::lock_guard<std::mutex> lock(_pendingConfigMutex);


### PR DESCRIPTION
Removes the old setting `store_full_document_ids` and adds a new DocumentDB-specific setting `document_id_attribute`.