### PR TITLE
Resolve tenant vault references in telemetry export configuration

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/TelemetryExporterConfiguration.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/TelemetryExporterConfiguration.java
@@ -2,25 +2,52 @@
 package com.yahoo.config.provision;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Immutable telemetry export configuration for an application deployment.
  *
  * @author onur
  */
-public record TelemetryExporterConfiguration(List<Exporter> exporters) {
+public record TelemetryExporterConfiguration(List<Exporter> exporters, List<VaultReference> vaultReferences) {
 
-    private static final TelemetryExporterConfiguration EMPTY = new TelemetryExporterConfiguration(List.of());
+    private static final TelemetryExporterConfiguration EMPTY = new TelemetryExporterConfiguration(List.of(), List.of());
+
+    public TelemetryExporterConfiguration(List<Exporter> exporters) {
+        this(exporters, List.of());
+    }
 
     public TelemetryExporterConfiguration {
         exporters = List.copyOf(Objects.requireNonNull(exporters));
+        vaultReferences = List.copyOf(Objects.requireNonNull(vaultReferences));
     }
 
     public boolean isEmpty() { return exporters.isEmpty(); }
 
     public static TelemetryExporterConfiguration empty() { return EMPTY; }
+
+    /** Returns a new config with resolved tenant vault metadata for vaults referenced by exporters with auth. Throws if any referenced vault is missing. */
+    public TelemetryExporterConfiguration withTenantVaultReferences(List<VaultReference> availableVaults) {
+        Map<String, VaultReference> vaultsByName = availableVaults.stream()
+                .collect(Collectors.toMap(VaultReference::name, v -> v));
+
+        List<VaultReference> resolved = exporters.stream()
+                .flatMap(exporter -> exporter.auth().stream())
+                .map(auth -> {
+                    var ref = vaultsByName.get(auth.vault());
+                    if (ref == null)
+                        throw new IllegalArgumentException("Telemetry exporter references vault '" + auth.vault() +
+                                "' but no matching vault metadata was found");
+                    return ref;
+                })
+                .distinct()
+                .toList();
+
+        return new TelemetryExporterConfiguration(exporters, resolved);
+    }
 
     /** A single telemetry exporter targeting an external endpoint or cloud project. */
     public record Exporter(String id, ExporterType type, Optional<String> endpoint, Optional<String> project,
@@ -73,6 +100,17 @@ public record TelemetryExporterConfiguration(List<Exporter> exporters) {
             if (passwordSecretName == null || passwordSecretName.isBlank()) throw new IllegalArgumentException("basic-auth password-secret-name must be non-empty");
             return new Auth("basic_auth", vault, Optional.empty(), Optional.empty(), Optional.of(usernameSecretName), Optional.of(passwordSecretName));
         }
+    }
+
+    /** Resolved vault metadata needed by host-admin to read tenant secrets from ASM. */
+    public record VaultReference(String id, String name, String externalId) {
+
+        public VaultReference {
+            if (id == null || id.isBlank()) throw new IllegalArgumentException("vault id must be non-blank");
+            if (name == null || name.isBlank()) throw new IllegalArgumentException("vault name must be non-blank");
+            if (externalId == null || externalId.isBlank()) throw new IllegalArgumentException("vault externalId must be non-blank");
+        }
+
     }
 
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/TelemetryExporterConfigurationSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/TelemetryExporterConfigurationSerializer.java
@@ -4,6 +4,7 @@ package com.yahoo.config.provision.serialization;
 import com.yahoo.config.provision.TelemetryExporterConfiguration;
 import com.yahoo.config.provision.TelemetryExporterConfiguration.Auth;
 import com.yahoo.config.provision.TelemetryExporterConfiguration.Exporter.ExporterType;
+import com.yahoo.config.provision.TelemetryExporterConfiguration.VaultReference;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
@@ -35,6 +36,8 @@ public class TelemetryExporterConfigurationSerializer {
     private static final String passwordSecretNameKey = "passwordSecretName";
     private static final String metricSetsKey = "metricSets";
     private static final String logFileTypesKey = "logFileTypes";
+    private static final String vaultReferencesKey = "vaultReferences";
+    private static final String externalIdKey = "externalId";
 
     public static byte[] toJson(TelemetryExporterConfiguration config) {
         Slime slime = new Slime();
@@ -76,6 +79,15 @@ public class TelemetryExporterConfigurationSerializer {
                 logFileTypesArray.addString(logFileType);
             }
         }
+        if ( ! config.vaultReferences().isEmpty()) {
+            Cursor vaultRefsArray = root.setArray(vaultReferencesKey);
+            for (var ref : config.vaultReferences()) {
+                Cursor refObject = vaultRefsArray.addObject();
+                refObject.setString(idKey, ref.id());
+                refObject.setString("name", ref.name());
+                refObject.setString(externalIdKey, ref.externalId());
+            }
+        }
     }
 
     public static TelemetryExporterConfiguration fromSlime(Inspector root) {
@@ -108,7 +120,15 @@ public class TelemetryExporterConfigurationSerializer {
                                                           Optional.ofNullable(auth), metricSets, logFileTypes));
         });
         if (exporters.isEmpty()) return TelemetryExporterConfiguration.empty();
