### PR TITLE
Re-organize QueryEvalStats class and collection of these stats

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -28,11 +28,13 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp) {
         EXPECT_EQ(&rhs.approximate_nns_nodes_visited(7), &rhs);
         EXPECT_EQ(&rhs.queries(2), &rhs);
         EXPECT_EQ(&rhs.limited_queries(1), &rhs);
+        search::queryeval::QuerySetupStats setup_stats;
+        setup_stats.add_to_approximate_nns_distances_computed(2);
+        setup_stats.add_to_approximate_nns_nodes_visited(3);
+        EXPECT_EQ(&stats.add_query_setup_stats(setup_stats), &stats);
         auto qe_stats = search::queryeval::QueryEvalStats::create();
         qe_stats->add_to_exact_nns_distances_computed(1);
-        qe_stats->add_to_approximate_nns_distances_computed(2);
-        qe_stats->add_to_approximate_nns_nodes_visited(3);
-        EXPECT_EQ(&stats.add_queryeval_stats(*qe_stats), &stats);
+        EXPECT_EQ(&stats.add_query_eval_stats(*qe_stats), &stats);
         EXPECT_EQ(&stats.add(rhs), &stats);
     }
     EXPECT_EQ(10000u, stats.docidSpaceCovered());

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -422,21 +422,24 @@ struct MyWorld {
     };
 
     void verify_diversity_filter(const SearchRequest& req, bool expectDiverse) {
-        Matcher::SP             matcher = createMatcher();
-        search::fef::Properties overrides;
-        auto mtf = matcher->create_match_tools_factory(req, searchContext, attributeContext, metaStore, overrides,
-                                                       ttb(), nullptr, searchContext.getDocIdLimit(), true);
+        Matcher::SP                        matcher = createMatcher();
+        search::fef::Properties            overrides;
+        search::queryeval::QuerySetupStats setup_stats;
+        auto                               mtf =
+            matcher->create_match_tools_factory(req, searchContext, attributeContext, metaStore, overrides, ttb(),
+                                                nullptr, setup_stats, searchContext.getDocIdLimit(), true);
         auto diversity = mtf->createDiversifier(HeapSize::lookup(config));
         EXPECT_EQ(expectDiverse, static_cast<bool>(diversity));
     }
 
     double get_first_phase_termwise_limit() {
-        Matcher::SP             matcher = createMatcher();
-        SearchRequest::SP       request = createSimpleRequest("f1", "spread");
-        search::fef::Properties overrides;
-        auto                    mtf =
+        Matcher::SP                        matcher = createMatcher();
+        SearchRequest::SP                  request = createSimpleRequest("f1", "spread");
+        search::fef::Properties            overrides;
+        search::queryeval::QuerySetupStats setup_stats;
+        auto                               mtf =
             matcher->create_match_tools_factory(*request, searchContext, attributeContext, metaStore, overrides,
-                                                ttb(), nullptr, searchContext.getDocIdLimit(), true);
+                                                ttb(), nullptr, setup_stats, searchContext.getDocIdLimit(), true);
         MatchTools::UP match_tools = mtf->createMatchTools();
         match_tools->setup_first_phase(nullptr);
         return match_tools->match_data().get_termwise_limit();

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -27,6 +27,7 @@
 #include <vespa/searchlib/queryeval/fake_requestcontext.h>
 #include <vespa/searchlib/queryeval/intermediate_blueprints.h>
 #include <vespa/searchlib/queryeval/leaf_blueprints.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/searchlib/queryeval/simpleresult.h>
 #include <vespa/searchlib/queryeval/termasstring.h>
@@ -1090,26 +1091,30 @@ GlobalFilterBlueprint::~GlobalFilterBlueprint() = default;
 TEST(QueryTest, global_filter_is_calculated_and_handled) {
     vespalib::Doom                             doom(vespalib::Doom::never());
     proton::matching::AnnDeadlineConfiguration ann_deadline_config(vespalib::steady_time::max());
+    search::queryeval::QuerySetupStats         setup_stats;
     // estimated hits = 3, estimated hit ratio = 0.3
     auto     result = SimpleResult().addHit(3).addHit(5).addHit(7);
     uint32_t docid_limit = 10;
     { // global filter is not wanted
         GlobalFilterBlueprint bp(result, false);
-        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0, 1, ttb(), nullptr);
+        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0, 1, ttb(), setup_stats,
+                                               nullptr);
         EXPECT_FALSE(res);
         EXPECT_FALSE(bp.filter);
         EXPECT_EQ(-1.0, bp.estimated_hit_ratio);
     }
     { // estimated_hit_ratio < global_filter_lower_limit
         GlobalFilterBlueprint bp(result, true);
-        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0.31, 1, ttb(), nullptr);
+        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0.31, 1, ttb(),
+                                               setup_stats, nullptr);
         EXPECT_FALSE(res);
         EXPECT_FALSE(bp.filter);
         EXPECT_EQ(-1.0, bp.estimated_hit_ratio);
     }
     { // estimated_hit_ratio <= global_filter_upper_limit
         GlobalFilterBlueprint bp(result, true);
-        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0, 0.3, ttb(), nullptr);
+        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0, 0.3, ttb(), setup_stats,
+                                               nullptr);
         EXPECT_TRUE(res);
         EXPECT_TRUE(bp.filter);
         EXPECT_TRUE(bp.filter->is_active());
