### PR TITLE
Magnus/language server fixes

### DIFF
--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -658,7 +658,7 @@ ParsedSchema rootSchema :
 rootSchemaItem(ParsedSchema schema) : {}
     (
         documentElm(schema)
-       | documentId(schema)
+       | documentIdElm(schema)
        | rawAsBase64(schema)
        | searchStemming(schema)
        | importField(schema)
@@ -1849,7 +1849,7 @@ void idElm(ParsedField field) :
  *
  * @param schema the schema object to add setting to
  */
-void documentId(ParsedSchema schema) :
+void documentIdElm(ParsedSchema schema) :
 {
     boolean attribute = false;
 }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -49,19 +49,20 @@ public class BodyKeywordCompletion implements CompletionProvider {
     // Currently key is the classLeafIdentifierString of a node with a body
     private static Map<Class<?>, List<CompletionItem>> bodyKeywordSnippets = new HashMap<>() {{
         put(rootSchema.class, List.of(
+            CompletionUtils.constructSnippet("annotation", "annotation ${1:name} {\n\t$0\n}"),
+            CompletionUtils.constructSnippet("constant", "constant ${1:name} {\n\t$0\n}"),
             CompletionUtils.constructSnippet("document", "document ${1:name} {\n\t$0\n}"),
-            FixedKeywordBodies.INDEX.getColonSnippet(true),
-            FixedKeywordBodies.INDEX.getBodySnippet(true),
+            CompletionUtils.constructSnippet("document-summary", "document-summary ${1:name} {\n\t$0\n}"),
             CompletionUtils.constructSnippet("field", "field ${1:name} type $2 {$0}"),
             CompletionUtils.constructSnippet("fieldset", "fieldset ${1:default} {\n\tfields: $0\n}"),
-            CompletionUtils.constructSnippet("rank-profile", "rank-profile ${1:name} {\n\t$0\n}"),
-            CompletionUtils.constructSnippet("constant", "constant ${1:name} {\n\t$0\n}"),
-            CompletionUtils.constructSnippet("onnx-model", "onnx-model ${1:name} {\n\t$0\n}"),
-            FixedKeywordBodies.STEMMING.getColonSnippet(),
-            CompletionUtils.constructSnippet("document-summary", "document-summary ${1:name} {\n\t$0\n}"),
-            CompletionUtils.constructSnippet("annotation", "annotation ${1:name} {\n\t$0\n}"),
             CompletionUtils.constructSnippet("import field", "import field ${1:name} as $2 {}"),
-            CompletionUtils.constructSnippet("raw-as-base64-in-summary", "raw-as-base64-in-summary")
+            CompletionUtils.constructSnippet("onnx-model", "onnx-model ${1:name} {\n\t$0\n}"),
+            CompletionUtils.constructSnippet("rank-profile", "rank-profile ${1:name} {\n\t$0\n}"),
+            CompletionUtils.constructSnippet("raw-as-base64-in-summary", "raw-as-base64-in-summary"),
+            FixedKeywordBodies.DOCUMENT_ID.getColonSnippet(),
+            FixedKeywordBodies.INDEX.getBodySnippet(true),
+            FixedKeywordBodies.INDEX.getColonSnippet(true),
+            FixedKeywordBodies.STEMMING.getColonSnippet()
         ));
 
         put(documentElm.class, List.of(

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/FixedKeywordBodies.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/FixedKeywordBodies.java
@@ -12,6 +12,7 @@ import ai.vespa.schemals.parser.Token.TokenType;
 import ai.vespa.schemals.parser.ast.attributeElm;
 import ai.vespa.schemals.parser.ast.attributeSetting;
 import ai.vespa.schemals.parser.ast.dictionarySetting;
+import ai.vespa.schemals.parser.ast.documentIdElm;
 import ai.vespa.schemals.parser.ast.fieldRankFilter;
 import ai.vespa.schemals.parser.ast.fieldStemming;
 import ai.vespa.schemals.parser.ast.hnswIndex;
@@ -222,5 +223,10 @@ public class FixedKeywordBodies {
     public static FixedKeywordBody EXECUTION_MODE = new FixedKeywordBody("execution-mode", TokenType.EXECUTION_MODE, onnxModelItem.class, List.of(
         CompletionUtils.constructBasic("parallel"),
         CompletionUtils.constructBasic("sequential")
+    ));
+
+    public static FixedKeywordBody DOCUMENT_ID = new FixedKeywordBody("documentid", TokenType.DOCUMENTID, documentIdElm.class, List.of(
+        CompletionUtils.constructBasic("attribute"),
+        CompletionUtils.constructBasic("from-disk")
     ));
 }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokenConfig.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokenConfig.java
@@ -65,6 +65,7 @@ class SchemaSemanticTokenConfig {
         add(TokenType.DENSE_POSTING_LIST_THRESHOLD);
         add(TokenType.DIVERSITY);
         add(TokenType.DOCUMENT);
+        add(TokenType.DOCUMENTID);
         add(TokenType.DOCUMENT_SUMMARY);
         add(TokenType.ELEMENT_GAP);
         add(TokenType.ENABLE_BM25);

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokens.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokens.java
@@ -26,10 +26,14 @@ import ai.vespa.schemals.lsp.common.semantictokens.CommonSemanticTokens;
 import ai.vespa.schemals.lsp.common.semantictokens.SemanticTokenMarker;
 import ai.vespa.schemals.parser.Token.TokenType;
 import ai.vespa.schemals.parser.TokenSource;
+import ai.vespa.schemals.parser.ast.ATTRIBUTE;
+import ai.vespa.schemals.parser.ast.DOCUMENTID;
 import ai.vespa.schemals.parser.ast.FILTER;
 import ai.vespa.schemals.parser.ast.RANK_TYPE;
 import ai.vespa.schemals.parser.ast.bool;
 import ai.vespa.schemals.parser.ast.dataType;
+import ai.vespa.schemals.parser.ast.documentElm;
+import ai.vespa.schemals.parser.ast.documentIdElm;
 import ai.vespa.schemals.parser.ast.fieldRankType;
 import ai.vespa.schemals.parser.ast.integerElm;
 import ai.vespa.schemals.parser.ast.matchItem;
@@ -198,8 +202,10 @@ public class SchemaSemanticTokens {
         if (node.getParent().getASTClass() == integerElm.class || node.getParent().getASTClass() == quotedString.class || node.getParent().getASTClass() == bool.class) return false;
         if (!node.isLeaf()) return false;
 
-        // ugly special case
+        // ugly special cases
         if (node.isASTInstance(FILTER.class)) return true;
+
+        if (node.isLeaf() && node.getParent().isASTInstance(documentIdElm.class) && !node.isASTInstance(DOCUMENTID.class)) return true;
 
         if (node.isASTInstance(RANK_TYPE.class)) return false;
 


### PR DESCRIPTION
Bug in congocc made it impossible to build the language server on macos (i think OS was the problem at least).
Fixed by ensuring no name collisions (even case insensitive). 
While I was at it, improved support for documentid in schema.

@johansolbakken PTAL