### PR TITLE
Resolve near and onear grammar aliases in QueryType.

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -2165,7 +2165,9 @@
       "public static final enum com.yahoo.search.Query$Type SELECT",
       "public static final enum com.yahoo.search.Query$Type WEAKAND",
       "public static final enum com.yahoo.search.Query$Type TOKENIZE",
-      "public static final enum com.yahoo.search.Query$Type LINGUISTICS"
+      "public static final enum com.yahoo.search.Query$Type LINGUISTICS",
+      "public static final enum com.yahoo.search.Query$Type NEAR",
+      "public static final enum com.yahoo.search.Query$Type ONEAR"
     ]
   },
   "com.yahoo.search.Query" : {

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -104,7 +104,9 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
         SELECT(7, "select"),
         WEAKAND(8, "weakAnd"),
         TOKENIZE(9, "tokenize"),
-        LINGUISTICS(10, "linguistics");
+        LINGUISTICS(10, "linguistics"),
+        NEAR(11, "near"),
+        ONEAR(12, "onear");
 
         private final int intValue;
         private final String stringValue;

--- a/container-search/src/main/java/com/yahoo/search/query/QueryType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryType.java
@@ -4,11 +4,7 @@ import com.yahoo.search.Query;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileType;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Detailed query type deciding how a query string is to be interpreted and processed.
@@ -219,14 +215,7 @@ public class QueryType {
         };
     }
 
