### PR TITLE
feat(cli): add support for easier mTLS key rotation

### DIFF
--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func newCertCmd(cli *CLI) *cobra.Command {
 		skipApplicationPackage bool
 		overwriteCertificate   bool
 		appendCertificate      bool
-		pruneCertificate       bool
+		keepOneCertificate     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "cert",
@@ -68,16 +69,16 @@ $ vespa auth cert -a my-tenant.my-app.my-instance path/to/application/package`,
 		SilenceUsage:      true,
 		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if pruneCertificate {
-				return doPruneCert(cli, skipApplicationPackage, args)
+			if keepOneCertificate {
+				return doKeepOne(cli, skipApplicationPackage, args)
 			}
 			return doCert(cli, overwriteCertificate, skipApplicationPackage, appendCertificate, args)
 		},
 	}
 	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate and private key")
 	cmd.Flags().BoolVarP(&appendCertificate, "append", "A", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
-	cmd.Flags().BoolVarP(&pruneCertificate, "prune", "p", false, "Remove all but the newest certificate from the certificate file. Useful after completing credential rotation")
-	cmd.MarkFlagsMutuallyExclusive("prune", "force", "append")
+	cmd.Flags().BoolVarP(&keepOneCertificate, "keep-one", "k", false, "Remove all but the newest certificate from the certificate file. Useful after completing credential rotation")
+	cmd.MarkFlagsMutuallyExclusive("keep-one", "force", "append")
 	// TODO(mpolden): Stop adding certificate to application package and remove this flag
 	cmd.Flags().BoolVarP(&skipApplicationPackage, "no-add", "N", false, "Do not add certificate to the application package")
 	cmd.MarkPersistentFlagRequired(applicationFlag)
@@ -177,7 +178,7 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, appendC
 	return nil
 }
 
-func doPruneCert(cli *CLI, skipApplicationPackage bool, args []string) error {
+func doKeepOne(cli *CLI, skipApplicationPackage bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -194,6 +195,26 @@ func doPruneCert(cli *CLI, skipApplicationPackage bool, args []string) error {
 		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
 			"Run 'vespa auth cert' first to create an initial certificate")
 	}
+	data, err := os.ReadFile(certificateFile.path)
+	if err != nil {
+		return fmt.Errorf("could not read certificate file: %w", err)
+	}
+	certs, err := vespa.ParseCertificates(data)
+	if err != nil {
+		return fmt.Errorf("could not parse certificates: %w", err)
+	}
+	if len(certs) == 1 {
+		cli.printInfo("Only one certificate is present, will not remove any other certificates.")
+		return nil
+	}
+	for i, cert := range certs[1:] {
+		cli.printWarning(fmt.Sprintf("Will remove certificate %d: CN=%s, issued %s, expires %s",
+			i+1,
+			cert.Subject.CommonName,
+			cert.NotBefore.Format(time.RFC3339),
+			cert.NotAfter.Format(time.RFC3339),
+		))
+	}
 	hints := []string{}
 	if !skipApplicationPackage {
 		hints = append(hints, "This will also overwrite security/clients.pem in the current application package (use --no-add to skip)")
@@ -206,7 +227,7 @@ func doPruneCert(cli *CLI, skipApplicationPackage bool, args []string) error {
 	if !ok {
 		return nil
 	}
-	if err := vespa.PruneCertificateFile(certificateFile.path); err != nil {
+	if err := vespa.KeepOneCertificateFile(certificateFile.path); err != nil {
 		return fmt.Errorf("could not prune certificate file: %w", err)
 	}
 	cli.printSuccess("Pruned certificate file ", color.CyanString("'"+certificateFile.path+"'"))

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -344,6 +344,11 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 		return fmt.Errorf("could not prune certificate file: %w", err)
 	}
 	cli.printSuccess("Pruned certificate file ", color.CyanString("'"+certificateFile.path+"'"))
+	if ioutil.Exists(oldPrivateKeyFile.path) {
+		cli.printInfo("Next step: deploy the application again, then you can safely remove ", color.CyanString("'"+oldPrivateKeyFile.path+"'"))
+	} else {
+		cli.printInfo("Next step: deploy the application again.")
+	}
 	if !skipApplicationPackage {
 		return doCertAdd(cli, force, args)
 	}

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -90,10 +90,7 @@ $ vespa auth cert -a my-tenant.my-app.my-instance path/to/application/package`,
 }
 
 func newCertAddCmd(cli *CLI) *cobra.Command {
-	var (
-		overwriteCertificate bool
-		appendCertificate    bool
-	)
+	var overwriteCertificate bool
 
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -111,11 +108,10 @@ $ vespa auth cert add -a my-tenant.my-app.my-instance path/to/application/packag
 		SilenceUsage:      true,
 		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doCertAdd(cli, overwriteCertificate, appendCertificate, args)
+			return doCertAdd(cli, overwriteCertificate, args)
 		},
 	}
 	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate")
-	cmd.Flags().BoolVarP(&appendCertificate, "append", "A", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
 	cmd.MarkPersistentFlagRequired(applicationFlag)
 	return cmd
 }
@@ -196,7 +192,7 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyA
 		cli.printSuccess("Next step: deploy with 'vespa prod deploy' and then remove unused certificates with 'vespa auth cert --prune-old'. See ", color.GreenString("https://docs.vespa.ai/en/security/guide.html"))
 	}
 	if !skipApplicationPackage {
-		return doCertAdd(cli, overwriteCertificate, newKeyAndCertificate, args)
+		return doCertAdd(cli, overwriteCertificate, args)
 	}
 	return nil
 }
@@ -349,12 +345,12 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 	}
 	cli.printSuccess("Pruned certificate file ", color.CyanString("'"+certificateFile.path+"'"))
 	if !skipApplicationPackage {
-		return doCertAdd(cli, true, false, args)
+		return doCertAdd(cli, force, args)
 	}
 	return nil
 }
 
-func doCertAdd(cli *CLI, overwriteCertificate bool, appendCertificate bool, args []string) error {
+func doCertAdd(cli *CLI, overwriteCertificate bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -367,8 +363,8 @@ func doCertAdd(cli *CLI, overwriteCertificate bool, appendCertificate bool, args
 	if err != nil {
 		return err
 	}
-	if pkg.HasCertificate() && !overwriteCertificate && !appendCertificate {
-		return errHint(fmt.Errorf("application package '%s' already contains a certificate", pkg.Path), "Use -f to force overwriting, or -A to append a new certificate for rotation")
+	if pkg.HasCertificate() && !overwriteCertificate {
+		return errHint(fmt.Errorf("application package '%s' already contains a certificate", pkg.Path), "Use -f to force overwriting")
 	}
 	if pkg.IsZip() {
 		return errHint(fmt.Errorf("cannot add certificate to compressed application package: '%s'", pkg.Path),

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -171,9 +172,12 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyA
 		}
 		backupKeyPath, err := cli.config.backupPrivateKey(app, targetType.name)
 		if err != nil {
-			return err
+			if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("could not back up private key: %w", err)
+			}
+		} else {
+			cli.printInfo("Private key backup created at ", backupKeyPath)
 		}
-		cli.printInfo("Private key backup created at ", backupKeyPath)
 	}
 
 	keyPair, err := vespa.CreateKeyPair()
@@ -222,7 +226,7 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 	if err != nil {
 		return fmt.Errorf("could not parse certificates: %w", err)
 	}
-	if len(certs) <= 1 {
+	if len(certs) == 1 {
 		cli.printInfo("Only one certificate is present, nothing to remove.")
 		return nil
 	}

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -143,14 +143,18 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, appendC
 			return errHint(fmt.Errorf("certificate '%s' already exists", color.CyanString(certificateFile.path)), hint)
 		}
 	}
-	if appendCertificate && !ioutil.Exists(certificateFile.path) {
-		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
-			"Run 'vespa auth cert' first to create an initial certificate")
-	}
-
-	if appendCertificate && !ioutil.Exists(certificateFile.path) {
-		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
-			"Run 'vespa auth cert' first to create an initial certificate")
+	if appendCertificate {
+		if !ioutil.Exists(certificateFile.path) {
+			return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
+				"Run 'vespa auth cert' first to create an initial certificate")
+		}
+		ok, err := cli.confirm("Your old private key will be overwritten.", false)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
 	}
 	if appendCertificate {
 		if _, err := os.Stat(privateKeyFile.path); err != nil {

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -79,7 +79,7 @@ $ vespa auth cert -a my-tenant.my-app.my-instance path/to/application/package`,
 			return doCert(cli, overwriteCertificate, skipApplicationPackage, newPrivateKeyAndCertificate, args)
 		},
 	}
-	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate and private key")
+	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force changes without prompting (overwrite when creating, prune when pruning)")
 	cmd.Flags().BoolVar(&newPrivateKeyAndCertificate, "new-key", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
 	cmd.Flags().BoolVar(&pruneOldCertificates, "prune-old", false, "Remove all but the newest certificate from the certificate file. Useful after completing credential rotation")
 	cmd.MarkFlagsMutuallyExclusive("new-key", "prune-old")

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -18,6 +18,8 @@ func newCertCmd(cli *CLI) *cobra.Command {
 	var (
 		skipApplicationPackage bool
 		overwriteCertificate   bool
+		appendCertificate      bool
+		pruneCertificate       bool
 	)
 	cmd := &cobra.Command{
 		Use:   "cert",
@@ -66,10 +68,16 @@ $ vespa auth cert -a my-tenant.my-app.my-instance path/to/application/package`,
 		SilenceUsage:      true,
 		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doCert(cli, overwriteCertificate, skipApplicationPackage, args)
+			if pruneCertificate {
+				return doPruneCert(cli, skipApplicationPackage, args)
+			}
+			return doCert(cli, overwriteCertificate, skipApplicationPackage, appendCertificate, args)
 		},
 	}
 	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate and private key")
