### PR TITLE
fix: sort HTTP compliance violations for stable config generation

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
@@ -106,7 +106,7 @@ public class HostedSslConnectorFactory extends ConnectorFactory {
                                                             .maxSize(e.maxEntitySize.toBytes()))
                                                     .toList()))
                 .compliance(new ConnectorConfig.Compliance.Builder()
-                        .httpViolations(httpComplianceViolations))
+                        .httpViolations(httpComplianceViolations.stream().sorted().toList()))
                 .serverName.known(knownServerNames);
 
     }


### PR DESCRIPTION
- `httpComplianceViolations` is a `Set<String>` with non-deterministic iteration order, so consecutive model builds with identical input could emit `ConnectorConfig` with the violations listed in different orders.
- This triggered `Config has changed unexpectedly` warnings on config reload even though the effective configuration was unchanged.
- Sort the violations before passing them to the config builder so the serialized config is deterministic.