### PR TITLE
Add feature flag require-explicit-docproc-cluster

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1440,6 +1440,7 @@
       "public boolean ignoreConnectivityChecksAtStartup()",
       "public int searchCoreMaxOutstandingMoveOps()",
       "public double docprocHandlerThreadpool()",
+      "public boolean requireExplicitDocprocCluster()",
       "public boolean applyOnRestartForApplicationMetadataConfig()",
       "public java.util.OptionalInt metricsProxyHeapSizeInMib()",
       "public java.util.OptionalInt metricsProxyAdminNodeHeapSizeInMib()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -122,6 +122,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"arnej"}) default boolean ignoreConnectivityChecksAtStartup() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int searchCoreMaxOutstandingMoveOps() { return 100; }
         @ModelFeatureFlag(owners = {"johsol"}) default double docprocHandlerThreadpool() { return 1.0; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default boolean requireExplicitDocprocCluster() { return false; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default boolean applyOnRestartForApplicationMetadataConfig() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default OptionalInt metricsProxyHeapSizeInMib() { return OptionalInt.empty(); }
         @ModelFeatureFlag(owners = {"hmusum"}) default OptionalInt metricsProxyAdminNodeHeapSizeInMib() { return OptionalInt.empty(); }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -244,11 +244,12 @@ public class Content extends ConfigModel {
                 setExistingIndexingCluster(content, indexingDocproc, content.containers);
             } else {
                 if (content.containers.size() > 1) {
-                    modelContext.getDeployState().getDeployLogger().logApplicationPackage(
-                            Level.WARNING,
-                            "Content cluster '" + content.getCluster().getName() + "' does not have an explicit " +
-                            "document-processing cluster configured. Add '<document-processing cluster=\"<name>\"/>' " +
-                            "in <content> to ensure deterministic indexing cluster selection.");
+                    String message = "Content cluster '" + content.getCluster().getName() + "' does not have an explicit " +
+                                     "document-processing cluster configured. Add '<document-processing cluster=\"<name>\"/>' " +
+                                     "in <content> to ensure deterministic indexing cluster selection.";
+                    if (modelContext.getDeployState().featureFlags().requireExplicitDocprocCluster())
+                        throw new IllegalArgumentException(message);
+                    modelContext.getDeployState().getDeployLogger().logApplicationPackage(Level.WARNING, message);
                 }
                 setContainerAsIndexingCluster(search.getSearchNodes(), indexingDocproc, content, modelContext, root);
             }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -258,6 +258,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean ignoreConnectivityChecksAtStartup() { return flag(PermanentFlags.IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP).value(); }
         @Override public int searchCoreMaxOutstandingMoveOps() { return flag(Flags.SEARCH_CORE_MAX_OUTSTANDING_MOVE_OPS).value(); }
         @Override public double docprocHandlerThreadpool() { return flag(Flags.DOCPROC_HANDLER_THREADPOOL).value(); }
+        @Override public boolean requireExplicitDocprocCluster() { return flag(Flags.REQUIRE_EXPLICIT_DOCPROC_CLUSTER).value(); }
         @Override public boolean applyOnRestartForApplicationMetadataConfig() { return flag(Flags.APPLY_ON_RESTART_FOR_APPLICATION_METADATA_CONFIG).value(); }
         @Override public double autoscalerTargetWriteCpuPercentage(Optional<String> clusterId) {
             var flag = flag(Flags.AUTOSCALER_TARGET_WRITE_CPU_PERCENTAGE);

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -147,6 +147,13 @@ public class Flags {
             "Takes effect at redeployment",
             APPLICATION);
 
+    public static final UnboundBooleanFlag REQUIRE_EXPLICIT_DOCPROC_CLUSTER = defineFeatureFlag(
+            "require-explicit-docproc-cluster", false,
+            List.of("hmusum"), "2026-05-26", "2026-12-01",
+            "Whether to require an explicit document-processing cluster to be configured in content clusters when there is more than one container cluster",
+            "Takes effect at redeployment",
+            APPLICATION, INSTANCE_ID, TENANT_ID);
+
     public static UnboundBooleanFlag LOGSERVER_OTELCOL_AGENT = defineFeatureFlag(
             "logserver-otelcol-agent", false,
             List.of("olaa"), "2024-04-03", "2026-08-01",


### PR DESCRIPTION
## Summary
- Adds `require-explicit-docproc-cluster` feature flag (default: `false`) to `Flags.java`
- Wires the flag through `ModelContext.FeatureFlags` and `ModelContextImpl`
- In `Content.java`, when the flag is enabled and a content cluster has multiple container clusters but no explicit `<document-processing cluster="..."/>`, deployment fails with an `IllegalArgumentException` instead of logging a warning

---
*Auto-generated by [Claude Code](https://claude.ai/code)*