### PR TITLE
Reserve tag headroom and validate resolved tags per cloud

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -92,11 +92,12 @@ public class CloudResourceTags {
     }
 
     /**
-     * Returns a new instance with all template variables substituted.
-     * Throws if any {@code ${...}} placeholders remain after substitution.
+     * Returns a new instance with all template variables substituted and validated against the target cloud's
+     * character set, length, and count limits. Throws if any {@code ${...}} placeholders remain after
+     * substitution, or if the resolved tags violate the cloud's rules.
      */
     public CloudResourceTags resolve(ApplicationId application, Environment environment, RegionName region,
-                                     ClusterSpec.Id clusterId, ClusterSpec.Type clusterType) {
+                                     ClusterSpec.Id clusterId, ClusterSpec.Type clusterType, CloudName cloud) {
         if (tags.isEmpty()) return this;
         Map<String, String> resolved = new LinkedHashMap<>();
         for (var entry : tags.entrySet()) {
@@ -113,7 +114,9 @@ public class CloudResourceTags {
                                                    entry.getKey() + "': " + value);
             resolved.put(entry.getKey(), value);
         }
-        return from(resolved);
+        CloudResourceTags result = from(resolved);
+        result.validateFor(cloud);
+        return result;
     }
 
     /**

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -26,6 +26,9 @@ public class CloudResourceTags {
     /** Max across all clouds (GCP). Per-cloud limits enforced in {@link #validateFor}. */
     private static final int MAX_TAGS = 64;
 
+    /** Tags reserved for platform/system use; subtracted from each cloud's hard limit to derive the per-cloud customer {@code MAX_TAGS}. */
+    private static final int MAX_SYSTEM_TAGS = 15;
+
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\$\\{[^}]+\\}");
 
     /**
@@ -182,7 +185,7 @@ public class CloudResourceTags {
         private static final String ALLOWED = "letters, digits, spaces, and + - = . _ : / @";
         private static final int MAX_KEY_LENGTH = 128;
         private static final int MAX_VALUE_LENGTH = 256; // matches structural cap
-        private static final int MAX_TAGS = 50;
+        private static final int MAX_TAGS = 50 - MAX_SYSTEM_TAGS; // AWS allows 50 tags total
 
         static void validate(Map<String, String> tags) {
             checkTagCount(tags.size(), MAX_TAGS, NAME);
@@ -203,7 +206,7 @@ public class CloudResourceTags {
         private static final String VALUE_ALLOWED = "lowercase letters, digits, underscores, and hyphens";
         private static final int MAX_KEY_LENGTH = 63;
         private static final int MAX_VALUE_LENGTH = 63;
-        private static final int MAX_TAGS = 64; // matches structural cap
+        private static final int MAX_TAGS = 64 - MAX_SYSTEM_TAGS; // GCP allows 64 tags total; matches structural cap
 
         static void validate(Map<String, String> tags) {
             checkTagCount(tags.size(), MAX_TAGS, NAME);
@@ -224,7 +227,7 @@ public class CloudResourceTags {
         private static final Pattern FORBIDDEN_KEY_CHARS = Pattern.compile("[<>%&\\\\?/]");
         private static final int MAX_KEY_LENGTH = 512; // matches structural cap
         private static final int MAX_VALUE_LENGTH = 256; // matches structural cap
-        private static final int MAX_TAGS = 50;
+        private static final int MAX_TAGS = 50 - MAX_SYSTEM_TAGS; // Azure allows 50 tags total
 
         static void validate(Map<String, String> tags) {
             checkTagCount(tags.size(), MAX_TAGS, NAME);
@@ -241,7 +244,8 @@ public class CloudResourceTags {
     private static void checkTagCount(int count, int max, String cloud) {
         if (count > max)
             throw new IllegalArgumentException("Too many cloud resource tags (" + count +
-                                               "): " + cloud + " allows at most " + max);
+                                               "): " + cloud + " allows at most " + max +
+                                               " customer tags (" + MAX_SYSTEM_TAGS + " of the provider limit are reserved for system tags)");
     }
 
     private static void checkLength(String value, int max, String field, String cloud) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -19,12 +19,14 @@ public class CloudResourceTags {
 
     private static final CloudResourceTags EMPTY = new CloudResourceTags(Map.of());
 
-    /** Max across all clouds (Azure). Per-cloud limits enforced in {@link #validateFor}. */
-    private static final int MAX_KEY_LENGTH = 512;
-    /** Max across all clouds (AWS, Azure). Per-cloud limits enforced in {@link #validateFor}. */
-    private static final int MAX_VALUE_LENGTH = 256;
-    /** Max across all clouds (GCP). Per-cloud limits enforced in {@link #validateFor}. */
-    private static final int MAX_TAGS = 64;
+    // Coarse structural ceilings checked in from(), independent of the per-cloud customer limits
+    // enforced in validateFor(). They bound resource usage when constructing tags from untrusted
+    // input (deployment.xml, persisted state) so a pathologically large map or string cannot be
+    // held in memory or echoed in an exception message. Set to the loosest value any supported
+    // cloud allows, so they never reject input a per-cloud check would accept.
+    private static final int MAX_KEY_LENGTH = 512;   // Azure hard limit (max across clouds)
+    private static final int MAX_VALUE_LENGTH = 256;  // AWS/Azure hard limit (max across clouds)
+    private static final int MAX_TAGS = 64;           // GCP hard limit (max across clouds)
 
     /** Tags reserved for platform/system use; subtracted from each cloud's hard limit to derive the per-cloud customer {@code MAX_TAGS}. */
     private static final int MAX_SYSTEM_TAGS = 15;