-    /**
-     * Returns the query type represented by {@code typeName}.
-     * <p>
-     * If {@code typeName} matches a grammar alias, the query type is resolved from
-     * that alias definition. Otherwise, {@code typeName} is resolved as a
-     * {@link Query.Type} name. If {@code typeName} is null, this returns the
-     * default query type.
-     */
+    /** Returns the query type given by this string, or the default type (WEAKAND) if the given type is null. */
     public static QueryType from(String typeName) {
         if (typeName == null) return QueryType.from(Query.Type.WEAKAND);
         return QueryType.from(Query.Type.getType(typeName));

--- a/container-search/src/main/java/com/yahoo/search/query/QueryType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryType.java
@@ -210,8 +210,8 @@ public class QueryType {
             case WEAKAND ->      new QueryType(type, Composite.weakAnd, Tokenization.internal,    Syntax.simple);
             case WEB ->          new QueryType(type, Composite.and,     Tokenization.internal,    Syntax.web);
             case YQL ->          new QueryType(type, Composite.and,     Tokenization.internal,    Syntax.yql);
-            case NEAR ->         new QueryType(type, Composite.near,    Tokenization.linguistics, Syntax.none);
-            case ONEAR ->        new QueryType(type, Composite.oNear,   Tokenization.linguistics, Syntax.none);
+            case NEAR ->         new QueryType(type, Composite.near,    Tokenization.internal,    Syntax.simple);
+            case ONEAR ->        new QueryType(type, Composite.oNear,   Tokenization.internal,    Syntax.simple);
         };
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/QueryType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryType.java
@@ -4,7 +4,11 @@ import com.yahoo.search.Query;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileType;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Detailed query type deciding how a query string is to be interpreted and processed.
@@ -30,6 +34,9 @@ public class QueryType {
     public static final String PROFILE = "profile";
     public static final String IS_YQL_DEFAULT = "isYqlDefault";
 
+    private static final String NEAR_GRAMMAR_ALIAS = "near";
+    private static final String ONEAR_GRAMMAR_ALIAS = "onear";
+
     static {
         argumentType = new QueryProfileType(Model.TYPE);
         argumentType.setStrict(true);
@@ -42,6 +49,12 @@ public class QueryType {
         argumentType.addField(new FieldDescription(IS_YQL_DEFAULT, "boolean"));
         argumentType.freeze();
     }
+
+    /** Aliases for grammar names that resolve to a base query type with a specific composite operator. */
+    private static final Map<String, GrammarAlias> grammarAliases = GrammarAlias.aliases(
+        new GrammarAlias(NEAR_GRAMMAR_ALIAS, Query.Type.LINGUISTICS, Composite.near),
+        new GrammarAlias(ONEAR_GRAMMAR_ALIAS, Query.Type.LINGUISTICS, Composite.oNear)
+    );
 
     public static QueryProfileType getArgumentType() { return argumentType; }
 
@@ -216,18 +229,33 @@ public class QueryType {
     /**
      * Returns the query type represented by {@code typeName}.
      * <p>
-     * In addition to {@link Query.Type} names, this accepts grammar aliases:
-     * {@code near} resolves to linguistics tokenization with {@link Composite#near},
-     * and {@code onear} resolves to linguistics tokenization with {@link Composite#oNear}.
-     * If {@code typeName} is null, this returns the default query type.
+     * If {@code typeName} matches a grammar alias, the query type is resolved from
+     * that alias definition. Otherwise, {@code typeName} is resolved as a
+     * {@link Query.Type} name. If {@code typeName} is null, this returns the
+     * default query type.
      */
     public static QueryType from(String typeName) {
         if (typeName == null) return QueryType.from(Query.Type.WEAKAND);
-        return switch (typeName) {
-            case "near" -> QueryType.from(Query.Type.LINGUISTICS).setComposite(Composite.near);
-            case "onear" -> QueryType.from(Query.Type.LINGUISTICS).setComposite(Composite.oNear);
-            default -> QueryType.from(Query.Type.getType(typeName));
-        };
+
+        GrammarAlias grammarAlias = grammarAliases.get(typeName);
+        if (grammarAlias != null) return QueryType.from(grammarAlias);
+
+        return QueryType.from(Query.Type.getType(typeName));
+    }
+
+    /** Returns a new query type resolved from a grammar alias. */
+    private static QueryType from(GrammarAlias alias) {
+        return QueryType.from(alias.type()).setComposite(alias.composite());
+    }
+
+    /** A grammar alias definition: alias name, base query type, and composite operator override. */
+    private record GrammarAlias(String name, Query.Type type, Composite composite) {
+
+        /** Returns the alias definitions indexed by alias name. */
+        static Map<String, GrammarAlias> aliases(GrammarAlias... aliases) {
+            return Arrays.stream(aliases)
+                    .collect(Collectors.toUnmodifiableMap(GrammarAlias::name, Function.identity()));
+        }
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/query/QueryType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryType.java
@@ -213,10 +213,21 @@ public class QueryType {
         };
     }
 
-    /** Returns the query type given by this string, or the default type (WEAKAND) if the given type is null. */
+    /**
+     * Returns the query type represented by {@code typeName}.
+     * <p>
+     * In addition to {@link Query.Type} names, this accepts grammar aliases:
+     * {@code near} resolves to linguistics tokenization with {@link Composite#near},
+     * and {@code onear} resolves to linguistics tokenization with {@link Composite#oNear}.
+     * If {@code typeName} is null, this returns the default query type.
+     */
     public static QueryType from(String typeName) {
         if (typeName == null) return QueryType.from(Query.Type.WEAKAND);
-        return QueryType.from(Query.Type.getType(typeName));
+        return switch (typeName) {
+            case "near" -> QueryType.from(Query.Type.LINGUISTICS).setComposite(Composite.near);
+            case "onear" -> QueryType.from(Query.Type.LINGUISTICS).setComposite(Composite.oNear);
+            default -> QueryType.from(Query.Type.getType(typeName));
+        };
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/query/QueryType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryType.java
@@ -34,9 +34,6 @@ public class QueryType {
     public static final String PROFILE = "profile";
     public static final String IS_YQL_DEFAULT = "isYqlDefault";
 
-    private static final String NEAR_GRAMMAR_ALIAS = "near";
-    private static final String ONEAR_GRAMMAR_ALIAS = "onear";
-
     static {
         argumentType = new QueryProfileType(Model.TYPE);
         argumentType.setStrict(true);
@@ -49,12 +46,6 @@ public class QueryType {
         argumentType.addField(new FieldDescription(IS_YQL_DEFAULT, "boolean"));
         argumentType.freeze();
     }
-
-    /** Aliases for grammar names that resolve to a base query type with a specific composite operator. */
-    private static final Map<String, GrammarAlias> grammarAliases = GrammarAlias.aliases(
-        new GrammarAlias(NEAR_GRAMMAR_ALIAS, Query.Type.LINGUISTICS, Composite.near),
-        new GrammarAlias(ONEAR_GRAMMAR_ALIAS, Query.Type.LINGUISTICS, Composite.oNear)
-    );
 
     public static QueryProfileType getArgumentType() { return argumentType; }
 
@@ -223,6 +214,8 @@ public class QueryType {
             case WEAKAND ->      new QueryType(type, Composite.weakAnd, Tokenization.internal,    Syntax.simple);
             case WEB ->          new QueryType(type, Composite.and,     Tokenization.internal,    Syntax.web);
             case YQL ->          new QueryType(type, Composite.and,     Tokenization.internal,    Syntax.yql);
+            case NEAR ->         new QueryType(type, Composite.near,    Tokenization.linguistics, Syntax.none);
+            case ONEAR ->        new QueryType(type, Composite.oNear,   Tokenization.linguistics, Syntax.none);
         };
     }
 
@@ -236,26 +229,7 @@ public class QueryType {
      */
     public static QueryType from(String typeName) {
         if (typeName == null) return QueryType.from(Query.Type.WEAKAND);
-
-        GrammarAlias grammarAlias = grammarAliases.get(typeName);
-        if (grammarAlias != null) return QueryType.from(grammarAlias);
-
         return QueryType.from(Query.Type.getType(typeName));
-    }
-
-    /** Returns a new query type resolved from a grammar alias. */
-    private static QueryType from(GrammarAlias alias) {
-        return QueryType.from(alias.type()).setComposite(alias.composite());
-    }
-
-    /** A grammar alias definition: alias name, base query type, and composite operator override. */
-    private record GrammarAlias(String name, Query.Type type, Composite composite) {
-
-        /** Returns the alias definitions indexed by alias name. */
-        static Map<String, GrammarAlias> aliases(GrammarAlias... aliases) {
-            return Arrays.stream(aliases)
-                    .collect(Collectors.toUnmodifiableMap(GrammarAlias::name, Function.identity()));
-        }
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
@@ -80,11 +80,11 @@ public class UserInputTestCase {
     }
 
     @Test
-    public void testNearGrammarAliases() {
+    public void testNearAndONearGrammarTypes() {
         URIBuilder builder = searchUri();
-        builder.setParameter("yql", "select * from sources * where ({grammar:'near'}userInput('a b'))");
+        builder.setParameter("yql", "select * from sources * where ({grammar:'near'}userInput('Noëlᛁ continuation'))");
         Query near = searchAndAssertNoErrors(builder);
-        assertEquals("select * from sources * where default contains near(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\"))",
+        assertEquals("select * from sources * where default contains near(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"noel\\u16C1\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"continuation\"))",
                      near.yqlRepresentation());
 
         builder.setParameter("yql", "select * from sources * where ({grammar:'near',distance:3}userInput('a b'))");

--- a/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
@@ -80,6 +80,30 @@ public class UserInputTestCase {
     }
 
     @Test
+    public void testNearGrammarAliases() {
+        URIBuilder builder = searchUri();
+        builder.setParameter("yql", "select * from sources * where ({grammar:'near'}userInput('a b'))");
+        Query near = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where default contains near(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\"))",
+                     near.yqlRepresentation());
+
+        builder.setParameter("yql", "select * from sources * where ({grammar:'near',distance:3}userInput('a b'))");
+        near = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where default contains ({distance: 3}near(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\")))",
+                     near.yqlRepresentation());
+
+        builder.setParameter("yql", "select * from sources * where ({grammar:'onear'}userInput('a b'))");
+        Query oNear = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where default contains onear(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\"))",
+                     oNear.yqlRepresentation());
+
+        builder.setParameter("yql", "select * from sources * where ({grammar:'onear',distance:4}userInput('a b'))");
+        oNear = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where default contains ({distance: 4}onear(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\")))",
+                     oNear.yqlRepresentation());
+    }
+
+    @Test
     void testSimpleUserInput() {
         {
             URIBuilder builder = searchUri();

--- a/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
@@ -82,24 +82,24 @@ public class UserInputTestCase {
     @Test
     public void testNearAndONearGrammarTypes() {
         URIBuilder builder = searchUri();
-        builder.setParameter("yql", "select * from sources * where ({grammar:'near'}userInput('Noëlᛁ continuation'))");
+        builder.setParameter("yql", "select * from sources * where ({grammar:'near'}userInput('a b'))");
         Query near = searchAndAssertNoErrors(builder);
-        assertEquals("select * from sources * where default contains near(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"noel\\u16C1\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"continuation\"))",
+        assertEquals("select * from sources * where default contains near(\"a\", \"b\")",
                      near.yqlRepresentation());
 
         builder.setParameter("yql", "select * from sources * where ({grammar:'near',distance:3}userInput('a b'))");
         near = searchAndAssertNoErrors(builder);
-        assertEquals("select * from sources * where default contains ({distance: 3}near(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\")))",
+        assertEquals("select * from sources * where default contains ({distance: 3}near(\"a\", \"b\"))",
                      near.yqlRepresentation());
 
         builder.setParameter("yql", "select * from sources * where ({grammar:'onear'}userInput('a b'))");
         Query oNear = searchAndAssertNoErrors(builder);
-        assertEquals("select * from sources * where default contains onear(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\"))",
+        assertEquals("select * from sources * where default contains onear(\"a\", \"b\")",
                      oNear.yqlRepresentation());
 
         builder.setParameter("yql", "select * from sources * where ({grammar:'onear',distance:4}userInput('a b'))");
         oNear = searchAndAssertNoErrors(builder);
-        assertEquals("select * from sources * where default contains ({distance: 4}onear(({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"a\"), ({stem: false, normalizeCase: false, accentDrop: false, implicitTransforms: false}\"b\")))",
+        assertEquals("select * from sources * where default contains ({distance: 4}onear(\"a\", \"b\"))",
                      oNear.yqlRepresentation());
     }
 


### PR DESCRIPTION
## Summary

  Adds `near` and `onear` as supported `grammar` values for `userInput()`.

  This lets users write:

  ```yql
  {grammar:'near'}userInput('web search engine')
  {grammar:'onear'}userInput('web search engine')
```
  instead of configuring the composite operator separately.

  ## Implementation

  The new grammar values are represented as explicit query types:

  - Query.Type.NEAR
  - Query.Type.ONEAR

  They are mapped in QueryType.from(...) to:

  - Composite.near / Composite.oNear
  - Tokenization.internal
  - Syntax.simple

  This follows the existing Query.Type mapping structure and keeps the grammar resolution centralized in QueryType.

  ## Tests

  Added coverage for:

  - grammar:'near'
  - grammar:'near' with distance
  - grammar:'onear'
  - grammar:'onear' with distance

  The existing long-form grammar configuration remains supported separately, for example:

  {grammar.syntax:'none',grammar.tokenization:'linguistics',grammar.composite:'near'}userInput('web search engine')

  ## Issue

  Fixes #7294


> I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
