### PR TITLE
ConfigRetriever: avoid subscribing on a closed subscriber

### DIFF
--- a/config/src/vespa/config/retriever/configretriever.cpp
+++ b/config/src/vespa/config/retriever/configretriever.cpp
@@ -54,6 +54,9 @@ ConfigSnapshot ConfigRetriever::getConfigs(const ConfigKeySet& keySet, vespalib:
         }
         _subscriptionList.clear();
         for (const auto& key : keySet) {
+            std::lock_guard guard(_lock);
+            if (isClosed())
+                return ConfigSnapshot();
             _subscriptionList.push_back(_configSubscriber->subscribe(key, _subscribeTimeout));
         }
     }

--- a/config/src/vespa/config/subscription/configsubscriptionset.cpp
+++ b/config/src/vespa/config/subscription/configsubscriptionset.cpp
@@ -125,7 +125,11 @@ void ConfigSubscriptionSet::close() {
 
 std::shared_ptr<ConfigSubscription> ConfigSubscriptionSet::subscribe(const ConfigKey& key, duration timeout) {
     if (_state != OPEN) {
-        throw ConfigRuntimeException("Adding subscription after calling nextConfig() is not allowed");
+        if (_state == CLOSED) {
+            throw ConfigRuntimeException("Calling subscribe() after calling close() is not allowed");
+        } else {
+            throw ConfigRuntimeException("Adding subscription after calling nextConfig() is not allowed");
+        }
     }
     LOG(debug, "Subscribing with config Id(%s), defName(%s)", key.getConfigId().c_str(), key.getDefName().c_str());
 


### PR DESCRIPTION
A concurrent close() on a ConfigRetriever could race with getConfigs(): close() would close _configSubscriber while the subscribe loop was still running, and the next subscribe() call would then throw the misleading "Adding subscription after calling nextConfig() is not allowed" because ConfigSubscriptionSet's state had already transitioned to CLOSED.

Check isClosed() under _lock inside the subscribe loop and bail out with an empty ConfigSnapshot if close() has been called. Also split the ConfigSubscriptionSet::subscribe() error into two cases so the genuinely closed case reports an accurate message instead of blaming nextConfig().
