### PR TITLE
Add timing-related ANN metrics

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
@@ -112,10 +112,13 @@ void DocumentDBTaggedMetrics::MatchingMetrics::update(const MatchingStats& stats
     exact_nns_distances_computed.inc(stats.exact_nns_distances_computed());
     approximate_nns_distances_computed.inc(stats.approximate_nns_distances_computed());
     approximate_nns_nodes_visited.inc(stats.approximate_nns_nodes_visited());
+    approximate_nns_timed_out_queries.inc(stats.approximate_nns_timed_out_queries());
     softDoomedQueries.inc(stats.softDoomed());
     queries.inc(stats.queries());
     querySetupTime.addValueBatch(stats.querySetupTimeAvg(), stats.querySetupTimeCount(), stats.querySetupTimeMin(),
                                  stats.querySetupTimeMax());
+    query_approximate_nns_time.addValueBatch(stats.approximate_nns_time_avg(), stats.approximate_nns_time_count(),
+                                             stats.approximate_nns_time_min(), stats.approximate_nns_time_max());
     queryLatency.addValueBatch(stats.queryLatencyAvg(), stats.queryLatencyCount(), stats.queryLatencyMin(),
                                stats.queryLatencyMax());
 }
@@ -133,8 +136,15 @@ DocumentDBTaggedMetrics::MatchingMetrics::MatchingMetrics(MetricSet* parent)
       approximate_nns_nodes_visited("approximate_nns_nodes_visited", {},
                                     "Number of nodes visited in approximate nearest-neighbor search", this),
       queries("queries", {}, "Number of queries executed", this),
+      approximate_nns_timed_out_queries("approximate_nns_timed_out_queries", {},
+                                        "Number of queries hitting the approximate nearest-neighbor search timeout",
+                                        this),
       softDoomedQueries("soft_doomed_queries", {}, "Number of queries hitting the soft timeout", this),
       querySetupTime("query_setup_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
+      query_approximate_nns_time(
+          "query_approximate_nns_time", {},
+          "Average time (sec) spent on approximate nearest-neighbor search in queries that perform such searches",
+          this),
       queryLatency("query_latency", {}, "Total average latency (sec) when matching and ranking a query", this) {
 }
 
@@ -156,12 +166,19 @@ DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::RankProfileMetrics
                                     "Number of nodes visited in approximate nearest-neighbor search", this),
       queries("queries", {}, "Number of queries executed", this),
       limitedQueries("limited_queries", {}, "Number of queries limited in match phase", this),
+      approximate_nns_timed_out_queries("approximate_nns_timed_out_queries", {},
+                                        "Number of queries hitting the approximate nearest-neighbor search timeout",
+                                        this),
       softDoomedQueries("soft_doomed_queries", {}, "Number of queries hitting the soft timeout", this),
       softDoomFactor("soft_doom_factor", {}, "Factor used to compute soft-timeout", this),
       matchTime("match_time", {}, "Average time (sec) for matching a query (1st phase)", this),
       groupingTime("grouping_time", {}, "Average time (sec) spent on grouping", this),
       rerankTime("rerank_time", {}, "Average time (sec) spent on 2nd phase ranking", this),
       querySetupTime("query_setup_time", {}, "Average time (sec) spent setting up and tearing down queries", this),
+      query_approximate_nns_time(
+          "query_approximate_nns_time", {},
+          "Average time (sec) spent on approximate nearest-neighbor search in queries that perform such searches",
+          this),
       queryLatency("query_latency", {}, "Total average latency (sec) when matching and ranking a query", this) {
     softDoomFactor.set(MatchingStats::INITIAL_SOFT_DOOM_FACTOR);
     for (size_t i = 0; i < numDocIdPartitions; ++i) {
@@ -205,6 +222,7 @@ void DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::update(const 
     approximate_nns_nodes_visited.inc(stats.approximate_nns_nodes_visited());
     queries.inc(stats.queries());
     limitedQueries.inc(stats.limited_queries());
+    approximate_nns_timed_out_queries.inc(stats.approximate_nns_timed_out_queries());
     softDoomedQueries.inc(stats.softDoomed());
     softDoomFactor.set(stats.softDoomFactor());
     matchTime.addValueBatch(stats.matchTimeAvg(), stats.matchTimeCount(), stats.matchTimeMin(), stats.matchTimeMax());
@@ -214,6 +232,8 @@ void DocumentDBTaggedMetrics::MatchingMetrics::RankProfileMetrics::update(const 
                              stats.rerankTimeMax());
     querySetupTime.addValueBatch(stats.querySetupTimeAvg(), stats.querySetupTimeCount(), stats.querySetupTimeMin(),
                                  stats.querySetupTimeMax());
+    query_approximate_nns_time.addValueBatch(stats.approximate_nns_time_avg(), stats.approximate_nns_time_count(),
+                                             stats.approximate_nns_time_min(), stats.approximate_nns_time_max());
     queryLatency.addValueBatch(stats.queryLatencyAvg(), stats.queryLatencyCount(), stats.queryLatencyMin(),
                                stats.queryLatencyMax());
     if (stats.getNumPartitions() > 0) {

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
@@ -107,8 +107,10 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet {
         metrics::LongCountMetric     approximate_nns_distances_computed;
         metrics::LongCountMetric     approximate_nns_nodes_visited;
         metrics::LongCountMetric     queries;
+        metrics::LongCountMetric     approximate_nns_timed_out_queries;
         metrics::LongCountMetric     softDoomedQueries;
         metrics::DoubleAverageMetric querySetupTime;
+        metrics::DoubleAverageMetric query_approximate_nns_time;
         metrics::DoubleAverageMetric queryLatency;
 
         struct RankProfileMetrics : metrics::MetricSet {
@@ -135,12 +137,14 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet {
             metrics::LongCountMetric     approximate_nns_nodes_visited;
             metrics::LongCountMetric     queries;
             metrics::LongCountMetric     limitedQueries;
+            metrics::LongCountMetric     approximate_nns_timed_out_queries;
             metrics::LongCountMetric     softDoomedQueries;
             metrics::DoubleValueMetric   softDoomFactor;
             metrics::DoubleAverageMetric matchTime;
             metrics::DoubleAverageMetric groupingTime;
             metrics::DoubleAverageMetric rerankTime;
             metrics::DoubleAverageMetric querySetupTime;
+            metrics::DoubleAverageMetric query_approximate_nns_time;
             metrics::DoubleAverageMetric queryLatency;
             DocIdPartitions              partitions;
 


### PR DESCRIPTION
`approximate_nns_timed_out_queries` and `query_approximate_nns_time`.

The naming is a bit verbose. Tried to follow the `approximate_nns_` naming scheme of the existing metrics and to combine that with `soft_doomed_queries` and `query_setup_time`, respectively.

@arnej27959 fyi