### PR TITLE
Repair unit tests of language server

### DIFF
--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -184,6 +184,7 @@ TOKEN :
     <FILTER: "filter"> |
     <FIXEDWIDTH: "fixedwidth"> |
     <FLOOR: "floor"> |
+    <GEO_DISTANCE: "geo_distance"> |
     <GROUP: "group"> |
     <HINT: "hint"> |
     <HYPOT: "hypot"> |
@@ -248,6 +249,8 @@ TOKEN :
     <X: "x"> |
     <XOR: "xor"> |
     <XORBIT: "xorbit"> |
+    <KM: "km"> |
+    <MILES: "miles"> |
     <Y: "y"> |
     <ZCURVE: "zcurve"> |
     <IDENTIFIER: ["A"-"Z","a"-"z"](["A"-"Z","a"-"z","0"-"9","_","@"])*>

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -314,7 +314,7 @@ public class SchemaParserTest {
             new BadFileTestCase("../../../config-model/src/test/examples/rankingexpressionfunction/rankingexpressionfunction.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/rankpropvars.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/stemmingresolver.sd", 1),
-            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 41),
+            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 44),
             new BadFileTestCase("../../../config-model/src/test/derived/renamedfeatures/foo.sd", 4),
 
             new BadFileTestCase("../../../config-model/src/test/derived/rankprofiles/rankprofiles.sd", 1), // only throws a warning during vespa deploy, but it is an unresolved reference case.


### PR DESCRIPTION
Fixes the unit tests together with the previous PR https://github.com/vespa-engine/vespa/pull/36876. Not sure about the change in `SchemaParserTest` (`41` -> `44`).

@toregge fyi
@theodorklauritzen fyi
@Mangern fyi