@@ -155,16 +157,18 @@ public class CloudResourceTags {
         tags.forEach((key, value) -> {
             Objects.requireNonNull(key, "Tag key cannot be null");
             Objects.requireNonNull(value, "Tag value cannot be null");
+            // Length checks first, reporting only lengths, so a pathologically large key or value
+            // is rejected before any message below echoes it.
+            if (key.length() > MAX_KEY_LENGTH)
+                throw new IllegalArgumentException("Tag key exceeds " + MAX_KEY_LENGTH +
+                                                   " characters (was " + key.length() + ")");
+            if (value.length() > MAX_VALUE_LENGTH)
+                throw new IllegalArgumentException("Tag value exceeds " + MAX_VALUE_LENGTH +
+                                                   " characters (was " + value.length() + ")");
             if (key.isEmpty())
                 throw new IllegalArgumentException("Tag key cannot be empty");
             if (value.isEmpty())
                 throw new IllegalArgumentException("Tag value cannot be empty for key '" + key + "'");
-            if (key.length() > MAX_KEY_LENGTH)
-                throw new IllegalArgumentException("Tag key exceeds " + MAX_KEY_LENGTH +
-                                                   " characters: '" + key + "'");
-            if (value.length() > MAX_VALUE_LENGTH)
-                throw new IllegalArgumentException("Tag value exceeds " + MAX_VALUE_LENGTH +
-                                                   " characters for key '" + key + "'");
             if (key.indexOf('\0') >= 0 || value.indexOf('\0') >= 0)
                 throw new IllegalArgumentException("Tag key or value contains null bytes for key '" + key + "'");
             for (String reserved : RESERVED_TAG_NAMES) {
@@ -184,7 +188,7 @@ public class CloudResourceTags {
         private static final Pattern TAG_PATTERN = Pattern.compile("[a-zA-Z0-9 +\\-=._:/@]+");
         private static final String ALLOWED = "letters, digits, spaces, and + - = . _ : / @";
         private static final int MAX_KEY_LENGTH = 128;
-        private static final int MAX_VALUE_LENGTH = 256; // matches structural cap
+        private static final int MAX_VALUE_LENGTH = 256;
         private static final int MAX_TAGS = 50 - MAX_SYSTEM_TAGS; // AWS allows 50 tags total
 
         static void validate(Map<String, String> tags) {
@@ -206,7 +210,7 @@ public class CloudResourceTags {
         private static final String VALUE_ALLOWED = "lowercase letters, digits, underscores, and hyphens";
         private static final int MAX_KEY_LENGTH = 63;
         private static final int MAX_VALUE_LENGTH = 63;
-        private static final int MAX_TAGS = 64 - MAX_SYSTEM_TAGS; // GCP allows 64 tags total; matches structural cap
+        private static final int MAX_TAGS = 64 - MAX_SYSTEM_TAGS; // GCP allows 64 tags total
 
         static void validate(Map<String, String> tags) {
             checkTagCount(tags.size(), MAX_TAGS, NAME);
@@ -225,8 +229,8 @@ public class CloudResourceTags {
     private static class Azure {
         private static final String NAME = "Azure";
         private static final Pattern FORBIDDEN_KEY_CHARS = Pattern.compile("[<>%&\\\\?/]");
-        private static final int MAX_KEY_LENGTH = 512; // matches structural cap
-        private static final int MAX_VALUE_LENGTH = 256; // matches structural cap
+        private static final int MAX_KEY_LENGTH = 512;
+        private static final int MAX_VALUE_LENGTH = 256;
         private static final int MAX_TAGS = 50 - MAX_SYSTEM_TAGS; // Azure allows 50 tags total
 
         static void validate(Map<String, String> tags) {

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -487,7 +487,8 @@ class CloudResourceTagsTest {
                 "type", "${clustertype}",
                 "combined", "${environment}-${clustername}-${clustertype}"));
         var resolved = tags.resolve(testApp, testEnv, testRegion,
-                                    ClusterSpec.Id.from("my-search"), ClusterSpec.Type.content);
+                                    ClusterSpec.Id.from("my-search"), ClusterSpec.Type.content,
+                                    CloudName.AWS);
         assertEquals("prod", resolved.asMap().get("env"));
         assertEquals("aws-us-east-1c", resolved.asMap().get("loc"));
         assertEquals("tenant1-app1-default", resolved.asMap().get("team"));
@@ -500,14 +501,16 @@ class CloudResourceTagsTest {
     void resolve_lowercases_tenant_application_instance_and_cluster_id() {
         var tags = CloudResourceTags.from(Map.of("tag", "${tenant}-${clustername}"));
         var resolved = tags.resolve(testApp, testEnv, testRegion,
-                                    ClusterSpec.Id.from("MyCluster"), ClusterSpec.Type.container);
+                                    ClusterSpec.Id.from("MyCluster"), ClusterSpec.Type.container,
+                                    CloudName.AWS);
         assertEquals("tenant1-mycluster", resolved.asMap().get("tag"));
     }
 
     @Test
     void resolve_on_empty_returns_empty() {
         var resolved = CloudResourceTags.empty().resolve(testApp, testEnv, testRegion,
-                                                         ClusterSpec.Id.from("c"), ClusterSpec.Type.admin);
+                                                         ClusterSpec.Id.from("c"), ClusterSpec.Type.admin,
+                                                         CloudName.AWS);
         assertTrue(resolved.isEmpty());
     }
 
@@ -515,8 +518,21 @@ class CloudResourceTagsTest {
     void resolve_on_tags_without_placeholders() {
         var tags = CloudResourceTags.from(Map.of("env", "prod"));
         var resolved = tags.resolve(testApp, testEnv, testRegion,
-                                    ClusterSpec.Id.from("c"), ClusterSpec.Type.content);
+                                    ClusterSpec.Id.from("c"), ClusterSpec.Type.content,
+                                    CloudName.AWS);
         assertEquals("prod", resolved.asMap().get("env"));
+    }
+
+    @Test
+    void resolve_validates_resolved_values_against_cloud_limits() {
+        // Raw value is 59 chars and passes GCP's 63-char value limit, but resolves to 64 chars and must fail.
+        String prefix = "p".repeat(50);
+        var tags = CloudResourceTags.from(Map.of("tag", prefix + "${region}"));
+        var e = assertThrows(IllegalArgumentException.class,
+                             () -> tags.resolve(testApp, testEnv, testRegion,
+                                                ClusterSpec.Id.from("c"), ClusterSpec.Type.content,
+                                                CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"), "error must mention GCP: " + e.getMessage());
     }
 
     @Test

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -90,12 +90,12 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void key_exceeding_max_length_rejected() {
+    void key_exceeding_structural_max_length_rejected() {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("k".repeat(513), "value")));
     }
 
     @Test
-    void value_exceeding_max_length_rejected() {
+    void value_exceeding_structural_max_length_rejected() {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("key", "v".repeat(257))));
     }
 
@@ -106,7 +106,7 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void too_many_tags_rejected() {
+    void exceeding_structural_max_tags_rejected() {
         Map<String, String> tooMany = IntStream.rangeClosed(1, 65)
                                                .boxed()
                                                .collect(toMap(i -> "key" + i, i -> "val" + i));
@@ -114,12 +114,11 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void max_allowed_tags_accepted() {
+    void structural_max_tags_accepted() {
         Map<String, String> maxTags = IntStream.rangeClosed(1, 64)
                                                .boxed()
                                                .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(maxTags);
-        assertEquals(64, tags.size());
+        assertEquals(64, CloudResourceTags.from(maxTags).size());
     }
 
     @Test

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -312,10 +312,10 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void aws_rejects_more_than_50_tags() {
-        Map<String, String> tags51 = IntStream.rangeClosed(1, 51).boxed()
+    void aws_rejects_more_than_35_tags() {
+        Map<String, String> tags36 = IntStream.rangeClosed(1, 36).boxed()
                 .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(tags51);
+        var tags = CloudResourceTags.from(tags36);
         var e = assertThrows(IllegalArgumentException.class, () -> tags.validateFor(CloudName.AWS));
         assertTrue(e.getMessage().contains("AWS"));
     }
@@ -358,6 +358,15 @@ class CloudResourceTagsTest {
                          () -> tags.validateFor(CloudName.GCP),
                          "Should reject key: " + key);
         }
+    }
+
+    @Test
+    void gcp_rejects_more_than_49_tags() {
+        Map<String, String> tags50 = IntStream.rangeClosed(1, 50).boxed()
+                .collect(toMap(i -> "key" + i, i -> "val" + i));
+        var tags = CloudResourceTags.from(tags50);
+        var e = assertThrows(IllegalArgumentException.class, () -> tags.validateFor(CloudName.GCP));
+        assertTrue(e.getMessage().contains("GCP"));
     }
 
     @Test
@@ -437,10 +446,10 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void azure_rejects_more_than_50_tags() {
-        Map<String, String> tags51 = IntStream.rangeClosed(1, 51).boxed()
+    void azure_rejects_more_than_35_tags() {
+        Map<String, String> tags36 = IntStream.rangeClosed(1, 36).boxed()
                 .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(tags51);
+        var tags = CloudResourceTags.from(tags36);
         var e = assertThrows(IllegalArgumentException.class, () -> tags.validateFor(CloudName.AZURE));
         assertTrue(e.getMessage().contains("Azure"));
     }


### PR DESCRIPTION
- Reserves 15 tags per cloud for platform/system use, lowering the  customer-facing per-cloud MAX_TAGS.
- Drops the structural length/count caps in `from()` that fired only above the most permissive cloud's limit, redundant with per-cloud validation.
- Validates resolved tags against the target cloud in `resolve()` so values that grow during placeholder substitution don't slip past raw-tag validation and fail later at the cloud API.

@olaaun - do you see a case for increasing the number from 15?
