### PR TITLE
Add inference request timeout for triton

### DIFF
--- a/model-evaluation/src/main/java/ai/vespa/models/evaluation/OnnxModel.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/evaluation/OnnxModel.java
@@ -195,7 +195,7 @@ class OnnxModel implements AutoCloseable {
     }
 
     Tensor unmappedEvaluate(Map<String, Tensor> inputs, String onnxOutputName) {
-        return evaluator().evaluate(inputs, onnxOutputName);
+        return evaluator().evaluate(inputs, onnxOutputName, null);
     }
 
     private OnnxEvaluator evaluator() {

--- a/model-integration/abi-spec.json
+++ b/model-integration/abi-spec.json
@@ -301,6 +301,7 @@
       "public ai.vespa.llm.clients.TritonConfig$Builder target(java.lang.String)",
       "public ai.vespa.llm.clients.TritonConfig$Builder modelRepositoryPath(java.lang.String)",
       "public ai.vespa.llm.clients.TritonConfig$Builder modelControlMode(ai.vespa.llm.clients.TritonConfig$ModelControlMode$Enum)",
+      "public ai.vespa.llm.clients.TritonConfig$Builder timeout(long)",
       "public final boolean dispatchGetConfig(com.yahoo.config.ConfigInstance$Producer)",
       "public final java.lang.String getDefMd5()",
       "public final java.lang.String getDefName()",
@@ -375,7 +376,8 @@
       "public void <init>(ai.vespa.llm.clients.TritonConfig$Builder)",
       "public java.lang.String target()",
       "public java.lang.String modelRepositoryPath()",
-      "public ai.vespa.llm.clients.TritonConfig$ModelControlMode$Enum modelControlMode()"
+      "public ai.vespa.llm.clients.TritonConfig$ModelControlMode$Enum modelControlMode()",
+      "public long timeout()"
     ],
     "fields" : [
       "public static final java.lang.String CONFIG_DEF_MD5",

--- a/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
@@ -15,6 +15,7 @@ import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import java.util.Map;
  * See bert-base-embedder.def for configurable parameters.
  *
  * @author lesters
+ * @author glebashnik
  */
 public class BertBaseEmbedder extends AbstractComponent implements Embedder {
 
@@ -108,7 +110,7 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
         }
         List<Integer> tokens = embedWithSeparatorTokens(text, context, maxTokens);
         runtime.sampleSequenceLength(tokens.size(), context);
-        var embedding = embedTokens(tokens, type);
+        var embedding = embedTokens(tokens, type, OnnxEmbedderTimeout.remainingOrThrow(context));
         runtime.sampleEmbeddingLatency((System.nanoTime() - start)/1_000_000d, context);
         return embedding;
     }
@@ -118,6 +120,10 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
     private List<Integer> tokenize(String text, Context ctx) { return tokenizer.embed(text, ctx); }
 
     Tensor embedTokens(List<Integer> tokens, TensorType type) {
+        return embedTokens(tokens, type, null);
+    }
+
+    Tensor embedTokens(List<Integer> tokens, TensorType type, Duration timeout) {
         Tensor inputSequence = createTensorRepresentation(tokens, "d1");
         Tensor attentionMask = createAttentionMask(inputSequence);
         Tensor tokenTypeIds = createTokenTypeIds(inputSequence);
@@ -132,7 +138,7 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
             inputs = Map.of(inputIdsName, inputSequence.expand("d0"),
                                  attentionMaskName, attentionMask.expand("d0"));
         }
-        Map<String, Tensor> outputs = evaluator.evaluate(inputs);
+        Map<String, Tensor> outputs = evaluator.evaluate(inputs, timeout);
 
         Tensor tokenEmbeddings = outputs.get(outputName);
 

--- a/model-integration/src/main/java/ai/vespa/embedding/ColBertEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/ColBertEmbedder.java
@@ -38,6 +38,7 @@ import static com.yahoo.language.huggingface.ModelInfo.TruncationStrategy.LONGES
  * See col-bert-embedder.def for configurable parameters.
  *
  * @author bergum
