### PR TITLE
Add documentid setting to language-server schema parser

### DIFF
--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -391,6 +391,7 @@ TOKEN :
 | < AS: "as" >
 | < INDEXING: "indexing" >
 | < SUMMARY_TO: "summary-to" >
+| < DOCUMENTID: "documentid" >
 | < DOCUMENT_SUMMARY: "document-summary" >
 | < ELEMENT_GAP: "element-gap" >
 | < INFINITY: "infinity" >
@@ -657,6 +658,7 @@ ParsedSchema rootSchema :
 rootSchemaItem(ParsedSchema schema) : {}
     (
         documentElm(schema)
+       | documentId(schema)
        | rawAsBase64(schema)
        | searchStemming(schema)
        | importField(schema)
@@ -1839,6 +1841,23 @@ void idElm(ParsedField field) :
     <ID> <COLON> fieldId = integerElm
     {
         field.setId(fieldId);
+    }
+;
+
+/**
+ * Consumes the documentid setting.
+ *
+ * @param schema the schema object to add setting to
+ */
+void documentId(ParsedSchema schema) :
+{
+    boolean attribute = false;
+}
+
+    <DOCUMENTID>
+    <COLON> ( ( <ATTRIBUTE> { attribute = true; } ) | ( <FROM_DISK> { attribute = false; } ) )
+    {
+        schema.enableDocumentIdAttribute(attribute);
     }
 ;
 
@@ -3499,6 +3518,7 @@ String identifierStr :
       | <DIRECT>
       | <DIVERSITY>
       | <DOCUMENT>
+      | <DOCUMENTID>
       | <DOUBLE_KEYWORD>
       | <FLOAT_KEYWORD>
       | <LONG_KEYWORD>

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -281,6 +281,7 @@ public class SchemaParserTest {
              */
             "src/test/sdfiles/multi/types/",
             "src/test/sdfiles/multi/bookandmusic/",
+            "src/test/sdfiles/multi/documentid/",
         };
 
         return Arrays.stream(directories)

--- a/integration/schema-language-server/language-server/src/test/sdfiles/multi/documentid/attr.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/multi/documentid/attr.sd
@@ -1,0 +1,14 @@
+# Copyright Vespa.ai. All rights reserved.
+schema attr {
+  documentid: attribute
+  document attr {
+    field some_field type int {
+        indexing: attribute | summary
+    }
+  }
+  document-summary empty-summary {
+    summary documentid {
+      source: documentid
+    }
+  }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/multi/documentid/disk.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/multi/documentid/disk.sd
@@ -1,0 +1,15 @@
+# Copyright Vespa.ai. All rights reserved.
+schema disk {
+  documentid: from-disk
+  document disk {
+    field some_field type int {
+        indexing: attribute | summary
+    }
+  }
+  document-summary empty-summary {
+    summary documentid {
+      source: documentid
+    }
+    from-disk
+  }
+}


### PR DESCRIPTION
Reflects changes in main schema parser. Unit tests remain broken, will create a separate PR for this.