### PR TITLE
Make ANN timeout result in not full coverage

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -175,18 +175,12 @@ public class Coverage {
         if ((total == 0) && isDegradedByTimeout()) {
             return 0;
         }
-        // This should not be happening (?)
-        // We fall back to result sets
-        // XMLRendererTestCase.testXmlRendering() depends on this (by accident?)
-        // Might be a good idea to remove this case and return 100% anyway
-        if (docs > total) {
-            return getFullResultSets() * 100 / getResultSets();
-        }
         // At this point:
-        // 1. docs == targetActive
+        // 1. docs >= targetActive
         // 2. if targetActive > 0, then not degraded by timeout
-        // That is, whether we are full or not only depends on whether there was an ANN timeout
-        // But either way, we return 100%
+        // If docs > targetActive, we are not full according to getFull(), but returning 100% still makes sense
+        // If docs == targetActive, whether we are full or not only depends on whether there was an ANN timeout
+        // Either way, we return 100%
         return 100;
     }
 

--- a/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -107,12 +107,19 @@ public class Coverage {
     public boolean isDegradedByAnnTimeout() { return (degradedReason & DEGRADED_BY_ANN_TIMEOUT) != 0; }
     public boolean isDegradedByNonIdealState() { return (degradedReason == 0) && (getResultPercentage() != 100);}
 
-    /** Returns whether the search had full coverage or not */
+    /**
+     * Returns whether the search had full coverage or not
+     *
+     * In general, full coverage means that all active documents were covered,
+     * with the following two additional requirements:
+     * 1. If there were no active documents, a soft-timeout must not have occurred.
+     * 2. An ANN timeout must not have occurred.
+     * */
     public boolean getFull() {
         return switch (fullReason) {
             case EXPLICITLY_FULL: yield true;
             case EXPLICITLY_INCOMPLETE: yield false;
-            case DOCUMENT_COUNT: yield (docs == active) && !((active == 0) && isDegradedByTimeout()) ;
+            case DOCUMENT_COUNT: yield (docs == active) && !((active == 0) && isDegradedByTimeout()) && !isDegradedByAnnTimeout();
         };
     }
 
@@ -167,6 +174,10 @@ public class Coverage {
         }
         if ((total == 0) && isDegradedByTimeout()) {
             return 0;
+        }
+        if (isDegradedByAnnTimeout()) {
+            // The coverage is not full, but the only reason for this is the ANN timeout
+            return 100;
         }
         return getFullResultSets() * 100 / getResultSets();
     }

--- a/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -119,7 +119,7 @@ public class Coverage {
         return switch (fullReason) {
             case EXPLICITLY_FULL: yield true;
             case EXPLICITLY_INCOMPLETE: yield false;
-            case DOCUMENT_COUNT: yield (docs == active) && !((active == 0) && isDegradedByTimeout()) && !isDegradedByAnnTimeout();
+            case DOCUMENT_COUNT: yield (docs >= active) && !((active == 0) && isDegradedByTimeout()) && !isDegradedByAnnTimeout();
         };
     }
 
@@ -178,8 +178,7 @@ public class Coverage {
         // At this point:
         // 1. docs >= targetActive
         // 2. if targetActive > 0, then not degraded by timeout
-        // If docs > targetActive, we are not full according to getFull(), but returning 100% still makes sense
-        // If docs == targetActive, whether we are full or not only depends on whether there was an ANN timeout
+        // Whether we are full or not only depends on whether there was an ANN timeout
         // Either way, we return 100%
         return 100;
     }

