### PR TITLE
Add transient_memory_for_flush member function to attribute vectors and

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -598,6 +598,7 @@ TEST(DocumentMetaStoreTest, gids_can_be_saved_and_loaded) {
     uint64_t expSaveBytesSize =
         DocumentMetaStore::minHeaderLen + (1000 - 4) * DocumentMetaStore::entry_size(true, false);
     EXPECT_EQ(expSaveBytesSize, dms1.getEstimatedSaveByteSize());
+    EXPECT_EQ(0, dms1.transient_memory_for_flush());
     TuneFileAttributes      tuneFileAttributes;
     DummyFileHeaderContext  fileHeaderContext;
     AttributeFileSaveTarget saveTarget(tuneFileAttributes, fileHeaderContext);

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -1138,6 +1138,10 @@ uint64_t DocumentMetaStore::getEstimatedSaveByteSize() const {
     return estimate;
 }
 
+size_t DocumentMetaStore::transient_memory_for_flush() const noexcept {
+    return 0;
+}
+
 uint32_t DocumentMetaStore::getVersion() const {
     return _trackDocumentSizes ? (_track_32bit_document_sizes ? documentmetastore::DOCUMENT_SIZE32_TRACKING_VERSION
                                                               : documentmetastore::DOCUMENT_SIZE24_TRACKING_VERSION)

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -297,6 +297,7 @@ public:
     void onShrinkLidSpace() override;
     size_t getEstimatedShrinkLidSpaceGain() const override;
     uint64_t getEstimatedSaveByteSize() const override;
+    size_t transient_memory_for_flush() const noexcept override;
     uint32_t getVersion() const override;
     void setTrackDocumentSizes(bool trackDocumentSizes) { _trackDocumentSizes = trackDocumentSizes; }
     void set_track_32bit_document_sizes(bool value) noexcept { _track_32bit_document_sizes = value; }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -297,7 +297,7 @@ public:
     void onShrinkLidSpace() override;
     size_t getEstimatedShrinkLidSpaceGain() const override;
     uint64_t getEstimatedSaveByteSize() const override;
-    size_t transient_memory_for_flush() const noexcept override;
+    [[nodiscard]] size_t transient_memory_for_flush() const noexcept override;
     uint32_t getVersion() const override;
     void setTrackDocumentSizes(bool trackDocumentSizes) { _trackDocumentSizes = trackDocumentSizes; }
     void set_track_32bit_document_sizes(bool value) noexcept { _track_32bit_document_sizes = value; }

--- a/searchlib/src/tests/attribute/array_bool_attribute/array_bool_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/array_bool_attribute/array_bool_attribute_test.cpp
@@ -538,6 +538,7 @@ TEST_F(ArrayBoolAttributeTest, estimated_save_byte_size) {
     // 4096 + (8+7)/8 + 6*5 = 4096 + 1 + 30 = 4127 (with 1 reserved doc, 5 added = 6 docs)
     uint64_t expected = 4096 + (8 + 7) / 8 + 6 * 5;
     EXPECT_EQ(expected, estimate);
+    EXPECT_EQ(6 * sizeof(vespalib::datastore::EntryRef), _attr->transient_memory_for_flush());
 }
 
 class ArrayBoolExtAttributeTest : public ::testing::Test {

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -15,6 +15,7 @@
 #include <vespa/searchlib/attribute/multistringattribute.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/searchlib/attribute/singlestringattribute.h>
+#include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/test/weighted_type_test_utils.h>
 #include <vespa/searchlib/util/disk_space_calculator.h>
@@ -42,6 +43,7 @@ using search::index::DummyFileHeaderContext;
 using std::shared_ptr;
 using std::string;
 using vespalib::Generation;
+using vespalib::datastore::EntryRef;
 namespace fs = std::filesystem;
 
 namespace {
@@ -463,6 +465,14 @@ template <typename VectorType, typename BufferType> void AttributeTest::testRelo
     EXPECT_NE(zero_flush_duration, a->last_flush_duration());
     a->commit(CommitParam::UpdateStats::FORCE);
     {
+        bool   multivalue_attr = a->getConfig().collectionType().isMultiValue();
+        size_t entry_size = (a->hasEnum() || multivalue_attr) ? sizeof(EntryRef) : a->getFixedWidth();
+        size_t exp_transient_memory_for_flush = a->getCommittedDocIdLimit() * entry_size;
+        if (a->getBasicType() == BasicType::BOOL && !multivalue_attr) {
+            exp_transient_memory_for_flush =
+                BitVector::legacy_num_bytes_with_single_guard_bit(a->getCommittedDocIdLimit());
+        }
+        EXPECT_EQ(exp_transient_memory_for_flush, a->transient_memory_for_flush());
         double actSize = statSize(*b);
         EXPECT_LE(actSize, a->size_on_disk());
         EXPECT_EQ(stat_size_on_disk(*b), a->size_on_disk());

--- a/searchlib/src/tests/attribute/predicate_attribute/predicate_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/predicate_attribute/predicate_attribute_test.cpp
@@ -123,6 +123,7 @@ TEST_F(PredicateAttributeTest, save_and_load_predicate_attribute) {
     auto                  attr = make_sample_predicate_attribute();
     std::filesystem::path file_name(tmp_dir);
     file_name.append(attr_name);
+    EXPECT_NE(0, attr->transient_memory_for_flush());
     attr->save(file_name.native());
     EXPECT_NE(0, attr->size_on_disk());
     auto attr2 = make_attribute(file_name.native(), attr->getConfig(), false);
@@ -131,6 +132,7 @@ TEST_F(PredicateAttributeTest, save_and_load_predicate_attribute) {
     EXPECT_TRUE(attr2->isLoaded());
     EXPECT_EQ(11, attr2->getCommittedDocIdLimit());
     EXPECT_EQ(attr->size_on_disk(), attr2->size_on_disk());
+    EXPECT_EQ(attr->transient_memory_for_flush(), attr2->transient_memory_for_flush());
 }
 
 TEST_F(PredicateAttributeTest, buffer_size_mismatch_is_fatal_during_load) {

--- a/searchlib/src/tests/attribute/raw_attribute/raw_attribute_test.cpp
+++ b/searchlib/src/tests/attribute/raw_attribute/raw_attribute_test.cpp
@@ -32,6 +32,7 @@ using search::common::sortspec::MissingPolicy;
 using vespalib::Base64;
 using vespalib::IllegalArgumentException;
 using vespalib::Issue;
+using vespalib::datastore::EntryRef;
 
 using namespace std::literals;
 
@@ -231,6 +232,7 @@ TEST_F(RawAttributeTest, save_and_load) {
     EXPECT_EQ(0, _attr->size_on_disk());
     EXPECT_EQ(zero_flush_duration, _attr->last_flush_duration());
     auto estimated_write_bytes = _attr->getEstimatedSaveByteSize();
+    EXPECT_EQ(11 * sizeof(EntryRef), _attr->transient_memory_for_flush());
     _attr->save();
     EXPECT_EQ(std::filesystem::file_size(attr_path), estimated_write_bytes);
     auto saved_size_on_disk = _attr->size_on_disk();

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -79,6 +79,7 @@ using vespalib::GenerationGuard;
 using vespalib::GenerationHandler;
 using vespalib::SharedStringRepo;
 using vespalib::datastore::CompactionStrategy;
+using vespalib::datastore::EntryRef;
 using vespalib::eval::CellType;
 using vespalib::eval::FastValueBuilderFactory;
 using vespalib::eval::SimpleValue;
@@ -1697,15 +1698,18 @@ TEST_F(SparseTensorAttributeTest, size_on_disk_factor_is_calculated_and_used) {
     }
     EXPECT_LT(10, attr.getCommittedDocIdLimit());
     EXPECT_THAT(attr.getEstimatedSaveByteSize(), AllOf(Ge(40_Ki), Le(50_Ki)));
+    EXPECT_EQ(attr.getCommittedDocIdLimit() * sizeof(EntryRef), attr.transient_memory_for_flush());
     attr.save((_test_dir / "tensor").string());
     auto size_on_disk = attr.size_on_disk();
     EXPECT_LT(60_Ki, size_on_disk);
     EXPECT_THAT(attr.getEstimatedSaveByteSize(), AllOf(Ge(size_on_disk - 4_Ki), Le(size_on_disk + 4_Ki)));
+    EXPECT_EQ(attr.getCommittedDocIdLimit() * sizeof(EntryRef), attr.transient_memory_for_flush());
     auto real_attr2 = std::make_shared<SerializedFastValueAttribute>((_test_dir / "tensor").string(), cfg);
     AttributeVector& attr2 = *real_attr2;
     ASSERT_TRUE(attr2.load());
     EXPECT_EQ(size_on_disk, attr2.size_on_disk());
     EXPECT_THAT(attr2.getEstimatedSaveByteSize(), AllOf(Ge(size_on_disk - 4_Ki), Le(size_on_disk + 4_Ki)));
+    EXPECT_EQ(attr2.getCommittedDocIdLimit() * sizeof(EntryRef), attr2.transient_memory_for_flush());
     EXPECT_EQ(dynamic_memory_usage, attr2.getStatus().get_used_minus_dead_and_onhold() - initial_memory_usage);
     EXPECT_EQ(attr.getEstimatedSaveByteSize(), attr2.getEstimatedSaveByteSize());
 }

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -615,6 +615,25 @@ uint64_t AttributeVector::getEstimatedSaveByteSize() const {
     return datFileSize + weightFileSize + idxFileSize + udatFileSize;
 }
 
+size_t AttributeVector::transient_memory_for_flush() const noexcept {
+    uint32_t    committedDocIdLimit = getCommittedDocIdLimit();
+    const auto& cfg = getConfig();
+    size_t      elem_size = 4;
+    if (!cfg.collectionType().isMultiValue() && !hasEnum()) {
+        BasicType::Type basicType(getBasicType());
+        switch (basicType) {
+        case BasicType::Type::PREDICATE:
+        case BasicType::Type::TENSOR:
+        case BasicType::Type::REFERENCE:
+        case BasicType::Type::RAW:
+            break;
+        default:
+            elem_size = cfg.basicType().fixedSize();
+        }
+    }
+    return elem_size * committedDocIdLimit;
+}
+
 size_t AttributeVector::getEstimatedShrinkLidSpaceGain() const {
     size_t canFree = 0;
     if (canShrinkLidSpace()) {

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -494,7 +494,7 @@ public:
 
     virtual std::unique_ptr<AttributeSaver> onInitSave(std::string_view fileName);
     virtual uint64_t getEstimatedSaveByteSize() const;
-    virtual size_t transient_memory_for_flush() const noexcept;
+    [[nodiscard]] virtual size_t transient_memory_for_flush() const noexcept;
 
     static bool isEnumerated(const vespalib::GenericHeader& header);
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -494,6 +494,7 @@ public:
 
     virtual std::unique_ptr<AttributeSaver> onInitSave(std::string_view fileName);
     virtual uint64_t getEstimatedSaveByteSize() const;
+    virtual size_t transient_memory_for_flush() const noexcept;
 
     static bool isEnumerated(const vespalib::GenericHeader& header);
 

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
@@ -90,7 +90,8 @@ PredicateAttribute::PredicateAttribute(const std::string& base_file_name, const 
       _upper_bound(adjustUpperBound(config.predicateParams().arity(), config.predicateParams().upper_bound())),
       _min_feature(config.getGrowStrategy(), getGenerationHolder()),
       _interval_range_vector(config.getGrowStrategy(), getGenerationHolder()),
-      _max_interval_range(1) {
+      _max_interval_range(1),
+      _transient_memory_for_flush_stats(0) {
 }
 
 PredicateAttribute::~PredicateAttribute() {
@@ -127,6 +128,7 @@ void PredicateAttribute::onUpdateStat(CommitParam::UpdateStats updateStats) {
     combined.mergeGenerationHeldBytes(getGenerationHolder().get_held_bytes());
     this->updateStatistics(_min_feature.size(), _min_feature.size(), combined.allocatedBytes(), combined.usedBytes(),
                            combined.deadBytes(), combined.allocatedBytesOnHold());
+    update_transient_memory_for_flush();
 }
 
 void PredicateAttribute::reclaim_memory(Generation oldest_used_gen) {
@@ -150,6 +152,17 @@ std::unique_ptr<AttributeSaver> PredicateAttribute::onInitSave(std::string_view 
         PredicateAttributeSaver::IntervalRangeVector{interval_range_vector_view.begin(),
                                                      interval_range_vector_view.end()},
         _max_interval_range);
+}
+
+size_t PredicateAttribute::transient_memory_for_flush() const noexcept {
+    return _transient_memory_for_flush_stats.load(std::memory_order_relaxed);
+}
+
+void PredicateAttribute::update_transient_memory_for_flush() noexcept {
+    size_t transient_memory = _min_feature.size() * sizeof(uint8_t) +
+                              _interval_range_vector.size() * sizeof(IntervalRange) +
+                              _index->transient_memory_for_flush();
+    _transient_memory_for_flush_stats.store(transient_memory, std::memory_order_relaxed);
 }
 
 uint32_t PredicateAttribute::getVersion() const {
@@ -229,6 +242,7 @@ bool PredicateAttribute::onLoad(vespalib::Executor*) {
     set_size_on_disk(loaded_buffer->size_on_disk() + DiskSpaceCalculator::directory_placeholder_size());
     set_last_flush_duration(loaded_buffer->flush_duration());
     _index->onDeserializationCompleted();
+    update_transient_memory_for_flush();
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
@@ -50,7 +50,7 @@ public:
     predicate::PredicateIndex& getIndex() { return *_index; }
 
     std::unique_ptr<AttributeSaver> onInitSave(std::string_view fileName) override;
-    size_t transient_memory_for_flush() const noexcept override;
+    [[nodiscard]] size_t transient_memory_for_flush() const noexcept override;
     bool onLoad(vespalib::Executor* executor) override;
     void onCommit() override;
     void reclaim_memory(vespalib::Generation oldest_used_gen) override;

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.h
@@ -50,6 +50,7 @@ public:
     predicate::PredicateIndex& getIndex() { return *_index; }
 
     std::unique_ptr<AttributeSaver> onInitSave(std::string_view fileName) override;
+    size_t transient_memory_for_flush() const noexcept override;
     bool onLoad(vespalib::Executor* executor) override;
     void onCommit() override;
     void reclaim_memory(vespalib::Generation oldest_used_gen) override;
@@ -91,6 +92,9 @@ private:
 
     IntervalRangeVector _interval_range_vector;
     IntervalRange       _max_interval_range;
+    std::atomic<size_t> _transient_memory_for_flush_stats;
+
+    void update_transient_memory_for_flush() noexcept;
 
 public:
     static constexpr uint8_t  MIN_FEATURE_FILL = 255;

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
@@ -241,6 +241,10 @@ uint64_t SingleBoolAttribute::getEstimatedSaveByteSize() const {
     return headerSize + BitVector::legacy_num_bytes_with_single_guard_bit(getCommittedDocIdLimit());
 }
 
+size_t SingleBoolAttribute::transient_memory_for_flush() const noexcept {
+    return BitVector::legacy_num_bytes_with_single_guard_bit(getCommittedDocIdLimit());
+}
+
 void SingleBoolAttribute::reclaim_memory(Generation oldest_used_gen) {
     getGenerationHolder().reclaim(oldest_used_gen);
 }

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.h
@@ -32,6 +32,7 @@ public:
     void reclaim_memory(vespalib::Generation oldest_used_gen) override;
     void before_inc_generation(vespalib::Generation current_gen) override;
     uint64_t getEstimatedSaveByteSize() const override;
+    size_t transient_memory_for_flush() const noexcept override;
 
     std::unique_ptr<attribute::SearchContext> getSearch(std::unique_ptr<QueryTermSimple>      term,
                                                         const attribute::SearchContextParams& params) const override;

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.h
@@ -32,7 +32,7 @@ public:
     void reclaim_memory(vespalib::Generation oldest_used_gen) override;
     void before_inc_generation(vespalib::Generation current_gen) override;
     uint64_t getEstimatedSaveByteSize() const override;
-    size_t transient_memory_for_flush() const noexcept override;
+    [[nodiscard]] size_t transient_memory_for_flush() const noexcept override;
 
     std::unique_ptr<attribute::SearchContext> getSearch(std::unique_ptr<QueryTermSimple>      term,
                                                         const attribute::SearchContextParams& params) const override;

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.cpp
@@ -261,4 +261,8 @@ std::unique_ptr<ISaver> DocumentFeaturesStore::make_saver() const {
     return std::make_unique<DocumentFeaturesStoreSaver>(*this);
 }
 
+size_t DocumentFeaturesStore::transient_memory_for_flush() const noexcept {
+    return _refs.size() * sizeof(Refs);
+}
+
 } // namespace search::predicate

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.h
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.h
@@ -95,7 +95,7 @@ public:
     vespalib::MemoryUsage getMemoryUsage() const;
 
     std::unique_ptr<ISaver> make_saver() const;
-    size_t transient_memory_for_flush() const noexcept;
+    [[nodiscard]] size_t transient_memory_for_flush() const noexcept;
 };
 
 } // namespace search::predicate

--- a/searchlib/src/vespa/searchlib/predicate/document_features_store.h
+++ b/searchlib/src/vespa/searchlib/predicate/document_features_store.h
@@ -95,6 +95,7 @@ public:
     vespalib::MemoryUsage getMemoryUsage() const;
 
     std::unique_ptr<ISaver> make_saver() const;
+    size_t transient_memory_for_flush() const noexcept;
 };
 
 } // namespace search::predicate

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.cpp
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.cpp
@@ -133,6 +133,11 @@ std::unique_ptr<ISaver> PredicateIndex::make_saver() const {
         _bounds_index.make_saver(std::make_unique<IntervalSaver<IntervalWithBounds>>(_interval_store)));
 }
 
+size_t PredicateIndex::transient_memory_for_flush() const noexcept {
+    return _features_store.transient_memory_for_flush() + _interval_index.transient_memory_for_flush() +
+           _bounds_index.transient_memory_for_flush();
+};
+
 void PredicateIndex::onDeserializationCompleted() {
     _interval_index.promoteOverThresholdVectors();
     _bounds_index.promoteOverThresholdVectors();

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.h
@@ -65,6 +65,7 @@ public:
 
     ~PredicateIndex() override;
     std::unique_ptr<ISaver> make_saver() const;
+    size_t transient_memory_for_flush() const noexcept;
     void onDeserializationCompleted();
 
     void indexEmptyDocument(uint32_t doc_id);

--- a/searchlib/src/vespa/searchlib/predicate/predicate_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/predicate_index.h
@@ -65,7 +65,7 @@ public:
 
     ~PredicateIndex() override;
     std::unique_ptr<ISaver> make_saver() const;
-    size_t transient_memory_for_flush() const noexcept;
+    [[nodiscard]] size_t transient_memory_for_flush() const noexcept;
     void onDeserializationCompleted();
 
     void indexEmptyDocument(uint32_t doc_id);

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.h
@@ -207,6 +207,7 @@ public:
     }
 
     std::unique_ptr<ISaver> make_saver(std::unique_ptr<PostingSaver<Posting>> subsaver) const;
+    size_t transient_memory_for_flush() const noexcept;
 };
 
 template <typename Posting, typename Key, typename DocId>

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.h
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.h
@@ -207,7 +207,7 @@ public:
     }
 
     std::unique_ptr<ISaver> make_saver(std::unique_ptr<PostingSaver<Posting>> subsaver) const;
-    size_t transient_memory_for_flush() const noexcept;
+    [[nodiscard]] size_t transient_memory_for_flush() const noexcept;
 };
 
 template <typename Posting, typename Key, typename DocId>

--- a/searchlib/src/vespa/searchlib/predicate/simple_index.hpp
+++ b/searchlib/src/vespa/searchlib/predicate/simple_index.hpp
@@ -298,4 +298,9 @@ SimpleIndex<Posting, Key, DocId>::make_saver(std::unique_ptr<PostingSaver<Postin
                                                                    std::move(subsaver));
 }
 
+template <typename Posting, typename Key, typename DocId>
+size_t SimpleIndex<Posting, Key, DocId>::transient_memory_for_flush() const noexcept {
+    return _dictionary.size() * sizeof(vespalib::datastore::EntryRef);
+}
+
 } // namespace search::predicate


### PR DESCRIPTION
document meta store.

@vekterli : please review
