### PR TITLE
Fix schema-language-server to compile with CongoCC 2.1.0

### DIFF
--- a/integration/schema-language-server/language-server/pom.xml
+++ b/integration/schema-language-server/language-server/pom.xml
@@ -176,67 +176,24 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.congocc</groupId>   
-        <artifactId>org.congocc.maven.plugin</artifactId>   
-        <version>2.1.0</version>   
-        <executions>   
-          <execution>   
-            <id>1</id>   
-            <goals>   
-              <goal>ccc-generate</goal>   
-            </goals>   
-            <configuration>   
-                <grammarFile>${project.basedir}/src/main/ccc/SchemaParser.ccc</grammarFile>   
-                <outputDir>${project.basedir}/target/generated-sources/ccc</outputDir>   
-                <jdk>17</jdk>   
-            </configuration>   
-          </execution>   
-          <execution>   
-            <id>2</id>   
-            <goals>   
-              <goal>ccc-generate</goal>   
-            </goals>   
-            <configuration>   
-                <grammarFile>${project.basedir}/src/main/ccc/indexinglanguage/IndexingParser.ccc</grammarFile>   
-                <outputDir>${project.basedir}/target/generated-sources/ccc</outputDir>   
-                <jdk>17</jdk>   
-            </configuration>   
-          </execution>   
-          <execution>   
-            <id>3</id>   
-            <goals>   
-              <goal>ccc-generate</goal>   
-            </goals>   
-            <configuration>   
-                <grammarFile>${project.basedir}/src/main/ccc/rankingexpression/RankingExpressionParser.ccc</grammarFile>   
-                <outputDir>${project.basedir}/target/generated-sources/ccc</outputDir>   
-                <jdk>17</jdk>   
-            </configuration>
-          </execution>
+        <groupId>org.congocc</groupId>
+        <artifactId>org.congocc.maven.plugin</artifactId>
+        <version>2.1.0</version>
+        <executions>
           <execution>
-            <id>4</id>
+            <id>generate-parsers</id>
             <goals>
               <goal>ccc-generate</goal>
             </goals>
             <configuration>
-              <grammarFile>${project.basedir}/src/main/ccc/yqlplus/YQLPlus.ccc</grammarFile>
-              <outputDir>${project.basedir}/target/generated-sources/ccc</outputDir>
+              <sourceDirectory>${project.basedir}/src/main/ccc</sourceDirectory>
+              <outputDirectory>${project.basedir}/target/generated-sources/ccc</outputDirectory>
               <jdk>17</jdk>
+              <quiet>true</quiet>
             </configuration>
           </execution>
-          <execution>
-            <id>5</id>   
-            <goals>   
-              <goal>ccc-generate</goal>   
-            </goals>   
-            <configuration>   
-                <grammarFile>${project.basedir}/src/main/ccc/grouping/GroupingParser.ccc</grammarFile>   
-                <outputDir>${project.basedir}/target/generated-sources/ccc</outputDir>   
-                <jdk>17</jdk>   
-            </configuration>
-          </execution>
-        </executions>   
-      </plugin>   
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -1232,16 +1232,15 @@ void indexingElm(ParsedField field) :
  *
  * @param field The field to modify.
  */
-SubLanguageData indexingOperationElm(ParsedField field, boolean multiLine) : { }
-
-    {
-        return newIndexingOperation(multiLine);
-        //IndexingOperation oldOp = newIndexingOperation(multiLine);
-        //if (oldOp != null) {
-        //    //ParsedIndexingOp newOp = new ParsedIndexingOp(oldOp.getScript());
-        //    //field.setIndexingOperation(newOp);
-        //}
-    }
+SubLanguageData indexingOperationElm(ParsedField field, boolean multiLine) : {
+    SubLanguageData result = null;
+}
+    (
+        <EOF>
+        |
+        { result = newIndexingOperation(multiLine); }
+    )
+    { return result; }
 ;
 
 /**
@@ -2213,9 +2212,15 @@ void uriInOnnxModel(OnnxModel onnxModel) :
 ;
 
 
-String rankingConstantErrorMessage(String name) : {}
-
-    { return "For ranking constant ' " + name + "'"; }
+String rankingConstantErrorMessage(String name) : {
+    String result = null;
+}
+    (
+        <EOF>
+        |
+        { result = "For ranking constant ' " + name + "'"; }
+    )
+    { return result; }
 ;
 
 
@@ -2641,11 +2646,16 @@ InputType valueType(Reference reference) :
  * See details about why this is needed in consumedExpressionElm.
  */
 Node consumedFeatureListElm(boolean multiline) :