@@ -1122,7 +1127,8 @@ TEST(QueryTest, global_filter_is_calculated_and_handled) {
     }
     { // estimated_hit_ratio > global_filter_upper_limit
         GlobalFilterBlueprint bp(result, true);
-        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0, 0.29, ttb(), nullptr);
+        auto res = Query::handle_global_filter(bp, doom, ann_deadline_config, docid_limit, 0, 0.29, ttb(),
+                                               setup_stats, nullptr);
         EXPECT_TRUE(res);
         EXPECT_TRUE(bp.filter);
         EXPECT_FALSE(bp.filter->is_active());

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -153,7 +153,8 @@ MatchToolsFactory::MatchToolsFactory(
     const SerializedQueryTree& queryTree, const std::string& location, const ViewResolver& viewResolver,
     const IDocumentMetaStore& metaStore, const IIndexEnvironment& indexEnv, const RankSetup& rankSetup,
     const Properties& rankProperties, const Properties& featureOverrides, vespalib::ThreadBundle& thread_bundle,
-    const search::IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard, uint32_t maxNumHits, bool is_search)
+    const search::IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard,
+    search::queryeval::QuerySetupStats& setup_stats, uint32_t maxNumHits, bool is_search)
     : _queryLimiter(queryLimiter),
       _create_blueprint_params(extract_create_blueprint_params(
           rankSetup, rankProperties, metaStore.getNumActiveLids(), searchContext.getDocIdLimit())),
@@ -215,8 +216,8 @@ MatchToolsFactory::MatchToolsFactory(
             bool use_lazy_filter = LazyFilter::check(_queryEnv.getProperties());
             _query.handle_global_filter(_requestContext, ann_deadline_config, searchContext.getDocIdLimit(),
                                         _create_blueprint_params.global_filter_lower_limit,
-                                        _create_blueprint_params.global_filter_upper_limit, trace, sort_by_cost,
-                                        use_lazy_filter, setup_profiler.get());
+                                        _create_blueprint_params.global_filter_upper_limit, setup_stats, trace,
+                                        sort_by_cost, use_lazy_filter, setup_profiler.get());
         }
         if (setup_profiler) {
             setup_profiler->report(trace.createCursor("setup_profiling"));

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -19,6 +19,7 @@
 #include <vespa/searchlib/common/stringmap.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/idiversifier.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/vespalib/util/doom.h>
 
 namespace vespalib {
@@ -161,7 +162,7 @@ public:
                       const IIndexEnvironment& indexEnv, const RankSetup& rankSetup, const Properties& rankProperties,
                       const Properties& featureOverrides, vespalib::ThreadBundle& thread_bundle,
                       const search::IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard,
-                      uint32_t maxNumHits, bool is_search);
+                      search::queryeval::QuerySetupStats& setup_stats, uint32_t maxNumHits, bool is_search);
     ~MatchToolsFactory();
     bool valid() const { return _valid; }
     const MaybeMatchPhaseLimiter& match_limiter() const { return *_match_limiter; }

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -140,12 +140,11 @@ MatchingStats Matcher::getStats() {
     return stats;
 }
 
-std::unique_ptr<MatchToolsFactory>
-Matcher::create_match_tools_factory(const search::engine::Request& request, ISearchContext& searchContext,
-                                    IAttributeContext& attrContext, const search::IDocumentMetaStore& metaStore,
-                                    const Properties& feature_overrides, vespalib::ThreadBundle& thread_bundle,
-                                    const IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard,
-                                    uint32_t maxHits, bool is_search) const {
+std::unique_ptr<MatchToolsFactory> Matcher::create_match_tools_factory(
+    const search::engine::Request& request, ISearchContext& searchContext, IAttributeContext& attrContext,
+    const search::IDocumentMetaStore& metaStore, const Properties& feature_overrides,
+    vespalib::ThreadBundle& thread_bundle, const IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard,
+    search::queryeval::QuerySetupStats& setup_stats, uint32_t maxHits, bool is_search) const {
     const Properties& rankProperties = request.propertiesMap.rankProperties();
     bool   softTimeoutEnabled = softtimeout::Enabled::lookup(rankProperties, _rankSetup->getSoftTimeoutEnabled());
     bool   hasFactorOverride = softtimeout::Factor::isPresent(rankProperties);
@@ -182,7 +181,7 @@ Matcher::create_match_tools_factory(const search::engine::Request& request, ISea
     return std::make_unique<MatchToolsFactory>(_queryLimiter, doom, ann_deadline_config, searchContext, attrContext,
                                                request.trace(), queryTree, request.location, _viewResolver, metaStore,
                                                _indexEnv, *_rankSetup, rankProperties, feature_overrides,
-                                               thread_bundle, metaStoreReadGuard, maxHits, is_search);
+                                               thread_bundle, metaStoreReadGuard, setup_stats, maxHits, is_search);
 }
 
 size_t Matcher::computeNumThreadsPerSearch(Blueprint::HitEstimate hits, const Properties& rankProperties) const {
@@ -287,9 +286,11 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
             owned_objects.queryTree = request.getSerializedQueryTree().shared_from_this();
         }
 
-        MatchToolsFactory::UP mtf =
-            create_match_tools_factory(request, searchContext, attrContext, metaStore, *feature_overrides,
-                                       threadBundle, &owned_objects.readGuard, searchContext.getDocIdLimit(), true);
+        // Collect more detailed statistics from query setup
+        search::queryeval::QuerySetupStats setup_stats;
+        MatchToolsFactory::UP              mtf = create_match_tools_factory(
+            request, searchContext, attrContext, metaStore, *feature_overrides, threadBundle,
+            &owned_objects.readGuard, setup_stats, searchContext.getDocIdLimit(), true);
         isDoomExplicit = mtf->get_request_context().getDoom().isExplicitSoftDoom();
         traceQuery(6, request.trace(), mtf->query());
 
@@ -297,7 +298,7 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
             return reply;
         }
 
