### PR TITLE
Rename "document-id" setting in schema to "documentid"

### DIFF
--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -166,7 +166,7 @@ TOKEN :
 | < AS: "as" >
 | < INDEXING: "indexing" >
 | < SUMMARY_TO: "summary-to" >
-| < DOCUMENT_ID: "document-id" >
+| < DOCUMENTID: "documentid" >
 | < DOCUMENT_SUMMARY: "document-summary" >
 | < ELEMENT_GAP: "element-gap" >
 | < INFINITY: "infinity" >
@@ -1533,7 +1533,7 @@ void id(ParsedField field) :
 }
 
 /**
- * Consumes the document-id setting.
+ * Consumes the documentid setting.
  *
  * @param schema the schema object to add setting to
  */
@@ -1542,7 +1542,7 @@ void documentId(ParsedSchema schema) :
     boolean attribute = false;
 }
 {
-    <DOCUMENT_ID>
+    <DOCUMENTID>
     <COLON> ( ( <ATTRIBUTE> { attribute = true; } ) | ( <FROM_DISK> { attribute = false; } ) )
     {
         schema.enableDocumentIdAttribute(attribute);
@@ -2928,7 +2928,6 @@ String identifierWithDash() :
     | <CUTOFF_STRATEGY>
     | <DENSE_POSTING_LIST_THRESHOLD>
     | <DISTANCE_METRIC>
-    | <DOCUMENT_ID>
     | <DOCUMENT_SUMMARY>
     | <ELEMENT_GAP>
     | <ENABLE_BIT_VECTORS>
@@ -3026,6 +3025,7 @@ String identifier() : { }
       | <DIRECT>
       | <DIVERSITY>
       | <DOCUMENT>
+      | <DOCUMENTID>
       | <DOUBLE_KEYWORD>
       | <FLOAT_KEYWORD>
       | <LONG_KEYWORD>

--- a/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
@@ -357,7 +357,7 @@ public class SchemaTestCase {
                         "    summary pf1 {}" +
                         "  }" +
                         "  import field parentschema_ref.name as parent_imported {}" +
-                        "  document-id: attribute" +
+                        "  documentid: attribute" +
                         "  raw-as-base64-in-summary" +
                         "}");
         String childLines = joinLines(
@@ -991,7 +991,7 @@ public class SchemaTestCase {
         String schema_fromdisk =
                 """
                 schema doc {
-                    document-id: from-disk
+                    documentid: from-disk
                     document doc {
                     }
                 }""";
@@ -1000,7 +1000,7 @@ public class SchemaTestCase {
         String schema_attribute =
                 """
                 schema doc {
-                    document-id: attribute
+                    documentid: attribute
                     document doc {
                     }
                 }""";

--- a/config-model/src/test/java/com/yahoo/schema/processing/SummaryDiskAccessValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/SummaryDiskAccessValidatorTestCase.java
@@ -17,8 +17,8 @@ public class SummaryDiskAccessValidatorTestCase {
     void logs_warning_when_accessing_field_that_needs_disk_access() throws ParseException {
         var sd = joinLines(
                 "schema test {",
-                "  # Using the document-id attribute should not affect warning below",
-                "  document-id: attribute",
+                "  # Using the document-ids-as-attribute setting should not affect warning below",
+                "  documentid: attribute",
                 "  document test {",
                 "    field str_map type map<string, string> {",
                 "      indexing: summary",
@@ -43,7 +43,7 @@ public class SummaryDiskAccessValidatorTestCase {
     void logs_warning_when_accessing_documentid_when_not_an_attribute() throws ParseException {
         var sd = joinLines(
                 "schema test {",
-                "  document-id: from-disk",
+                "  documentid: from-disk",
                 "  document test {",
                 "  }",
                 "  document-summary my_sum {",
@@ -64,7 +64,7 @@ public class SummaryDiskAccessValidatorTestCase {
     void does_not_log_warning_when_accessing_documentid_when_an_attribute() throws ParseException {
         var sd = joinLines(
                 "schema test {",
-                "  document-id: attribute",
+                "  documentid: attribute",
                 "  document test {",
                 "  }",
                 "  document-summary my_sum {",

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -230,14 +230,14 @@ public class ContentClusterTest extends ContentBaseTest {
         String schema_fromdisk =
                 """
                 schema type1 {
-                    document-id: from-disk
+                    documentid: from-disk
                     document type1 {
                     }
                 }""";
         String schema_attribute =
                 """
                 schema type2 {
-                    document-id: attribute
+                    documentid: attribute
                     document type2 {
                     }
                 }""";


### PR DESCRIPTION
`documentid` is used throughout Vespa, e.g., in document summaries, so it makes sense to stick to that here.