### PR TITLE
Suppress valgrind error for LLVM 21 on AlmaLinux 9. [MERGEOK]

### DIFF
--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -746,10 +746,9 @@
    ...
 }
 {
-   for LLVM 19 (almalinux 9) 3
+   for LLVM 19, LLVM 20 or LLVM 21 (almalinux 9) 3
    Memcheck:Cond
    ...
-   fun:_ZN4llvm10MCStreamer6finishENS_5SMLocE
    fun:_ZN4llvm10AsmPrinter14doFinalizationERNS_6ModuleE
    fun:_ZN4llvm13FPPassManager14doFinalizationERNS_6ModuleE
    ...


### PR DESCRIPTION
@arnej27959 : please review
