### PR TITLE
Warn when map field has indexed array field in value struct

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ComplexFieldsWithStructFieldIndexesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/ComplexFieldsWithStructFieldIndexesValidator.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation;
 
+import com.yahoo.document.ArrayDataType;
+import com.yahoo.document.MapDataType;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.derived.SchemaInfo;
 import com.yahoo.schema.document.ImmutableSDField;
@@ -48,6 +50,29 @@ public class ComplexFieldsWithStructFieldIndexesValidator implements Validator {
                                   "Remove setting or change to 'indexing: attribute' if needed for matching.",
                                   clusterName, schema.getName(), unsupportedFields));
         }
+        validateMapFieldsWithIndexedArraysInValueStruct(context, clusterName, schema);
+    }
+
+    private static void validateMapFieldsWithIndexedArraysInValueStruct(Context context, String clusterName, Schema schema) {
+        schema.allFields()
+              .filter(field -> !field.isImportedField())
+              .filter(field -> field.getDataType() instanceof MapDataType)
+              .forEach(field -> {
+                  var valueField = field.getStructField("value");
+                  if (valueField == null) return;
+                  var indexedArrayFields = valueField.getStructFields().stream()
+                          .filter(f -> f.getDataType() instanceof ArrayDataType && f.wasConfiguredToDoIndexing())
+                          .map(ImmutableSDField::getName)
+                          .collect(Collectors.joining(", "));
+                  if (!indexedArrayFields.isEmpty()) {
+                      context.deployState().getDeployLogger().logApplicationPackage(
+                              Level.WARNING,
+                              Text.format("For cluster '%s', schema '%s': Map field '%s' has value struct fields of array type" +
+                                          " with 'indexing: index': %s. This creates an indexed map of arrays which is not" +
+                                          " recommended. Consider removing 'index' from the array field.",
+                                          clusterName, schema.getName(), field.getName(), indexedArrayFields));
+                  }
+              });
     }
 
     private static boolean hasStructFieldsWithIndex(ImmutableSDField field) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ComplexFieldsValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ComplexFieldsValidatorTestCase.java
@@ -144,6 +144,33 @@ public class ComplexFieldsValidatorTestCase {
     }
 
     @Test
+    void logs_warning_when_map_field_has_indexed_array_in_value_struct() throws IOException, SAXException {
+        var logger = new MyLogger();
+        createModelAndValidate(joinLines(
+                "schema test {",
+                "document test {",
+                "struct output {",
+                "  field id type string {}",
+                "  field fileKey type string {}",
+                "  field directories type array<string> {}",
+                "}",
+                "field outputs type map<string, output> {",
+                "  indexing: summary",
+                "  struct-field key { indexing: attribute }",
+                "  struct-field value.id { indexing: summary | attribute }",
+                "  struct-field value.directories { indexing: summary | index }",
+                "  struct-field value.fileKey { indexing: summary }",
+                "}",
+                "}",
+                "}"), logger);
+        assertTrue(logger.message.toString().contains(
+                "For cluster 'mycluster', schema 'test': Map field 'outputs' has value struct fields" +
+                " of array type with 'indexing: index': outputs.value.directories." +
+                " This creates an indexed map of arrays which is not recommended." +
+                " Consider removing 'index' from the array field."));
+    }
+
+    @Test
     void logs_warning_when_complex_fields_have_struct_fields_with_index_and_exact_match() throws IOException, SAXException {
         var logger = new MyLogger();
         createModelAndValidate(joinLines(


### PR DESCRIPTION
## Summary
- Add `validateMapFieldsWithIndexedArraysInValueStruct()` to `ComplexFieldsWithStructFieldIndexesValidator`
- Logs a `WARNING` via `logApplicationPackage` when a `map<K, struct>` field has a value struct field of array type with `indexing: index`
- Add test case covering the pattern

## Background
When a schema defines a `map<K, struct>` where the value struct contains an `array<T>` field configured with `indexing: index`, this creates an indexed map of arrays. The configuration can be deployed but is not recommended and may not behave as expected. Previously no specific warning was emitted for this case.

## Test plan
- [x] New test `logs_warning_when_map_field_has_indexed_array_in_value_struct` passes
- [x] All existing `ComplexFieldsValidatorTestCase` tests pass

*This PR was generated with Claude Code*