+	cmd.Flags().BoolVarP(&appendCertificate, "append", "A", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
+	cmd.Flags().BoolVarP(&pruneCertificate, "prune", "p", false, "Remove all but the newest certificate from the certificate file. Useful after completing credential rotation")
+	cmd.MarkFlagsMutuallyExclusive("prune", "force", "append")
 	// TODO(mpolden): Stop adding certificate to application package and remove this flag
 	cmd.Flags().BoolVarP(&skipApplicationPackage, "no-add", "N", false, "Do not add certificate to the application package")
 	cmd.MarkPersistentFlagRequired(applicationFlag)
@@ -77,7 +85,11 @@ $ vespa auth cert -a my-tenant.my-app.my-instance path/to/application/package`,
 }
 
 func newCertAddCmd(cli *CLI) *cobra.Command {
-	var overwriteCertificate bool
+	var (
+		overwriteCertificate bool
+		appendCertificate    bool
+	)
+
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add certificate to application package",
@@ -94,15 +106,16 @@ $ vespa auth cert add -a my-tenant.my-app.my-instance path/to/application/packag
 		SilenceUsage:      true,
 		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doCertAdd(cli, overwriteCertificate, args)
+			return doCertAdd(cli, overwriteCertificate, appendCertificate, args)
 		},
 	}
 	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate")
+	cmd.Flags().BoolVarP(&appendCertificate, "append", "A", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
 	cmd.MarkPersistentFlagRequired(applicationFlag)
 	return cmd
 }
 
-func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, args []string) error {
+func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, appendCertificate bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -120,8 +133,8 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, args []
 		return err
 	}
 
-	if !overwriteCertificate {
-		hint := "Use -f flag to force overwriting"
+	if !overwriteCertificate && !appendCertificate {
+		hint := "Use -f flag to force overwriting or -A flag to append new certificate"
 		if ioutil.Exists(privateKeyFile.path) {
 			return errHint(fmt.Errorf("private key '%s' already exists", color.CyanString(privateKeyFile.path)), hint)
 		}
@@ -129,26 +142,82 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, args []
 			return errHint(fmt.Errorf("certificate '%s' already exists", color.CyanString(certificateFile.path)), hint)
 		}
 	}
+	if appendCertificate && !ioutil.Exists(certificateFile.path) {
+		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
+			"Run 'vespa auth cert' first to create an initial certificate")
+	}
 
+	if appendCertificate && !ioutil.Exists(certificateFile.path) {
+		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
+			"Run 'vespa auth cert' first to create an initial certificate")
+	}
+	if appendCertificate {
+		if _, err := os.Stat(privateKeyFile.path); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("private key file does not exist: %s", privateKeyFile.path)
+			}
+			return fmt.Errorf("could not stat private key file %s: %w", privateKeyFile.path, err)
+		}
+	}
 	keyPair, err := vespa.CreateKeyPair()
 	if err != nil {
 		return err
 	}
-	if err := keyPair.WriteCertificateFile(certificateFile.path, overwriteCertificate); err != nil {
+	if err := keyPair.WriteCertificateFile(certificateFile.path, overwriteCertificate, appendCertificate); err != nil {
 		return fmt.Errorf("could not write certificate: %w", err)
 	}
-	if err := keyPair.WritePrivateKeyFile(privateKeyFile.path, overwriteCertificate); err != nil {
+	if err := keyPair.WritePrivateKeyFile(privateKeyFile.path, overwriteCertificate || appendCertificate); err != nil {
 		return fmt.Errorf("could not write private key: %w", err)
 	}
 	cli.printSuccess("Certificate written to ", color.CyanString("'"+certificateFile.path+"'"))
 	cli.printSuccess("Private key written to ", color.CyanString("'"+privateKeyFile.path+"'"))
 	if !skipApplicationPackage {
-		return doCertAdd(cli, overwriteCertificate, args)
+		return doCertAdd(cli, overwriteCertificate, appendCertificate, args)
 	}
 	return nil
 }
 
-func doCertAdd(cli *CLI, overwriteCertificate bool, args []string) error {
+func doPruneCert(cli *CLI, skipApplicationPackage bool, args []string) error {
+	targetType, err := cli.targetType(cloudTargetOnly)
+	if err != nil {
+		return err
+	}
+	app, err := cli.config.application()
+	if err != nil {
+		return err
+	}
+	certificateFile, err := cli.config.certificatePath(app, targetType.name)
+	if err != nil {
+		return err
+	}
+	if !ioutil.Exists(certificateFile.path) {
+		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
+			"Run 'vespa auth cert' first to create an initial certificate")
+	}
+	hints := []string{}
+	if !skipApplicationPackage {
+		hints = append(hints, "This will also overwrite security/clients.pem in the current application package (use --no-add to skip)")
+	}
+	cli.printWarning("Any clients still using old certificates will stop working after pruning", hints...)
+	ok, err := cli.confirm("Prune old certificates from '"+certificateFile.path+"'?", false)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if err := vespa.PruneCertificateFile(certificateFile.path); err != nil {
+		return fmt.Errorf("could not prune certificate file: %w", err)
+	}
+	cli.printSuccess("Pruned certificate file ", color.CyanString("'"+certificateFile.path+"'"))
+	if !skipApplicationPackage {
+		overwrite, appendCertificate := true, false
+		return doCertAdd(cli, overwrite, appendCertificate, args)
+	}
+	return nil
+}
+
+func doCertAdd(cli *CLI, overwriteCertificate bool, appendCertificate bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -161,8 +230,8 @@ func doCertAdd(cli *CLI, overwriteCertificate bool, args []string) error {
 	if err != nil {
 		return err
 	}
-	if pkg.HasCertificate() && !overwriteCertificate {
-		return errHint(fmt.Errorf("application package '%s' already contains a certificate", pkg.Path), "Use -f flag to force overwriting")
+	if pkg.HasCertificate() && !overwriteCertificate && !appendCertificate {
+		return errHint(fmt.Errorf("application package '%s' already contains a certificate", pkg.Path), "Use -f to force overwriting, or -A to append a new certificate for rotation")
 	}
 	if pkg.IsZip() {
 		return errHint(fmt.Errorf("cannot add certificate to compressed application package: '%s'", pkg.Path),

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -4,6 +4,9 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,10 +20,10 @@ import (
 
 func newCertCmd(cli *CLI) *cobra.Command {
 	var (
-		skipApplicationPackage bool
-		overwriteCertificate   bool
-		appendCertificate      bool
-		keepOneCertificate     bool
+		skipApplicationPackage      bool
+		overwriteCertificate        bool
+		newPrivateKeyAndCertificate bool
+		pruneOldCertificates        bool
 	)
 	cmd := &cobra.Command{
 		Use:   "cert",
@@ -69,16 +72,16 @@ $ vespa auth cert -a my-tenant.my-app.my-instance path/to/application/package`,
 		SilenceUsage:      true,
 		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if keepOneCertificate {
-				return doKeepOne(cli, skipApplicationPackage, args)
+			if pruneOldCertificates {
+				return doPruneOldCertificates(cli, overwriteCertificate, skipApplicationPackage, args)
 			}
-			return doCert(cli, overwriteCertificate, skipApplicationPackage, appendCertificate, args)
+			return doCert(cli, overwriteCertificate, skipApplicationPackage, newPrivateKeyAndCertificate, args)
 		},
 	}
 	cmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate and private key")
