### PR TITLE
Rewrite variable definition in test to fix warning

### DIFF
--- a/searchlib/src/tests/hitcollector/hitcollector_test.cpp
+++ b/searchlib/src/tests/hitcollector/hitcollector_test.cpp
@@ -263,8 +263,8 @@ TEST(HitCollectorTest, require_that_hits_for_2nd_phase_candidates_can_be_retriev
 }
 
 TEST(HitCollectorTest, require_that_score_ranges_can_be_read_and_set) {
-    std::pair<Scores, Scores> ranges = std::make_pair(Scores(1.0, 2.0), Scores(3.0, 4.0));
-    HitCollector              hc(20, 10);
+    auto         ranges = std::pair{Scores(1.0, 2.0), Scores(3.0, 4.0)};
+    HitCollector hc(20, 10);
     hc.setRanges(ranges);
     EXPECT_EQ(ranges.first.low, hc.getRanges().first.low);
     EXPECT_EQ(ranges.first.high, hc.getRanges().first.high);


### PR DESCRIPTION
The warning:

```
In file included from /opt/rh/gcc-toolset-15/root/usr/include/c++/15/utility:71,
                 from /home/johsol/git/vespa/vespalib/src/vespa/vespalib/util/memory_allocator.h:8,
                 from /home/johsol/git/vespa/vespalib/src/vespa/vespalib/util/alloc.h:4,
                 from /home/johsol/git/vespa/searchlib/src/vespa/searchlib/common/bitvector.h:7,
                 from /home/johsol/git/vespa/searchlib/src/tests/hitcollector/hitcollector_test.cpp:3:
/opt/rh/gcc-toolset-15/root/usr/include/c++/15/bits/stl_pair.h: In instantiation of 'constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = search::queryeval::Scores; _T2 = search::queryeval::Scores; typename __strip_reference_wrapper<typename decay<_Tp>::type>::__type = search::queryeval::Scores; typename decay<_Tp>::type = search::queryeval::Scores; typename __strip_reference_wrapper<typename decay<_Tp2>::type>::__type = search::queryeval::Scores; typename decay<_Tp2>::type = search::queryeval::Scores]':
/home/johsol/git/vespa/searchlib/src/tests/hitcollector/hitcollector_test.cpp:266:54:   required from here
  266 |     std::pair<Scores, Scores> ranges = std::make_pair(Scores(1.0, 2.0), Scores(3.0, 4.0));
      |                                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rh/gcc-toolset-15/root/usr/include/c++/15/bits/stl_pair.h:1164:5: note: parameter passing for argument of type 'std::pair<search::queryeval::Scores, search::queryeval::Scores>' when C++17 is enabled changed to match C++14 in GCC 10.1
 1164 |     make_pair(_T1&& __x, _T2&& __y)
      |     ^~~~~~~~~
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