-        // Collect more detailed statistics about query evaluation
+        // Collect more detailed statistics from query evaluation
         queryeval_stats = search::queryeval::QueryEvalStats::create();
         mtf->install_stats(*queryeval_stats);
 
@@ -334,6 +335,7 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
         ResultProcessor::Result::UP result =
             master.match(request.trace(), params, limitedThreadBundle, *mtf, rp, _distributionKey, numParts);
         my_stats = MatchMaster::getStats(std::move(master));
+        my_stats.add_query_setup_stats(setup_stats);
         reply = std::move(result->_reply);
         updateCoverage(reply->coverage, mtf->match_limiter(), my_stats, metaStore, bucketdb);
 
@@ -349,7 +351,9 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
             sessionMgr.insert(std::move(session));
         }
     }
-    my_stats.add_queryeval_stats(*queryeval_stats);
+    // Destructors of search iterators have written stats to queryeval_stats
+    // We can now merge the stats into my_stats
+    my_stats.add_query_eval_stats(*queryeval_stats);
     queryeval_stats.reset(); // Manually reset pointer to include object tear-down in measured time
     double querySetupTime = vespalib::to_s(total_matching_time.elapsed()) - my_stats.queryLatencyAvg();
     my_stats.querySetupTime(querySetupTime);
@@ -434,10 +438,12 @@ DocsumMatcher::UP Matcher::create_docsum_matcher(const DocsumRequest& req, ISear
     if (session) {
         return std::make_unique<DocsumMatcher>(std::move(session), std::move(docs));
     }
-    StupidMetaStore       meta;
-    MatchToolsFactory::UP mtf =
+    StupidMetaStore meta;
+    // We disregard these collected statistics for now
+    search::queryeval::QuerySetupStats setup_stats;
+    MatchToolsFactory::UP              mtf =
         create_match_tools_factory(req, search_ctx, attr_ctx, meta, req.propertiesMap.featureOverrides(),
-                                   vespalib::ThreadBundle::trivial(), nullptr, docs.size(), false);
+                                   vespalib::ThreadBundle::trivial(), nullptr, setup_stats, docs.size(), false);
     if (!mtf->valid()) {
         LOG(warning, "could not initialize docsum matching: %s",
             (expectedSessionCached) ? "session has expired" : "invalid query");

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.h
@@ -17,6 +17,7 @@
 #include <vespa/searchlib/fef/i_ranking_assets_repo.h>
 #include <vespa/searchlib/query/base.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/vespalib/util/featureset.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 
@@ -116,12 +117,11 @@ public:
      * Create the low-level tools needed to perform matching. This
      * function is exposed for testing purposes.
      **/
-    std::unique_ptr<MatchToolsFactory>
-    create_match_tools_factory(const search::engine::Request& request, ISearchContext& searchContext,
-                               IAttributeContext& attrContext, const search::IDocumentMetaStore& metaStore,
-                               const Properties& feature_overrides, vespalib::ThreadBundle& thread_bundle,
-                               const IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard, uint32_t maxHits,
-                               bool is_search) const;
+    std::unique_ptr<MatchToolsFactory> create_match_tools_factory(
+        const search::engine::Request& request, ISearchContext& searchContext, IAttributeContext& attrContext,
+        const search::IDocumentMetaStore& metaStore, const Properties& feature_overrides,
+        vespalib::ThreadBundle& thread_bundle, const IDocumentMetaStoreContext::IReadGuard::SP* metaStoreReadGuard,
+        search::queryeval::QuerySetupStats& setup_stats, uint32_t maxHits, bool is_search) const;
 
     /**
      * Perform a search against this matcher.

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -60,10 +60,15 @@ MatchingStats& MatchingStats::merge_partition(const Partition& partition, size_t
     return *this;
 }
 
-MatchingStats& MatchingStats::add_queryeval_stats(const search::queryeval::QueryEvalStats& stats) noexcept {
-    _exact_nns_distances_computed += stats.exact_nns_distances_computed();
+MatchingStats& MatchingStats::add_query_setup_stats(const search::queryeval::QuerySetupStats& stats) noexcept {
     _approximate_nns_distances_computed += stats.approximate_nns_distances_computed();
     _approximate_nns_nodes_visited += stats.approximate_nns_nodes_visited();
+
+    return *this;
+}
+
+MatchingStats& MatchingStats::add_query_eval_stats(const search::queryeval::QueryEvalStats& stats) noexcept {
+    _exact_nns_distances_computed += stats.exact_nns_distances_computed();
 
     return *this;
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -10,7 +10,8 @@
 
 namespace search::queryeval {
 class QueryEvalStats;
-}
+class QuerySetupStats;
+} // namespace search::queryeval
 
 namespace proton::matching {
 
@@ -294,9 +295,10 @@ public:
     size_t getNumPartitions() const { return _partitions.size(); }
     const Partition& getPartition(size_t index) const { return _partitions[index]; }
 
-    // used to merge in queryeval stats
-    // these are collected in a distinct, thread-safe object
-    MatchingStats& add_queryeval_stats(const search::queryeval::QueryEvalStats& stats) noexcept;
+    // Merge in stats from query setup from a separate QuerySetupStats object
+    MatchingStats& add_query_setup_stats(const search::queryeval::QuerySetupStats& stats) noexcept;
+    // Merge in stats from query evaluation from a separate, thread-safe QueryEvalStats object
+    MatchingStats& add_query_eval_stats(const search::queryeval::QueryEvalStats& stats) noexcept;
 
     // used to aggregate accross searches (and configurations)
     MatchingStats& add(const MatchingStats& rhs) noexcept;

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -22,6 +22,7 @@
 #include <vespa/searchlib/queryeval/intermediate_blueprints.h>
 #include <vespa/searchlib/queryeval/lazy_filter.h>
 #include <vespa/searchlib/queryeval/nearest_neighbor_blueprint.h>
+#include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 
@@ -249,11 +250,12 @@ void Query::fetchPostings(const ExecuteInfo& executeInfo) {
 void Query::handle_global_filter(const IRequestContext&          requestContext,
                                  const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                                  double global_filter_lower_limit, double global_filter_upper_limit,
-                                 search::engine::Trace& trace, bool sort_by_cost, bool use_lazy_filter,
+                                 search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace& trace,
+                                 bool sort_by_cost, bool use_lazy_filter,
                                  vespalib::ExecutionProfiler* setup_profiler) {
     if (!handle_global_filter(*_blueprint, requestContext.getDoom(), ann_deadline_config, docid_limit,
                               global_filter_lower_limit, global_filter_upper_limit, requestContext.thread_bundle(),
-                              &trace, use_lazy_filter))
+                              setup_stats, &trace, use_lazy_filter))
     {
         return;
     }
@@ -272,7 +274,8 @@ void Query::handle_global_filter(const IRequestContext&          requestContext,
 bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doom,
                                  const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                                  double global_filter_lower_limit, double global_filter_upper_limit,
-                                 vespalib::ThreadBundle& thread_bundle, search::engine::Trace* trace,
+                                 vespalib::ThreadBundle&             thread_bundle,
+                                 search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace* trace,
                                  bool use_lazy_filter) {
     using search::queryeval::Blueprint;
     using search::queryeval::GlobalFilter;
@@ -344,12 +347,13 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
         trace->addEvent(5, "Handle global filter in query execution plan");
     }
     blueprint.set_global_filter(*global_filter, estimated_hit_ratio);
-    perform_ann_searches(blueprint, doom, ann_deadline_config);
+    perform_ann_searches(blueprint, doom, ann_deadline_config, setup_stats);
     return true;
 }
 
 void Query::perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doom,
-                                 const AnnDeadlineConfiguration& ann_deadline_config) {
+                                 const AnnDeadlineConfiguration&     ann_deadline_config,
+                                 search::queryeval::QuerySetupStats& setup_stats) {
     std::queue<search::queryeval::NearestNeighborBlueprint*> ann_blueprints;
     blueprint.each_node_post_order([&ann_blueprints](Blueprint& bp) {
         if (auto nearest_neighbor = bp.asNearestNeighbor()) {
@@ -360,7 +364,7 @@ void Query::perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doo
     });
     while (!ann_blueprints.empty()) {
         const vespalib::Deadline deadline = ann_deadline_config.make_ann_deadline(doom, ann_blueprints.size());
-        ann_blueprints.front()->perform_index_search(deadline);
+        ann_blueprints.front()->perform_index_search(deadline, setup_stats);
         ann_blueprints.pop();
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -17,6 +17,9 @@ struct ThreadBundle;
 namespace search::engine {
 class Trace;
 }
+namespace search::queryeval {
+class QuerySetupStats;
+}
 
 namespace proton::matching {
 
@@ -112,7 +115,8 @@ public:
     void handle_global_filter(const IRequestContext&          requestContext,
                               const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                               double global_filter_lower_limit, double global_filter_upper_limit,
-                              search::engine::Trace& trace, bool sort_by_cost, bool use_lazy_filter = false,
+                              search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace& trace,
+                              bool sort_by_cost, bool use_lazy_filter = false,
                               vespalib::ExecutionProfiler* setup_profiler = nullptr);
 
     /**
@@ -131,11 +135,13 @@ public:
     static bool handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doom,
                                      const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                                      double global_filter_lower_limit, double global_filter_upper_limit,
-                                     vespalib::ThreadBundle& thread_bundle, search::engine::Trace* trace,
+                                     vespalib::ThreadBundle&             thread_bundle,
+                                     search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace* trace,
                                      bool use_lazy_filter = false);
 
     static void perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doom,
-                                     const AnnDeadlineConfiguration& ann_deadline_config);
+                                     const AnnDeadlineConfiguration&     ann_deadline_config,
+                                     search::queryeval::QuerySetupStats& setup_stats);
 
     void freeze();
     void set_matching_phase(search::queryeval::MatchingPhase matching_phase) const noexcept;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1317,7 +1317,8 @@ TEST(TensorAttributeTest, Nearest_neighbor_index_with_mips_distance_metrics_stor
 
 template <typename ParentT> class NearestNeighborBlueprintFixtureBase : public ParentT {
 private:
-    std::unique_ptr<Value> _query_tensor;
+    std::unique_ptr<Value>             _query_tensor;
+    search::queryeval::QuerySetupStats _stats;
 
 public:
     NearestNeighborBlueprintFixtureBase() : _query_tensor() {
@@ -1334,6 +1335,8 @@ public:
     }
 
     ~NearestNeighborBlueprintFixtureBase();
+
+    search::queryeval::QuerySetupStats& stats() { return _stats; }
 
     const Value& create_query_tensor(const TensorSpec& spec) {
         _query_tensor = SimpleValue::from_spec(spec);
@@ -1389,7 +1392,7 @@ TEST(TensorAttributeTest, NN_blueprint_handles_empty_filter_for_post_filtering) 
     EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*empty_filter, 0.6);
     EXPECT_TRUE(bp->pending_index_search());
-    bp->perform_index_search(vespalib::Deadline::never());
+    bp->perform_index_search(vespalib::Deadline::never(), f.stats());
     EXPECT_FALSE(bp->pending_index_search());
     // targetHits is adjusted based on the estimated hit ratio of the query.
     EXPECT_EQ(3u, bp->get_target_hits());
@@ -1405,7 +1408,7 @@ TEST(TensorAttributeTest, NN_blueprint_adjustment_of_targetHits_is_bound_for_pos
     EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*empty_filter, 0.2);
     EXPECT_TRUE(bp->pending_index_search());
-    bp->perform_index_search(vespalib::Deadline::never());
+    bp->perform_index_search(vespalib::Deadline::never(), f.stats());
     EXPECT_FALSE(bp->pending_index_search());
     // targetHits is adjusted based on the estimated hit ratio of the query,
     // but bound by target-hits-max-adjustment-factor
@@ -1425,7 +1428,7 @@ TEST(TensorAttributeTest, NN_blueprint_handles_strong_filter_for_pre_filtering) 
     EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*strong_filter, 0.25);
     EXPECT_TRUE(bp->pending_index_search());
-    bp->perform_index_search(vespalib::Deadline::never());
+    bp->perform_index_search(vespalib::Deadline::never(), f.stats());
     EXPECT_FALSE(bp->pending_index_search());
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(3u, bp->get_adjusted_target_hits());
@@ -1447,7 +1450,7 @@ TEST(TensorAttributeTest, NN_blueprint_handles_weak_filter_for_pre_filtering) {
     EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*weak_filter, 0.6);
     EXPECT_TRUE(bp->pending_index_search());
-    bp->perform_index_search(vespalib::Deadline::never());
+    bp->perform_index_search(vespalib::Deadline::never(), f.stats());
     EXPECT_FALSE(bp->pending_index_search());
     EXPECT_EQ(3u, bp->get_target_hits());
     EXPECT_EQ(3u, bp->get_adjusted_target_hits());
@@ -1496,7 +1499,7 @@ TEST(TensorAttributeTest, NN_blueprint_updates_pending_index_search_after_filter
     EXPECT_FALSE(bp->pending_index_search());
     bp->set_global_filter(*weak_filter, 0.6);
     EXPECT_TRUE(bp->pending_index_search());
-    bp->perform_index_search(vespalib::Deadline::never());
+    bp->perform_index_search(vespalib::Deadline::never(), f.stats());
     EXPECT_FALSE(bp->pending_index_search());
 }
 
@@ -1523,25 +1526,22 @@ TEST(TensorAttributeTest, NN_blueprint_do_NOT_want_global_filter_when_NOT_having
 
 TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     NearestNeighborBlueprintFixture f;
-    auto                            stats = search::queryeval::QueryEvalStats::create();
     // Without filter (with inactive filter)
     {
         auto bp = f.make_blueprint(true);
-        bp->install_stats(*stats);
         auto inactive_filter = GlobalFilter::create();
         EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*inactive_filter, 0.6);
         EXPECT_TRUE(bp->pending_index_search());
-        bp->perform_index_search(vespalib::Deadline::never());
+        bp->perform_index_search(vespalib::Deadline::never(), f.stats());
         EXPECT_FALSE(bp->pending_index_search());
     }
-    EXPECT_EQ(1, stats->approximate_nns_distances_computed());
-    EXPECT_EQ(2, stats->approximate_nns_nodes_visited());
+    EXPECT_EQ(1, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(2, f.stats().approximate_nns_nodes_visited());
 
     // With filter active
     {
         auto bp = f.make_blueprint(true);
-        bp->install_stats(*stats);
         auto filter = search::BitVector::create(1, 11);
         filter->setBit(1);
         filter->setBit(3);
@@ -1553,16 +1553,15 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
         EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*weak_filter, 0.6);
         EXPECT_TRUE(bp->pending_index_search());
-        bp->perform_index_search(vespalib::Deadline::never());
+        bp->perform_index_search(vespalib::Deadline::never(), f.stats());
         EXPECT_FALSE(bp->pending_index_search());
     }
-    EXPECT_EQ(2, stats->approximate_nns_distances_computed());
-    EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
+    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
 
     // Hitting fallback
     {
         auto bp = f.make_blueprint(true, 0.2);
-        bp->install_stats(*stats);
         auto filter = search::BitVector::create(1, 11);
         filter->setBit(3);
         filter->invalidateCachedCount();
@@ -1571,20 +1570,19 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
         bp->set_global_filter(*strong_filter, 0.6);
         EXPECT_FALSE(bp->pending_index_search());
     }
-    EXPECT_EQ(2, stats->approximate_nns_distances_computed());
-    EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
+    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
 
     // Using exact search in the first place
     {
         auto bp = f.make_blueprint(false);
-        bp->install_stats(*stats);
         auto inactive_filter = GlobalFilter::create();
         EXPECT_FALSE(bp->pending_index_search());
         bp->set_global_filter(*inactive_filter, 0.6);
         EXPECT_FALSE(bp->pending_index_search());
     }
-    EXPECT_EQ(2, stats->approximate_nns_distances_computed());
-    EXPECT_EQ(4, stats->approximate_nns_nodes_visited());
+    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
 }
 
 auto test_values = ::testing::Values(1u, 2u);

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -869,26 +869,30 @@ TEST(QueryEvalTest, test_andnotsearchstrict_iterators_adheres_to_init_range) {
     }
 }
 
-TEST(QueryEvalTest, test_stats) {
+TEST(QueryEvalTest, test_eval_stats) {
     auto stats = QueryEvalStats::create();
-    EXPECT_EQ(0u, stats->exact_nns_distances_computed());
-    EXPECT_EQ(0u, stats->approximate_nns_distances_computed());
-    EXPECT_EQ(0u, stats->approximate_nns_nodes_visited());
 
+    EXPECT_EQ(0u, stats->exact_nns_distances_computed());
     stats->add_to_exact_nns_distances_computed(42u);
     EXPECT_EQ(42u, stats->exact_nns_distances_computed());
     stats->add_to_exact_nns_distances_computed(42u);
     EXPECT_EQ(84u, stats->exact_nns_distances_computed());
+}
 
-    stats->add_to_approximate_nns_distances_computed(1u);
-    EXPECT_EQ(1u, stats->approximate_nns_distances_computed());
-    stats->add_to_approximate_nns_distances_computed(1u);
-    EXPECT_EQ(2u, stats->approximate_nns_distances_computed());
+TEST(QueryEvalTest, test_setup_stats) {
+    QuerySetupStats stats;
 
-    stats->add_to_approximate_nns_nodes_visited(2u);
-    EXPECT_EQ(2u, stats->approximate_nns_nodes_visited());
-    stats->add_to_approximate_nns_nodes_visited(2u);
-    EXPECT_EQ(4u, stats->approximate_nns_nodes_visited());
+    EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
+    stats.add_to_approximate_nns_distances_computed(1u);
+    EXPECT_EQ(1u, stats.approximate_nns_distances_computed());
+    stats.add_to_approximate_nns_distances_computed(1u);
+    EXPECT_EQ(2u, stats.approximate_nns_distances_computed());
+
+    EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
+    stats.add_to_approximate_nns_nodes_visited(2u);
+    EXPECT_EQ(2u, stats.approximate_nns_nodes_visited());
+    stats.add_to_approximate_nns_nodes_visited(2u);
+    EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -51,6 +51,28 @@ double NearestNeighborBlueprint::convert_distance_threshold(double distance_thre
     return std::numeric_limits<double>::max();
 }
 
+NearestNeighborBlueprint::AnnStats::AnnStats()
+    : time_allocated(vespalib::duration::zero()),
+      time_used(vespalib::duration::zero()),
+      terminated_early(false),
+      timeout_hit(false),
+      index_stats() {
+}
+
+void NearestNeighborBlueprint::AnnStats::flush(search::queryeval::QuerySetupStats& setup_stats) const {
+    setup_stats.add_to_approximate_nns_distances_computed(index_stats.distances_computed());
+    setup_stats.add_to_approximate_nns_nodes_visited(index_stats.nodes_visited());
+}
+
+void NearestNeighborBlueprint::AnnStats::visit(vespalib::ObjectVisitor& visitor) const {
+    visitor.visitFloat("time_allocated", vespalib::count_ns(time_allocated) / 1000000.0);
+    visitor.visitFloat("time_used", vespalib::count_ns(time_used) / 1000000.0);
+    visitor.visitBool("terminated_early", terminated_early);
+    visitor.visitBool("timeout_hit", timeout_hit);
+    visitor.visitInt("distances_computed", index_stats.distances_computed());
+    visitor.visitInt("nodes_visited", index_stats.nodes_visited());
+}
+
 NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec&                         field,
                                                    std::unique_ptr<search::tensor::DistanceCalculator> distance_calc,
                                                    uint32_t target_hits, bool approximate,
@@ -84,12 +106,8 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec&  
       _low_hit_ratio(false),
       _pending_index_search(false),
       _matching_phase(MatchingPhase::FIRST_PHASE),
-      _ann_time_allocated(vespalib::duration::zero()),
-      _ann_time_used(vespalib::duration::zero()),
-      _ann_terminated_early(false),
-      _ann_timeout_hit(false),
-      _nni_stats(),
-      _stats() {
+      _ann_stats(),
+      _eval_stats() {
     _distance_heap.set_distance_threshold(_hnsw_params.distance_threshold);
     uint32_t est_hits = _attr_tensor.get_num_docs();
     // Default to the expensive cost tier to allow the WhiteListBlueprint to come before this blueprint.
@@ -154,17 +172,22 @@ bool NearestNeighborBlueprint::pending_index_search() const {
     return _pending_index_search;
 }
 
-void NearestNeighborBlueprint::perform_index_search(const vespalib::Deadline& deadline) {
+void NearestNeighborBlueprint::perform_index_search(const vespalib::Deadline&           deadline,
+                                                    search::queryeval::QuerySetupStats& setup_stats) {
     if (_pending_index_search) {
-        _ann_time_allocated = deadline.time_left();
+        _ann_stats.time_allocated = deadline.time_left();
 
         vespalib::Timer timer;
         perform_top_k(_attr_tensor.nearest_neighbor_index(), deadline);
-        _ann_time_used = timer.elapsed();
+        _ann_stats.time_used = timer.elapsed();
 
-        _ann_terminated_early = deadline.was_missed();
-        _ann_timeout_hit = _ann_terminated_early && deadline.type() == vespalib::Deadline::TIMEOUT;
+        _ann_stats.terminated_early = deadline.was_missed();
+        _ann_stats.timeout_hit = _ann_stats.terminated_early && deadline.type() == vespalib::Deadline::TIMEOUT;
         _pending_index_search = false;
+
+        // Flush, but do not reset the collected stats here
+        // We still want them available in visitMembers
+        _ann_stats.flush(setup_stats);
     }
 }
 
@@ -172,6 +195,7 @@ void NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighb
                                              const vespalib::Deadline&                   doom) {
     uint32_t    k = _adjusted_target_hits;
     const auto& df = _distance_calc->function();
+    _ann_stats.index_stats.reset();
     if (_lazy_filter && _lazy_filter->is_active()) { // Global filter might or might not be active
         std::shared_ptr<const GlobalFilter> use_filter = _lazy_filter;
         if (_global_filter->is_active()) { // Both global filter and lazy filter
@@ -181,28 +205,23 @@ void NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighb
         _lazy_filter_hit_ratio = static_cast<double>(_lazy_filter_hits.value()) / _attr_tensor.get_num_docs();
         _low_hit_ratio = _lazy_filter_hit_ratio.value() < _hnsw_params.filter_first_upper_limit;
         _found_hits = nns_index->find_top_k_with_filter(
-            _nni_stats, k, df, *use_filter, _low_hit_ratio, _hnsw_params.filter_first_exploration,
+            _ann_stats.index_stats, k, df, *use_filter, _low_hit_ratio, _hnsw_params.filter_first_exploration,
             k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _hnsw_params.prefetch_tensors,
             doom, _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K_WITH_FILTER;
     } else if (_global_filter->is_active()) {
         _low_hit_ratio = _global_filter_hit_ratio.value() < _hnsw_params.filter_first_upper_limit;
         _found_hits = nns_index->find_top_k_with_filter(
-            _nni_stats, k, df, *_global_filter, _low_hit_ratio, _hnsw_params.filter_first_exploration,
+            _ann_stats.index_stats, k, df, *_global_filter, _low_hit_ratio, _hnsw_params.filter_first_exploration,
             k + _hnsw_params.explore_additional_hits, _hnsw_params.exploration_slack, _hnsw_params.prefetch_tensors,
             doom, _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K_WITH_FILTER;
     } else {
-        _found_hits = nns_index->find_top_k(_nni_stats, k, df, k + _hnsw_params.explore_additional_hits,
+        _found_hits = nns_index->find_top_k(_ann_stats.index_stats, k, df, k + _hnsw_params.explore_additional_hits,
                                             _hnsw_params.exploration_slack, _hnsw_params.prefetch_tensors, doom,
                                             _hnsw_params.distance_threshold);
         _algorithm = Algorithm::INDEX_TOP_K;
     }
-
-    // Flush collected statistics if a QueryEvalStats object is already installed.
-    // (This is not the case in the matching pipeline as of now. The stats will be flushed later when install_stats()
-    // is called.)
-    flush_stats();
 }
 
 void NearestNeighborBlueprint::sort(InFlow in_flow) {
@@ -220,23 +239,13 @@ NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
     default:;
     }
     return ExactNearestNeighborIterator::create(
-        _stats, strict(), tfmd, std::make_unique<search::tensor::DistanceCalculator>(_attr_tensor, _query_tensor),
-        _distance_heap, *_global_filter, _matching_phase != MatchingPhase::FIRST_PHASE);
+        _eval_stats, strict(), tfmd,
+        std::make_unique<search::tensor::DistanceCalculator>(_attr_tensor, _query_tensor), _distance_heap,
+        *_global_filter, _matching_phase != MatchingPhase::FIRST_PHASE);
 }
 
 void NearestNeighborBlueprint::install_stats(QueryEvalStats& stats) {
-    _stats = stats.shared_from_this();
-
-    // Flush statistics collected so far
-    flush_stats();
-}
-
-void NearestNeighborBlueprint::flush_stats() {
-    if (_stats) {
-        _stats->add_to_approximate_nns_distances_computed(_nni_stats.distances_computed());
-        _stats->add_to_approximate_nns_nodes_visited(_nni_stats.nodes_visited());
-        _nni_stats.reset();
-    }
+    _eval_stats = stats.shared_from_this();
 }
 
 void NearestNeighborBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) const {
@@ -253,12 +262,7 @@ void NearestNeighborBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) co
         visitor.visitBool("filter_first_heuristic_used", _low_hit_ratio);
     }
     if (_algorithm == Algorithm::INDEX_TOP_K || _algorithm == Algorithm::INDEX_TOP_K_WITH_FILTER) {
-        visitor.visitFloat("time_allocated", vespalib::count_ns(_ann_time_allocated) / 1000000.0);
-        visitor.visitFloat("time_used", vespalib::count_ns(_ann_time_used) / 1000000.0);
-        visitor.visitBool("terminated_early", _ann_terminated_early);
-        visitor.visitBool("timeout_hit", _ann_timeout_hit);
-        visitor.visitInt("distances_computed", _nni_stats.distances_computed());
-        visitor.visitInt("nodes_visited", _nni_stats.nodes_visited());
+        _ann_stats.visit(visitor);
         visitor.visitInt("top_k_hits", _found_hits.size());
     }
 

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -4,6 +4,7 @@
 #include "blueprint.h"
 #include "lazy_filter.h"
 #include "nearest_neighbor_distance_heap.h"
+#include "queryeval_stats.h"
 
 #include <vespa/searchlib/tensor/distance_calculator.h>
 #include <vespa/searchlib/tensor/distance_function.h>
@@ -42,6 +43,17 @@ public:
     };
 
 private:
+    struct AnnStats {
+        vespalib::duration                          time_allocated;
+        vespalib::duration                          time_used;
+        bool                                        terminated_early;
+        bool                                        timeout_hit;
+        search::tensor::NearestNeighborIndex::Stats index_stats;
+        AnnStats();
+        void flush(search::queryeval::QuerySetupStats& setup_stats) const;
+        void visit(vespalib::ObjectVisitor& visitor) const;
+    };
+
     std::unique_ptr<search::tensor::DistanceCalculator>         _distance_calc;
     const tensor::ITensorAttribute&                             _attr_tensor;
     const vespalib::eval::Value&                                _query_tensor;
@@ -62,12 +74,8 @@ private:
     bool                                                        _low_hit_ratio;
     bool                                                        _pending_index_search;
     MatchingPhase                                               _matching_phase;
-    vespalib::duration                                          _ann_time_allocated;
-    vespalib::duration                                          _ann_time_used;
-    bool                                                        _ann_terminated_early;
-    bool                                                        _ann_timeout_hit;
-    search::tensor::NearestNeighborIndex::Stats                 _nni_stats;
-    std::shared_ptr<QueryEvalStats>                             _stats;
+    AnnStats                                                    _ann_stats;
+    std::shared_ptr<QueryEvalStats>                             _eval_stats;
 
     static double convert_distance_threshold(double                                    distance_threshold,
                                              const search::tensor::DistanceCalculator& distance_calc);
@@ -93,7 +101,7 @@ public:
     // Whether the last call to want_global_filter() resulted in the decision to search the index.
     bool pending_index_search() const;
     // Perform the index search scheduled by the last call to set_global_filter().
-    void perform_index_search(const vespalib::Deadline& doom);
+    void perform_index_search(const vespalib::Deadline& doom, search::queryeval::QuerySetupStats& setup_stats);
     Algorithm get_algorithm() const { return _algorithm; }
     double get_distance_threshold() const { return _hnsw_params.distance_threshold; }
     const HnswParams& get_hnsw_params() const { return _hnsw_params; }
@@ -108,13 +116,10 @@ public:
     SearchIteratorUP createFilterSearchImpl(FilterConstraint constraint) const override {
         return create_default_filter(constraint);
     }
-    // Install the given QueryEvalStats object in this blueprint. The blueprint writes the stats it collects
-    // to this object. Moreover, this object is also passed to the exact search iterators this blueprint creates,
+    // Install the given QueryEvalStats object in this blueprint.
+    // The blueprint passes itt to the exact search iterators it creates,
     // and these write their stats to this object on their destruction.
     void install_stats(QueryEvalStats& stats);
-    // Flush metrics collected in this blueprint to the QueryEvalStats object installed before with install_stats().
-    // This method is called internally and does not have to be called from the outside.
-    void flush_stats();
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;
     void set_matching_phase(MatchingPhase matching_phase) noexcept override;

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -8,8 +8,30 @@
 namespace search::queryeval {
 
 /**
- * Class for collecting statistics within blueprints and search iterators.
- * Thread-safe such that search iterators from different threads can write their collected statistics here.
+ * Class for collecting statistics from query setup.
+ * Not thread safe.
+ **/
+class QuerySetupStats {
+private:
+    size_t _approximate_nns_distances_computed;
+    size_t _approximate_nns_nodes_visited;
+
+public:
+    QuerySetupStats() noexcept : _approximate_nns_distances_computed(0), _approximate_nns_nodes_visited(0) {}
+
+    size_t approximate_nns_distances_computed() const noexcept { return _approximate_nns_distances_computed; }
+    void add_to_approximate_nns_distances_computed(size_t value) noexcept {
+        _approximate_nns_distances_computed += value;
+    }
+
+    size_t approximate_nns_nodes_visited() const noexcept { return _approximate_nns_nodes_visited; }
+    void add_to_approximate_nns_nodes_visited(size_t value) noexcept { _approximate_nns_nodes_visited += value; }
+};
+
+/**
+ * Class for collecting statistics from query evaluation.
+ * Its methods are thread-safe so that search iterators from different threads
+ * can write their collected statistics here.
  **/
 class QueryEvalStats : public std::enable_shared_from_this<QueryEvalStats> {
 private:
@@ -17,15 +39,10 @@ private:
         explicit Private() = default;
     };
     std::atomic<size_t> _exact_nns_distances_computed;
-    std::atomic<size_t> _approximate_nns_distances_computed;
-    std::atomic<size_t> _approximate_nns_nodes_visited;
 
 public:
     // Constructor is only usable by this class
-    QueryEvalStats(Private) noexcept
-        : _exact_nns_distances_computed(0),
-          _approximate_nns_distances_computed(0),
-          _approximate_nns_nodes_visited(0) {}
+    QueryEvalStats(Private) noexcept : _exact_nns_distances_computed(0) {}
     // This factory function has to be used to create objects, meaning that all such objects will be in a shared_ptr
     static std::shared_ptr<QueryEvalStats> create() { return std::make_shared<QueryEvalStats>(Private()); }
 
@@ -34,20 +51,6 @@ public:
     }
     void add_to_exact_nns_distances_computed(size_t value) noexcept {
         _exact_nns_distances_computed.fetch_add(value, std::memory_order_relaxed);
-    }
-
-    size_t approximate_nns_distances_computed() const noexcept {
-        return _approximate_nns_distances_computed.load(std::memory_order_relaxed);
-    }
-    void add_to_approximate_nns_distances_computed(size_t value) noexcept {
-        _approximate_nns_distances_computed.fetch_add(value, std::memory_order_relaxed);
-    }
-
-    size_t approximate_nns_nodes_visited() const noexcept {
-        return _approximate_nns_nodes_visited.load(std::memory_order_relaxed);
-    }
-    void add_to_approximate_nns_nodes_visited(size_t value) noexcept {
-        _approximate_nns_nodes_visited.fetch_add(value, std::memory_order_relaxed);
     }
 };
 


### PR DESCRIPTION
Splits the class `QueryEvalStats` into `QuerySetupStats` (not thread safe, written to in `NearestNeighborBlueprint`) and `QueryEvalStats` (thread safe, written to in `ExactNearestNeighborIterator`). The ANN stats in `QueryEvalStats` were atomic before, but I do not see a reason for this as we only write to these in the query setup and not from the search iterators.

The class `QuerySetupStats` is then wired into the `perform_ann_searches` method to avoid the awkward flushing in the `NearestNeighborBlueprint` (the `QueryEvalStats` was and is not installed when performing the ANN searches).