### PR TITLE
Notify about ANN timeout in search protocol

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -223,6 +223,10 @@ void updateCoverage(Coverage& coverage, const MaybeMatchPhaseLimiter& limiter, c
         coverage.degradeMatchPhase();
         LOG(debug, "was limited, degraded from match phase");
     }
+    if (my_stats.approximate_nns_timed_out_queries() > 0) {
+        coverage.degrade_ann_timeout();
+        LOG(debug, "ann timeout, degraded from timed-out ann search");
+    }
     if (my_stats.softDoomed()) {
         coverage.degradeTimeout();
         LOG(debug, "soft doomed, degraded from timeout covered = %" PRIu64, coverage.getCovered());

--- a/searchlib/src/protobuf/search_protocol.proto
+++ b/searchlib/src/protobuf/search_protocol.proto
@@ -66,6 +66,7 @@ message SearchReply {
     bytes slime_trace = 9;
     repeated Error errors = 10;
     repeated string match_feature_names = 11;
+    bool degraded_by_ann_timeout = 12;
 }
 
 message Error {

--- a/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
+++ b/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
@@ -274,6 +274,15 @@ TEST_F(SearchReplyTest, require_that_degraded_by_match_phase_is_converted) {
     reply.coverage.degradeMatchPhase();
     convert();
     EXPECT_TRUE(proto.degraded_by_match_phase());
+    EXPECT_FALSE(proto.degraded_by_ann_timeout());
+    EXPECT_FALSE(proto.degraded_by_soft_timeout());
+}
+
+TEST_F(SearchReplyTest, require_that_degraded_by_ann_timeout_is_converted) {
+    reply.coverage.degrade_ann_timeout();
+    convert();
+    EXPECT_FALSE(proto.degraded_by_match_phase());
+    EXPECT_TRUE(proto.degraded_by_ann_timeout());
     EXPECT_FALSE(proto.degraded_by_soft_timeout());
 }
 
@@ -281,14 +290,17 @@ TEST_F(SearchReplyTest, require_that_degraded_by_soft_timeout_is_converted) {
     reply.coverage.degradeTimeout();
     convert();
     EXPECT_FALSE(proto.degraded_by_match_phase());
+    EXPECT_FALSE(proto.degraded_by_ann_timeout());
     EXPECT_TRUE(proto.degraded_by_soft_timeout());
 }
 
 TEST_F(SearchReplyTest, require_that_multiple_degraded_reasons_are_converted) {
     reply.coverage.degradeMatchPhase();
+    reply.coverage.degrade_ann_timeout();
     reply.coverage.degradeTimeout();
     convert();
     EXPECT_TRUE(proto.degraded_by_match_phase());
+    EXPECT_TRUE(proto.degraded_by_ann_timeout());
     EXPECT_TRUE(proto.degraded_by_soft_timeout());
 }
 

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
@@ -147,6 +147,7 @@ void ProtoConverter::search_reply_to_proto(const SearchReply& reply, ProtoSearch
     proto.set_active_docs(reply.coverage.getActive());
     proto.set_target_active_docs(reply.coverage.getTargetActive());
     proto.set_degraded_by_match_phase(reply.coverage.wasDegradedByMatchPhase());
+    proto.set_degraded_by_ann_timeout(reply.coverage.was_degraded_by_ann_timeout());
     proto.set_degraded_by_soft_timeout(reply.coverage.wasDegradedByTimeout());
     bool has_sort_data = !reply.sortIndex.empty();
     assert(!has_sort_data || (reply.sortIndex.size() == (reply.hits.size() + 1)));

--- a/searchlib/src/vespa/searchlib/engine/searchreply.h
+++ b/searchlib/src/vespa/searchlib/engine/searchreply.h
@@ -25,6 +25,7 @@ public:
     uint64_t getTargetActive() const { return _targetActive; }
 
     bool wasDegradedByMatchPhase() const { return ((_degradeReason & MATCH_PHASE) != 0); }
+    bool was_degraded_by_ann_timeout() const { return ((_degradeReason & ANN_TIMEOUT) != 0); }
     bool wasDegradedByTimeout() const { return ((_degradeReason & TIMEOUT) != 0); }
 
     Coverage& setCovered(uint64_t v) {
@@ -44,11 +45,17 @@ public:
         _degradeReason |= MATCH_PHASE;
         return *this;
     }
+
+    Coverage& degrade_ann_timeout() {
+        _degradeReason |= ANN_TIMEOUT;
+        return *this;
+    }
+
     Coverage& degradeTimeout() {
         _degradeReason |= TIMEOUT;
         return *this;
     }
-    enum DegradeReason { MATCH_PHASE = 0x01, TIMEOUT = 0x02 };
+    enum DegradeReason { MATCH_PHASE = 0x01, TIMEOUT = 0x02, ANN_TIMEOUT = 0x04 };
 
 private:
     uint64_t _covered;


### PR DESCRIPTION
This is needed to notify about an ANN timeout in the search response.