### PR TITLE
Add low-level (multi-)bit packing/unpacking utilities

### DIFF
--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(vespalib_quant_test_app TEST
     SOURCES
     centroid_test.cpp
     hadamard_test.cpp
+    multi_bit_packer_test.cpp
     rotator_test.cpp
     sign_flip_test.cpp
     DEPENDS

--- a/vespalib/src/tests/quant/multi_bit_packer_test.cpp
+++ b/vespalib/src/tests/quant/multi_bit_packer_test.cpp
@@ -1,0 +1,171 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/quant/multi_bit_packer.h>
+#include <vespa/vespalib/util/xoshiro.h>
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <format>
+#include <random>
+#include <span>
+#include <vector>
+
+using namespace ::testing;
+
+namespace vespalib::quant {
+
+template <uint8_t Bits>
+void do_test_bit_packing_of_all_representable_values() {
+    SCOPED_TRACE("bit packing of all representable values");
+    using BP = MultiBitPacker<Bits>;
+
+    // Ensure we can pack/unpack all representable values for Bits
+    for (uint8_t v = 0; v < (1u << Bits); ++v) {
+        // For a range of sizes that includes multiple full blocks with and without remainders
+        for (size_t n = 0; n < 32; ++n) {
+            // Test with destination arrays (both for packing and unpacking) that
+            // are all zeroes and all ones to ensure we do not accidentally leave
+            // dirty bits behind from the destination.
+            for (const uint8_t packed_init_value : {0x00, 0xff}) {
+                for (const uint8_t unpacked_init_value : {0x00, 0xff}) {
+                    std::vector<uint8_t> in(n);
+                    std::ranges::fill(in, v);
+                    // Input bits > Bits should be masked away to avoid tainting the output
+                    std::vector tainted_in = in;
+                    for (uint8_t& b : tainted_in) {
+                        b |= (0xff << Bits);
+                    }
+                    std::vector<uint8_t> packed(BP::packed_bytes(n), packed_init_value);
+                    BP::pack(packed.data(), tainted_in.data(), n);
+
+                    std::vector<uint8_t> unpacked(n, unpacked_init_value);
+                    BP::unpack(unpacked.data(), packed.data(), n);
+
+                    ASSERT_THAT(unpacked, ElementsAreArray(in))
+                        << "n=" << n << ", v=" << int(v) << "packed_init_value=" << int(packed_init_value)
+                        << ", unpacked_init_value=" << int(unpacked_init_value);
+                }
+            }
+        }
+    }
+}
+
+// Just testing with the same value for all packed/unpacked elements hides
+// possible permutation errors, so also test with random element values.
+template <uint8_t Bits>
+void do_test_bit_packing_of_randomized_values() {
+    SCOPED_TRACE("bit packing of randomized values");
+    using BP = MultiBitPacker<Bits>;
+    const uint64_t         seed = std::random_device{}();
+    Xoshiro256PlusPlusPrng prng(seed);
+
+    auto gen_rand_value = [&prng]() noexcept { return prng() & ((1u << Bits) - 1); };
+
+    for (size_t n = 1; n < 32; ++n) {
+        // Reuse vectors across rounds to help catch any dirty bit reuse
+        std::vector<uint8_t> in(n);
+        std::vector<uint8_t> packed(BP::packed_bytes(n));
+        std::vector<uint8_t> unpacked(n);
+
+        for (size_t i = 0; i < 1'000; ++i) {
+            std::ranges::generate(in, gen_rand_value);
+            BP::pack(packed.data(), in.data(), n);
+            BP::unpack(unpacked.data(), packed.data(), n);
+            ASSERT_THAT(unpacked, ElementsAreArray(in)) << "n=" << n << ", seed=" << std::hex << seed;
+        }
+    }
+}
+
+template <uint8_t Bits>
+void do_test_remainder_bits_are_zeroed() {
+    SCOPED_TRACE("remainder bits are zeroed");
+    using BP = MultiBitPacker<Bits>;
+    static_assert(BP::packed_bytes(1) == 1);
+    std::array<uint8_t, 1> dst{};
+    std::array<uint8_t, 1> src = {(1u << Bits) - 1};
+    BP::pack(dst.data(), src.data(), 1);
+    // Every 1-element packing fits within a byte and should live in its LSBs.
+    // The MSBs should then consequently be zero. This is not an exhaustive test.
+    constexpr uint8_t msb_mask = static_cast<uint8_t>(0xff << Bits);
+    EXPECT_EQ(dst[0] & msb_mask, 0);
+}
+
+template <uint8_t Bits>
+void do_run_bit_pack_unpack_tests() {
+    ASSERT_NO_FATAL_FAILURE(do_test_bit_packing_of_all_representable_values<Bits>());
+    ASSERT_NO_FATAL_FAILURE(do_test_bit_packing_of_randomized_values<Bits>());
+    ASSERT_NO_FATAL_FAILURE(do_test_remainder_bits_are_zeroed<Bits>());
+}
+
+TEST(MultiBitPackerTest, packed_byte_count_is_calculated_for_1_bit) {
+    using BP = MultiBitPacker<1>;
+    EXPECT_EQ(BP::packed_bytes(0), 0);
+    for (size_t i = 1; i <= 8; ++i) {
+        EXPECT_EQ(BP::packed_bytes(i), 1);
+    }
+    EXPECT_EQ(BP::packed_bytes(9), 2);
+    EXPECT_EQ(BP::packed_bytes(16), 2);
+    EXPECT_EQ(BP::packed_bytes(17), 3);
+}
+
+TEST(MultiBitPackerTest, can_pack_and_unpack_1_bit_values) {
+    do_run_bit_pack_unpack_tests<1>();
+}
+
+TEST(MultiBitPackerTest, packed_byte_count_is_calculated_for_2_bits) {
+    using BP = MultiBitPacker<2>;
+    EXPECT_EQ(BP::packed_bytes(0), 0);
+    for (size_t i = 1; i <= 4; ++i) {
+        EXPECT_EQ(BP::packed_bytes(i), 1);
+    }
+    EXPECT_EQ(BP::packed_bytes(5), 2);
+    EXPECT_EQ(BP::packed_bytes(8), 2);
+    EXPECT_EQ(BP::packed_bytes(9), 3);
+}
+
+TEST(MultiBitPackerTest, can_pack_and_unpack_2_bit_values) {
+    do_run_bit_pack_unpack_tests<2>();
+}
+
+TEST(MultiBitPackerTest, packed_byte_count_is_calculated_for_3_bits) {
+    using BP = MultiBitPacker<3>;
+    EXPECT_EQ(BP::packed_bytes(0), 0);
+    EXPECT_EQ(BP::packed_bytes(1), 1);
+    EXPECT_EQ(BP::packed_bytes(2), 1);
+    EXPECT_EQ(BP::packed_bytes(3), 2); // 3rd value is split across 2 bytes
+    EXPECT_EQ(BP::packed_bytes(4), 2);
+    EXPECT_EQ(BP::packed_bytes(5), 2);
+    EXPECT_EQ(BP::packed_bytes(6), 3); // Also split across 2 bytes
+    EXPECT_EQ(BP::packed_bytes(7), 3);
+    EXPECT_EQ(BP::packed_bytes(8), 3);
+    EXPECT_EQ(BP::packed_bytes(9), 4);
+}
+
+TEST(MultiBitPackerTest, can_pack_and_unpack_3_bit_values) {
+    do_run_bit_pack_unpack_tests<3>();
+}
+
+TEST(MultiBitPackerTest, packed_byte_count_is_calculated_for_4_bits) {
+    using BP = MultiBitPacker<4>;
+    EXPECT_EQ(BP::packed_bytes(0), 0);
+    EXPECT_EQ(BP::packed_bytes(1), 1);
+    EXPECT_EQ(BP::packed_bytes(2), 1);
+    EXPECT_EQ(BP::packed_bytes(3), 2);
+    EXPECT_EQ(BP::packed_bytes(4), 2);
+    EXPECT_EQ(BP::packed_bytes(5), 3);
+}
+
+TEST(MultiBitPackerTest, can_pack_and_unpack_4_bit_values) {
+    do_run_bit_pack_unpack_tests<4>();
+}
+
+TEST(MultiBitPackerTest, bit_packer_function_dispatch_chooses_correct_packer_type) {
+    for (const uint8_t b : {1, 2, 3, 4}) {
+        const size_t bytes = with_packer_for_bit_count(b, [](auto bp) { return decltype(bp)::packed_bytes(8); });
+        ASSERT_EQ(bytes, b); // 1-1 for 8 element packing
+    }
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/block_multi_bit_packer.h
+++ b/vespalib/src/vespa/vespalib/quant/block_multi_bit_packer.h
@@ -1,0 +1,342 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+
+namespace vespalib::quant {
+
+/*
+ * Bit count-specialized functions for efficiently packing and unpacking multiple
+ * bits in a blockwise manner, with dedicated functions for handling non-block
+ * sized remainder cases (somewhat less efficiently).
+ */
+
+template <uint8_t B> struct BlockMultiBitPacker;
+
+/*
+ * General notes:
+ *  - We can't make any assumptions about the initial state of the destination
+ *    array elements (both for packing and unpacking), so we must ensure that all
+ *    "unrelated" bits are zeroed.
+ *  - Related to the above point, we also don't make any assumptions on the
+ *    _source_ element bits that are > the packing bit-count, so we must mask
+ *    those away.
+ *  - (un)pack1_to_7 is only called in a context where the compiler knows (due
+ *    to the branches taken and the constraints on the input) that `n` is
+ *    guaranteed to be in the range [1, 7]. This allows for opportunistically
+ *    unrolling remainder for-loops when inlined.
+ */
+
+/*
+ * 1-bit packed layout:
+ *
+ *    byte 0
+ * | 7654 3210 |
+ *
+ */
+template <>
+struct BlockMultiBitPacker<1> {
+    inline static void pack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        *dst = (src[0] & 0x1) << 0;
+        *dst |= (src[1] & 0x1) << 1;
+        *dst |= (src[2] & 0x1) << 2;
+        *dst |= (src[3] & 0x1) << 3;
+        *dst |= (src[4] & 0x1) << 4;
+        *dst |= (src[5] & 0x1) << 5;
+        *dst |= (src[6] & 0x1) << 6;
+        *dst |= (src[7] & 0x1) << 7;
+    }
+
+    inline static void pack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                  const size_t n) noexcept {
+        *dst = (src[0] & 0x1); // Must ensure `dst` is initialized before ORing in anything
+        for (size_t i = 1; i < n; ++i) {
+            *dst |= (src[i] & 0x1) << i;
+        }
+    }
+
+    inline static void unpack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        dst[0] = (*src >> 0) & 0x1;
+        dst[1] = (*src >> 1) & 0x1;
+        dst[2] = (*src >> 2) & 0x1;
+        dst[3] = (*src >> 3) & 0x1;
+        dst[4] = (*src >> 4) & 0x1;
+        dst[5] = (*src >> 5) & 0x1;
+        dst[6] = (*src >> 6) & 0x1;
+        dst[7] = (*src >> 7) & 0x1;
+    }
+
+    inline static void unpack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                    const size_t n) noexcept {
+        for (size_t i = 0; i < n; ++i) {
+            dst[i] = (*src >> i) & 0x1;
+        }
+    }
+};
+
+/*
+ * 2-bit packed layout:
+ *
+ *    byte 0      byte 1
+ * | 3322 1100 | 7766 5544 |
+ */
+template <>
+struct BlockMultiBitPacker<2> {
+    inline static void pack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        dst[0] = (src[0] & 0x3) << 0;
+        dst[0] |= (src[1] & 0x3) << 2;
+        dst[0] |= (src[2] & 0x3) << 4;
+        dst[0] |= (src[3] & 0x3) << 6;
+        dst[1] = (src[4] & 0x3) << 0;
+        dst[1] |= (src[5] & 0x3) << 2;
+        dst[1] |= (src[6] & 0x3) << 4;
+        dst[1] |= (src[7] & 0x3) << 6;
+    }
+
+    inline static void pack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                  const size_t n) noexcept {
+        dst[0] = (src[0] & 0x3) << 0;
+        if (n == 1) {
+            return;
+        }
+        dst[0] |= (src[1] & 0x3) << 2;
+        if (n == 2) {
+            return;
+        }
+        dst[0] |= (src[2] & 0x3) << 4;
+        if (n == 3) {
+            return;
+        }
+        dst[0] |= (src[3] & 0x3) << 6;
+        if (n == 4) {
+            return;
+        }
+        dst[1] = (src[4] & 0x3) << 0;
+        if (n == 5) {
+            return;
+        }
+        dst[1] |= (src[5] & 0x3) << 2;
+        if (n == 6) {
+            return;
+        }
+        dst[1] |= (src[6] & 0x3) << 4;
+        if (n == 7) {
+            return;
+        }
+        dst[1] |= (src[7] & 0x3) << 6;
+    }
+
+    inline static void unpack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        dst[0] = (src[0] >> 0) & 0x3;
+        dst[1] = (src[0] >> 2) & 0x3;
+        dst[2] = (src[0] >> 4) & 0x3;
+        dst[3] = (src[0] >> 6) & 0x3;
+        dst[4] = (src[1] >> 0) & 0x3;
+        dst[5] = (src[1] >> 2) & 0x3;
+        dst[6] = (src[1] >> 4) & 0x3;
+        dst[7] = (src[1] >> 6) & 0x3;
+    }
+
+    inline static void unpack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                    const size_t n) noexcept {
+        dst[0] = (src[0] >> 0) & 0x3;
+        if (n == 1) {
+            return;
+        }
+        dst[1] = (src[0] >> 2) & 0x3;
+        if (n == 2) {
+            return;
+        }
+        dst[2] = (src[0] >> 4) & 0x3;
+        if (n == 3) {
+            return;
+        }
+        dst[3] = (src[0] >> 6) & 0x3;
+        if (n == 4) {
+            return;
+        }
+        dst[4] = (src[1] >> 0) & 0x3;
+        if (n == 5) {
+            return;
+        }
+        dst[5] = (src[1] >> 2) & 0x3;
+        if (n == 6) {
+            return;
+        }
+        dst[6] = (src[1] >> 4) & 0x3;
+        if (n == 7) {
+            return;
+        }
+        dst[7] = (src[1] >> 6) & 0x3;
+    }
+};
+
+/*
+ * 3-bit packed layout:
+ *
+ *    byte 0      byte 1      byte 2
+ * | 2211 1000 | 5444 3332 | 7776 6655 |
+ */
+template <>
+struct BlockMultiBitPacker<3> {
+    static_assert(std::endian::native == std::endian::little);
+
+    inline static void pack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        uint32_t tmp = 0;
+        tmp |= (src[0] & 0x7) << (3 * 0);
+        tmp |= (src[1] & 0x7) << (3 * 1);
+        tmp |= (src[2] & 0x7) << (3 * 2);
+        tmp |= (src[3] & 0x7) << (3 * 3);
+        tmp |= (src[4] & 0x7) << (3 * 4);
+        tmp |= (src[5] & 0x7) << (3 * 5);
+        tmp |= (src[6] & 0x7) << (3 * 6);
+        tmp |= (src[7] & 0x7) << (3 * 7);
+        memcpy(dst, &tmp, 3); // Assumes little-endian
+    }
+
+    inline static void pack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                  const size_t n) noexcept {
+        uint32_t tmp = 0;
+        for (size_t i = 0; i < n; ++i) {
+            tmp |= (src[i] & 0x7) << (3 * i);
+        }
+        dst[0] = tmp & 0xff;
+        if (n < 3) {
+            return; // 6 bits packed, 2 remainder zero bits
+        }
+        dst[1] = (tmp >> 8) & 0xff;
+        if (n < 6) {
+            return; // 8+5 bits packed, 1 remainder zero bit
+        }
+        dst[2] = tmp >> 16;
+    }
+
+    inline static void unpack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        const uint32_t tmp = src[0] | (src[1] << 8) | (src[2] << 16);
+        dst[0] = (tmp >> (3 * 0)) & 0x7;
+        dst[1] = (tmp >> (3 * 1)) & 0x7;
+        dst[2] = (tmp >> (3 * 2)) & 0x7;
+        dst[3] = (tmp >> (3 * 3)) & 0x7;
+        dst[4] = (tmp >> (3 * 4)) & 0x7;
+        dst[5] = (tmp >> (3 * 5)) & 0x7;
+        dst[6] = (tmp >> (3 * 6)) & 0x7;
+        dst[7] = (tmp >> (3 * 7)) & 0x7;
+    }
+
+    inline static void unpack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                    const size_t n) noexcept {
+        uint32_t tmp = src[0];
+        if (n > 2) {
+            tmp |= src[1] << 8;
+        }
+        if (n > 5) {
+            tmp |= src[2] << 16;
+        }
+        for (size_t i = 0; i < n; ++i) {
+            dst[i] = (tmp >> (3 * i)) & 0x7;
+        }
+    }
+};
+
+/*
+ * 4-bit packed layout:
+ *
+ *    byte 0      byte 1      byte 2      byte 3
+ * | 1111 0000 | 3333 2222 | 5555 4444 | 7777 6666 |
+ */
+template <>
+struct BlockMultiBitPacker<4> {
+    inline static void pack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        dst[0] = (src[0] & 0xf);
+        dst[0] |= (src[1] & 0xf) << 4;
+        dst[1] = (src[2] & 0xf);
+        dst[1] |= (src[3] & 0xf) << 4;
+        dst[2] = (src[4] & 0xf);
+        dst[2] |= (src[5] & 0xf) << 4;
+        dst[3] = (src[6] & 0xf);
+        dst[3] |= (src[7] & 0xf) << 4;
+    }
+
+    inline static void pack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                  const size_t n) noexcept {
+        dst[0] = (src[0] & 0xf) << 0;
+        if (n == 1) {
+            return;
+        }
+        dst[0] |= (src[1] & 0xf) << 4;
+        if (n == 2) {
+            return;
+        }
+        dst[1] = (src[2] & 0xf) << 0;
+        if (n == 3) {
+            return;
+        }
+        dst[1] |= (src[3] & 0xf) << 4;
+        if (n == 4) {
+            return;
+        }
+        dst[2] = (src[4] & 0xf) << 0;
+        if (n == 5) {
+            return;
+        }
+        dst[2] |= (src[5] & 0xf) << 4;
+        if (n == 6) {
+            return;
+        }
+        dst[3] = (src[6] & 0xf) << 0;
+        if (n == 7) {
+            return;
+        }
+        dst[3] |= (src[7] & 0xf) << 4;
+    }
+
+    inline static void unpack8(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src) noexcept {
+        dst[0] = src[0] & 0xf;
+        dst[1] = src[0] >> 4;
+        dst[2] = src[1] & 0xf;
+        dst[3] = src[1] >> 4;
+        dst[4] = src[2] & 0xf;
+        dst[5] = src[2] >> 4;
+        dst[6] = src[3] & 0xf;
+        dst[7] = src[3] >> 4;
+    }
+
+    // TODO reverse order switch-case fallthrough (quasi Duff's device)?
+    inline static void unpack1_to_7(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src,
+                                    const size_t n) noexcept {
+        dst[0] = src[0] & 0xf;
+        if (n == 1) {
+            return;
+        }
+        dst[1] = src[0] >> 4;
+        if (n == 2) {
+            return;
+        }
+        dst[2] = src[1] & 0xf;
+        if (n == 3) {
+            return;
+        }
+        dst[3] = src[1] >> 4;
+        if (n == 4) {
+            return;
+        }
+        dst[4] = src[2] & 0xf;
+        if (n == 5) {
+            return;
+        }
+        dst[5] = src[2] >> 4;
+        if (n == 6) {
+            return;
+        }
+        dst[6] = src[3] & 0xf;
+        if (n == 7) {
+            return;
+        }
+        dst[7] = src[3] >> 4;
+    }
+};
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/multi_bit_packer.h
+++ b/vespalib/src/vespa/vespalib/quant/multi_bit_packer.h
@@ -1,0 +1,120 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "block_multi_bit_packer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+namespace vespalib::quant {
+
+template <uint8_t B> struct BlockMultiBitPacker;
+
+/*
+ * Utility for packing and unpacking u8 values to/from `Bits` number of bits per value.
+ *
+ * The packing layout used is very simple; the packed buffer is treated as a large
+ * contiguous sequence of bits packed into bytes LSB-first, with zero-bit MSB padding
+ * of remainders in the last byte.
+ *
+ * Example: a sequence of 4-bit values [ A, B, C, D, E] is packed as follows:
+ *
+ * byte:         0           1           2
+ *         | BBBB AAAA | DDDD CCCC | 0000 EEEE |
+ * bit:      7       0   7       0   7       0
+ */
+template <uint8_t Bits>
+struct MultiBitPacker {
+    static_assert(Bits >= 1 && Bits <= 4, "bit count outside valid range [1, 4]");
+
+    /*
+     * Pack `n` u8 values from `src` into `packed_bytes(n)` bytes in `dst`, representing
+     * each value using exactly `Bits` number of bits. Source values that are greater than
+     * or equal to 2**Bits are _truncated_; there is no implicit _saturation_ of values.
+     *
+     * `dst` does not have to be zeroed out prior to calling this function.
+     *
+     * If the number of written elements*Bits does not evenly divide into bytes, the last
+     * byte will be padded with 0-bits.
+     *
+     * Preconditions:
+     *   - `dst` and `src` arrays must not alias.
+     */
+    static void pack(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src, const size_t n) noexcept {
+        // We process elements in blocks of 8 since this allows us to write (for
+        // packing) or read (for unpacking) 1, 2, 3 or 4 bytes at a time for
+        // 1, 2, 3 and 4 bits, respectively. So the number of bits conveniently
+        // happens to be == the number of bytes.
+        constexpr size_t out_bytes_per_block = Bits;
+        const size_t     blocks = n / 8;
+        const size_t     rem = n % 8;
+
+        for (size_t b = 0; b < blocks; ++b) {
+            BlockMultiBitPacker<Bits>::pack8(dst, src);
+            src += 8;
+            dst += out_bytes_per_block;
+        }
+        if (rem != 0) {
+            BlockMultiBitPacker<Bits>::pack1_to_7(dst, src, rem);
+        }
+    }
+
+    /*
+     * Unpack `n` u8 values from `packed_bytes(n)` bytes in `src` into `dst`. I.e. each
+     * packed value is unpacked and written as its own u8. Exactly `n` bytes are written
+     * to `dst`.
+     *
+     * Preconditions:
+     *   - `dst` and `src` arrays must not alias.
+     */
+    static void unpack(uint8_t* __restrict__ dst, const uint8_t* __restrict__ src, const size_t n) noexcept {
+        constexpr size_t in_bytes_per_block = Bits;
+        const size_t     blocks = n / 8;
+        const size_t     rem = n % 8;
+
+        for (size_t b = 0; b < blocks; ++b) {
+            BlockMultiBitPacker<Bits>::unpack8(dst, src);
+            src += in_bytes_per_block;
+            dst += 8;
+        }
+        if (rem != 0) {
+            BlockMultiBitPacker<Bits>::unpack1_to_7(dst, src, rem);
+        }
+    }
+
+    /*
+     * Computes the number of bytes that `pack(dst, src, n)` will write into `dst` when
+     * packing `n` elements from `src`.
+     */
+    [[nodiscard]] static constexpr size_t packed_bytes(const size_t n) noexcept {
+        return ((n * Bits) / 8) + (((n * Bits) % 8) != 0 ? 1 : 0);
+    }
+};
+
+/*
+ * Compile-time instantiates `fn` for all possible BitPacker bit-specializations
+ * and invokes the one matching `bits` at runtime as `fn(BitPacker<bits> bp)`.
+ *
+ * Use `declspec(bp)` to get access to the static functions on the passed BitPacker.
+ *
+ * Precondition: `bits` is in the range [1, 4].
+ */
+template <typename Fn>
+auto with_packer_for_bit_count(uint8_t bits, Fn fn) {
+    switch (bits) {
+    case 1:
+        return fn(MultiBitPacker<1>());
+    case 2:
+        return fn(MultiBitPacker<2>());
+    case 3:
+        return fn(MultiBitPacker<3>());
+    case 4:
+        return fn(MultiBitPacker<4>());
+    default:
+        abort();
+    }
+}
+
+} // namespace vespalib::quant


