### PR TITLE
config-provisioning: Add initializer for ClusterMembership with profile

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -155,6 +155,11 @@ public class ClusterMembership {
     }
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
+            ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, Optional<String> profile) {
+        return from(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, List.of(), profile);
+    }
+
+    public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                                          ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, List<AzName> availabilityZones) {
         return from(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, availabilityZones, Optional.empty());
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -155,7 +155,7 @@ public class ClusterMembership {
     }
 
     public static ClusterMembership from(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
-            ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, Optional<String> profile) {
+                                         ZoneEndpoint zoneEndpoint, List<SidecarSpec> sidecars, Optional<String> profile) {
         return from(stringValue, vespaVersion, dockerImageRepo, zoneEndpoint, sidecars, List.of(), profile);
     }
 


### PR DESCRIPTION
We should probably consolidate these initializers to the availabilityZone variants in the future. 

This is to enable marshalling from the node-repository. Refer to #37022