### PR TITLE
buildkite: pre-fetch system-test maven deps on host before container [MERGEOK]

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -87,7 +87,7 @@ git archive HEAD --format tar | tar x -C docker/vespa-systemtests
 before="\\\$[{]vespa.version[}]"
 after="${VESPA_VERSION}"
 find docker/vespa-systemtests -name pom.xml -print0 | xargs -0 perl -pi -e "s,>${before}<,>${after}<,"
-mvn -Daether.dependencyCollector.impl=bf -Dvespa.version=${VESPA_VERSION} \
+mvn -Daether.dependencyCollector.impl=bf -Dvespa.version="${VESPA_VERSION}" \
     --threads 1 --batch-mode \
     --file docker/vespa-systemtests/tests/pom.xml \
     dependency:go-offline

--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -87,6 +87,10 @@ git archive HEAD --format tar | tar x -C docker/vespa-systemtests
 before="\\\$[{]vespa.version[}]"
 after="${VESPA_VERSION}"
 find docker/vespa-systemtests -name pom.xml -print0 | xargs -0 perl -pi -e "s,>${before}<,>${after}<,"
+mvn -Daether.dependencyCollector.impl=bf -Dvespa.version=${VESPA_VERSION} \
+    --threads 1 --batch-mode \
+    --file docker/vespa-systemtests/tests/pom.xml \
+    dependency:go-offline
 cd docker
 echo "Copying Maven repository and RPMs for system-test container..."
 rm -rf maven-repo


### PR DESCRIPTION
…build

Run `mvn dependency:go-offline` against docker/vespa-systemtests/tests/pom.xml on the build host, before the system-test container is built and the host's ~/.m2/repository is copied into docker/maven-repo as the container's offline repo.

Why: doing this on the host (instead of inside the container) populates the persistent ~/.m2 cache on the build agent, so subsequent Buildkite runs reuse the downloaded artifacts instead of re-fetching them every time.
