### PR TITLE
Report ANN timeout in search response

### DIFF
--- a/container-disc/abi-spec.json
+++ b/container-disc/abi-spec.json
@@ -211,6 +211,7 @@
       "public boolean isDegradedByMatchPhase()",
       "public boolean isDegradedByTimeout()",
       "public boolean isDegradedByAdapativeTimeout()",
+      "public boolean isDegradedByAnnTimeout()",
       "public boolean isDegradedByNonIdealState()",
       "public boolean getFull()",
       "public int getNodes()",
@@ -232,7 +233,8 @@
       "protected com.yahoo.container.handler.Coverage$FullCoverageDefinition fullReason",
       "public static final int DEGRADED_BY_MATCH_PHASE",
       "public static final int DEGRADED_BY_TIMEOUT",
-      "public static final int DEGRADED_BY_ADAPTIVE_TIMEOUT"
+      "public static final int DEGRADED_BY_ADAPTIVE_TIMEOUT",
+      "public static final int DEGRADED_BY_ANN_TIMEOUT"
     ]
   },
   "com.yahoo.container.handler.FilterBackingRequestHandler" : {

--- a/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -28,6 +28,7 @@ public class Coverage {
     public final static int DEGRADED_BY_MATCH_PHASE = 1;
     public final static int DEGRADED_BY_TIMEOUT = 2;
     public final static int DEGRADED_BY_ADAPTIVE_TIMEOUT = 4;
+    public final static int DEGRADED_BY_ANN_TIMEOUT = 8;
 
     protected Coverage(long docs, long active, int nodes, int resultSets) {
         this(docs, active, nodes, resultSets, FullCoverageDefinition.DOCUMENT_COUNT);
@@ -103,6 +104,7 @@ public class Coverage {
     public boolean isDegradedByMatchPhase() { return (degradedReason & DEGRADED_BY_MATCH_PHASE) != 0; }
     public boolean isDegradedByTimeout() { return (degradedReason & DEGRADED_BY_TIMEOUT) != 0; }
     public boolean isDegradedByAdapativeTimeout() { return (degradedReason & DEGRADED_BY_ADAPTIVE_TIMEOUT) != 0; }
+    public boolean isDegradedByAnnTimeout() { return (degradedReason & DEGRADED_BY_ANN_TIMEOUT) != 0; }
     public boolean isDegradedByNonIdealState() { return (degradedReason == 0) && (getResultPercentage() != 100);}
 
     /** Returns whether the search had full coverage or not */
@@ -172,7 +174,8 @@ public class Coverage {
     public com.yahoo.container.logging.Coverage toLoggingCoverage() {
         int degradation = com.yahoo.container.logging.Coverage.toDegradation(isDegradedByMatchPhase(),
                 isDegradedByTimeout(),
-                isDegradedByAdapativeTimeout());
+                isDegradedByAdapativeTimeout(),
+                isDegradedByAnnTimeout());
         return new com.yahoo.container.logging.Coverage(getDocs(), getActive(), getTargetActive(), degradation);
     }
 

--- a/container-disc/src/main/java/com/yahoo/container/logging/Coverage.java
+++ b/container-disc/src/main/java/com/yahoo/container/logging/Coverage.java
@@ -12,6 +12,7 @@ public class Coverage {
     private final static int DEGRADED_BY_MATCH_PHASE = 1;
     private final static int DEGRADED_BY_TIMEOUT = 2;
     private final static int DEGRADED_BY_ADAPTIVE_TIMEOUT = 4;
+    private final static int DEGRADED_BY_ANN_TIMEOUT = 8;
     public Coverage(long docs, long active, long targetActive, int degradedReason) {
         this.docs = docs;
         this.active = active;
@@ -27,7 +28,7 @@ public class Coverage {
         return active;
     }
 
-    public static int toDegradation(boolean degradeByMatchPhase, boolean degradedByTimeout, boolean degradedByAdaptiveTimeout) {
+    public static int toDegradation(boolean degradeByMatchPhase, boolean degradedByTimeout, boolean degradedByAdaptiveTimeout, boolean degradedByAnnTimeout) {
         int v = 0;
         if (degradeByMatchPhase) {
             v |= DEGRADED_BY_MATCH_PHASE;
@@ -38,6 +39,9 @@ public class Coverage {
         if (degradedByAdaptiveTimeout) {
             v |= DEGRADED_BY_ADAPTIVE_TIMEOUT;
         }
+        if (degradedByAnnTimeout) {
+            v |= DEGRADED_BY_ANN_TIMEOUT;
+        }
         return v;
     }
 
@@ -47,6 +51,7 @@ public class Coverage {
     public boolean isDegradedByMatchPhase() { return (degradedReason & DEGRADED_BY_MATCH_PHASE) != 0; }
     public boolean isDegradedByTimeout() { return (degradedReason & DEGRADED_BY_TIMEOUT) != 0; }
     public boolean isDegradedByAdapativeTimeout() { return (degradedReason & DEGRADED_BY_ADAPTIVE_TIMEOUT) != 0; }
+    public boolean isDegradedByAnnTimeout() { return (degradedReason & DEGRADED_BY_ANN_TIMEOUT) != 0; }
     public boolean isDegradedByNonIdealState() { return (degradedReason == 0) && (getResultPercentage() != 100);}
 
     /**

--- a/container-disc/src/main/java/com/yahoo/container/logging/JSONFormatter.java
+++ b/container-disc/src/main/java/com/yahoo/container/logging/JSONFormatter.java
@@ -29,6 +29,7 @@ public class JSONFormatter implements LogWriter<RequestLogEntry> {
     private static final String COVERAGE_DEGRADE_MATCHPHASE = "match-phase";
     private static final String COVERAGE_DEGRADE_TIMEOUT = "timeout";
     private static final String COVERAGE_DEGRADE_ADAPTIVE_TIMEOUT = "adaptive-timeout";
+    private static final String COVERAGE_DEGRADE_ANN_TIMEOUT = "anntimeout";
     private static final String COVERAGE_DEGRADED_NON_IDEAL_STATE = "non-ideal-state";
 
     private final JsonFactory generatorFactory;
@@ -131,6 +132,8 @@ public class JSONFormatter implements LogWriter<RequestLogEntry> {
                             generator.writeBooleanField(COVERAGE_DEGRADE_TIMEOUT, c.isDegradedByTimeout());
                         if (c.isDegradedByAdapativeTimeout())
                             generator.writeBooleanField(COVERAGE_DEGRADE_ADAPTIVE_TIMEOUT, c.isDegradedByAdapativeTimeout());
+                        if (c.isDegradedByAnnTimeout())
+                            generator.writeBooleanField(COVERAGE_DEGRADE_ANN_TIMEOUT, c.isDegradedByAnnTimeout());
                         if (c.isDegradedByNonIdealState())
                             generator.writeBooleanField(COVERAGE_DEGRADED_NON_IDEAL_STATE, c.isDegradedByNonIdealState());
                         generator.writeEndObject();

--- a/container-disc/src/test/java/com/yahoo/container/logging/JSONLogTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/logging/JSONLogTestCase.java
@@ -294,6 +294,10 @@ public class JSONLogTestCase {
                 newRequestLogEntry("test",  new Coverage(100, 200, 200, 4)).build());
         verifyCoverage("\"coverage\":{\"coverage\":0,\"documents\":0,\"degraded\":{\"timeout\":true}}",
                 newRequestLogEntry("test",  new Coverage(0, 0, 0, 2)).build());
+        verifyCoverage("\"coverage\":{\"coverage\":50,\"documents\":100,\"degraded\":{\"anntimeout\":true}}",
+                newRequestLogEntry("test",  new Coverage(100, 200, 200, 8)).build());
+        verifyCoverage("\"coverage\":{\"coverage\":100,\"documents\":0,\"degraded\":{\"anntimeout\":true}}",
+                newRequestLogEntry("test",  new Coverage(0, 0, 0, 8)).build());
     }
 
     private String formatEntry(RequestLogEntry entry) {

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -77,7 +77,7 @@ public class StatisticsSearcher extends Searcher {
     private final PeakQpsReporter peakQpsReporter;
 
     // Naming of enums are reflected directly in metric dimensions and should not be changed as they are public API
-    private enum DegradedReason { match_phase, adaptive_timeout, timeout, non_ideal_state }
+    private enum DegradedReason { match_phase, adaptive_timeout, timeout, non_ideal_state, ann_timeout }
 
     private final Metric metric;
     private final Map<String, Metric.Context> chainContexts = new CopyOnWriteHashMap<>();
@@ -216,6 +216,9 @@ public class StatisticsSearcher extends Searcher {
         }
         if (coverage.isDegradedByAdapativeTimeout()) {
             return DegradedReason.adaptive_timeout;
+        }
+        if (coverage.isDegradedByAnnTimeout()) {
+            return DegradedReason.ann_timeout;
         }
         return DegradedReason.non_ideal_state;
     }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -84,9 +84,9 @@ public class ProtobufSerialization {
         return convertFromQuery(query, hits, nodeId, contentShare, requestTimeout, qrSearchersConfig).toByteArray();
     }
 
-    private static void convertSearchReplyErrors(Result target, List<SearchProtocol.Error> errors, boolean softTimeout) {
+    private static void convertSearchReplyErrors(Result target, List<SearchProtocol.Error> errors, boolean softTimeout, boolean annTimeout) {
         for (var error : errors) {
-            target.hits().addError(softTimeout
+            target.hits().addError(annTimeout || softTimeout
                     ? ErrorMessage.createTimeout(error.getMessage())
                     : ErrorMessage.createSearchReplyError(error.getMessage()));
         }
@@ -288,7 +288,7 @@ public class ProtobufSerialization {
         result.getResult().setTotalHitCount(protobuf.getTotalHitCount());
         result.getResult().setCoverage(convertToCoverage(protobuf));
 
-        convertSearchReplyErrors(result.getResult(), protobuf.getErrorsList(), protobuf.getDegradedBySoftTimeout());
+        convertSearchReplyErrors(result.getResult(), protobuf.getErrorsList(), protobuf.getDegradedBySoftTimeout(), protobuf.getDegradedByAnnTimeout());
         List<String> featureNames = protobuf.getMatchFeatureNamesList();
         var haveMatchFeatures = ! featureNames.isEmpty();
         MatchFeatureData matchFeatures = haveMatchFeatures ? new MatchFeatureData(featureNames) : null;
@@ -350,6 +350,8 @@ public class ProtobufSerialization {
             degradedReason |= Coverage.DEGRADED_BY_MATCH_PHASE;
         if (protobuf.getDegradedBySoftTimeout())
             degradedReason |= Coverage.DEGRADED_BY_TIMEOUT;
+        if (protobuf.getDegradedByAnnTimeout())
+            degradedReason |= Coverage.DEGRADED_BY_ANN_TIMEOUT;
         coverage.setDegradedReason(degradedReason);
 
         return coverage;
@@ -361,7 +363,8 @@ public class ProtobufSerialization {
         var coverage = result.getCoverage(false);
         if (coverage != null) {
             builder.setCoverageDocs(coverage.getDocs()).setActiveDocs(coverage.getActive()).setTargetActiveDocs(coverage.getTargetActive())
-                    .setDegradedBySoftTimeout(coverage.isDegradedByTimeout()).setDegradedByMatchPhase(coverage.isDegradedByMatchPhase());
+                    .setDegradedBySoftTimeout(coverage.isDegradedByTimeout()).setDegradedByMatchPhase(coverage.isDegradedByMatchPhase())
+                    .setDegradedByAnnTimeout(coverage.isDegradedByAnnTimeout());
         }
 
         result.hits().iterator().forEachRemaining(hit -> {

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -99,6 +99,7 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
     private static final String COVERAGE_DEGRADE_MATCHPHASE = "match-phase";
     private static final String COVERAGE_DEGRADE_TIMEOUT = "timeout";
     private static final String COVERAGE_DEGRADE_ADAPTIVE_TIMEOUT = "adaptive-timeout";
+    private static final String COVERAGE_DEGRADE_ANN_TIMEOUT = "anntimeout";
     private static final String COVERAGE_DEGRADED_NON_IDEAL_STATE = "non-ideal-state";
     private static final String COVERAGE_FULL = "full";
     private static final String COVERAGE_NODES = "nodes";
@@ -388,6 +389,7 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
             generator.writeBooleanField(COVERAGE_DEGRADE_MATCHPHASE, c.isDegradedByMatchPhase());
             generator.writeBooleanField(COVERAGE_DEGRADE_TIMEOUT, c.isDegradedByTimeout());
             generator.writeBooleanField(COVERAGE_DEGRADE_ADAPTIVE_TIMEOUT, c.isDegradedByAdapativeTimeout());
+            generator.writeBooleanField(COVERAGE_DEGRADE_ANN_TIMEOUT, c.isDegradedByAnnTimeout());
             generator.writeBooleanField(COVERAGE_DEGRADED_NON_IDEAL_STATE, c.isDegradedByNonIdealState());
             generator.writeEndObject();
         }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -40,6 +40,7 @@ import java.util.stream.StreamSupport;
 
 import static com.yahoo.container.handler.Coverage.DEGRADED_BY_MATCH_PHASE;
 import static com.yahoo.container.handler.Coverage.DEGRADED_BY_TIMEOUT;
+import static com.yahoo.container.handler.Coverage.DEGRADED_BY_ANN_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -173,6 +174,29 @@ public class InterleavedSearchInvokerTest {
             assertEquals(0, cov.getFullResultSets());
             assertTrue(cov.isDegraded());
             assertTrue(cov.isDegradedByTimeout());
+        }
+    }
+
+    @Test
+    void correctCoverageCalculationWhenResultsAreLimitedByAnnTimeout() throws IOException {
+        invokers.add(new MockInvoker(0, createCoverage(50155, 50155, 50155, 1, 1, 0)));
+        invokers.add(new MockInvoker(1, createCoverage(49845, 49845, 49845, 1, 1, DEGRADED_BY_ANN_TIMEOUT)));
+        try (SearchInvoker invoker = createInterleavedInvoker(new Group(0, List.of()), 0)) {
+
+            expectedEvents.add(new Event(5000, 100, 0));
+            expectedEvents.add(new Event(null, 5200, 1));
+
+            Result result = invoker.search(query, 1.0);
+
+            Coverage cov = result.getCoverage(true);
+            assertEquals(100_000L, cov.getDocs());
+            assertEquals(2, cov.getNodes());
+            assertTrue(cov.getFull()); // All docs covered despite ANN timeout
+            assertEquals(100, cov.getResultPercentage());
+            assertEquals(1, cov.getResultSets());
+            assertEquals(1, cov.getFullResultSets());
+            assertTrue(cov.isDegraded());
+            assertTrue(cov.isDegradedByAnnTimeout());
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -186,4 +186,20 @@ public class ProtobufSerializationTest {
         assertEquals(com.yahoo.container.protect.Error.TIMEOUT.code, error.getCode());
     }
 
+    @Test
+    void ann_timeout_errors_use_timeout_error_code() {
+        Query q = new Query("search/?query=test");
+        SearchProtocol.SearchReply reply = SearchProtocol.SearchReply.newBuilder()
+                .setDegradedByAnnTimeout(true)
+                .addErrors(SearchProtocol.Error.newBuilder()
+                        .setMessage("Hypothetical ANN timeout error message.")) // No such error message as of now (that does not also trigger a soft timeout)
+                .build();
+        Node node = new Node("test", 1, "host", 3, true);
+        node.setPathIndex(2);
+        InvokerResult result = ProtobufSerialization.convertToResult(q, reply, null, node);
+        var error = result.getResult().hits().getError();
+        assertNotNull(error);
+        assertEquals(com.yahoo.container.protect.Error.TIMEOUT.code, error.getCode());
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/rendering/JsonRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/JsonRendererTestCase.java
@@ -973,6 +973,7 @@ public class JsonRendererTestCase {
                 + "                \"match-phase\" : true,"
                 + "                \"timeout\" : false,"
                 + "                \"adaptive-timeout\" : true,"
+                + "                \"anntimeout\" : false,"
                 + "                \"non-ideal-state\" : false"
                 + "            },"
                 + "            \"full\": false,"

--- a/container-search/src/test/java/com/yahoo/search/rendering/JsonRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/JsonRendererTestCase.java
@@ -961,20 +961,18 @@ public class JsonRendererTestCase {
         assertEqualJsonContent(expected, summary);
     }
 
-    @Test
-    @Timeout(300)
-    void testCoverage() throws InterruptedException, ExecutionException, IOException {
+    void verifyCoverage(Coverage coverage) throws InterruptedException, ExecutionException, IOException {
         String expected = "{"
                 + "    \"root\": {"
                 + "        \"coverage\": {"
                 + "            \"coverage\": 83,"
                 + "            \"documents\": 500,"
                 + "            \"degraded\" : {"
-                + "                \"match-phase\" : true,"
-                + "                \"timeout\" : false,"
-                + "                \"adaptive-timeout\" : true,"
-                + "                \"anntimeout\" : false,"
-                + "                \"non-ideal-state\" : false"
+                + "                \"match-phase\" : " + coverage.isDegradedByMatchPhase() + ","
+                + "                \"timeout\" : " + coverage.isDegradedByTimeout() + ","
+                + "                \"adaptive-timeout\" : " + coverage.isDegradedByAdapativeTimeout() + ","
+                + "                \"anntimeout\" : " + coverage.isDegradedByAnnTimeout() + ","
+                + "                \"non-ideal-state\" : " + coverage.isDegradedByNonIdealState()
                 + "            },"
                 + "            \"full\": false,"
                 + "            \"nodes\": 1,"
@@ -988,13 +986,23 @@ public class JsonRendererTestCase {
                 + "        \"relevance\": 1.0"
                 + "    }"
                 + "}";
+
         Query q = new Query("/?query=a&tracelevel=5");
         Execution execution = new Execution(Execution.Context.createContextStub());
         Result r = new Result(q);
-        r.setCoverage(new Coverage(500, 600, 1).setDegradedReason(5));
+        r.setCoverage(coverage);
 
         String summary = render(execution, r);
         assertEqualJsonContent(expected, summary);
+    }
+
+    @Test
+    @Timeout(300)
+    void testCoverage() throws InterruptedException, ExecutionException, IOException {
+        verifyCoverage(new Coverage(500, 600, 1).setDegradedReason(5)); // match-phase and adaptive-timeout
+        verifyCoverage(new Coverage(500, 600, 1).setDegradedReason(7)); // match-phase, timeout, and adaptive-timeout
+        verifyCoverage(new Coverage(500, 600, 1).setDegradedReason(13)); // match-phase, adaptive-timeout, and anntimeout
+        verifyCoverage(new Coverage(500, 600, 1).setDegradedReason(15)); // match-phase, timeout, adaptive-timeout, and anntimeout
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/result/CoverageTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/result/CoverageTestCase.java
@@ -130,4 +130,23 @@ public class CoverageTestCase {
         verifyNoCoverage(new Coverage(0, 0, 1));
     }
 
+    private void verifyCoverageWithAnnTimeout(Coverage zero) {
+        assertFalse(zero.isDegraded());
+        assertEquals(100, zero.getResultPercentage());
+        assertTrue(zero.getFull());
+        zero.setDegradedReason(com.yahoo.container.handler.Coverage.DEGRADED_BY_ANN_TIMEOUT);
+        assertTrue(zero.isDegraded());
+        assertEquals(100, zero.getResultPercentage());
+        assertTrue(zero.getFull());
+    }
+
+    @Test
+    void testCoverageWithNoResponseFromSearchNodesAndAnnTimeout() {
+        verifyCoverageWithAnnTimeout(new Coverage(0, 0, 0));
+    }
+    @Test
+    void testCoverageWithResponseFromSearchNodesAndAnnTimeout() {
+        verifyCoverageWithAnnTimeout(new Coverage(0, 0, 1));
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/result/CoverageTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/result/CoverageTestCase.java
@@ -85,11 +85,18 @@ public class CoverageTestCase {
         assertEquals(lc.isDegradedByAdapativeTimeout(), c.isDegradedByAdapativeTimeout());
         assertEquals(lc.isDegradedByMatchPhase(), c.isDegradedByMatchPhase());
         assertEquals(lc.isDegradedByTimeout(), c.isDegradedByTimeout());
+        assertEquals(lc.isDegradedByAnnTimeout(), c.isDegradedByAnnTimeout());
     }
 
     @Test
     void testCoverageConversion() {
         verifyCoverageConversion(new Coverage(6, 10, 1).setDegradedReason(7).setTargetActive(12));
+
+        // With all degradation reasons including DEGRADED_BY_ANN_TIMEOUT
+        verifyCoverageConversion(new Coverage(6, 10, 1).setDegradedReason(15).setTargetActive(12));
+
+        // With DEGRADED_BY_ANN_TIMEOUT only
+        verifyCoverageConversion(new Coverage(6, 10, 1).setDegradedReason(8).setTargetActive(12));
     }
 
     @Test


### PR DESCRIPTION
Reports the ANN timeout in a search response by adding a new entry in the `degraded` section. I tried to find all places where this and unit tests had to be added.

The coverage can still be `100` with an ANN timeout if all documents are considered in matching and, hence, the result will still be reported as full. Not sure if this is what we want. For the soft-timeout, there is the special case of having no active documents together with a soft-timeout, which is reported as `0` coverage and not as full. This is reported as `100` and full with the ANN timeout as of now. @havardpe @hmusum Any opinions on this?

Example:
```
"root": {
  "id": "toplevel",
  "relevance": 1.0,
  "fields": {
    "totalCount": 1130
  },
  "coverage": {
    "coverage": 100,
    "documents": 100000,
    "degraded": {
      "match-phase": false,
      "timeout": false,
      "adaptive-timeout": false,
      "anntimeout": true,
      "non-ideal-state": false
    },
    "full": true,
    "nodes": 1,
    "results": 1,
    "resultsFull": 1
  },
  "children": [
    {
      "id": "index:search/0/71e6912fbbf06becd059acff",
      "relevance": 0.00039879915554576553,
      "source": "search",
      "fields": {
        "sddocname": "test",
        "id": 89767
      }
    }
  ]
}

```