### PR TITLE
Extend ExecutionProfiler functionality

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
@@ -213,9 +213,11 @@ public:
     }
     static Blueprint::UP build(const IRequestContext& requestContext, Node& node, ISearchContext& context,
                                search::fef::MatchDataLayout& global_layout) {
-        BlueprintBuilderVisitor visitor(requestContext, context, global_layout);
+        CreateBlueprintProfilerGuard profiler_guard;
+        BlueprintBuilderVisitor      visitor(requestContext, context, global_layout);
         node.accept(visitor);
         Blueprint::UP result = visitor.build();
+        profiler_guard.set_name_with(*result);
         return result;
     }
 };

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -181,6 +181,13 @@ MatchToolsFactory::MatchToolsFactory(
     trace.addEvent(5, "Deserialize and build query tree");
     _valid = _query.buildTree(queryTree, location, viewResolver, indexEnv);
     if (_valid) {
+        std::unique_ptr<vespalib::ExecutionProfiler> setup_profiler;
+        if (trace.getLevel() > 0) {
+            if (int32_t depth = root_trace.match_profile_depth(); depth != 0) {
+                setup_profiler = std::make_unique<vespalib::ExecutionProfiler>(depth);
+            }
+        }
+        auto bind_profiler = vespalib::ExecutionProfiler::ThreadBinder::bind(setup_profiler.get());
         _query.extractTerms(_queryEnv.terms());
         _query.extractLocations(_queryEnv.locations());
         trace.addEvent(5, "Build query execution plan");
@@ -197,25 +204,17 @@ MatchToolsFactory::MatchToolsFactory(
         double hitRate = std::min(1.0, double(maxNumHits) / double(searchContext.getDocIdLimit()));
         auto   in_flow = InFlow(is_search, hitRate);
         _query.optimize(in_flow, sort_by_cost);
-        std::unique_ptr<vespalib::ExecutionProfiler> setup_profiler;
-        if (trace.getLevel() > 0) {
-            if (int32_t depth = root_trace.match_profile_depth(); depth != 0) {
-                setup_profiler = std::make_unique<vespalib::ExecutionProfiler>(depth);
-            }
-        }
         trace.addEvent(4, "Perform dictionary lookups and posting lists initialization");
         {
-            auto info =
-                ExecuteInfo::create(in_flow.rate(), _requestContext.getDoom(), thread_bundle, setup_profiler.get());
-            FetchPostingsProfilerGuard guard(setup_profiler.get(), *_query.peekRoot());
-            _query.fetchPostings(info);
+            FetchPostingsProfilerGuard guard(*_query.peekRoot());
+            _query.fetchPostings(ExecuteInfo::create(in_flow.rate(), _requestContext.getDoom(), thread_bundle));
         }
         if (is_search) {
             bool use_lazy_filter = LazyFilter::check(_queryEnv.getProperties());
             _query.handle_global_filter(_requestContext, ann_deadline_config, searchContext.getDocIdLimit(),
                                         _create_blueprint_params.global_filter_lower_limit,
                                         _create_blueprint_params.global_filter_upper_limit, setup_stats, trace,
-                                        sort_by_cost, use_lazy_filter, setup_profiler.get());
+                                        sort_by_cost, use_lazy_filter);
         }
         if (setup_profiler) {
             setup_profiler->report(trace.createCursor("setup_profiling"));

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -247,8 +247,7 @@ void Query::handle_global_filter(const IRequestContext&          requestContext,
                                  const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                                  double global_filter_lower_limit, double global_filter_upper_limit,
                                  search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace& trace,
-                                 bool sort_by_cost, bool use_lazy_filter,
-                                 vespalib::ExecutionProfiler* setup_profiler) {
+                                 bool sort_by_cost, bool use_lazy_filter) {
     if (!handle_global_filter(*_blueprint, requestContext.getDoom(), ann_deadline_config, docid_limit,
                               global_filter_lower_limit, global_filter_upper_limit, requestContext.thread_bundle(),
                               setup_stats, &trace, use_lazy_filter))
@@ -261,10 +260,8 @@ void Query::handle_global_filter(const IRequestContext&          requestContext,
     _blueprint = Blueprint::optimize_and_sort(std::move(_blueprint), _in_flow, opts);
     LOG(debug, "blueprint after handle_global_filter:\n%s\n", _blueprint->asString().c_str());
     // strictness may change if optimized order changed:
-    auto info = ExecuteInfo::create(_in_flow.rate(), requestContext.getDoom(), requestContext.thread_bundle(),
-                                    setup_profiler);
-    search::queryeval::FetchPostingsProfilerGuard guard(setup_profiler, *_blueprint);
-    fetchPostings(info);
+    search::queryeval::FetchPostingsProfilerGuard guard(*_blueprint);
+    fetchPostings(ExecuteInfo::create(_in_flow.rate(), requestContext.getDoom(), requestContext.thread_bundle()));
 }
 
 bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doom,

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -114,8 +114,7 @@ public:
                               const AnnDeadlineConfiguration& ann_deadline_config, uint32_t docid_limit,
                               double global_filter_lower_limit, double global_filter_upper_limit,
                               search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace& trace,
-                              bool sort_by_cost, bool use_lazy_filter = false,
-                              vespalib::ExecutionProfiler* setup_profiler = nullptr);
+                              bool sort_by_cost, bool use_lazy_filter = false);
 
     /**
      * Calculates and handles the global filter if needed by the blueprint tree.

--- a/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
@@ -249,10 +249,10 @@ TEST(IntermediateBlueprintsTest, test_fetch_postings_can_be_profiled) {
     bp->setDocIdLimit(5000);
     optimize(bp, true);
     vespalib::ExecutionProfiler profiler(64);
-    auto info = ExecuteInfo::create(1.0, vespalib::Doom::never(), vespalib::ThreadBundle::trivial(), &profiler);
+    auto                        profiler_guard = vespalib::ExecutionProfiler::ThreadBinder::bind(&profiler);
     {
-        FetchPostingsProfilerGuard guard(&profiler, *bp);
-        bp->fetchPostings(info);
+        FetchPostingsProfilerGuard guard(*bp);
+        bp->fetchPostings(ExecuteInfo::createForTest());
     }
     Slime slime;
     profiler.report(slime.setObject());
@@ -268,8 +268,9 @@ TEST(IntermediateBlueprintsTest, test_fetch_postings_can_be_profiled) {
 TEST(IntermediateBlueprintsTest, test_fetch_postings_profile_omits_id_when_unset) {
     auto                        leaf = ap(MyLeafSpec(20).create());
     vespalib::ExecutionProfiler profiler(64);
+    auto                        profiler_guard = vespalib::ExecutionProfiler::ThreadBinder::bind(&profiler);
     {
-        FetchPostingsProfilerGuard guard(&profiler, *leaf);
+        FetchPostingsProfilerGuard guard(*leaf);
     }
     Slime slime;
     profiler.report(slime.setObject());

--- a/searchlib/src/vespa/searchlib/engine/trace.cpp
+++ b/searchlib/src/vespa/searchlib/engine/trace.cpp
@@ -24,7 +24,7 @@ void Trace::constructTraces() const {
 
 vespalib::slime::Cursor& LazyTraceInserter::get_entry() {
     if (!_entry) {
-        _entry = &_parent.createCursor(_name);
+        _entry = &_parent.createCursor(_name.view());
     }
     return *_entry;
 }

--- a/searchlib/src/vespa/searchlib/engine/trace.h
+++ b/searchlib/src/vespa/searchlib/engine/trace.h
@@ -63,7 +63,7 @@ class Trace;
 class LazyTraceInserter {
 private:
     Trace&                                     _parent;
-    std::string_view                           _name;
+    vespalib::StaticStringView                 _name;
     vespalib::slime::Cursor*                   _entry;
     std::unique_ptr<vespalib::slime::Inserter> _thread_inserter;
     vespalib::slime::Cursor& get_entry();

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -24,6 +24,7 @@
 
 #include <vespa/vespalib/objects/visit.hpp>
 
+#include <format>
 #include <map>
 
 #include <vespa/log/log.h>
@@ -157,6 +158,13 @@ Blueprint::Blueprint() noexcept
 }
 
 Blueprint::~Blueprint() = default;
+
+std::string Blueprint::profiler_name(std::string_view operation) const {
+    if (id() == 0) {
+        return std::format("[]{}::{}", getClassName(), operation);
+    }
+    return std::format("[{}]{}::{}", id(), getClassName(), operation);
+}
 
 void Blueprint::resolve_strict(InFlow& in_flow) noexcept {
     // simple local estimation of absolute cost based on in flow and flow stats.
@@ -663,12 +671,11 @@ void IntermediateBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) const
 }
 
 void IntermediateBlueprint::fetchPostings(const ExecuteInfo& execInfo) {
-    auto  flow = my_flow(InFlow(strict(), execInfo.hit_rate()));
-    auto* profiler = execInfo.profiler();
+    auto flow = my_flow(InFlow(strict(), execInfo.hit_rate()));
     for (const auto& child : _children) {
         double                     nextHitRate = flow.flow();
         auto                       childInfo = ExecuteInfo::create(nextHitRate, execInfo);
-        FetchPostingsProfilerGuard guard(profiler, *child);
+        FetchPostingsProfilerGuard guard(*child);
         child->fetchPostings(childInfo);
         flow.add(child->estimate());
     }

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -315,6 +315,10 @@ public:
     Blueprint& operator=(const Blueprint&) = delete;
     virtual ~Blueprint();
 
+    // create a string on the form [id]className::operation
+    // to be used  when profiling
+    std::string profiler_name(std::string_view operation) const;
+
     void setParent(Blueprint* parent) noexcept { _parent = parent; }
     Blueprint* getParent() const noexcept { return _parent; }
     bool has_parent() const { return (_parent != nullptr); }
@@ -643,20 +647,21 @@ struct ComplexLeafBlueprint : LeafBlueprint {
 //-----------------------------------------------------------------------------
 
 /**
- * RAII profiler guard for the fetchPostings phase of a single blueprint node.
- * Produces task names of the form "[<id>]<ClassName>::fetchPostings", or
- * "[]<ClassName>::fetchPostings" when the blueprint id is unset (0). The
- * format matches the one used by ProfiledIterator. Name production is
- * skipped when the profiler is null.
+ * RAII profiler guard for the fetchPostings operation on a single
+ * blueprint node.
  **/
-struct FetchPostingsProfilerGuard : vespalib::ProfilerNameGuard {
-    FetchPostingsProfilerGuard(vespalib::ExecutionProfiler* profiler_in, const Blueprint& bp) noexcept
-        : ProfilerNameGuard(profiler_in, [&] {
-              if (bp.id() == 0) {
-                  return vespalib::make_string("[]%s::fetchPostings", bp.getClassName().c_str());
-              }
-              return vespalib::make_string("[%u]%s::fetchPostings", bp.id(), bp.getClassName().c_str());
-          }) {}
+struct FetchPostingsProfilerGuard : vespalib::ExecutionProfiler::NameGuard {
+    FetchPostingsProfilerGuard(const Blueprint& bp)
+        : NameGuard([&bp] { return bp.profiler_name("fetchPostings"); }) {}
+};
+
+/**
+ * RAII profiler guard for the creation of a single blueprint node.
+ **/
+struct CreateBlueprintProfilerGuard : vespalib::ExecutionProfiler::PostNameGuard {
+    void set_name_with(const Blueprint& bp) {
+        set_name([&bp] { return bp.profiler_name("create"); });
+    }
 };
 
 } // namespace search::queryeval

--- a/searchlib/src/vespa/searchlib/queryeval/executeinfo.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/executeinfo.cpp
@@ -5,9 +5,9 @@
 using vespalib::Doom;
 namespace search::queryeval {
 
-const ExecuteInfo ExecuteInfo::FULL(1.0, Doom::never(), vespalib::ThreadBundle::trivial(), nullptr);
+const ExecuteInfo ExecuteInfo::FULL(1.0, Doom::never(), vespalib::ThreadBundle::trivial());
 
-ExecuteInfo::ExecuteInfo() noexcept : ExecuteInfo(1.0, Doom::never(), vespalib::ThreadBundle::trivial(), nullptr) {
+ExecuteInfo::ExecuteInfo() noexcept : ExecuteInfo(1.0, Doom::never(), vespalib::ThreadBundle::trivial()) {
 }
 
 ExecuteInfo ExecuteInfo::createForTest(double hitRate) noexcept {

--- a/searchlib/src/vespa/searchlib/queryeval/executeinfo.h
+++ b/searchlib/src/vespa/searchlib/queryeval/executeinfo.h
@@ -5,10 +5,6 @@
 #include <vespa/vespalib/util/doom.h>
 #include <vespa/vespalib/util/thread_bundle.h>
 
-namespace vespalib {
-class ExecutionProfiler;
-}
-
 namespace search::queryeval {
 
 /**
@@ -21,21 +17,16 @@ public:
     double hit_rate() const noexcept { return _hitRate; }
     const vespalib::Doom& doom() const noexcept { return _doom; }
     vespalib::ThreadBundle& thread_bundle() const noexcept { return _thread_bundle; }
-    vespalib::ExecutionProfiler* profiler() const noexcept { return _profiler; }
 
     static const ExecuteInfo FULL;
     static ExecuteInfo create(const ExecuteInfo& org) noexcept { return create(org._hitRate, org); }
     static ExecuteInfo create(double hitRate, const ExecuteInfo& org) noexcept {
-        return {hitRate, org._doom, org.thread_bundle(), org._profiler};
+        return {hitRate, org._doom, org.thread_bundle()};
     }
 
     static ExecuteInfo create(double hitRate, const vespalib::Doom& doom,
                               vespalib::ThreadBundle& thread_bundle_in) noexcept {
-        return {hitRate, doom, thread_bundle_in, nullptr};
-    }
-    static ExecuteInfo create(double hitRate, const vespalib::Doom& doom, vespalib::ThreadBundle& thread_bundle_in,
-                              vespalib::ExecutionProfiler* profiler_in) noexcept {
-        return {hitRate, doom, thread_bundle_in, profiler_in};
+        return {hitRate, doom, thread_bundle_in};
     }
     static ExecuteInfo createForTest() noexcept { return createForTest(1.0); }
     static ExecuteInfo createForTest(double hitRate) noexcept;
@@ -44,13 +35,11 @@ public:
     }
 
 private:
-    ExecuteInfo(double hitRate_in, const vespalib::Doom& doom, vespalib::ThreadBundle& thread_bundle_in,
-                vespalib::ExecutionProfiler* profiler_in) noexcept
-        : _doom(doom), _thread_bundle(thread_bundle_in), _profiler(profiler_in), _hitRate(hitRate_in) {}
-    const vespalib::Doom         _doom;
-    vespalib::ThreadBundle&      _thread_bundle;
-    vespalib::ExecutionProfiler* _profiler;
-    double                       _hitRate;
+    ExecuteInfo(double hitRate_in, const vespalib::Doom& doom, vespalib::ThreadBundle& thread_bundle_in) noexcept
+        : _doom(doom), _thread_bundle(thread_bundle_in), _hitRate(hitRate_in) {}
+    const vespalib::Doom    _doom;
+    vespalib::ThreadBundle& _thread_bundle;
+    double                  _hitRate;
 };
 
 } // namespace search::queryeval

--- a/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
@@ -20,7 +20,7 @@ namespace search::queryeval {
 namespace {
 
 using Profiler = vespalib::ExecutionProfiler;
-using TaskGuard = vespalib::ProfilerTaskGuard;
+using TaskGuard = Profiler::TaskGuard;
 
 std::string name_of(const SearchIterator& search) {
     return search.getClassName();

--- a/vespalib/src/tests/execution_profiler/execution_profiler_test.cpp
+++ b/vespalib/src/tests/execution_profiler/execution_profiler_test.cpp
@@ -70,6 +70,14 @@ TEST(ExecutionProfilerTest, resolve_names) {
     EXPECT_EQ(profiler.resolve("foo"), 0);
     EXPECT_EQ(profiler.resolve("bar"), 1);
     EXPECT_EQ(profiler.resolve("baz"), 2);
+    EXPECT_EQ(profiler.resolve(""), 3);
+    EXPECT_EQ(profiler.resolve(""), 4);
+    EXPECT_EQ(profiler.resolve(""), 5);
+    profiler.set_name(2, "new_name");
+    EXPECT_EQ(profiler.resolve("baz"), 2);
+    EXPECT_EQ(profiler.resolve("new_name"), 6);
+    profiler.set_name(4, "named_later");
+    EXPECT_EQ(profiler.resolve("named_later"), 4);
 }
 
 TEST(ExecutionProfilerTest, empty_tree_report) {
@@ -229,6 +237,122 @@ TEST(ExecutionProfilerTest, flat_profiling_does_not_report_tasks_with_count_0) {
     EXPECT_EQ(slime["roots"].entries(), 1);
     EXPECT_EQ(slime["roots"][0]["name"].asString().make_stringview(), "baz");
     EXPECT_EQ(slime["roots"][0]["count"].asLong(), 1);
+}
+
+TEST(ExecutionProfilerTest, profile_using_task_guard) {
+    Profiler profiler(64);
+    auto     foo = profiler.resolve("foo");
+    auto     bar = profiler.resolve("bar");
+    {
+        Profiler::TaskGuard g1(profiler, foo);
+        {
+            Profiler::TaskGuard g2(profiler, bar);
+        }
+        {
+            Profiler::TaskGuard g2(profiler, bar);
+        }
+    }
+    Slime slime;
+    profiler.report(slime.setObject());
+    fprintf(stderr, "%s\n", slime.toString().c_str());
+    EXPECT_EQ(slime["roots"].entries(), 1);
+    EXPECT_TRUE(find_path(slime, {{"foo", 1}, {"bar", 2}}));
+}
+
+TEST(ExecutionProfilerTest, profile_using_name_guard) {
+    Profiler profiler(64);
+    auto     binder = Profiler::ThreadBinder::bind(&profiler);
+    auto     make_guard = [](const char* name) { return Profiler::NameGuard([name]() { return name; }); };
+    {
+        auto g1 = make_guard("foo");
+        {
+            auto g2 = make_guard("bar");
+        }
+        {
+            auto g2 = make_guard("bar");
+        }
+    }
+    Slime slime;
+    profiler.report(slime.setObject());
+    fprintf(stderr, "%s\n", slime.toString().c_str());
+    EXPECT_EQ(slime["roots"].entries(), 1);
+    EXPECT_TRUE(find_path(slime, {{"foo", 1}, {"bar", 2}}));
+}
+
+TEST(ExecutionProfilerTest, name_guard_does_not_resolve_name_if_profiler_is_null) {
+    bool called = false;
+    auto name_fun = [&called] {
+        called = true;
+        return "foo";
+    };
+    EXPECT_EQ(Profiler::ThreadBinder::current(), nullptr);
+    {
+        Profiler::NameGuard g(name_fun);
+    }
+    EXPECT_FALSE(called);
+}
+
+TEST(ExecutionProfilerTest, profiler_thread_bind_nesting) {
+    Profiler p1(64);
+    Profiler p2(64);
+    EXPECT_EQ(Profiler::ThreadBinder::current(), nullptr);
+    {
+        // binding nullptr is no-op
+        auto bz = Profiler::ThreadBinder::bind(nullptr);
+        EXPECT_EQ(Profiler::ThreadBinder::current(), nullptr);
+    }
+    {
+        auto b1 = Profiler::ThreadBinder::bind(&p1);
+        EXPECT_EQ(Profiler::ThreadBinder::current(), &p1);
+        {
+            // binding nullptr is no-op
+            auto bz = Profiler::ThreadBinder::bind(nullptr);
+            EXPECT_EQ(Profiler::ThreadBinder::current(), &p1);
+            {
+                auto b2 = Profiler::ThreadBinder::bind(&p2);
+                EXPECT_EQ(Profiler::ThreadBinder::current(), &p2);
+            }
+            EXPECT_EQ(Profiler::ThreadBinder::current(), &p1);
+        }
+        EXPECT_EQ(Profiler::ThreadBinder::current(), &p1);
+    }
+    EXPECT_EQ(Profiler::ThreadBinder::current(), nullptr);
+}
+
+TEST(ExecutionProfilerTest, profile_using_post_name_guard) {
+    Profiler profiler(64);
+    auto     binder = Profiler::ThreadBinder::bind(&profiler);
+    {
+        auto g1 = Profiler::PostNameGuard();
+        {
+            auto g2 = Profiler::PostNameGuard();
+            g2.set_name([] { return "bar"; });
+        }
+        {
+            auto g2 = Profiler::PostNameGuard();
+        }
+        g1.set_name([] { return "foo"; });
+    }
+    Slime slime;
+    profiler.report(slime.setObject());
+    fprintf(stderr, "%s\n", slime.toString().c_str());
+    EXPECT_EQ(slime["roots"].entries(), 1);
+    EXPECT_TRUE(find_path(slime, {{"foo", 1}, {"bar", 1}}));
+    EXPECT_TRUE(find_path(slime, {{"foo", 1}, {"#2", 1}}));
+}
+
+TEST(ExecutionProfilerTest, post_name_guard_does_not_resolve_name_if_profiler_is_null) {
+    bool called = false;
+    auto name_fun = [&called] {
+        called = true;
+        return "foo";
+    };
+    EXPECT_EQ(Profiler::ThreadBinder::current(), nullptr);
+    {
+        auto g = Profiler::PostNameGuard();
+        g.set_name(name_fun);
+    }
+    EXPECT_FALSE(called);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/tests/util/static_string_test.cpp
+++ b/vespalib/src/tests/util/static_string_test.cpp
@@ -9,20 +9,10 @@ using namespace vespalib::literals;
 TEST(StaticStringViewTest, simple_usage) {
     auto        value = "foo bar"_ssv;
     std::string expect("foo bar");
-    std::string expect_std("foo bar");
     static_assert(std::same_as<decltype(value), StaticStringView>);
-    auto a_ref = value.ref();
-    auto a_view = value.view();
-    static_assert(std::same_as<decltype(a_ref), std::string_view>);
-    static_assert(std::same_as<decltype(a_view), std::string_view>);
-    std::string_view ref = value;
-    std::string_view view = value;
-    EXPECT_EQ(a_ref, expect);
-    EXPECT_EQ(a_view, expect_std);
-    EXPECT_EQ(ref, expect);
-    EXPECT_EQ(view, expect_std);
-    EXPECT_EQ(value.ref(), expect);
-    EXPECT_EQ(value.view(), expect_std);
+    auto view = value.view();
+    static_assert(std::same_as<decltype(view), std::string_view>);
+    EXPECT_EQ(view, expect);
 }
 
 TEST(StaticStringViewTest, with_null_byte) {

--- a/vespalib/src/vespa/vespalib/util/execution_profiler.cpp
+++ b/vespalib/src/vespa/vespalib/util/execution_profiler.cpp
@@ -22,13 +22,24 @@ struct ExecutionProfiler::ReportContext {
     const std::string& resolve_name(TaskId task) {
         auto pos = name_cache.find(task);
         if (pos == name_cache.end()) {
-            pos = name_cache.insert(std::make_pair(task, name_mapper(profiler.name_of(task)))).first;
+            const std::string& name = profiler.name_of(task);
+            if (name.empty()) {
+                auto my_name = std::format("#{}", task);
+                pos = name_cache.insert(std::make_pair(task, my_name)).first;
+            } else {
+                pos = name_cache.insert(std::make_pair(task, name_mapper(name))).first;
+            }
         }
         return pos->second;
     }
 };
 
 namespace {
+
+ExecutionProfiler*& current_profiler_ref() {
+    thread_local ExecutionProfiler* current_profiler = nullptr;
+    return current_profiler;
+}
 
 double as_ms(duration d) {
     return (count_ns(d) / 1000000.0);
@@ -220,6 +231,12 @@ ExecutionProfiler::ExecutionProfiler(int32_t profile_depth)
 ExecutionProfiler::~ExecutionProfiler() = default;
 
 ExecutionProfiler::TaskId ExecutionProfiler::resolve(const std::string& name) {
+    if (name.empty()) {
+        // make new unnamed id
+        auto result = _names.size();
+        _names.push_back(name);
+        return result;
+    }
     auto [pos, was_new] = _name_map.insert(std::make_pair(name, _names.size()));
     if (was_new) {
         assert(pos->second == _names.size());
@@ -229,9 +246,38 @@ ExecutionProfiler::TaskId ExecutionProfiler::resolve(const std::string& name) {
     return pos->second;
 }
 
+void ExecutionProfiler::set_name(TaskId task, const std::string& name) {
+    size_t idx = task;
+    assert(idx < _names.size());
+    if (!_names[idx].empty() || name.empty()) {
+        // set_name may only change an unnamed task to a named one
+        return;
+    }
+    _names[idx] = name;
+    _name_map.insert(std::make_pair(name, idx));
+}
+
 void ExecutionProfiler::report(slime::Cursor& obj, const NameMapper& name_mapper) const {
     ReportContext ctx(*this, name_mapper, _names.size());
     _impl->report(obj, ctx);
+}
+
+ExecutionProfiler::ThreadBinder::ThreadBinder(ExecutionProfiler* profiler) noexcept {
+    if (profiler != nullptr) {
+        _old = current_profiler_ref();
+        current_profiler_ref() = profiler;
+        _active = true;
+    }
+}
+
+ExecutionProfiler* ExecutionProfiler::ThreadBinder::current() noexcept {
+    return current_profiler_ref();
+}
+
+ExecutionProfiler::ThreadBinder::~ThreadBinder() {
+    if (_active) {
+        current_profiler_ref() = _old;
+    }
 }
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/execution_profiler.h
+++ b/vespalib/src/vespa/vespalib/util/execution_profiler.h
@@ -48,6 +48,8 @@ public:
     ExecutionProfiler(int32_t profile_depth);
     ~ExecutionProfiler();
     TaskId resolve(const std::string& name);
+    // set_name will only have effect on unnamed tasks
+    void set_name(TaskId task, const std::string& name);
     const std::string& name_of(TaskId task) const { return _names[task]; }
     void start(TaskId task) {
         if (++_level <= _max_depth) {
@@ -62,46 +64,94 @@ public:
     void report(
         slime::Cursor&    obj,
         const NameMapper& name_mapper = [](const std::string& name) noexcept { return name; }) const;
-};
 
-/**
- * RAII helper that brackets a single task on an ExecutionProfiler.
- * Hot-path form: takes a pre-resolved TaskId. Use when the same task is
- * entered many times and the cost of resolving names per entry matters.
- **/
-struct ProfilerTaskGuard {
-    ExecutionProfiler& profiler;
-    ProfilerTaskGuard(ExecutionProfiler& profiler_in, ExecutionProfiler::TaskId task) noexcept
-        : profiler(profiler_in) {
-        profiler.start(task);
-    }
-    ProfilerTaskGuard(const ProfilerTaskGuard&) = delete;
-    ProfilerTaskGuard& operator=(const ProfilerTaskGuard&) = delete;
-    ~ProfilerTaskGuard() { profiler.complete(); }
-};
+    // Used to bind an ExecutionProfiler to the current
+    // thread. Binding nullptr will do absolutely nothing. Will revert
+    // back to the previously bound profiler when destructed.
+    class ThreadBinder {
+    private:
+        ExecutionProfiler* _old = nullptr;
+        bool               _active = false;
+        ThreadBinder(ExecutionProfiler* profiler) noexcept;
+        ThreadBinder(ThreadBinder&&) = delete;
+        ThreadBinder(const ThreadBinder&) = delete;
+        ThreadBinder& operator=(ThreadBinder&&) = delete;
+        ThreadBinder& operator=(const ThreadBinder&) = delete;
 
-/**
- * RAII helper that brackets a single task on an ExecutionProfiler.
- * Cold-path form: takes a nullable profiler and a name-producing callable.
- * The name is built and resolved only when the profiler is non-null, so
- * callers do not need to branch around profiling being disabled.
- **/
-class ProfilerNameGuard {
-    ExecutionProfiler* _profiler;
+    public:
+        static ThreadBinder bind(ExecutionProfiler* profiler) noexcept { return ThreadBinder(profiler); }
+        static ExecutionProfiler* current() noexcept;
+        ~ThreadBinder();
+    };
 
-public:
-    ProfilerNameGuard(ExecutionProfiler* profiler_in, auto&& name_fn) noexcept : _profiler(profiler_in) {
-        if (_profiler != nullptr) {
-            _profiler->start(_profiler->resolve(name_fn()));
+    /**
+     * RAII helper that brackets a single task on an
+     * ExecutionProfiler. Hot-path form: takes a pre-resolved
+     * TaskId. Use when the same task is entered many times and the
+     * cost of resolving names per entry matters.
+     **/
+    class TaskGuard {
+    private:
+        ExecutionProfiler& _profiler;
+
+    public:
+        TaskGuard(ExecutionProfiler& profiler, TaskId task) noexcept : _profiler(profiler) { profiler.start(task); }
+        TaskGuard(TaskGuard&&) = delete;
+        TaskGuard(const TaskGuard&) = delete;
+        TaskGuard& operator=(TaskGuard&&) = delete;
+        TaskGuard& operator=(const TaskGuard&) = delete;
+        ~TaskGuard() { _profiler.complete(); }
+    };
+
+    /**
+     * RAII helper that brackets a single task on an
+     * ExecutionProfiler. Cold-path form: uses the profiler bound to
+     * the current thread (if any). The name is built and resolved
+     * only when the profiler is non-null.
+     **/
+    class NameGuard {
+    private:
+        ExecutionProfiler* _profiler;
+        TaskId             _task{};
+
+    protected:
+        ExecutionProfiler* profiler() const noexcept { return _profiler; }
+        TaskId task_id() const noexcept { return _task; }
+
+    public:
+        explicit NameGuard(auto&& name_fn) : _profiler(ThreadBinder::current()) {
+            if (_profiler != nullptr) {
+                _task = _profiler->resolve(name_fn());
+                _profiler->start(_task);
+            }
         }
-    }
-    ProfilerNameGuard(const ProfilerNameGuard&) = delete;
-    ProfilerNameGuard& operator=(const ProfilerNameGuard&) = delete;
-    ~ProfilerNameGuard() {
-        if (_profiler != nullptr) {
-            _profiler->complete();
+        NameGuard(NameGuard&& rhs) = delete;
+        NameGuard(const NameGuard&) = delete;
+        NameGuard& operator=(NameGuard&&) = delete;
+        NameGuard& operator=(const NameGuard&) = delete;
+        ~NameGuard() {
+            if (_profiler != nullptr) {
+                _profiler->complete();
+            }
         }
-    }
+    };
+
+    /**
+     * RAII helper that brackets a single task on an
+     * ExecutionProfiler. Cold-path form: uses the profiler bound to
+     * the current thread (if any). The name is given later via the
+     * set_name function. The name is built and resolved only when the
+     * profiler is non-null.
+     **/
+    struct PostNameGuard : NameGuard {
+        // start out unnamed
+        PostNameGuard() : NameGuard([] { return ""; }) {}
+        void set_name(auto&& name_fn) {
+            if (profiler() != nullptr) {
+                profiler()->set_name(task_id(), name_fn());
+            }
+        }
+    };
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/static_string.h
+++ b/vespalib/src/vespa/vespalib/util/static_string.h
@@ -23,8 +23,6 @@ private:
 
 public:
     constexpr std::string_view view() const noexcept { return _view; }
-    constexpr operator std::string_view() const noexcept { return _view; }
-    std::string_view ref() const noexcept { return {_view.data(), _view.size()}; }
 };
 
 namespace literals {


### PR DESCRIPTION
- name based guards now use a profiler bound to the current thread
- post name guards allow unnamed tasks that are named later
- update profiling of fetchPostings to new API
- add profiling of blueprint creation

@arnej27959 please review
@johansolbakken FYI