### PR TITLE
Add Jetty HTTP compliance violation metric to infrastructure metric set

### DIFF
--- a/metrics/src/main/java/ai/vespa/metrics/set/InfrastructureMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/InfrastructureMetricSet.java
@@ -150,6 +150,7 @@ public class InfrastructureMetricSet {
         addMetric(metrics, ContainerMetrics.SERVER_NUM_REQUESTS.count());
         addMetric(metrics, ContainerMetrics.SERVER_STARTED_MILLIS.max());
         addMetric(metrics, ContainerMetrics.JDISC_HTTP_LATENCY.max());
+        addMetric(metrics, ContainerMetrics.JETTY_HTTP_COMPLIANCE_VIOLATION.count());
 
         return metrics;
     }


### PR DESCRIPTION
## Summary
- Add `jdisc.http.jetty.http_compliance.violation` to the infrastructure metric set so it is reported by configservers and controllers.