### PR TITLE
Bragehk/mulitple applications cli

### DIFF
--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	configFile = "config.yaml"
+	configFile               = "config.yaml"
+	defaultConfigScopeOption = "default_config_scope"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -115,7 +116,14 @@ zone
 Specifies a custom zone to use when connecting to a Vespa Cloud application.
 This is only relevant for cloud and hosted targets and defaults to a dev zone.
 See https://docs.vespa.ai/en/operations/zones.html for available zones. Examples:
-dev.aws-us-east-1c, dev.gcp-us-central1-f`,
+dev.aws-us-east-1c, dev.gcp-us-central1-f
+
+default_config_scope
+
+Controls whether config set and config unset write to local or global
+configuration by default. Valid values are "local" and "global". When unset,
+defaults to "global". In Vespa 9, the default will change to "local". Use
+--local or --global on individual commands to override this setting.`,
 		DisableAutoGenTag: true,
 		SilenceUsage:      false,
 		Args:              cobra.MinimumNArgs(1),
@@ -127,6 +135,7 @@ dev.aws-us-east-1c, dev.gcp-us-central1-f`,
 
 func newConfigSetCmd(cli *CLI) *cobra.Command {
 	var localArg bool
+	var globalArg bool
 	cmd := &cobra.Command{
 		Use:   "set option-name value",
 		Short: "Set a configuration option.",
@@ -142,14 +151,32 @@ $ vespa config set application my-tenant.my-application.my-instance
 # Set the instance explicitly. This will take precedence over an instance specified as part of the application option.
 $ vespa config set instance other-instance
 
-# Set an option in local configuration, for the current application only
-$ vespa config set --local zone dev.aws-us-east-1c`,
+# Control whether config set/unset writes to local or global config by default
+$ vespa config set default_config_scope local
+
+# Set an option in local configuration, for the current application only. Overrides default_config_scope
+$ vespa config set --local zone dev.aws-us-east-1c
+
+# Set an option in global configuration. Overrides default_config_scope
+$ vespa config set --global target cloud`,
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		Args:              cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if localArg && globalArg {
+				return fmt.Errorf("cannot use both --local and --global flags")
+			}
+			if localArg && args[0] == defaultConfigScopeOption {
+				return fmt.Errorf("%s can only be set in global configuration", defaultConfigScopeOption)
+			}
+			useLocal := localArg
+			scopeValue, scopeIsSet := cli.config.getNonEmpty(defaultConfigScopeOption)
+			implicitScope := !localArg && !globalArg && args[0] != defaultConfigScopeOption
+			if implicitScope && scopeValue == "local" {
+				useLocal = true
+			}
 			config := cli.config
-			if localArg {
+			if useLocal {
 				// Need an application package in working directory to allow local configuration
 				if _, err := cli.applicationPackageFrom(nil, vespa.PackageOptions{}); err != nil {
 					return fmt.Errorf("failed to write local configuration: %w", err)
@@ -159,15 +186,29 @@ $ vespa config set --local zone dev.aws-us-east-1c`,
 			if err := config.set(args[0], args[1]); err != nil {
 				return err
 			}
-			return config.write()
+			if err := config.write(); err != nil {
+				return err
+			}
+			scope := "global"
+			if useLocal {
+				scope = "local"
+			}
+			cli.printSuccess(fmt.Sprintf("set %s to %s in %s config at %s", args[0], args[1], scope, filepath.Join(config.homeDir, configFile)))
+			if implicitScope && !scopeIsSet {
+				cli.printWarning(`default_config_scope is unset, wrote to global config`,
+					`set default_config_scope to "local" or "global" to silence this warning; in Vespa 9 unset will default to "local"`)
+			}
+			return nil
 		},
 	}
 	cmd.Flags().BoolVarP(&localArg, "local", "l", false, "Write option to local configuration, i.e. for the current application")
