### PR TITLE
Log repeated-flush-target warning at WARNING level

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -475,7 +475,7 @@ std::string FlushEngine::flushNextTarget(const std::string& name, const FlushStr
         return "";
     }
     if (name == ctx->getName()) {
-        LOG(info,
+        LOG(warning,
             "The same target %s out of %ld has been asked to flush again. "
             "This might indicate flush logic flaw so I will wait 100 ms before doing it.",
             name.c_str(), flush_strategy_result.list().size());


### PR DESCRIPTION
In FlushEngine::flushNextTarget, when the same target that was just flushed is immediately selected again, the engine sleeps 100 ms and logs a message about a possible flush logic flaw. Raise this message from info to warning to make it easier to monitor.