-	cmd.Flags().BoolVarP(&appendCertificate, "append", "A", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
-	cmd.Flags().BoolVarP(&keepOneCertificate, "keep-one", "k", false, "Remove all but the newest certificate from the certificate file. Useful after completing credential rotation")
-	cmd.MarkFlagsMutuallyExclusive("keep-one", "force", "append")
+	cmd.Flags().BoolVar(&newPrivateKeyAndCertificate, "new-key", false, "Appends a new certificate if certificate already exists. Useful for rotating credentials")
+	cmd.Flags().BoolVar(&pruneOldCertificates, "prune-old", false, "Remove all but the newest certificate from the certificate file. Useful after completing credential rotation")
+	cmd.MarkFlagsMutuallyExclusive("new-key", "prune-old")
 	// TODO(mpolden): Stop adding certificate to application package and remove this flag
 	cmd.Flags().BoolVarP(&skipApplicationPackage, "no-add", "N", false, "Do not add certificate to the application package")
 	cmd.MarkPersistentFlagRequired(applicationFlag)
@@ -116,7 +119,7 @@ $ vespa auth cert add -a my-tenant.my-app.my-instance path/to/application/packag
 	return cmd
 }
 
-func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, appendCertificate bool, args []string) error {
+func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyAndCertificate bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -134,8 +137,8 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, appendC
 		return err
 	}
 
-	if !overwriteCertificate && !appendCertificate {
-		hint := "Use -f flag to force overwriting or -A flag to append new certificate"
+	if !overwriteCertificate && !newKeyAndCertificate {
+		hint := "Use -f flag to force overwriting of certificate, or use --new-key flag to rotate certificates"
 		if ioutil.Exists(privateKeyFile.path) {
 			return errHint(fmt.Errorf("private key '%s' already exists", color.CyanString(privateKeyFile.path)), hint)
 		}
@@ -143,46 +146,58 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, appendC
 			return errHint(fmt.Errorf("certificate '%s' already exists", color.CyanString(certificateFile.path)), hint)
 		}
 	}
-	if appendCertificate {
-		if !ioutil.Exists(certificateFile.path) {
-			return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
-				"Run 'vespa auth cert' first to create an initial certificate")
+
+	if newKeyAndCertificate {
+		oldPrivateKeyFile, err := cli.config.oldPrivateKeyPath(app, targetType.name)
+		if err == nil && ioutil.Exists(oldPrivateKeyFile.path) {
+			return errHint(fmt.Errorf("backup of private key already exists at %s", color.CyanString(oldPrivateKeyFile.path)),
+				"If you still want to rotate your private key and certificate, remove the old private key first. Documentation for rotation help: "+color.GreenString("https://docs.vespa.ai/en/security/guide.html"))
 		}
-		ok, err := cli.confirm("Your old private key will be overwritten.", false)
+
+		if !ioutil.Exists(certificateFile.path) {
+			cli.printWarning("No certificate file exists. A new certificate will be created.")
+		}
+		if !ioutil.Exists(privateKeyFile.path) {
+			cli.printWarning("No private key file exists. A new private key will be created.")
+		}
+		if !overwriteCertificate {
+			ok, err := cli.confirm("This will create a backup of your existing private key and add a new certificate. Continue?", false)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+		}
+		backupKeyPath, err := cli.config.backupPrivateKey(app, targetType.name)
 		if err != nil {
 			return err
 		}
-		if !ok {
-			return nil
-		}
+		cli.printInfo("Private key backup created at ", backupKeyPath)
 	}
-	if appendCertificate {
-		if _, err := os.Stat(privateKeyFile.path); err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("private key file does not exist: %s", privateKeyFile.path)
-			}
-			return fmt.Errorf("could not stat private key file %s: %w", privateKeyFile.path, err)
-		}
-	}
+
 	keyPair, err := vespa.CreateKeyPair()
 	if err != nil {
 		return err
 	}
