### PR TITLE
configserver: Update profile during redeploy

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/HostSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/HostSpec.java
@@ -102,6 +102,10 @@ public class HostSpec implements Comparable<HostSpec> {
         return new HostSpec(hostname, realResources, advertisedResources, requestedResources, membership, version, ports, dockerImageRepo);
     }
 
+    public HostSpec withMembership(ClusterMembership membership) {
+        return new HostSpec(hostname, realResources, advertisedResources, requestedResources, membership, version, networkPorts, dockerImageRepo);
+    }
+
     @Override
     public String toString() {
         return hostname +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -308,7 +308,7 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
      * Returns a host provisioner returning the previously allocated hosts
      */
     HostProvisioner createStaticProvisionerForHosted(AllocatedHosts allocatedHosts, HostProvisioner nodeRepositoryProvisioner) {
-        return new StaticProvisioner(allocatedHosts, nodeRepositoryProvisioner);
+        return new StaticProvisioner(allocatedHosts, nodeRepositoryProvisioner, zone.system());
     }
 
     Optional<HostProvisioner> createNodeRepositoryProvisioner(ApplicationId applicationId, Provisioned provisioned) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/provision/StaticProvisioner.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/provision/StaticProvisioner.java
@@ -7,7 +7,7 @@ import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.ProvisionLogger;
-
+import com.yahoo.config.provision.SystemName;
 import java.util.List;
 
 /**
@@ -21,14 +21,16 @@ public class StaticProvisioner implements HostProvisioner {
     
     /** The fallback provisioner to use for unknown clusters, or null to not fall back */
     private final HostProvisioner fallback;
+    private final SystemName systemName;
 
     /**
      * Creates a static host provisioner which will fall back to using the given provisioner
      * if a request is made for nodes in a cluster which is not present in this allocation.
      */
-    public StaticProvisioner(AllocatedHosts allocatedHosts, HostProvisioner fallback) {
+    public StaticProvisioner(AllocatedHosts allocatedHosts, HostProvisioner fallback, SystemName systemName) {
         this.allocatedHosts = allocatedHosts;
         this.fallback = fallback;
+        this.systemName = systemName;
     }
 
     @Override
@@ -37,10 +39,19 @@ public class StaticProvisioner implements HostProvisioner {
                 allocatedHosts.getHosts().stream()
                                          .filter(host -> host.membership().isPresent() && matches(host.membership().get().cluster(), cluster))
                                          .toList();
-        if ( ! hostsAlreadyAllocatedToCluster.isEmpty()) 
-            return hostsAlreadyAllocatedToCluster;
-        else
+        if (hostsAlreadyAllocatedToCluster.isEmpty()) {
             return fallback.prepare(cluster, capacity, logger);
+        }
+
+        if (systemName.isKubernetesLike()) {
+            return hostsAlreadyAllocatedToCluster.stream()
+                    .map(host -> host.membership()
+                            .map(membership -> host.withMembership(membership.with(cluster)))
+                            .orElse(host))
+                    .toList();
+        }
+
+        return hostsAlreadyAllocatedToCluster;
     }
 
     private boolean matches(ClusterSpec nodeCluster, ClusterSpec requestedCluster) {

--- a/configserver/src/test/apps/hosted-with-profile/schemas/music.sd
+++ b/configserver/src/test/apps/hosted-with-profile/schemas/music.sd
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+schema music {
+  document music {
+    field title type string {
+      indexing: index | summary
+    }
+  }
+}
+

--- a/configserver/src/test/apps/hosted-with-profile/services.xml
+++ b/configserver/src/test/apps/hosted-with-profile/services.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+
+  <container version="1.0">
+    <http>
+      <filtering>
+        <access-control domain="myDomain" write="true" />
+      </filtering>
+      <server id="foo"/>
+    </http>
+    <search/>
+    <nodes count='1' profile="my-profile"/>
+  </container>
+
+  <content id="music" version="1.0">
+    <redundancy>2</redundancy>
+    <documents>
+      <document type="music" mode="index" />
+    </documents>
+    <nodes count="4" groups="2"/>
+  </content>
+
+</services>

--- a/configserver/src/test/apps/hosted-with-profile/validation-overrides.xml
+++ b/configserver/src/test/apps/hosted-with-profile/validation-overrides.xml
@@ -1,0 +1,3 @@
+<validation-overrides>
+    <allow until='2026-02-01'>minimum-node-count</allow>
+</validation-overrides>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.config.server.provision;
 
 import com.yahoo.cloud.config.ModelConfig;
+import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
 import com.yahoo.config.model.api.ApplicationClusterEndpoint;
@@ -11,6 +12,14 @@ import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
+import com.yahoo.config.provision.AllocatedHosts;
+import com.yahoo.config.provision.Capacity;
+import com.yahoo.config.provision.ClusterMembership;
+import com.yahoo.config.provision.ClusterResources;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.HostSpec;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.SystemName;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.Test;
@@ -20,9 +29,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Ulf Lilleengen
@@ -35,10 +46,33 @@ public class StaticProvisionerTest {
         InMemoryProvisioner inMemoryHostProvisioner = new InMemoryProvisioner(false, false, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com", "host4.yahoo.com");
         VespaModel firstModel = createModel(app, inMemoryHostProvisioner);
 
-        StaticProvisioner staticProvisioner = new StaticProvisioner(firstModel.allocatedHosts(), null);
+        StaticProvisioner staticProvisioner = new StaticProvisioner(firstModel.allocatedHosts(), null, SystemName.Public);
         VespaModel secondModel = createModel(app, staticProvisioner);
 
         assertModelConfig(firstModel, secondModel);
+    }
+
+    @Test
+    public void profileIsEmittedForKubernetes() throws IOException, SAXException {
+        ApplicationPackage appWithoutProfile = FilesApplicationPackage.fromDir(new File("src/test/apps/hosted"), Map.of());
+        ApplicationPackage appWithProfile = FilesApplicationPackage.fromDir(new File("src/test/apps/hosted-with-profile"), Map.of());
+        InMemoryProvisioner inMemoryProvisioner = new InMemoryProvisioner(false, false, "host1.yahoo.com", "host2.yahoo.com", "host3.yahoo.com", "host4.yahoo.com");
+
+        VespaModel firstModel = createModel(appWithoutProfile, inMemoryProvisioner);
+        assertTrue(firstModel.allClusters().stream().allMatch(c -> c.profile().isEmpty()));
+
+        StaticProvisioner staticProvisioner = new StaticProvisioner(firstModel.allocatedHosts(), null, SystemName.kubernetes);
+        VespaModel secondModel = createModel(appWithProfile, staticProvisioner);
+
+        assertTrue(secondModel.allClusters().stream()
+                              .filter(c -> c.type() == ClusterSpec.Type.container)
+                              .allMatch(c -> c.profile().isPresent() && c.profile().get().equals("my-profile")));
+
+        StaticProvisioner redeployProvisioner = new StaticProvisioner(secondModel.allocatedHosts(), null, SystemName.kubernetes);
+        VespaModel thirdModel = createModel(appWithProfile, redeployProvisioner);
+        assertTrue(thirdModel.allClusters().stream()
+                             .filter(c -> c.type() == ClusterSpec.Type.container)
+                             .allMatch(c -> c.profile().isPresent() && c.profile().get().equals("my-profile")));
     }
 
     private void assertModelConfig(VespaModel firstModel, VespaModel secondModel) {


### PR DESCRIPTION
The ClusterSpec did not emit the latest `profile` attribute when an application package was redeployed. i.e. after the initial `prepare()`, the `ClusterSpec.profile()` was always null.

This was due to reusing the stale `ClusterSpec` in `StaticProvisioner.prepare()` from the already allocated `HostSpecs`. This didn't seem to matter before (?) since most of the `ClusterSpec` attributes are immutable for the Cluster's lifetime, except for group which has special handling.

Changed `prepare()` to always maintain an up-to-date `ClusterSpec`. Toggled it conservatively only for the kubernetes system for now.