### PR TITLE
Only count queries with ANN searches for ANN time stat in MatchingStats

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_stats_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_stats_test.cpp
@@ -373,11 +373,12 @@ TEST(MatchingStatsTest, require_that_query_setup_stats_is_added_correctly) {
     EXPECT_EQ(0u, stats.approximate_nns_nodes_visited());
     EXPECT_EQ(0u, stats.approximate_nns_timed_out_queries());
     EXPECT_NEAR(0.0, stats.approximate_nns_time_avg(), 0.00001);
-    EXPECT_EQ(1u, stats.approximate_nns_time_count());
+    EXPECT_EQ(0u, stats.approximate_nns_time_count()); // Still zero since there were no searches in setup_stats
     {
         search::queryeval::QuerySetupStats setup_stats;
         setup_stats.add_to_approximate_nns_distances_computed(3);
         setup_stats.add_to_approximate_nns_nodes_visited(2);
+        setup_stats.add_to_approximate_nns_searches_performed(1);
         setup_stats.add_to_approximate_nns_timeouts_hit(1);
         setup_stats.add_to_approximate_nns_time_used(10ms);
         stats.add_query_setup_stats(setup_stats);
@@ -385,12 +386,13 @@ TEST(MatchingStatsTest, require_that_query_setup_stats_is_added_correctly) {
     EXPECT_EQ(3u, stats.approximate_nns_distances_computed());
     EXPECT_EQ(2u, stats.approximate_nns_nodes_visited());
     EXPECT_EQ(1u, stats.approximate_nns_timed_out_queries());
-    EXPECT_NEAR(0.005, stats.approximate_nns_time_avg(), 0.00001);
-    EXPECT_EQ(2u, stats.approximate_nns_time_count());
+    EXPECT_NEAR(0.01, stats.approximate_nns_time_avg(), 0.00001);
+    EXPECT_EQ(1u, stats.approximate_nns_time_count());
     {
         search::queryeval::QuerySetupStats setup_stats;
         setup_stats.add_to_approximate_nns_distances_computed(7);
         setup_stats.add_to_approximate_nns_nodes_visited(6);
+        setup_stats.add_to_approximate_nns_searches_performed(3);
         setup_stats.add_to_approximate_nns_timeouts_hit(5);
         setup_stats.add_to_approximate_nns_time_used(20ms);
         stats.add_query_setup_stats(setup_stats);
@@ -399,8 +401,8 @@ TEST(MatchingStatsTest, require_that_query_setup_stats_is_added_correctly) {
     EXPECT_EQ(8u, stats.approximate_nns_nodes_visited());
     // There were six timeouts, but these came from the same query/QuerySetupStats!
     EXPECT_EQ(2u, stats.approximate_nns_timed_out_queries());
-    EXPECT_NEAR(0.01, stats.approximate_nns_time_avg(), 0.00001);
-    EXPECT_EQ(3u, stats.approximate_nns_time_count());
+    EXPECT_NEAR(0.015, stats.approximate_nns_time_avg(), 0.00001);
+    EXPECT_EQ(2u, stats.approximate_nns_time_count());
 }
 
 TEST(MatchingStatsTest, require_that_query_eval_stats_is_added_correctly) {

--- a/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matching_stats.cpp
@@ -65,7 +65,9 @@ MatchingStats& MatchingStats::merge_partition(const Partition& partition, size_t
 MatchingStats& MatchingStats::add_query_setup_stats(const search::queryeval::QuerySetupStats& stats) noexcept {
     _approximate_nns_distances_computed += stats.approximate_nns_distances_computed();
     _approximate_nns_nodes_visited += stats.approximate_nns_nodes_visited();
-    _approximate_nns_time.add(Avg().set(vespalib::to_s(stats.approximate_nns_time_used())));
+    if (stats.approximate_nns_searches_performed() > 0) {
+        _approximate_nns_time.add(Avg().set(vespalib::to_s(stats.approximate_nns_time_used())));
+    }
     _approximate_nns_timed_out_queries += stats.approximate_nns_timeouts_hit() > 0 ? 1 : 0;
 
     return *this;

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1545,6 +1545,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(1, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(2, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(1, f.stats().approximate_nns_searches_performed());
     EXPECT_GT(f.stats().approximate_nns_time_used(), vespalib::duration::zero());
     EXPECT_EQ(0, f.stats().approximate_nns_timeouts_hit());
     vespalib::duration last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
@@ -1568,6 +1569,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(2, f.stats().approximate_nns_searches_performed());
     EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
     EXPECT_EQ(0, f.stats().approximate_nns_timeouts_hit());
     last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
@@ -1585,6 +1587,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(3, f.stats().approximate_nns_searches_performed());
     EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
     EXPECT_EQ(0, f.stats().approximate_nns_timeouts_hit());
     last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
@@ -1602,10 +1605,12 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(2, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(4, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(4, f.stats().approximate_nns_searches_performed());
     EXPECT_GT(f.stats().approximate_nns_time_used(), last_approximate_nns_time_used);
     EXPECT_EQ(1, f.stats().approximate_nns_timeouts_hit());
     size_t last_approximate_nns_distances_computed = f.stats().approximate_nns_distances_computed();
     size_t last_approximate_nns_nodes_visited = f.stats().approximate_nns_nodes_visited();
+    size_t last_approximate_nns_searches_performed = f.stats().approximate_nns_searches_performed();
     last_approximate_nns_time_used = f.stats().approximate_nns_time_used();
     size_t last_approximate_nns_timeouts_hit = f.stats().approximate_nns_timeouts_hit();
 
@@ -1622,6 +1627,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(last_approximate_nns_distances_computed, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(last_approximate_nns_nodes_visited, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(last_approximate_nns_searches_performed, f.stats().approximate_nns_searches_performed());
     EXPECT_EQ(last_approximate_nns_time_used, f.stats().approximate_nns_time_used());
     EXPECT_EQ(last_approximate_nns_timeouts_hit, f.stats().approximate_nns_timeouts_hit());
 
@@ -1635,6 +1641,7 @@ TEST(TensorAttributeTest, NN_blueprint_collects_stats) {
     }
     EXPECT_EQ(last_approximate_nns_distances_computed, f.stats().approximate_nns_distances_computed());
     EXPECT_EQ(last_approximate_nns_nodes_visited, f.stats().approximate_nns_nodes_visited());
+    EXPECT_EQ(last_approximate_nns_searches_performed, f.stats().approximate_nns_searches_performed());
     EXPECT_EQ(last_approximate_nns_time_used, f.stats().approximate_nns_time_used());
     EXPECT_EQ(last_approximate_nns_timeouts_hit, f.stats().approximate_nns_timeouts_hit());
 }

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -894,6 +894,12 @@ TEST(QueryEvalTest, test_setup_stats) {
     stats.add_to_approximate_nns_nodes_visited(2u);
     EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
 
+    EXPECT_EQ(0u, stats.approximate_nns_searches_performed());
+    stats.add_to_approximate_nns_searches_performed(11u);
+    EXPECT_EQ(11u, stats.approximate_nns_searches_performed());
+    stats.add_to_approximate_nns_searches_performed(7u);
+    EXPECT_EQ(18u, stats.approximate_nns_searches_performed());
+
     EXPECT_EQ(vespalib::duration::zero(), stats.approximate_nns_time_used());
     stats.add_to_approximate_nns_time_used(vespalib::duration(1234));
     EXPECT_EQ(vespalib::duration(1234), stats.approximate_nns_time_used());
@@ -909,6 +915,7 @@ TEST(QueryEvalTest, test_setup_stats) {
     // Make sure all stats are unchanged
     EXPECT_EQ(2u, stats.approximate_nns_distances_computed());
     EXPECT_EQ(4u, stats.approximate_nns_nodes_visited());
+    EXPECT_EQ(18u, stats.approximate_nns_searches_performed());
     EXPECT_EQ(vespalib::duration(2000), stats.approximate_nns_time_used());
     EXPECT_EQ(3u, stats.approximate_nns_timeouts_hit());
 }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -62,7 +62,7 @@ NearestNeighborBlueprint::AnnStats::AnnStats()
 void NearestNeighborBlueprint::AnnStats::flush(search::queryeval::QuerySetupStats& setup_stats) const {
     setup_stats.add_to_approximate_nns_distances_computed(index_stats.distances_computed());
     setup_stats.add_to_approximate_nns_nodes_visited(index_stats.nodes_visited());
-
+    setup_stats.add_to_approximate_nns_searches_performed(1u);
     setup_stats.add_to_approximate_nns_time_used(time_used);
     setup_stats.add_to_approximate_nns_timeouts_hit(timeout_hit);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -17,6 +17,7 @@ class QuerySetupStats {
 private:
     size_t             _approximate_nns_distances_computed;
     size_t             _approximate_nns_nodes_visited;
+    size_t             _approximate_nns_searches_performed;
     vespalib::duration _approximate_nns_time_used;
     size_t             _approximate_nns_timeouts_hit;
 
@@ -24,6 +25,7 @@ public:
     QuerySetupStats() noexcept
         : _approximate_nns_distances_computed(0),
           _approximate_nns_nodes_visited(0),
+          _approximate_nns_searches_performed(0),
           _approximate_nns_time_used(vespalib::duration::zero()),
           _approximate_nns_timeouts_hit(0) {}
 
@@ -34,6 +36,11 @@ public:
 
     size_t approximate_nns_nodes_visited() const noexcept { return _approximate_nns_nodes_visited; }
     void add_to_approximate_nns_nodes_visited(size_t value) noexcept { _approximate_nns_nodes_visited += value; }
+
+    size_t approximate_nns_searches_performed() const noexcept { return _approximate_nns_searches_performed; }
+    void add_to_approximate_nns_searches_performed(size_t value) noexcept {
+        _approximate_nns_searches_performed += value;
+    }
 
     vespalib::duration approximate_nns_time_used() const noexcept { return _approximate_nns_time_used; }
     void add_to_approximate_nns_time_used(vespalib::duration ann_time) noexcept {


### PR DESCRIPTION
Follow-up to https://github.com/vespa-engine/vespa/pull/36965. Adds the number of ANN searches to `QuerySetupStats` (but not to `MatchingStats`). Uses this to decide whether to add the time to `MatchingStats`. Seemed like the cleanest solution to me.