-        return new TelemetryExporterConfiguration(exporters);
+
+        List<VaultReference> vaultReferences = new ArrayList<>();
+        root.field(vaultReferencesKey).traverse((ArrayTraverser) (i, refInspector) ->
+                vaultReferences.add(new VaultReference(
+                        refInspector.field(idKey).asString(),
+                        refInspector.field("name").asString(),
+                        refInspector.field(externalIdKey).asString())));
+
+        return new TelemetryExporterConfiguration(exporters, vaultReferences);
     }
 
     private static String optionalString(Inspector inspector) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/TelemetryExporterConfigurationSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/TelemetryExporterConfigurationSerializer.java
@@ -37,6 +37,7 @@ public class TelemetryExporterConfigurationSerializer {
     private static final String metricSetsKey = "metricSets";
     private static final String logFileTypesKey = "logFileTypes";
     private static final String vaultReferencesKey = "vaultReferences";
+    private static final String nameKey = "name";
     private static final String externalIdKey = "externalId";
 
     public static byte[] toJson(TelemetryExporterConfiguration config) {
@@ -84,7 +85,7 @@ public class TelemetryExporterConfigurationSerializer {
             for (var ref : config.vaultReferences()) {
                 Cursor refObject = vaultRefsArray.addObject();
                 refObject.setString(idKey, ref.id());
-                refObject.setString("name", ref.name());
+                refObject.setString(nameKey, ref.name());
                 refObject.setString(externalIdKey, ref.externalId());
             }
         }
@@ -125,7 +126,7 @@ public class TelemetryExporterConfigurationSerializer {
         root.field(vaultReferencesKey).traverse((ArrayTraverser) (i, refInspector) ->
                 vaultReferences.add(new VaultReference(
                         refInspector.field(idKey).asString(),
-                        refInspector.field("name").asString(),
+                        refInspector.field(nameKey).asString(),
                         refInspector.field(externalIdKey).asString())));
 
         return new TelemetryExporterConfiguration(exporters, vaultReferences);

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/TelemetryExporterConfigurationSerializerTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/TelemetryExporterConfigurationSerializerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.TelemetryExporterConfiguration;
 import com.yahoo.config.provision.TelemetryExporterConfiguration.Auth;
 import com.yahoo.config.provision.TelemetryExporterConfiguration.Exporter;
 import com.yahoo.config.provision.TelemetryExporterConfiguration.Exporter.ExporterType;
+import com.yahoo.config.provision.TelemetryExporterConfiguration.VaultReference;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TelemetryExporterConfigurationSerializerTest {
@@ -224,6 +226,76 @@ public class TelemetryExporterConfigurationSerializerTest {
         var b = new TelemetryExporterConfiguration(List.of(exporter));
         assertEquals(a, b);
         assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void testRoundTripWithVaultReferences() {
+        var auth = Auth.bearerToken("my-vault", "my-token");
+        var exporter = new Exporter("exp1", ExporterType.otlphttp, Optional.of("https://otel.example.com/v1"), Optional.empty(),
+                Optional.of(auth), List.of("default"), List.of());
+        var vaultRef = new VaultReference("vault-id-1", "my-vault", "ext-id-1");
+        var config = new TelemetryExporterConfiguration(List.of(exporter), List.of(vaultRef));
+
+        var deserialized = TelemetryExporterConfigurationSerializer.fromJson(TelemetryExporterConfigurationSerializer.toJson(config));
+        assertEquals(config, deserialized);
+        assertEquals(1, deserialized.vaultReferences().size());
+        assertEquals("vault-id-1", deserialized.vaultReferences().get(0).id());
+        assertEquals("my-vault", deserialized.vaultReferences().get(0).name());
+        assertEquals("ext-id-1", deserialized.vaultReferences().get(0).externalId());
+    }
+
+    @Test
+    void testRoundTripWithoutVaultReferences() {
+        var exporter = new Exporter("exp1", ExporterType.otlp, Optional.of("https://ep"), Optional.empty(),
+                Optional.empty(), List.of(), List.of());
+        var config = new TelemetryExporterConfiguration(List.of(exporter));
+
+        var deserialized = TelemetryExporterConfigurationSerializer.fromJson(TelemetryExporterConfigurationSerializer.toJson(config));
+        assertEquals(config, deserialized);
+        assertTrue(deserialized.vaultReferences().isEmpty());
+    }
+
+    @Test
+    void testWithResolvedVaults() {
+        var exporter1 = new Exporter("exp1", ExporterType.otlphttp, Optional.of("https://ep1"), Optional.empty(),
+                Optional.of(Auth.bearerToken("vault-a", "token-a")), List.of(), List.of());
+        var exporter2 = new Exporter("exp2", ExporterType.otlp, Optional.of("https://ep2"), Optional.empty(),
+                Optional.of(Auth.apiKey("vault-b", "key-b", "X-Key")), List.of(), List.of());
+        var exporter3 = new Exporter("exp3", ExporterType.otlp, Optional.of("https://ep3"), Optional.empty(),
+                Optional.empty(), List.of(), List.of());
+        var config = new TelemetryExporterConfiguration(List.of(exporter1, exporter2, exporter3));
+
+        var available = List.of(
+                new VaultReference("id-a", "vault-a", "ext-a"),
+                new VaultReference("id-b", "vault-b", "ext-b"));
+
+        var resolved = config.withTenantVaultReferences(available);
+        assertEquals(2, resolved.vaultReferences().size());
+        assertEquals("vault-a", resolved.vaultReferences().get(0).name());
+        assertEquals("vault-b", resolved.vaultReferences().get(1).name());
+        assertEquals(3, resolved.exporters().size());
+    }
+
+    @Test
+    void testWithResolvedVaultsDeduplicate() {
+        var exporter1 = new Exporter("exp1", ExporterType.otlphttp, Optional.of("https://ep1"), Optional.empty(),
+                Optional.of(Auth.bearerToken("same-vault", "token-1")), List.of(), List.of());
+        var exporter2 = new Exporter("exp2", ExporterType.otlphttp, Optional.of("https://ep2"), Optional.empty(),
+                Optional.of(Auth.bearerToken("same-vault", "token-2")), List.of(), List.of());
+        var config = new TelemetryExporterConfiguration(List.of(exporter1, exporter2));
+
+        var resolved = config.withTenantVaultReferences(List.of(new VaultReference("id-1", "same-vault", "ext-1")));
+        assertEquals(1, resolved.vaultReferences().size());
+    }
+
+    @Test
+    void testWithResolvedVaultsThrowsOnMissing() {
+        var exporter = new Exporter("exp1", ExporterType.otlphttp, Optional.of("https://ep"), Optional.empty(),
+                Optional.of(Auth.bearerToken("missing-vault", "token")), List.of(), List.of());
+        var config = new TelemetryExporterConfiguration(List.of(exporter));
+
+        var e = assertThrows(IllegalArgumentException.class, () -> config.withTenantVaultReferences(List.of()));
+        assertTrue(e.getMessage().contains("missing-vault"));
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -33,6 +33,7 @@ import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.Tags;
 import com.yahoo.config.provision.TelemetryExporterConfiguration;
+import com.yahoo.config.provision.TelemetryExporterConfiguration.VaultReference;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.net.HostName;
 import com.yahoo.path.Path;
@@ -377,7 +378,10 @@ public class SessionPreparer {
                                   params.cloudResourceTags(),
                                   params.dataplaneTokens(),
                                   ActivationTriggers.from(prepareResult.getConfigChangeActions(), params.isInternalRedeployment()),
-                                  telemetryExporterConfiguration());
+                                  telemetryExporterConfiguration().withTenantVaultReferences(
+                                          params.tenantVaults().stream()
+                                                .map(v -> new VaultReference(v.id(), v.name(), v.externalId()))
+                                                .toList()));
             checkTimeout("write state to zookeeper");
         }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeploymentConfigStoreTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeploymentConfigStoreTest.java
@@ -9,6 +9,8 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.TelemetryExporterConfiguration;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.config.model.api.TenantVault;
+import com.yahoo.vespa.config.server.session.PrepareParams;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -79,7 +81,10 @@ public class DeploymentConfigStoreTest {
                 .deploymentConfigStore(store)
                 .build();
 
-        tester.deployApp("src/test/apps/hosted-with-telemetry/");
+        tester.deployApp("src/test/apps/hosted-with-telemetry/",
+                new PrepareParams.Builder().tenantVaults(List.of(
+                        new TenantVault("vault-id-1", "my-vault", "ext-id-1", List.of(
+                                new TenantVault.Secret("secret-id-1", "my-token"))))));
 
         assertEquals(1, store.calls.size());
         TelemetryExporterConfiguration telemetry = store.calls.get(0).telemetryExporterConfiguration();
@@ -97,6 +102,11 @@ public class DeploymentConfigStoreTest {
         assertEquals("my-token", exporter.auth().get().secretName().get());
 
         assertEquals(List.of("default"), exporter.metricSets());
+
+        assertEquals(1, telemetry.vaultReferences().size());
+        assertEquals("vault-id-1", telemetry.vaultReferences().get(0).id());
+        assertEquals("my-vault", telemetry.vaultReferences().get(0).name());
+        assertEquals("ext-id-1", telemetry.vaultReferences().get(0).externalId());
     }
 
     @Test


### PR DESCRIPTION
## Background

Self-service telemetry export allows enclave tenants to configure metrics/logs export to external backends via `<admin><telemetry>` in services.xml. The telemetry config includes authentication credentials that reference tenant secret vaults:

```xml
<exporter id="my-exporter" type="otlphttp" endpoint="https://otel.example.com/v1">
  <auth>
    <bearer-token vault="my-vault" secret-name="my-token"/>
  </auth>
</exporter>
```

The vault name and secret name are validated at submit time (controller checks vault existence, secret existence, and cloud account access rules). However, to actually **read** these secrets at runtime, host-admin needs the resolved vault metadata — specifically the internal `vaultId` and `externalId` that are required to authenticate to AWS Secrets Manager via the Athenz/ZTS/STS chain.

## The problem

Today, tenant vault metadata (`TenantVault` records with id, name, externalId) flows from the controller through the deploy request into session ZK, and from there only into the config model for tenant container secret injection (`AsmTenantSecretReader`). Host-admin has no access to this metadata — it operates on a different ZK tree (node-repository) and reads node data via the `/nodes/v2/` REST API.

The telemetry export config is already propagated to host-admin via: session ZK → `DeploymentConfigStore` → Application ZK → NodesResponse → NodeSpec. But without the vault metadata, host-admin cannot instantiate an `AsmTenantSecretReader` to resolve the secret references.

## Solution

Embed resolved vault metadata directly into `TelemetryExporterConfiguration` during prepare. This way the vault metadata travels alongside the telemetry config through the entire existing propagation chain without requiring any new storage or API paths.

### Changes

**`TelemetryExporterConfiguration`** (config-provisioning):
- Add `VaultReference` nested record: `(String id, String name, String externalId)`
- Add `vaultReferences` field (root level, deduplicated list of vaults referenced by any exporter's auth)
- Add `withTenantVaultReferences(List<VaultReference>)` — resolves vault metadata by matching auth vault names to available vaults. Throws if a referenced vault is missing (fail-fast at deploy time)
- Backwards-compatible: existing single-arg constructor defaults to empty vault references

**`TelemetryExporterConfigurationSerializer`** (config-provisioning):
- Serialize/deserialize `vaultReferences` array. Absent field gracefully defaults to empty list

**`SessionPreparer`** (configserver):
- Chain `.withTenantVaultReferences(...)` when writing telemetry config to session ZK, mapping `TenantVault` → `VaultReference` from the deploy params

### Data flow

```
Controller sends TenantVault metadata in deploy request (existing)
  → PrepareParams.tenantVaults()
    → SessionPreparer maps TenantVault → VaultReference
      → telemetryExporterConfiguration().withTenantVaultReferences(vaultRefs)
        → persisted to session ZK with vault metadata embedded
          → DeploymentConfigStore → Application ZK → NodesResponse → NodeSpec
            → host-admin has vaultId + externalId to instantiate AsmTenantSecretReader
```

## Test plan

- [x] Serializer round-trip with vault references
- [x] Backwards compatibility (absent vault references → empty list)
- [x] `withTenantVaultReferences` resolution, deduplication, and missing vault error
- [x] `DeploymentConfigStoreTest` — full deploy with tenant vaults, verifies vault references persisted
- [x] All existing tests in config-provisioning, config-model, configserver pass