### PR TITLE
Add per-cloud validation to CloudResourceTags

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -19,18 +19,33 @@ public class CloudResourceTags {
 
     private static final CloudResourceTags EMPTY = new CloudResourceTags(Map.of());
 
-    private static final int MAX_KEY_LENGTH = 63;
-    private static final int MAX_VALUE_LENGTH = 63;
-    private static final int MAX_TAGS = 20;
+    /** Max across all clouds (Azure). Per-cloud limits enforced in {@link #validateForCloud}. */
+    private static final int MAX_KEY_LENGTH = 512;
+    /** Max across all clouds (AWS, Azure). Per-cloud limits enforced in {@link #validateForCloud}. */
+    private static final int MAX_VALUE_LENGTH = 256;
+    /** Max across all clouds (GCP). Per-cloud limits enforced in {@link #validateForCloud}. */
+    private static final int MAX_TAGS = 64;
 
-    /** Keys must start with a lowercase letter (GCP requirement) and contain only [a-z0-9_-]. */
-    private static final Pattern VALID_KEY_PATTERN = Pattern.compile("[a-z][a-z0-9_-]*");
-
-    /** Values may contain alphanumeric characters (upper- or lowercase), hyphens and underscores. */
-    private static final Pattern VALID_VALUE_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
-
-    /** Pattern for template variables, e.g. ${environment}, ${region}. */
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\$\\{[^}]+\\}");
+
+    // AWS: cross-service safe character set
+    private static final Pattern AWS_TAG_PATTERN = Pattern.compile("[a-zA-Z0-9 +\\-=._:/@]+");
+    private static final int AWS_MAX_KEY_LENGTH = 128;
+    private static final int AWS_MAX_VALUE_LENGTH = 256; // matches structural cap
+    private static final int AWS_MAX_TAGS = 50;
+
+    // GCP: lowercase letters, digits, underscores, hyphens. Keys must start with lowercase letter.
+    private static final Pattern GCP_KEY_PATTERN = Pattern.compile("[a-z][a-z0-9_-]*");
+    private static final Pattern GCP_VALUE_PATTERN = Pattern.compile("[a-z0-9_-]*");
+    private static final int GCP_MAX_KEY_LENGTH = 63;
+    private static final int GCP_MAX_VALUE_LENGTH = 63;
+    private static final int GCP_MAX_TAGS = 64; // matches structural cap
+
+    // Azure: keys may not contain < > % & \ ? /. Values unrestricted.
+    private static final Pattern AZURE_FORBIDDEN_KEY_CHARS = Pattern.compile("[<>%&\\\\?/]");
+    private static final int AZURE_MAX_KEY_LENGTH = 512; // matches structural cap
+    private static final int AZURE_MAX_VALUE_LENGTH = 256; // matches structural cap
+    private static final int AZURE_MAX_TAGS = 50;
 
     /** System tag names reserved by the platform. */
     private static final List<String> RESERVED_TAG_NAMES = List.of(
@@ -68,6 +83,20 @@ public class CloudResourceTags {
                 throw new IllegalArgumentException("Unknown template variable in resource tag value for key '" +
                                                    entry.getKey() + "': " + entry.getValue());
         }
+    }
+
+    /**
+     * Validates these tags against the character set and length limits of the given cloud provider.
+     * Template-variable placeholders are stripped from values before checking per-cloud character
+     * rules; keys are validated as-is. Callers should also invoke {@link #validatePlaceholders()}
+     * to reject unrecognized template variables.
+     */
+    public void validateForCloud(CloudName cloud) {
+        if (tags.isEmpty()) return;
+        if (cloud.equals(CloudName.AWS)) validateAws();
+        else if (cloud.equals(CloudName.GCP)) validateGcp();
+        else if (cloud.equals(CloudName.AZURE)) validateAzure();
+        else throw new IllegalArgumentException("No resource tag validation rules for cloud '" + cloud + "'");
     }
 
     /**
@@ -146,13 +175,8 @@ public class CloudResourceTags {
             if (value.length() > MAX_VALUE_LENGTH)
                 throw new IllegalArgumentException("Tag value exceeds " + MAX_VALUE_LENGTH +
                                                    " characters for key '" + key + "'");
-            if ( ! VALID_KEY_PATTERN.matcher(key).matches())
-                throw new IllegalArgumentException("Tag key contains invalid characters: '" + key +
-                                                   "'. Must start with a lowercase letter and contain only [a-z0-9_-]");
-            String strippedValue = TEMPLATE_VARIABLE.matcher(value).replaceAll("");
-            if ( ! strippedValue.isEmpty() && ! VALID_VALUE_PATTERN.matcher(strippedValue).matches())
-                throw new IllegalArgumentException("Tag value contains invalid characters for key '" + key +
-                                                   "'. Only [A-Za-z0-9_-] and template variables like ${environment} are allowed");
+            if (key.indexOf('\0') >= 0 || value.indexOf('\0') >= 0)
+                throw new IllegalArgumentException("Tag key or value contains null bytes for key '" + key + "'");
             for (String reserved : RESERVED_TAG_NAMES) {
                 if (key.equals(reserved))
                     throw new IllegalArgumentException("Tag key '" + key + "' is reserved by the platform");
@@ -162,6 +186,70 @@ public class CloudResourceTags {
                     throw new IllegalArgumentException("Tag key prefix '" + prefix + "' is reserved by the platform: '" + key + "'");
             }
         });
+    }
+
+    private void validateAws() {
+        validateTagCount(tags.size(), AWS_MAX_TAGS, "AWS");
+        for (var entry : tags.entrySet()) {
+            validateLength(entry.getKey(), AWS_MAX_KEY_LENGTH, "key", "AWS");
+            validateLength(entry.getValue(), AWS_MAX_VALUE_LENGTH, "value", "AWS");
+            validatePattern(entry.getKey(), AWS_TAG_PATTERN, "key", "AWS",
+                           "letters, digits, spaces, and + - = . _ : / @");
+            validateLiteralParts(entry.getKey(), entry.getValue(), AWS_TAG_PATTERN, "AWS",
+                                "letters, digits, spaces, and + - = . _ : / @");
+        }
+    }
+
+    private void validateGcp() {
+        validateTagCount(tags.size(), GCP_MAX_TAGS, "GCP");
+        for (var entry : tags.entrySet()) {
+            validateLength(entry.getKey(), GCP_MAX_KEY_LENGTH, "key", "GCP");
+            validateLength(entry.getValue(), GCP_MAX_VALUE_LENGTH, "value", "GCP");
+            if ( ! GCP_KEY_PATTERN.matcher(entry.getKey()).matches())
+                throw new IllegalArgumentException("Tag key '" + entry.getKey() + "' is not valid for GCP: " +
+                                                   "must start with a lowercase letter and contain only [a-z0-9_-]");
+            validateLiteralParts(entry.getKey(), entry.getValue(), GCP_VALUE_PATTERN, "GCP",
+                                "lowercase letters, digits, underscores, and hyphens");
+        }
+    }
+
+    private void validateAzure() {
+        validateTagCount(tags.size(), AZURE_MAX_TAGS, "Azure");
+        for (var entry : tags.entrySet()) {
+            validateLength(entry.getKey(), AZURE_MAX_KEY_LENGTH, "key", "Azure");
+            validateLength(entry.getValue(), AZURE_MAX_VALUE_LENGTH, "value", "Azure");
+            if (AZURE_FORBIDDEN_KEY_CHARS.matcher(entry.getKey()).find())
+                throw new IllegalArgumentException("Tag key '" + entry.getKey() + "' contains characters " +
+                                                   "not allowed in Azure: < > % & \\ ? /");
+        }
+    }
+
+    private static void validateTagCount(int count, int max, String cloud) {
+        if (count > max)
+            throw new IllegalArgumentException("Too many cloud resource tags (" + count +
+                                               "): " + cloud + " allows at most " + max);
+    }
+
+    private static void validateLength(String value, int max, String field, String cloud) {
+        if (value.length() > max)
+            throw new IllegalArgumentException("Tag " + field + " exceeds " + cloud + " limit of " +
+                                               max + " characters: '" + value + "'");
+    }
+
+    private static void validatePattern(String value, Pattern pattern, String field, String cloud,
+                                        String allowed) {
+        if ( ! pattern.matcher(value).matches())
+            throw new IllegalArgumentException("Tag " + field + " '" + value + "' contains characters " +
+                                               "not allowed in " + cloud + ". Allowed: " + allowed);
+    }
+
+    private static void validateLiteralParts(String key, String value, Pattern pattern, String cloud,
+                                             String allowed) {
+        String stripped = TEMPLATE_VARIABLE.matcher(value).replaceAll("");
+        if ( ! stripped.isEmpty() && ! pattern.matcher(stripped).matches())
+            throw new IllegalArgumentException("Tag value for key '" + key + "' contains characters " +
+                                               "not allowed in " + cloud + ". Allowed: " + allowed +
+                                               ". Value: '" + value + "'");
     }
 
 }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -76,44 +77,11 @@ class CloudResourceTagsTest {
         assertEquals("3", merged.asMap().get("c"));
     }
 
+    // --- Structural validation (from()) ---
+
     @Test
     void empty_key_rejected() {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("", "value")));
-    }
-
-    @Test
-    void key_exceeding_max_length_rejected() {
-        String longKey = "k".repeat(64);
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of(longKey, "value")));
-    }
-
-    @Test
-    void value_exceeding_max_length_rejected() {
-        String longValue = "v".repeat(64);
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", longValue)));
-    }
-
-    @Test
-    void max_length_keys_and_values_accepted() {
-        var tags = CloudResourceTags.from(Map.of("k".repeat(63), "v".repeat(63)));
-        assertEquals(1, tags.size());
-    }
-
-    @Test
-    void too_many_tags_rejected() {
-        Map<String, String> tooMany = IntStream.rangeClosed(1, 21)
-                                               .boxed()
-                                               .collect(toMap(i -> "key" + i, i -> "val" + i));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(tooMany));
-    }
-
-    @Test
-    void max_allowed_tags_accepted() {
-        Map<String, String> maxTags = IntStream.rangeClosed(1, 20)
-                                               .boxed()
-                                               .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(maxTags);
-        assertEquals(20, tags.size());
     }
 
     @Test
@@ -122,29 +90,67 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void key_with_invalid_characters_rejected() {
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("My Key", "value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("KEY", "value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key.name", "value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("123key", "value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("_key", "value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("-key", "value")));
+    void key_exceeding_max_length_rejected() {
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("k".repeat(513), "value")));
     }
 
     @Test
-    void value_with_invalid_characters_rejected() {
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "My Value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "value.with.dots")));
+    void value_exceeding_max_length_rejected() {
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "v".repeat(257))));
     }
 
     @Test
-    void value_uppercase_values_accepted() {
+    void max_length_keys_and_values_accepted() {
+        var tags = CloudResourceTags.from(Map.of("k".repeat(512), "v".repeat(256)));
+        assertEquals(1, tags.size());
+    }
+
+    @Test
+    void too_many_tags_rejected() {
+        Map<String, String> tooMany = IntStream.rangeClosed(1, 65)
+                                               .boxed()
+                                               .collect(toMap(i -> "key" + i, i -> "val" + i));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(tooMany));
+    }
+
+    @Test
+    void max_allowed_tags_accepted() {
+        Map<String, String> maxTags = IntStream.rangeClosed(1, 64)
+                                               .boxed()
+                                               .collect(toMap(i -> "key" + i, i -> "val" + i));
+        var tags = CloudResourceTags.from(maxTags);
+        assertEquals(64, tags.size());
+    }
+
+    @Test
+    void null_bytes_rejected() {
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key\0", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "val\0ue")));
+    }
+
+    @Test
+    void permissive_key_characters_accepted() {
         var tags = CloudResourceTags.from(Map.of(
-                "component", "ABCZ",
-                "mixed", "MyValue-1"
+                "My Key", "value",
+                "KEY", "value2",
+                "key.name", "value3",
+                "indeed:cost_tag_01", "value4",
+                "key/path", "value5",
+                "key+extra=1@host", "value6"
         ));
-        assertEquals("ABCZ", tags.asMap().get("component"));
-        assertEquals("MyValue-1", tags.asMap().get("mixed"));
+        assertEquals(6, tags.size());
+    }
+
+    @Test
+    void permissive_value_characters_accepted() {
+        var tags = CloudResourceTags.from(Map.of(
+                "key1", "My Value with spaces",
+                "key2", "value.with.dots",
+                "key3", "UPPERCASE",
+                "key4", "path/to/thing",
+                "key5", "a:b:c"
+        ));
+        assertEquals(5, tags.size());
     }
 
     @Test
@@ -170,38 +176,265 @@ class CloudResourceTagsTest {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("bastion_tag", "value")));
     }
 
+    // --- Template variables ---
+
     @Test
     void template_variables_in_values_accepted() {
-        // Pure template variable
         var tags1 = CloudResourceTags.from(Map.of("env", "${environment}"));
         assertEquals("${environment}", tags1.asMap().get("env"));
 
-        // Template variable mixed with literal text
         var tags2 = CloudResourceTags.from(Map.of("env", "prefix-${region}"));
         assertEquals("prefix-${region}", tags2.asMap().get("env"));
 
-        // Multiple template variables
         var tags3 = CloudResourceTags.from(Map.of("env", "${environment}-${region}"));
         assertEquals("${environment}-${region}", tags3.asMap().get("env"));
     }
 
     @Test
-    void template_variables_with_invalid_literal_parts_rejected() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> CloudResourceTags.from(Map.of("env", "${environment} space")));
-    }
-
-    @Test
-    void template_variables_mixed_with_uppercase_literals_accepted() {
-        var tags = CloudResourceTags.from(Map.of("env", "UPPER${environment}"));
-        assertEquals("UPPER${environment}", tags.asMap().get("env"));
+    void template_variables_mixed_with_literals_accepted() {
+        var tags = CloudResourceTags.from(Map.of(
+                "env1", "UPPER${environment}",
+                "env2", "${environment} with space",
+                "env3", "prefix:${region}/suffix"
+        ));
+        assertEquals("UPPER${environment}", tags.asMap().get("env1"));
+        assertEquals("${environment} with space", tags.asMap().get("env2"));
+        assertEquals("prefix:${region}/suffix", tags.asMap().get("env3"));
     }
 
     @Test
     void valid_key_patterns_accepted() {
-        var tags = CloudResourceTags.from(Map.of("my-key", "value", "my-key2", "value2", "k123", "v456"));
-        assertEquals(3, tags.size());
+        var tags = CloudResourceTags.from(Map.of(
+                "my-key", "value",
+                "123key", "value2",
+                "_key", "value3",
+                "-key", "value4"
+        ));
+        assertEquals(4, tags.size());
     }
+
+    @Test
+    void validate_placeholders_accepts_all_known() {
+        var tags = CloudResourceTags.from(Map.of(
+                "a", "${tenant}-${application}-${instance}",
+                "b", "${environment}-${region}",
+                "c", "${clustername}-${clustertype}"));
+        tags.validatePlaceholders();
+    }
+
+    @Test
+    void validate_placeholders_rejects_unknown() {
+        var tags = CloudResourceTags.from(Map.of("bad", "${unknown}"));
+        var e = assertThrows(IllegalArgumentException.class, tags::validatePlaceholders);
+        assertTrue(e.getMessage().contains("Unknown template variable"));
+    }
+
+    // --- Per-cloud validation: AWS ---
+
+    @Test
+    void aws_allows_colons_in_keys() {
+        var tags = CloudResourceTags.from(Map.of("indeed:cost_tag_01", "value"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AWS));
+    }
+
+    @Test
+    void aws_allows_uppercase_in_keys_and_values() {
+        var tags = CloudResourceTags.from(Map.of("MyKey", "MyValue"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AWS));
+    }
+
+    @Test
+    void aws_allows_slashes_dots_spaces_in_keys() {
+        var tags = CloudResourceTags.from(Map.of("path/to.key with-spaces", "value"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AWS));
+    }
+
+    @Test
+    void aws_rejects_forbidden_characters() {
+        var tags = CloudResourceTags.from(Map.of("key<bad", "value"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.AWS));
+        assertTrue(e.getMessage().contains("AWS"));
+    }
+
+    @Test
+    void aws_rejects_key_exceeding_128_chars() {
+        var tags = CloudResourceTags.from(Map.of("k".repeat(129), "value"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.AWS));
+        assertTrue(e.getMessage().contains("AWS"));
+    }
+
+    @Test
+    void aws_accepts_value_at_256_char_limit() {
+        var tags = CloudResourceTags.from(Map.of("key", "v".repeat(256)));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AWS));
+    }
+
+    @Test
+    void aws_allows_template_variables_in_values() {
+        var tags = CloudResourceTags.from(Map.of("env", "prefix-${environment}-suffix"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AWS));
+    }
+
+    @Test
+    void aws_rejects_forbidden_literal_mixed_with_template() {
+        var tags = CloudResourceTags.from(Map.of("env", "${environment}<bad>"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.AWS));
+        assertTrue(e.getMessage().contains("AWS"));
+    }
+
+    @Test
+    void aws_rejects_more_than_50_tags() {
+        Map<String, String> tags51 = IntStream.rangeClosed(1, 51).boxed()
+                .collect(toMap(i -> "key" + i, i -> "val" + i));
+        var tags = CloudResourceTags.from(tags51);
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.AWS));
+        assertTrue(e.getMessage().contains("AWS"));
+    }
+
+    // --- Per-cloud validation: GCP ---
+
+    @Test
+    void gcp_rejects_uppercase_keys() {
+        var tags = CloudResourceTags.from(Map.of("MyKey", "value"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    @Test
+    void gcp_rejects_uppercase_values() {
+        var tags = CloudResourceTags.from(Map.of("key", "MyValue"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    @Test
+    void gcp_rejects_colons_in_keys() {
+        var tags = CloudResourceTags.from(Map.of("cost:tag", "value"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    @Test
+    void gcp_rejects_key_starting_with_digit() {
+        var tags = CloudResourceTags.from(Map.of("1key", "value"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    @Test
+    void gcp_rejects_key_starting_with_underscore_or_hyphen() {
+        for (String key : new String[]{"_key", "-key"}) {
+            var tags = CloudResourceTags.from(Map.of(key, "value"));
+            assertThrows(IllegalArgumentException.class,
+                         () -> tags.validateForCloud(CloudName.GCP),
+                         "Should reject key: " + key);
+        }
+    }
+
+    @Test
+    void gcp_rejects_key_exceeding_63_chars() {
+        var tags = CloudResourceTags.from(Map.of("k".repeat(64), "value"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    @Test
+    void gcp_rejects_value_exceeding_63_chars() {
+        var tags = CloudResourceTags.from(Map.of("key", "v".repeat(64)));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    @Test
+    void gcp_allows_valid_lowercase_tags() {
+        var tags = CloudResourceTags.from(Map.of("env", "prod", "team-name", "search_team"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.GCP));
+    }
+
+    @Test
+    void gcp_allows_template_variables_in_values() {
+        var tags = CloudResourceTags.from(Map.of("env", "${environment}-${region}"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.GCP));
+    }
+
+    @Test
+    void gcp_rejects_uppercase_literal_mixed_with_template() {
+        var tags = CloudResourceTags.from(Map.of("env", "PREFIX-${environment}"));
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
+    }
+
+    // --- Per-cloud validation: Azure ---
+
+    @Test
+    void azure_allows_uppercase_in_keys_and_values() {
+        var tags = CloudResourceTags.from(Map.of("MyKey", "MyValue"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AZURE));
+    }
+
+    @Test
+    void azure_allows_colons_in_keys() {
+        var tags = CloudResourceTags.from(Map.of("cost:tag", "value"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AZURE));
+    }
+
+    @Test
+    void azure_rejects_forbidden_key_characters() {
+        for (String forbidden : new String[]{"key<", "key>", "key%x", "key&x", "key\\x", "key?x", "key/x"}) {
+            var tags = CloudResourceTags.from(Map.of(forbidden, "value"));
+            var e = assertThrows(IllegalArgumentException.class,
+                                 () -> tags.validateForCloud(CloudName.AZURE),
+                                 "Should reject key: " + forbidden);
+            assertTrue(e.getMessage().contains("Azure"));
+        }
+    }
+
+    @Test
+    void azure_allows_forbidden_key_chars_in_values() {
+        var tags = CloudResourceTags.from(Map.of("key", "value<with>special%chars&more"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AZURE));
+    }
+
+    @Test
+    void azure_accepts_key_at_512_char_limit() {
+        var tags = CloudResourceTags.from(Map.of("k".repeat(512), "value"));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AZURE));
+    }
+
+    @Test
+    void azure_accepts_value_at_256_char_limit() {
+        var tags = CloudResourceTags.from(Map.of("key", "v".repeat(256)));
+        assertDoesNotThrow(() -> tags.validateForCloud(CloudName.AZURE));
+    }
+
+    @Test
+    void azure_rejects_more_than_50_tags() {
+        Map<String, String> tags51 = IntStream.rangeClosed(1, 51).boxed()
+                .collect(toMap(i -> "key" + i, i -> "val" + i));
+        var tags = CloudResourceTags.from(tags51);
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateForCloud(CloudName.AZURE));
+        assertTrue(e.getMessage().contains("Azure"));
+    }
+
+    // --- Per-cloud validation: cross-cloud ---
+
+    @Test
+    void empty_tags_accepted_for_all_clouds() {
+        var empty = CloudResourceTags.empty();
+        assertDoesNotThrow(() -> empty.validateForCloud(CloudName.AWS));
+        assertDoesNotThrow(() -> empty.validateForCloud(CloudName.GCP));
+        assertDoesNotThrow(() -> empty.validateForCloud(CloudName.AZURE));
+    }
+
+    @Test
+    void unknown_cloud_throws() {
+        var tags = CloudResourceTags.from(Map.of("key", "value"));
+        var e = assertThrows(IllegalArgumentException.class,
+                             () -> tags.validateForCloud(CloudName.from("unknown")));
+        assertTrue(e.getMessage().contains("No resource tag validation rules"));
+    }
+
+    // --- Resolution ---
 
     private static final ApplicationId testApp = ApplicationId.from("Tenant1", "App1", "Default");
     private static final Environment testEnv = Environment.prod;
@@ -247,22 +480,6 @@ class CloudResourceTagsTest {
         var resolved = tags.resolve(testApp, testEnv, testRegion,
                                     ClusterSpec.Id.from("c"), ClusterSpec.Type.content);
         assertEquals("prod", resolved.asMap().get("env"));
-    }
-
-    @Test
-    void validate_placeholders_accepts_all_known() {
-        var tags = CloudResourceTags.from(Map.of(
-                "a", "${tenant}-${application}-${instance}",
-                "b", "${environment}-${region}",
-                "c", "${clustername}-${clustertype}"));
-        tags.validatePlaceholders();
-    }
-
-    @Test
-    void validate_placeholders_rejects_unknown() {
-        var tags = CloudResourceTags.from(Map.of("bad", "${unknown}"));
-        var e = assertThrows(IllegalArgumentException.class, tags::validatePlaceholders);
-        assertTrue(e.getMessage().contains("Unknown template variable"));
     }
 
     @Test


### PR DESCRIPTION
Add `validateForCloud(CloudName)` to `CloudResourceTags`, enforcing per-cloud character set and length limits. The existing `from()` method keeps cloud-agnostic structural checks (non-empty, null bytes, reserved keys, generous length ceilings).

Per-cloud rules (verified against current AWS, GCP, Azure docs):
- **AWS**: `[a-zA-Z0-9 +-=._:/@]`, key max 128, value max 256, max 50 tags
- **GCP**: `[a-z][a-z0-9_-]*` keys, `[a-z0-9_-]*` values, max 63 chars, max 64 tags
- **Azure**: keys forbid `< > %% & \ ? /`, values unrestricted, key max 512, value max 256, max 50 tags

Template-variable placeholders are stripped before per-cloud character checks. Throws on unknown cloud to force adding rules when a new cloud is introduced.

Related: vespaai/cloud#2845