### PR TITLE
Don't wrap UncheckedTimeoutException when deploy times out

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.config.server.modelfactory;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
+import com.yahoo.concurrent.UncheckedTimeoutException;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.HostProvisioner;
@@ -114,7 +115,7 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
                 buildLatestModelForThisMajor = false; // We have successfully built latest model version, do it only for this major
                 versionToBuildFirst = Optional.empty(); // Set to empty, cannot build this first on another major
             }
-            catch (NodeAllocationException | ApplicationLockException | TransientException | QuotaExceededException e) {
+            catch (NodeAllocationException | ApplicationLockException | TransientException | QuotaExceededException | UncheckedTimeoutException e) {
                 // Don't wrap this exception, and don't try to load other model versions as this is (most likely)
                 // caused by the state of the system, not the model version/application combination
                 throw e;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -165,7 +165,7 @@ public class HostedDeployTest {
     }
 
     @Test
-    public void testDeployMultipleVersionsSpecifyingWhicVersionToBuildFirst() {
+    public void testDeployMultipleVersionsSpecifyingWhichVersionToBuildFirst() {
         List<ModelFactory> modelFactories = List.of(createHostedModelFactory(Version.fromString("8.1.0"), clock),
                                                     createHostedModelFactory(Version.fromString("8.2.0"), clock),
                                                     createHostedModelFactory(Version.fromString("8.3.0"), clock));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilderTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilderTest.java
@@ -1,0 +1,93 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.server.modelfactory;
+
+import com.yahoo.cloud.config.ConfigserverConfig;
+import com.yahoo.component.Version;
+import com.yahoo.concurrent.UncheckedTimeoutException;
+import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.Model;
+import com.yahoo.config.model.api.ModelContext;
+import com.yahoo.config.model.api.ModelCreateResult;
+import com.yahoo.config.model.api.ModelFactory;
+import com.yahoo.config.model.api.ValidationParameters;
+import com.yahoo.config.model.test.MockApplicationPackage;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.DockerImage;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class ModelsBuilderTest {
+
+    @Test
+    public void unchecked_timeout_exception_is_propagated_without_wrapping() {
+        var version = Version.fromString("8.1.1");
+        var exception = new UncheckedTimeoutException("timed out building models");
+        var registry = new ModelFactoryRegistry(List.of(new ThrowingModelFactory(version, exception)));
+        var builder = new TestModelsBuilder(registry);
+        var applicationPackage = new MockApplicationPackage.Builder().withEmptyHosts().withEmptyServices().build();
+
+        var thrown = assertThrows(UncheckedTimeoutException.class,
+                () -> builder.buildModels(ApplicationId.defaultId(),
+                                          Optional.empty(),
+                                          version,
+                                          Optional.empty(),
+                                          applicationPackage,
+                                          new AllocatedHostsFromAllModels(),
+                                          Instant.now()));
+        assertTrue(thrown.getMessage().contains("timed out"));
+    }
+
+    private static class TestModelsBuilder extends ModelsBuilder<ModelResult> {
+
+        TestModelsBuilder(ModelFactoryRegistry registry) {
+            super(registry,
+                  new ConfigserverConfig(new ConfigserverConfig.Builder()),
+                  Zone.defaultZone(),
+                  HostProvisionerProvider.empty(),
+                  (level, message) -> {});
+        }
+
+        @Override
+        protected ModelResult buildModelVersion(ModelFactory modelFactory, ApplicationPackage applicationPackage,
+                                                ApplicationId applicationId, Optional<DockerImage> dockerImageRepository,
+                                                Version wantedNodeVespaVersion) {
+            modelFactory.createModel(null);
+            throw new IllegalStateException("should not reach here");
+        }
+
+    }
+
+    private static class ThrowingModelFactory implements ModelFactory {
+
+        private final Version version;
+        private final RuntimeException exception;
+
+        ThrowingModelFactory(Version version, RuntimeException exception) {
+            this.version = version;
+            this.exception = exception;
+        }
+
+        @Override
+        public Version version() { return version; }
+
+        @Override
+        public Model createModel(ModelContext modelContext) { throw exception; }
+
+        @Override
+        public ModelCreateResult createAndValidateModel(ModelContext modelContext, ValidationParameters validationParameters) {
+            throw exception;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This should make sure it ends up with a proper http response code and json error code instead of giving internal server error