### PR DESCRIPTION
@havardpe please review~

This adds some hopefully reasonably efficient utilities for packing a sequence of u8 values uniformly into a specified number of bits, and similarly for unpacking said sequence of bits pack to the original u8 sequence. Input values that are too large to be represented by the desired number of bits are implicitly truncated (_not_ saturated).

1-4 bits (inclusive) are supported.

Since I couldn't find a good way of making a _generic_ n-bit packing/unpacking algorithm that was both understandable and fast, this uses hand-rolled "kernels" for each bit width. We split processing into N 8-element blocks and 0-1 remainder blocks. Packing/unpacking 8 u8 elements at a time has the convenient property that {1, 2, 3, 4} bits writes/reads {1, 2, 3, 4} full bytes, respectively.

The packing layout used is very simple; the packed buffer is treated as a large contiguous sequence of bits packed into bytes LSB-first, with zero-bit MSB padding of remainders (if any) in the last byte.

Example: a sequence of 4-bit values `[A, B, C, D, E]` is packed as follows:
```
 byte:         0           1           2
         | BBBB AAAA | DDDD CCCC | 0000 EEEE |
 bit:      7       0   7       0   7       0
```
Similarly, 3-bit packing of the same sequence:
```
 byte:         0           1
         | CCBB BAAA | 0EEE DDDC
 bit:      7       0   7       0
```