### PR TITLE
Remove flag definitions with no callers in this repository

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.flags;
 
 import com.yahoo.component.Vtag;
 import com.yahoo.vespa.defaults.Defaults;
-import com.yahoo.vespa.flags.custom.CustomerOtelExportParameters;
 import com.yahoo.vespa.flags.custom.Sidecars;
 
 import java.time.Instant;
@@ -17,10 +16,8 @@ import java.util.function.Predicate;
 
 import static com.yahoo.vespa.flags.Dimension.APPLICATION;
 import static com.yahoo.vespa.flags.Dimension.ARCHITECTURE;
-import static com.yahoo.vespa.flags.Dimension.CLOUD_ACCOUNT;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_ID;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_TYPE;
-import static com.yahoo.vespa.flags.Dimension.CONSOLE_USER_EMAIL;
 import static com.yahoo.vespa.flags.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 import static com.yahoo.vespa.flags.Dimension.NODE_TYPE;
@@ -58,12 +55,6 @@ public class Flags {
             "Whether to use non-public endpoint in test and staging environments (except Azure since it's not supported yet)",
             "Takes effect on next deployment of the application",
             INSTANCE_ID, VESPA_VERSION);
-
-    public static final UnboundBooleanFlag LOCKED_GCP_PROVISION = defineFeatureFlag(
-            "locked-gcp-provision", true,
-            List.of("hakonhall"), "2025-08-05", "2026-07-15",
-            "Whether to provision GCP hosts under the application- and unallocated- locks, even though it takes ~1m.",
-            "Takes effect on next host being provisioned");
 
     public static final UnboundStringFlag RESPONSE_SEQUENCER_TYPE = defineStringFlag(
             "response-sequencer-type", "ADAPTIVE",
@@ -130,19 +121,6 @@ public class Flags {
             "Takes effect at redeployment",
             INSTANCE_ID);
 
-    public static final UnboundListFlag<String> ZONAL_WEIGHTED_ENDPOINT_RECORDS = defineListFlag(
-            "zonal-weighted-endpoint-records", List.of(), String.class,
-            List.of("hmusum"), "2023-12-15", "2026-06-01",
-            "A list of weighted (application) endpoint fqdns for which we should use zonal endpoints as targets, not LBs.",
-            "Takes effect at redeployment from controller");
-
-    public static final UnboundListFlag<String> WEIGHTED_ENDPOINT_RECORD_TTL = defineListFlag(
-            "weighted-endpoint-record-ttl", List.of(), String.class,
-            List.of("hmusum"), "2023-05-16", "2026-06-01",
-            "A list of endpoints and custom TTLs, on the form \"endpoint-fqdn:TTL-seconds\". " +
-            "Where specified, CNAME records are used instead of the default ALIAS records, which have a default 60s TTL.",
-            "Takes effect at redeployment from controller");
-
     public static final UnboundBooleanFlag WRITE_CONFIG_SERVER_SESSION_DATA_AS_ONE_BLOB = defineFeatureFlag(
             "write-config-server-session-data-as-blob", false,
             List.of("hmusum"), "2023-07-19", "2026-06-01",
@@ -162,27 +140,6 @@ public class Flags {
             "Takes effect on next autoscaler evaluation",
             INSTANCE_ID, CLUSTER_ID);
 
-    public static final UnboundBooleanFlag MORE_WIREGUARD = defineFeatureFlag(
-            "more-wireguard", false,
-            List.of("andreer"), "2023-08-21", "2026-06-01",
-            "Use wireguard in INternal enCLAVES",
-            "Takes effect on next host-admin run",
-            HOSTNAME, CLOUD_ACCOUNT);
-
-    public static final UnboundBooleanFlag IPV6_AWS_TARGET_GROUPS = defineFeatureFlag(
-            "ipv6-aws-target-groups", false,
-            List.of("andreer"), "2023-08-28", "2026-06-01",
-            "Always use IPv6 target groups for load balancers in aws",
-            "Takes effect on next load-balancer provisioning",
-            HOSTNAME, CLOUD_ACCOUNT);
-
-    public static final UnboundBooleanFlag PROVISION_IPV6_ONLY_AWS = defineFeatureFlag(
-            "provision-ipv6-only", false,
-            List.of("andreer"), "2023-08-28", "2026-06-01",
-            "Provision without private IPv4 addresses in INternal enCLAVES in AWS",
-            "Takes effect on next host provisioning / run of host-admin",
-            HOSTNAME, CLOUD_ACCOUNT);
-
     public static final UnboundDoubleFlag DOCPROC_HANDLER_THREADPOOL = defineDoubleFlag(
             "docproc-handler-threadpool", 1.0,
             List.of("johsol"), "2025-10-17", "2026-06-01",
@@ -190,35 +147,11 @@ public class Flags {
             "Takes effect at redeployment",
             APPLICATION);
 
-    public static final UnboundStringFlag ENDPOINT_CONFIG = defineStringFlag(
-            "endpoint-config", "legacy",
-            List.of("andreer", "olaa"), "2023-10-06", "2026-08-01",
-            "Set the endpoint config to use for an application. Must be 'legacy', 'combined' or 'generated'. See EndpointConfig for further details",
-            "Takes effect on next deployment through controller",
-            TENANT_ID, APPLICATION, INSTANCE_ID);
-
     public static UnboundBooleanFlag LOGSERVER_OTELCOL_AGENT = defineFeatureFlag(
             "logserver-otelcol-agent", false,
             List.of("olaa"), "2024-04-03", "2026-08-01",
             "Whether logserver container should run otel agent",
             "Takes effect at redeployment",
-            TENANT_ID, APPLICATION, INSTANCE_ID);
-
-    public static final UnboundBooleanFlag USE_GRAFANA_ALLOY = defineFeatureFlag(
-            "use-grafana-alloy", false,
-            List.of("onur"), "2026-02-17", "2026-08-01",
-            "Whether to use Grafana Alloy instead of otelcol-contrib for telemetry collection",
-            "Takes effect on next host-admin tick",
-            TENANT_ID, APPLICATION, INSTANCE_ID);
-
-    public static final UnboundJacksonFlag<CustomerOtelExportParameters> CUSTOMER_OTEL_EXPORT = defineJacksonFlag(
-            "customer-otel-export", new CustomerOtelExportParameters(null, null, null), CustomerOtelExportParameters.class,
-            List.of("onur"), "2026-03-02", "2027-01-01",
-            "Export telemetry to a customer-owned OTel endpoint in addition to the internal otel-gateway. " +
-            "metrics and logs are independently optional. " +
-            "logs.logFileNames is a list of log file enum names (e.g. CONTAINER_VESPA_LOGS, VAR_LOG_MESSAGES).",
-            "Takes effect on next host-admin tick",
-            __ -> true,
             TENANT_ID, APPLICATION, INSTANCE_ID);
 
     public static final UnboundBooleanFlag USE_LEGACY_WAND_QUERY_PARSING = defineFeatureFlag(
@@ -234,19 +167,6 @@ public class Flags {
             "Enable lightweight annotation representation for StringFieldValue",
             "Takes effect at redeployment",
             INSTANCE_ID);
-
-    public static final UnboundBooleanFlag SNAPSHOTS_ENABLED = defineFeatureFlag(
-            "snapshots-enabled", false,
-            List.of("olaa"), "2024-10-22", "2026-08-01",
-            "Whether node snapshots should be created when host storage is discarded",
-            "Takes effect immediately");
-
-    public static final UnboundBooleanFlag ENABLE_UI_VERSION_TOGGLE = defineFeatureFlag(
-            "enable-ui-version-toggle", false,
-            List.of("laura", "jille"), "2026-04-20", "2026-12-31",
-            "Enable a toggle to switch between different versions of the Console UI",
-            "Takes effect immediately",
-            CONSOLE_USER_EMAIL);
 
     public static final UnboundJacksonFlag<Sidecars> SIDECARS_FOR_TEST = defineJacksonFlag(
             "sidecars-for-test", Sidecars.DEFAULT, Sidecars.class,
@@ -304,12 +224,6 @@ public class Flags {
             "Takes effect at redeployment",
             TENANT_ID, APPLICATION, INSTANCE_ID);
 
-    public static final UnboundBooleanFlag SKIP_AUTOSCALING_WHEN_UPGRADING_CONFIG_SERVERS = defineFeatureFlag(
-            "skip-autoscaling-when-upgrading-config-servers", false,
-            List.of("hmusum"), "2026-05-05", "2026-06-05",
-            "Whether to skip autoscaling when config server upgrades or downgrades.",
-            "Takes effect immediately",
-            HOSTNAME);
     public static final UnboundBooleanFlag SEND_OLD_QUERY_STACK = defineFeatureFlag(
             "send-old-query-stack", false,
             List.of("arnej"), "2026-05-07", "2026-09-01",

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
-import com.yahoo.vespa.flags.custom.CustomerRpmServiceList;
 import com.yahoo.vespa.flags.custom.RoleList;
 import com.yahoo.vespa.flags.custom.SharedHost;
 
@@ -15,21 +14,13 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static com.yahoo.vespa.flags.Dimension.APPLICATION;
-import static com.yahoo.vespa.flags.Dimension.ARCHITECTURE;
-import static com.yahoo.vespa.flags.Dimension.CERTIFICATE_PROVIDER;
-import static com.yahoo.vespa.flags.Dimension.CLAVE;
-import static com.yahoo.vespa.flags.Dimension.CLOUD_ACCOUNT;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_ID;
 import static com.yahoo.vespa.flags.Dimension.CLUSTER_TYPE;
-import static com.yahoo.vespa.flags.Dimension.CONSOLE_USER_EMAIL;
-import static com.yahoo.vespa.flags.Dimension.ENVIRONMENT;
-import static com.yahoo.vespa.flags.Dimension.FLAVOR;
 import static com.yahoo.vespa.flags.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 import static com.yahoo.vespa.flags.Dimension.NODE_TYPE;
 import static com.yahoo.vespa.flags.Dimension.TENANT_ID;
 import static com.yahoo.vespa.flags.Dimension.VESPA_VERSION;
-import static com.yahoo.vespa.flags.Dimension.ZONE_ID;
 
 /**
  * Definition for permanent feature flags
@@ -60,25 +51,6 @@ public class PermanentFlags {
             "Takes effect at redeployment (requires restart)",
             INSTANCE_ID);
 
-    public static final UnboundIntFlag REBOOT_INTERVAL_IN_DAYS = defineIntFlag(
-            "reboot-interval-in-days", 30,
-            "No reboots are scheduled 0x-1x reboot intervals after the previous reboot, while reboot is " +
-                    "scheduled evenly distributed in the 1x-2x range (and naturally guaranteed at the 2x boundary).",
-            "Takes effect on next run of NodeRebooter");
-
-    public static final UnboundIntFlag KEEP_PROVISIONED_EXPIRED_HOSTS_MAX = defineIntFlag(
-            "keep-provisioned-expired-hosts-max", 0,
-            "The maximum number of provisioned expired hosts to keep for investigation of provisioning issues.",
-            "Takes effect on next run of ProvisionedExpirer");
-
-    public static final UnboundIntFlag OS_MAJOR_VERSION = defineIntFlag(
-            "os-major-version", 0,
-            "The OS major version to use for provisioned hosts. " +
-            "Value 0 means use lowest major version available. " +
-            "Common values: 8 (AlmaLinux 8), 9 (AlmaLinux 9).",
-            "Takes effect when a host is provisioned",
-            CLAVE, NODE_TYPE, CLOUD_ACCOUNT, HOSTNAME);
-
     public static final UnboundJacksonFlag<SharedHost> SHARED_HOST = defineJacksonFlag(
             "shared-host", SharedHost.createDisabled(), SharedHost.class,
             "Specifies whether shared hosts can be provisioned, and if so, the advertised " +
@@ -86,69 +58,10 @@ public class PermanentFlags {
             "Takes effect on next iteration of HostCapacityMaintainer.",
             __ -> true);
 
-    public static final UnboundStringFlag HOST_FLAVOR = defineStringFlag(
-            "host-flavor", "",
-            "Specifies the Vespa flavor name that the hosts of the matching nodes should have.",
-            "Takes effect on next deployment (including internal redeployment).",
-            INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID);
-
-    public static final UnboundBooleanFlag SKIP_MAINTENANCE_DEPLOYMENT = defineFeatureFlag(
-            "node-repository-skip-maintenance-deployment", false,
-            "Whether PeriodicApplicationMaintainer should skip deployment for an application",
-            "Takes effect at next run of maintainer",
-            INSTANCE_ID);
-
     public static final UnboundListFlag<String> INACTIVE_MAINTENANCE_JOBS = defineListFlag(
             "inactive-maintenance-jobs", List.of(), String.class,
             "The list of maintenance jobs that are inactive.",
             "Takes effect immediately, but any currently running jobs will run until completion.");
-
-    public static final UnboundListFlag<String> OUTBOUND_BLOCKED_IPV4 = defineListFlag(
-            "container-outbound-blocked-ipv4", List.of(), String.class,
-            "List of IPs or CIDRs that are blocked for outbound connections",
-            "Takes effect on next tick");
-
-    public static final UnboundListFlag<String> OUTBOUND_BLOCKED_IPV6 = defineListFlag(
-            "container-outbound-blocked-ipv6", List.of(), String.class,
-            "List of IPs or CIDRs that are blocked for outbound connections",
-            "Takes effect on next tick");
-
-    public static final UnboundDoubleFlag GLOBAL_HOURLY_TRIAL_CREDIT_SPENDING_LIMIT = defineDoubleFlag(
-            "global-hourly-trial-credit-spending-limit", 0.0,
-            "The global maximum credit limit per hour (for all tenants). If this limit is exceeded, trial tenant deployments are blocked. Zero/negative value indicates no limit.",
-            "Takes effect immediately");
-
-    public static final UnboundDoubleFlag CONTAINER_CPU_CAP = defineDoubleFlag(
-            "container-cpu-cap", 0,
-            "Hard limit on how many CPUs a container may use. This value is multiplied by CPU allocated to node, so " +
-                    "to cap CPU at 200%, set this to 2, etc. 0 disables the cap to allow unlimited CPU.",
-            "Takes effect on next node agent tick. Change is orchestrated, but does NOT require container restart",
-            HOSTNAME, INSTANCE_ID, CLUSTER_ID, CLUSTER_TYPE);
-
-    public static final UnboundIntFlag MIN_DISK_THROUGHPUT_MB_S = defineIntFlag(
-            "min-disk-throughput-mb-s", 0,
-            "Minimum required disk throughput performance, 0 = default, Only when using remote disk",
-            "Takes effect when node is provisioned",
-            INSTANCE_ID, TENANT_ID, CLUSTER_ID, CLUSTER_TYPE);
-
-    public static final UnboundIntFlag MIN_DISK_IOPS_K = defineIntFlag(
-            "min-disk-iops-k", 0,
-            "Minimum required disk I/O operations per second, unit is kilo, 0 = default, Only when using remote disk",
-            "Takes effect when node is provisioned",
-            INSTANCE_ID, TENANT_ID, CLUSTER_ID, CLUSTER_TYPE);
-
-    public static final UnboundListFlag<String> DISABLED_HOST_ADMIN_TASKS = defineListFlag(
-            "disabled-host-admin-tasks", List.of(), String.class,
-            "List of host-admin task names (as they appear in the log, e.g. root>main>UpgradeTask), or some node-agent " +
-                    "functionality (see NodeAgentTask), that should be skipped",
-            "Takes effect on next host admin tick",
-            HOSTNAME, NODE_TYPE, CLAVE, CLOUD_ACCOUNT);
-
-    public static final UnboundStringFlag DOCKER_IMAGE_REPO = defineStringFlag(
-            "docker-image-repo", "",
-            "Override default docker image repo. Docker image version will be Vespa version.",
-            "Takes effect on next deployment from controller",
-            ZONE_ID, TENANT_ID, APPLICATION, INSTANCE_ID);
 
     public static final UnboundStringFlag METRIC_SET = defineStringFlag(
             "metric-set", "Vespa9",
@@ -156,42 +69,11 @@ public class PermanentFlags {
             "Takes effect on next host admin tick",
             TENANT_ID, APPLICATION, INSTANCE_ID);
 
-    public static final UnboundStringFlag CONTAINER_IMAGE_TAG_SUFFIX = defineStringFlag(
-            "container-image-tag-suffix", "",
-            "Tag suffix appended to the wanted container image of synthesized config-server, " +
-            "controller, and tenant nodes (e.g. 'alma9' -> <image-name>:<version>-alma9). " +
-            "Empty means no suffix; the default AlmaLinux 8 docker container image is used.",
-            "Takes effect on next host-admin tick",
-            HOSTNAME, NODE_TYPE, TENANT_ID, APPLICATION, INSTANCE_ID, ZONE_ID, CLOUD_ACCOUNT);
-
     public static final UnboundBooleanFlag VERBOSE_DEPLOY_PARAMETER = defineFeatureFlag(
             "verbose-deploy-parameter", false,
             "Whether (external) deployments should set verbose flag (will mean more logging in practice). " +
                     "Will only be used if flag in request is false (which is the default)",
             "Takes effect at next deployment");
-
-    public static final UnboundJacksonFlag<CustomerRpmServiceList> CUSTOMER_RPM_SERVICES = defineJacksonFlag(
-            "customer-rpm-services", CustomerRpmServiceList.empty(), CustomerRpmServiceList.class,
-            "Specifies customer rpm services to run on enclave tenant hosts.",
-            "Takes effect on next host admin tick.",
-            __ -> true,
-            TENANT_ID, APPLICATION, INSTANCE_ID, ARCHITECTURE, CLUSTER_ID, CLUSTER_TYPE);
-
-
-    public static final UnboundBooleanFlag DEFER_OS_UPGRADE = defineFeatureFlag(
-            "defer-os-upgrade", false,
-            "Whether OS upgrade should be deferred",
-            "Takes effect immediately",
-            CLOUD_ACCOUNT
-    );
-
-
-    public static final UnboundListFlag<String> OTELCOL_LOGS = defineListFlag(
-            "otelcol-logs", List.of(), String.class,
-            "Determines log files handled by the OpenTelemetry collector",
-            "Takes effect at next tick",
-            TENANT_ID, APPLICATION, INSTANCE_ID
-    );
 
     private static final String VERSION_QUALIFIER_REGEX = "[a-zA-Z0-9_-]+";
     private static final Pattern QUALIFIER_PATTERN = Pattern.compile("^" + VERSION_QUALIFIER_REGEX + "$");
@@ -206,23 +88,11 @@ public class PermanentFlags {
             value -> value.isEmpty() || QUALIFIER_PATTERN.matcher(value).find() || VERSION_PATTERN.matcher(value).find(),
             HOSTNAME, NODE_TYPE, TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, VESPA_VERSION);
 
-    public static final UnboundStringFlag ZOOKEEPER_SERVER_VERSION = defineStringFlag(
-            "zookeeper-server-version", "3.9.5",
-            "ZooKeeper server version, a jar file zookeeper-server-<ZOOKEEPER_SERVER_VERSION>-jar-with-dependencies.jar must exist",
-            "Takes effect on restart of Docker container",
-            NODE_TYPE, INSTANCE_ID, HOSTNAME);
-
     public static final UnboundBooleanFlag ALLOW_DISABLE_MTLS = defineFeatureFlag(
             "allow-disable-mtls", true,
             "Allow application to disable client authentication",
             "Takes effect on redeployment",
             INSTANCE_ID);
-
-    public static final UnboundIntFlag MAX_OS_UPGRADES = defineIntFlag(
-            "max-os-upgrades", 30,
-            "The maximum number hosts that can perform OS upgrade at a time",
-            "Takes effect immediately, but any current excess upgrades will not be cancelled"
-    );
 
     public static final UnboundListFlag<String> TLS_CIPHERS_OVERRIDE = defineListFlag(
             "tls-ciphers-override", List.of(), String.class,
@@ -230,13 +100,6 @@ public class PermanentFlags {
             "Takes effect on redeployment",
             INSTANCE_ID
     );
-
-    public static final UnboundStringFlag ENDPOINT_CERTIFICATE_ALGORITHM = defineStringFlag(
-            "endpoint-certificate-algorithm", "ecdsa_p256",
-            // Acceptable values are: "rsa_4096", "ecdsa_p256"
-            "Selects algorithm used for an applications endpoint certificate",
-            "Takes effect when a new endpoint certificate is requested (on first deployment or deployment adding new endpoints)",
-            INSTANCE_ID);
 
     public static final UnboundDoubleFlag RESOURCE_LIMIT_DISK = defineDoubleFlag(
             "resource-limit-disk", 0.8,
@@ -259,14 +122,6 @@ public class PermanentFlags {
             INSTANCE_ID
     );
 
-    public static final UnboundListFlag<String> LOGCTL_OVERRIDE = defineListFlag(
-            "logctl-override", List.of(), String.class,
-            "A list of vespa-logctl statements that are run on container startup. " +
-                    "Each item should be on the form <service>:<component> <level>=on",
-            "Takes effect on Podman container (re)start",
-            INSTANCE_ID, HOSTNAME
-    );
-
     public static final UnboundListFlag<String> ENVIRONMENT_VARIABLES = defineListFlag(
             "environment-variables", List.of(), String.class,
             "A list of environment variables set for all services. " +
@@ -275,46 +130,10 @@ public class PermanentFlags {
             INSTANCE_ID
     );
 
-    public static final UnboundStringFlag CONFIG_PROXY_JVM_ARGS = defineStringFlag(
-            "config-proxy-jvm-args", "",
-            "Sets jvm args for config proxy (added at the end of startup command, will override existing ones)",
-            "Takes effect on restart of Docker container",
-            INSTANCE_ID
-    );
-
-    public static final UnboundIntFlag DELAY_HOST_SECURITY_AGENT_START_MINUTES = defineIntFlag(
-            "delay-host-security-agent-start-minutes", 5,
-            "The number of minutes (from host admin start) to delay the start of the host security agent",
-            "Takes effect on next host-admin tick",
-            NODE_TYPE);
-
-    // This must be set in a feature flag to avoid flickering between the new and old value during config server upgrade
-    public static final UnboundDoubleFlag HOST_MEMORY = defineDoubleFlag(
-            "host-memory", -1.0,
-            "The memory in GB required by a host's management processes. " +
-            "A negative value falls back to hard-coded defaults.",
-            "Affects future deployments, JVM settings for new config server Podman containers, auto scaling modelling.",
-            ARCHITECTURE, CLAVE, CLOUD_ACCOUNT, FLAVOR);
-
-    // This must be set in a feature flag to avoid flickering between the new and old value during config server upgrade
-    public static final UnboundDoubleFlag HOST_MEMORY_RATIO = defineDoubleFlag(
-            "host-memory-ratio", -1.0,
-            "The ratio of MemTotal reserved for Linux or host processes, and not available to the Podman containers. " +
-            "A value outside the range [0.0, 1.0] will use a hard-coded ratio.",
-            "Affects future deployments, JVM settings for new config server Podman containers, auto scaling modelling.",
-            ARCHITECTURE, CLAVE, CLOUD_ACCOUNT, FLAVOR);
-
     public static final UnboundBooleanFlag FORWARD_ISSUES_AS_ERRORS = defineFeatureFlag(
             "forward-issues-as-errors", true,
             "When the backend detects a problematic issue with a query, it will by default send it as an error message to the QRS, which adds it in an ErrorHit in the result.  May be disabled using this flag.",
             "Takes effect immediately",
-            INSTANCE_ID);
-
-    public static final UnboundBooleanFlag DEACTIVATE_ROUTING = defineFeatureFlag(
-            "deactivate-routing", false,
-            "Deactivates routing for an application by removing all reals from its load balancers. Used in " +
-            "cases where we immediately need to stop serving an application, i.e. in case of service violations",
-            "Takes effect on next redeployment",
             INSTANCE_ID);
 
     public static final UnboundListFlag<String> IGNORED_HTTP_USER_AGENTS = defineListFlag(
@@ -366,50 +185,11 @@ public class PermanentFlags {
             "Takes effect at redeployment",
             INSTANCE_ID);
 
-    public static final UnboundListFlag<String> DISABLED_DEPLOYMENT_ZONES = defineListFlag(
-            "disabled-deployment-zones", List.of(), String.class,
-            "The zones, e.g., prod.norway-71, where deployments jobs are currently disabled",
-            "Takes effect immediately",
-            TENANT_ID, APPLICATION, INSTANCE_ID
-    );
-
     public static final UnboundBooleanFlag ALLOW_USER_FILTERS = defineFeatureFlag(
             "allow-user-filters", true,
             "Allow user filter (chains) in application",
             "Takes effect on next redeployment",
             INSTANCE_ID);
-
-    public static final UnboundBooleanFlag ALLOW_STATUS_PAGE = defineFeatureFlag(
-            "allow-status-page", false,
-            "Shows link to status page for nodes of a specific tenant",
-            "Takes effect on browser reload of /user/v1/user",
-            CONSOLE_USER_EMAIL, TENANT_ID);
-
-    public static final UnboundIntFlag PRE_PROVISIONED_LB_COUNT = defineIntFlag(
-            "pre-provisioned-lb-count", 0,
-            "Number of application load balancers to have pre-provisioned at any time",
-            "Takes immediate effect");
-
-    public static final UnboundLongFlag CONFIG_SERVER_SESSION_LIFETIME = defineLongFlag(
-            "config-server-session-lifetime", 3600,
-            "Lifetime / expiry time in seconds for config sessions. " +
-            "This can be lowered if there are incidents/bugs where one needs to delete sessions quickly",
-            "Takes effect immediately"
-    );
-
-    public static final UnboundIntFlag KEEP_FILE_REFERENCES_DAYS = defineIntFlag(
-            "keep-file-references-days", 30,
-            "How many days to keep file references on tenant nodes (based on last modification time)",
-            "Takes effect on restart of Docker container",
-            INSTANCE_ID
-    );
-
-    public static final UnboundIntFlag KEEP_FILE_REFERENCES_COUNT = defineIntFlag(
-            "keep-file-references-count", 20,
-            "How many file references to keep on tenant nodes (no matter what last modification time is)",
-            "Takes effect on restart of Docker container",
-            ZONE_ID, INSTANCE_ID
-    );
 
     public static final UnboundIntFlag ENDPOINT_CONNECTION_TTL = defineIntFlag(
             "endpoint-connection-ttl", 45,
@@ -422,55 +202,6 @@ public class PermanentFlags {
             "Whether to enable autoscaling",
             "Takes effect immediately",
             INSTANCE_ID);
-
-    public static final UnboundBooleanFlag AUTOSCALING_DETAILED_LOGGING = defineFeatureFlag(
-            "autoscaling-detailed-logging", false,
-            "Whether to log autoscaling decision data",
-            "Takes effect immediately",
-            INSTANCE_ID);
-
-    public static final UnboundIntFlag MAX_HOSTS_PER_HOUR = defineIntFlag(
-            "max-hosts-per-hour", 125,
-            "The number of hosts that can be provisioned per hour in a zone, before throttling is " +
-            "triggered",
-            "Takes effect immediately");
-
-    public static final UnboundIntFlag MAX_CERTIFICATES_PER_HOUR = defineIntFlag(
-            "max-certificates-per-hour", 10,
-            "The number of certificates can be provisioned per hour, before throttling is triggered",
-            "Takes effect immediately");
-
-    public static final UnboundBooleanFlag DROP_CACHES = defineFeatureFlag(
-            "drop-caches", true,
-            "Drop pagecache. " +
-            "This is combined with the drop-dentries-and-inodes flag for a single write to /proc/sys/vm/drop_caches.",
-            "Takes effect on next tick",
-            // The tenant, application, and instance ID dimensions are set from the exclusive ApplicationId
-            // associated with the host, if any, or otherwise hosted-vespa:tenant-host:default.
-            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_ID, CLUSTER_TYPE);
-
-    public static final UnboundIntFlag DROP_DENTRIES = defineIntFlag(
-            "drop-dentries", -1,
-            "Drop dentries and inodes every N minutes.  0 means every tick. -1 means disabled. " +
-            "This is combined with the drop-caches flag for a single write to /proc/sys/vm/drop_caches.",
-            "Takes effect on next tick",
-            // The tenant, application, and instance ID dimensions are set from the exclusive ApplicationId
-            // associated with the host, if any, or otherwise hosted-vespa:tenant-host:default.
-            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_ID, CLUSTER_TYPE);
-
-    public static final UnboundIntFlag CERT_POOL_SIZE = defineIntFlag(
-            "cert-pool-size", 0,
-            "Target number of preprovisioned endpoints certificates to maintain",
-            "Takes effect on next run of CertificatePoolMaintainer",
-            CERTIFICATE_PROVIDER
-    );
-
-    public static final UnboundStringFlag REFRESH_IDENTITY_BOUNDARY = defineStringFlag(
-            "refresh-identity-after", "",
-            "Refresh the identity document and certificates issued before this timestamp. Timestamp in ISO8601 format",
-            "Takes effect on next host admin tick",
-            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, HOSTNAME
-    );
 
     public static final UnboundListFlag<String> LOG_REQUEST_CONTENT = defineListFlag(
             "log-request-content", List.of(), String.class,
@@ -526,14 +257,6 @@ public class PermanentFlags {
             "Takes effect at redeployment",
             INSTANCE_ID);
 
-    public static final UnboundStringFlag SYSTEM_MEMORY_MAX = defineStringFlag(
-            "system-memory-max", "",
-            "The value to write to /sys/fs/cgroup/system.slice/memory.max, if non-empty. " +
-                    "You may want lower memory.high before lowering memory.max, " +
-                    "and raise memory.high after raising memory.max.",
-            "Takes effect on next tick.",
-            NODE_TYPE);
-
     public static final UnboundIntFlag MAX_UNCOMMITTED_MEMORY = defineIntFlag(
             "max-uncommitted-memory", 130000,
             "Max amount of memory holding updates to an attribute before we do a commit.",
@@ -560,23 +283,6 @@ public class PermanentFlags {
             "Takes effect at startup of search node",
             TENANT_ID, APPLICATION, INSTANCE_ID);
 
-    public static final UnboundListFlag<String> IGNORE_CORE_DUMP_TYPE_WHEN_REPORTING = defineListFlag(
-            "ignore-core-dump-type-when-reporting", List.of(), String.class,
-            "Whether to ignore core dump reporting (creating or updating a Jira ticket) for the specified core dump types." +
-                    "Typically set to JVM_HEAP and/or OOM for apps that have issues in application code " +
-                    "that the customer needs to fix and we don't want to create or update a Jira issue for.",
-            "Takes effect immediately",
-            list -> Set.of("CORE_DUMP", "JVM_HEAP", "OOM").containsAll(list),
-            TENANT_ID, APPLICATION, INSTANCE_ID, ZONE_ID, ENVIRONMENT
-    );
-
-    public static final UnboundBooleanFlag LOCK_APPLICATION_PACKAGE_ACCESS = defineFeatureFlag(
-            "lock-application-package-access", false,
-            "Whether application package access should be locked down",
-            "Takes effect immediately",
-            TENANT_ID, APPLICATION
-    );
-
     public static final UnboundBooleanFlag IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP = defineFeatureFlag(
             "ignore-connectivity-checks-at-startup", false,
             "Ignore connectivity checks in config-sentinel at startup. " +
@@ -584,22 +290,6 @@ public class PermanentFlags {
                     "When this flag is set, services are started immediately regardless of connectivity check results.",
             "Takes effect on next host restart",
             TENANT_ID, APPLICATION, INSTANCE_ID);
-
-    public static final UnboundListFlag<String> ALLOW_FLAVORS = defineListFlag(
-            "allow-flavors", List.of(), String.class,
-            "Flavors that that we will allow provisioning (flavors with lifecycle 'active' are allowed by default)" +
-                    ". Each string in the list is a regexp, e.g. 'c4d-.*' or 'c4d-high.*'.",
-            "Takes effect immediately",
-            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_ID, CLUSTER_TYPE
-    );
-
-    public static final UnboundListFlag<String> DENY_FLAVORS = defineListFlag(
-            "deny-flavors", List.of(), String.class,
-            "Flavors that that we will deny provisioning (flavors with lifecycle 'new' and 'retired' are disallowed by default)" +
-                    ". Each string in the list is a regexp, e.g. 'c4d-.*' or 'c4d-high.*'.",
-            "Takes effect immediately",
-            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_ID, CLUSTER_TYPE
-    );
 
     public static final UnboundLongFlag ZOOKEEPER_PRE_ALLOC_SIZE_KIB = defineLongFlag(
             "zookeeper-pre-alloc-size", 65536,
@@ -622,12 +312,6 @@ public class PermanentFlags {
             "for query visibility if they are out of sync with a majority of other replicas",
             "Takes effect at redeployment",
             INSTANCE_ID);
-
-    public static final UnboundStringFlag CORE_ENCRYPTION_PUBLIC_KEY_ID = defineStringFlag(
-            "core-encryption-public-key-id", "",
-            "Specifies which public key to use for core dump encryption.",
-            "Takes effect on the next tick.",
-            NODE_TYPE, HOSTNAME);
 
     public static final UnboundIntFlag MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY = defineIntFlag(
             "max-content-node-maintenance-op-concurrency", -1,


### PR DESCRIPTION
## Summary
- Remove feature and permanent flag definitions from `Flags.java` and `PermanentFlags.java` that are no longer referenced anywhere in this repository.
- Clean up now-unused imports.

This keeps `Flags.java` and `PermanentFlags.java` focused on flags actually consumed by code in this repo.

## Test plan
- [x] \`mvn install -DskipTests\` succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)