### PR TITLE
Benchmark ENN for several inflows

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -659,14 +659,19 @@ void postprocess_pond(DataPond& pond) {
 }
 
 void print_pond_summary(const DataPond& pond) {
+    auto in_flow_str = [](const Record& r) -> std::string {
+        bool   strict = r.get<bool>(f.strict_context);
+        double rate = r.get<double>(f.filter_hit_ratio);
+        return strict ? std::string("STRICT") : std::format("{:.5f}", rate);
+    };
     std::println("calibration score: ms_per_cost={:.3f} ({} cases)\n",
                  pond.records().front().get<double>(f.calibration_constant), pond.records().size());
-    std::println("{:<60} {:>12} {:>12} {:>12} {:>12} {:>12} {:>10} {:>10}", "case", "time_ms", "actual_cost",
-                 "ms_per_cost", "pred_ms", "time_error_abs", "error", "class");
+    std::println("{:<60} {:>9} {:>12} {:>12} {:>12} {:>12} {:>12} {:>10} {:>10}", "case", "in_flow", "time_ms",
+                 "actual_cost", "ms_per_cost", "pred_ms", "time_error_abs", "error", "class");
     for (const auto& record : pond.records()) {
         auto case_id = record.get<std::string>(f.group);
-        std::println("{:<60} {:>12.3f} {:>12.3f} {:>12.3f} {:>12.3f} {:>12.3f} {:>9.3f}x {:>10}", case_id,
-                     record.get<double>(f.time_ms), record.get<double>(f.actual_cost),
+        std::println("{:<60} {:>9} {:>12.3f} {:>12.3f} {:>12.3f} {:>12.3f} {:>12.3f} {:>9.3f}x {:>10}", case_id,
+                     in_flow_str(record), record.get<double>(f.time_ms), record.get<double>(f.actual_cost),
                      record.get<double>(f.ms_per_cost), record.get<double>(f.pred_ms),
                      record.get<double>(f.time_error_abs), record.get<double>(f.error),
                      record.get<std::string>(f.class_));
@@ -874,6 +879,65 @@ void run_benchmarks(const BenchmarkSetup& setup, BenchmarkSummary& summary) {
 
 void run_benchmarks(const BenchmarkSetup& setup) {
     run_benchmarks(setup, global_summary);
+}
+
+//-----------------------------------------------------------------------------
+// Generalized run_benchmark: drive an arbitrary BenchmarkBlueprintFactory
+// across a list of InFlow values and record per-run samples to the pond so
+// postprocess_pond can compute actual_cost / calibration_constant / pred_ms.
+//-----------------------------------------------------------------------------
+
+struct FactoryBenchmarkSetup {
+    std::string         group;
+    FactoryPtr          factory;
+    uint32_t            docid_limit;
+    std::vector<InFlow> in_flows;
+    bool                unpack = false;
+    bool                force_strict = false;
+    PlanningAlgo        algo = PlanningAlgo::Cost;
+};
+
+void add_factory_run_to_pond(DataPond& pond, const FactoryBenchmarkSetup& setup, const BenchmarkResult& res,
+                             InFlow in_flow) {
+    Record record;
+    record.set(f.actual_cost, res.actual_cost);
+    record.set(f.algo, to_string(setup.algo));
+    record.set(f.blueprint_name, res.blueprint_name);
+    record.set(f.children, static_cast<int64_t>(0));
+    record.set(f.flow.cost, res.flow.cost);
+    record.set(f.flow.estimate, res.flow.estimate);
+    record.set(f.field_cfg, std::string{});
+    record.set(f.filter_hit_ratio, in_flow.rate());
+    record.set(f.force_strict, setup.force_strict);
+    record.set(f.group, setup.group);
+    record.set(f.hits, static_cast<int64_t>(res.hits));
+    record.set(f.iterator_name, res.iterator_name);
+    record.set(f.op_hit_ratio, 0.0);
+    record.set(f.query_op, std::string{});
+    record.set(f.seeks, static_cast<int64_t>(res.seeks));
+    record.set(f.strict_context, in_flow.strict());
+    record.set(f.flow.strict_cost, res.flow.strict_cost);
+    record.set(f.time_ms, res.time_ms);
+    record.set(f.unpack, setup.unpack);
+    pond.add(record);
+}
+
+BenchmarkCaseResult run_benchmark(const FactoryBenchmarkSetup& setup) {
+    assert(setup.factory);
+    assert(setup.docid_limit > 0);
+    BenchmarkCaseResult result;
+    std::cout << "-------- run_benchmark: " << setup.group << " --------" << std::endl;
+    print_result_header();
+    uint32_t num_docs_for_print = setup.docid_limit - 1;
+    for (InFlow in_flow : setup.in_flows) {
+        auto res = benchmark_search(*setup.factory, setup.docid_limit, in_flow.strict(), setup.force_strict,
+                                    setup.unpack, in_flow.rate(), setup.algo);
+        print_result(res, /*children*/ 0, /*op_hit_ratio*/ 0.0, in_flow, num_docs_for_print);
+        result.add(res);
+        add_factory_run_to_pond(global_pond, setup, res, in_flow);
+    }
+    print_result(result);
+    return result;
 }
 
 //---------------------------------------------------------------------------------------
@@ -1242,38 +1306,16 @@ TEST(IteratorBenchmark, btree_vs_array_nonstrict_crossover) {
     }
 }
 
-TEST(IteratorBenchmark, analyze_AND_plan_variants_ENN) {
-    auto enn_factory = enn({.num_docs = num_docs, .target_hits = 100});
-    auto term_hit_ratios = gen_ratios(0.01, 10.0, 7);
-
-    auto run_plan = [&](const std::string& tag, FactoryPtr root, double term_hit_ratio) {
-        auto res = benchmark_search(*root, num_docs + 1, /*strict*/ true, /*force_strict*/ false,
-                                    /*unpack_iterator*/ false, /*filter_hit_ratio*/ 1.0, PlanningAlgo::Order);
-        std::println("  {:>16} | term_hr={:>8.5f} | hits={:>8} | time_ms={:>8.3f} | plan={}", tag, term_hit_ratio,
-                     res.hits, res.time_ms, res.blueprint_name);
-        return res.time_ms;
-    };
-
-    std::println("Plan variants for AND(term{{int32_fs}}, ENN{{num_docs={},target_hits=100,dim=2}})", num_docs);
-    std::println("term-alone, enn-alone are baselines. AND rows force build order via PlanningAlgo::Order.");
-
-    double max_penalty = 0.0;
-    for (double hr : term_hit_ratios) {
-        auto term_factory = term(int32_fs, num_docs, 0, hr);
-
-        std::println("----- term_hit_ratio={} -----", hr);
-        run_plan("term-alone", term_factory, hr);
-        run_plan("enn-alone", enn_factory, hr);
-        double t_term_first = run_plan("AND[term,enn]", and_(term_factory, enn_factory), hr);
-        double t_enn_first = run_plan("AND[enn,term]", and_(enn_factory, term_factory), hr);
-
-        double best = std::min(t_term_first, t_enn_first);
-        double worst = std::max(t_term_first, t_enn_first);
-        double penalty = (best > 0) ? (worst / best) : 0.0;
-        max_penalty = std::max(max_penalty, penalty);
-        std::println("  worst/best ratio={:.4f}", penalty);
+TEST(IteratorBenchmark, analyze_ENN) {
+    std::vector<InFlow> in_flows;
+    in_flows.emplace_back(true);
+    for (double rate : {0.001, 0.005, 0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}) {
+        in_flows.emplace_back(false, rate);
     }
-    std::println("max worst-plan penalty={:.4f}", max_penalty);
+    run_benchmark({.group = "ENN[num_docs=" + std::to_string(num_docs) + ",target_hits=100]",
+                   .factory = enn({.num_docs = num_docs, .target_hits = 100}),
+                   .docid_limit = num_docs + 1,
+                   .in_flows = in_flows});
 }
 
 TEST(IteratorBenchmark, data_pond_test) {
@@ -1317,7 +1359,7 @@ TEST(IteratorBenchmark, data_pond_test) {
 }
 
 static std::string smoke_test_filter = "--gtest_filter="
-                                       "IteratorBenchmark.analyze_term_search_in_disk_index";
+                                       "IteratorBenchmark.analyze_ENN";
 
 int main(int argc, char** argv) {
     bool opt_dump_pond = false;


### PR DESCRIPTION
*:robot: AI has been used to help write this code.*

- Add `FactoryBenchmarkSetup` to run benchmark on a `FactoryPtr` (example: `EnnBlueprintFactory`).
- Adds `in_flow` to pond presentation.
- Benchmarks ENN over `in_flow`.

Example:

```
calibration score: ms_per_cost=55.529 (15 cases)

case                                                           in_flow      time_ms  actual_cost  ms_per_cost      pred_ms time_error_abs      error      class
ENN[num_docs=10000000,target_hits=100]                          STRICT       46.666        1.000       46.666       55.529        8.863     0.840x         OK
ENN[num_docs=10000000,target_hits=100]                         0.00100        0.095        0.001       95.125        0.056        0.040     1.713x      UNDER
ENN[num_docs=10000000,target_hits=100]                         0.00500        0.372        0.005       74.358        0.278        0.094     1.339x         OK
ENN[num_docs=10000000,target_hits=100]                         0.01000        1.149        0.010      114.929        0.555        0.594     2.070x      UNDER
ENN[num_docs=10000000,target_hits=100]                         0.05000        7.597        0.050      151.934        2.776        4.820     2.736x      UNDER
ENN[num_docs=10000000,target_hits=100]                         0.10000        4.419        0.100       44.193        5.553        1.134     0.796x         OK
ENN[num_docs=10000000,target_hits=100]                         0.20000        9.161        0.200       45.805       11.106        1.945     0.825x         OK
ENN[num_docs=10000000,target_hits=100]                         0.30000       15.329        0.300       51.098       16.659        1.329     0.920x         OK
ENN[num_docs=10000000,target_hits=100]                         0.40000       23.350        0.400       58.374       22.212        1.138     1.051x         OK
ENN[num_docs=10000000,target_hits=100]                         0.50000       22.651        0.500       45.302       27.765        5.113     0.816x         OK
ENN[num_docs=10000000,target_hits=100]                         0.60000       46.884        0.600       78.140       33.318       13.566     1.407x      UNDER
ENN[num_docs=10000000,target_hits=100]                         0.70000       46.574        0.700       66.534       38.870        7.704     1.198x         OK
ENN[num_docs=10000000,target_hits=100]                         0.80000       46.825        0.800       58.531       44.423        2.402     1.054x         OK
ENN[num_docs=10000000,target_hits=100]                         0.90000       46.881        0.900       52.090       49.976        3.095     0.938x         OK
ENN[num_docs=10000000,target_hits=100]                         1.00000       46.651        1.000       46.651       55.529        8.879     0.840x         OK
```