-	if err := keyPair.WriteCertificateFile(certificateFile.path, overwriteCertificate, appendCertificate); err != nil {
+	if err := keyPair.WriteCertificateFile(certificateFile.path, overwriteCertificate, newKeyAndCertificate); err != nil {
 		return fmt.Errorf("could not write certificate: %w", err)
 	}
-	if err := keyPair.WritePrivateKeyFile(privateKeyFile.path, overwriteCertificate || appendCertificate); err != nil {
+	if err := keyPair.WritePrivateKeyFile(privateKeyFile.path, overwriteCertificate || newKeyAndCertificate); err != nil {
 		return fmt.Errorf("could not write private key: %w", err)
 	}
 	cli.printSuccess("Certificate written to ", color.CyanString("'"+certificateFile.path+"'"))
 	cli.printSuccess("Private key written to ", color.CyanString("'"+privateKeyFile.path+"'"))
+	if newKeyAndCertificate {
+		cli.printSuccess("Next step: deploy with 'vespa prod deploy' and then remove unused certificates with 'vespa auth cert --prune-old'. See ", color.GreenString("https://docs.vespa.ai/en/security/guide.html"))
+	}
 	if !skipApplicationPackage {
-		return doCertAdd(cli, overwriteCertificate, appendCertificate, args)
+		return doCertAdd(cli, overwriteCertificate, newKeyAndCertificate, args)
 	}
 	return nil
 }
 
-func doKeepOne(cli *CLI, skipApplicationPackage bool, args []string) error {
+func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -199,45 +214,138 @@ func doKeepOne(cli *CLI, skipApplicationPackage bool, args []string) error {
 		return errHint(fmt.Errorf("no certificate found at '%s'", color.CyanString(certificateFile.path)),
 			"Run 'vespa auth cert' first to create an initial certificate")
 	}
-	data, err := os.ReadFile(certificateFile.path)
+	certificateData, err := os.ReadFile(certificateFile.path)
 	if err != nil {
 		return fmt.Errorf("could not read certificate file: %w", err)
 	}
-	certs, err := vespa.ParseCertificates(data)
+	certs, err := vespa.ParseCertificates(certificateData)
 	if err != nil {
 		return fmt.Errorf("could not parse certificates: %w", err)
 	}
-	if len(certs) == 1 {
-		cli.printInfo("Only one certificate is present, will not remove any other certificates.")
+	if len(certs) <= 1 {
+		cli.printInfo("Only one certificate is present, nothing to remove.")
 		return nil
 	}
-	for i, cert := range certs[1:] {
-		cli.printWarning(fmt.Sprintf("Will remove certificate %d: CN=%s, issued %s, expires %s",
-			i+1,
-			cert.Subject.CommonName,
-			cert.NotBefore.Format(time.RFC3339),
-			cert.NotAfter.Format(time.RFC3339),
-		))
-	}
-	hints := []string{}
-	if !skipApplicationPackage {
-		hints = append(hints, "This will also overwrite security/clients.pem in the current application package (use --no-add to skip)")
-	}
-	cli.printWarning("Any clients still using old certificates will stop working after pruning", hints...)
-	ok, err := cli.confirm("Prune old certificates from '"+certificateFile.path+"'?", false)
+	privateKeyFile, err := cli.config.privateKeyPath(app, targetType.name)
 	if err != nil {
 		return err
 	}
-	if !ok {
+	privateKeyData, err := os.ReadFile(privateKeyFile.path)
+	if err != nil {
+		return fmt.Errorf("could not read private key file: %w", err)
+	}
+	// Old key backup is optional — used only to label certs.
+	oldPrivateKeyFile, _ := cli.config.oldPrivateKeyPath(app, targetType.name)
+	oldPrivateKeyData, _ := os.ReadFile(oldPrivateKeyFile.path)
+
+	// Classify every certificate in the file.
+	var currentCerts, oldCerts, unknownCerts []*x509.Certificate
+	for _, cert := range certs {
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		if _, err := tls.X509KeyPair(certPEM, privateKeyData); err == nil {
+			currentCerts = append(currentCerts, cert)
+			continue
+		}
+		if len(oldPrivateKeyData) > 0 {
+			if _, err := tls.X509KeyPair(certPEM, oldPrivateKeyData); err == nil {
+				oldCerts = append(oldCerts, cert)
+				continue
+			}
+		}
+		unknownCerts = append(unknownCerts, cert)
+	}
+
+	if len(currentCerts) == 0 {
+		return errHint(
+			fmt.Errorf("no certificate in '%s' matches the current private key", color.CyanString(certificateFile.path)),
+			"Ensure the private key at '"+privateKeyFile.path+"' is correct, or re-create the certificate with 'vespa auth cert -f'",
+		)
+	}
+	certInfo := func(cert *x509.Certificate) string {
+		return fmt.Sprintf("CN=%s, issued %s, expires %s", cert.Subject.CommonName,
+			cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+	}
+
+	removeSet := make(map[*x509.Certificate]bool)
+
+	if len(currentCerts) > 1 {
+		cli.printWarning(fmt.Sprintf("%d certificates match the current private key", len(currentCerts)))
+		newestCurrent := currentCerts[0]
+		for _, cert := range currentCerts[1:] {
+			if cert.NotAfter.After(newestCurrent.NotAfter) {
+				newestCurrent = cert
+			}
+		}
+		if force {
+			for _, cert := range currentCerts {
+				if cert != newestCurrent {
+					removeSet[cert] = true
+				}
+			}
+		} else {
+			ok, err := cli.confirm(fmt.Sprintf(
+				"Remove %d extra certificate(s) matching the current key, keeping the one expiring %s?",
+				len(currentCerts)-1, newestCurrent.NotAfter.Format(time.RFC3339),
+			), false)
+			if err != nil {
+				return err
+			}
+			if ok {
+				for _, cert := range currentCerts {
+					if cert != newestCurrent {
+						removeSet[cert] = true
+					}
+				}
+			}
+		}
+	}
+	for _, cert := range oldCerts {
+		if force {
+			removeSet[cert] = true
+		} else {
+			cli.printInfo("This certificate is associated with the private key in ", oldPrivateKeyFile.path)
+			ok, err := cli.confirm(fmt.Sprintf("Remove certificate %s?", certInfo(cert)), false)
+			if err != nil {
+				return err
+			}
+			if ok {
+				removeSet[cert] = true
+			}
+		}
+	}
+	for _, cert := range unknownCerts {
+		cli.printWarning("This certificate is not associated with any of your saved private keys")
+		if force {
+			removeSet[cert] = true
+		} else {
+			ok, err := cli.confirm(fmt.Sprintf("Remove certificate %s?", certInfo(cert)), false)
+			if err != nil {
+				return err
+			}
+			if ok {
+				removeSet[cert] = true
+			}
+		}
+	}
+
+	if len(removeSet) == 0 {
+		cli.printInfo("No certificates removed.")
 		return nil
 	}
-	if err := vespa.KeepOneCertificateFile(certificateFile.path); err != nil {
+
+	// Write all certs not selected for removal, preserving original order.
+	var keepPEM []byte
+	for _, cert := range certs {
+		if !removeSet[cert] {
+			keepPEM = append(keepPEM, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})...)
+		}
+	}
+	if err := ioutil.AtomicWriteFile(certificateFile.path, keepPEM); err != nil {
 		return fmt.Errorf("could not prune certificate file: %w", err)
 	}
 	cli.printSuccess("Pruned certificate file ", color.CyanString("'"+certificateFile.path+"'"))
 	if !skipApplicationPackage {
-		overwrite, appendCertificate := true, false
-		return doCertAdd(cli, overwrite, appendCertificate, args)
+		return doCertAdd(cli, true, false, args)
 	}
 	return nil
 }

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -330,6 +330,7 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 	}
 	for _, cert := range unknownCerts {
 		if force {
+			cli.printWarning("Removing certificate not associated with any of your saved private keys: " + certInfo(cert))
 			removeSet[cert] = true
 		} else {
 			cli.printWarning("This certificate is not associated with any of your saved private keys")

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -242,9 +242,16 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 	if err != nil {
 		return fmt.Errorf("could not read private key file: %w", err)
 	}
-	// Old key backup is optional — used only to label certs.
-	oldPrivateKeyFile, _ := cli.config.oldPrivateKeyPath(app, targetType.name)
-	oldPrivateKeyData, _ := os.ReadFile(oldPrivateKeyFile.path)
+	// Old key backup is optional — used only to label certs. A backup that exists but cannot be
+	// read must not be treated as absent, as that would misclassify its certificates as unknown.
+	oldPrivateKeyFile, err := cli.config.oldPrivateKeyPath(app, targetType.name)
+	if err != nil {
+		return err
+	}
+	oldPrivateKeyData, err := os.ReadFile(oldPrivateKeyFile.path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("could not read old private key file: %w", err)
+	}
 
 	// Classify every certificate in the file.
 	var currentCerts, oldCerts, unknownCerts []*x509.Certificate
@@ -280,7 +287,7 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 		cli.printWarning(fmt.Sprintf("%d certificates match the current private key", len(currentCerts)))
 		newestCurrent := currentCerts[0]
 		for _, cert := range currentCerts[1:] {
-			if cert.NotAfter.After(newestCurrent.NotAfter) {
+			if cert.NotBefore.After(newestCurrent.NotBefore) {
 				newestCurrent = cert
 			}
 		}
@@ -292,8 +299,8 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 			}
 		} else {
 			ok, err := cli.confirm(fmt.Sprintf(
-				"Remove %d extra certificate(s) matching the current key, keeping the one expiring %s?",
-				len(currentCerts)-1, newestCurrent.NotAfter.Format(time.RFC3339),
+				"Remove %d extra certificate(s) matching the current key, keeping %s?",
+				len(currentCerts)-1, certInfo(newestCurrent),
 			), false)
 			if err != nil {
 				return err

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -116,7 +116,7 @@ $ vespa auth cert add -a my-tenant.my-app.my-instance path/to/application/packag
 	return cmd
 }
 
-func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyAndCertificate bool, args []string) error {
+func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newPrivateKeyAndCertificate bool, args []string) error {
 	targetType, err := cli.targetType(cloudTargetOnly)
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyA
 		return err
 	}
 
-	if !overwriteCertificate && !newKeyAndCertificate {
+	if !overwriteCertificate && !newPrivateKeyAndCertificate {
 		hint := "Use -f flag to force overwriting of certificate, or use --new-key flag to rotate certificates"
 		if ioutil.Exists(privateKeyFile.path) {
 			return errHint(fmt.Errorf("private key '%s' already exists", color.CyanString(privateKeyFile.path)), hint)
@@ -144,9 +144,12 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyA
 		}
 	}
 
-	if newKeyAndCertificate {
+	if newPrivateKeyAndCertificate {
 		oldPrivateKeyFile, err := cli.config.oldPrivateKeyPath(app, targetType.name)
-		if err == nil && ioutil.Exists(oldPrivateKeyFile.path) {
+		if err != nil {
+			return err
+		}
+		if ioutil.Exists(oldPrivateKeyFile.path) {
 			return errHint(fmt.Errorf("backup of private key already exists at %s", color.CyanString(oldPrivateKeyFile.path)),
 				"If you still want to rotate your private key and certificate, remove the old private key first. Documentation for rotation help: "+color.GreenString("https://docs.vespa.ai/en/security/guide.html"))
 		}
@@ -154,11 +157,16 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyA
 		if !ioutil.Exists(certificateFile.path) {
 			cli.printWarning("No certificate file exists. A new certificate will be created.")
 		}
-		if !ioutil.Exists(privateKeyFile.path) {
+		privateKeyExists := ioutil.Exists(privateKeyFile.path)
+		if !privateKeyExists {
 			cli.printWarning("No private key file exists. A new private key will be created.")
 		}
 		if !overwriteCertificate {
-			ok, err := cli.confirm("This will create a backup of your existing private key and add a new certificate. Continue?", false)
+			question := "This will create a backup of your existing private key and add a new certificate. Continue?"
+			if !privateKeyExists {
+				question = "This will create a new private key and certificate. Continue?"
+			}
+			ok, err := cli.confirm(question, false)
 			if err != nil {
 				return err
 			}
@@ -180,19 +188,19 @@ func doCert(cli *CLI, overwriteCertificate, skipApplicationPackage bool, newKeyA
 	if err != nil {
 		return err
 	}
-	if err := keyPair.WriteCertificateFile(certificateFile.path, overwriteCertificate, newKeyAndCertificate); err != nil {
+	if err := keyPair.WriteCertificateFile(certificateFile.path, overwriteCertificate, newPrivateKeyAndCertificate); err != nil {
 		return fmt.Errorf("could not write certificate: %w", err)
 	}
-	if err := keyPair.WritePrivateKeyFile(privateKeyFile.path, overwriteCertificate || newKeyAndCertificate); err != nil {
+	if err := keyPair.WritePrivateKeyFile(privateKeyFile.path, overwriteCertificate || newPrivateKeyAndCertificate); err != nil {
 		return fmt.Errorf("could not write private key: %w", err)
 	}
 	cli.printSuccess("Certificate written to ", color.CyanString("'"+certificateFile.path+"'"))
 	cli.printSuccess("Private key written to ", color.CyanString("'"+privateKeyFile.path+"'"))
-	if newKeyAndCertificate {
+	if newPrivateKeyAndCertificate {
 		cli.printSuccess("Next step: deploy with 'vespa prod deploy' and then remove unused certificates with 'vespa auth cert --prune-old'. See ", color.GreenString("https://docs.vespa.ai/en/security/guide.html"))
 	}
 	if !skipApplicationPackage {
-		return doCertAdd(cli, overwriteCertificate, args)
+		return doCertAdd(cli, overwriteCertificate || newPrivateKeyAndCertificate, args)
 	}
 	return nil
 }
@@ -314,10 +322,10 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 		}
 	}
 	for _, cert := range unknownCerts {
-		cli.printWarning("This certificate is not associated with any of your saved private keys")
 		if force {
 			removeSet[cert] = true
 		} else {
+			cli.printWarning("This certificate is not associated with any of your saved private keys")
 			ok, err := cli.confirm(fmt.Sprintf("Remove certificate %s?", certInfo(cert)), false)
 			if err != nil {
 				return err
@@ -350,7 +358,7 @@ func doPruneOldCertificates(cli *CLI, force, skipApplicationPackage bool, args [
 		cli.printInfo("Next step: deploy the application again.")
 	}
 	if !skipApplicationPackage {
-		return doCertAdd(cli, force, args)
+		return doCertAdd(cli, true, args)
 	}
 	return nil
 }

--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -4,6 +4,9 @@
 package cmd
 
 import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,6 +97,132 @@ func TestCertAdd(t *testing.T) {
 	stdout.Reset()
 	require.Nil(t, cli.Run("auth", "cert", "add", "-f", pkgDir))
 	assert.Equal(t, fmt.Sprintf("Success: Copied certificate from '%s' to '%s'\n", certificate, pkgCertificate), stdout.String())
+}
+
+func countPEMBlocks(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.Nil(t, err)
+	count := 0
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		_, err := x509.ParseCertificate(block.Bytes)
+		require.Nil(t, err)
+		count++
+	}
+	return count
+}
+
+func TestCertAppendNoExisting(t *testing.T) {
+	cli, _, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+
+	err := cli.Run("auth", "cert", "-N", "-A")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "no certificate found")
+	assert.Contains(t, stderr.String(), "Run 'vespa auth cert' first")
+}
+
+func TestCertAppend(t *testing.T) {
+	cli, stdout, _ := newTestCLI(t)
+	configureCloud(t, cli)
+	stdout.Reset()
+
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+
+	stdout.Reset()
+	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
+	assert.Contains(t, stdout.String(), "Certificate written to")
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+}
+
+func TestCertAppendTwice(t *testing.T) {
+	cli, _, _ := newTestCLI(t)
+	configureCloud(t, cli)
+
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+
+	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
+	assert.Equal(t, 3, countPEMBlocks(t, certFile))
+}
+
+func TestCertPruneNoExisting(t *testing.T) {
+	cli, _, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+
+	err := cli.Run("auth", "cert", "-N", "--prune")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "no certificate found")
+}
+
+func TestCertPrune(t *testing.T) {
+	cli, _, _ := newTestCLI(t)
+	configureCloud(t, cli)
+
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
+	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+	assert.Equal(t, 3, countPEMBlocks(t, certFile))
+
+	// Read newest cert (first block) before pruning
+	certData, err := os.ReadFile(certFile)
+	require.Nil(t, err)
+	newestBlock, _ := pem.Decode(certData)
+	require.NotNil(t, newestBlock)
+
+	// Fresh CLI needed: pflag doesn't reset flag vars between Execute() calls, so
+	// appendCertificate stays true from the -A runs above and would trip the
+	// "cannot combine --prune with --append" guard when using --prune.
+	cli2, stdout2, _ := newTestCLI(t, "VESPA_CLI_HOME="+cli.config.homeDir)
+	cli2.isTerminal = func() bool { return true }
+	cli2.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli2.Run("auth", "cert", "-N", "--prune"))
+	assert.Contains(t, stdout2.String(), "Pruned certificate file")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+
+	// Verify pruned file contains the newest cert
+	prunedData, err := os.ReadFile(certFile)
+	require.Nil(t, err)
+	prunedBlock, _ := pem.Decode(prunedData)
+	require.NotNil(t, prunedBlock)
+	assert.Equal(t, newestBlock.Bytes, prunedBlock.Bytes)
+}
+
+func TestCertPruneInvalidFlagForce(t *testing.T) {
+	cli, _, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+	err := cli.Run("auth", "cert", "-N", "--prune", "-f")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "if any flags in the group [prune force append] are set none of the others can be")
+}
+
+func TestCertPruneInvalidFlagAppend(t *testing.T) {
+	cli, _, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+	err := cli.Run("auth", "cert", "-N", "--prune", "-A")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "if any flags in the group [prune force append] are set none of the others can be")
 }
 
 func TestCertNoAdd(t *testing.T) {

--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -163,16 +163,16 @@ func TestCertAppendTwice(t *testing.T) {
 	assert.Equal(t, 3, countPEMBlocks(t, certFile))
 }
 
-func TestCertPruneNoExisting(t *testing.T) {
+func TestCertKeepOneNoExisting(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	configureCloud(t, cli)
 
-	err := cli.Run("auth", "cert", "-N", "--prune")
+	err := cli.Run("auth", "cert", "-N", "--keep-one")
 	require.NotNil(t, err)
 	assert.Contains(t, stderr.String(), "no certificate found")
 }
 
-func TestCertPrune(t *testing.T) {
+func TestCertKeepOne(t *testing.T) {
 	cli, _, _ := newTestCLI(t)
 	configureCloud(t, cli)
 
@@ -185,7 +185,7 @@ func TestCertPrune(t *testing.T) {
 	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
 	assert.Equal(t, 3, countPEMBlocks(t, certFile))
 
-	// Read newest cert (first block) before pruning
+	// Read newest cert (first block) before keeping one
 	certData, err := os.ReadFile(certFile)
 	require.Nil(t, err)
 	newestBlock, _ := pem.Decode(certData)
@@ -193,11 +193,11 @@ func TestCertPrune(t *testing.T) {
 
 	// Fresh CLI needed: pflag doesn't reset flag vars between Execute() calls, so
 	// appendCertificate stays true from the -A runs above and would trip the
-	// "cannot combine --prune with --append" guard when using --prune.
+	// "cannot combine --keep-one with --append" guard when using --keep-one.
 	cli2, stdout2, _ := newTestCLI(t, "VESPA_CLI_HOME="+cli.config.homeDir)
 	cli2.isTerminal = func() bool { return true }
 	cli2.Stdin = bytes.NewBufferString("y\n")
-	require.Nil(t, cli2.Run("auth", "cert", "-N", "--prune"))
+	require.Nil(t, cli2.Run("auth", "cert", "-N", "--keep-one"))
 	assert.Contains(t, stdout2.String(), "Pruned certificate file")
 	assert.Equal(t, 1, countPEMBlocks(t, certFile))
 
@@ -209,20 +209,20 @@ func TestCertPrune(t *testing.T) {
 	assert.Equal(t, newestBlock.Bytes, prunedBlock.Bytes)
 }
 
-func TestCertPruneInvalidFlagForce(t *testing.T) {
+func TestCertKeepOneInvalidFlagForce(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	configureCloud(t, cli)
-	err := cli.Run("auth", "cert", "-N", "--prune", "-f")
+	err := cli.Run("auth", "cert", "-N", "--keep-one", "-f")
 	require.NotNil(t, err)
-	assert.Contains(t, stderr.String(), "if any flags in the group [prune force append] are set none of the others can be")
+	assert.Contains(t, stderr.String(), "if any flags in the group [keep-one force append] are set none of the others can be")
 }
 
-func TestCertPruneInvalidFlagAppend(t *testing.T) {
+func TestCertKeepOneInvalidFlagAppend(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	configureCloud(t, cli)
-	err := cli.Run("auth", "cert", "-N", "--prune", "-A")
+	err := cli.Run("auth", "cert", "-N", "--keep-one", "-A")
 	require.NotNil(t, err)
-	assert.Contains(t, stderr.String(), "if any flags in the group [prune force append] are set none of the others can be")
+	assert.Contains(t, stderr.String(), "if any flags in the group [keep-one force append] are set none of the others can be")
 }
 
 func TestCertNoAdd(t *testing.T) {

--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -141,6 +141,8 @@ func TestCertAppend(t *testing.T) {
 	assert.Equal(t, 1, countPEMBlocks(t, certFile))
 
 	stdout.Reset()
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
 	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
 	assert.Contains(t, stdout.String(), "Certificate written to")
 	assert.Equal(t, 2, countPEMBlocks(t, certFile))
@@ -149,6 +151,8 @@ func TestCertAppend(t *testing.T) {
 func TestCertAppendTwice(t *testing.T) {
 	cli, _, _ := newTestCLI(t)
 	configureCloud(t, cli)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\ny\n")
 
 	require.Nil(t, cli.Run("auth", "cert", "-N"))
 
@@ -175,6 +179,8 @@ func TestCertKeepOneNoExisting(t *testing.T) {
 func TestCertKeepOne(t *testing.T) {
 	cli, _, _ := newTestCLI(t)
 	configureCloud(t, cli)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\ny\n")
 
 	require.Nil(t, cli.Run("auth", "cert", "-N"))
 	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))

--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -117,118 +117,296 @@ func countPEMBlocks(t *testing.T, path string) int {
 	return count
 }
 
-func TestCertAppendNoExisting(t *testing.T) {
+// setupRotation creates an initial certificate and performs one key rotation.
+// Returns the homeDir and path to the certificate file.
+func setupRotation(t *testing.T) (homeDir string, certFile string) {
+	t.Helper()
+	cli, _, _ := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--new-key"))
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	return cli.config.homeDir, filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+}
+
+func TestCertNewKey(t *testing.T) {
+	cli, stdout, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+	backupKeyFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-private-key.pem.old")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+
+	stdout.Reset()
+	stderr.Reset()
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--new-key"))
+
+	assert.Contains(t, stdout.String(), "Certificate written to")
+	assert.Contains(t, stderr.String(), "Private key backup created at")
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+	_, err = os.Stat(backupKeyFile)
+	assert.Nil(t, err, "backup key file should exist after rotation")
+}
+
+func TestCertNewKeyDecline(t *testing.T) {
+	cli, _, _ := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+	backupKeyFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-private-key.pem.old")
+
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("n\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--new-key"))
+
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+	_, err = os.Stat(backupKeyFile)
+	assert.True(t, os.IsNotExist(err), "backup key file should not exist after declining rotation")
+}
+
+func TestCertNewKeyForce(t *testing.T) {
+	cli, stdout, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+	backupKeyFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-private-key.pem.old")
+
+	stdout.Reset()
+	stderr.Reset()
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--new-key", "-f"))
+
+	assert.Contains(t, stdout.String(), "Certificate written to")
+	assert.Contains(t, stderr.String(), "Private key backup created at")
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+	_, err = os.Stat(backupKeyFile)
+	assert.Nil(t, err, "backup key file should exist after forced rotation")
+}
+
+func TestCertNewKeyBackupExists(t *testing.T) {
+	cli, _, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--new-key"))
+
+	// Subsequent rotations blocked because backup key still exists.
+	cli.Stdin = bytes.NewBufferString("y\n")
+	err := cli.Run("auth", "cert", "-N", "--new-key")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "backup of private key already exists")
+
+	err = cli.Run("auth", "cert", "-N", "--new-key", "-f")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "backup of private key already exists")
+}
+
+func TestPruneOldNoExisting(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	configureCloud(t, cli)
 
-	err := cli.Run("auth", "cert", "-N", "-A")
+	err := cli.Run("auth", "cert", "-N", "--prune-old")
 	require.NotNil(t, err)
 	assert.Contains(t, stderr.String(), "no certificate found")
 	assert.Contains(t, stderr.String(), "Run 'vespa auth cert' first")
 }
 
-func TestCertAppend(t *testing.T) {
-	cli, stdout, _ := newTestCLI(t)
-	configureCloud(t, cli)
-	stdout.Reset()
-
-	require.Nil(t, cli.Run("auth", "cert", "-N"))
-
-	app, err := vespa.ApplicationFromString("t1.a1.i1")
-	require.Nil(t, err)
-	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
-
-	assert.Equal(t, 1, countPEMBlocks(t, certFile))
-
-	stdout.Reset()
-	cli.isTerminal = func() bool { return true }
-	cli.Stdin = bytes.NewBufferString("y\n")
-	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
-	assert.Contains(t, stdout.String(), "Certificate written to")
-	assert.Equal(t, 2, countPEMBlocks(t, certFile))
-}
-
-func TestCertAppendTwice(t *testing.T) {
-	cli, _, _ := newTestCLI(t)
-	configureCloud(t, cli)
-	cli.isTerminal = func() bool { return true }
-	cli.Stdin = bytes.NewBufferString("y\ny\n")
-
-	require.Nil(t, cli.Run("auth", "cert", "-N"))
-
-	app, err := vespa.ApplicationFromString("t1.a1.i1")
-	require.Nil(t, err)
-	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
-
-	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
-	assert.Equal(t, 2, countPEMBlocks(t, certFile))
-
-	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
-	assert.Equal(t, 3, countPEMBlocks(t, certFile))
-}
-
-func TestCertKeepOneNoExisting(t *testing.T) {
+func TestPruneOldSingleCert(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
 
-	err := cli.Run("auth", "cert", "-N", "--keep-one")
-	require.NotNil(t, err)
-	assert.Contains(t, stderr.String(), "no certificate found")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old"))
+	assert.Contains(t, stderr.String(), "Only one certificate is present")
 }
 
-func TestCertKeepOne(t *testing.T) {
-	cli, _, _ := newTestCLI(t)
+func TestPruneOldNoCertMatchingCurrentKey(t *testing.T) {
+	cli, _, stderr := newTestCLI(t)
 	configureCloud(t, cli)
-	cli.isTerminal = func() bool { return true }
-	cli.Stdin = bytes.NewBufferString("y\ny\n")
-
 	require.Nil(t, cli.Run("auth", "cert", "-N"))
-	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
-	require.Nil(t, cli.Run("auth", "cert", "-N", "-A"))
 
 	app, err := vespa.ApplicationFromString("t1.a1.i1")
 	require.Nil(t, err)
 	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
-	assert.Equal(t, 3, countPEMBlocks(t, certFile))
+	keyFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-private-key.pem")
 
-	// Read newest cert (first block) before keeping one
+	// Duplicate cert to satisfy the len > 1 check.
 	certData, err := os.ReadFile(certFile)
 	require.Nil(t, err)
-	newestBlock, _ := pem.Decode(certData)
-	require.NotNil(t, newestBlock)
+	require.Nil(t, os.WriteFile(certFile, append(certData, certData...), 0o600))
 
-	// Fresh CLI needed: pflag doesn't reset flag vars between Execute() calls, so
-	// appendCertificate stays true from the -A runs above and would trip the
-	// "cannot combine --keep-one with --append" guard when using --keep-one.
-	cli2, stdout2, _ := newTestCLI(t, "VESPA_CLI_HOME="+cli.config.homeDir)
+	// Replace private key with an unrelated key so no cert matches.
+	unrelatedPair, err := vespa.CreateKeyPair()
+	require.Nil(t, err)
+	require.Nil(t, os.WriteFile(keyFile, unrelatedPair.PrivateKey, 0o600))
+
+	err = cli.Run("auth", "cert", "-N", "--prune-old")
+	require.NotNil(t, err)
+	assert.Contains(t, stderr.String(), "no certificate in")
+	assert.Contains(t, stderr.String(), "matches the current private key")
+}
+
+func TestPruneOldConfirm(t *testing.T) {
+	homeDir, certFile := setupRotation(t)
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	cli, stdout, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old"))
+
+	assert.Contains(t, stdout.String(), "Pruned certificate file")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldDecline(t *testing.T) {
+	homeDir, certFile := setupRotation(t)
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	cli, _, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("n\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old"))
+
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldForce(t *testing.T) {
+	homeDir, certFile := setupRotation(t)
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	cli, stdout, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old", "-f"))
+
+	assert.Contains(t, stdout.String(), "Pruned certificate file")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldPartialRemoval(t *testing.T) {
+	homeDir, certFile := setupRotation(t)
+
+	// Append a third cert from an unknown key pair.
+	unknownPair, err := vespa.CreateKeyPair()
+	require.Nil(t, err)
+	certData, err := os.ReadFile(certFile)
+	require.Nil(t, err)
+	require.Nil(t, os.WriteFile(certFile, append(certData, unknownPair.Certificate...), 0o600))
+	assert.Equal(t, 3, countPEMBlocks(t, certFile))
+
+	// Confirm removal of old cert (y), decline removal of unknown cert (n).
+	cli2, stdout2, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	cli2.isTerminal = func() bool { return true }
+	cli2.Stdin = bytes.NewBufferString("y\nn\n")
+	require.Nil(t, cli2.Run("auth", "cert", "-N", "--prune-old"))
+
+	assert.Contains(t, stdout2.String(), "Pruned certificate file")
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+}
+
+func multipleCurrentCertsSetup(t *testing.T) (homeDir, certFile string) {
+	t.Helper()
+	cli, _, _ := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile = filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+	certData, err := os.ReadFile(certFile)
+	require.Nil(t, err)
+	require.Nil(t, os.WriteFile(certFile, append(certData, certData...), 0o600))
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+	return cli.config.homeDir, certFile
+}
+
+func TestPruneOldMultipleCurrentCertsDecline(t *testing.T) {
+	homeDir, certFile := multipleCurrentCertsSetup(t)
+
+	cli, _, stderr := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("n\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old"))
+
+	assert.Contains(t, stderr.String(), "2 certificates match the current private key")
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldMultipleCurrentCertsConfirm(t *testing.T) {
+	homeDir, certFile := multipleCurrentCertsSetup(t)
+
+	cli, stdout, stderr := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old"))
+
+	assert.Contains(t, stderr.String(), "2 certificates match the current private key")
+	assert.Contains(t, stdout.String(), "Pruned certificate file")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldMultipleCurrentCertsForce(t *testing.T) {
+	homeDir, certFile := multipleCurrentCertsSetup(t)
+
+	cli, stdout, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old", "-f"))
+
+	assert.Contains(t, stdout.String(), "Pruned certificate file")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldUnknownCert(t *testing.T) {
+	cli, stdout, stderr := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+
+	// Append a cert from an unknown key pair.
+	unknownPair, err := vespa.CreateKeyPair()
+	require.Nil(t, err)
+	certData, err := os.ReadFile(certFile)
+	require.Nil(t, err)
+	require.Nil(t, os.WriteFile(certFile, append(certData, unknownPair.Certificate...), 0o600))
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "-N", "--prune-old"))
+
+	assert.Contains(t, stderr.String(), "not associated with any of your saved private keys")
+	assert.Contains(t, stdout.String(), "Pruned certificate file")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+}
+
+func TestPruneOldUpdatesAppPackage(t *testing.T) {
+	homeDir, certFile := setupRotation(t)
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	appDir, pkgDir := mock.ApplicationPackageDir(t, false, false)
+	cli2, stdout2, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
 	cli2.isTerminal = func() bool { return true }
 	cli2.Stdin = bytes.NewBufferString("y\n")
-	require.Nil(t, cli2.Run("auth", "cert", "-N", "--keep-one"))
+	require.Nil(t, cli2.Run("auth", "cert", "--prune-old", pkgDir))
+
 	assert.Contains(t, stdout2.String(), "Pruned certificate file")
+	assert.Contains(t, stdout2.String(), "Copied certificate")
 	assert.Equal(t, 1, countPEMBlocks(t, certFile))
-
-	// Verify pruned file contains the newest cert
-	prunedData, err := os.ReadFile(certFile)
-	require.Nil(t, err)
-	prunedBlock, _ := pem.Decode(prunedData)
-	require.NotNil(t, prunedBlock)
-	assert.Equal(t, newestBlock.Bytes, prunedBlock.Bytes)
-}
-
-func TestCertKeepOneInvalidFlagForce(t *testing.T) {
-	cli, _, stderr := newTestCLI(t)
-	configureCloud(t, cli)
-	err := cli.Run("auth", "cert", "-N", "--keep-one", "-f")
-	require.NotNil(t, err)
-	assert.Contains(t, stderr.String(), "if any flags in the group [keep-one force append] are set none of the others can be")
-}
-
-func TestCertKeepOneInvalidFlagAppend(t *testing.T) {
-	cli, _, stderr := newTestCLI(t)
-	configureCloud(t, cli)
-	err := cli.Run("auth", "cert", "-N", "--keep-one", "-A")
-	require.NotNil(t, err)
-	assert.Contains(t, stderr.String(), "if any flags in the group [keep-one force append] are set none of the others can be")
+	assert.Equal(t, 1, countPEMBlocks(t, filepath.Join(appDir, "security", "clients.pem")))
 }
 
 func TestCertNoAdd(t *testing.T) {

--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -409,6 +409,48 @@ func TestPruneOldUpdatesAppPackage(t *testing.T) {
 	assert.Equal(t, 1, countPEMBlocks(t, filepath.Join(appDir, "security", "clients.pem")))
 }
 
+func TestCertNewKeyUpdatesExistingPackageCert(t *testing.T) {
+	cli, _, _ := newTestCLI(t)
+	configureCloud(t, cli)
+	require.Nil(t, cli.Run("auth", "cert", "-N"))
+
+	app, err := vespa.ApplicationFromString("t1.a1.i1")
+	require.Nil(t, err)
+	certFile := filepath.Join(cli.config.homeDir, app.String(), "data-plane-public-cert.pem")
+
+	// Package already contains a certificate, as it would after a previous 'vespa auth cert'.
+	appDir, pkgDir := mock.ApplicationPackageDir(t, false, true)
+	pkgCertificate := filepath.Join(appDir, "security", "clients.pem")
+
+	cli2, stdout2, _ := newTestCLI(t, "VESPA_CLI_HOME="+cli.config.homeDir)
+	cli2.isTerminal = func() bool { return true }
+	cli2.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli2.Run("auth", "cert", "--new-key", pkgDir))
+
+	assert.Contains(t, stdout2.String(), "Certificate written to")
+	assert.Contains(t, stdout2.String(), "Copied certificate")
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+	assert.Equal(t, 2, countPEMBlocks(t, pkgCertificate))
+}
+
+func TestPruneOldUpdatesExistingPackageCert(t *testing.T) {
+	homeDir, certFile := setupRotation(t)
+	assert.Equal(t, 2, countPEMBlocks(t, certFile))
+
+	appDir, pkgDir := mock.ApplicationPackageDir(t, false, true)
+	pkgCertificate := filepath.Join(appDir, "security", "clients.pem")
+
+	cli, stdout, _ := newTestCLI(t, "VESPA_CLI_HOME="+homeDir)
+	cli.isTerminal = func() bool { return true }
+	cli.Stdin = bytes.NewBufferString("y\n")
+	require.Nil(t, cli.Run("auth", "cert", "--prune-old", pkgDir))
+
+	assert.Contains(t, stdout.String(), "Pruned certificate file")
+	assert.Contains(t, stdout.String(), "Copied certificate")
+	assert.Equal(t, 1, countPEMBlocks(t, certFile))
+	assert.Equal(t, 1, countPEMBlocks(t, pkgCertificate))
+}
+
 func TestCertNoAdd(t *testing.T) {
 	cli, stdout, stderr := newTestCLI(t)
 	configureCloud(t, cli)

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/vespa-engine/vespa/client/go/internal/cli/config"
+	"github.com/vespa-engine/vespa/client/go/internal/ioutil"
 	"github.com/vespa-engine/vespa/client/go/internal/vespa"
 )
 
@@ -442,6 +443,43 @@ func (c *Config) credentialsFile(app vespa.ApplicationID, targetType string, cer
 		return credentialsFile{}, err
 	}
 	return credentialsFile{path, true}, nil
+}
+
+func (c *Config) oldPrivateKeyPath(app vespa.ApplicationID, targetType string) (credentialsFile, error) {
+	applicationFile := "data-plane-private-key.pem"
+	envVar := "VESPA_CLI_DATA_PLANE_KEY_FILE"
+	if override, ok := c.environment[envVar]; ok {
+		return credentialsFile{override + ".old", false}, nil
+	}
+	if targetType == vespa.TargetHosted {
+		authenzFile := "key"
+		path, err := athenzPath(authenzFile)
+		if err != nil {
+			return credentialsFile{}, err
+		}
+		return credentialsFile{path + ".old", false}, nil
+	}
+	path, err := c.applicationFilePath(app, applicationFile)
+	if err != nil {
+		return credentialsFile{}, err
+	}
+	return credentialsFile{path + ".old", true}, nil
+}
+
+func (c *Config) backupPrivateKey(app vespa.ApplicationID, targetType string) (backupKeyPath string, err error) {
+	src, err := c.privateKeyPath(app, targetType)
+	if err != nil {
+		return "", err
+	}
+	dst, err := c.oldPrivateKeyPath(app, targetType)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(src.path)
+	if err != nil {
+		return "", err
+	}
+	return dst.path, ioutil.AtomicWriteFile(dst.path, data)
 }
 
 func (c *Config) certificatePath(app vespa.ApplicationID, targetType string) (credentialsFile, error) {

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -446,24 +446,11 @@ func (c *Config) credentialsFile(app vespa.ApplicationID, targetType string, cer
 }
 
 func (c *Config) oldPrivateKeyPath(app vespa.ApplicationID, targetType string) (credentialsFile, error) {
-	applicationFile := "data-plane-private-key.pem"
-	envVar := "VESPA_CLI_DATA_PLANE_KEY_FILE"
-	if override, ok := c.environment[envVar]; ok {
-		return credentialsFile{override + ".old", false}, nil
-	}
-	if targetType == vespa.TargetHosted {
-		authenzFile := "key"
-		path, err := athenzPath(authenzFile)
-		if err != nil {
-			return credentialsFile{}, err
-		}
-		return credentialsFile{path + ".old", false}, nil
-	}
-	path, err := c.applicationFilePath(app, applicationFile)
+	f, err := c.privateKeyPath(app, targetType)
 	if err != nil {
 		return credentialsFile{}, err
 	}
-	return credentialsFile{path + ".old", true}, nil
+	return credentialsFile{f.path + ".old", f.optional}, nil
 }
 
 func (c *Config) backupPrivateKey(app vespa.ApplicationID, targetType string) (backupKeyPath string, err error) {

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -51,13 +51,13 @@ type PemKeyPair struct {
 }
 
 // WriteCertificateFile writes the certificate contained in this key pair to certificateFile.
-func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, addNewCretential bool) error {
-	if ioutil.Exists(certificateFile) && !overwrite && !addNewCretential {
+func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, addNewIdentity bool) error {
+	if ioutil.Exists(certificateFile) && !overwrite && !addNewIdentity {
 		return fmt.Errorf("cannot overwrite existing file: %s", certificateFile)
 	}
 	data := kp.Certificate
 
-	if addNewCretential {
+	if addNewIdentity {
 		existing, err := os.ReadFile(certificateFile)
 		if err == nil {
 			data = append(data, existing...)

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -60,8 +60,9 @@ func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite boo
 	if addNewCretential {
 		existing, err := os.ReadFile(certificateFile)
 		if err == nil {
-			// TODO: does there exist a weird error that can be bad?
 			data = append(data, existing...)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("could not read existing certificate file %s: %w", certificateFile, err)
 		}
 	}
 	return ioutil.AtomicWriteFile(certificateFile, data)

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -85,19 +85,6 @@ func ParseCertificates(data []byte) ([]*x509.Certificate, error) {
 	return certs, nil
 }
 
-// KeepOneCertificateFile keeps only the first (newest) PEM certificate in certificateFile, removing any older ones.
-func KeepOneCertificateFile(certificateFile string) error {
-	data, err := os.ReadFile(certificateFile)
-	if err != nil {
-		return fmt.Errorf("could not read certificate file: %w", err)
-	}
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return fmt.Errorf("no PEM certificate found in %s", certificateFile)
-	}
-	return ioutil.AtomicWriteFile(certificateFile, pem.EncodeToMemory(block))
-}
-
 // WritePrivateKeyFile writes the private key contained in this key pair to privateKeyFile.
 func (kp *PemKeyPair) WritePrivateKeyFile(privateKeyFile string, overwrite bool) error {
 	if ioutil.Exists(privateKeyFile) && !overwrite {

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -51,18 +51,18 @@ type PemKeyPair struct {
 }
 
 // WriteCertificateFile writes the certificate contained in this key pair to certificateFile.
-func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, appendCredentials bool) error {
-	if ioutil.Exists(certificateFile) && !overwrite && !appendCredentials {
+func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, addNewCretential bool) error {
+	if ioutil.Exists(certificateFile) && !overwrite && !addNewCretential {
 		return fmt.Errorf("cannot overwrite existing file: %s", certificateFile)
 	}
 	data := kp.Certificate
 
-	if appendCredentials {
+	if addNewCretential {
 		existing, err := os.ReadFile(certificateFile)
-		if err != nil {
-			return fmt.Errorf("could not read existing certificate file %s: %w", certificateFile, err)
+		if err == nil {
+			// TODO: does there exist a weird error that can be bad?
+			data = append(data, existing...)
 		}
-		data = append(data, existing...)
 	}
 	return ioutil.AtomicWriteFile(certificateFile, data)
 }

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -76,11 +76,17 @@ func ParseCertificates(data []byte) ([]*x509.Certificate, error) {
 		if block == nil {
 			break
 		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("unexpected PEM block type %q; expected CERTIFICATE", block.Type)
+		}
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, err
 		}
 		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates found in PEM data")
 	}
 	return certs, nil
 }

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -67,8 +67,25 @@ func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite boo
 	return ioutil.AtomicWriteFile(certificateFile, data)
 }
 
-// PruneCertificateFile keeps only the first (newest) PEM certificate in certificateFile, removing any older ones.
-func PruneCertificateFile(certificateFile string) error {
+func ParseCertificates(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	for rest := data; ; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
+}
+
+// KeepOneCertificateFile keeps only the first (newest) PEM certificate in certificateFile, removing any older ones.
+func KeepOneCertificateFile(certificateFile string) error {
 	data, err := os.ReadFile(certificateFile)
 	if err != nil {
 		return fmt.Errorf("could not read certificate file: %w", err)

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -51,11 +51,33 @@ type PemKeyPair struct {
 }
 
 // WriteCertificateFile writes the certificate contained in this key pair to certificateFile.
-func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool) error {
-	if ioutil.Exists(certificateFile) && !overwrite {
+func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, appendCredentials bool) error {
+	if ioutil.Exists(certificateFile) && !overwrite && !appendCredentials {
 		return fmt.Errorf("cannot overwrite existing file: %s", certificateFile)
 	}
-	return ioutil.AtomicWriteFile(certificateFile, kp.Certificate)
+	data := kp.Certificate
+
+	if appendCredentials {
+		existing, err := os.ReadFile(certificateFile)
+		if err != nil {
+			return fmt.Errorf("could not read existing certificate file %s: %w", certificateFile, err)
+		}
+		data = append(data, existing...)
+	}
+	return ioutil.AtomicWriteFile(certificateFile, data)
+}
+
+// PruneCertificateFile keeps only the first (newest) PEM certificate in certificateFile, removing any older ones.
+func PruneCertificateFile(certificateFile string) error {
+	data, err := os.ReadFile(certificateFile)
+	if err != nil {
+		return fmt.Errorf("could not read certificate file: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return fmt.Errorf("no PEM certificate found in %s", certificateFile)
+	}
+	return ioutil.AtomicWriteFile(certificateFile, pem.EncodeToMemory(block))
 }
 
 // WritePrivateKeyFile writes the private key contained in this key pair to privateKeyFile.

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -51,16 +51,16 @@ type PemKeyPair struct {
 }
 
 // WriteCertificateFile writes the certificate contained in this key pair to certificateFile.
-func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, addNewIdentity bool) error {
-	if ioutil.Exists(certificateFile) && !overwrite && !addNewIdentity {
+func (kp *PemKeyPair) WriteCertificateFile(certificateFile string, overwrite bool, newCertificate bool) error {
+	if ioutil.Exists(certificateFile) && !overwrite && !newCertificate {
 		return fmt.Errorf("cannot overwrite existing file: %s", certificateFile)
 	}
 	data := kp.Certificate
 
-	if addNewIdentity {
+	if newCertificate {
 		existing, err := os.ReadFile(certificateFile)
 		if err == nil {
-			data = append(data, existing...)
+			data = append(append([]byte{}, kp.Certificate...), existing...)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("could not read existing certificate file %s: %w", certificateFile, err)
 		}


### PR DESCRIPTION

This pull request introduces certificate rotation and pruning features to the Vespa CLI, allowing users to safely rotate data plane certificates and remove old or unused certificates. The changes add new flags to the `vespa auth cert` command, implement the supporting logic, and provide comprehensive tests for these scenarios.

**Certificate rotation and pruning support:**

* Added `--new-key` flag to `vespa auth cert` to support appending a new certificate and rotating the private key. The command now backs up the old private key, appends a new certificate, and provides user prompts and guidance for safe rotation. [[1]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedR26-R27) [[2]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedL69-R85) [[3]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedL123-R138) [[4]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedR147-R357)
* Added `--prune-old` flag to `vespa auth cert` to remove all but the newest certificate from the certificate file. The implementation classifies certificates by matching them to current, old, or unknown private keys, and provides interactive or forced removal options. [[1]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedR26-R27) [[2]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedL69-R85) [[3]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedR94) [[4]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedL165-R372)

**Command and flag improvements:**

* Updated the `-f/--force` flag to work consistently for both overwriting and pruning actions, and improved flag mutual exclusivity and help text.
* Improved error messages and user guidance for certificate management scenarios, including backup file checks and next steps after rotation or pruning. [[1]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedL123-R138) [[2]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedR147-R357) [[3]](diffhunk://#diff-453d79835c4a07b52db3ea495dce649653ba09f24312ff4512b7f660d9f06eedL165-R372)

**Test coverage:**

* Added extensive tests covering certificate rotation, backup file management, pruning scenarios (single/multiple/unknown certificates), user confirmation flows, and integration with application packages.

These changes make certificate lifecycle management safer and more user-friendly for Vespa CLI users.