### PR TITLE
Add pre-commit config to enforce C++ formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.4  # Use the latest tag or a specific version
+    hooks:
+      - id: clang-format
+        files: \.(cpp|h|hpp)$


### PR DESCRIPTION
Adds a .pre-commit-config.yaml that runs clang-format (v22.1.4) on all C++ source files (.cpp, .h, .hpp), suitable for a pre-commit hook.
