### PR TITLE
Support @-references in geoLocation/geoBoundingBox

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -539,13 +539,27 @@ public class YqlParser implements Parser {
         return nonTaggableLeafStyleSettings(ast, item);
     }
 
-    private ParsedDegree degreesFromArg(OperatorNode<ExpressionOperator> ast, boolean first) {
-        Object arg = switch (ast.getOperator()) {
+    private String derefVar(OperatorNode<ExpressionOperator> ast) {
+        Preconditions.checkState(ast.getOperator() == ExpressionOperator.VARREF, "derefVar() only accepts VARREF");
+        Preconditions.checkState(userQuery != null, "Query properties are not available");
+        String propName = ast.getArgument(0, String.class);
+        String prop = userQuery.properties().getString(propName);
+        Preconditions.checkState(prop != null, "Error, missing query property: " + propName);
+        return prop;
+    }
+
+    private Object fetchLiteralOrRef(OperatorNode<ExpressionOperator> ast) {
+        return switch (ast.getOperator()) {
             case LITERAL -> ast.getArgument(0);
-            case READ_FIELD -> ast.getArgument(1);
+            case READ_FIELD -> ast.getArgument(1); // TODO: Should probably remove this option
+            case VARREF -> derefVar(ast);
             default -> throw newUnexpectedArgumentException(ast.getOperator(),
-                    ExpressionOperator.READ_FIELD, ExpressionOperator.PROPREF);
+                    ExpressionOperator.LITERAL, ExpressionOperator.READ_FIELD, ExpressionOperator.VARREF);
         };
+    }
+
+    private ParsedDegree degreesFromArg(OperatorNode<ExpressionOperator> ast, boolean first) {
+        Object arg = fetchLiteralOrRef(ast);
         if (arg instanceof Number n) {
             return new ParsedDegree(n.doubleValue(), first, !first);
         }
@@ -573,7 +587,7 @@ public class YqlParser implements Parser {
         String field = fetchFieldName(args.get(0));
         var coord_1 = degreesFromArg(args.get(1), true);
         var coord_2 = degreesFromArg(args.get(2), false);
-        double radius = DistanceParser.parse(fetchLiteral(args.get(3)));
+        double radius = DistanceParser.parse(fetchLiteralOrRef(args.get(3)).toString());
         Location.Point center;
         if (coord_1.isLatitude && coord_2.isLongitude) {
             center = new Location.Point(coord_1.degrees, coord_2.degrees);

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -886,27 +886,54 @@ public class YqlParserTestCase {
     @Test
     void testGeoLocation() {
         assertParse("select foo from bar where geoLocation(workplace, 63.418417, 10.433033, \"0.5 deg\")",
-                "GEO_LOCATION workplace:(2,10433033,63418417,500000,0,1,0,1921876103)");
-        assertParse("select foo from bar where geoLocation(headquarters, \"37.416383\", \"-122.024683\", \"100 miles\")",
-                "GEO_LOCATION headquarters:(2,-122024683,37416383,1450561,0,1,0,3411238761)");
+            "GEO_LOCATION workplace:(2,10433033,63418417,500000,0,1,0,1921876103)");
+        assertParse(
+            "select foo from bar where geoLocation(headquarters, \"37.416383\", \"-122.024683\", \"100 miles\")",
+            "GEO_LOCATION headquarters:(2,-122024683,37416383,1450561,0,1,0,3411238761)");
         assertParse("select foo from bar where geoLocation(home, \"E10.433033\", \"N63.418417\", \"5km\")",
-                "GEO_LOCATION home:(2,10433033,63418417,45066,0,1,0,1921876103)");
+            "GEO_LOCATION home:(2,10433033,63418417,45066,0,1,0,1921876103)");
 
         assertParseFail("select foo from bar where geoLocation(qux, 1, 2)",
-                new IllegalArgumentException("Expected 4 arguments, got 3."));
+            new IllegalArgumentException("Expected 4 arguments, got 3."));
         assertParseFail("select foo from bar where geoLocation(qux, 2.0, \"N5.0\", \"0.5 deg\");",
-                new IllegalArgumentException(
-                        "Invalid geoLocation coordinates 'Latitude: 2.0 degrees' and 'Latitude: 5.0 degrees'"));
+            new IllegalArgumentException(
+                "Invalid geoLocation coordinates 'Latitude: 2.0 degrees' and 'Latitude: 5.0 degrees'"));
         assertParse("select foo from bar where geoLocation(workplace, -12, -34, \"-77 d\")",
-                "GEO_LOCATION workplace:(2,-34000000,-12000000,-1,0,1,0,4201111954)");
+            "GEO_LOCATION workplace:(2,-34000000,-12000000,-1,0,1,0,4201111954)");
         assertParse("select * from test_index where geoLocation(coordinate, 0.000010, 0.000010, \"10.000000 km\")",
-                "GEO_LOCATION coordinate:(2,10,10,90133,0,1,0,4294967294)");
+            "GEO_LOCATION coordinate:(2,10,10,90133,0,1,0,4294967294)");
+
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        var builder = new Query.Builder();
+        var query = builder.build();
+        query.properties().set("mylatitude", "42.123456");
+        query.properties().set("mylongitude", "17.123456");
+        query.properties().set("myradius", "10 km");
+        parser.setUserQuery(query);
+        var qt = parse("select * from sources * where geoLocation(mypos, @mylatitude, @mylongitude, @myradius);");
+        assertEquals("GEO_LOCATION mypos:(2,17123456,42123456,90133,0,1,0,3185582897)", qt.toString());
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        parser.setUserQuery(query);
+        var ex = assertThrows(IllegalStateException.class,
+            () -> parse("select * from sources * where geoLocation(mypos, @mylatitude, @bad, @myradius);"));
+        assertTrue(ex.getMessage().contains("missing"));
     }
 
     @Test
     void testGeoBoundingBox() {
         assertParse("select foo from bar where geoBoundingBox('workplace', -63.418, -10.433, 63.5, 10.5)",
                     "GEO_LOCATION workplace:[2,-10433000,-63418000,10500000,63500000]");
+
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        var builder = new Query.Builder();
+        var query = builder.build();
+        query.properties().set("my_s", "-63.418");
+        query.properties().set("my_n", "63.5");
+        query.properties().set("my_w", "-10.433");
+        query.properties().set("my_e", "10.5");
+        parser.setUserQuery(query);
+        var qt = parse("select foo from bar where geoBoundingBox('workplace', @my_s, @my_w, @my_n, @my_e);");
+        assertEquals("GEO_LOCATION workplace:[2,-10433000,-63418000,10500000,63500000]", qt.toString());
     }
 
     @Test

--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
@@ -35,8 +35,7 @@ public:
     ~TensorFromStructsBlueprint() override;
     fef::Blueprint::UP createInstance() const override { return Blueprint::UP(new TensorFromStructsBlueprint()); }
     fef::ParameterDescriptions getDescriptions() const override {
-        return fef::ParameterDescriptions()
-                .desc().string().string().string().string().string().repeat();
+        return fef::ParameterDescriptions().desc().string().string().string().string().string().repeat();
     }
     bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
     fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;


### PR DESCRIPTION
Generalize the literal-extraction path in YqlParser into a new fetchLiteralOrRef helper that also resolves VARREF nodes against the user query's properties. This lets coordinate and radius arguments to geoLocation/geoBoundingBox be passed as @-references (e.g. geoLocation(pos, @lat, @lon, @radius)) instead of having to inline values into the YQL string, so callers can parameterize geo queries via query properties. Throws if the referenced property is unset.

@kkraune @bratseth FYI
