### PR TITLE
run cfmt to format, then commit pre-hook to re-format

### DIFF
--- a/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_structs_feature.h
@@ -35,8 +35,7 @@ public:
     ~TensorFromStructsBlueprint() override;
     fef::Blueprint::UP createInstance() const override { return Blueprint::UP(new TensorFromStructsBlueprint()); }
     fef::ParameterDescriptions getDescriptions() const override {
-        return fef::ParameterDescriptions()
-                .desc().string().string().string().string().string().repeat();
+        return fef::ParameterDescriptions().desc().string().string().string().string().string().repeat();
     }
     bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
     fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;


### PR DESCRIPTION
the two versions of clang-format do not agree on how to format the code, which is not optimal.

@arnej27959 please review