### PR TITLE
Restrict --enable-preview compiler arg to the searchlib module

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -93,7 +93,6 @@
                         <showWarnings>true</showWarnings>
                         <showDeprecation>false</showDeprecation>
                         <compilerArgs>
-                            <arg>${vespaCompilerArgs.preview}</arg>
                             <arg>${vespaCompilerArgs.xlint}</arg>
                             <arg>-Xlint:-serial</arg>
                             <arg>-Xlint:-try</arg>

--- a/searchlib/pom.xml
+++ b/searchlib/pom.xml
@@ -97,6 +97,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>${vespaCompilerArgs.preview}</arg>
+            <arg>${vespaCompilerArgs.xlint}</arg>
+            <arg>-Xlint:-serial</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>io.github.tulipcc</groupId>


### PR DESCRIPTION
Only searchlib currently needs preview language features, so move the arg out of the shared parent config and into searchlib's own maven-compiler-plugin configuration.
