### PR TITLE
Test that Xoshiro256++ state can be deep-copied and compared

### DIFF
--- a/vespalib/src/tests/util/xoshiro_test.cpp
+++ b/vespalib/src/tests/util/xoshiro_test.cpp
@@ -1,10 +1,11 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/util/xoshiro.h>
-#include <limits>
-#include <random>
 
 #include <gmock/gmock.h>
+
+#include <limits>
+#include <random>
 
 using namespace ::testing;
 
@@ -50,8 +51,7 @@ TEST(Xoshiro256PlusPlusTest, u256_seeded_state_is_deterministic) {
     // is to seed with something that isn't completely bogus...!
     // It's probably a lot better to seed with a single low quality u64 that is
     // then splitmix64'ed into something OK than to seed with 256 bits of crap.
-    XoPrng rng(0x1111'1111'1111'1111, 0x2222'2222'2222'2222,
-               0x3333'3333'3333'3333, 0x4444'4444'4444'4444);
+    XoPrng rng(0x1111'1111'1111'1111, 0x2222'2222'2222'2222, 0x3333'3333'3333'3333, 0x4444'4444'4444'4444);
     EXPECT_EQ(rng(), 0xbbbbbbbbbbbbbbbb);
     EXPECT_EQ(rng(), 0x9999999999199999);
     EXPECT_EQ(rng(), 0x6666666665e66665);
@@ -70,6 +70,24 @@ TEST(Xoshiro256PlusPlusTest, can_be_used_with_stl_prng_statistical_distributions
         const int v = dist(rng);
         EXPECT_TRUE(v >= 0 && v <= 10) << v;
     }
+}
+
+TEST(Xoshiro256PlusPlusTest, instances_can_be_deep_copied_and_compared) {
+    XoPrng rng1(0x1337cafe), rng2(0x1337caff);
+
+    XoPrng rng1_copy(rng1);
+    auto   rng2_copy = rng2;
+
+    EXPECT_TRUE(rng1 == rng1);
+    EXPECT_TRUE(rng1_copy == rng1);
+    EXPECT_FALSE(rng1 == rng2);
+    EXPECT_TRUE(rng2_copy == rng2);
+
+    EXPECT_EQ(rng1_copy(), 0xee5d31f96adfacd);
+    EXPECT_EQ(rng2_copy(), 0x422bd9d0409b5bca);
+    // Internal state has changed
+    EXPECT_FALSE(rng1_copy == rng1);
+    EXPECT_FALSE(rng2_copy == rng2);
 }
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/xoshiro.h
+++ b/vespalib/src/vespa/vespalib/util/xoshiro.h
@@ -58,6 +58,9 @@ public:
         _s[3] = 0x5642ca7dc7c0482f;
     }
 
+    constexpr Xoshiro256PlusPlusPrng(const Xoshiro256PlusPlusPrng&) noexcept = default;
+    constexpr Xoshiro256PlusPlusPrng& operator=(const Xoshiro256PlusPlusPrng&) noexcept = default;
+
     // Explicitly 256-bit seeded PRNG. The seed parts should ideally have high
     // entropy and be statistically uncorrelated, such as from a CSPRNG source.
     constexpr Xoshiro256PlusPlusPrng(const uint64_t s0, const uint64_t s1,
@@ -102,6 +105,8 @@ public:
 
         return result;
     }
+
+    constexpr bool operator==(const Xoshiro256PlusPlusPrng&) const noexcept = default;
 
 private:
     [[nodiscard]] static constexpr uint64_t rotl(const uint64_t x, const int k) noexcept {


### PR DESCRIPTION
@havardpe please review

By copying PRNG state we can keep full PRNGs around as "seeds" without having to re-derive internal state with `splitmix64`.

Make implicit copy ctor/operator explicitly defaulted.