### PR TITLE
Collect time-related ANN stats in QuerySetupStats

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1538,6 +1538,8 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(1, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(2, f.stats().approximate_nns_nodes_visited());
+    EXPECT_GT(f.stats().approximate_nns_time_used(), vespalib::duration::zero());
+    vespalib::duration last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
 
     // With filter active
     {
@@ -1558,6 +1560,8 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
+    last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
 
     // Hitting fallback
     {
@@ -1572,6 +1576,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
 
     // Using exact search in the first place
     {
@@ -1583,6 +1588,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
 }
 
 auto test_values = ::testing::Values(1u, 2u);

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -32,6 +32,7 @@
 #include <vespa/vespalib/data/fileheader.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/net/http/state_explorer.h>
+#include <vespa/vespalib/util/fake_deadline.h>
 #include <vespa/vespalib/util/mmap_file_allocator_factory.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
@@ -300,6 +301,10 @@ public:
     std::vector<Neighbor> find_top_k(Stats& stats, uint32_t k, const search::tensor::BoundDistanceFunction& df,
                                      uint32_t explore_k, double exploration_slack, bool prefetch_tensors,
                                      const vespalib::Deadline& doom, double distance_threshold) const override {
+        std::this_thread::sleep_for(1ms); // Make sure that test does not fail because it ran too fast
+        if (doom.is_missed()) {
+            return {};
+        }
         stats.count_computed_distance();
         stats.count_visited_node();
         stats.count_visited_node();
@@ -308,7 +313,6 @@ public:
         (void)explore_k;
         (void)exploration_slack;
         (void)prefetch_tensors;
-        (void)doom;
         (void)distance_threshold;
         return {};
     }
@@ -318,6 +322,10 @@ public:
                                                  uint32_t explore_k, double exploration_slack, bool prefetch_tensors,
                                                  const vespalib::Deadline& doom,
                                                  double                    distance_threshold) const override {
+        std::this_thread::sleep_for(1ms); // Make sure that test does not fail because it ran too fast
+        if (doom.is_missed()) {
+            return {};
+        }
         stats.count_computed_distance();
         stats.count_visited_node();
         stats.count_visited_node();
@@ -330,7 +338,6 @@ public:
         (void)filter;
         (void)low_hit_ratio;
         (void)exploration;
-        (void)doom;
         (void)distance_threshold;
         return {};
     }
@@ -1539,6 +1546,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     EXPECT_EQ(1, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(2, f.stats().approximate_nns_nodes_visited());
     EXPECT_GT(f.stats().approximate_nns_time_used(), vespalib::duration::zero());
+    EXPECT_EQ(0, f.stats().approximate_nns_timeouts_hit());
     vespalib::duration last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
 
     // With filter active
@@ -1561,7 +1569,45 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
     EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
+    EXPECT_EQ(0, f.stats().approximate_nns_timeouts_hit());
     last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
+
+    // Using up time budget (but not hitting timeout)
+    {
+        auto bp = f.make_blueprint(true);
+        auto inactive_filter = GlobalFilter::create();
+        EXPECT_FALSE(bp->pending_index_search());
+        bp->set_global_filter(*inactive_filter, 0.6);
+        EXPECT_TRUE(bp->pending_index_search());
+        vespalib::FakeDeadline fake_deadline(-1s, vespalib::Deadline::Type::BUDGET);
+        bp->perform_index_search(fake_deadline.get_deadline(), f.stats());
+        EXPECT_FALSE(bp->pending_index_search());
+    }
+    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
+    EXPECT_EQ(0, f.stats().approximate_nns_timeouts_hit());
+    last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
+
+    // Hitting timeout
+    {
+        auto bp = f.make_blueprint(true);
+        auto inactive_filter = GlobalFilter::create();
+        EXPECT_FALSE(bp->pending_index_search());
+        bp->set_global_filter(*inactive_filter, 0.6);
+        EXPECT_TRUE(bp->pending_index_search());
+        vespalib::FakeDeadline fake_deadline(-1s, vespalib::Deadline::Type::TIMEOUT);
+        bp->perform_index_search(fake_deadline.get_deadline(), f.stats());
+        EXPECT_FALSE(bp->pending_index_search());
+    }
+    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
+    EXPECT_EQ(1, f.stats().approximate_nns_timeouts_hit());
+    size_t last_approximate_nns_distances_computed = f.stats().approximate_nns_distances_computed();
+    size_t last_approximate_nns_nodes_visited = f.stats().approximate_nns_nodes_visited();
+    last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
+    size_t last_approximate_nns_timeouts_hit = f.stats().approximate_nns_timeouts_hit();
 
     // Hitting fallback
     {
@@ -1574,9 +1620,10 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
         bp->set_global_filter(*strong_filter, 0.6);
         EXPECT_FALSE(bp->pending_index_search());
     }
-    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
-    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
-    EXPECT_EQ(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
+    EXPECT_EQ(last_approximate_nns_distances_computed, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(last_approximate_nns_nodes_visited, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(last_approximate_nns_time_used, f.stats().approximate_nns_time_used());
+    EXPECT_EQ(last_approximate_nns_timeouts_hit, f.stats().approximate_nns_timeouts_hit());
 
     // Using exact search in the first place
     {
@@ -1586,9 +1633,10 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
         bp->set_global_filter(*inactive_filter, 0.6);
         EXPECT_FALSE(bp->pending_index_search());
     }
-    EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
-    EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
-    EXPECT_EQ(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
+    EXPECT_EQ(last_approximate_nns_distances_computed, f.stats().approximate_nns_distances_computed());
+    EXPECT_EQ(last_approximate_nns_nodes_visited, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(last_approximate_nns_time_used, f.stats().approximate_nns_time_used());
+    EXPECT_EQ(last_approximate_nns_timeouts_hit, f.stats().approximate_nns_timeouts_hit());
 }
 
 auto test_values = ::testing::Values(1u, 2u);

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -893,6 +893,12 @@ TEST(QueryEvalTest, test_setup_stats) {
     EXPECT_EQ(2u, stats.approximate_nns_nodes_visited());
     stats.add_to_approximate_nns_nodes_visited(2u);
     EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
+
+    EXPECT_EQ(vespalib::duration::zero(), stats.approximate_nns_time_used());
+    stats.add_to_approximate_nns_time_used(vespalib::duration(1234));
+    EXPECT_EQ(vespalib::duration(1234), stats.approximate_nns_time_used());
+    stats.add_to_approximate_nns_time_used(vespalib::duration(766));
+    EXPECT_EQ(vespalib::duration(2000), stats.approximate_nns_time_used());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -899,6 +899,18 @@ TEST(QueryEvalTest, test_setup_stats) {
     EXPECT_EQ(vespalib::duration(1234), stats.approximate_nns_time_used());
     stats.add_to_approximate_nns_time_used(vespalib::duration(766));
     EXPECT_EQ(vespalib::duration(2000), stats.approximate_nns_time_used());
+
+    EXPECT_EQ(0u, stats.approximate_nns_timeouts_hit());
+    stats.add_to_approximate_nns_timeouts_hit(1u);
+    EXPECT_EQ(1u, stats.approximate_nns_timeouts_hit());
+    stats.add_to_approximate_nns_timeouts_hit(2u);
+    EXPECT_EQ(3u, stats.approximate_nns_timeouts_hit());
+
+    // Make sure all stats are unchanged
+    EXPECT_EQ(2u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(vespalib::duration(2000), stats.approximate_nns_time_used());
+    EXPECT_EQ(3u, stats.approximate_nns_timeouts_hit());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -62,6 +62,8 @@ NearestNeighborBlueprint::AnnStats::AnnStats()
 void NearestNeighborBlueprint::AnnStats::flush(search::queryeval::QuerySetupStats& setup_stats) const {
     setup_stats.add_to_approximate_nns_distances_computed(index_stats.distances_computed());
     setup_stats.add_to_approximate_nns_nodes_visited(index_stats.nodes_visited());
+
+    setup_stats.add_to_approximate_nns_time_used(time_used);
 }
 
 void NearestNeighborBlueprint::AnnStats::visit(vespalib::ObjectVisitor& visitor) const {

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -64,6 +64,7 @@ void NearestNeighborBlueprint::AnnStats::flush(search::queryeval::QuerySetupStat
     setup_stats.add_to_approximate_nns_nodes_visited(index_stats.nodes_visited());
 
     setup_stats.add_to_approximate_nns_time_used(time_used);
+    setup_stats.add_to_approximate_nns_timeouts_hit(timeout_hit);
 }
 
 void NearestNeighborBlueprint::AnnStats::visit(vespalib::ObjectVisitor& visitor) const {

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <vespa/vespalib/util/time.h>
+
 #include <atomic>
 #include <memory>
 
@@ -13,11 +15,15 @@ namespace search::queryeval {
  **/
 class QuerySetupStats {
 private:
-    size_t _approximate_nns_distances_computed;
-    size_t _approximate_nns_nodes_visited;
+    size_t             _approximate_nns_distances_computed;
+    size_t             _approximate_nns_nodes_visited;
+    vespalib::duration _approximate_nns_time_used;
 
 public:
-    QuerySetupStats() noexcept : _approximate_nns_distances_computed(0), _approximate_nns_nodes_visited(0) {}
+    QuerySetupStats() noexcept
+        : _approximate_nns_distances_computed(0),
+          _approximate_nns_nodes_visited(0),
+          _approximate_nns_time_used(vespalib::duration::zero()) {}
 
     size_t approximate_nns_distances_computed() const noexcept { return _approximate_nns_distances_computed; }
     void add_to_approximate_nns_distances_computed(size_t value) noexcept {
@@ -26,6 +32,11 @@ public:
 
     size_t approximate_nns_nodes_visited() const noexcept { return _approximate_nns_nodes_visited; }
     void add_to_approximate_nns_nodes_visited(size_t value) noexcept { _approximate_nns_nodes_visited += value; }
+
+    vespalib::duration approximate_nns_time_used() const noexcept { return _approximate_nns_time_used; }
+    void add_to_approximate_nns_time_used(vespalib::duration ann_time) noexcept {
+        _approximate_nns_time_used += ann_time;
+    }
 };
 
 /**

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -18,12 +18,14 @@ private:
     size_t             _approximate_nns_distances_computed;
     size_t             _approximate_nns_nodes_visited;
     vespalib::duration _approximate_nns_time_used;
+    size_t             _approximate_nns_timeouts_hit;
 
 public:
     QuerySetupStats() noexcept
         : _approximate_nns_distances_computed(0),
           _approximate_nns_nodes_visited(0),
-          _approximate_nns_time_used(vespalib::duration::zero()) {}
+          _approximate_nns_time_used(vespalib::duration::zero()),
+          _approximate_nns_timeouts_hit(0) {}
 
     size_t approximate_nns_distances_computed() const noexcept { return _approximate_nns_distances_computed; }
     void add_to_approximate_nns_distances_computed(size_t value) noexcept {
@@ -37,6 +39,9 @@ public:
     void add_to_approximate_nns_time_used(vespalib::duration ann_time) noexcept {
         _approximate_nns_time_used += ann_time;
     }
+
+    size_t approximate_nns_timeouts_hit() const noexcept { return _approximate_nns_timeouts_hit; }
+    void add_to_approximate_nns_timeouts_hit(size_t value) noexcept { _approximate_nns_timeouts_hit += value; }
 };
 
 /**


### PR DESCRIPTION
Adds the time used on ANN searches and the number of ANN timeouts hit.