### PR TITLE
Profile fetchPostings during match setup

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -16,6 +16,7 @@
 #include <vespa/searchlib/queryeval/create_blueprint_params.h>
 #include <vespa/searchlib/queryeval/flow.h>
 #include <vespa/searchlib/queryeval/wand/wand_parts.h>
+#include <vespa/vespalib/util/execution_profiler.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 
@@ -24,6 +25,7 @@ using search::attribute::BasicType;
 using search::attribute::diversity::DiversityFilter;
 using search::queryeval::CreateBlueprintParams;
 using search::queryeval::ExecuteInfo;
+using search::queryeval::FetchPostingsProfilerGuard;
 using search::queryeval::IDiversifier;
 using vespalib::Issue;
 
@@ -192,17 +194,32 @@ MatchToolsFactory::MatchToolsFactory(
         double hitRate = std::min(1.0, double(maxNumHits) / double(searchContext.getDocIdLimit()));
         auto   in_flow = InFlow(is_search, hitRate);
         _query.optimize(in_flow, sort_by_cost);
-        if (trace.getLevel() >= 6) { // will dump blueprint later
+        std::unique_ptr<vespalib::ExecutionProfiler> setup_profiler;
+        if (trace.getLevel() > 0) {
+            if (int32_t depth = root_trace.match_profile_depth(); depth != 0) {
+                setup_profiler = std::make_unique<vespalib::ExecutionProfiler>(depth);
+            }
+        }
+        if (trace.getLevel() >= 6 || setup_profiler) {
+            // need stable ids in the blueprint tree for profiler / dump output
             _query.enumerate_blueprint_nodes();
         }
         trace.addEvent(4, "Perform dictionary lookups and posting lists initialization");
-        _query.fetchPostings(ExecuteInfo::create(in_flow.rate(), _requestContext.getDoom(), thread_bundle));
+        {
+            auto info = ExecuteInfo::create(in_flow.rate(), _requestContext.getDoom(), thread_bundle,
+                                            setup_profiler.get());
+            FetchPostingsProfilerGuard guard(setup_profiler.get(), *_query.peekRoot());
+            _query.fetchPostings(info);
+        }
         if (is_search) {
             bool use_lazy_filter = LazyFilter::check(_queryEnv.getProperties());
             _query.handle_global_filter(_requestContext, ann_deadline_config, searchContext.getDocIdLimit(),
                                         _create_blueprint_params.global_filter_lower_limit,
                                         _create_blueprint_params.global_filter_upper_limit, trace, sort_by_cost,
-                                        use_lazy_filter);
+                                        use_lazy_filter, setup_profiler.get());
+        }
+        if (setup_profiler) {
+            setup_profiler->report(trace.createCursor("setup_profiling"));
         }
         _query.freeze();
         trace.addEvent(5, "Prepare shared state for multi-threaded rank executors");

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -249,7 +249,8 @@ void Query::fetchPostings(const ExecuteInfo& executeInfo) {
 void Query::handle_global_filter(const IRequestContext&          requestContext,
                                  const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                                  double global_filter_lower_limit, double global_filter_upper_limit,
-                                 search::engine::Trace& trace, bool sort_by_cost, bool use_lazy_filter) {
+                                 search::engine::Trace& trace, bool sort_by_cost, bool use_lazy_filter,
+                                 vespalib::ExecutionProfiler* setup_profiler) {
     if (!handle_global_filter(*_blueprint, requestContext.getDoom(), ann_deadline_config, docid_limit,
                               global_filter_lower_limit, global_filter_upper_limit, requestContext.thread_bundle(),
                               &trace, use_lazy_filter))
@@ -262,7 +263,10 @@ void Query::handle_global_filter(const IRequestContext&          requestContext,
     _blueprint = Blueprint::optimize_and_sort(std::move(_blueprint), _in_flow, opts);
     LOG(debug, "blueprint after handle_global_filter:\n%s\n", _blueprint->asString().c_str());
     // strictness may change if optimized order changed:
-    fetchPostings(ExecuteInfo::create(_in_flow.rate(), requestContext.getDoom(), requestContext.thread_bundle()));
+    auto info = ExecuteInfo::create(_in_flow.rate(), requestContext.getDoom(), requestContext.thread_bundle(),
+                                    setup_profiler);
+    search::queryeval::FetchPostingsProfilerGuard guard(setup_profiler, *_blueprint);
+    fetchPostings(info);
 }
 
 bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doom,

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -112,7 +112,8 @@ public:
     void handle_global_filter(const IRequestContext&          requestContext,
                               const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                               double global_filter_lower_limit, double global_filter_upper_limit,
-                              search::engine::Trace& trace, bool sort_by_cost, bool use_lazy_filter = false);
+                              search::engine::Trace& trace, bool sort_by_cost, bool use_lazy_filter = false,
+                              vespalib::ExecutionProfiler* setup_profiler = nullptr);
 
     /**
      * Calculates and handles the global filter if needed by the blueprint tree.

--- a/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
@@ -27,6 +27,7 @@
 #include <gmock/gmock.h>
 
 #include <filesystem>
+#include <map>
 
 #include <vespa/log/log.h>
 LOG_SETUP("blueprint_test");
@@ -218,6 +219,65 @@ TEST(IntermediateBlueprintsTest, test_Or_propagates_updated_histestimate) {
     EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo&>(bp->getChild(1)).hit_rate);
     EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo&>(bp->getChild(2)).hit_rate);
     EXPECT_EQ(1.0, dynamic_cast<const RememberExecuteInfo&>(bp->getChild(3)).hit_rate);
+}
+
+namespace {
+
+void collect_fetch_postings_counts(std::map<std::string, size_t>& counts, const auto& node) {
+    if (!node.valid()) {
+        return;
+    }
+    collect_fetch_postings_counts(counts, node["roots"]);
+    collect_fetch_postings_counts(counts, node["children"]);
+    for (size_t i = 0; i < node.entries(); ++i) {
+        collect_fetch_postings_counts(counts, node[i]);
+    }
+    const auto& name = node["name"];
+    if (name.valid()) {
+        counts[name.asString().make_string()] += node["count"].asLong();
+    }
+}
+
+} // namespace
+
+TEST(IntermediateBlueprintsTest, test_fetch_postings_can_be_profiled) {
+    auto bp = std::make_unique<AndBlueprint>();
+    bp->addChild(ap(MyLeafSpec(20).create()));
+    bp->addChild(ap(MyLeafSpec(200).create()));
+    bp->addChild(ap(MyLeafSpec(2000).create()));
+    bp->setDocIdLimit(5000);
+    optimize(bp, true);
+    bp->enumerate(1);
+    vespalib::ExecutionProfiler profiler(64);
+    auto info = ExecuteInfo::create(1.0, vespalib::Doom::never(),
+                                    vespalib::ThreadBundle::trivial(), &profiler);
+    {
+        FetchPostingsProfilerGuard guard(&profiler, *bp);
+        bp->fetchPostings(info);
+    }
+    Slime slime;
+    profiler.report(slime.setObject());
+    std::map<std::string, size_t> counts;
+    collect_fetch_postings_counts(counts, slime.get());
+    EXPECT_EQ(counts.size(), 4u);
+    EXPECT_EQ(counts["[1]search::queryeval::AndBlueprint::fetchPostings"], 1u);
+    EXPECT_EQ(counts["[2]search::queryeval::MyLeaf::fetchPostings"], 1u);
+    EXPECT_EQ(counts["[3]search::queryeval::MyLeaf::fetchPostings"], 1u);
+    EXPECT_EQ(counts["[4]search::queryeval::MyLeaf::fetchPostings"], 1u);
+}
+
+TEST(IntermediateBlueprintsTest, test_fetch_postings_profile_omits_id_when_unset) {
+    auto leaf = ap(MyLeafSpec(20).create());
+    vespalib::ExecutionProfiler profiler(64);
+    {
+        FetchPostingsProfilerGuard guard(&profiler, *leaf);
+    }
+    Slime slime;
+    profiler.report(slime.setObject());
+    std::map<std::string, size_t> counts;
+    collect_fetch_postings_counts(counts, slime.get());
+    EXPECT_EQ(counts.size(), 1u);
+    EXPECT_EQ(counts["[]search::queryeval::MyLeaf::fetchPostings"], 1u);
 }
 
 TEST(IntermediateBlueprintsTest, test_And_Blueprint) {

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -18,7 +18,9 @@
 #include <vespa/vespalib/objects/object2slime.h>
 #include <vespa/vespalib/objects/objectdumper.h>
 #include <vespa/vespalib/util/classname.h>
+#include <vespa/vespalib/util/execution_profiler.h>
 #include <vespa/vespalib/util/require.h>
+#include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/vespalib/objects/visit.hpp>
 
@@ -641,9 +643,12 @@ void IntermediateBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) const
 
 void IntermediateBlueprint::fetchPostings(const ExecuteInfo& execInfo) {
     auto flow = my_flow(InFlow(strict(), execInfo.hit_rate()));
+    auto* profiler = execInfo.profiler();
     for (const auto& child : _children) {
         double nextHitRate = flow.flow();
-        child->fetchPostings(ExecuteInfo::create(nextHitRate, execInfo));
+        auto childInfo = ExecuteInfo::create(nextHitRate, execInfo);
+        FetchPostingsProfilerGuard guard(profiler, *child);
+        child->fetchPostings(childInfo);
         flow.add(child->estimate());
     }
 }

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -11,6 +11,8 @@
 #include "unpackinfo.h"
 
 #include <vespa/searchlib/common/bitvector.h>
+#include <vespa/vespalib/util/execution_profiler.h>
+#include <vespa/vespalib/util/stringfmt.h>
 
 #include <optional>
 #include <span>
@@ -559,7 +561,7 @@ public:
                                                       fef::MatchData&       md) const = 0;
 
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
-    void fetchPostings(const ExecuteInfo& execInfo) override;
+    void fetchPostings(const ExecuteInfo& execInfo) final;
     void freeze() final;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;
 
@@ -627,6 +629,23 @@ struct ComplexLeafBlueprint : LeafBlueprint {
 };
 
 //-----------------------------------------------------------------------------
+
+/**
+ * RAII profiler guard for the fetchPostings phase of a single blueprint node.
+ * Produces task names of the form "[<id>]<ClassName>::fetchPostings", or
+ * "[]<ClassName>::fetchPostings" when the blueprint id is unset (0). The
+ * format matches the one used by ProfiledIterator. Name production is
+ * skipped when the profiler is null.
+ **/
+struct FetchPostingsProfilerGuard : vespalib::ProfilerNameGuard {
+    FetchPostingsProfilerGuard(vespalib::ExecutionProfiler* profiler_in, const Blueprint& bp) noexcept
+        : ProfilerNameGuard(profiler_in, [&]{
+              if (bp.id() == 0) {
+                  return vespalib::make_string("[]%s::fetchPostings", bp.getClassName().c_str());
+              }
+              return vespalib::make_string("[%u]%s::fetchPostings", bp.id(), bp.getClassName().c_str());
+          }) {}
+};
 
 } // namespace search::queryeval
 

--- a/searchlib/src/vespa/searchlib/queryeval/executeinfo.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/executeinfo.cpp
@@ -5,9 +5,9 @@
 using vespalib::Doom;
 namespace search::queryeval {
 
-const ExecuteInfo ExecuteInfo::FULL(1.0, Doom::never(), vespalib::ThreadBundle::trivial());
+const ExecuteInfo ExecuteInfo::FULL(1.0, Doom::never(), vespalib::ThreadBundle::trivial(), nullptr);
 
-ExecuteInfo::ExecuteInfo() noexcept : ExecuteInfo(1.0, Doom::never(), vespalib::ThreadBundle::trivial()) {
+ExecuteInfo::ExecuteInfo() noexcept : ExecuteInfo(1.0, Doom::never(), vespalib::ThreadBundle::trivial(), nullptr) {
 }
 
 ExecuteInfo ExecuteInfo::createForTest(double hitRate) noexcept {

--- a/searchlib/src/vespa/searchlib/queryeval/executeinfo.h
+++ b/searchlib/src/vespa/searchlib/queryeval/executeinfo.h
@@ -5,6 +5,8 @@
 #include <vespa/vespalib/util/doom.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 
+namespace vespalib { class ExecutionProfiler; }
+
 namespace search::queryeval {
 
 /**
@@ -17,16 +19,22 @@ public:
     double hit_rate() const noexcept { return _hitRate; }
     const vespalib::Doom& doom() const noexcept { return _doom; }
     vespalib::ThreadBundle& thread_bundle() const noexcept { return _thread_bundle; }
+    vespalib::ExecutionProfiler* profiler() const noexcept { return _profiler; }
 
     static const ExecuteInfo FULL;
     static ExecuteInfo create(const ExecuteInfo& org) noexcept { return create(org._hitRate, org); }
     static ExecuteInfo create(double hitRate, const ExecuteInfo& org) noexcept {
-        return {hitRate, org._doom, org.thread_bundle()};
+        return {hitRate, org._doom, org.thread_bundle(), org._profiler};
     }
 
     static ExecuteInfo create(double hitRate, const vespalib::Doom& doom,
                               vespalib::ThreadBundle& thread_bundle_in) noexcept {
-        return {hitRate, doom, thread_bundle_in};
+        return {hitRate, doom, thread_bundle_in, nullptr};
+    }
+    static ExecuteInfo create(double hitRate, const vespalib::Doom& doom,
+                              vespalib::ThreadBundle& thread_bundle_in,
+                              vespalib::ExecutionProfiler* profiler_in) noexcept {
+        return {hitRate, doom, thread_bundle_in, profiler_in};
     }
     static ExecuteInfo createForTest() noexcept { return createForTest(1.0); }
     static ExecuteInfo createForTest(double hitRate) noexcept;
@@ -35,11 +43,13 @@ public:
     }
 
 private:
-    ExecuteInfo(double hitRate_in, const vespalib::Doom& doom, vespalib::ThreadBundle& thread_bundle_in) noexcept
-        : _doom(doom), _thread_bundle(thread_bundle_in), _hitRate(hitRate_in) {}
-    const vespalib::Doom    _doom;
-    vespalib::ThreadBundle& _thread_bundle;
-    double                  _hitRate;
+    ExecuteInfo(double hitRate_in, const vespalib::Doom& doom, vespalib::ThreadBundle& thread_bundle_in,
+                vespalib::ExecutionProfiler* profiler_in) noexcept
+        : _doom(doom), _thread_bundle(thread_bundle_in), _profiler(profiler_in), _hitRate(hitRate_in) {}
+    const vespalib::Doom         _doom;
+    vespalib::ThreadBundle&      _thread_bundle;
+    vespalib::ExecutionProfiler* _profiler;
+    double                       _hitRate;
 };
 
 } // namespace search::queryeval

--- a/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
@@ -20,12 +20,7 @@ namespace search::queryeval {
 namespace {
 
 using Profiler = vespalib::ExecutionProfiler;
-
-struct TaskGuard {
-    Profiler& profiler;
-    TaskGuard(Profiler& profiler_in, Profiler::TaskId task) noexcept : profiler(profiler_in) { profiler.start(task); }
-    ~TaskGuard() { profiler.complete(); }
-};
+using TaskGuard = vespalib::ProfilerTaskGuard;
 
 std::string name_of(const SearchIterator& search) {
     return search.getClassName();

--- a/vespalib/src/vespa/vespalib/util/execution_profiler.h
+++ b/vespalib/src/vespa/vespalib/util/execution_profiler.h
@@ -64,4 +64,43 @@ public:
         const NameMapper& name_mapper = [](const std::string& name) noexcept { return name; }) const;
 };
 
+/**
+ * RAII helper that brackets a single task on an ExecutionProfiler.
+ * Hot-path form: takes a pre-resolved TaskId. Use when the same task is
+ * entered many times and the cost of resolving names per entry matters.
+ **/
+struct ProfilerTaskGuard {
+    ExecutionProfiler& profiler;
+    ProfilerTaskGuard(ExecutionProfiler& profiler_in, ExecutionProfiler::TaskId task) noexcept
+        : profiler(profiler_in) { profiler.start(task); }
+    ProfilerTaskGuard(const ProfilerTaskGuard&) = delete;
+    ProfilerTaskGuard& operator=(const ProfilerTaskGuard&) = delete;
+    ~ProfilerTaskGuard() { profiler.complete(); }
+};
+
+/**
+ * RAII helper that brackets a single task on an ExecutionProfiler.
+ * Cold-path form: takes a nullable profiler and a name-producing callable.
+ * The name is built and resolved only when the profiler is non-null, so
+ * callers do not need to branch around profiling being disabled.
+ **/
+class ProfilerNameGuard {
+    ExecutionProfiler* _profiler;
+public:
+    ProfilerNameGuard(ExecutionProfiler* profiler_in, auto&& name_fn) noexcept
+        : _profiler(profiler_in)
+    {
+        if (_profiler != nullptr) {
+            _profiler->start(_profiler->resolve(name_fn()));
+        }
+    }
+    ProfilerNameGuard(const ProfilerNameGuard&) = delete;
+    ProfilerNameGuard& operator=(const ProfilerNameGuard&) = delete;
+    ~ProfilerNameGuard() {
+        if (_profiler != nullptr) {
+            _profiler->complete();
+        }
+    }
+};
+
 } // namespace vespalib


### PR DESCRIPTION
Wire an ExecutionProfiler through the fetchPostings phase, gated by the existing match_profile_depth trace setting and reported under "setup_profiling". Both setup call sites are instrumented: the initial fetch and the re-fetch after global filter handling.

Plumbing:
 - ExecuteInfo carries a nullable ExecutionProfiler*.
 - New FetchPostingsProfilerGuard names tasks as "[<id>]<ClassName>::fetchPostings" (or "[]..." when id is unset), matching the ProfiledIterator format so setup and execution profiles can be correlated.
 - IntermediateBlueprint::fetchPostings is now final and brackets each child call with the guard.
 - Two reusable RAII helpers in execution_profiler.h: ProfilerTaskGuard (hot-path, pre-resolved TaskId) and ProfilerNameGuard (cold-path, nullable profiler + lazy name). ProfiledIterator's local TaskGuard is replaced by ProfilerTaskGuard.