+ * @author glebashnik
  */
 @Beta
 public class ColBertEmbedder extends AbstractComponent implements Embedder {
@@ -218,7 +219,7 @@ public class ColBertEmbedder extends AbstractComponent implements Embedder {
         var inputs = Map.of(inputIdsName,
                             inputIdsTensor.expand("d0"),
                             attentionMaskName, attentionMaskTensor.expand("d0"));
-        Map<String, Tensor> outputs = evaluator.evaluate(inputs);
+        Map<String, Tensor> outputs = evaluator.evaluate(inputs, OnnxEmbedderTimeout.remainingOrThrow(context));
         runtime.sampleEmbeddingLatency((System.nanoTime() - start) / 1_000_000d, context);
         return new EmbeddingResult(input.inputIds.size(), outputs);
     }

--- a/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/HuggingFaceEmbedder.java
@@ -20,12 +20,17 @@ import com.yahoo.tensor.Tensors;
 import com.yahoo.text.Text;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 
 import static com.yahoo.language.huggingface.ModelInfo.TruncationStrategy.LONGEST_FIRST;
 
+/**
+ * Embedder backed by a HuggingFace-style transformer ONNX model and a HuggingFace tokenizer.
+ *
+ * @author arnej
+ * @author glebashnik
+ */
 @Beta
 public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
 
@@ -189,7 +194,9 @@ public class HuggingFaceEmbedder extends AbstractComponent implements Embedder {
         } else {
             inputs = Map.of(analysis.inputIdsName(), inputSequence);
         }
-        IndexedTensor tokenEmbeddings = (IndexedTensor) evaluator.evaluate(inputs).get(analysis.outputName());
+        IndexedTensor tokenEmbeddings = (IndexedTensor) evaluator
+                .evaluate(inputs, OnnxEmbedderTimeout.remainingOrThrow(context))
+                .get(analysis.outputName());
         long[] resultShape = tokenEmbeddings.shape();
         // shape should have batch, sequence, embedding dimensionality
         if (resultShape.length != analysis.outputDimensions()) {

--- a/model-integration/src/main/java/ai/vespa/embedding/OnnxEmbedderTimeout.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/OnnxEmbedderTimeout.java
@@ -1,0 +1,32 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.TimeoutException;
+
+import java.time.Duration;
+
+/**
+ * Resolves a per-call timeout from an {@link Embedder.Context} deadline, for use by
+ * ONNX-backed embedders.
+ *
+ * @author glebashnik
+ */
+final class OnnxEmbedderTimeout {
+
+    private OnnxEmbedderTimeout() {}
+
+    /**
+     * Returns the time remaining until the request deadline, or {@code null} if no deadline is set.
+     *
+     * @throws TimeoutException if the deadline has already expired
+     */
+    static Duration remainingOrThrow(Embedder.Context context) {
+        var deadline = context.getDeadline().orElse(null);
+        if (deadline == null) return null;
+        long remainingMs = deadline.timeRemaining().toMillis();
+        if (remainingMs <= 0)
+            throw new TimeoutException("Request deadline exceeded before ONNX evaluation");
+        return Duration.ofMillis(remainingMs);
+    }
+}

--- a/model-integration/src/main/java/ai/vespa/embedding/SpladeEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/SpladeEmbedder.java
@@ -29,6 +29,7 @@ import static com.yahoo.language.huggingface.ModelInfo.TruncationStrategy.LONGES
  * are the subword strings from the wordpiece vocabulary that has a score above a threshold (default 0.0).
  *
  * @author bergum
+ * @author glebashnik
  */
 @Beta
 public class SpladeEmbedder extends AbstractComponent implements Embedder {
@@ -129,7 +130,9 @@ public class SpladeEmbedder extends AbstractComponent implements Embedder {
         Map<String, Tensor> inputs = Map.of(inputIdsName, inputSequence.expand("d0"),
                                             attentionMaskName, attentionMask.expand("d0"),
                                             tokenTypeIdsName, tokenTypeIds.expand("d0"));
-        IndexedTensor output = (IndexedTensor) evaluator.evaluate(inputs).get(outputName);
+        IndexedTensor output = (IndexedTensor) evaluator
+                .evaluate(inputs, OnnxEmbedderTimeout.remainingOrThrow(context))
+                .get(outputName);
         Tensor spladeTensor = useCustomReduce
                 ? sparsifyCustomReduce(output, tensorType)
                 : sparsifyReduce(output, tensorType);

--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluator.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluator.java
@@ -10,6 +10,7 @@ import ai.onnxruntime.OrtSession;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +23,7 @@ import static com.yahoo.protect.Process.logAndDie;
  *
  * @author lesters
  * @author bjorncs
+ * @author glebashnik
  */
 class EmbeddedOnnxEvaluator implements OnnxEvaluator {
 
@@ -50,7 +52,7 @@ class EmbeddedOnnxEvaluator implements OnnxEvaluator {
     }
 
     @Override
-    public Tensor evaluate(Map<String, Tensor> inputs, String output) {
+    public Tensor evaluate(Map<String, Tensor> inputs, String output, Duration timeout) {
         Map<String, OnnxTensor> onnxInputs = null;
         try {
             output = mapToInternalName(output);
@@ -66,9 +68,10 @@ class EmbeddedOnnxEvaluator implements OnnxEvaluator {
             }
         }
     }
-
+    
+    // EmbeddedOnnxEvaluator ignores timeout.
     @Override
-    public Map<String, Tensor> evaluate(Map<String, Tensor> inputs) {
+    public Map<String, Tensor> evaluate(Map<String, Tensor> inputs, Duration timeout) {
         Map<String, OnnxTensor> onnxInputs = null;
         try {
             onnxInputs = TensorConverter.toOnnxTensors(inputs, ortEnvironment, session.instance());

--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluator.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluator.java
@@ -5,19 +5,29 @@ package ai.vespa.modelintegration.evaluator;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 
+import java.time.Duration;
 import java.util.Map;
 
 /**
  * Evaluator for ONNX models.
  *
  * @author bjorncs
+ * @author glebashnik
  */
 public interface OnnxEvaluator extends AutoCloseable {
 
     record IdAndType(String id, TensorType type) { }
 
-    Tensor evaluate(Map<String, Tensor> inputs, String output);
-    Map<String, Tensor> evaluate(Map<String, Tensor> inputs);
+    default Tensor evaluate(Map<String, Tensor> inputs, String output) {
+        return evaluate(inputs, output, null);
+    }
+
+    default Map<String, Tensor> evaluate(Map<String, Tensor> inputs) {
+        return evaluate(inputs, (Duration) null);
+    }
+
+    Tensor evaluate(Map<String, Tensor> inputs, String output, Duration timeout);
+    Map<String, Tensor> evaluate(Map<String, Tensor> inputs, Duration timeout);
 
     Map<String, OnnxEvaluator.IdAndType> getInputs();
     Map<String, OnnxEvaluator.IdAndType> getOutputs();

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
@@ -12,6 +12,7 @@ import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.text.Text;
+import com.yahoo.language.process.TimeoutException;
 import grpc.health.v1.HealthGrpc;
 import grpc.health.v1.HealthOuterClass.HealthCheckRequest;
 import grpc.health.v1.HealthOuterClass.HealthCheckResponse;
@@ -19,6 +20,7 @@ import inference.GRPCInferenceServiceGrpc;
 import inference.GrpcService;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.AbstractBlockingStub;
@@ -26,17 +28,18 @@ import io.grpc.stub.AbstractStub;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -57,6 +60,7 @@ public class TritonOnnxClient implements AutoCloseable {
 
     private final GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingV2Stub grpcInferenceStub;
     private final HealthGrpc.HealthBlockingV2Stub grpcHealthStub;
+    private final Duration defaultTimeout;
 
     public static class TritonException extends RuntimeException {
         public TritonException(String message) {
@@ -81,6 +85,7 @@ public class TritonOnnxClient implements AutoCloseable {
                 .build();
         this.grpcInferenceStub = GRPCInferenceServiceGrpc.newBlockingV2Stub(ch);
         this.grpcHealthStub = HealthGrpc.newBlockingV2Stub(ch);
+        this.defaultTimeout = Duration.ofMillis(config.timeout());
     }
 
     public static class ModelMetadata {
@@ -243,16 +248,39 @@ public class TritonOnnxClient implements AutoCloseable {
     }
 
     public Map<String, Tensor> evaluate(String modelName, ModelMetadata modelMetadata, Map<String, Tensor> inputs) {
-        return evaluate(modelName, modelMetadata, inputs, Set.of());
+        return evaluate(modelName, modelMetadata, inputs, Set.of(), null);
+    }
+
+    public Map<String, Tensor> evaluate(
+            String modelName, ModelMetadata modelMetadata, Map<String, Tensor> inputs, Duration timeout) {
+        return evaluate(modelName, modelMetadata, inputs, Set.of(), timeout);
     }
 
     public Tensor evaluate(
             String modelName, ModelMetadata modelMetadata, Map<String, Tensor> inputs, String outputName) {
-        return evaluate(modelName, modelMetadata, inputs, Set.of(outputName)).get(outputName);
+        return evaluate(modelName, modelMetadata, inputs, Set.of(outputName), null).get(outputName);
+    }
+
+    public Tensor evaluate(
+            String modelName, ModelMetadata modelMetadata, Map<String, Tensor> inputs, String outputName,
+            Duration timeout) {
+        return evaluate(modelName, modelMetadata, inputs, Set.of(outputName), timeout).get(outputName);
     }
 
     public Map<String, Tensor> evaluate(
             String modelName, ModelMetadata modelMetadata, Map<String, Tensor> inputs, Set<String> outputNames) {
+        return evaluate(modelName, modelMetadata, inputs, outputNames, null);
+    }
+
+    public Map<String, Tensor> evaluate(
+            String modelName, ModelMetadata modelMetadata, Map<String, Tensor> inputs, Set<String> outputNames,
+            Duration timeout) {
+        Duration effectiveTimeout = timeout != null ? timeout : defaultTimeout;
+        if (effectiveTimeout.toMillis() <= 0) {
+            throw new TimeoutException(
+                    "Request deadline exceeded before Triton ONNX evaluation of model " + modelName);
+        }
+
         var requestBuilder = GrpcService.ModelInferRequest.newBuilder().setModelName(modelName);
 
         inputs.forEach((name, tensor) -> addInputToBuilder(modelMetadata.tritonInputs, requestBuilder, tensor, name));
@@ -263,8 +291,8 @@ public class TritonOnnxClient implements AutoCloseable {
                         .setName(name)
                         .build()));
 
-        var response =
-                invokeGrpc(grpcInferenceStub, s -> s.modelInfer(requestBuilder.build()), "Failed to evaluate model");
+        var stub = grpcInferenceStub.withDeadlineAfter(effectiveTimeout.toMillis(), MILLISECONDS);
+        var response = invokeGrpc(stub, s -> s.modelInfer(requestBuilder.build()), "Failed to evaluate model");
 
         Map<String, Tensor> outputs = new HashMap<>();
         for (int i = 0; i < response.getOutputsCount(); i++) {
@@ -486,8 +514,16 @@ public class TritonOnnxClient implements AutoCloseable {
             S stub, GrpcInvocation<T, S> invocation, String errorMessage) {
         try {
             return invocation.apply(stub);
-        } catch (StatusException | StatusRuntimeException e) {
-            throw new TritonException(errorMessage, e);
+        } catch (StatusException e) {
+            throw translateGrpcFailure(e.getStatus(), errorMessage, e);
+        } catch (StatusRuntimeException e) {
+            throw translateGrpcFailure(e.getStatus(), errorMessage, e);
         }
+    }
+
+    private static RuntimeException translateGrpcFailure(Status status, String errorMessage, Throwable cause) {
+        if (status.getCode() == Status.Code.DEADLINE_EXCEEDED)
+            return new TimeoutException(errorMessage + ": deadline exceeded", cause);
+        return new TritonException(errorMessage, cause);
     }
 }

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxEvaluator.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxEvaluator.java
@@ -6,6 +6,7 @@ import com.yahoo.jdisc.ResourceReference;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -40,14 +41,14 @@ class TritonOnnxEvaluator implements OnnxEvaluator {
     }
 
     @Override
-    public Tensor evaluate(Map<String, Tensor> inputs, String output) {
-        return evaluate(inputs).get(output);
+    public Tensor evaluate(Map<String, Tensor> inputs, String output, Duration timeout) {
+        return evaluate(inputs, timeout).get(output);
     }
 
     @Override
-    public Map<String, Tensor> evaluate(Map<String, Tensor> inputs) {
+    public Map<String, Tensor> evaluate(Map<String, Tensor> inputs, Duration timeout) {
         try {
-            return tritonClient.evaluate(modelName, modelMetadata, inputs);
+            return tritonClient.evaluate(modelName, modelMetadata, inputs, timeout);
         } catch (TritonOnnxClient.TritonException e) {
             if (!isExplicitControl) {
                 throw e;
@@ -59,7 +60,7 @@ class TritonOnnxEvaluator implements OnnxEvaluator {
                     e);
             tritonClient.loadUntilModelReady(modelName);
             modelMetadata = tritonClient.getModelMetadata(modelName);
-            return tritonClient.evaluate(modelName, modelMetadata, inputs);
+            return tritonClient.evaluate(modelName, modelMetadata, inputs, timeout);
         }
     }
 

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxEvaluator.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxEvaluator.java
@@ -56,7 +56,7 @@ class TritonOnnxEvaluator implements OnnxEvaluator {
 
             log.log(
                     Level.WARNING,
-                    "Failed to evaluate ONNX model " + modelName + " in Trion, will retry after reload.",
+                    "Failed to evaluate ONNX model " + modelName + " in Triton, will retry after reload.",
                     e);
             tritonClient.loadUntilModelReady(modelName);
             modelMetadata = tritonClient.getModelMetadata(modelName);

--- a/model-integration/src/main/resources/configdefinitions/triton.def
+++ b/model-integration/src/main/resources/configdefinitions/triton.def
@@ -10,3 +10,8 @@ modelRepositoryPath string default="/sidecars/triton/models"
 
 # Model control mode. Client will only issue model load/unload requests if mode is EXPLICIT.
 modelControlMode enum {NONE, POLL, EXPLICIT} default=EXPLICIT
+
+# Default per-call gRPC deadline for inference requests, in milliseconds.
+# Used as a fallback when the caller (e.g. an embedder) does not supply a deadline derived
+# from the Vespa request context. When the caller does supply one, that value takes precedence.
+timeout long default=60000

--- a/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/HuggingFaceEmbedderTest.java
@@ -7,6 +7,8 @@ import ai.vespa.modelintegration.utils.ModelPathHelper;
 import com.yahoo.config.ModelReference;
 import com.yahoo.embedding.huggingface.HuggingFaceEmbedderConfig;
 import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.InvocationContext;
+import com.yahoo.language.process.TimeoutException;
 import ai.vespa.modelintegration.evaluator.config.OnnxEvaluatorConfig;
 import com.yahoo.searchlib.rankingexpression.evaluation.MapContext;
 import com.yahoo.searchlib.rankingexpression.evaluation.TensorValue;
@@ -19,6 +21,7 @@ import com.yahoo.tensor.Tensors;
 import org.junit.Test;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -168,6 +171,15 @@ public class HuggingFaceEmbedderTest {
         Tensor binarizedResultQuery = getNormalizePrefixdEmbedder().embed(input, queryContext, TensorType.fromSpec(("tensor<int8>(x[2])")));
         assertNotEquals(binarizedResult.toAbbreviatedString(), binarizedResultQuery.toAbbreviatedString());
         assertEquals("tensor<int8>(x[2]):[119, -116]", binarizedResultQuery.toAbbreviatedString());
+    }
+
+    @Test
+    public void testEmbedThrowsTimeoutExceptionOnExpiredDeadline() {
+        var context = new Embedder.Context("schema.indexing")
+                .setDeadline(InvocationContext.Deadline.of(Instant.now().minusSeconds(1)));
+        var ex = assertThrows(TimeoutException.class,
+                () -> embedder.embed("anything", context, TensorType.fromSpec("tensor<float>(x[8])")));
+        assertEquals("Request deadline exceeded before ONNX evaluation", ex.getMessage());
     }
 
     @Test

--- a/model-integration/src/test/java/ai/vespa/embedding/OnnxEmbedderTimeoutTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/OnnxEmbedderTimeoutTest.java
@@ -1,0 +1,46 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.embedding;
+
+import com.yahoo.language.process.Embedder;
+import com.yahoo.language.process.InvocationContext;
+import com.yahoo.language.process.TimeoutException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author glebashnik
+ */
+class OnnxEmbedderTimeoutTest {
+
+    @Test
+    void returns_null_when_no_deadline_is_set() {
+        var context = new Embedder.Context("test");
+        assertNull(OnnxEmbedderTimeout.remainingOrThrow(context));
+    }
+
+    @Test
+    void returns_remaining_duration_when_deadline_is_in_the_future() {
+        var context = new Embedder.Context("test")
+                .setDeadline(InvocationContext.Deadline.of(Duration.ofSeconds(5)));
+        var remaining = OnnxEmbedderTimeout.remainingOrThrow(context);
+        assertTrue(remaining != null && remaining.toMillis() > 0,
+                "expected a positive remaining duration, got " + remaining);
+        assertTrue(remaining.toMillis() <= 5_000,
+                "remaining must not exceed deadline budget, got " + remaining.toMillis() + " ms");
+    }
+
+    @Test
+    void throws_when_deadline_already_expired() {
+        var context = new Embedder.Context("test")
+                .setDeadline(InvocationContext.Deadline.of(Instant.now().minusSeconds(1)));
+        var ex = assertThrows(TimeoutException.class, () -> OnnxEmbedderTimeout.remainingOrThrow(context));
+        assertEquals("Request deadline exceeded before ONNX evaluation", ex.getMessage());
+    }
+}

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxClientTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxClientTest.java
@@ -2,6 +2,7 @@
 package ai.vespa.triton;
 
 import ai.vespa.llm.clients.TritonConfig;
+import com.yahoo.language.process.TimeoutException;
 import com.yahoo.tensor.Tensor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -84,6 +86,38 @@ class TritonOnnxClientTest {
                             + " -0.48628148, 0.10357287, 0.8698752, -0.39116782, 1.006429, 0.5442105, 0.29821596,"
                             + " 1.142777, -0.58772075, -1.0151181, 0.9173087]]]");
             assertEquals(output, expectedOutput);
+        }
+    }
+
+    @Test
+    void evaluate_throws_timeout_exception_for_pre_expired_deadline() {
+        try (var tritonClient = createTritonClient()) {
+            tritonClient.loadModel(MODEL_NAME);
+            var metadata = tritonClient.getModelMetadata(MODEL_NAME);
+            var inputs = Map.of(
+                    "input_ids",      Tensor.from("tensor<float>(d0[1],d1[1]):[1.0]"),
+                    "attention_mask", Tensor.from("tensor<float>(d0[1],d1[1]):[1.0]"),
+                    "token_type_ids", Tensor.from("tensor<float>(d0[1],d1[1]):[0.0]"));
+
+            var ex = assertThrows(TimeoutException.class,
+                    () -> tritonClient.evaluate(MODEL_NAME, metadata, inputs, "output_0", Duration.ZERO));
+            assertTrue(ex.getMessage().contains("deadline exceeded") || ex.getMessage().contains("Request deadline"),
+                    "unexpected message: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    void evaluate_throws_timeout_exception_when_deadline_fires_during_rpc() {
+        try (var tritonClient = createTritonClient()) {
+            tritonClient.loadModel(MODEL_NAME);
+            var metadata = tritonClient.getModelMetadata(MODEL_NAME);
+            var inputs = Map.of(
+                    "input_ids",      Tensor.from("tensor<float>(d0[1],d1[5]):[1.0, 2.0, 3.0, 4.0, 5.0]"),
+                    "attention_mask", Tensor.from("tensor<float>(d0[1],d1[5]):[1.0, 1.0, 1.0, 1.0, 1.0]"),
+                    "token_type_ids", Tensor.from("tensor<float>(d0[1],d1[5]):[0.0, 0.0, 0.0, 0.0, 0.0]"));
+
+            assertThrows(TimeoutException.class,
+                    () -> tritonClient.evaluate(MODEL_NAME, metadata, inputs, "output_0", Duration.ofMillis(1)));
         }
     }
 

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxEvaluatorTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxEvaluatorTest.java
@@ -2,19 +2,32 @@
 package ai.vespa.triton;
 
 import ai.vespa.llm.clients.TritonConfig;
+import com.yahoo.jdisc.ResourceReference;
+import com.yahoo.language.process.TimeoutException;
 import com.yahoo.tensor.Tensor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
-import com.yahoo.jdisc.ResourceReference;
-import static org.mockito.Mockito.mock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author glebashnik
@@ -70,6 +83,23 @@ class TritonOnnxEvaluatorTest {
                             + " -0.48628148, 0.10357287, 0.8698752, -0.39116782, 1.006429, 0.5442105, 0.29821596,"
                             + " 1.142777, -0.58772075, -1.0151181, 0.9173087]]]");
             assertEquals(output, expectedOutput);
+        }
+    }
+
+    @Test
+    void evaluate_throws_timeout_exception_when_deadline_fires() {
+        try (var tritonClient = createTritonClient()) {
+            tritonClient.loadModel(MODEL_NAME);
+            var modelReference = mock(ResourceReference.class);
+            var evaluator = new TritonOnnxEvaluator(MODEL_NAME, modelReference, tritonClient, false);
+
+            var inputs = Map.of(
+                    "input_ids",      Tensor.from("tensor<float>(d0[1],d1[5]):[1.0, 2.0, 3.0, 4.0, 5.0]"),
+                    "attention_mask", Tensor.from("tensor<float>(d0[1],d1[5]):[1.0, 1.0, 1.0, 1.0, 1.0]"),
+                    "token_type_ids", Tensor.from("tensor<float>(d0[1],d1[5]):[0.0, 0.0, 0.0, 0.0, 0.0]"));
+
+            assertThrows(TimeoutException.class,
+                    () -> evaluator.evaluate(inputs, "output_0", Duration.ofMillis(1)));
         }
     }
 

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxEvaluatorTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxEvaluatorTest.java
@@ -9,25 +9,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author glebashnik

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adds per-call request timeouts to Triton ONNX inference, similar to OpenAI embedders.
Timeout is derived from embedder context deadline. 
If absent, falls back to a config default 60s.

This should help to recover faster from request spikes and abnormally expensive inference requests.

The implementation touches all ONNX-based embedders to propagate the timeout.
The timeout is then used by triton gRPC client.
