### PR TITLE
Tighten reserved CloudResourceTags validation

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -28,11 +28,11 @@ public class CloudResourceTags {
 
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\$\\{[^}]+\\}");
 
-    /** System tag names reserved by the platform. */
+    /** System tag names reserved by the platform. Compared case-insensitively against customer keys. */
     private static final List<String> RESERVED_TAG_NAMES = List.of(
             "applicationid", "athenz", "athenz-domain", "athenzservice", "fqdn", "name", "owner", "zone");
 
-    /** Key prefixes reserved by the platform. */
+    /** Key prefixes reserved by the platform. Compared case-insensitively against customer keys. */
     private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "bastion_");
 
     private static final List<String> PLACEHOLDERS = List.of(
@@ -159,11 +159,11 @@ public class CloudResourceTags {
             if (key.indexOf('\0') >= 0 || value.indexOf('\0') >= 0)
                 throw new IllegalArgumentException("Tag key or value contains null bytes for key '" + key + "'");
             for (String reserved : RESERVED_TAG_NAMES) {
-                if (key.equals(reserved))
+                if (key.equalsIgnoreCase(reserved))
                     throw new IllegalArgumentException("Tag key '" + key + "' is reserved by the platform");
             }
             for (String prefix : RESERVED_KEY_PREFIXES) {
-                if (key.startsWith(prefix))
+                if (key.regionMatches(true, 0, prefix, 0, prefix.length()))
                     throw new IllegalArgumentException("Tag key prefix '" + prefix + "' is reserved by the platform: '" + key + "'");
             }
         });

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -28,9 +28,15 @@ public class CloudResourceTags {
 
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\$\\{[^}]+\\}");
 
-    /** System tag names reserved by the platform. Compared case-insensitively against customer keys. */
+    /**
+     * System tag names reserved by the platform. Compared case-insensitively against customer keys.
+     * All new tag names must use the 'vai_' prefix.
+     */
     private static final List<String> RESERVED_TAG_NAMES = List.of(
-            "applicationid", "athenz", "athenz-domain", "athenzservice", "fqdn", "name", "owner", "zone");
+            "applicationid", "athenz", "athenz-domain", "athenzservice", "fqdn", "name", "owner", "zone",
+            "tenant", "tenantName", "app", "clusterid",
+            "system", "application", "cluster", "generation", "auth-method",
+            "preprovisioned");
 
     /** Key prefixes reserved by the platform. Compared case-insensitively against customer keys. */
     private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "bastion_");

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -168,6 +168,19 @@ class CloudResourceTagsTest {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("name", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("owner", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("zone", "value")));
+
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("tenant", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("tenantName", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("app", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("clusterid", "value")));
+
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("system", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("application", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("cluster", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("generation", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("auth-method", "value")));
+
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("preprovisioned", "value")));
     }
 
     @Test
@@ -462,7 +475,7 @@ class CloudResourceTagsTest {
                 "env", "${environment}",
                 "loc", "${region}",
                 "team", "${tenant}-${application}-${instance}",
-                "cluster", "${clustername}",
+                "cluster_name", "${clustername}",
                 "type", "${clustertype}",
                 "combined", "${environment}-${clustername}-${clustertype}"));
         var resolved = tags.resolve(testApp, testEnv, testRegion,
@@ -470,7 +483,7 @@ class CloudResourceTagsTest {
         assertEquals("prod", resolved.asMap().get("env"));
         assertEquals("aws-us-east-1c", resolved.asMap().get("loc"));
         assertEquals("tenant1-app1-default", resolved.asMap().get("team"));
-        assertEquals("my-search", resolved.asMap().get("cluster"));
+        assertEquals("my-search", resolved.asMap().get("cluster_name"));
         assertEquals("content", resolved.asMap().get("type"));
         assertEquals("prod-my-search-content", resolved.asMap().get("combined"));
     }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -171,9 +171,25 @@ class CloudResourceTagsTest {
     }
 
     @Test
+    void reserved_tag_names_rejected_case_insensitively() {
+        // System tags like "Name" (capital N) must collide with reserved "name".
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Name", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("APPLICATIONID", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Owner", "value")));
+    }
+
+    @Test
     void reserved_key_prefixes_rejected() {
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("vai_tag", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("corp_tag", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("bastion_tag", "value")));
+    }
+
+    @Test
+    void reserved_key_prefixes_rejected_case_insensitively() {
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("VAI_tag", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("CORP_tag", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Bastion_tag", "value")));
     }
 
     // --- Template variables ---


### PR DESCRIPTION
Tightens CloudResourceTags validation so customer keys cannot collide with platform tags. Ask for details if needed.