### PR TITLE
Support 1, 2, ... up to 5 key fields in tensorFromStructs

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -354,17 +354,21 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             }
         }
         if (reference.name().equals("tensorFromStructs")) {
-            if (reference.arguments().size() != 4) {
-                throw new IllegalArgumentException(reference + " should have 4 arguments: (attribute(myarray), mykeyfield, myvaluefield, celltype)");
+            int numArgs = reference.arguments().size();
+            if (numArgs < 4 || numArgs > 6) {
+                throw new IllegalArgumentException(reference + " should have 4-6 arguments, not " + numArgs + ": (attribute(myarray), mykeyfield1[, mykeyfield2[, mykeyfield3]], myvaluefield, celltype)");
             }
-            if (arg0 instanceof ReferenceNode arg0ref && FeatureNames.isAttributeFeature(arg0ref.reference())) {
-                dimension = String.valueOf(arg1);
-                cellType = TensorType.Value.fromId(String.valueOf(arg3));
-            } else {
+            if ( ! (arg0 instanceof ReferenceNode arg0ref && FeatureNames.isAttributeFeature(arg0ref.reference()))) {
                 throw new IllegalArgumentException("Bad first argument of " + reference.name() +
                                                    " must be an attribute feature, not " + arg0);
             }
-            return Optional.of(new TensorType.Builder(cellType).mapped(dimension).build());
+            int numKeys = numArgs - 3;
+            cellType = TensorType.Value.fromId(String.valueOf(getArgExp(reference, numArgs - 1)));
+            var builder = new TensorType.Builder(cellType);
+            for (int i = 0; i < numKeys; i++) {
+                builder.mapped(String.valueOf(getArgExp(reference, 1 + i)));
+            }
+            return Optional.of(builder.build());
         }
         if (reference.name().equals("tensorFromLabels") ||
             reference.name().equals("tensorFromWeightedSet"))

--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -355,8 +355,8 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
         }
         if (reference.name().equals("tensorFromStructs")) {
             int numArgs = reference.arguments().size();
-            if (numArgs < 4 || numArgs > 6) {
-                throw new IllegalArgumentException(reference + " should have 4-6 arguments, not " + numArgs + ": (attribute(myarray), mykeyfield1[, mykeyfield2[, mykeyfield3]], myvaluefield, celltype)");
+            if (numArgs < 4 || numArgs > 8) {
+                throw new IllegalArgumentException(reference + " should have 4-8 arguments, not " + numArgs + ": (attribute(myarray), mykeyfield1[, ...[, mykeyfield5]], myvaluefield, celltype)");
             }
             if ( ! (arg0 instanceof ReferenceNode arg0ref && FeatureNames.isAttributeFeature(arg0ref.reference()))) {
                 throw new IllegalArgumentException("Bad first argument of " + reference.name() +

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -110,6 +110,25 @@ public class BuiltInFunctions {
                 new StringArgument("key3"),
                 new StringArgument("value"),
                 new EnumArgument("type", List.of("float", "double"))
+            )),
+            new FunctionSignature(List.of(
+                new FieldArgument(FieldArgument.AnyFieldType, FieldArgument.IndexAttributeType, "attribute"),
+                new StringArgument("key1"),
+                new StringArgument("key2"),
+                new StringArgument("key3"),
+                new StringArgument("key4"),
+                new StringArgument("value"),
+                new EnumArgument("type", List.of("float", "double"))
+            )),
+            new FunctionSignature(List.of(
+                new FieldArgument(FieldArgument.AnyFieldType, FieldArgument.IndexAttributeType, "attribute"),
+                new StringArgument("key1"),
+                new StringArgument("key2"),
+                new StringArgument("key3"),
+                new StringArgument("key4"),
+                new StringArgument("key5"),
+                new StringArgument("value"),
+                new EnumArgument("type", List.of("float", "double"))
             ))
         )));
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -89,15 +89,29 @@ public class BuiltInFunctions {
         )));
 
         // TODO: requires you to write attribute(name)
