### PR TITLE
Add restart flag to Proton setting for document-id attribute

### DIFF
--- a/configdefinitions/src/vespa/proton.def
+++ b/configdefinitions/src/vespa/proton.def
@@ -289,7 +289,7 @@ documentdb[].visibilitydelay double default=0.0
 ## Whether this document type is globally distributed or not.
 documentdb[].global bool default=false
 ## Whether the full document ids are stored in memory
-documentdb[].document_id_attribute bool default=false
+documentdb[].document_id_attribute bool default=false restart
 
 ## Minimum initial size for any per document tables.
 documentdb[].allocation.initialnumdocs long default=1024


### PR DESCRIPTION
Enabling the attribute requires a restart, so it makes sense to add the flag to notify the user about this.