+	cmd.Flags().BoolVarP(&globalArg, "global", "g", false, "Write option to global configuration, overriding default_config_scope")
 	return cmd
 }
 
 func newConfigUnsetCmd(cli *CLI) *cobra.Command {
 	var localArg bool
+	var globalArg bool
 	cmd := &cobra.Command{
 		Use:   "unset option-name",
 		Short: "Unset a configuration option.",
@@ -179,30 +220,59 @@ Unsetting a configuration option will reset it to its default value, which may b
 $ vespa config unset target
 
 # Stop overriding application option in local config
-$ vespa config unset --local application`,
+$ vespa config unset --local application
+
+# Unset a global option, overriding default_config_scope
+$ vespa config unset --global target`,
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		Args:              cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config := cli.config
-			if localArg {
+			if localArg && globalArg {
+				return fmt.Errorf("cannot use both --local and --global flags")
+			}
+			if localArg && args[0] == defaultConfigScopeOption {
+				return fmt.Errorf("%s can only be set in global configuration", defaultConfigScopeOption)
+			}
+			useLocal := localArg
+			scopeValue, scopeIsSet := cli.config.getNonEmpty(defaultConfigScopeOption)
+			implicitScope := !localArg && !globalArg && args[0] != defaultConfigScopeOption
+			if implicitScope && scopeValue == "local" {
+				useLocal = true
+			}
+			cfg := cli.config
+			if useLocal {
 				if _, err := cli.applicationPackageFrom(nil, vespa.PackageOptions{}); err != nil {
 					return fmt.Errorf("failed to write local configuration: %w", err)
 				}
-				config = cli.config.local
+				cfg = cli.config.local
 			}
-			if err := config.unset(args[0]); err != nil {
+			if err := cfg.unset(args[0]); err != nil {
 				return err
 			}
-			return config.write()
+			if err := cfg.write(); err != nil {
+				return err
+			}
+			scope := "global"
+			if useLocal {
+				scope = "local"
+			}
+			cli.printSuccess(fmt.Sprintf("unset %s in %s config at %s", args[0], scope, filepath.Join(cfg.homeDir, configFile)))
+			if implicitScope && !scopeIsSet {
+				cli.printWarning(`default_config_scope is unset, wrote to global config`,
+					`set default_config_scope to "local" or "global" to silence this warning; in Vespa 9 unset will default to "local"`)
+			}
+			return nil
 		},
 	}
 	cmd.Flags().BoolVarP(&localArg, "local", "l", false, "Unset option in local configuration, i.e. for the current application")
+	cmd.Flags().BoolVarP(&globalArg, "global", "g", false, "Unset option in global configuration, overriding default_config_scope")
 	return cmd
 }
 
 func newConfigGetCmd(cli *CLI) *cobra.Command {
 	var localArg bool
+	var globalArg bool
 	cmd := &cobra.Command{
 		Use:   "get [option-name]",
 		Short: "Show given configuration option, or all configuration options",
@@ -211,14 +281,27 @@ func newConfigGetCmd(cli *CLI) *cobra.Command {
 By default, this command prints the effective configuration for the current
 application, i.e. it takes into account any local configuration located in
 [working-directory]/.vespa.
+
+When default_config_scope is set to "local", this command shows only local
+configuration by default, if any local configuration is present.
 `,
 		Example: `$ vespa config get
 $ vespa config get target
-$ vespa config get --local`,
+$ vespa config get --local
+$ vespa config get --global`,
 		Args:              cobra.MaximumNArgs(1),
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if localArg && globalArg {
+				return fmt.Errorf("cannot use both --local and --global flags")
+			}
+			if !localArg && !globalArg {
+				scopeValue, _ := cli.config.getNonEmpty(defaultConfigScopeOption)
+				if scopeValue == "local" && !cli.config.local.isEmpty() {
+					localArg = true
+				}
+			}
 			config := cli.config
 			if localArg {
 				if cli.config.local.isEmpty() {
@@ -227,6 +310,11 @@ $ vespa config get --local`,
 				}
 				config = cli.config.local
 			}
+			scope := "Global"
+			if localArg {
+				scope = "Local"
+			}
+			log.Printf("%s config at %s", scope, filepath.Join(config.homeDir, configFile))
 			if len(args) == 0 { // Print all values
 				for _, option := range config.list(!localArg) {
 					config.printOption(option)
@@ -238,6 +326,7 @@ $ vespa config get --local`,
 		},
 	}
 	cmd.Flags().BoolVarP(&localArg, "local", "l", false, "Show only local configuration, if any")
+	cmd.Flags().BoolVarP(&globalArg, "global", "g", false, "Show global configuration, overriding default_config_scope")
 	return cmd
 }
 
@@ -316,6 +405,7 @@ func (c *Config) loadLocalConfigFrom(parent string) error {
 	if err != nil {
 		return err
 	}
+	startDir := dir
 	// Use home directory as a boundary for walking up, if available
 	// This prevents accidentally picking up a .vespa from unrelated locations
 	homeDir, _ := os.UserHomeDir() // Ignore error - just skip boundary check if unavailable
@@ -342,7 +432,7 @@ func (c *Config) loadLocalConfigFrom(parent string) error {
 		dir = parentDir
 	}
 	// No .vespa directory found, create empty local config for current directory
-	config, err := loadConfigFrom(filepath.Join(parent, ".vespa"), c.environment, c.flags)
+	config, err := loadConfigFrom(filepath.Join(startDir, ".vespa"), c.environment, c.flags)
 	if err != nil {
 		return err
 	}
@@ -619,6 +709,7 @@ func (c *Config) list(includeUnset bool) []string {
 	for k := range c.flags {
 		flags = append(flags, k)
 	}
+	flags = append(flags, defaultConfigScopeOption)
 	sort.Strings(flags)
 	return flags
 }
@@ -665,6 +756,17 @@ func (c *Config) get(option string) (string, bool) {
 
 func (c *Config) set(option, value string) error {
 	switch option {
+	case defaultConfigScopeOption:
+		switch value {
+		case "local", "global":
+			c.config.Set(option, value)
+			return nil
+		}
+		return errHint(
+			fmt.Errorf("invalid value for %s: %q", defaultConfigScopeOption, value),
+			`valid values are "local" and "global"`,
+			`when unset, defaults to "global"; in Vespa 9 the default will change to "local"`,
+		)
 	case targetFlag:
 		switch value {
 		case vespa.TargetLocal, vespa.TargetCloud, vespa.TargetHosted, vespa.TargetCD, vespa.TargetPublicCD:
@@ -719,6 +821,9 @@ func (c *Config) unset(option string) error {
 }
 
 func (c *Config) checkOption(option string) error {
+	if option == defaultConfigScopeOption {
+		return nil
+	}
 	if _, ok := c.flags[option]; !ok {
 		return fmt.Errorf("invalid option: %s", option)
 	}

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -138,7 +138,7 @@ func resolveWriteConfig(cli *CLI, local, global bool, optionName string) (cfg *C
 		return nil, false, false, false, fmt.Errorf("cannot use both --local and --global flags")
 	}
 	if local && optionName == defaultConfigScopeOption {
-		return nil, false, false, false, fmt.Errorf("%s can only be set in global configuration", defaultConfigScopeOption)
+		return nil, false, false, false, fmt.Errorf("%s can only be modified in global configuration", defaultConfigScopeOption)
 	}
 	useLocal = local
 	scopeValue, scopeIsSet := cli.config.getNonEmpty(defaultConfigScopeOption)

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -133,6 +133,29 @@ defaults to "global". In Vespa 9, the default will change to "local". Use
 	}
 }
 
+func resolveWriteConfig(cli *CLI, local, global bool, optionName string) (cfg *Config, useLocal, implicitScope, scopeIsSet bool, err error) {
+	if local && global {
+		return nil, false, false, false, fmt.Errorf("cannot use both --local and --global flags")
+	}
+	if local && optionName == defaultConfigScopeOption {
+		return nil, false, false, false, fmt.Errorf("%s can only be set in global configuration", defaultConfigScopeOption)
+	}
+	useLocal = local
+	scopeValue, scopeIsSet := cli.config.getNonEmpty(defaultConfigScopeOption)
+	implicitScope = !local && !global && optionName != defaultConfigScopeOption
+	if implicitScope && scopeValue == "local" {
+		useLocal = true
+	}
+	cfg = cli.config
+	if useLocal {
+		if _, err := cli.applicationPackageFrom(nil, vespa.PackageOptions{}); err != nil {
+			return nil, false, false, false, fmt.Errorf("failed to write local configuration: %w", err)
+		}
+		cfg = cli.config.local
+	}
+	return cfg, useLocal, implicitScope, scopeIsSet, nil
+}
+
 func newConfigSetCmd(cli *CLI) *cobra.Command {
 	var localArg bool
 	var globalArg bool
@@ -163,37 +186,21 @@ $ vespa config set --global target cloud`,
 		SilenceUsage:      true,
 		Args:              cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if localArg && globalArg {
-				return fmt.Errorf("cannot use both --local and --global flags")
-			}
-			if localArg && args[0] == defaultConfigScopeOption {
-				return fmt.Errorf("%s can only be set in global configuration", defaultConfigScopeOption)
-			}
-			useLocal := localArg
-			scopeValue, scopeIsSet := cli.config.getNonEmpty(defaultConfigScopeOption)
-			implicitScope := !localArg && !globalArg && args[0] != defaultConfigScopeOption
-			if implicitScope && scopeValue == "local" {
-				useLocal = true
-			}
-			config := cli.config
-			if useLocal {
-				// Need an application package in working directory to allow local configuration
-				if _, err := cli.applicationPackageFrom(nil, vespa.PackageOptions{}); err != nil {
-					return fmt.Errorf("failed to write local configuration: %w", err)
-				}
-				config = cli.config.local
-			}
-			if err := config.set(args[0], args[1]); err != nil {
+			cfg, useLocal, implicitScope, scopeIsSet, err := resolveWriteConfig(cli, localArg, globalArg, args[0])
+			if err != nil {
 				return err
 			}
-			if err := config.write(); err != nil {
+			if err := cfg.set(args[0], args[1]); err != nil {
+				return err
+			}
+			if err := cfg.write(); err != nil {
 				return err
 			}
 			scope := "global"
 			if useLocal {
 				scope = "local"
 			}
-			cli.printSuccess(fmt.Sprintf("set %s to %s in %s config at %s", args[0], args[1], scope, filepath.Join(config.homeDir, configFile)))
+			cli.printSuccess(fmt.Sprintf("set %s to %s in %s config at %s", args[0], args[1], scope, filepath.Join(cfg.homeDir, configFile)))
 			if implicitScope && !scopeIsSet {
 				cli.printWarning(`default_config_scope is unset, wrote to global config`,
 					`set default_config_scope to "local" or "global" to silence this warning; in Vespa 9 unset will default to "local"`)
@@ -228,24 +235,9 @@ $ vespa config unset --global target`,
 		SilenceUsage:      true,
 		Args:              cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if localArg && globalArg {
-				return fmt.Errorf("cannot use both --local and --global flags")
-			}
-			if localArg && args[0] == defaultConfigScopeOption {
-				return fmt.Errorf("%s can only be set in global configuration", defaultConfigScopeOption)
-			}
-			useLocal := localArg
-			scopeValue, scopeIsSet := cli.config.getNonEmpty(defaultConfigScopeOption)
-			implicitScope := !localArg && !globalArg && args[0] != defaultConfigScopeOption
-			if implicitScope && scopeValue == "local" {
-				useLocal = true
-			}
-			cfg := cli.config
-			if useLocal {
-				if _, err := cli.applicationPackageFrom(nil, vespa.PackageOptions{}); err != nil {
-					return fmt.Errorf("failed to write local configuration: %w", err)
-				}
-				cfg = cli.config.local
+			cfg, useLocal, implicitScope, scopeIsSet, err := resolveWriteConfig(cli, localArg, globalArg, args[0])
+			if err != nil {
+				return err
 			}
 			if err := cfg.unset(args[0]); err != nil {
 				return err

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -249,7 +249,7 @@ $ vespa config unset --global target`,
 			if useLocal {
 				scope = "local"
 			}
-			cli.printSuccess(fmt.Sprintf("unset %s in %s config at %s", args[0], scope, filepath.Join(cfg.homeDir, configFile)))
+			cli.printSuccess(fmt.Sprintf("Unset %s in %s config at %s", args[0], scope, filepath.Join(cfg.homeDir, configFile)))
 			if implicitScope && !scopeIsSet {
 				cli.printWarning(`default_config_scope is unset, wrote to global config`,
 					`set default_config_scope to "local" or "global" to silence this warning; in Vespa 9 unset will default to "local"`)
@@ -302,11 +302,11 @@ $ vespa config get --global`,
 				}
 				config = cli.config.local
 			}
-			scope := "Global"
+			scope := "global"
 			if localArg {
-				scope = "Local"
+				scope = "local"
 			}
-			log.Printf("%s config at %s", scope, filepath.Join(config.homeDir, configFile))
+			log.Printf("Got %s config from %s", scope, filepath.Join(config.homeDir, configFile))
 			if len(args) == 0 { // Print all values
 				for _, option := range config.list(!localArg) {
 					config.printOption(option)

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -25,73 +26,75 @@ func TestConfig(t *testing.T) {
 	assertConfigCommandErr(t, configHome, "Error: invalid option or value: foo = bar\n", "config", "set", "foo", "bar")
 	assertConfigCommandErr(t, configHome, "Error: invalid option: foo\n", "config", "get", "foo")
 
+	gh := globalConfigHeader(configHome)
+
 	// target
-	assertConfigCommand(t, configHome, "target = local\n", "config", "get", "target") // default value
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "hosted")
-	assertConfigCommand(t, configHome, "target = hosted\n", "config", "get", "target")
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "cloud")
-	assertConfigCommand(t, configHome, "target = cloud\n", "config", "get", "target")
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "http://127.0.0.1:8080")
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "https://127.0.0.1")
-	assertConfigCommand(t, configHome, "target = https://127.0.0.1\n", "config", "get", "target")
-	assertConfigCommand(t, configHome, "target = local\n", "config", "get", "-t", "local", "target")
+	assertConfigCommand(t, configHome, gh+"target = local\n", "config", "get", "target") // default value
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "hosted"), "config", "set", "target", "hosted")
+	assertConfigCommand(t, configHome, gh+"target = hosted\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "cloud"), "config", "set", "target", "cloud")
+	assertConfigCommand(t, configHome, gh+"target = cloud\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "http://127.0.0.1:8080"), "config", "set", "target", "http://127.0.0.1:8080")
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "https://127.0.0.1"), "config", "set", "target", "https://127.0.0.1")
+	assertConfigCommand(t, configHome, gh+"target = https://127.0.0.1\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, gh+"target = local\n", "config", "get", "-t", "local", "target")
 	// Internal test system targets
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "cd")
-	assertConfigCommand(t, configHome, "target = cd\n", "config", "get", "target")
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "publiccd")
-	assertConfigCommand(t, configHome, "target = publiccd\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "cd"), "config", "set", "target", "cd")
+	assertConfigCommand(t, configHome, gh+"target = cd\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "publiccd"), "config", "set", "target", "publiccd")
+	assertConfigCommand(t, configHome, gh+"target = publiccd\n", "config", "get", "target")
 
 	// application
 	assertConfigCommandErr(t, configHome, "Error: invalid application: \"foo\"\n", "config", "set", "application", "foo")
-	assertConfigCommand(t, configHome, "application = <unset>\n", "config", "get", "application")
-	assertConfigCommand(t, configHome, "", "config", "set", "application", "t1.a1.i1")
-	assertConfigCommand(t, configHome, "application = t1.a1.i1\n", "config", "get", "application")
-	assertConfigCommand(t, configHome, "", "config", "set", "application", "t1.a1")
-	assertConfigCommand(t, configHome, "application = t1.a1.default\n", "config", "get", "application")
+	assertConfigCommand(t, configHome, gh+"application = <unset>\n", "config", "get", "application")
+	assertConfigCommand(t, configHome, successSet(configHome, "application", "t1.a1.i1"), "config", "set", "application", "t1.a1.i1")
+	assertConfigCommand(t, configHome, gh+"application = t1.a1.i1\n", "config", "get", "application")
+	assertConfigCommand(t, configHome, successSet(configHome, "application", "t1.a1"), "config", "set", "application", "t1.a1")
+	assertConfigCommand(t, configHome, gh+"application = t1.a1.default\n", "config", "get", "application")
 
 	// cluster
-	assertConfigCommand(t, configHome, "cluster = <unset>\n", "config", "get", "cluster")
-	assertConfigCommand(t, configHome, "", "config", "set", "cluster", "feed")
-	assertConfigCommand(t, configHome, "cluster = feed\n", "config", "get", "cluster")
+	assertConfigCommand(t, configHome, gh+"cluster = <unset>\n", "config", "get", "cluster")
+	assertConfigCommand(t, configHome, successSet(configHome, "cluster", "feed"), "config", "set", "cluster", "feed")
+	assertConfigCommand(t, configHome, gh+"cluster = feed\n", "config", "get", "cluster")
 
 	// instance
-	assertConfigCommand(t, configHome, "instance = <unset>\n", "config", "get", "instance")
-	assertConfigCommand(t, configHome, "", "config", "set", "instance", "i2")
-	assertConfigCommand(t, configHome, "instance = i2\n", "config", "get", "instance")
+	assertConfigCommand(t, configHome, gh+"instance = <unset>\n", "config", "get", "instance")
+	assertConfigCommand(t, configHome, successSet(configHome, "instance", "i2"), "config", "set", "instance", "i2")
+	assertConfigCommand(t, configHome, gh+"instance = i2\n", "config", "get", "instance")
 
 	// color
 	assertConfigCommandErr(t, configHome, "Error: invalid option or value: color = foo\n", "config", "set", "color", "foo")
-	assertConfigCommand(t, configHome, "", "config", "set", "color", "never")
-	assertConfigCommand(t, configHome, "color = never\n", "config", "get", "color")
-	assertConfigCommand(t, configHome, "", "config", "unset", "color")
-	assertConfigCommand(t, configHome, "color = auto\n", "config", "get", "color")
+	assertConfigCommand(t, configHome, successSet(configHome, "color", "never"), "config", "set", "color", "never")
+	assertConfigCommand(t, configHome, gh+"color = never\n", "config", "get", "color")
+	assertConfigCommand(t, configHome, successUnset(configHome, "color"), "config", "unset", "color")
+	assertConfigCommand(t, configHome, gh+"color = auto\n", "config", "get", "color")
 
-	// quiet
-	assertConfigCommand(t, configHome, "", "config", "set", "quiet", "true")
-	assertConfigCommand(t, configHome, "", "config", "set", "quiet", "false")
+	// quiet — setting quiet=true suppresses stdout for subsequent commands
+	assertConfigCommand(t, configHome, successSet(configHome, "quiet", "true"), "config", "set", "quiet", "true")
+	assertConfigCommand(t, configHome, "", "config", "set", "quiet", "false") // quiet=true loaded, stdout discarded
 
 	// zone
-	assertConfigCommand(t, configHome, "", "config", "set", "zone", "dev.us-east-1")
-	assertConfigCommand(t, configHome, "zone = dev.us-east-1\n", "config", "get", "zone")
-	assertConfigCommand(t, configHome, "zone = prod.us-north-1\n", "config", "get", "--zone", "prod.us-north-1", "zone") // flag overrides global config
+	assertConfigCommand(t, configHome, successSet(configHome, "zone", "dev.us-east-1"), "config", "set", "zone", "dev.us-east-1")
+	assertConfigCommand(t, configHome, gh+"zone = dev.us-east-1\n", "config", "get", "zone")
+	assertConfigCommand(t, configHome, gh+"zone = prod.us-north-1\n", "config", "get", "--zone", "prod.us-north-1", "zone") // flag overrides global config
 
 	// Write empty value to YAML config, which should be ignored. This is for compatibility with older config formats
 	configFile := filepath.Join(configHome, "config.yaml")
-	assertConfigCommand(t, configHome, "", "config", "unset", "zone")
+	assertConfigCommand(t, configHome, successUnset(configHome, "zone"), "config", "unset", "zone")
 	data, err := os.ReadFile(configFile)
 	require.Nil(t, err)
 	yamlConfig := string(data)
 	assert.NotContains(t, yamlConfig, "zone:")
 	config := yamlConfig + "zone: \"\"\n"
 	require.Nil(t, os.WriteFile(configFile, []byte(config), 0o600))
-	assertConfigCommand(t, configHome, "zone = <unset>\n", "config", "get", "zone")
+	assertConfigCommand(t, configHome, gh+"zone = <unset>\n", "config", "get", "zone")
 }
 
 func TestLocalConfig(t *testing.T) {
 	configHome := t.TempDir()
 	// Write a few global options
-	assertConfigCommand(t, configHome, "", "config", "set", "instance", "main")
-	assertConfigCommand(t, configHome, "", "config", "set", "target", "cloud")
+	assertConfigCommand(t, configHome, successSet(configHome, "instance", "main"), "config", "set", "instance", "main")
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "cloud"), "config", "set", "target", "cloud")
 
 	// Change directory to an application package and write local options
 	_, rootDir := mock.ApplicationPackageDir(t, false, false)
@@ -99,23 +102,27 @@ func TestLocalConfig(t *testing.T) {
 	require.Nil(t, err)
 	t.Cleanup(func() { os.Chdir(wd) })
 	require.Nil(t, os.Chdir(rootDir))
+	gh := globalConfigHeader(configHome)
+	lh := localConfigHeader(rootDir)
+
 	assertConfigCommandStdErr(t, configHome, "Warning: no local configuration present\n", "config", "get", "--local")
-	assertConfigCommand(t, configHome, "", "config", "set", "--local", "instance", "foo")
-	assertConfigCommand(t, configHome, "instance = foo\n", "config", "get", "instance")
-	assertConfigCommand(t, configHome, "instance = bar\n", "config", "get", "--instance", "bar", "instance") // flag overrides local config
+	assertConfigCommand(t, configHome, successSetLocal(rootDir, "instance", "foo"), "config", "set", "--local", "instance", "foo")
+	assertConfigCommand(t, configHome, gh+"instance = foo\n", "config", "get", "instance")
+	assertConfigCommand(t, configHome, gh+"instance = bar\n", "config", "get", "--instance", "bar", "instance") // flag overrides local config
 
 	// get --local prints only options set in local config
-	assertConfigCommand(t, configHome, "instance = foo\n", "config", "get", "--local")
+	assertConfigCommand(t, configHome, lh+"instance = foo\n", "config", "get", "--local")
 
 	// get reads global option if unset locally
-	assertConfigCommand(t, configHome, "target = cloud\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, gh+"target = cloud\n", "config", "get", "target")
 
 	// get merges settings from local and global config
-	assertConfigCommand(t, configHome, "", "config", "set", "--local", "application", "t1.a1")
-	assertConfigCommand(t, configHome, `application = t1.a1.default
+	assertConfigCommand(t, configHome, successSetLocal(rootDir, "application", "t1.a1"), "config", "set", "--local", "application", "t1.a1")
+	assertConfigCommand(t, configHome, gh+`application = t1.a1.default
 cluster = <unset>
 color = auto
 debug = false
+default_config_scope = <unset>
 instance = foo
 quiet = false
 target = cloud
@@ -131,12 +138,12 @@ zone = <unset>
 	subDir := filepath.Join(rootDir, "a", "b")
 	require.Nil(t, os.MkdirAll(subDir, 0755))
 	require.Nil(t, os.Chdir(subDir))
-	assertConfigCommand(t, configHome, "instance = foo\n", "config", "get", "--local", "instance")
+	assertConfigCommand(t, configHome, lh+"instance = foo\n", "config", "get", "--local", "instance")
 
 	// Changing back to original directory reads from global config
 	require.Nil(t, os.Chdir(wd))
-	assertConfigCommand(t, configHome, "instance = main\n", "config", "get", "instance")
-	assertConfigCommand(t, configHome, "target = cloud\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, gh+"instance = main\n", "config", "get", "instance")
+	assertConfigCommand(t, configHome, gh+"target = cloud\n", "config", "get", "target")
 }
 
 func TestLocalConfigSearch(t *testing.T) {
@@ -160,13 +167,121 @@ func TestLocalConfigSearch(t *testing.T) {
 
 	// Config should be found by walking up
 	configHome := t.TempDir()
-	assertConfigCommand(t, configHome, "instance = from-parent\n", "config", "get", "--local", "instance")
+	assertConfigCommand(t, configHome, localConfigHeader(appDir)+"instance = from-parent\n", "config", "get", "--local", "instance")
 
 	// Config in sibling directory should not be found
 	siblingDir := filepath.Join(tmpDir, "other")
 	require.Nil(t, os.MkdirAll(siblingDir, 0755))
 	require.Nil(t, os.Chdir(siblingDir))
 	assertConfigCommandStdErr(t, configHome, "Warning: no local configuration present\n", "config", "get", "--local")
+}
+
+func resolveSymlinks(path string) string {
+	if real, err := filepath.EvalSymlinks(path); err == nil {
+		return real
+	}
+	return path
+}
+
+func globalConfigHeader(configHome string) string {
+	return "Global config at " + filepath.Join(configHome, "config.yaml") + "\n"
+}
+
+func localConfigHeader(localDir string) string {
+	return "Local config at " + filepath.Join(resolveSymlinks(localDir), ".vespa", "config.yaml") + "\n"
+}
+
+func successSet(configHome, option, value string) string {
+	return fmt.Sprintf("Success: set %s to %s in global config at %s\n", option, value, filepath.Join(configHome, "config.yaml"))
+}
+
+func successSetLocal(localDir, option, value string) string {
+	return fmt.Sprintf("Success: set %s to %s in local config at %s\n", option, value, filepath.Join(resolveSymlinks(localDir), ".vespa", "config.yaml"))
+}
+
+func successUnset(configHome, option string) string {
+	return fmt.Sprintf("Success: unset %s in global config at %s\n", option, filepath.Join(configHome, "config.yaml"))
+}
+
+func TestDefaultConfigScopeWarning(t *testing.T) {
+	warnLine := "Warning: default_config_scope is unset, wrote to global config\n"
+	hintLine := "Hint: set default_config_scope to \"local\" or \"global\" to silence this warning; in Vespa 9 unset will default to \"local\"\n"
+	expectedStderr := warnLine + hintLine
+
+	// Warning fires when default_config_scope is unset and no explicit scope flag.
+	// Each CLI gets its own empty home dir (overrides the default written by newTestCLI).
+	cli, _, stderr := newTestCLI(t, "VESPA_CLI_HOME="+t.TempDir())
+	require.Nil(t, cli.Run("config", "set", "target", "cloud"))
+	assert.Equal(t, expectedStderr, stderr.String())
+
+	// --local and --global suppress the warning (explicit scope provided).
+	_, rootDir := mock.ApplicationPackageDir(t, false, false)
+	wd, err := os.Getwd()
+	require.Nil(t, err)
+	t.Cleanup(func() { os.Chdir(wd) })
+	require.Nil(t, os.Chdir(rootDir))
+
+	cli2, _, stderr2 := newTestCLI(t, "VESPA_CLI_HOME="+t.TempDir())
+	require.Nil(t, cli2.Run("config", "set", "--local", "target", "cloud"))
+	assert.Equal(t, "", stderr2.String())
+
+	cli3, _, stderr3 := newTestCLI(t, "VESPA_CLI_HOME="+t.TempDir())
+	require.Nil(t, cli3.Run("config", "set", "--global", "target", "cloud"))
+	assert.Equal(t, "", stderr3.String())
+}
+
+func TestDefaultConfigScope(t *testing.T) {
+	configHome := t.TempDir()
+
+	// Invalid value rejected with hints
+	assertConfigCommandErr(t, configHome,
+		"Error: invalid value for default_config_scope: \"bad\"\nHint: valid values are \"local\" and \"global\"\nHint: when unset, defaults to \"global\"; in Vespa 9 the default will change to \"local\"\n",
+		"config", "set", "default_config_scope", "bad")
+
+	gh := globalConfigHeader(configHome)
+
+	// Set and get
+	assertConfigCommand(t, configHome, successSet(configHome, "default_config_scope", "local"), "config", "set", "default_config_scope", "local")
+	assertConfigCommand(t, configHome, gh+"default_config_scope = local\n", "config", "get", "default_config_scope")
+	assertConfigCommand(t, configHome, successSet(configHome, "default_config_scope", "global"), "config", "set", "default_config_scope", "global")
+	assertConfigCommand(t, configHome, gh+"default_config_scope = global\n", "config", "get", "default_config_scope")
+
+	// Change to an application package dir
+	_, rootDir := mock.ApplicationPackageDir(t, false, false)
+	wd, err := os.Getwd()
+	require.Nil(t, err)
+	t.Cleanup(func() { os.Chdir(wd) })
+	require.Nil(t, os.Chdir(rootDir))
+
+	// --local flag with default_config_scope is an error
+	assertConfigCommandErr(t, configHome, "Error: default_config_scope can only be set in global configuration\n", "config", "set", "--local", "default_config_scope", "local")
+
+	// --local and --global together is an error
+	assertConfigCommandErr(t, configHome, "Error: cannot use both --local and --global flags\n", "config", "set", "--local", "--global", "target", "cloud")
+	assertConfigCommandErr(t, configHome, "Error: cannot use both --local and --global flags\n", "config", "unset", "--local", "--global", "target")
+
+	// With default_config_scope=local, config set writes to local config without --local flag
+	assertConfigCommand(t, configHome, successSet(configHome, "default_config_scope", "local"), "config", "set", "default_config_scope", "local")
+	assertConfigCommand(t, configHome, successSetLocal(rootDir, "target", "cloud"), "config", "set", "target", "cloud")
+
+	// --global forces global config even when default_config_scope=local
+	assertConfigCommand(t, configHome, successSet(configHome, "target", "cloud"), "config", "set", "--global", "target", "cloud")
+	assertConfigCommand(t, configHome, successUnset(configHome, "target"), "config", "unset", "--global", "target")
+
+	// Explicit --local still works and overrides default_config_scope
+	assertConfigCommand(t, configHome, successSetLocal(rootDir, "instance", "foo"), "config", "set", "--local", "instance", "foo")
+
+	// config get defaults to local when default_config_scope=local and inside an app package
+	lh := localConfigHeader(rootDir)
+	assertConfigCommand(t, configHome, lh+"instance = foo\ntarget = cloud\n", "config", "get")
+
+	// config get --global shows global config even when default_config_scope=local
+	gh2 := globalConfigHeader(configHome)
+	assertConfigCommand(t, configHome, lh+"default_config_scope = <unset>\n", "config", "get", "default_config_scope")
+	assertConfigCommand(t, configHome, gh2+"default_config_scope = local\n", "config", "get", "--global", "default_config_scope")
+
+	// config get --local and --global together is an error
+	assertConfigCommandErr(t, configHome, "Error: cannot use both --local and --global flags\n", "config", "get", "--local", "--global")
 }
 
 func assertConfigCommand(t *testing.T, configHome, expected string, args ...string) {

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -254,7 +254,7 @@ func TestDefaultConfigScope(t *testing.T) {
 	require.Nil(t, os.Chdir(rootDir))
 
 	// --local flag with default_config_scope is an error
-	assertConfigCommandErr(t, configHome, "Error: default_config_scope can only be set in global configuration\n", "config", "set", "--local", "default_config_scope", "local")
+	assertConfigCommandErr(t, configHome, "Error: default_config_scope can only be modified in global configuration\n", "config", "set", "--local", "default_config_scope", "local")
 
 	// --local and --global together is an error
 	assertConfigCommandErr(t, configHome, "Error: cannot use both --local and --global flags\n", "config", "set", "--local", "--global", "target", "cloud")

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -184,11 +184,11 @@ func resolveSymlinks(path string) string {
 }
 
 func globalConfigHeader(configHome string) string {
-	return "Global config at " + filepath.Join(configHome, "config.yaml") + "\n"
+	return "Got global config from " + filepath.Join(configHome, "config.yaml") + "\n"
 }
 
 func localConfigHeader(localDir string) string {
-	return "Local config at " + filepath.Join(resolveSymlinks(localDir), ".vespa", "config.yaml") + "\n"
+	return "Got local config from " + filepath.Join(resolveSymlinks(localDir), ".vespa", "config.yaml") + "\n"
 }
 
 func successSet(configHome, option, value string) string {
@@ -200,7 +200,7 @@ func successSetLocal(localDir, option, value string) string {
 }
 
 func successUnset(configHome, option string) string {
-	return fmt.Sprintf("Success: unset %s in global config at %s\n", option, filepath.Join(configHome, "config.yaml"))
+	return fmt.Sprintf("Success: Unset %s in global config at %s\n", option, filepath.Join(configHome, "config.yaml"))
 }
 
 func TestDefaultConfigScopeWarning(t *testing.T) {

--- a/client/go/internal/cli/cmd/testutil_test.go
+++ b/client/go/internal/cli/cmd/testutil_test.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/vespa-engine/vespa/client/go/internal/cli/auth/auth0"
 	"github.com/vespa-engine/vespa/client/go/internal/httputil"
 	"github.com/vespa-engine/vespa/client/go/internal/mock"
@@ -20,6 +22,10 @@ func newTestCLI(t *testing.T, envVars ...string) (*CLI, *bytes.Buffer, *bytes.Bu
 	t.Helper()
 	homeDir := filepath.Join(t.TempDir(), ".vespa")
 	cacheDir := filepath.Join(t.TempDir(), ".cache", "vespa")
+	// Pre-set default_config_scope to suppress the "unset" warning in all tests
+	// that are not specifically testing that warning.
+	require.Nil(t, os.MkdirAll(homeDir, 0o700))
+	require.Nil(t, os.WriteFile(filepath.Join(homeDir, "config.yaml"), []byte("default_config_scope: global\n"), 0o600))
 	env := []string{"VESPA_CLI_HOME=" + homeDir, "VESPA_CLI_CACHE_DIR=" + cacheDir}
 	env = append(env, envVars...)
 	var (


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This change makes working on multiple Vespa applications easier with the default_config_scope flag. It can be local or global. When unset will default to global, but should be updated in Vespa 9 to default to local instead.

- --global flag added. Only useful when default_config_scope is set to
    local. In the same way that --local is not useful if
    default_config_scope is unset or set to global.
- Warning when default_config_scope is unset

Because of better printing, almost all tests needed updating.