### PR TITLE
Do not produce a disk-access warning when using document-id attribute

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/SummaryDiskAccessValidator.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/SummaryDiskAccessValidator.java
@@ -63,7 +63,11 @@ public class SummaryDiskAccessValidator extends Processor {
     }
 
     private boolean isInMemory(ImmutableSDField field, SummaryField summaryField) {
-        if (field == null) return false; // For DOCUMENT_ID_FIELD, which may be implicit, but is then not in memory
+        if (field == null) {
+            // For DOCUMENT_ID_FIELD, which implicitly is a field.
+            // Whether it is in memory or not depends on the setting in the schema.
+            return schema.documentIdAttributeEnabled();
+        }
         if (isComplexFieldWithOnlyStructFieldAttributes(field) &&
                 (summaryField.getTransform() == SummaryTransform.ATTRIBUTECOMBINER)) {
             return true;

--- a/config-model/src/test/java/com/yahoo/schema/processing/SummaryDiskAccessValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/SummaryDiskAccessValidatorTestCase.java
@@ -38,6 +38,44 @@ public class SummaryDiskAccessValidatorTestCase {
     }
 
     @Test
+    void logs_warning_when_accessing_documentid_when_not_an_attribute() throws ParseException {
+        var sd = joinLines(
+                "schema test {",
+                "  document-id: from-disk",
+                "  document test {",
+                "  }",
+                "  document-summary my_sum {",
+                "    summary documentid { source: documentid }",
+                "  }",
+                "}");
+
+        var logger = new TestableDeployLogger();
+        ApplicationBuilder.createFromString(sd, logger);
+        assertEquals(1, logger.warnings.size());
+        assertThat(logger.warnings.get(0),
+                containsString("In document-summary 'my_sum' in schema 'test': " +
+                        "Fields [documentid] references non-attribute fields: Using this summary will cause disk accesses. " +
+                        "Set 'from-disk' on this document-summary to silence this warning."));
+    }
+
+    @Test
+    void does_not_log_warning_when_accessing_documentid_when_an_attribute() throws ParseException {
+        var sd = joinLines(
+                "schema test {",
+                "  document-id: attribute",
+                "  document test {",
+                "  }",
+                "  document-summary my_sum {",
+                "    summary documentid { source: documentid }",
+                "  }",
+                "}");
+
+        var logger = new TestableDeployLogger();
+        ApplicationBuilder.createFromString(sd, logger);
+        assertEquals(0, logger.warnings.size());
+    }
+
+    @Test
     void does_not_log_warning_when_accessing_imported_map_field() throws ParseException {
         var parent = joinLines(
                 "schema parent {",

--- a/config-model/src/test/java/com/yahoo/schema/processing/SummaryDiskAccessValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/SummaryDiskAccessValidatorTestCase.java
@@ -17,6 +17,8 @@ public class SummaryDiskAccessValidatorTestCase {
     void logs_warning_when_accessing_field_that_needs_disk_access() throws ParseException {
         var sd = joinLines(
                 "schema test {",
+                "  # Using the document-id attribute should not affect warning below",
+                "  document-id: attribute",
                 "  document test {",
                 "    field str_map type map<string, string> {",
                 "      indexing: summary",


### PR DESCRIPTION
Does not warn about disk access if a document summary uses `documentid` but the implicit document-id attribute is activated.