### PR TITLE
Add time-related ANN stats to MatchingStats

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -15,6 +15,7 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp) {
     EXPECT_EQ(0u, stats.exact_nns_distances_computed());
     EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
     EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(0u, stats.approximate_nns_timed_out_queries());
     EXPECT_EQ(0u, stats.queries());
     EXPECT_EQ(0u, stats.limited_queries());
     {
@@ -23,18 +24,12 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp) {
         EXPECT_EQ(&rhs.docsMatched(1000), &rhs);
         EXPECT_EQ(&rhs.docsRanked(100), &rhs);
         EXPECT_EQ(&rhs.docsReRanked(10), &rhs);
-        EXPECT_EQ(&rhs.exact_nns_distances_computed(42), &rhs);
-        EXPECT_EQ(&rhs.approximate_nns_distances_computed(53), &rhs);
-        EXPECT_EQ(&rhs.approximate_nns_nodes_visited(7), &rhs);
+        EXPECT_EQ(&rhs.exact_nns_distances_computed(43), &rhs);
+        EXPECT_EQ(&rhs.approximate_nns_distances_computed(55), &rhs);
+        EXPECT_EQ(&rhs.approximate_nns_nodes_visited(10), &rhs);
+        EXPECT_EQ(&rhs.approximate_nns_timed_out_queries(23), &rhs);
         EXPECT_EQ(&rhs.queries(2), &rhs);
         EXPECT_EQ(&rhs.limited_queries(1), &rhs);
-        search::queryeval::QuerySetupStats setup_stats;
-        setup_stats.add_to_approximate_nns_distances_computed(2);
-        setup_stats.add_to_approximate_nns_nodes_visited(3);
-        EXPECT_EQ(&stats.add_query_setup_stats(setup_stats), &stats);
-        auto qe_stats = search::queryeval::QueryEvalStats::create();
-        qe_stats->add_to_exact_nns_distances_computed(1);
-        EXPECT_EQ(&stats.add_query_eval_stats(*qe_stats), &stats);
         EXPECT_EQ(&stats.add(rhs), &stats);
     }
     EXPECT_EQ(10000u, stats.docidSpaceCovered());
@@ -44,6 +39,7 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp) {
     EXPECT_EQ(43u, stats.exact_nns_distances_computed());
     EXPECT_EQ(55u, stats.approximate_nns_distances_computed());
     EXPECT_EQ(10u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(23u, stats.approximate_nns_timed_out_queries());
     EXPECT_EQ(2u, stats.queries());
     EXPECT_EQ(1u, stats.limited_queries());
     EXPECT_EQ(&stats.add(MatchingStats()
@@ -51,6 +47,10 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp) {
                              .docsMatched(1000)
                              .docsRanked(100)
                              .docsReRanked(10)
+                             .exact_nns_distances_computed(11)
+                             .approximate_nns_distances_computed(12)
+                             .approximate_nns_nodes_visited(13)
+                             .approximate_nns_timed_out_queries(14)
                              .queries(2)
                              .limited_queries(1)),
               &stats);
@@ -58,6 +58,10 @@ TEST(MatchingStatsTest, requireThatDocCountsAddUp) {
     EXPECT_EQ(2000u, stats.docsMatched());
     EXPECT_EQ(200u, stats.docsRanked());
     EXPECT_EQ(20u, stats.docsReRanked());
+    EXPECT_EQ(54u, stats.exact_nns_distances_computed());
+    EXPECT_EQ(67u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(23u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(37u, stats.approximate_nns_timed_out_queries());
     EXPECT_EQ(4u, stats.queries());
     EXPECT_EQ(2u, stats.limited_queries());
 }
@@ -352,6 +356,68 @@ TEST(MatchingStatsTest, requireThatPartitionsAreAddedCorrectly) {
     EXPECT_EQ(1.0, all1.getPartition(1).wait_time_max());
     EXPECT_EQ(2u, all1.getPartition(1).softDoomed());
     EXPECT_EQ(1000ns, all1.getPartition(1).doomOvertime());
+}
+
+TEST(MatchingStatsTest, require_that_query_setup_stats_is_added_correctly) {
+    MatchingStats stats;
+    EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(0u, stats.approximate_nns_timed_out_queries());
+    EXPECT_NEAR(0.0, stats.approximate_nns_time_avg(), 0.00001);
+    EXPECT_EQ(0u, stats.approximate_nns_time_count());
+    {
+        search::queryeval::QuerySetupStats setup_stats;
+        stats.add_query_setup_stats(setup_stats);
+    }
+    EXPECT_EQ(0u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(0u, stats.approximate_nns_timed_out_queries());
+    EXPECT_NEAR(0.0, stats.approximate_nns_time_avg(), 0.00001);
+    EXPECT_EQ(1u, stats.approximate_nns_time_count());
+    {
+        search::queryeval::QuerySetupStats setup_stats;
+        setup_stats.add_to_approximate_nns_distances_computed(3);
+        setup_stats.add_to_approximate_nns_nodes_visited(2);
+        setup_stats.add_to_approximate_nns_timeouts_hit(1);
+        setup_stats.add_to_approximate_nns_time_used(10ms);
+        stats.add_query_setup_stats(setup_stats);
+    }
+    EXPECT_EQ(3u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(2u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(1u, stats.approximate_nns_timed_out_queries());
+    EXPECT_NEAR(0.005, stats.approximate_nns_time_avg(), 0.00001);
+    EXPECT_EQ(2u, stats.approximate_nns_time_count());
+    {
+        search::queryeval::QuerySetupStats setup_stats;
+        setup_stats.add_to_approximate_nns_distances_computed(7);
+        setup_stats.add_to_approximate_nns_nodes_visited(6);
+        setup_stats.add_to_approximate_nns_timeouts_hit(5);
+        setup_stats.add_to_approximate_nns_time_used(20ms);
+        stats.add_query_setup_stats(setup_stats);
+    }
+    EXPECT_EQ(10u, stats.approximate_nns_distances_computed());
+    EXPECT_EQ(8u, stats.approximate_nns_nodes_visited());
+    // There were six timeouts, but these came from the same query/QuerySetupStats!
+    EXPECT_EQ(2u, stats.approximate_nns_timed_out_queries());
+    EXPECT_NEAR(0.01, stats.approximate_nns_time_avg(), 0.00001);
+    EXPECT_EQ(3u, stats.approximate_nns_time_count());
+}
+
+TEST(MatchingStatsTest, require_that_query_eval_stats_is_added_correctly) {
+    MatchingStats stats;
+    EXPECT_EQ(0u, stats.exact_nns_distances_computed());
+    {
+        auto eval_stats = search::queryeval::QueryEvalStats::create();
+        eval_stats->add_to_exact_nns_distances_computed(1);
+        stats.add_query_eval_stats(*eval_stats);
+    }
+    EXPECT_EQ(1u, stats.exact_nns_distances_computed());
+    {
+        auto eval_stats = search::queryeval::QueryEvalStats::create();
+        eval_stats->add_to_exact_nns_distances_computed(2);
+        stats.add_query_eval_stats(*eval_stats);
+    }
+    EXPECT_EQ(3u, stats.exact_nns_distances_computed());
 }
 
 TEST(MatchingStatsTest, requireThatSoftDoomIsSetAndAdded) {

--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -68,27 +68,46 @@ TEST(MatchingStatsTest, requireThatAverageTimesAreRecorded) {
     EXPECT_NEAR(0.0, stats.groupingTimeAvg(), 0.00001);
     EXPECT_NEAR(0.0, stats.rerankTimeAvg(), 0.00001);
     EXPECT_NEAR(0.0, stats.querySetupTimeAvg(), 0.00001);
+    EXPECT_NEAR(0.0, stats.approximate_nns_time_avg(), 0.00001);
     EXPECT_NEAR(0.0, stats.queryLatencyAvg(), 0.00001);
     EXPECT_EQ(0u, stats.matchTimeCount());
     EXPECT_EQ(0u, stats.groupingTimeCount());
     EXPECT_EQ(0u, stats.rerankTimeCount());
     EXPECT_EQ(0u, stats.querySetupTimeCount());
+    EXPECT_EQ(0u, stats.approximate_nns_time_count());
     EXPECT_EQ(0u, stats.queryLatencyCount());
-    stats.matchTime(0.01).groupingTime(0.1).rerankTime(0.5).querySetupTime(2.0).queryLatency(1.0);
+    stats.matchTime(0.01)
+        .groupingTime(0.1)
+        .rerankTime(0.5)
+        .querySetupTime(2.0)
+        .approximate_nns_time(0.01)
+        .queryLatency(1.0);
     EXPECT_NEAR(0.01, stats.matchTimeAvg(), 0.00001);
     EXPECT_NEAR(0.1, stats.groupingTimeAvg(), 0.00001);
     EXPECT_NEAR(0.5, stats.rerankTimeAvg(), 0.00001);
     EXPECT_NEAR(2.0, stats.querySetupTimeAvg(), 0.00001);
+    EXPECT_NEAR(0.01, stats.approximate_nns_time_avg(), 0.00001);
     EXPECT_NEAR(1.0, stats.queryLatencyAvg(), 0.00001);
-    stats.add(
-        MatchingStats().matchTime(0.03).groupingTime(0.3).rerankTime(1.5).querySetupTime(6.0).queryLatency(3.0));
+    stats.add(MatchingStats()
+                  .matchTime(0.03)
+                  .groupingTime(0.3)
+                  .rerankTime(1.5)
+                  .querySetupTime(6.0)
+                  .approximate_nns_time(0.02)
+                  .queryLatency(3.0));
     EXPECT_NEAR(0.02, stats.matchTimeAvg(), 0.00001);
     EXPECT_NEAR(0.2, stats.groupingTimeAvg(), 0.00001);
     EXPECT_NEAR(1.0, stats.rerankTimeAvg(), 0.00001);
     EXPECT_NEAR(4.0, stats.querySetupTimeAvg(), 0.00001);
+    EXPECT_NEAR(0.015, stats.approximate_nns_time_avg(), 0.00001);
     EXPECT_NEAR(2.0, stats.queryLatencyAvg(), 0.00001);
-    stats.add(
-        MatchingStats().matchTime(0.05).groupingTime(0.5).rerankTime(2.5).querySetupTime(10.0).queryLatency(5.0));
+    stats.add(MatchingStats()
+                  .matchTime(0.05)
+                  .groupingTime(0.5)
+                  .rerankTime(2.5)
+                  .querySetupTime(10.0)
+                  .approximate_nns_time(0.045)
+                  .queryLatency(5.0));
     stats.add(MatchingStats()
                   .matchTime(0.05)
                   .matchTime(0.03)
@@ -98,17 +117,21 @@ TEST(MatchingStatsTest, requireThatAverageTimesAreRecorded) {
                   .rerankTime(1.5)
                   .querySetupTime(10.0)
                   .querySetupTime(6.0)
+                  .approximate_nns_time(0.1)
+                  .approximate_nns_time(0.045)
                   .queryLatency(5.0)
                   .queryLatency(3.0));
     EXPECT_NEAR(0.03, stats.matchTimeAvg(), 0.00001);
     EXPECT_NEAR(0.3, stats.groupingTimeAvg(), 0.00001);
     EXPECT_NEAR(1.5, stats.rerankTimeAvg(), 0.00001);
     EXPECT_NEAR(6.0, stats.querySetupTimeAvg(), 0.00001);
+    EXPECT_NEAR(0.03, stats.approximate_nns_time_avg(), 0.00001);
     EXPECT_NEAR(3.0, stats.queryLatencyAvg(), 0.00001);
     EXPECT_EQ(4u, stats.matchTimeCount());
     EXPECT_EQ(4u, stats.groupingTimeCount());
     EXPECT_EQ(4u, stats.rerankTimeCount());
     EXPECT_EQ(4u, stats.querySetupTimeCount());
+    EXPECT_EQ(4u, stats.approximate_nns_time_count());
     EXPECT_EQ(4u, stats.queryLatencyCount());
 }
 
@@ -118,37 +141,58 @@ TEST(MatchingStatsTest, requireThatMinMaxTimesAreRecorded) {
     EXPECT_NEAR(0.0, stats.groupingTimeMin(), 0.00001);
     EXPECT_NEAR(0.0, stats.rerankTimeMin(), 0.00001);
     EXPECT_NEAR(0.0, stats.querySetupTimeMin(), 0.00001);
+    EXPECT_NEAR(0.0, stats.approximate_nns_time_min(), 0.00001);
     EXPECT_NEAR(0.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_NEAR(0.0, stats.matchTimeMax(), 0.00001);
     EXPECT_NEAR(0.0, stats.groupingTimeMax(), 0.00001);
     EXPECT_NEAR(0.0, stats.rerankTimeMax(), 0.00001);
     EXPECT_NEAR(0.0, stats.querySetupTimeMax(), 0.00001);
+    EXPECT_NEAR(0.0, stats.approximate_nns_time_max(), 0.00001);
     EXPECT_NEAR(0.0, stats.queryLatencyMax(), 0.00001);
-    stats.matchTime(0.01).groupingTime(0.1).rerankTime(0.5).querySetupTime(2.0).queryLatency(1.0);
+    stats.matchTime(0.01)
+        .groupingTime(0.1)
+        .rerankTime(0.5)
+        .querySetupTime(2.0)
+        .approximate_nns_time(0.02)
+        .queryLatency(1.0);
     EXPECT_NEAR(0.01, stats.matchTimeMin(), 0.00001);
     EXPECT_NEAR(0.1, stats.groupingTimeMin(), 0.00001);
     EXPECT_NEAR(0.5, stats.rerankTimeMin(), 0.00001);
     EXPECT_NEAR(2.0, stats.querySetupTimeMin(), 0.00001);
+    EXPECT_NEAR(0.02, stats.approximate_nns_time_min(), 0.00001);
     EXPECT_NEAR(1.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_NEAR(0.01, stats.matchTimeMax(), 0.00001);
     EXPECT_NEAR(0.1, stats.groupingTimeMax(), 0.00001);
     EXPECT_NEAR(0.5, stats.rerankTimeMax(), 0.00001);
     EXPECT_NEAR(2.0, stats.querySetupTimeMax(), 0.00001);
+    EXPECT_NEAR(0.02, stats.approximate_nns_time_max(), 0.00001);
     EXPECT_NEAR(1.0, stats.queryLatencyMax(), 0.00001);
-    stats.add(
-        MatchingStats().matchTime(0.03).groupingTime(0.3).rerankTime(1.5).querySetupTime(6.0).queryLatency(3.0));
+    stats.add(MatchingStats()
+                  .matchTime(0.03)
+                  .groupingTime(0.3)
+                  .rerankTime(1.5)
+                  .querySetupTime(6.0)
+                  .approximate_nns_time(0.04)
+                  .queryLatency(3.0));
     EXPECT_NEAR(0.01, stats.matchTimeMin(), 0.00001);
     EXPECT_NEAR(0.1, stats.groupingTimeMin(), 0.00001);
     EXPECT_NEAR(0.5, stats.rerankTimeMin(), 0.00001);
     EXPECT_NEAR(2.0, stats.querySetupTimeMin(), 0.00001);
+    EXPECT_NEAR(0.02, stats.approximate_nns_time_min(), 0.00001);
     EXPECT_NEAR(1.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_NEAR(0.03, stats.matchTimeMax(), 0.00001);
     EXPECT_NEAR(0.3, stats.groupingTimeMax(), 0.00001);
     EXPECT_NEAR(1.5, stats.rerankTimeMax(), 0.00001);
     EXPECT_NEAR(6.0, stats.querySetupTimeMax(), 0.00001);
+    EXPECT_NEAR(0.04, stats.approximate_nns_time_max(), 0.00001);
     EXPECT_NEAR(3.0, stats.queryLatencyMax(), 0.00001);
-    stats.add(
-        MatchingStats().matchTime(0.05).groupingTime(0.5).rerankTime(2.5).querySetupTime(10.0).queryLatency(5.0));
+    stats.add(MatchingStats()
+                  .matchTime(0.05)
+                  .groupingTime(0.5)
+                  .rerankTime(2.5)
+                  .querySetupTime(10.0)
+                  .approximate_nns_time(0.2)
+                  .queryLatency(5.0));
     stats.add(MatchingStats()
                   .matchTime(0.05)
                   .matchTime(0.03)
@@ -158,17 +202,21 @@ TEST(MatchingStatsTest, requireThatMinMaxTimesAreRecorded) {
                   .rerankTime(1.5)
                   .querySetupTime(10.0)
                   .querySetupTime(6.0)
+                  .approximate_nns_time(0.2)
+                  .approximate_nns_time(0.1)
                   .queryLatency(5.0)
                   .queryLatency(3.0));
     EXPECT_NEAR(0.01, stats.matchTimeMin(), 0.00001);
     EXPECT_NEAR(0.1, stats.groupingTimeMin(), 0.00001);
     EXPECT_NEAR(0.5, stats.rerankTimeMin(), 0.00001);
     EXPECT_NEAR(2.0, stats.querySetupTimeMin(), 0.00001);
+    EXPECT_NEAR(0.02, stats.approximate_nns_time_min(), 0.00001);
     EXPECT_NEAR(1.0, stats.queryLatencyMin(), 0.00001);
     EXPECT_NEAR(0.05, stats.matchTimeMax(), 0.00001);
     EXPECT_NEAR(0.5, stats.groupingTimeMax(), 0.00001);
     EXPECT_NEAR(2.5, stats.rerankTimeMax(), 0.00001);
     EXPECT_NEAR(10.0, stats.querySetupTimeMax(), 0.00001);
+    EXPECT_NEAR(0.2, stats.approximate_nns_time_max(), 0.00001);
     EXPECT_NEAR(5.0, stats.queryLatencyMax(), 0.00001);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -32,6 +32,7 @@ MatchingStats::MatchingStats(double prev_soft_doom_factor) noexcept
       _exact_nns_distances_computed(0),
       _approximate_nns_distances_computed(0),
       _approximate_nns_nodes_visited(0),
+      _approximate_nns_timed_out_queries(0),
       _softDoomed(0),
       _doomOvertime(),
       _softDoomFactor(prev_soft_doom_factor),
@@ -85,6 +86,7 @@ MatchingStats& MatchingStats::add(const MatchingStats& rhs) noexcept {
     _exact_nns_distances_computed += rhs._exact_nns_distances_computed;
     _approximate_nns_distances_computed += rhs._approximate_nns_distances_computed;
     _approximate_nns_nodes_visited += rhs._approximate_nns_nodes_visited;
+    _approximate_nns_timed_out_queries += rhs._approximate_nns_timed_out_queries;
     _softDoomed += rhs.softDoomed();
     _doomOvertime.add(rhs._doomOvertime);
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -65,6 +65,7 @@ MatchingStats& MatchingStats::merge_partition(const Partition& partition, size_t
 MatchingStats& MatchingStats::add_query_setup_stats(const search::queryeval::QuerySetupStats& stats) noexcept {
     _approximate_nns_distances_computed += stats.approximate_nns_distances_computed();
     _approximate_nns_nodes_visited += stats.approximate_nns_nodes_visited();
+    _approximate_nns_time.add(Avg().set(vespalib::to_s(stats.approximate_nns_time_used())));
 
     return *this;
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -66,6 +66,7 @@ MatchingStats& MatchingStats::add_query_setup_stats(const search::queryeval::Que
     _approximate_nns_distances_computed += stats.approximate_nns_distances_computed();
     _approximate_nns_nodes_visited += stats.approximate_nns_nodes_visited();
     _approximate_nns_time.add(Avg().set(vespalib::to_s(stats.approximate_nns_time_used())));
+    _approximate_nns_timed_out_queries += stats.approximate_nns_timeouts_hit() > 0 ? 1 : 0;
 
     return *this;
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -36,6 +36,7 @@ MatchingStats::MatchingStats(double prev_soft_doom_factor) noexcept
       _doomOvertime(),
       _softDoomFactor(prev_soft_doom_factor),
       _querySetupTime(),
+      _approximate_nns_time(),
       _queryLatency(),
       _matchTime(),
       _groupingTime(),
@@ -88,6 +89,7 @@ MatchingStats& MatchingStats::add(const MatchingStats& rhs) noexcept {
     _doomOvertime.add(rhs._doomOvertime);
 
     _querySetupTime.add(rhs._querySetupTime);
+    _approximate_nns_time.add(rhs._approximate_nns_time);
     _queryLatency.add(rhs._queryLatency);
     _matchTime.add(rhs._matchTime);
     _groupingTime.add(rhs._groupingTime);

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -154,6 +154,7 @@ private:
     size_t _exact_nns_distances_computed;
     size_t _approximate_nns_distances_computed;
     size_t _approximate_nns_nodes_visited;
+    size_t _approximate_nns_timed_out_queries;
     size_t _softDoomed;
     Avg    _doomOvertime;
     using SoftDoomFactor = vespalib::datastore::AtomicValueWrapper<double>;
@@ -235,6 +236,12 @@ public:
         return *this;
     }
     size_t softDoomed() const { return _softDoomed; }
+
+    MatchingStats& approximate_nns_timed_out_queries(size_t value) {
+        _approximate_nns_timed_out_queries = value;
+        return *this;
+    }
+    size_t approximate_nns_timed_out_queries() const { return _approximate_nns_timed_out_queries; }
 
     vespalib::duration doomOvertime() const { return vespalib::from_s(_doomOvertime.max()); }
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.h
@@ -159,6 +159,7 @@ private:
     using SoftDoomFactor = vespalib::datastore::AtomicValueWrapper<double>;
     SoftDoomFactor         _softDoomFactor;
     Avg                    _querySetupTime;
+    Avg                    _approximate_nns_time;
     Avg                    _queryLatency;
     Avg                    _matchTime;
     Avg                    _groupingTime;
@@ -253,6 +254,15 @@ public:
     size_t querySetupTimeCount() const { return _querySetupTime.count(); }
     double querySetupTimeMin() const { return _querySetupTime.min(); }
     double querySetupTimeMax() const { return _querySetupTime.max(); }
+
+    MatchingStats& approximate_nns_time(double time_s) {
+        _approximate_nns_time.set(time_s);
+        return *this;
+    }
+    double approximate_nns_time_avg() const { return _approximate_nns_time.avg(); }
+    size_t approximate_nns_time_count() const { return _approximate_nns_time.count(); }
+    double approximate_nns_time_min() const { return _approximate_nns_time.min(); }
+    double approximate_nns_time_max() const { return _approximate_nns_time.max(); }
 
     MatchingStats& queryLatency(double time_s) {
         _queryLatency.set(time_s);


### PR DESCRIPTION
Adds a stat for the number of queries with an ANN timeout and stat for the time spent in ANN.

For the latter, a query without ANN searches is currently counted with no time (vs. not counted at all). I am planning to change that in a later PR as not counting these queries gives you more information. (We already have the total number of queries, so only counting these that actually perform ANN searches gives you the precise number of queries that perform ANN searches. If you want the average time spent on ANN over all queries, you can still compute that manually.)