### PR TITLE
Handle disappearing document IDs when saving document IDs in DocumentMetaStore [MERGEOK]

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -1756,7 +1756,7 @@ TEST(DocumentMetaStoreTest, move_works) {
     EXPECT_FALSE(dms.getGidEvenIfMoved(1u, gid));
     EXPECT_TRUE(dms.getGid(2u, gid));
     EXPECT_EQ(1u, dms.getNumUsedLids());
-    dms.move(2u, 1u, 0u);
+    dms.move(docid2, 2u, 1u, 0u);
     dms.commit();
     EXPECT_TRUE(dms.getGid(1u, gid));
     EXPECT_FALSE(dms.getGid(2u, gid));
@@ -1785,7 +1785,7 @@ TEST(DocumentMetaStoreTest, getting_full_document_id_works_after_move) {
     dms.removes_complete({1u});
     EXPECT_EQ("", dms.get_docid_string(gid1));
     EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
-    dms.move(2u, 1u, 0u);
+    dms.move(docid2, 2u, 1u, 0u);
     dms.commit();
     EXPECT_EQ("", dms.get_docid_string(gid1));
     EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -2132,6 +2132,43 @@ TEST(DocumentMetaStoreTest, dms_complains_about_missing_document_ids) {
     remove_save_files(documentmetastore6);
 }
 
+TEST(DocumentMetaStoreTest, invalid_entry_refs_do_not_affect_saving_of_full_document_ids) {
+    std::string       documentmetastore7("documentmetastore7");
+    DocumentMetaStore dms1(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), true, SubDbType::READY);
+    dms1.constructFreeList();
+    addLid(dms1, 1);
+    // Temporarily disable storing of document IDs to get an invalid document ID
+    dms1.set_store_full_document_id(false);
+    addLid(dms1, 2);
+    dms1.set_store_full_document_id(true);
+    addLid(dms1, 3);
+
+    // Lid 2 should have an invalid entry ref
+    EXPECT_FALSE(dms1.getRawMetadata(2).get_relaxed_docid_ref().valid());
+
+    TuneFileAttributes      tuneFileAttributes;
+    DummyFileHeaderContext  fileHeaderContext;
+    AttributeFileSaveTarget saveTarget(tuneFileAttributes, fileHeaderContext);
+    EXPECT_TRUE(dms1.save(saveTarget, documentmetastore7));
+
+    DocumentMetaStore dms_loaded_docids(createBucketDB(), documentmetastore7, search::GrowStrategy(), true,
+                                        SubDbType::READY);
+    EXPECT_TRUE(dms_loaded_docids.load());
+    dms_loaded_docids.constructFreeList();
+    EXPECT_FALSE(dms_loaded_docids.requires_document_ids_from_docstore());
+
+    // Lid 1 and 3 should have their document IDs
+    auto d1 = createDocId(1);
+    EXPECT_EQ(d1.toString(), dms_loaded_docids.get_docid_string(d1.getGlobalId()));
+    auto d3 = createDocId(3);
+    EXPECT_EQ(d3.toString(), dms_loaded_docids.get_docid_string(d3.getGlobalId()));
+
+    // Lid 2 should have an invalid entry ref
+    EXPECT_FALSE(dms_loaded_docids.getRawMetadata(2).get_relaxed_docid_ref().valid());
+
+    remove_save_files(documentmetastore7);
+}
+
 namespace {
 
 void assertLidGidFound(uint32_t lid, DocumentMetaStore& dms) {

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -1798,6 +1798,30 @@ TEST(DocumentMetaStoreTest, getting_full_document_id_works_after_move) {
     EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
 }
 
+TEST(DocumentMetaStoreTest, move_fills_in_missing_docids) {
+    // Start without storing document IDs
+    // Use this to simulate document IDs disappearing
+    DocumentMetaStore dms(createBucketDB(), "[documentmetastore]", search::GrowStrategy(), false, SubDbType::READY);
+    dms.constructFreeList();
+
+    assertPut(bucketId1, time1, 1u, docid1, dms);
+    assertPut(bucketId2, time2, 2u, docid2, dms);
+    EXPECT_TRUE(dms.remove(1u, 0u));
+    dms.commit();
+    dms.removes_complete({1u});
+
+    // Use super secret method to activate storing document ids while DocumentMetaStore exists
+    // This means that we leave lid 2 without a valid document ID
+    dms.set_store_full_document_id(true);
+    // The move should fill in the missing document ID
+    dms.move(docid2, 2u, 1u, 0u);
+    dms.commit();
+    // A wild document ID appeared!
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+    dms.removes_complete({2u});
+    EXPECT_EQ(docid2.toString(), dms.get_docid_string(gid2));
+}
+
 void assertLidSpace(uint32_t numDocs, uint32_t committedDocIdLimit, uint32_t numUsedLids, bool wantShrinkLidSpace,
                     bool canShrinkLidSpace, const DocumentMetaStore& dms) {
     EXPECT_EQ(numDocs, dms.getNumDocs());

--- a/searchcore/src/tests/proton/documentmetastore/lidreusedelayer/lidreusedelayer_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/lidreusedelayer/lidreusedelayer_test.cpp
@@ -65,7 +65,7 @@ public:
         _removes_complete_lids += lids.size();
     }
 
-    void move(DocId, DocId, uint64_t) override {}
+    void move(const document::DocumentId&, DocId, DocId, uint64_t) override {}
 
     bool validLid(DocId) const override { return true; }
 

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentidsaver.cpp
@@ -34,7 +34,10 @@ public:
         assert(lid < _metadata_view.size());
         const RawDocumentMetadata& metadata = _metadata_view[lid];
         auto                       docid_ref = metadata.acquire_docid_ref();
-        assert(docid_ref.valid());
+        // We do not check if the docid_ref is valid
+        // An invalid docid_ref becomes a string of length 0, which then becomes an invalid docid_ref again upon
+        // loading If the docid_ref became invalid due to a remove, this does not matter If it was due to a move, the
+        // document ID will be filled in again by the move
         auto span = _docid_store.get(docid_ref);
         assert(span.size() <= std::numeric_limits<uint32_t>::max()); // Document ids have a maximum length of 0x10000,
                                                                      // so 4 bytes are enough

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -706,7 +706,8 @@ void DocumentMetaStore::removes_complete(const std::vector<DocId>& lids) {
     incGeneration();
 }
 
-void DocumentMetaStore::move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) {
+void DocumentMetaStore::move(const document::DocumentId& docid, DocId fromLid, DocId toLid,
+                             uint64_t prepare_serial_num) {
     assert(fromLid != 0);
     assert(toLid != 0);
     assert(fromLid > toLid);
@@ -717,6 +718,13 @@ void DocumentMetaStore::move(DocId fromLid, DocId toLid, uint64_t prepare_serial
     _metadataStore[toLid] = _metadataStore[fromLid];
     if (_store_full_document_id) {
         _metadataStore[fromLid].set_docid_ref(EntryRef());
+        auto& metadata = _metadataStore[toLid];
+        // No document id for this document
+        // Gone missing during saving?
+        if (!metadata.get_relaxed_docid_ref().valid()) {
+            const auto ref = add_docid_string(docid.getScheme().toString());
+            metadata.set_docid_ref(ref);
+        }
     }
     const GlobalId& gid = getRawGid(fromLid);
     KeyComp         comp(gid, get_unbound_metadata_view());

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -299,8 +299,14 @@ public:
     uint64_t getEstimatedSaveByteSize() const override;
     [[nodiscard]] size_t transient_memory_for_flush() const noexcept override;
     uint32_t getVersion() const override;
+
+    /*
+     * Functions only intended for unit testing. Do not use these!
+     */
     void setTrackDocumentSizes(bool trackDocumentSizes) { _trackDocumentSizes = trackDocumentSizes; }
     void set_track_32bit_document_sizes(bool value) noexcept { _track_32bit_document_sizes = value; }
+    void set_store_full_document_id(bool value) noexcept { _store_full_document_id = value; }
+
     void foreach(const search::IGidToLidMapperVisitor& visitor) const override;
     bool is_sortable() const noexcept override;
     std::unique_ptr<search::attribute::ISortBlobWriter>

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -211,7 +211,7 @@ public:
      * document store).
      */
     void removes_complete(const std::vector<DocId>& lids) override;
-    void move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) override;
+    void move(const document::DocumentId& docid, DocId fromLid, DocId toLid, uint64_t prepare_serial_num) override;
     bool validButMaybeUnusedLid(DocId lid) const { return _lidAlloc.validButMaybeUnusedLid(lid); }
     bool validLidFast(DocId lid) const { return _lidAlloc.validLid(lid); }
     bool validLidFast(DocId lid, uint32_t limit) const { return _lidAlloc.validLid(lid, limit); }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/i_store.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/i_store.h
@@ -98,7 +98,7 @@ struct IStore {
      * is updated atomically from fromLid to toLid.
      * The caller must call removes_complete() with fromLid after document move is done.
      */
-    virtual void move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) = 0;
+    virtual void move(const document::DocumentId& docid, DocId fromLid, DocId toLid, uint64_t prepare_serial_num) = 0;
 
     /**
      * Check if the lid is valid.

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
@@ -136,7 +136,7 @@ void moveMetadata(documentmetastore::IStore& meta_store, const DocumentId& doc_i
     (void)meta;
     assert(meta.getGid() == doc_id.getGlobalId());
     assert(meta.getTimestamp() == op.getTimestamp());
-    meta_store.move(op.getPrevLid(), op.getLid(), op.get_prepare_serial_num());
+    meta_store.move(doc_id, op.getPrevLid(), op.getLid(), op.get_prepare_serial_num());
 }
 
 class UpdateScope final : public IFieldUpdateCallback {

--- a/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
@@ -73,8 +73,8 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore {
         _removes_complete_lids.insert(_removes_complete_lids.end(), lids.cbegin(), lids.cend());
         _store.removes_complete(lids);
     }
-    void move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) override {
-        _store.move(fromLid, toLid, prepare_serial_num);
+    void move(const document::DocumentId& docid, DocId fromLid, DocId toLid, uint64_t prepare_serial_num) override {
+        _store.move(docid, fromLid, toLid, prepare_serial_num);
     }
     bool validLid(DocId lid) const override { return _store.validLid(lid); }
     void removeBatch(const std::vector<DocId>& lidsToRemove, const DocId docIdLimit) override {


### PR DESCRIPTION
Just write an empty string to disk if a document ID disappeared. If this was due to a remove, we do not care. If this happened due to a move, the move will fill it in again.