### PR TITLE
Fix combining of vectors with different lengths

### DIFF
--- a/searchlib/src/tests/aggregator/perdocexpr_test.cpp
+++ b/searchlib/src/tests/aggregator/perdocexpr_test.cpp
@@ -1211,8 +1211,8 @@ TEST(PerDocExprTest, testArithmeticOperations) {
         r[2] = a[2] + b[2];
         r[3] = a[3] + b[3];
         r[4] = a[4] + b[4];
-        r[5] = a[0] + b[5];
-        r[6] = a[1] + b[6];
+        r[5] = b[5];
+        r[6] = b[6];
         AddFunctionNode f;
         testArithmeticArguments(f, a, b, r, a[0] + a[1] + a[2] + a[3] + a[4]);
     }
@@ -1222,8 +1222,8 @@ TEST(PerDocExprTest, testArithmeticOperations) {
         r[2] = a[2] * b[2];
         r[3] = a[3] * b[3];
         r[4] = a[4] * b[4];
-        r[5] = a[0] * b[5];
-        r[6] = a[1] * b[6];
+        r[5] = b[5];
+        r[6] = b[6];
         MultiplyFunctionNode f;
         testArithmeticArguments(f, a, b, r, a[0] * a[1] * a[2] * a[3] * a[4]);
     }

--- a/searchlib/src/vespa/searchlib/expression/numericfunctionnode.cpp
+++ b/searchlib/src/vespa/searchlib/expression/numericfunctionnode.cpp
@@ -66,25 +66,22 @@ void NumericFunctionNode::onCalculate(const ExpressionNodeVector& args, ResultNo
 
 template <typename T> void NumericFunctionNode::VectorHandler<T>::handle(const ResultNode& arg) {
     typename T::Vector& result = _result.getVector();
+    const size_t        old_res_sz = result.size();
     if (arg.getClass().inherits(ResultNodeVector::classId)) {
-        const ResultNodeVector& av = static_cast<const ResultNodeVector&>(arg);
-        const size_t            argSize(av.size());
-        const size_t            oldRSize(result.size());
-        if (argSize > oldRSize) {
+        const auto&  av = static_cast<const ResultNodeVector&>(arg);
+        const size_t argSize = av.size();
+        if (argSize > old_res_sz) {
             result.resize(argSize);
-            if (oldRSize > 0) {
-                for (size_t i(oldRSize); i < argSize; i++) {
-                    result[i] = result[i % oldRSize];
-                }
+            for (size_t i = old_res_sz; i < argSize; i++) {
+                result[i].set(av.get(i));
             }
         }
-        if (argSize > 0) {
-            for (size_t i(0), m(result.size()), isize(argSize); i < m; i++) {
-                function().executeIterative(av.get(i % isize), result[i]);
-            }
+        size_t m = std::min(argSize, old_res_sz);
+        for (size_t i = 0; i < m; i++) {
+            function().executeIterative(av.get(i), result[i]);
         }
     } else {
-        for (size_t i(0), m(result.size()); i < m; i++) {
+        for (size_t i = 0; i < old_res_sz; i++) {
             function().executeIterative(arg, result[i]);
         }
     }


### PR DESCRIPTION
VectorHandler previously used modular (wrap-around) indexing when the argument vector was shorter than the accumulated result. This caused surprising and asymmetrical behavior.

The fix applies the operation only to the overlapping positions (the minimum of the two sizes) and copies remaining elements from the longer vector unchanged. This gives consistent, intuitive results for unequal-length vector operands.
