### PR TITLE
Unreserve 'application' tag key [MERGEOK]

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -35,7 +35,7 @@ public class CloudResourceTags {
     private static final List<String> RESERVED_TAG_NAMES = List.of(
             "applicationid", "athenz", "athenz-domain", "athenzservice", "fqdn", "name", "owner", "zone",
             "tenant", "tenantName", "app", "clusterid",
-            "system", "application", "cluster", "generation", "auth-method",
+            "system", "cluster", "generation", "auth-method",
             "preprovisioned");
 
     /** Key prefixes reserved by the platform. Compared case-insensitively against customer keys. */

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -175,7 +175,6 @@ class CloudResourceTagsTest {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("clusterid", "value")));
 
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("system", "value")));
-        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("application", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("cluster", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("generation", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("auth-method", "value")));
@@ -189,6 +188,12 @@ class CloudResourceTagsTest {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Name", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("APPLICATIONID", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Owner", "value")));
+    }
+
+    @Test
+    void application_is_not_reserved() {
+        assertDoesNotThrow(() -> CloudResourceTags.from(Map.of("application", "value")));
+        assertDoesNotThrow(() -> CloudResourceTags.from(Map.of("Application", "value")));
     }
 
     @Test


### PR DESCRIPTION
Already used as a custom `<resource-tags>` key by an existing deployment. Reserving it would break that deployment on next session reload.