### PR TITLE
Add findCause overload to optionally find root cause

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -4007,6 +4007,7 @@
       "public void <init>()",
       "public static java.lang.String toMessageString(java.lang.Throwable)",
       "public static java.util.Optional findCause(java.lang.Throwable, java.lang.Class)",
+      "public static java.util.Optional findRootCause(java.lang.Throwable, java.lang.Class)",
       "public static void uncheck(com.yahoo.yolean.Exceptions$RunnableThrowingIOException)",
       "public static varargs void uncheck(com.yahoo.yolean.Exceptions$RunnableThrowingIOException, java.lang.String, java.lang.String[])",
       "public static void uncheckAndIgnore(com.yahoo.yolean.Exceptions$RunnableThrowingIOException, java.lang.Class)",

--- a/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
@@ -54,12 +54,31 @@ public class Exceptions {
      * Returns the first cause or the given throwable that is an instance of {@code clazz}
      */
     public static <T extends Throwable> Optional<T> findCause(Throwable t, Class<T> clazz) {
-        for (; t != null; t = t.getCause()) {
-            if (clazz.isInstance(t))
-                return Optional.of(clazz.cast(t));
-        }
-        return Optional.empty();
+        return findCause(t, clazz, false);
     }
+
+    /**
+    * Returns the root/innermost cause or the given throwable that is an instance of {@code clazz}
+    */
+    public static <T extends Throwable> Optional<T> findRootCause(Throwable t, Class<T> clazz) {
+        return findCause(t, clazz, true);
+    }
+
+    /**
+     * Returns the cause of a given throwable that is an instance of {@code clazz}.
+     * When {@code findRootCause} is false, the first cause found is returned. Otherwise, the root/innermost cause found is returned.
+     */
+    private static <T extends Throwable> Optional<T> findCause(Throwable t, Class<T> clazz, boolean findRootCause) {
+        T found = null;
+        for (; t != null; t = t.getCause()) {
+            if (clazz.isInstance(t)) {
+                found = clazz.cast(t);
+                if (!findRootCause) break;
+            }
+        }
+        return Optional.ofNullable(found);
+    }
+
 
     @FunctionalInterface
     public interface RunnableThrowingIOException {

--- a/vespajlib/src/test/java/com/yahoo/yolean/ExceptionsTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/yolean/ExceptionsTestCase.java
@@ -31,6 +31,19 @@ public class ExceptionsTestCase {
     }
 
     @Test
+    public void testFindRootCause() {
+        IllegalArgumentException root = new IllegalArgumentException("root");
+        IllegalStateException innerState = new IllegalStateException("inner-state", root);
+        RuntimeException middle = new RuntimeException("middle", innerState);
+        IllegalStateException outerState = new IllegalStateException("outer-state", middle);
+
+        assertEquals(Optional.of(outerState), Exceptions.findCause(outerState, IllegalStateException.class));
+        assertEquals(Optional.of(innerState), Exceptions.findRootCause(outerState, IllegalStateException.class));
+        assertEquals(Optional.of(root), Exceptions.findRootCause(outerState, IllegalArgumentException.class));
+        assertEquals(Optional.empty(), Exceptions.findRootCause(outerState, NumberFormatException.class));
+    }
+
+    @Test
     public void testToMessageStrings() {
         assertEquals("Blah",Exceptions.toMessageString(new Exception("Blah")));
         assertEquals("Blah", Exceptions.toMessageString(new Exception(new Exception("Blah"))));


### PR DESCRIPTION
## What
- Add `Exceptions.findCause(t, clazz, findRootCause)` overload that can return the innermost matching cause instead of the first.

## Why
- Allow callers to retrieve the root cause of a specific type when nested exceptions of the same class are present.