-        put("tensorFromStructs", new GenericFunction("tensorFromStructs", new FunctionSignature(List.of(
-            new FieldArgument(FieldArgument.AnyFieldType, FieldArgument.IndexAttributeType, "attribute"),
-            new StringArgument("key"),
-            new StringArgument("value"),
-            new EnumArgument("type", List.of(
-                "float",
-                "double"
+        put("tensorFromStructs", new GenericFunction("tensorFromStructs", List.of(
+            new FunctionSignature(List.of(
+                new FieldArgument(FieldArgument.AnyFieldType, FieldArgument.IndexAttributeType, "attribute"),
+                new StringArgument("key"),
+                new StringArgument("value"),
+                new EnumArgument("type", List.of("float", "double"))
+            )),
+            new FunctionSignature(List.of(
+                new FieldArgument(FieldArgument.AnyFieldType, FieldArgument.IndexAttributeType, "attribute"),
+                new StringArgument("key1"),
+                new StringArgument("key2"),
+                new StringArgument("value"),
+                new EnumArgument("type", List.of("float", "double"))
+            )),
+            new FunctionSignature(List.of(
+                new FieldArgument(FieldArgument.AnyFieldType, FieldArgument.IndexAttributeType, "attribute"),
+                new StringArgument("key1"),
+                new StringArgument("key2"),
+                new StringArgument("key3"),
+                new StringArgument("value"),
+                new EnumArgument("type", List.of("float", "double"))
             ))
-        ))));
+        )));
 
         // ==== Field match features - normalized ====
         put("fieldMatch", new GenericFunction("fieldMatch", new FieldArgument(FieldType.STRING), Set.of(

--- a/searchlib/src/tests/features/tensor_from_structs/tensor_from_structs_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_structs/tensor_from_structs_test.cpp
@@ -108,6 +108,17 @@ struct ExecFixture {
         attrs.push_back(AttributeFactory::createAttribute("single.key", AVC(AVBT::STRING, AVCT::SINGLE)));
         attrs.push_back(AttributeFactory::createAttribute("single.value", AVC(AVBT::FLOAT, AVCT::SINGLE)));
 
+        // Multi-key struct array: inv.category (string), inv.brand (string), inv.sku (int32), inv.qty (float)
+        attrs.push_back(AttributeFactory::createAttribute("inv.category", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("inv.brand",    AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("inv.sku",      AVC(AVBT::INT32,  AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("inv.qty",      AVC(AVBT::FLOAT,  AVCT::ARRAY)));
+
+        // Mixed collection-type struct for negative test (one ARRAY key, one SINGLE key, ARRAY value)
+        attrs.push_back(AttributeFactory::createAttribute("mixinv.a",   AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("mixinv.b",   AVC(AVBT::STRING, AVCT::SINGLE)));
+        attrs.push_back(AttributeFactory::createAttribute("mixinv.qty", AVC(AVBT::FLOAT,  AVCT::ARRAY)));
+
         // Register attributes in index environment
         test.getIndexEnv()
             .getBuilder()
@@ -125,7 +136,14 @@ struct ExecFixture {
             .addField(FieldType::ATTRIBUTE, CollectionType::SINGLE, "single.key")
             .addField(FieldType::ATTRIBUTE, CollectionType::SINGLE, "single.value")
             .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "missing.key")
-            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "missing.value");
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "missing.value")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "inv.category")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "inv.brand")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "inv.sku")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "inv.qty")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "mixinv.a")
+            .addField(FieldType::ATTRIBUTE, CollectionType::SINGLE, "mixinv.b")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "mixinv.qty");
 
         for (const auto& attr : attrs) {
             attr->addReservedDoc();
@@ -185,12 +203,47 @@ struct ExecFixture {
         FloatingPointAttribute& singleValue = dynamic_cast<FloatingPointAttribute&>(*attrs[11]);
         singleValue.update(1, 42.5);
 
+        // Setup document 1: multi-key struct array (inv)
+        StringAttribute& invCategory = dynamic_cast<StringAttribute&>(*attrs[12]);
+        invCategory.append(1, "food", 0);
+        invCategory.append(1, "food", 0);
+        invCategory.append(1, "drink", 0);
+
+        StringAttribute& invBrand = dynamic_cast<StringAttribute&>(*attrs[13]);
+        invBrand.append(1, "acme", 0);
+        invBrand.append(1, "globex", 0);
+        invBrand.append(1, "acme", 0);
+
+        IntegerAttribute& invSku = dynamic_cast<IntegerAttribute&>(*attrs[14]);
+        invSku.append(1, 10, 0);
+        invSku.append(1, 20, 0);
+        invSku.append(1, 30, 0);
+
+        FloatingPointAttribute& invQty = dynamic_cast<FloatingPointAttribute&>(*attrs[15]);
+        invQty.append(1, 1.5, 0);
+        invQty.append(1, 2.0, 0);
+        invQty.append(1, 3.5, 0);
+
+        // Setup document 1: mixed collection-type struct (for negative test)
+        StringAttribute& mixinvA = dynamic_cast<StringAttribute&>(*attrs[16]);
+        mixinvA.append(1, "x", 0);
+
+        StringAttribute& mixinvB = dynamic_cast<StringAttribute&>(*attrs[17]);
+        mixinvB.update(1, "y");
+
+        FloatingPointAttribute& mixinvQty = dynamic_cast<FloatingPointAttribute&>(*attrs[18]);
+        mixinvQty.append(1, 9.0, 0);
+
         // Setup document 2: empty arrays
         // (no appends, so arrays remain empty)
 
         // Setup document 3: single element arrays
         itemsName.append(3, "grape", 0);
         itemsPrice.append(3, 3.5, 0);
+        invCategory.append(3, "food", 0);
+        invBrand.append(3, "acme", 0);
+        invSku.append(3, 99, 0);
+        invQty.append(3, 7.5, 0);
 
         for (const auto& attr : attrs) {
             attr->commit();
@@ -312,6 +365,65 @@ TEST(TensorFromStructsTest, require_that_double_cell_type_is_preserved) {
     ExecFixture f("tensorFromStructs(attribute(items),name,price,double)");
     const auto& result = f.execute();
     EXPECT_TRUE(result.type().to_spec().find("tensor(") == 0 || result.type().to_spec().find("tensor<double>") == 0);
+}
+
+// Tests for multi-key (2 or 3 key fields)
+
+TEST(TensorFromStructsTest, require_that_two_string_keys_create_2d_sparse_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(brand{},category{})")
+                               .add({{"category", "food"},  {"brand", "acme"}},   1.5)
+                               .add({{"category", "food"},  {"brand", "globex"}}, 2.0)
+                               .add({{"category", "drink"}, {"brand", "acme"}},   3.5)),
+              f.execute());
+}
+
+TEST(TensorFromStructsTest, require_that_string_and_integer_keys_create_2d_sparse_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(inv),category,sku,qty,float)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(category{},sku{})")
+                               .add({{"category", "food"},  {"sku", "10"}}, 1.5)
+                               .add({{"category", "food"},  {"sku", "20"}}, 2.0)
+                               .add({{"category", "drink"}, {"sku", "30"}}, 3.5)),
+              f.execute());
+}
+
+TEST(TensorFromStructsTest, require_that_three_keys_create_3d_sparse_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(inv),category,brand,sku,qty,float)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(brand{},category{},sku{})")
+                               .add({{"category", "food"},  {"brand", "acme"},   {"sku", "10"}}, 1.5)
+                               .add({{"category", "food"},  {"brand", "globex"}, {"sku", "20"}}, 2.0)
+                               .add({{"category", "drink"}, {"brand", "acme"},   {"sku", "30"}}, 3.5)),
+              f.execute());
+}
+
+TEST(TensorFromStructsTest, require_that_multi_key_dimension_order_follows_argument_order) {
+    ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
+    const auto& result = f.execute();
+    // Tensor type specs sort mapped dimensions alphabetically.
+    EXPECT_EQ("tensor<float>(brand{},category{})", result.type().to_spec());
+}
+
+TEST(TensorFromStructsTest, require_that_empty_arrays_create_empty_multi_dim_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
+    EXPECT_EQ(*make_empty("tensor<float>(brand{},category{})"), f.execute(2));
+}
+
+TEST(TensorFromStructsTest, require_that_single_element_arrays_create_single_cell_multi_dim_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(brand{},category{})")
+                               .add({{"category", "food"}, {"brand", "acme"}}, 7.5)),
+              f.execute(3));
+}
+
+TEST(TensorFromStructsTest, require_that_duplicate_key_field_name_fails_setup) {
+    SetupFixture f;
+    FTA::FT_SETUP_FAIL(f.blueprint, f.indexEnv,
+                       StringList().add("attribute(inv)").add("category").add("category").add("qty").add("float"));
+}
+
+TEST(TensorFromStructsTest, require_that_collection_type_mismatch_across_keys_creates_empty_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(mixinv),a,b,qty,float)");
+    EXPECT_EQ(*make_empty("tensor<float>(a{},b{})"), f.execute());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/features/tensor_from_structs/tensor_from_structs_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_structs/tensor_from_structs_test.cpp
@@ -110,14 +110,14 @@ struct ExecFixture {
 
         // Multi-key struct array: inv.category (string), inv.brand (string), inv.sku (int32), inv.qty (float)
         attrs.push_back(AttributeFactory::createAttribute("inv.category", AVC(AVBT::STRING, AVCT::ARRAY)));
-        attrs.push_back(AttributeFactory::createAttribute("inv.brand",    AVC(AVBT::STRING, AVCT::ARRAY)));
-        attrs.push_back(AttributeFactory::createAttribute("inv.sku",      AVC(AVBT::INT32,  AVCT::ARRAY)));
-        attrs.push_back(AttributeFactory::createAttribute("inv.qty",      AVC(AVBT::FLOAT,  AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("inv.brand", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("inv.sku", AVC(AVBT::INT32, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("inv.qty", AVC(AVBT::FLOAT, AVCT::ARRAY)));
 
         // Mixed collection-type struct for negative test (one ARRAY key, one SINGLE key, ARRAY value)
-        attrs.push_back(AttributeFactory::createAttribute("mixinv.a",   AVC(AVBT::STRING, AVCT::ARRAY)));
-        attrs.push_back(AttributeFactory::createAttribute("mixinv.b",   AVC(AVBT::STRING, AVCT::SINGLE)));
-        attrs.push_back(AttributeFactory::createAttribute("mixinv.qty", AVC(AVBT::FLOAT,  AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("mixinv.a", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("mixinv.b", AVC(AVBT::STRING, AVCT::SINGLE)));
+        attrs.push_back(AttributeFactory::createAttribute("mixinv.qty", AVC(AVBT::FLOAT, AVCT::ARRAY)));
 
         // Register attributes in index environment
         test.getIndexEnv()
@@ -372,17 +372,17 @@ TEST(TensorFromStructsTest, require_that_double_cell_type_is_preserved) {
 TEST(TensorFromStructsTest, require_that_two_string_keys_create_2d_sparse_tensor) {
     ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
     EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(brand{},category{})")
-                               .add({{"category", "food"},  {"brand", "acme"}},   1.5)
-                               .add({{"category", "food"},  {"brand", "globex"}}, 2.0)
-                               .add({{"category", "drink"}, {"brand", "acme"}},   3.5)),
+                               .add({{"category", "food"}, {"brand", "acme"}}, 1.5)
+                               .add({{"category", "food"}, {"brand", "globex"}}, 2.0)
+                               .add({{"category", "drink"}, {"brand", "acme"}}, 3.5)),
               f.execute());
 }
 
 TEST(TensorFromStructsTest, require_that_string_and_integer_keys_create_2d_sparse_tensor) {
     ExecFixture f("tensorFromStructs(attribute(inv),category,sku,qty,float)");
     EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(category{},sku{})")
-                               .add({{"category", "food"},  {"sku", "10"}}, 1.5)
-                               .add({{"category", "food"},  {"sku", "20"}}, 2.0)
+                               .add({{"category", "food"}, {"sku", "10"}}, 1.5)
+                               .add({{"category", "food"}, {"sku", "20"}}, 2.0)
                                .add({{"category", "drink"}, {"sku", "30"}}, 3.5)),
               f.execute());
 }
@@ -390,13 +390,13 @@ TEST(TensorFromStructsTest, require_that_string_and_integer_keys_create_2d_spars
 TEST(TensorFromStructsTest, require_that_three_keys_create_3d_sparse_tensor) {
     ExecFixture f("tensorFromStructs(attribute(inv),category,brand,sku,qty,float)");
     EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(brand{},category{},sku{})")
-                               .add({{"category", "food"},  {"brand", "acme"},   {"sku", "10"}}, 1.5)
-                               .add({{"category", "food"},  {"brand", "globex"}, {"sku", "20"}}, 2.0)
-                               .add({{"category", "drink"}, {"brand", "acme"},   {"sku", "30"}}, 3.5)),
+                               .add({{"category", "food"}, {"brand", "acme"}, {"sku", "10"}}, 1.5)
+                               .add({{"category", "food"}, {"brand", "globex"}, {"sku", "20"}}, 2.0)
+                               .add({{"category", "drink"}, {"brand", "acme"}, {"sku", "30"}}, 3.5)),
               f.execute());
 }
 
-TEST(TensorFromStructsTest, require_that_multi_key_dimension_order_follows_argument_order) {
+TEST(TensorFromStructsTest, require_that_multi_key_mapped_dimensions_are_sorted_alphabetically_in_type_spec) {
     ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
     const auto& result = f.execute();
     // Tensor type specs sort mapped dimensions alphabetically.
@@ -410,9 +410,10 @@ TEST(TensorFromStructsTest, require_that_empty_arrays_create_empty_multi_dim_ten
 
 TEST(TensorFromStructsTest, require_that_single_element_arrays_create_single_cell_multi_dim_tensor) {
     ExecFixture f("tensorFromStructs(attribute(inv),category,brand,qty,float)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(brand{},category{})")
-                               .add({{"category", "food"}, {"brand", "acme"}}, 7.5)),
-              f.execute(3));
+    EXPECT_EQ(
+        *make_tensor(
+            TensorSpec("tensor<float>(brand{},category{})").add({{"category", "food"}, {"brand", "acme"}}, 7.5)),
+        f.execute(3));
 }
 
 TEST(TensorFromStructsTest, require_that_duplicate_key_field_name_fails_setup) {

--- a/searchlib/src/tests/features/tensor_from_structs/tensor_from_structs_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_structs/tensor_from_structs_test.cpp
@@ -119,6 +119,21 @@ struct ExecFixture {
         attrs.push_back(AttributeFactory::createAttribute("mixinv.b", AVC(AVBT::STRING, AVCT::SINGLE)));
         attrs.push_back(AttributeFactory::createAttribute("mixinv.qty", AVC(AVBT::FLOAT, AVCT::ARRAY)));
 
+        // 4-key struct array: quad.a/b/c/d (string) + quad.val (float)
+        attrs.push_back(AttributeFactory::createAttribute("quad.a", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("quad.b", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("quad.c", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("quad.d", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("quad.val", AVC(AVBT::FLOAT, AVCT::ARRAY)));
+
+        // 5-key struct array: pent.a/b/c/d/e (string) + pent.val (float)
+        attrs.push_back(AttributeFactory::createAttribute("pent.a", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("pent.b", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("pent.c", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("pent.d", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("pent.e", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("pent.val", AVC(AVBT::FLOAT, AVCT::ARRAY)));
+
         // Register attributes in index environment
         test.getIndexEnv()
             .getBuilder()
@@ -143,7 +158,18 @@ struct ExecFixture {
             .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "inv.qty")
             .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "mixinv.a")
             .addField(FieldType::ATTRIBUTE, CollectionType::SINGLE, "mixinv.b")
-            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "mixinv.qty");
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "mixinv.qty")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "quad.a")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "quad.b")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "quad.c")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "quad.d")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "quad.val")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "pent.a")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "pent.b")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "pent.c")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "pent.d")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "pent.e")
+            .addField(FieldType::ATTRIBUTE, CollectionType::ARRAY, "pent.val");
 
         for (const auto& attr : attrs) {
             attr->addReservedDoc();
@@ -233,6 +259,37 @@ struct ExecFixture {
 
         FloatingPointAttribute& mixinvQty = dynamic_cast<FloatingPointAttribute&>(*attrs[18]);
         mixinvQty.append(1, 9.0, 0);
+
+        // Setup document 1: 4-key struct array (quad)
+        StringAttribute&        quadA = dynamic_cast<StringAttribute&>(*attrs[19]);
+        StringAttribute&        quadB = dynamic_cast<StringAttribute&>(*attrs[20]);
+        StringAttribute&        quadC = dynamic_cast<StringAttribute&>(*attrs[21]);
+        StringAttribute&        quadD = dynamic_cast<StringAttribute&>(*attrs[22]);
+        FloatingPointAttribute& quadVal = dynamic_cast<FloatingPointAttribute&>(*attrs[23]);
+        quadA.append(1, "x", 0);
+        quadA.append(1, "p", 0);
+        quadB.append(1, "y", 0);
+        quadB.append(1, "q", 0);
+        quadC.append(1, "z", 0);
+        quadC.append(1, "r", 0);
+        quadD.append(1, "w", 0);
+        quadD.append(1, "s", 0);
+        quadVal.append(1, 1.0, 0);
+        quadVal.append(1, 2.0, 0);
+
+        // Setup document 1: 5-key struct array (pent)
+        StringAttribute&        pentA = dynamic_cast<StringAttribute&>(*attrs[24]);
+        StringAttribute&        pentB = dynamic_cast<StringAttribute&>(*attrs[25]);
+        StringAttribute&        pentC = dynamic_cast<StringAttribute&>(*attrs[26]);
+        StringAttribute&        pentD = dynamic_cast<StringAttribute&>(*attrs[27]);
+        StringAttribute&        pentE = dynamic_cast<StringAttribute&>(*attrs[28]);
+        FloatingPointAttribute& pentVal = dynamic_cast<FloatingPointAttribute&>(*attrs[29]);
+        pentA.append(1, "a1", 0);
+        pentB.append(1, "b1", 0);
+        pentC.append(1, "c1", 0);
+        pentD.append(1, "d1", 0);
+        pentE.append(1, "e1", 0);
+        pentVal.append(1, 5.0, 0);
 
         // Setup document 2: empty arrays
         // (no appends, so arrays remain empty)
@@ -425,6 +482,35 @@ TEST(TensorFromStructsTest, require_that_duplicate_key_field_name_fails_setup) {
 TEST(TensorFromStructsTest, require_that_collection_type_mismatch_across_keys_creates_empty_tensor) {
     ExecFixture f("tensorFromStructs(attribute(mixinv),a,b,qty,float)");
     EXPECT_EQ(*make_empty("tensor<float>(a{},b{})"), f.execute());
+}
+
+// Tests for 4 and 5 key fields
+
+TEST(TensorFromStructsTest, require_that_four_keys_create_4d_sparse_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(quad),a,b,c,d,val,float)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(a{},b{},c{},d{})")
+                               .add({{"a", "x"}, {"b", "y"}, {"c", "z"}, {"d", "w"}}, 1.0)
+                               .add({{"a", "p"}, {"b", "q"}, {"c", "r"}, {"d", "s"}}, 2.0)),
+              f.execute());
+}
+
+TEST(TensorFromStructsTest, require_that_four_key_mapped_dimensions_are_sorted_alphabetically_in_type_spec) {
+    ExecFixture f("tensorFromStructs(attribute(quad),d,c,b,a,val,float)");
+    const auto& result = f.execute();
+    EXPECT_EQ("tensor<float>(a{},b{},c{},d{})", result.type().to_spec());
+}
+
+TEST(TensorFromStructsTest, require_that_five_keys_create_5d_sparse_tensor) {
+    ExecFixture f("tensorFromStructs(attribute(pent),a,b,c,d,e,val,float)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(a{},b{},c{},d{},e{})")
+                               .add({{"a", "a1"}, {"b", "b1"}, {"c", "c1"}, {"d", "d1"}, {"e", "e1"}}, 5.0)),
+              f.execute());
+}
+
+TEST(TensorFromStructsTest, require_that_five_key_mapped_dimensions_are_sorted_alphabetically_in_type_spec) {
+    ExecFixture f("tensorFromStructs(attribute(pent),e,d,c,b,a,val,float)");
+    const auto& result = f.execute();
+    EXPECT_EQ("tensor<float>(a{},b{},c{},d{},e{})", result.type().to_spec());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.cpp
@@ -33,17 +33,17 @@ namespace search {
 namespace features {
 
 TensorFromStructsBlueprint::TensorFromStructsBlueprint()
-    : TensorFactoryBlueprint("tensorFromStructs"), _keyField(), _valueField(), _cellType(CellType::DOUBLE) {
+    : TensorFactoryBlueprint("tensorFromStructs"), _keyFields(), _valueField(), _cellType(CellType::DOUBLE) {
 }
 
 TensorFromStructsBlueprint::~TensorFromStructsBlueprint() = default;
 
 bool TensorFromStructsBlueprint::setup(const search::fef::IIndexEnvironment& env,
                                        const search::fef::ParameterList&     params) {
-    // _params[0] = source ('attribute(name)');
-    // _params[1] = keyField;
-    // _params[2] = valueField;
-    // _params[3] = cellType (e.g., 'float', 'double');
+    // params[0]       = source ('attribute(name)')
+    // params[1..N]    = key fields (1, 2, or 3)
+    // params[N+1]     = value field
+    // params[N+2]     = cell type (e.g. 'float', 'double')
 
     bool validSource = extractSource(params[0].getValue());
     if (!validSource) {
@@ -53,31 +53,49 @@ bool TensorFromStructsBlueprint::setup(const search::fef::IIndexEnvironment& env
         return fail("only attribute source is supported for tensorFromStructs, got: '%s'", _sourceType.c_str());
     }
 
-    _keyField = params[1].getValue();
-    _valueField = params[2].getValue();
+    const size_t total = params.size();
+    if (total < 4 || total > 6) {
+        // Note: this should be checked already from ParameterDescriptions
+        return fail("expected 4, 5, or 6 parameters, got %zu", total);
+    }
+    const size_t numKeys = total - 3;
 
-    auto cellTypeOpt = vespalib::eval::value_type::cell_type_from_name(params[3].getValue());
+    _keyFields.clear();
+    _keyFields.reserve(numKeys);
+    for (size_t i = 0; i < numKeys; ++i) {
+        _keyFields.push_back(params[1 + i].getValue());
+    }
+    _valueField = params[1 + numKeys].getValue();
+
+    auto cellTypeOpt = vespalib::eval::value_type::cell_type_from_name(params[2 + numKeys].getValue());
     if (!cellTypeOpt.has_value()) {
-        return fail("invalid cell type: '%s'", params[3].getValue().c_str());
+        return fail("invalid cell type: '%s'", params[2 + numKeys].getValue().c_str());
     }
     _cellType = cellTypeOpt.value();
 
-    auto vt = ValueType::make_type(_cellType, {{_keyField}});
+    std::vector<ValueType::Dimension> dims;
+    dims.reserve(numKeys);
+    for (const auto& kf : _keyFields) {
+        dims.emplace_back(kf);
+    }
+    auto vt = ValueType::make_type(_cellType, std::move(dims));
     _valueType = ValueType::from_spec(vt.to_spec());
     if (_valueType.is_error()) {
-        return fail("invalid dimension name: '%s'", _keyField.c_str());
+        return fail("invalid or duplicate dimension name(s) for key field(s)");
     }
-    std::string           keyAttrName = _sourceParam + "." + _keyField;
+    for (const auto& kf : _keyFields) {
+        std::string           keyAttrName = _sourceParam + "." + kf;
+        const fef::FieldInfo* kfInfo = env.getFieldByName(keyAttrName);
+        if (kfInfo == nullptr || !kfInfo->hasAttribute()) {
+            return fail("no such attribute '%s'", keyAttrName.c_str());
+        }
+    }
     std::string           valueAttrName = _sourceParam + "." + _valueField;
-    const fef::FieldInfo* kfInfo = env.getFieldByName(keyAttrName);
     const fef::FieldInfo* vfInfo = env.getFieldByName(valueAttrName);
-    if (kfInfo == nullptr || !kfInfo->hasAttribute()) {
-        return fail("no such attribute '%s'", keyAttrName.c_str());
-    }
     if (vfInfo == nullptr || !vfInfo->hasAttribute()) {
         return fail("no such attribute '%s'", valueAttrName.c_str());
     }
-    describeOutput("tensor", "The tensor created from struct field attributes (key and value fields)",
+    describeOutput("tensor", "The tensor created from struct field attributes (key field(s) and value field)",
                    FeatureType::object(_valueType));
     return true;
 }
@@ -138,19 +156,77 @@ template <typename KeyBufferType> void TensorFromStructsExecutor<KeyBufferType>:
     outputs().set_object(0, *_tensor);
 }
 
-FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& env, const std::string& baseAttrName,
-                                         const std::string& keyField, const std::string& valueField,
-                                         const ValueType& valueType, CellType cellType, vespalib::Stash& stash) {
-    std::string keyAttrName = baseAttrName + "." + keyField;
-    std::string valueAttrName = baseAttrName + "." + valueField;
+class TensorFromStructsMultiKeyExecutor : public fef::FeatureExecutor {
+private:
+    std::vector<const IAttributeVector*>   _keyAttributes;
+    const IAttributeVector*                _valueAttribute;
+    vespalib::eval::ValueType              _type;
+    vespalib::eval::CellType               _cellType;
+    // _keyDimSlot[k] = index in the tensor's (sorted) dimension list where
+    // the k-th user-supplied key field's value belongs in the subspace address.
+    std::vector<size_t>                    _keyDimSlot;
+    std::vector<WeightedStringContent>     _keyBuffers;
+    FloatContent                           _valueBuffer;
+    std::unique_ptr<vespalib::eval::Value> _tensor;
 
-    const IAttributeVector* keyAttribute = env.getAttributeContext().getAttribute(keyAttrName);
-    if (keyAttribute == nullptr) {
-        Issue::report("tensor_from_structs feature: The key attribute '%s' was not found."
-                      " Returning empty tensor.",
-                      keyAttrName.c_str());
-        return ConstantTensorExecutor::createEmpty(valueType, stash);
+public:
+    TensorFromStructsMultiKeyExecutor(std::vector<const IAttributeVector*> keyAttrs,
+                                      const IAttributeVector* valueAttr,
+                                      const vespalib::eval::ValueType& valueType,
+                                      vespalib::eval::CellType cellType,
+                                      std::vector<size_t> keyDimSlot)
+        : _keyAttributes(std::move(keyAttrs)),
+          _valueAttribute(valueAttr),
+          _type(valueType),
+          _cellType(cellType),
+          _keyDimSlot(std::move(keyDimSlot)),
+          _keyBuffers(_keyAttributes.size()),
+          _valueBuffer(),
+          _tensor() {
+        for (size_t i = 0; i < _keyAttributes.size(); ++i) {
+            _keyBuffers[i].allocate(_keyAttributes[i]->getMaxValueCount());
+        }
+        _valueBuffer.allocate(_valueAttribute->getMaxValueCount());
     }
+    ~TensorFromStructsMultiKeyExecutor() override = default;
+
+    void execute(uint32_t docId) override {
+        const size_t numKeys = _keyAttributes.size();
+        for (size_t k = 0; k < numKeys; ++k) {
+            _keyBuffers[k].fill(*_keyAttributes[k], docId);
+        }
+        _valueBuffer.fill(*_valueAttribute, docId);
+
+        uint32_t size = _valueBuffer.size();
+        for (size_t k = 0; k < numKeys; ++k) {
+            size = std::min(size, _keyBuffers[k].size());
+        }
+
+        auto factory = FastValueBuilderFactory::get();
+        _tensor = TypifyCellType::resolve(_cellType, [&](auto cell_type) {
+            using CT = typename decltype(cell_type)::type;
+            auto builder = factory.create_value_builder<CT>(_type, numKeys, 1, size);
+            std::vector<std::string>      keyOwners(numKeys);
+            std::vector<std::string_view> addr(numKeys);
+            for (size_t i = 0; i < size; ++i) {
+                for (size_t k = 0; k < numKeys; ++k) {
+                    keyOwners[k] = std::string(_keyBuffers[k][i].value());
+                    addr[_keyDimSlot[k]] = keyOwners[k];
+                }
+                auto cell_array = builder->add_subspace(addr);
+                cell_array[0] = static_cast<CT>(_valueBuffer[i]);
+            }
+            return builder->build(std::move(builder));
+        });
+
+        outputs().set_object(0, *_tensor);
+    }
+};
+
+FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& env, const std::string& baseAttrName,
+                                         const std::vector<std::string>& keyFields, const std::string& valueField,
+                                         const ValueType& valueType, CellType cellType, vespalib::Stash& stash) {
+    std::string valueAttrName = baseAttrName + "." + valueField;
 
     const IAttributeVector* valueAttribute = env.getAttributeContext().getAttribute(valueAttrName);
     if (valueAttribute == nullptr) {
@@ -160,15 +236,6 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
         return ConstantTensorExecutor::createEmpty(valueType, stash);
     }
 
-    // Validate key attribute type
-    if (keyAttribute->isFloatingPointType()) {
-        Issue::report("tensor_from_structs feature: The key attribute '%s' must have basic type string or integer."
-                      " Returning empty tensor.",
-                      keyAttrName.c_str());
-        return ConstantTensorExecutor::createEmpty(valueType, stash);
-    }
-
-    // Validate value attribute type
     if (!valueAttribute->isFloatingPointType() && !valueAttribute->isIntegerType()) {
         Issue::report("tensor_from_structs feature: The value attribute '%s' must have numeric type."
                       " Returning empty tensor.",
@@ -176,33 +243,68 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
         return ConstantTensorExecutor::createEmpty(valueType, stash);
     }
 
-    // Check collection type compatibility
-    if (keyAttribute->getCollectionType() != valueAttribute->getCollectionType()) {
-        Issue::report("tensor_from_structs feature: The key attribute '%s' and value attribute '%s' "
-                      "must have the same collection type. Returning empty tensor.",
-                      keyAttrName.c_str(), valueAttrName.c_str());
-        return ConstantTensorExecutor::createEmpty(valueType, stash);
+    std::vector<const IAttributeVector*> keyAttributes;
+    keyAttributes.reserve(keyFields.size());
+    for (const auto& kf : keyFields) {
+        std::string             keyAttrName = baseAttrName + "." + kf;
+        const IAttributeVector* keyAttribute = env.getAttributeContext().getAttribute(keyAttrName);
+        if (keyAttribute == nullptr) {
+            Issue::report("tensor_from_structs feature: The key attribute '%s' was not found."
+                          " Returning empty tensor.",
+                          keyAttrName.c_str());
+            return ConstantTensorExecutor::createEmpty(valueType, stash);
+        }
+        if (keyAttribute->isFloatingPointType()) {
+            Issue::report("tensor_from_structs feature: The key attribute '%s' must have basic type string or integer."
+                          " Returning empty tensor.",
+                          keyAttrName.c_str());
+            return ConstantTensorExecutor::createEmpty(valueType, stash);
+        }
+        if (keyAttribute->getCollectionType() != valueAttribute->getCollectionType()) {
+            Issue::report("tensor_from_structs feature: The key attribute '%s' and value attribute '%s' "
+                          "must have the same collection type. Returning empty tensor.",
+                          keyAttrName.c_str(), valueAttrName.c_str());
+            return ConstantTensorExecutor::createEmpty(valueType, stash);
+        }
+        if (keyAttribute->getCollectionType() == search::attribute::CollectionType::WSET) {
+            Issue::report("tensor_from_structs feature: Weighted set attributes are not supported."
+                          " Key attribute '%s' is a weighted set. Returning empty tensor.",
+                          keyAttrName.c_str());
+            return ConstantTensorExecutor::createEmpty(valueType, stash);
+        }
+        keyAttributes.push_back(keyAttribute);
     }
 
-    // Weighted sets not supported (arrays are supported)
-    if (keyAttribute->getCollectionType() == search::attribute::CollectionType::WSET) {
-        Issue::report("tensor_from_structs feature: Weighted set attributes are not supported."
-                      " Key attribute '%s' is a weighted set. Returning empty tensor.",
-                      keyAttrName.c_str());
-        return ConstantTensorExecutor::createEmpty(valueType, stash);
+    if (keyAttributes.size() == 1) {
+        const IAttributeVector* keyAttribute = keyAttributes[0];
+        if (keyAttribute->isIntegerType()) {
+            // Using WeightedStringContent ensures that the integer values are converted
+            // to strings while extracting them from the attribute.
+            return stash.create<TensorFromStructsExecutor<WeightedStringContent>>(keyAttribute, valueAttribute,
+                                                                                  valueType, cellType);
+        }
+        // When the underlying attribute is of type string we can reference these values
+        // using WeightedConstCharContent.
+        return stash.create<TensorFromStructsExecutor<WeightedConstCharContent>>(keyAttribute, valueAttribute,
+                                                                                 valueType, cellType);
     }
-
-    // Choose appropriate key buffer type
-    if (keyAttribute->isIntegerType()) {
-        // Using WeightedStringContent ensures that the integer values are converted
-        // to strings while extracting them from the attribute.
-        return stash.create<TensorFromStructsExecutor<WeightedStringContent>>(keyAttribute, valueAttribute, valueType,
-                                                                              cellType);
+    // valueType has its dimensions in sorted (canonical) order, which is what
+    // the value-builder expects in the subspace address. Map each user-supplied
+    // key field to its slot in that sorted dimension list.
+    const auto& dims = valueType.dimensions();
+    std::vector<size_t> keyDimSlot(keyFields.size());
+    for (size_t k = 0; k < keyFields.size(); ++k) {
+        size_t slot = dims.size();
+        for (size_t d = 0; d < dims.size(); ++d) {
+            if (dims[d].name == keyFields[k]) {
+                slot = d;
+                break;
+            }
+        }
+        keyDimSlot[k] = slot;
     }
-    // When the underlying attribute is of type string we can reference these values
-    // using WeightedConstCharContent.
-    return stash.create<TensorFromStructsExecutor<WeightedConstCharContent>>(keyAttribute, valueAttribute, valueType,
-                                                                             cellType);
+    return stash.create<TensorFromStructsMultiKeyExecutor>(std::move(keyAttributes), valueAttribute, valueType,
+                                                           cellType, std::move(keyDimSlot));
 }
 
 } // namespace
@@ -210,7 +312,7 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
 FeatureExecutor& TensorFromStructsBlueprint::createExecutor(const search::fef::IQueryEnvironment& env,
                                                             vespalib::Stash&                      stash) const {
     if (_sourceType == ATTRIBUTE_SOURCE) {
-        return createAttributeExecutor(env, _sourceParam, _keyField, _valueField, _valueType, _cellType, stash);
+        return createAttributeExecutor(env, _sourceParam, _keyFields, _valueField, _valueType, _cellType, stash);
     }
     return ConstantTensorExecutor::createEmpty(_valueType, stash);
 }

--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.cpp
@@ -41,7 +41,7 @@ TensorFromStructsBlueprint::~TensorFromStructsBlueprint() = default;
 bool TensorFromStructsBlueprint::setup(const search::fef::IIndexEnvironment& env,
                                        const search::fef::ParameterList&     params) {
     // params[0]       = source ('attribute(name)')
-    // params[1..N]    = key fields (1, 2, or 3)
+    // params[1..N]    = key fields (1 to 5)
     // params[N+1]     = value field
     // params[N+2]     = cell type (e.g. 'float', 'double')
 
@@ -54,9 +54,9 @@ bool TensorFromStructsBlueprint::setup(const search::fef::IIndexEnvironment& env
     }
 
     const size_t total = params.size();
-    if (total < 4 || total > 6) {
+    if (total < 4 || total > 8) {
         // Note: this should be checked already from ParameterDescriptions
-        return fail("expected 4, 5, or 6 parameters, got %zu", total);
+        return fail("expected 4 to 8 parameters, got %zu", total);
     }
     const size_t numKeys = total - 3;
 

--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.cpp
@@ -158,10 +158,10 @@ template <typename KeyBufferType> void TensorFromStructsExecutor<KeyBufferType>:
 
 class TensorFromStructsMultiKeyExecutor : public fef::FeatureExecutor {
 private:
-    std::vector<const IAttributeVector*>   _keyAttributes;
-    const IAttributeVector*                _valueAttribute;
-    vespalib::eval::ValueType              _type;
-    vespalib::eval::CellType               _cellType;
+    std::vector<const IAttributeVector*> _keyAttributes;
+    const IAttributeVector*              _valueAttribute;
+    vespalib::eval::ValueType            _type;
+    vespalib::eval::CellType             _cellType;
     // _keyDimSlot[k] = index in the tensor's (sorted) dimension list where
     // the k-th user-supplied key field's value belongs in the subspace address.
     std::vector<size_t>                    _keyDimSlot;
@@ -171,10 +171,8 @@ private:
 
 public:
     TensorFromStructsMultiKeyExecutor(std::vector<const IAttributeVector*> keyAttrs,
-                                      const IAttributeVector* valueAttr,
-                                      const vespalib::eval::ValueType& valueType,
-                                      vespalib::eval::CellType cellType,
-                                      std::vector<size_t> keyDimSlot)
+                                      const IAttributeVector* valueAttr, const vespalib::eval::ValueType& valueType,
+                                      vespalib::eval::CellType cellType, std::vector<size_t> keyDimSlot)
         : _keyAttributes(std::move(keyAttrs)),
           _valueAttribute(valueAttr),
           _type(valueType),
@@ -205,13 +203,11 @@ public:
         auto factory = FastValueBuilderFactory::get();
         _tensor = TypifyCellType::resolve(_cellType, [&](auto cell_type) {
             using CT = typename decltype(cell_type)::type;
-            auto builder = factory.create_value_builder<CT>(_type, numKeys, 1, size);
-            std::vector<std::string>      keyOwners(numKeys);
+            auto                          builder = factory.create_value_builder<CT>(_type, numKeys, 1, size);
             std::vector<std::string_view> addr(numKeys);
             for (size_t i = 0; i < size; ++i) {
                 for (size_t k = 0; k < numKeys; ++k) {
-                    keyOwners[k] = std::string(_keyBuffers[k][i].value());
-                    addr[_keyDimSlot[k]] = keyOwners[k];
+                    addr[_keyDimSlot[k]] = _keyBuffers[k][i].value();
                 }
                 auto cell_array = builder->add_subspace(addr);
                 cell_array[0] = static_cast<CT>(_valueBuffer[i]);
@@ -254,10 +250,11 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
                           keyAttrName.c_str());
             return ConstantTensorExecutor::createEmpty(valueType, stash);
         }
-        if (keyAttribute->isFloatingPointType()) {
-            Issue::report("tensor_from_structs feature: The key attribute '%s' must have basic type string or integer."
-                          " Returning empty tensor.",
-                          keyAttrName.c_str());
+        if (!keyAttribute->isStringType() && !keyAttribute->isIntegerType()) {
+            Issue::report(
+                "tensor_from_structs feature: The key attribute '%s' must have basic type string or integer."
+                " Returning empty tensor.",
+                keyAttrName.c_str());
             return ConstantTensorExecutor::createEmpty(valueType, stash);
         }
         if (keyAttribute->getCollectionType() != valueAttribute->getCollectionType()) {
@@ -291,7 +288,7 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
     // valueType has its dimensions in sorted (canonical) order, which is what
     // the value-builder expects in the subspace address. Map each user-supplied
     // key field to its slot in that sorted dimension list.
-    const auto& dims = valueType.dimensions();
+    const auto&         dims = valueType.dimensions();
     std::vector<size_t> keyDimSlot(keyFields.size());
     for (size_t k = 0; k < keyFields.size(); ++k) {
         size_t slot = dims.size();

--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
@@ -10,9 +10,13 @@ namespace search::features {
 
 /**
  * Blueprint for a rank feature that creates a tensor from struct field attributes.
- * Takes two struct fields: one for dimension labels (keys) and one for cell values.
+ * Takes 1, 2, or 3 key fields (each becomes a mapped dimension) plus one value field.
  *
- * Signature: tensorFromStructs(attribute(baseAttr), keyField, valueField, type)
+ * Signatures:
+ *   tensorFromStructs(attribute(baseAttr), keyField,                        valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2,            valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2, keyField3, valueField, type)
+ *
  * Example: tensorFromStructs(attribute(items), "itemname", "price", "float")
  *   - Creates tensor<float>(itemname{})
  *   - Labels from items.itemname attribute
@@ -20,7 +24,7 @@ namespace search::features {
  */
 class TensorFromStructsBlueprint : public TensorFactoryBlueprint {
 private:
-    std::string              _keyField;
+    std::vector<std::string> _keyFields;
     std::string              _valueField;
     vespalib::eval::CellType _cellType;
 
@@ -29,7 +33,10 @@ public:
     ~TensorFromStructsBlueprint() override;
     fef::Blueprint::UP createInstance() const override { return Blueprint::UP(new TensorFromStructsBlueprint()); }
     fef::ParameterDescriptions getDescriptions() const override {
-        return fef::ParameterDescriptions().desc().string().string().string().string();
+        return fef::ParameterDescriptions()
+                .desc().string().string().string().string()
+                .desc().string().string().string().string().string()
+                .desc().string().string().string().string().string().string();
     }
     bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
     fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;

--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
@@ -10,12 +10,14 @@ namespace search::features {
 
 /**
  * Blueprint for a rank feature that creates a tensor from struct field attributes.
- * Takes 1, 2, or 3 key fields (each becomes a mapped dimension) plus one value field.
+ * Takes 1 to 5 key fields (each becomes a mapped dimension) plus one value field.
  *
  * Signatures:
- *   tensorFromStructs(attribute(baseAttr), keyField,                        valueField, type)
- *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2,            valueField, type)
- *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2, keyField3, valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField,                                    valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2,                        valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2, keyField3,             valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField1, keyField2, keyField3, keyField4,  valueField, type)
+ *   tensorFromStructs(attribute(baseAttr), keyField1, ...,                  keyField5,  valueField, type)
  *
  * Example: tensorFromStructs(attribute(items), "itemname", "price", "float")
  *   - Creates tensor<float>(itemname{})
@@ -36,7 +38,9 @@ public:
         return fef::ParameterDescriptions()
                 .desc().string().string().string().string()
                 .desc().string().string().string().string().string()
-                .desc().string().string().string().string().string().string();
+                .desc().string().string().string().string().string().string()
+                .desc().string().string().string().string().string().string().string()
+                .desc().string().string().string().string().string().string().string().string();
     }
     bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
     fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;


### PR DESCRIPTION
Extends the tensorFromStructs rank feature to optionally accept 2 or 3 key fields, producing a 2D or 3D sparse tensor whose dimensions are addressed by the tuple of key values from parallel struct-array attributes. The existing single-key path is unchanged.

A new non-templated multi-key executor handles the 2/3-key cases using WeightedStringContent uniformly across keys, and computes a key-to-dimension-slot permutation so the subspace address matches the tensor type's sorted dimension order.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>