### PR TITLE
Add a utility for performing randomized rotations of vectors.

### DIFF
--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(vespalib_quant_test_app TEST
     SOURCES
     centroid_test.cpp
     hadamard_test.cpp
+    rotator_test.cpp
     sign_flip_test.cpp
     DEPENDS
     vespalib

--- a/vespalib/src/tests/quant/rotator_test.cpp
+++ b/vespalib/src/tests/quant/rotator_test.cpp
@@ -1,0 +1,94 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/quant/rotator.h>
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <random>
+#include <span>
+#include <vector>
+
+using namespace ::testing;
+
+namespace vespalib::quant {
+
+TEST(RotatorTest, power_of_two_rotations_are_deterministic_and_invertible) {
+    Rotator            rot(16, 0xc0ffeed00d);
+    std::vector<float> v = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    const std::vector  v_orig = v;
+
+    rot.rotate_forward(v);
+    // 16 is a nice and round input size since the FWHT normalization factor becomes
+    // 1/sqrt(16), i.e. 1/4. This avoids most floating point precision issues since
+    // it's a "clean" power-of-2 exponent.
+    const std::vector<float> expected = {-9, 2, 5, -6, -17, 2, -9, 2, -7, -20, 3, 16, 11, 8, 3, -8};
+    EXPECT_THAT(v, ElementsAreArray(expected));
+
+    rot.rotate_inverse(v);
+    EXPECT_THAT(v, ElementsAreArray(v_orig));
+
+    // Different seed should give different rotation
+    Rotator rot2(16, 0xca7f00d);
+    v = v_orig;
+    rot2.rotate_forward(v);
+    const std::vector<float> expected2 = {-8.75, 3.25, -0.25, 7.75, -7.25, 12.75, -20.75, 17.25,
+                                          9.75,  8.75, 5.25,  0.25, -1.75, 7.25,  -10.25, 6.75};
+    EXPECT_THAT(v, ElementsAreArray(expected2));
+
+    rot2.rotate_inverse(v);
+    EXPECT_THAT(v, ElementsAreArray(v_orig));
+}
+
+TEST(RotatorTest, non_power_of_two_rotations_are_deterministic_and_invertible_hi_lo_overlap) {
+    Rotator rot(9, 0xc0ffeed00d);
+    // 1 greater than a power of 2 size has _maximal_ overlap (8 lo, 8 hi, 7 overlapping),
+    // so only high/low FWHT is used
+    std::vector<float> v = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    const std::vector  v_orig = v;
+
+    rot.rotate_forward(v);
+    const std::vector<float> expected = {2.3169422, 4.0296335, 1.247017, 2.5236673, 6.7529817,
+                                         12.110977, 1.1656718, 3.889022, 6.834327};
+    EXPECT_THAT(v, Pointwise(FloatEq(), expected));
+
+    rot.rotate_inverse(v);
+    // Though rotations are fully invertible, in the common case this is a lossy
+    // operation due to FP precision.
+    EXPECT_THAT(v, Pointwise(FloatNear(0.00001), v_orig));
+}
+
+TEST(RotatorTest, non_power_of_two_rotations_are_deterministic_and_invertible_hi_lo_mid_overlap) {
+    Rotator rot(7, 0xc0ffeed00d);
+    // 1 less than power a of 2 size has _minimal_ overlap (4 lo, 4 hi, 1 overlapping),
+    // so full high/low/mid FWHT is used
+    std::vector<float> v = {1, 2, 3, 4, 5, 6, 7};
+    const std::vector  v_orig = v;
+
+    rot.rotate_forward(v);
+    const std::vector<float> expected = {-4, 9.75, 2, -0.25, 4.5, -1.75, -1.25};
+    EXPECT_THAT(v, Pointwise(FloatEq(), expected));
+
+    rot.rotate_inverse(v);
+    EXPECT_THAT(v, Pointwise(FloatNear(0.000001), v_orig));
+}
+
+TEST(RotatorTest, rotations_are_invertible_across_dimension_range) {
+    // Since this involves floating point comparisons, make the seed deterministic.
+    Xoshiro256PlusPlusPrng prng(0x1234567890);
+    for (size_t d = 1; d < 1025; ++d) {
+        std::uniform_real_distribution<float> dist(-1.f, 1.f);
+        std::vector<float>                    v(d);
+        std::ranges::generate(v, [&]() mutable { return dist(prng); });
+        const std::vector v_orig = v;
+
+        Rotator rot(d, prng());
+        rot.rotate_forward(v);
+        rot.rotate_inverse(v);
+
+        ASSERT_THAT(v, Pointwise(FloatNear(0.000001), v_orig)) << "dimensions=" << d;
+    }
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
@@ -2,5 +2,6 @@
 vespa_add_library(vespalib_vespalib_quant OBJECT
     SOURCES
     codebooks.cpp
+    rotator.cpp
     DEPENDS
 )

--- a/vespalib/src/vespa/vespalib/quant/hadamard.h
+++ b/vespalib/src/vespa/vespalib/quant/hadamard.h
@@ -14,15 +14,27 @@ namespace vespalib::quant {
 // "The Walsh Hadamard Transform - Basics and Applications" (2021)
 // by Sean O'Connor (in public domain).
 
+// Returns a multiplicative scaling factor for post-normalizing a Hadamard
+// transform of a vector of size n.
+// TODO constexpr when all compilers are >= C++26
+template <std::floating_point T>
+[[nodiscard]] T hadamard_normalization_factor(const size_t n) noexcept {
+    // Normalization is just dividing all elements by the square root of the size
+    return T{1} / std::sqrt(n);
+}
+
+template <std::floating_point T>
+void post_hadamard_normalize_precomputed(T* v, const size_t n, const T scale) {
+    for (size_t i = 0; i < n; ++i) {
+        v[i] *= scale;
+    }
+}
+
 // Normalize a Walsh-Hadamard-transformed vector so that its magnitude is
 // the same as prior to the transformation.
 template <std::floating_point T>
 void post_hadamard_normalize(T* v, const size_t n) {
-    // Normalization is just dividing all elements by the square root of the size
-    const T sqrt_recip = T{1} / std::sqrt(n);
-    for (size_t i = 0; i < n; ++i) {
-        v[i] *= sqrt_recip;
-    }
+    post_hadamard_normalize_precomputed(v, n, hadamard_normalization_factor<T>(n));
 }
 
 /**

--- a/vespalib/src/vespa/vespalib/quant/rotator.cpp
+++ b/vespalib/src/vespa/vespalib/quant/rotator.cpp
@@ -1,0 +1,90 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "rotator.h"
+
+#include "hadamard.h"
+#include "sign_flip.h"
+
+#include <bit>
+#include <cassert>
+
+namespace vespalib::quant {
+
+// splitmix by _ref_ is intentional; must have different seeds per distinct round
+Rotator::RoundSeeds::RoundSeeds(splitmix64& mixer) noexcept : lo(mixer()), hi(mixer()), mid(mixer()) {
+}
+
+Rotator::Rotator(const size_t dimensions, splitmix64 mixer) noexcept
+    : _dimensions(dimensions),
+      _dimensions_capped(std::bit_floor(dimensions)),
+      _fwht_norm_scale(hadamard_normalization_factor<float>(_dimensions_capped)), // _not_ `_dimensions`
+      // List element init of element N shall be sequenced before N+1, so this should be
+      // well-defined even though the RoundSeeds constructor has side effects on its argument.
+      _sign_flip_seeds({RoundSeeds(mixer), RoundSeeds(mixer)}) {
+    assert(dimensions > 0);
+}
+
+// Precondition: v.size() is a power of 2
+void Rotator::fwd_rand_rotate(std::span<float> v, const PrngType& seed) const noexcept {
+    // Sign flips, then FWHT
+    PrngType prng(seed);
+    flip_sign_bits(v, prng);
+    hadamard(v.data(), v.size());
+    post_hadamard_normalize_precomputed(v.data(), v.size(), _fwht_norm_scale);
+}
+
+// Precondition: v.size() is a power of 2
+void Rotator::inv_rand_rotate(std::span<float> v, const PrngType& seed) const noexcept {
+    // FWHT, then sign flips
+    hadamard(v.data(), v.size());
+    post_hadamard_normalize_precomputed(v.data(), v.size(), _fwht_norm_scale);
+    PrngType prng(seed);
+    flip_sign_bits(v, prng);
+}
+
+// See the Rotator "Implementation details" comments for algorithm description and rationale.
+void Rotator::rotate_forward(std::span<float> v) const noexcept {
+    assert(v.size() == _dimensions);
+    const size_t d = _dimensions;
+    const size_t d_capped = _dimensions_capped;
+
+    for (uint32_t r = 0; r < RotationRounds; ++r) {
+        const RoundSeeds& sfs = _sign_flip_seeds[r];
+        fwd_rand_rotate(v.subspan(0, d_capped), sfs.lo);
+        if (d != d_capped) {
+            fwd_rand_rotate(v.subspan(d - d_capped, d_capped), sfs.hi);
+            const size_t overlap = d_capped - (d - d_capped);
+            if (overlap < d_capped / 2) {
+                const size_t mid_start = (d / 2) - (d_capped / 2);
+                fwd_rand_rotate(v.subspan(mid_start, d_capped), sfs.mid);
+            }
+        }
+    }
+}
+
+// This is rotate_forward, but with every step in the exact reverse order.
+void Rotator::rotate_inverse(std::span<float> v) const noexcept {
+    assert(v.size() == _dimensions);
+    const size_t d = _dimensions;
+    const size_t d_capped = _dimensions_capped;
+
+    for (uint32_t r = 0; r < RotationRounds; ++r) {
+        // Important: seeds must also be in reverse order of forward rotation
+        const RoundSeeds& sfs = _sign_flip_seeds[RotationRounds - r - 1];
+        if (d != d_capped) {
+            const size_t overlap = d_capped - (d - d_capped);
+            if (overlap < d_capped / 2) {
+                const size_t mid_start = (d / 2) - (d_capped / 2);
+                inv_rand_rotate(v.subspan(mid_start, d_capped), sfs.mid);
+            }
+            inv_rand_rotate(v.subspan(d - d_capped, d_capped), sfs.hi);
+        }
+        inv_rand_rotate(v.subspan(0, d_capped), sfs.lo);
+    }
+}
+
+// TODO defer Hadamard normalization until the end
+//  - we can precompute the resulting scale since the number of sub-rotations
+//    is deterministic for a given dimensionality.
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/rotator.h
+++ b/vespalib/src/vespa/vespalib/quant/rotator.h
@@ -1,0 +1,159 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/util/xoshiro.h>
+
+#include <array>
+#include <cstdint>
+#include <span>
+
+namespace vespalib::quant {
+
+/*
+ * Utility for performing pseudo-random rotations of `d`-dimensional vectors.
+ *
+ * This models the effects of multiplying a vector with a (pseudo-)random
+ * rotation matrix (or its inverse/transpose), but does so in O(d lg d) instead
+ * of O(d^2). Both forward and inverse (transposed) rotations are supported.
+ * The rotated "space" induced by the rotator depends entirely on the seed value
+ * provided in the Rotator constructor and must therefore be identical for all
+ * related rotations (forward and/or inverse).
+ *
+ * `d` does not have to be a power of two, but the rotator will be most efficient
+ * when it is.
+ *
+ * Rotations (both forward and inverse) are vector length-preserving.
+ *
+ * After a forward rotation, the expected distribution of each (normalized)
+ * vector coordinate is expected to be N(0, 1/d) with high probability. I.e.
+ * coordinate values follow a Gaussian distribution. This is _regardless_ of
+ * the input coordinate distribution.
+ *
+ * Note about inverse rotations: although this is conceptually a lossless
+ * transform, in reality the inverse will be very close, but not exactly equal,
+ * to the original vector due precision loss incurred by floating point
+ * arithmetic.
+ *
+ * Implementation details:
+ *
+ * We use the O(n lg n) fast Walsh-Hadamard transform (FWHT) as the main work
+ * horse algorithm to implement rotations. The FWHT is a deterministic transform
+ * and not a "true" matrix multiplication, but we can get results as if we had
+ * used a random matrix multiplication if we pseudo-randomly flip the signs of
+ * the input vector prior to rotation. We can then undo these sign flips after
+ * the inverse rotation to get back the original vector. In the literature(tm)
+ * this is often referred to as using a Rademacher distribution, as that is a
+ * 50-50% probability distribution of {-1, +1}.
+ *
+ * Fast Hadamard transforms are only defined for power-of-two input/outputs, so
+ * vectors that are not aligned at such a boundary gives us some challenges in
+ * how randomized rotations should be done. Note that the FWHT requires all
+ * dimensions to be present to be invertible.
+ *
+ * The FWHT can be seen as "distributing" the energy of every input dimension
+ * across all the other dimensions. This is easy to get right when the vector
+ * size is a power of two, because the FWHT can run across the entire range, and
+ * we have to preserve all output dimensions anyway. But if d=513 we don’t want
+ * to have to preserve 1024, i.e. 511 "redundant" quantized dimensions to be able
+ * to run the FWHT in reverse.
+ *
+ * Our pragmatic solution to this is that non-power of two rotations are done
+ * as multiple partially overlapping transforms of size 2^floor(log2(d)), i.e.
+ * the highest power of two value that is < `d`. We'll call this `d_C` ("d capped").
+ *
+ *  1. FWH transform range [0, d_C), i.e. lower coordinates
+ *  2. FWH transform range [d - d_C, d_C). i.e. upper coordinates
+ *
+ * The overlap between transforms 1 and 2 may range from d_C-1 down to 1,
+ * depending on the value of `d`. The latter case is insufficient to distribute
+ * well across high/low dimensions, so if the overlap (defined as d_C - (d - d_C))
+ * is < d_C / 2, a 3rd transform is done:
+ *
+ *  3. FWH transform range [d/2 - d_C/2, (d/2 - d_C/2) + d_C), i.e. middle coords
+ *
+ * This transform is explicitly intended to distribute energy between the high
+ * and low dimensions.
+ *
+ * We then run the entire process a second time so that energy distributed into
+ * overlapping ranges in the first pass can be distributed _away_ from these
+ * again. Empirically this seems to work pretty well.
+ *
+ * The high/low partial overlap approach is directly inspired by the RaBitQ
+ * rotation algorithm. They use a different mechanism (random Kac's walk) to
+ * "bridge the gap" across the sub-transforms. This is O(n) rather than O(n lg n),
+ * but this operates on a padded output vector whereas we do not do any padding.
+ * We may revisit the choice of algorithm if we _do_ add padding, assuming the
+ * resulting distributions are at least as good as what we currently have.
+ *
+ * RaBitQ will also always do 4 rounds of sign flips+FWHT even when the vector
+ * is a power of 2. Based on empirical observations we only do 2 rounds in this
+ * case, though this also seems to be theoretically optimal for our particular
+ * purposes; see the comments for `Rotator::RotationRounds`.
+ *
+ * A note on algorithm observations/experiments:
+ *
+ * The quality of the rotator algorithm has been estimated by sampling the
+ * _expected_ Gaussian vs _actual_ post-rotation coordinate distributions for
+ * several scenarios (sparse vectors, shifted mean normal distribution), and
+ * then computing the Kullback-Leibler divergence between the two distributions.
+ * The intuition and assumption(tm) being that a divergence close to zero means
+ * that the rotation has the desired properties for our quantization purposes.
+ *
+ * Run-time complexity details (for one rotation round): The _lower_ bound is
+ * always O(d lg d) (when d_C == d). When this is not the case the _upper_
+ * bound is O(2d log d).
+ */
+class Rotator {
+    using PrngType = Xoshiro256PlusPlusPrng;
+
+    // The true goal(tm) of the rotator is to transform an arbitrary input
+    // distribution into one where all coordinates are expected to follow a
+    // Gaussian one.
+    // According to the paper "Quantizing With Randomized Hadamard Transforms:
+    // Efficient Heuristic Now Proven" (Ben-Basat et al., 2026), 2 randomized
+    // Hadamard transforms (RHTs) suffices to achieve this:
+    //
+    //  "We show that after composing two RHTs on any d-sized input vector,
+    //   the marginal distribution of every fixed coordinate of the normalized
+    //   rotated vector is within O(d−1/2) of a standard Gaussian both in
+    //   Kolmogorov distance and in 1-Wasserstein distance."
+    //
+    // We ensure that we always do at least 2 rotations covering every coordinate,
+    // though non-power of two vectors will incur more rotations on average due
+    // to our "workarounds" for handling these.
+    constexpr static uint32_t RotationRounds = 2;
+
+    // Use full PRNG states as sign flip seeds to avoid having to recompute
+    // the internal state from a single seed for each flip round.
+    // All internal PRNG seed derivations must be stable and deterministic
+    // across Vespa versions for a given rotation strategy.
+    struct RoundSeeds {
+        const PrngType lo;
+        const PrngType hi;
+        const PrngType mid;
+
+        explicit RoundSeeds(splitmix64&) noexcept;
+    };
+    const size_t                                 _dimensions;
+    const size_t                                 _dimensions_capped;
+    const float                                  _fwht_norm_scale;
+    const std::array<RoundSeeds, RotationRounds> _sign_flip_seeds;
+
+    Rotator(size_t dimensions, splitmix64 mixer) noexcept;
+
+    void fwd_rand_rotate(std::span<float> v, const PrngType& seed) const noexcept;
+    void inv_rand_rotate(std::span<float> v, const PrngType& seed) const noexcept;
+
+public:
+    Rotator(const size_t dimensions, const uint64_t seed) noexcept : Rotator(dimensions, splitmix64(seed)) {}
+
+    [[nodiscard]] size_t dimensions() const noexcept { return _dimensions; }
+
+    // Precondition: v.size() == dimensions()
+    void rotate_forward(std::span<float> v) const noexcept;
+    // Precondition: v.size() == dimensions()
+    void rotate_inverse(std::span<float> v) const noexcept;
+};
+
+} // namespace vespalib::quant


### PR DESCRIPTION
@havardpe and/or @arnej27959 please review.

This aims to implement the "exercise left for the reader"/"draw the rest of the owl" $y \gets \Pi x$ and $x \gets \Pi^\top y$ parts found in most quantization papers (where $\Pi$ is a random rotation matrix, $\Pi^\top$ its inverse/transpose, and $x$, $y$ are pre/post rotation vectors, respectively).

We use the fast Walsh-Hadamard transform (FWHT) as the work horse algorithm to implement rotations. The FWHT is a deterministic transform and not a "true" matrix multiplication, but we can get results as if we had used a random matrix multiplication if we pseudo-randomly flip the signs of the input vector prior to rotation.

Fast Hadamard transforms are only defined for power-of-two vectors, so for vectors where this property does not hold we use multiple overlapping sub-transforms to achieve a statistically similar result. Note that this requires more computations (up to 2x) than if the vectors were powers of two.

The partially overlapping transforms are inspired by the RaBitQ rotation algorithm, but we use a different strategy for "bridging the gap" (well, technically bridging the _overlap_) across the sub-transforms; see the comment for the `Rotator` class for details.

The quality of the rotator algorithm has been estimated by sampling the _expected_ Gaussian vs _actual_ post- rotation coordinate distributions for several scenarios (sparse vectors, shifted mean normal distribution), and then computing the Kullback-Leibler divergence between the two distributions. The intuition and assumption™ being that a divergence close to zero means that the rotation has the desired properties for our quantization purposes.

This implementation is not yet optimized for speed, and we may change things around based on further experiments. But it should be a functionally complete starting point.