### PR TITLE
Shrink summary lid space flush target is a GC style flush target that [MERGEOK]

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/docsummary/summarymanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summarymanager.cpp
@@ -58,7 +58,7 @@ class ShrinkSummaryLidSpaceFlushTarget : public ShrinkLidSpaceFlushTarget {
 
 public:
     ShrinkSummaryLidSpaceFlushTarget(const std::string& name, Type type, Component component,
-                                     SerialNum flushedSerialNum, vespalib::system_time lastFlushTime,
+                                     SerialNum flushedSerialNum,
                                      vespalib::Executor&                   summaryService,
                                      std::shared_ptr<ICompactableLidSpace> target);
     ~ShrinkSummaryLidSpaceFlushTarget() override;
@@ -67,10 +67,9 @@ public:
 
 ShrinkSummaryLidSpaceFlushTarget::ShrinkSummaryLidSpaceFlushTarget(const std::string& name, Type type,
                                                                    Component component, SerialNum flushedSerialNum,
-                                                                   vespalib::system_time lastFlushTime,
                                                                    vespalib::Executor&   summaryService,
                                                                    std::shared_ptr<ICompactableLidSpace> target)
-    : ShrinkLidSpaceFlushTarget(name, type, component, flushedSerialNum, lastFlushTime, std::move(target)),
+    : ShrinkLidSpaceFlushTarget(name, type, component, flushedSerialNum, vespalib::system_clock::now(), std::move(target)),
       _summaryService(summaryService) {
 }
 
@@ -170,8 +169,8 @@ namespace {
 
 IFlushTarget::SP createShrinkLidSpaceFlushTarget(vespalib::Executor& summaryService, IDocumentStore::SP docStore) {
     return std::make_shared<ShrinkSummaryLidSpaceFlushTarget>(
-        "summary.shrink", IFlushTarget::Type::GC, IFlushTarget::Component::DOCUMENT_STORE, docStore->lastSyncToken(),
-        docStore->getLastFlushTime(), summaryService, std::move(docStore));
+        "summary.shrink", IFlushTarget::Type::GC, IFlushTarget::Component::DOCUMENT_STORE, docStore->tentativeLastSyncToken(),
+        summaryService, std::move(docStore));
 }
 
 } // namespace


### PR DESCRIPTION
doesn't affect transaction log replay. Use current serial number and current time instead of values meant for summary flush target.

@vekterli or @arnej27959 : please review
