### PR TITLE
Add document-id setting to schema

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/Schema.java
+++ b/config-model/src/main/java/com/yahoo/schema/Schema.java
@@ -63,6 +63,8 @@ public class Schema implements ImmutableSchema {
     /** True if this doesn't define a search, just a document type */
     private final boolean documentsOnly;
 
+    private Boolean documentIdAttribute = null;
+
     private Boolean rawAsBase64 = null;
 
     private Stemming stemming = null;
@@ -175,6 +177,19 @@ public class Schema implements ImmutableSchema {
     public Optional<Schema> inherited() {
         return inherited.map(name -> owner.schemas().get(name));
     }
+
+    /**
+     * Returns true if document ids should be stored in an implicit attribute
+     *
+     * @return true if document ids should be stored in an implicit attribute
+     */
+    public boolean documentIdAttributeEnabled() {
+        if (documentIdAttribute != null) return documentIdAttribute;
+        if (inherited.isEmpty()) return false;
+        return requireInherited().documentIdAttributeEnabled();
+    }
+
+    public void enableDocumentIdAttribute(boolean value) { documentIdAttribute = value; }
 
     /**
      * Returns true if 'raw' fields shall be presented as base64 in summary

--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedSchemas.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedSchemas.java
@@ -280,6 +280,7 @@ public class ConvertParsedSchemas {
         if (parsed.hasStemming()) {
             schema.setStemming(parsed.getStemming());
         }
+        parsed.getDocumentIdAttribute().ifPresent(schema::enableDocumentIdAttribute);
         parsed.getRawAsBase64().ifPresent(value -> schema.enableRawAsBase64(value));
         var typeContext = typeConverter.makeContext(parsed.getDocument());
         var sfResolver = new SummaryFieldTypeResolver(schema, parsed.getDocumentSummaries());

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedSchema.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedSchema.java
@@ -35,6 +35,7 @@ public class ParsedSchema extends ParsedBlock {
     }
 
     private boolean documentWithoutSchema = false;
+    private Boolean documentIdAttribute = null;
     private Boolean rawAsBase64 = null;
     private ParsedDocument myDocument = null;
     private Stemming defaultStemming = null;
@@ -58,6 +59,7 @@ public class ParsedSchema extends ParsedBlock {
     }
 
     boolean getDocumentWithoutSchema() { return documentWithoutSchema; }
+    Optional<Boolean> getDocumentIdAttribute() { return Optional.ofNullable(documentIdAttribute); }
     Optional<Boolean> getRawAsBase64() { return Optional.ofNullable(rawAsBase64); }
     boolean hasDocument() { return myDocument != null; }
     ParsedDocument getDocument() { return myDocument; }
@@ -143,6 +145,10 @@ public class ParsedSchema extends ParsedBlock {
         String sName = struct.name();
         verifyThat(! extraStructs.containsKey(sName), "already has struct", sName);
         extraStructs.put(sName, struct);
+    }
+
+    public void enableDocumentIdAttribute(boolean value) {
+        this.documentIdAttribute = value;
     }
 
     public void enableRawAsBase64(boolean value) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -209,6 +209,14 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
         return !hasIndexingModeStreaming(type) && !hasIndexingModeIndexed(type);
     }
 
+    private boolean hasDocumentIdAttributeEnabled(NewDocumentType type) {
+        if (searchCluster == null) return false;
+        var schemaInfo = searchCluster.schemas().get(type.getName());
+        if (schemaInfo == null) return false;
+        var schema = schemaInfo.fullSchema();
+        return (schema != null) && (schema.documentIdAttributeEnabled());
+    }
+
     @Override
     public void getConfig(ProtonConfig.Builder builder) {
         boolean hasAnyNonIndexedSchema = false;
@@ -219,7 +227,8 @@ public class ContentSearchCluster extends TreeConfigProducer<AnyConfigProducer> 
             ddbB.inputdoctypename(docTypeName)
                 .configid(getConfigId())
                 .visibilitydelay(visibilityDelay)
-                .global(globalDocType);
+                .global(globalDocType)
+                .document_id_attribute(hasDocumentIdAttributeEnabled(type));
 
             if (hasIndexingModeStreaming(type)) {
                 hasAnyNonIndexedSchema = true;

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -166,6 +166,7 @@ TOKEN :
 | < AS: "as" >
 | < INDEXING: "indexing" >
 | < SUMMARY_TO: "summary-to" >
+| < DOCUMENT_ID: "document-id" >
 | < DOCUMENT_SUMMARY: "document-summary" >
 | < ELEMENT_GAP: "element-gap" >
 | < INFINITY: "infinity" >
@@ -431,6 +432,7 @@ ParsedSchema rootSchema() :
 void rootSchemaItem(ParsedSchema schema) : { }
 {
     ( document(schema)
+      | documentId(schema)
       | rawAsBase64(schema)
       | searchStemming(schema)
       | importField(schema)
@@ -1527,6 +1529,23 @@ void id(ParsedField field) :
     <ID> <COLON> fieldId = integer()
     {
         field.setId(fieldId);
+    }
+}
+
+/**
+ * Consumes the document-id setting.
+ *
+ * @param schema the schema object to add setting to
+ */
+void documentId(ParsedSchema schema) :
+{
+    boolean attribute = false;
+}
+{
+    <DOCUMENT_ID>
+    <COLON> ( ( <ATTRIBUTE> { attribute = true; } ) | ( <FROM_DISK> { attribute = false; } ) )
+    {
+        schema.enableDocumentIdAttribute(attribute);
     }
 }
 
@@ -2909,6 +2928,7 @@ String identifierWithDash() :
     | <CUTOFF_STRATEGY>
     | <DENSE_POSTING_LIST_THRESHOLD>
     | <DISTANCE_METRIC>
+    | <DOCUMENT_ID>
     | <DOCUMENT_SUMMARY>
     | <ELEMENT_GAP>
     | <ENABLE_BIT_VECTORS>

--- a/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
@@ -978,6 +978,43 @@ public class SchemaTestCase {
         assertTrue(schemaInfoConfig.contains("totalMatchPhaseMaxHits 4567"));
     }
 
+    @Test
+    void testDocumentIdAttributeToSchema() throws Exception {
+        String schema_default =
+                """
+                schema doc {
+                    document doc {
+                    }
+                }""";
+        assertFalse(documentIdAttributeEnabled(schema_default));
+
+        String schema_fromdisk =
+                """
+                schema doc {
+                    document-id: from-disk
+                    document doc {
+                    }
+                }""";
+        assertFalse(documentIdAttributeEnabled(schema_fromdisk));
+
+        String schema_attribute =
+                """
+                schema doc {
+                    document-id: attribute
+                    document doc {
+                    }
+                }""";
+        assertTrue(documentIdAttributeEnabled(schema_attribute));
+    }
+
+    private boolean documentIdAttributeEnabled(String schema_string) throws Exception {
+        ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+        builder.addSchema(schema_string);
+        var application = builder.build(true);
+        var schema = application.schemas().get("doc");
+        return schema.documentIdAttributeEnabled();
+    }
+
     private void assertInheritedFromParent(Schema schema, RankProfileRegistry rankProfileRegistry) {
         assertEquals("pf1", schema.fieldSets().userFieldSets().get("parent_set").getFieldNames().stream().findFirst().get());
         assertEquals(Stemming.NONE, schema.getStemming());

--- a/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
@@ -357,6 +357,7 @@ public class SchemaTestCase {
                         "    summary pf1 {}" +
                         "  }" +
                         "  import field parentschema_ref.name as parent_imported {}" +
+                        "  document-id: attribute" +
                         "  raw-as-base64-in-summary" +
                         "}");
         String childLines = joinLines(
@@ -994,6 +995,7 @@ public class SchemaTestCase {
         assertNotNull(schema.getExplicitSummaryField("pf1"));
         assertNotNull(schema.getUniqueNamedSummaryFields().get("pf1"));
         assertNotNull(schema.temporaryImportedFields().get().fields().get("parent_imported"));
+        assertTrue(schema.documentIdAttributeEnabled());
         assertTrue(schema.isRawAsBase64());
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -226,6 +226,54 @@ public class ContentClusterTest extends ContentBaseTest {
     }
 
     @Test
+    void testSchemaDocumentIdAttributeSettingIsPropagated() {
+        String schema_fromdisk =
+                """
+                schema type1 {
+                    document-id: from-disk
+                    document type1 {
+                    }
+                }""";
+        String schema_attribute =
+                """
+                schema type2 {
+                    document-id: attribute
+                    document type2 {
+                    }
+                }""";
+
+        String xml = "<?xml version='1.0' encoding='UTF-8' ?>" +
+                "<services version='1.0'>" +
+                "  <container id='default' version='1.0'>" +
+                "    <search/>" +
+                "  </container>" +
+                "  <content id='search' version='1.0'>" +
+                "    <redundancy>1</redundancy>" +
+                "    <documents>" +
+                "      <document type='type1' mode='index'/>" +
+                "      <document type='type2' mode='index'/>" +
+                "    </documents>" +
+                "  </content>" +
+                "</services>";
+
+        List<String> sds = List.of(schema_fromdisk, schema_attribute);
+        VespaModel model = new VespaModelCreatorWithMockPkg(null, xml, sds).create();
+        ContentCluster cc = model.getContentClusters().get("search");
+
+        ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
+        cc.getSearch().getConfig(protonBuilder);
+        ProtonConfig protonConfig = new ProtonConfig(protonBuilder);
+
+        var foo_documentdb = protonConfig.documentdb().get(0);
+        assertEquals("type1", foo_documentdb.inputdoctypename());
+        assertFalse(foo_documentdb.document_id_attribute());
+
+        var bar_documentdb = protonConfig.documentdb().get(1);
+        assertEquals("type2", bar_documentdb.inputdoctypename());
+        assertTrue(bar_documentdb.document_id_attribute());
+    }
+
+    @Test
     void pseudo_row_column_distribution_setting_is_propagated_to_distribution_config() {
         ContentCluster cc = parse("""
               <content version="1.0" id="storage">


### PR DESCRIPTION
Still have to add the setting to the remaining parsers and adapt the document-summary warning. Will do that in a separate PR.