--- a/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -175,11 +175,19 @@ public class Coverage {
         if ((total == 0) && isDegradedByTimeout()) {
             return 0;
         }
-        if (isDegradedByAnnTimeout()) {
-            // The coverage is not full, but the only reason for this is the ANN timeout
-            return 100;
+        // This should not be happening (?)
+        // We fall back to result sets
+        // XMLRendererTestCase.testXmlRendering() depends on this (by accident?)
+        // Might be a good idea to remove this case and return 100% anyway
+        if (docs > total) {
+            return getFullResultSets() * 100 / getResultSets();
         }
-        return getFullResultSets() * 100 / getResultSets();
+        // At this point:
+        // 1. docs == targetActive
+        // 2. if targetActive > 0, then not degraded by timeout
+        // That is, whether we are full or not only depends on whether there was an ANN timeout
+        // But either way, we return 100%
+        return 100;
     }
 
     public com.yahoo.container.logging.Coverage toLoggingCoverage() {

--- a/container-search/src/main/java/com/yahoo/search/result/Coverage.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Coverage.java
@@ -40,7 +40,14 @@ public class Coverage extends com.yahoo.container.handler.Coverage {
      * @param degradedReason reason for degradation
      * @return self for chaining
      */
-    public Coverage setDegradedReason(int degradedReason) { this.degradedReason = degradedReason; return this; }
+    public Coverage setDegradedReason(int degradedReason) {
+        this.degradedReason = degradedReason;
+        // Updating the degraded reason can make the coverage not full
+        if (!getFull()) {
+            this.fullResultSets = 0;
+        }
+        return this;
+    }
 
     public Coverage setNodesTried(int nodesTried) { super.setNodesTried(nodesTried); return this; }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -191,10 +191,12 @@ public class InterleavedSearchInvokerTest {
             Coverage cov = result.getCoverage(true);
             assertEquals(100_000L, cov.getDocs());
             assertEquals(2, cov.getNodes());
-            assertTrue(cov.getFull()); // All docs covered despite ANN timeout
+
+            // A node with an ANN timeout should still be reported as 100 percentage, but not as full
+            assertFalse(cov.getFull());
             assertEquals(100, cov.getResultPercentage());
             assertEquals(1, cov.getResultSets());
-            assertEquals(1, cov.getFullResultSets());
+            assertEquals(0, cov.getFullResultSets());
             assertTrue(cov.isDegraded());
             assertTrue(cov.isDegradedByAnnTimeout());
         }

--- a/container-search/src/test/java/com/yahoo/search/rendering/XMLRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/XMLRendererTestCase.java
@@ -82,7 +82,7 @@ public class XMLRendererTestCase {
 
         String expected =
                 "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
-                        "<result total-hit-count=\"0\" coverage-docs=\"500\" coverage-nodes=\"1\" coverage-full=\"false\" coverage=\"0\" results-full=\"0\" results=\"1\">\n" +
+                        "<result total-hit-count=\"0\" coverage-docs=\"500\" coverage-nodes=\"1\" coverage-full=\"true\" coverage=\"100\" results-full=\"1\" results=\"1\">\n" +
                         "  <error code=\"18\">Internal server error.</error>\n" +
                         "  <errordetails>\n" +
                         "    <error error=\"Internal server error.\" code=\"18\">message</error>\n" +

--- a/container-search/src/test/java/com/yahoo/search/result/CoverageTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/result/CoverageTestCase.java
@@ -134,10 +134,12 @@ public class CoverageTestCase {
         assertFalse(zero.isDegraded());
         assertEquals(100, zero.getResultPercentage());
         assertTrue(zero.getFull());
+        // Degrade with ANN timeout
+        // This should still be reported as 100 percentage, but not as full
         zero.setDegradedReason(com.yahoo.container.handler.Coverage.DEGRADED_BY_ANN_TIMEOUT);
         assertTrue(zero.isDegraded());
         assertEquals(100, zero.getResultPercentage());
-        assertTrue(zero.getFull());
+        assertFalse(zero.getFull());
     }
 
     @Test


### PR DESCRIPTION
Makes the ANN timeout result in 100% coverage while reporting it as not full.

The existing behavior of `getResultPercentage()` is a bit weird. If `docs >= targetActive`, it has a fallback to using the number of full result sets for the percentage: `return getFullResultSets() * 100 / getResultSets();` I do not really see the reason for this, i.e., why one does not simply return 100% in this case.

In a way, this is consistent with the way the full result sets are determined: `this.fullResultSets = getFull() ? resultSets : 0;`. Having `docs > targetActive` means "not full" and results in a not full result set. There is a test case that relies on that behavior, `XMLRendererTestCase.testXmlRendering()`, but I do not know if this is on purpose or by accident. I also don't know whether `docs > targetActive` can even happen in practice.

Moreover, a coverage can explicitly be set to be full or not, which affects whether it result sets are considered full or not. So, maybe that is the point of `return getFullResultSets() * 100 / getResultSets();`. But then, why only use that if `docs >= targetActive` and not if such an explicit reason is used. 🤔 

Judging by the git history, the `return getFullResultSets() * 100 / getResultSets();` was the original way of computing the coverage and using `targetActive` only came in later. That could be a reasonable explanation of this inconsistency.

@havardpe @hmusum Any knowledge or opinions on this? Seems like the most reasonable thing to do is to remove the `return getFullResultSets() * 100 / getResultSets();` and return 100% either way. And then to repair that unit test.