### PR TITLE
Reserve colon tag prefixes

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -44,7 +44,7 @@ public class CloudResourceTags {
             "preprovisioned");
 
     /** Key prefixes reserved by the platform. Compared case-insensitively against customer keys. */
-    private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "bastion_");
+    private static final List<String> RESERVED_KEY_PREFIXES = List.of("vai_", "corp_", "corp:", "bastion_", "bastion:");
 
     private static final List<String> PLACEHOLDERS = List.of(
             "${tenant}", "${application}", "${instance}", "${environment}", "${region}",

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -194,14 +194,18 @@ class CloudResourceTagsTest {
     void reserved_key_prefixes_rejected() {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("vai_tag", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("corp_tag", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("corp:tag", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("bastion_tag", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("bastion:tag", "value")));
     }
 
     @Test
     void reserved_key_prefixes_rejected_case_insensitively() {
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("VAI_tag", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("CORP_tag", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("CORP:tag", "value")));
         assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Bastion_tag", "value")));
+        assertThrows(IllegalArgumentException.class, () -> CloudResourceTags.from(Map.of("Bastion:tag", "value")));
     }
 
     // --- Template variables ---


### PR DESCRIPTION
Reserve AWS-style `corp:` and `bastion:` tag key prefixes in addition to the existing underscore variants. This prevents customer resource tags from colliding with platform-owned AWS tag namespaces now that colons are allowed in AWS tag keys.

Adds coverage for both lowercase and case-insensitive prefix matching.