### PR TITLE
config-provisioning: Serialize profile in Zookeeper

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -22,7 +22,7 @@ public class ClusterMembership {
 
     private ClusterMembership(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                               ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones,
-                              String profile) {
+                              Optional<String> profile) {
         String[] components = stringValue.split("/");
         if (components.length < 3)
             throw new RuntimeException("Could not parse '" + stringValue + "' to a cluster membership. " +
@@ -64,7 +64,7 @@ public class ClusterMembership {
                                   .stateful(stateful)
                                   .sidecars(sidecars)
                                   .availabilityZones(availabilityZones)
-                                  .profile(profile)
+                                  .profile(profile.orElse(null))
                                   .build();
         this.index = nodeIndex;
         this.retired = retired;
@@ -156,12 +156,12 @@ public class ClusterMembership {
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                                          ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones) {
-        return from(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones, null);
+        return from(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones, Optional.empty());
     }
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                                          ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones,
-                                         String profile) {
+                                         Optional<String> profile) {
         return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones, profile);
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -21,7 +21,8 @@ public class ClusterMembership {
     private final String stringValue;
 
     private ClusterMembership(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
-                              ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones) {
+                              ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones,
+                              String profile) {
         String[] components = stringValue.split("/");
         if (components.length < 3)
             throw new RuntimeException("Could not parse '" + stringValue + "' to a cluster membership. " +
@@ -63,6 +64,7 @@ public class ClusterMembership {
                                   .stateful(stateful)
                                   .sidecars(sidecars)
                                   .availabilityZones(availabilityZones)
+                                  .profile(profile)
                                   .build();
         this.index = nodeIndex;
         this.retired = retired;
@@ -154,7 +156,13 @@ public class ClusterMembership {
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                                          ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones) {
-        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones);
+        return from(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones, null);
+    }
+
+    public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
+                                         ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones,
+                                         String profile) {
+        return new ClusterMembership(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones, profile);
     }
 
     public static ClusterMembership from(ClusterSpec cluster, int index) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
@@ -251,7 +251,7 @@ public class AllocatedHostsSerializer {
                                       zoneEndpoint(object.field(loadBalancerSettingsKey)),
                                       sidecars(object.field(sidecarsKey)),
                                       availabilityZones(object.field(availabilityZonesKey)),
-                                      object.field(profileKey).valid() ? object.field(profileKey).asString() : null);
+                                      object.field(profileKey).valid() ? Optional.of(object.field(profileKey).asString()) : Optional.empty());
     }
 
     private static void sidecarsToSlime(List<SidecarSpec> sidecars, Cursor arrayCursor) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializer.java
@@ -84,6 +84,7 @@ public class AllocatedHostsSerializer {
     private static final String hostSpecNetworkPortsKey = "ports";
     private static final String sidecarsKey = "sidecars";
     private static final String availabilityZonesKey = "azs";
+    private static final String profileKey = "profile";
 
     public static byte[] toJson(AllocatedHosts allocatedHosts) throws IOException {
         Slime slime = new Slime();
@@ -111,6 +112,7 @@ public class AllocatedHostsSerializer {
                 sidecarsToSlime(sidecars, object.setArray(sidecarsKey));
 
             availabilityZonesToSlime(membership.cluster().availabilityZones(), object.setArray(availabilityZonesKey));
+            membership.cluster().profile().ifPresent(profile -> object.setString(profileKey, profile));
         });
         toSlime(host.realResources(), object.setObject(realResourcesKey));
         toSlime(host.advertisedResources(), object.setObject(advertisedResourcesKey));
@@ -246,9 +248,10 @@ public class AllocatedHostsSerializer {
                                       object.field(hostSpecDockerImageRepoKey).valid()
                                       ? Optional.of(DockerImage.fromString(object.field(hostSpecDockerImageRepoKey).asString()))
                                       : Optional.empty(),
-                                      zoneEndpoint(object.field(loadBalancerSettingsKey)), 
+                                      zoneEndpoint(object.field(loadBalancerSettingsKey)),
                                       sidecars(object.field(sidecarsKey)),
-                                      availabilityZones(object.field(availabilityZonesKey)));
+                                      availabilityZones(object.field(availabilityZonesKey)),
+                                      object.field(profileKey).valid() ? object.field(profileKey).asString() : null);
     }
 
     private static void sidecarsToSlime(List<SidecarSpec> sidecars, Cursor arrayCursor) {

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
@@ -108,7 +108,7 @@ public class ClusterMembershipTest {
                 ZoneEndpoint.defaultEndpoint,
                 List.of(),
                 List.of(),
-                "large-storage"
+                Optional.of("large-storage")
         );
         assertEquals(Optional.of("large-storage"), withProfile.cluster().profile());
         ClusterMembership withoutProfile = ClusterMembership.from(
@@ -118,7 +118,7 @@ public class ClusterMembershipTest {
                 ZoneEndpoint.defaultEndpoint,
                 List.of(),
                 List.of(),
-                null
+                Optional.empty()
         );
         assertEquals(Optional.empty(), withoutProfile.cluster().profile());
     }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
@@ -4,6 +4,7 @@ package com.yahoo.config.provision;
 import com.yahoo.component.Vtag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,6 +96,31 @@ public class ClusterMembershipTest {
         ClusterMembership membership = ClusterMembership.from(cluster, 37);
         assertEquals(Optional.of("large-storage"), membership.cluster().profile());
         assertEquals("content/id1//37/stateful", membership.stringValue());
+    }
+
+    @Test
+    void testProfilePropagatedFromDeserializationParameters() {
+        String membershipString = "content/id1//37/stateful";
+        ClusterMembership withProfile = ClusterMembership.from(
+                membershipString,
+                Vtag.currentVersion,
+                Optional.empty(),
+                ZoneEndpoint.defaultEndpoint,
+                List.of(),
+                List.of(),
+                "large-storage"
+        );
+        assertEquals(Optional.of("large-storage"), withProfile.cluster().profile());
+        ClusterMembership withoutProfile = ClusterMembership.from(
+                membershipString,
+                Vtag.currentVersion,
+                Optional.empty(),
+                ZoneEndpoint.defaultEndpoint,
+                List.of(),
+                List.of(),
+                null
+        );
+        assertEquals(Optional.empty(), withoutProfile.cluster().profile());
     }
 
     private void assertContainerService(ClusterMembership instance) {

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
@@ -106,7 +106,7 @@ public class AllocatedHostsSerializerTest {
                                anyDiskSpeedNode,
                                ClusterMembership.from("container/test/0/0", Version.fromString("6.73.1"),
                                                       Optional.empty(), ZoneEndpoint.defaultEndpoint, List.of(), List.of(),
-                                                      "large-storage"),
+                                                      Optional.of("large-storage")),
                                Optional.empty(),
                                Optional.empty(),
                                Optional.empty()));
@@ -176,6 +176,19 @@ public class AllocatedHostsSerializerTest {
             if (host.hostname().equals(hostname))
                 return host;
         throw new IllegalArgumentException("No host " + hostname + " is present");
+    }
+
+    @Test
+    void testProfileRoundTrip() throws IOException {
+        var membership = ClusterMembership.from("container/test/0/0", Version.fromString("6.73.1"),
+                                                Optional.empty(), ZoneEndpoint.defaultEndpoint, List.of(), List.of(),
+                                                Optional.of("large-storage"));
+        var host = new HostSpec("with-profile",
+                                smallSlowDiskSpeedNode, bigSlowDiskSpeedNode, anyDiskSpeedNode,
+                                membership, Optional.empty(), Optional.empty(), Optional.empty());
+        AllocatedHosts deserialized = fromJson(toJson(AllocatedHosts.withHosts(Set.of(host))));
+        assertEquals(Optional.of("large-storage"),
+                     requireHost("with-profile", deserialized).membership().get().cluster().profile());
     }
 
     @Test

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/serialization/AllocatedHostsSerializerTest.java
@@ -100,7 +100,16 @@ public class AllocatedHostsSerializerTest {
                                Optional.of(new NetworkPorts(List.of(new NetworkPorts.Allocation(1234, "service1", "configId1", "suffix1"),
                                                       new NetworkPorts.Allocation(4567, "service2", "configId2", "suffix2")))),
                                Optional.empty()));
-
+        hosts.add(new HostSpec("with-profile",
+                               smallSlowDiskSpeedNode,
+                               bigSlowDiskSpeedNode,
+                               anyDiskSpeedNode,
+                               ClusterMembership.from("container/test/0/0", Version.fromString("6.73.1"),
+                                                      Optional.empty(), ZoneEndpoint.defaultEndpoint, List.of(), List.of(),
+                                                      "large-storage"),
+                               Optional.empty(),
+                               Optional.empty(),
+                               Optional.empty()));
         hosts.add(new HostSpec("with-sidecars",
                 smallSlowDiskSpeedNode,
                 bigSlowDiskSpeedNode,
@@ -152,6 +161,7 @@ public class AllocatedHostsSerializerTest {
             HostSpec deserializedHost = requireHost(expectedHost.hostname(), deserializedHosts);
             assertEquals(expectedHost.hostname(), deserializedHost.hostname());
             assertEquals(expectedHost.membership(), deserializedHost.membership());
+            assertEquals(expectedHost.membership().map(m -> m.cluster().profile()), deserializedHost.membership().map(m -> m.cluster().profile()));
             assertEquals(expectedHost.realResources(), deserializedHost.realResources());
             assertEquals(expectedHost.advertisedResources(), deserializedHost.advertisedResources());
             assertEquals(expectedHost.requestedResources(), deserializedHost.requestedResources());


### PR DESCRIPTION
`ClusterSpec.profile` was not persisted in Zookeeper through the `AllocatedHostsSerializer`, and thus was not propagated  to the `StaticProvisioner` during application package redeployments.

Serialized the profile in Zookeeper, and ensured it was wired back to `ClusterMembership`.