-{
-    SubLanguageData featureList = consumeRankingExpression(multiline);
-    thisProduction.setFeatureListData(featureList);
-    return thisProduction;
-}
+{}
+    (
+        <EOF>
+        |
+        {
+            SubLanguageData featureList = consumeRankingExpression(multiline);
+            thisProduction.setFeatureListData(featureList);
+        }
+    )
+    { return thisProduction; }
 ;
 
 /**
@@ -3154,9 +3164,15 @@ void constantTensor(ParsedRankProfile profile, Reference name) :
     }
 ;
 
-String constantTensorErrorMessage(String rankProfileName, Reference name) : {}
-
-    { return "For constant tensor '" + name + "' in rank profile '" + rankProfileName + "'"; }
+String constantTensorErrorMessage(String rankProfileName, Reference name) : {
+    String result = null;
+}
+    (
+        <EOF>
+        |
+        { result = "For constant tensor '" + name + "' in rank profile '" + rankProfileName + "'"; }
+    )
+    { return result; }
 ;
 
 
@@ -3377,11 +3393,16 @@ void importField(ParsedSchema schema) :
  * allowing the manipulated offsets to propagate upwards in the tree.
  */
 Node consumedExpressionElm(boolean multiline) :
-{
-    SubLanguageData expr = consumeRankingExpression(multiline);
-    thisProduction.setRankingExpressionData(expr);
-    return thisProduction;
-}
+{}
+    (
+        <EOF>
+        |
+        {
+            SubLanguageData expr = consumeRankingExpression(multiline);
+            thisProduction.setRankingExpressionData(expr);
+        }
+    )
+    { return thisProduction; }
 ;
 
 /**

--- a/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/grouping/GroupingParser.ccc
@@ -1137,9 +1137,11 @@ FilterExpression notPredicate(GroupingOperation grp) :
 {
     FilterExpression inner;
 }
+(
     ( <NOT> spaceElm inner = notPredicate(grp) {
         return new NotPredicate(inner);
     } ) | ( inner = filterPrimary(grp) )
+)
     { return inner; }
 ;
 

--- a/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
@@ -449,7 +449,7 @@ Expression chunkExp() :
 }
 
     (
-      <CHUNK> [ SCAN((identifierStr)+) => (chunkerId = identifierStr()) ] arguments = arguments()
+      <CHUNK> [ SCAN(identifierStr) => (chunkerId = identifierStr()) ] arguments = arguments()
     )
     {
         return new ChunkExpression(chunkers, chunkerId, arguments);
@@ -475,7 +475,7 @@ Expression embedExp() :
 }
  
     (
-      <EMBED> [ SCAN((identifierStr)+) => (embedderId = identifierStr()) ] arguments = arguments()
+      <EMBED> [ SCAN(identifierStr) => (embedderId = identifierStr()) ] arguments = arguments()
     )
     {
         return new EmbedExpression(linguistics, embedders, embedderId, arguments);
@@ -513,7 +513,7 @@ Expression generateExp() :
 }
 
     (
-      <GENERATE> [ SCAN((identifierStr)+) => (generatorId = identifierStr()) ] arguments = arguments()
+      <GENERATE> [ SCAN(identifierStr) => (generatorId = identifierStr()) ] arguments = arguments()
     )
     {
         return new GenerateExpression(linguistics, generators, generatorId, arguments);
@@ -931,9 +931,11 @@ String valueString() :
     String value;
     NumericFieldValue numericValue;
 }
-    numericValue = numericValue() { return numericValue.getNumber().toString(); } |
-    value = stringLiteral() { return value; } |
-    value = identifierStr() { return value; }
+(
+    ( numericValue = numericValue() { return numericValue.getNumber().toString(); } ) |
+    ( value = stringLiteral() { return value; } ) |
+    ( value = identifierStr() { return value; } )
+)
 ;
 
 String identifierStr() :

--- a/integration/schema-language-server/language-server/src/main/ccc/rankingexpression/RankingExpressionParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/rankingexpression/RankingExpressionParser.ccc
@@ -435,7 +435,7 @@ FunctionNode scalarOrTensorFunction() :
     Function function;
     ExpressionNode arg1, arg2;
 }
-
+(
     (
       ( function = unaryFunctionName() <LBRACE> arg1 = expression() <RBRACE> )
       {
@@ -450,6 +450,7 @@ FunctionNode scalarOrTensorFunction() :
           return (FunctionNode)thisProduction.expressionNode;
       }
     )
+)
 ;
 
 TensorFunctionNode tensorFunction() :
@@ -985,7 +986,7 @@ String tensorFunctionName() :
 {
     Reduce.Aggregator aggregator;
 }
-
+(
     ( <F>                    { return lastConsumedToken.toString(); } ) |
     ( <MAP>                  { return lastConsumedToken.toString(); } ) |
     ( <MAP_SUBSPACES>        { return lastConsumedToken.toString(); } ) |
@@ -1013,6 +1014,7 @@ String tensorFunctionName() :
     ( <CELL_CAST>            { return lastConsumedToken.toString(); } ) |
     ( <EXPAND>               { return lastConsumedToken.toString(); } ) |
     ( aggregator = tensorReduceAggregator() { return aggregator.toString(); } )
+)
 ;
 
 Function unaryFunctionName() : { }
@@ -1093,17 +1095,18 @@ String identifierStr() :
     Function func;
 }
 
-    SCAN 2 name = tensorFunctionName() { return name; }            |
-    func = unaryFunctionName()  { return func.toString(); } |
-    func = binaryFunctionName() { return func.toString(); } |
-    <IF>                        { return lastConsumedToken.toString(); }     |
-    <IN>                        { return lastConsumedToken.toString(); }     |
-    <SWITCH>                    { return lastConsumedToken.toString(); }     |
-    <CASE>                      { return lastConsumedToken.toString(); }     |
-    <SWITCHDEFAULT>             { return lastConsumedToken.toString(); }     |
-    <IDENTIFIER>                { return lastConsumedToken.toString(); }     |
-    <TRUE>                      { return lastConsumedToken.toString(); }     |
-    <FALSE>                     { return lastConsumedToken.toString(); }
+    ( SCAN 2 name = tensorFunctionName() { return name; }            |
+      func = unaryFunctionName()  { return func.toString(); } |
+      func = binaryFunctionName() { return func.toString(); } |
+      <IF>                        { return lastConsumedToken.toString(); }     |
+      <IN>                        { return lastConsumedToken.toString(); }     |
+      <SWITCH>                    { return lastConsumedToken.toString(); }     |
+      <CASE>                      { return lastConsumedToken.toString(); }     |
+      <SWITCHDEFAULT>             { return lastConsumedToken.toString(); }     |
+      <IDENTIFIER>                { return lastConsumedToken.toString(); }     |
+      <TRUE>                      { return lastConsumedToken.toString(); }     |
+      <FALSE>                     { return lastConsumedToken.toString(); }
+    )
 ;
 
 List<String> identifierList() :
@@ -1122,10 +1125,11 @@ List<String> bracedIdentifierList() :
     List<String> list = new ArrayList<String>();
     String element;
 }
-
+(
     ( element = identifierStr() { return List.of(element); } )
     |
     ( <LBRACE> list = identifierList() <RBRACE> { return list; } )
+)
 ;
 
 // An identifier or integer
@@ -1270,10 +1274,11 @@ void indexedTensorCellSubspace(List cells) :
 {
     ExpressionNode value;
 }
-
+(
     ( <LSQUARE> indexedTensorCellSubspaceList(cells) <RSQUARE> )
     |
     ( value = expression() { cells.add(value); } )
+)
 ;
 
 void tensorCell(TensorType type, java.util.Map cells) :

--- a/integration/schema-language-server/language-server/src/main/ccc/yqlplus/YQLPlus.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/yqlplus/YQLPlus.ccc
@@ -227,9 +227,10 @@ vespa_grouping_arg:
 String ident: {
     String identifier;
 }
-
+(
     ( identifier = identifierStr { return identifier; } )
     | (identifier = keyword_as_ident { return identifier; })
+)
 ;
 
 String keyword_as_ident:


### PR DESCRIPTION
## Summary

- Update `pom.xml` to use the new CongoCC 2.1.0 plugin API (`sourceDirectory`/`outputDirectory`), consolidating 5 separate executions into one
- Fix variable scope issues across 5 grammar files caused by CongoCC 2.1.0 now scoping declarations block variables inside the first `|` alternative only
- Fix 5 productions in `SchemaParser.ccc` with empty first sets that caused invalid Java (`if (\n)`) in fault-tolerant recovery functions, breaking INJECT injection

_Generated with Claude Code_