### PR TITLE
fix(config-model): discard per-Container default JettyHttpServer when cluster Http is set [MERGEOK]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -150,6 +150,17 @@ public abstract class Container extends AbstractService implements
         return defaultHttpServer;
     }
 
+    /**
+     * Remove the per-Container default JettyHttpServer from this Container's children.
+     * Invoked when a cluster-level Http is set after Container construction, so the
+     * cluster-level JettyHttpServer becomes the sole component with id "DefaultHttpServer".
+     */
+    void discardDefaultHttpServer() {
+        if (defaultHttpServer.getParent() == this) {
+            removeChild(defaultHttpServer);
+        }
+    }
+
     /** Returns the index of this node. The index of a given node is stable through changes with best effort. */
     public final int index() { return index; }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -381,6 +381,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public void setHttp(Http http) {
         this.http = http;
         addChild(http);
+        getContainers().forEach(Container::discardDefaultHttpServer);
     }
 
     public Http getHttp() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -30,6 +30,8 @@ import com.yahoo.vespa.model.admin.clustercontroller.ClusterControllerContainer;
 import com.yahoo.vespa.model.admin.clustercontroller.ClusterControllerContainerCluster;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.docproc.ContainerDocproc;
+import com.yahoo.vespa.model.container.http.FilterChains;
+import com.yahoo.vespa.model.container.http.Http;
 import com.yahoo.vespa.model.container.search.ContainerSearch;
 import com.yahoo.vespa.model.container.search.searchchain.SearchChains;
 import com.yahoo.vespa.model.container.xml.ContainerModelBuilderTestBase;
@@ -423,6 +425,28 @@ public class ContainerClusterTest {
         List<String> installedBundles = bundleBuilder.build().bundlePaths();
 
         expectedBundleNames.forEach(b -> assertTrue(installedBundles.stream().anyMatch(p -> p.endsWith(b))));
+    }
+
+    @Test
+    void setHttp_discards_per_container_default_http_server() {
+        // Containers constructed before cluster.setHttp(...) each attach a JettyHttpServer
+        // named "DefaultHttpServer". A later cluster-level setHttp would then produce two
+        // components with the same id in the JDisc graph. Verify the cluster cleans up.
+        MockRoot root = createRoot(true);
+        ApplicationContainerCluster cluster = newClusterWithSearch(root);
+        addContainer(root, cluster, "c1", "host-c1");
+        addContainer(root, cluster, "c2", "host-c2");
+        for (var c : cluster.getContainers()) {
+            assertTrue(c.getChildren().containsKey(c.getDefaultHttpServer().getSubId()),
+                       "Container should hold its default JettyHttpServer before setHttp");
+        }
+
+        cluster.setHttp(new Http(new FilterChains(cluster)));
+
+        for (var c : cluster.getContainers()) {
+            assertFalse(c.getChildren().containsKey(c.getDefaultHttpServer().getSubId()),
+                        "Container default JettyHttpServer should be discarded after setHttp");
+        }
     }
 
     private static ApplicationContainerCluster newClusterWithSearch(MockRoot root) {


### PR DESCRIPTION
Follow-up fix for #36874. After the refactor moved hosted HTTP setup out of `ContainerModelBuilder`, downstream amenders set the cluster-level `Http` only after `Container` construction. Each `Container` had already attached its own `JettyHttpServer` named `DefaultHttpServer` (because `cluster.getHttp() == null` at construction time), and the later cluster-level `Http.httpServer` is a separate `JettyHttpServer` with the same id — causing JDisc to reject component graph activation with `Multiple components with the same id DefaultHttpServer`.

- Have `ContainerCluster.setHttp(Http)` call `Container.discardDefaultHttpServer()` on every container so the cluster-level `JettyHttpServer` becomes the sole component with that id
- Expose `Container.discardDefaultHttpServer()` (package-private) for any future amender that needs to perform the cleanup directly
- Add a `ContainerClusterTest` regression covering the multi-container case