### PR TITLE
Add utility for pseudo-randomly flipping floating-point signs

### DIFF
--- a/vespalib/src/tests/quant/.gitignore
+++ b/vespalib/src/tests/quant/.gitignore
@@ -1,0 +1,2 @@
+Makefile
+vespalib_quant_test_app

--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(vespalib_quant_test_app TEST
     SOURCES
     centroid_test.cpp
     hadamard_test.cpp
+    sign_flip_test.cpp
     DEPENDS
     vespalib
     GTest::gtest

--- a/vespalib/src/tests/quant/sign_flip_test.cpp
+++ b/vespalib/src/tests/quant/sign_flip_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <random>
 #include <span>
 #include <vector>
@@ -21,7 +22,25 @@ template <std::floating_point T> void flip(std::span<T> f, const uint64_t seed) 
     flip_sign_bits(f, prng);
 }
 
-template <std::floating_point T> void do_test_sign_flips_are_deterministic_and_invertible() {
+template <std::floating_point T> void do_test_full_block_sign_flips_are_deterministic_and_invertible() {
+    SCOPED_TRACE("full block");
+    std::vector<T> v(64); // Leaky abstraction alert: fixed block size of 64 due to 64 PRNG output bits.
+    std::iota(v.begin(), v.end(), 1);
+    const std::vector v_orig = v;
+
+    flip<T>(v, 0xf00d);
+    std::vector<T> expected = {1,   2,   -3,  4,   -5,  -6,  7,   -8,  9,   10, 11,  -12, -13, -14, -15, -16,
+                               17,  -18, 19,  20,  -21, 22,  23,  24,  -25, 26, 27,  -28, 29,  30,  31,  32,
+                               -33, 34,  -35, -36, -37, -38, -39, 40,  41,  42, -43, 44,  -45, -46, 47,  -48,
+                               -49, -50, 51,  52,  53,  54,  -55, -56, 57,  58, -59, 60,  -61, 62,  -63, -64};
+    EXPECT_THAT(v, ElementsAreArray(expected));
+
+    flip<T>(v, 0xf00d);
+    EXPECT_THAT(v, ElementsAreArray(v_orig));
+}
+
+template <std::floating_point T> void do_test_remainder_sign_flips_are_deterministic_and_invertible() {
+    SCOPED_TRACE("block remainder");
     std::vector<T> v = {1, 2, 3, 4, 5, 6, 7, 8};
     std::vector<T> v2 = {9, 10, 11, 12, 13, 14, 15, 16};
 
@@ -35,25 +54,18 @@ template <std::floating_point T> void do_test_sign_flips_are_deterministic_and_i
     EXPECT_THAT(v, ElementsAre(1, 2, 3, 4, 5, 6, 7, 8));
     flip<T>(v2, 0xc0ffee);
     EXPECT_THAT(v2, ElementsAre(9, 10, 11, 12, 13, 14, 15, 16));
-
-    // Abstraction leak alert: test that chunk remainders are handled
-    std::vector<T> v3(64);
-    // TODO append_range() when we know all our compiler versions have it
-    v3.insert(v3.end(), v.begin(), v.end()); // 64 + 8 elements
-    flip<T>(v3, 0x1337);
-    EXPECT_THAT(std::span(v3).subspan(64), ElementsAre(-1, -2, -3, 4, -5, 6, -7, -8));
-    flip<T>(v3, 0x1337);
-    EXPECT_THAT(std::span(v3).subspan(64), ElementsAreArray(v));
 }
 
 } // namespace
 
 TEST(SignFlipTest, float_sign_flips_are_deterministic_and_invertible) {
-    do_test_sign_flips_are_deterministic_and_invertible<float>();
+    do_test_full_block_sign_flips_are_deterministic_and_invertible<float>();
+    do_test_remainder_sign_flips_are_deterministic_and_invertible<float>();
 }
 
 TEST(SignFlipTest, double_sign_flips_are_deterministic_and_invertible) {
-    do_test_sign_flips_are_deterministic_and_invertible<double>();
+    do_test_full_block_sign_flips_are_deterministic_and_invertible<double>();
+    do_test_remainder_sign_flips_are_deterministic_and_invertible<double>();
 }
 
 TEST(SignFlipTest, sign_flipping_buffer_boundary_cases) {

--- a/vespalib/src/tests/quant/sign_flip_test.cpp
+++ b/vespalib/src/tests/quant/sign_flip_test.cpp
@@ -1,0 +1,88 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/quant/sign_flip.h>
+#include <vespa/vespalib/util/xoshiro.h>
+
+#include <gmock/gmock.h>
+
+#include <random>
+#include <span>
+#include <vector>
+
+using namespace ::testing;
+
+namespace vespalib::quant {
+
+namespace {
+
+template <std::floating_point T> void flip(std::span<T> f, const uint64_t seed) {
+    Xoshiro256PlusPlusPrng prng(seed);
+    flip_sign_bits(f, prng);
+}
+
+template <std::floating_point T> void do_test_sign_flips_are_deterministic_and_invertible() {
+    std::vector<T> v = {1, 2, 3, 4, 5, 6, 7, 8};
+    std::vector<T> v2 = {9, 10, 11, 12, 13, 14, 15, 16};
+
+    flip<T>(v, 0x1337);
+    EXPECT_THAT(v, ElementsAre(1, -2, -3, 4, 5, -6, 7, 8));
+    flip<T>(v2, 0xc0ffee);
+    EXPECT_THAT(v2, ElementsAre(-9, -10, -11, 12, -13, -14, 15, 16));
+
+    // Invert flipping by running with same PRNG state
+    flip<T>(v, 0x1337);
+    EXPECT_THAT(v, ElementsAre(1, 2, 3, 4, 5, 6, 7, 8));
+    flip<T>(v2, 0xc0ffee);
+    EXPECT_THAT(v2, ElementsAre(9, 10, 11, 12, 13, 14, 15, 16));
+
+    // Abstraction leak alert: test that chunk remainders are handled
+    std::vector<T> v3(64);
+    // TODO append_range() when we know all our compiler versions have it
+    v3.insert(v3.end(), v.begin(), v.end()); // 64 + 8 elements
+    flip<T>(v3, 0x1337);
+    EXPECT_THAT(std::span(v3).subspan(64), ElementsAre(-1, -2, -3, 4, -5, 6, -7, -8));
+    flip<T>(v3, 0x1337);
+    EXPECT_THAT(std::span(v3).subspan(64), ElementsAreArray(v));
+}
+
+} // namespace
+
+TEST(SignFlipTest, float_sign_flips_are_deterministic_and_invertible) {
+    do_test_sign_flips_are_deterministic_and_invertible<float>();
+}
+
+TEST(SignFlipTest, double_sign_flips_are_deterministic_and_invertible) {
+    do_test_sign_flips_are_deterministic_and_invertible<double>();
+}
+
+TEST(SignFlipTest, sign_flipping_buffer_boundary_cases) {
+    Xoshiro256PlusPlusPrng prng(std::random_device{}());
+
+    constexpr size_t max_dims = 1024;
+    for (size_t d = 0; d < max_dims; ++d) {
+        std::vector<float>           v(d);
+        const Xoshiro256PlusPlusPrng flip_seed_prng(prng());
+        Xoshiro256PlusPlusPrng       value_prng(prng());
+
+        for (size_t i = 0; i < d; ++i) {
+            // We do not care about silly things such as creating NaNs and subnormals etc.,
+            // just about the raw bit patterns.
+            v[i] = std::bit_cast<float>(static_cast<uint32_t>(value_prng()));
+        }
+        const std::vector v_check = v;
+
+        Xoshiro256PlusPlusPrng flip_prng(flip_seed_prng);
+        flip_sign_bits<float>(v, flip_prng);
+
+        Xoshiro256PlusPlusPrng inv_flip_prng(flip_seed_prng);
+        flip_sign_bits<float>(v, inv_flip_prng);
+        // Check exact before/after bit patterns. Don't defer to FP equality rules, as we
+        // (as mentioned above) may create all kinds of exciting special-case FP values.
+        for (size_t i = 0; i < d; ++i) {
+            ASSERT_EQ(std::bit_cast<uint32_t>(v[i]), std::bit_cast<uint32_t>(v_check[i]));
+        }
+    }
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/sign_flip.h
+++ b/vespalib/src/vespa/vespalib/quant/sign_flip.h
@@ -1,0 +1,70 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <span>
+
+namespace vespalib::quant {
+
+template <typename> struct ToUintT;
+template <> struct ToUintT<float> {
+    using type = uint32_t;
+};
+template <> struct ToUintT<double> {
+    using type = uint64_t;
+};
+
+template <std::floating_point T> using ToUint = ToUintT<T>::type;
+
+/*
+ * Pseudo-randomly flip the sign bits in-place of all floating point values contained in `v`.
+ *
+ * This operation is _invertible_. Assume `flip_sign_bits` takes in span V and PRNG state
+ * foo, yielding V'. Calling `flip_sign_bits` with span V' and the _same_ PRNG state foo
+ * will yield back the original V. Needless to say, the PRNG invocations must generate
+ * bitwise exact identical output sequences across the two flip-calls for this to work.
+ *
+ * This will always invoke `prng()` ceil(v.size() / 64) times.
+ */
+template <std::floating_point T, std::uniform_random_bit_generator Prng>
+void flip_sign_bits(std::span<T> v, Prng& prng) noexcept {
+    static_assert(Prng::max() == std::numeric_limits<uint64_t>::max());
+    const size_t blocks = v.size() / 64;
+    const size_t rem = v.size() % 64;
+    using UintType = ToUint<T>;
+
+    // Each PRNG invocation yields 64 presumed independent pseudo-random bits.
+    // For each distinct bit we XOR it with the MSB (IEEE fp sign bit) of its
+    // corresponding input/output span element of a given processing block.
+    // This results in a pretty efficient and also fully invertible sign transform.
+    auto flip_msb = [](T& elem, const uint64_t rand_bits, const size_t idx) noexcept {
+        const UintType as_uint = std::bit_cast<UintType>(elem);
+        const UintType rand_msb = ((rand_bits >> idx) & 1) << ((sizeof(UintType) * 8) - 1);
+        elem = std::bit_cast<T>(as_uint ^ rand_msb);
+    };
+
+    size_t i = 0;
+    // We dangle fixed block size processing alluringly in front of the compiler,
+    // tempting it to unroll and/or auto-vectorize the inner loop. GCC will happily
+    // bite (https://godbolt.org/z/15r655n9P), although the generated code does
+    // look a bit on the heavy side...
+    for (; i < blocks; ++i) {
+        const uint64_t bits = prng();
+        for (size_t j = 0; j < 64; ++j) {
+            flip_msb(v[i * 64 + j], bits, j);
+        }
+    }
+    if (rem != 0) {
+        const uint64_t bits = prng();
+        for (size_t j = 0; j < rem; ++j) {
+            flip_msb(v[i * 64 + j], bits, j);
+        }
+    }
+}
+
+} // namespace vespalib::quant


### PR DESCRIPTION
@havardpe please review
@arnej27959 FYI

This adds a pseudo-random (and thus deterministic given the same input seeds) and _invertible_ sign flip transform of a sequence of floating point values.

This is a prerequisite for using the fast Walsh-Hadamard transform for rotations, as random sign flips on the input makes the otherwise deterministic transform induce a (pseudo-) _randomized_ matrix rotation.
