### PR TITLE
Add EDEN vector quantization algorithm implementation

### DIFF
--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_executable(vespalib_quant_test_app TEST
     SOURCES
     centroid_test.cpp
+    eden_quantizer_test.cpp
     hadamard_test.cpp
     multi_bit_packer_test.cpp
     rotator_test.cpp

--- a/vespalib/src/tests/quant/eden_quantizer_test.cpp
+++ b/vespalib/src/tests/quant/eden_quantizer_test.cpp
@@ -1,0 +1,219 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/quant/eden.h>
+
+#include <gmock/gmock.h>
+
+#include <cmath>
+#include <ranges>
+#include <span>
+#include <vector>
+
+using namespace ::testing;
+
+namespace vespalib::quant {
+
+namespace {
+
+// Your friendly neighborhood Euclidean vector length
+[[nodiscard]] float l2_norm(std::span<const float> v) noexcept {
+    float l2 = 0;
+    for (float c : v) {
+        l2 += c * c;
+    }
+    return std::sqrtf(l2);
+}
+
+void normalize(std::span<float> v) noexcept {
+    const float norm_recip = 1.f / l2_norm(v);
+    for (auto& c : v) {
+        c *= norm_recip;
+    }
+}
+
+[[nodiscard]] float extract_scale(std::span<const uint8_t> v) noexcept {
+    assert(v.size() >= 4);
+    float scale;
+    memcpy(&scale, v.data(), sizeof(float));
+    return scale;
+}
+
+struct QuantTestParams {
+    uint8_t              bits = 1;
+    uint64_t             seed = 0;
+    QuantMode            quant_mode = QuantMode::MSE;
+    std::vector<float>   in_v;
+    float                expected_scale = 0;
+    std::vector<uint8_t> expected_quant_bytes;
+    std::vector<float>   expected_dequant;
+
+    QuantTestParams();
+    ~QuantTestParams();
+};
+
+QuantTestParams::QuantTestParams() = default;
+QuantTestParams::~QuantTestParams() = default;
+
+void do_test_quantization_roundtrip(const QuantTestParams& qtp) {
+    EdenQuantizer        q(qtp.in_v.size(), qtp.bits, qtp.seed);
+    std::vector<uint8_t> v_q(q.quantized_size());
+    q.quantize(qtp.in_v, v_q, qtp.quant_mode);
+    // We extract the scale and compare it as a float to avoid precision issues
+    float scale = extract_scale(v_q);
+    EXPECT_THAT(scale, FloatEq(qtp.expected_scale));
+    EXPECT_THAT(std::span(v_q).subspan(4), ElementsAreArray(qtp.expected_quant_bytes));
+
+    std::vector<float> v_dq(qtp.in_v.size());
+    q.dequantize(v_q, v_dq);
+    EXPECT_THAT(v_dq, Pointwise(FloatEq(), qtp.expected_dequant));
+}
+
+[[nodiscard]] std::vector<float> my_16d_test_vector() {
+    // Test numbers expertly chosen by human poking at a keyboard(tm)
+    return {3, -4, 5, -5, -4, 3, 2, -3, 4, -5, 4, -3, -3, 4, 5, -4};
+}
+
+} // namespace
+
+TEST(EdenQuantizerTest, quantizer_properties_have_expected_values) {
+    {
+        EdenQuantizer q(16, 1, 0x12345678);
+        EXPECT_EQ(q.dimensions(), 16);
+        EXPECT_EQ(q.bits(), 1);
+        EXPECT_EQ(q.seed(), 0x12345678);
+        EXPECT_EQ(q.quantized_size(), 4 + 2);
+    }
+    {
+        EdenQuantizer q(21, 4, 0xfeedbaaaaaadf00dULL);
+        EXPECT_EQ(q.dimensions(), 21);
+        EXPECT_EQ(q.bits(), 4);
+        EXPECT_EQ(q.seed(), 0xfeedbaaaaaadf00dULL);
+        EXPECT_EQ(q.quantized_size(), 4 + 11); // last byte will only use 1 nibble
+    }
+}
+
+TEST(EdenQuantizerTest, quantization_is_deterministic_for_a_given_seed_1_bit) {
+    QuantTestParams qtp;
+    qtp.bits = 1;
+    qtp.in_v = my_16d_test_vector();
+    qtp.seed = 0x1337beef;
+    qtp.quant_mode = QuantMode::MSE;
+    qtp.expected_scale = 3.79910803;
+    qtp.expected_quant_bytes = std::vector<uint8_t>{0x46, 0x71};
+    // "We have vector at home":
+    qtp.expected_dequant = std::vector<float>{
+        1.51562476,     -7.57812405,     1.51562476, -1.51562476, -1.51562476, 1.51562476, 1.51562476, -4.54687452,
+        1.78813934e-07, -2.38418579e-07, 3.03124976, -3.03124976, -3.03124976, 3.03124976, 3.03124976, -3.03124976};
+    ASSERT_NO_FATAL_FAILURE(do_test_quantization_roundtrip(qtp));
+
+    qtp.quant_mode = QuantMode::InnerProduct;
+    // Quantization bits shall be the same as for MSE; only the scaling factor differs.
+    qtp.expected_scale = 6.33117437;
+    qtp.expected_dequant = std::vector<float>{
+        2.52577353,      -12.6288662,    2.52577353, -2.52577353, -2.52577353, 2.52577353, 2.52577353, -7.57731962,
+        -3.57627869e-07, 4.76837158e-07, 5.05154657, -5.05154657, -5.05154657, 5.05154657, 5.05154657, -5.051546576};
+    ASSERT_NO_FATAL_FAILURE(do_test_quantization_roundtrip(qtp));
+
+    // Different seed results in different rotations. We only test multiple seeds for 1 bit
+    // and make the simplifying assumption that this also holds for the other bit widths
+    // since this is technically a property of the Rotator component, which has its own suite
+    // of tests.
+    qtp.seed = 0xdeadbeef;
+    qtp.quant_mode = QuantMode::MSE;
+    qtp.expected_scale = 3.83827376;
+    qtp.expected_quant_bytes = std::vector<uint8_t>{0x78, 0xB2};
+    qtp.expected_dequant = std::vector<float>{
+        3.06249952, -3.06249952, 3.06249952, -3.06249952, -6.12499905, 0,          1.1920929e-07, -1.1920929e-07,
+        3.06249952, -3.06249952, 3.06249952, -3.06249952, -0,          6.12499905, 1.1920929e-07, -1.1920929e-07};
+    ASSERT_NO_FATAL_FAILURE(do_test_quantization_roundtrip(qtp));
+}
+
+TEST(EdenQuantizerTest, quantization_is_deterministic_for_a_given_seed_2_bits) {
+    QuantTestParams qtp;
+    qtp.bits = 2;
+    qtp.in_v = my_16d_test_vector();
+    qtp.seed = 0x1337beef;
+    qtp.quant_mode = QuantMode::MSE;
+    qtp.expected_scale = 4.7562151;
+    qtp.expected_quant_bytes = std::vector<uint8_t>{0x29, 0x64, 0x56, 0x7A};
+    qtp.expected_dequant = std::vector<float>{
+        1.0767597,  -5.38379765, 3.5919354,  -3.59193587, -6.10711145, 1.07675958, 1.0767591,  -3.23027873,
+        1.25758827, -3.77276397, 3.41110682, -3.4111073,  -3.41110754, 3.41110682, 5.92628288, -3.4111073};
+    ASSERT_NO_FATAL_FAILURE(do_test_quantization_roundtrip(qtp));
+    // InnerProduct only differs in scale, so we assume testing that for 1 bit is sufficient.
+}
+
+TEST(EdenQuantizerTest, quantization_is_deterministic_for_a_given_seed_3_bits) {
+    QuantTestParams qtp;
+    qtp.bits = 3;
+    qtp.in_v = my_16d_test_vector();
+    qtp.seed = 0x1337beef;
+    qtp.quant_mode = QuantMode::MSE;
+    qtp.expected_scale = 3.91597676;
+    qtp.expected_quant_bytes = std::vector<uint8_t>{0x2A, 0x81, 0x71, 0xD5, 0xD6, 0x5A};
+    qtp.expected_dequant = std::vector<float>{
+        1.48024964, -3.39981604, 5.21384239, -5.21384239, -4.36423588, 2.06201744, 1.4802494,  -4.44074869,
+        3.1580379,  -4.30914736, 3.53605366, -3.53605366, -3.53605318, 3.53605366, 5.26893044, -4.11782122};
+    ASSERT_NO_FATAL_FAILURE(do_test_quantization_roundtrip(qtp));
+}
+
+TEST(EdenQuantizerTest, quantization_is_deterministic_for_a_given_seed_4_bits) {
+    QuantTestParams qtp;
+    qtp.bits = 4;
+    qtp.in_v = my_16d_test_vector();
+    qtp.seed = 0x1337beef;
+    qtp.quant_mode = QuantMode::MSE;
+    qtp.expected_scale = 3.70460153;
+    qtp.expected_quant_bytes = std::vector<uint8_t>{0xB5, 0x09, 0x61, 0x68, 0x5A, 0x77, 0xAA, 0x4C};
+    qtp.expected_dequant = std::vector<float>{
+        2.81700802, -3.76831293, 5.44971228, -5.4497118,  -4.02572727, 2.86288738, 1.80706978, -3.05899167,
+        3.52310324, -5.16248846, 3.78170633, -2.72374034, -2.77176738, 3.73367882, 5.37091684, -3.73153186};
+    ASSERT_NO_FATAL_FAILURE(do_test_quantization_roundtrip(qtp));
+}
+
+TEST(EdenQuantizerTest, zero_norm_vector_emits_zero_scale_and_quantization_indexes) {
+    std::vector<float>   v(16, 0.0f);
+    EdenQuantizer        q(16, 4, 0xbeefd00d);
+    std::vector<uint8_t> v_q(q.quantized_size());
+
+    q.quantize(v, v_q, QuantMode::MSE);
+    float scale = extract_scale(v_q);
+    EXPECT_EQ(scale, 0.0f); // Bitwise exact
+    // With a scale of zero, the actual centroid indexes don't matter. But for
+    // consistency these will also always be zero when the norm is zero.
+    EXPECT_THAT(std::span(v_q).subspan(4), Each(Eq(0x00)));
+    // Similarly, dequantization should yield all zeros
+    std::vector<float> v_dq(v.size());
+    q.dequantize(v_q, v_dq);
+    EXPECT_THAT(v_dq, Each(Eq(0.0f)));
+}
+
+TEST(EdenQuantizerTest, can_compute_dot_product_with_pre_rotated_vector) {
+    EdenQuantizer        q(16, 4, 0xbeefd00d);
+    std::vector<uint8_t> v_q(q.quantized_size());
+
+    std::vector v = my_16d_test_vector();
+    // Normalize v so that <v, v> is 1
+    normalize(v);
+    ASSERT_THAT(l2_norm(v), FloatEq(1));
+    q.quantize(v, v_q, QuantMode::InnerProduct);
+    // First let's do a silly dot product between a _non-rotated_ query and its quantized
+    // version; the result should be completely uncorrelated.
+    EXPECT_THAT(q.pre_rotated_query_dot_product(v, v_q), FloatEq(-0.30234611));
+    // Now let's do it properly
+    std::vector q_rot = v;
+    q.rotate_vector_inplace(q_rot);
+    // Vector length shall be preserved
+    EXPECT_THAT(l2_norm(q_rot), FloatEq(1));
+    // <v, v> == 1, so <v, v_q> should be ~= 1
+    EXPECT_THAT(q.pre_rotated_query_dot_product(q_rot, v_q), FloatEq(1));
+    // Point the query vector the other way
+    for (float& c : q_rot) {
+        c = -c;
+    }
+    EXPECT_THAT(q.pre_rotated_query_dot_product(q_rot, v_q), FloatEq(-1));
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(vespalib_vespalib_quant OBJECT
     SOURCES
     codebooks.cpp
+    eden.cpp
     rotator.cpp
     DEPENDS
 )

--- a/vespalib/src/vespa/vespalib/quant/block_multi_bit_packer.h
+++ b/vespalib/src/vespa/vespalib/quant/block_multi_bit_packer.h
@@ -5,6 +5,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 namespace vespalib::quant {
 

--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -1,0 +1,163 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "eden.h"
+
+#include "centroid.h"
+#include "codebooks.h"
+#include "hadamard.h"
+#include "multi_bit_packer.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+
+namespace vespalib::quant {
+
+namespace {
+
+[[nodiscard]] size_t compute_quantized_buffer_size(const size_t dimensions, const uint8_t bits) noexcept {
+    (void)bits;
+    constexpr size_t scale_bytes = sizeof(float); // TODO configurable scale factor precision (f16 vs f32)?
+    const size_t     dim_bytes =
+        with_packer_for_bit_count(bits, [dimensions](auto bp) { return decltype(bp)::packed_bytes(dimensions); });
+    return scale_bytes + dim_bytes;
+}
+
+} // namespace
+
+EdenQuantizer::EdenQuantizer(const size_t dimensions, const uint8_t bits, const uint64_t seed)
+    : _dimensions(dimensions),
+      _quantized_size(compute_quantized_buffer_size(dimensions, bits)),
+      _rotator(dimensions, seed),
+      _rot_tmp(dimensions),
+      _idx_tmp(dimensions),
+      _seed(seed),
+      _sqrt_d(std::sqrtf(static_cast<float>(dimensions))),
+      _bits(bits) {
+    assert(bits >= 1 && bits <= 4);
+}
+
+EdenQuantizer::~EdenQuantizer() = default;
+
+std::span<const float> EdenQuantizer::my_codebook() const noexcept {
+    return {codebooks::unit_norm_centroids_f32[_bits - 1], 1u << _bits};
+}
+
+// Note for quantize() and dequantize(): the algorithm implementations try to closely
+// follow the pseudocode outlined in [1], with some additional normalization factor
+// details from [0].
+
+void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, const QuantMode quant_mode) noexcept {
+    assert(x.size() == _dimensions);
+    assert(q_x.size() == _quantized_size);
+    const size_t d = _dimensions;
+    // We compute the vector norm _prior_ to rotation to minimize errors introduced by
+    // floating point arithmetic. Our rotation abstraction is mathematically speaking
+    // length-preserving, but this is implemented with a FWH transform that increases
+    // the magnitude by sqrt(d), which is then subsequently divided away in a subsequent
+    // normalization step. Changes in magnitude are more likely to cause precision loss
+    // since exponent adjustments can truncate mantissa LSBs.
+    // TODO add explicitly vectorized squared L2 norm functionality. Multiple parallel
+    //  accumulators will also likely _reduce_ accumulated floating point error.
+    float x_norm2 = 0;
+    for (size_t i = 0; i < d; ++i) {
+        x_norm2 += x[i] * x[i];
+    }
+    if (x_norm2 == 0) [[unlikely]] {
+        // Zero norm vectors must be special-cased, or we'll end up dividing by zero
+        // when computing `nx` below. Set the scale explicitly to zero. For consistency,
+        // also set all centroid indexes to zero, although this technically doesn't
+        // matter since they are nullified by the scale.
+        memset(q_x.data(), 0, q_x.size());
+        return;
+    }
+    std::copy(x.begin(), x.end(), _rot_tmp.begin());
+    _rotator.rotate_forward(_rot_tmp);
+    // By convention, `y <- Rx`, i.e. the result of rotating `x` by matrix `R`
+    const float* y = _rot_tmp.data();
+    const auto   codebook = my_codebook();
+    // Normalization factor to bring each rotated coordinate into expected N(0, 1).
+    // Moving the sqrt(d) factor here means that we don't have to precompute scaled
+    // centroids specifically for our dimensionality, but can use the N(0, 1) ones.
+    // The scale factor subsumes this normalization so that the dequantization step
+    // does not have to explicitly care about it (i.e. it can also just use the
+    // N(0, 1) codebook centroids directly). x_norm2 is guaranteed to be non-zero.
+    // This corresponds to "eta_x" in the [1] pseudocode, but I refuse to use Unicode
+    // symbols in source code, so you'll have your ASCII, and you'll like it!
+    const float nx = _sqrt_d / std::sqrtf(x_norm2);
+
+    // By convention, `q` is the quantized vector as represented by each input
+    // coordinate replaced by the value of the centroid its quantized index refers
+    // to. We don't explicitly keep around `q` (just the _indexes_ that we then bit
+    // pack), but we maintain a running dot product of it vs. the unquantized (but
+    // rotated) vector, which is used to derive a scale factor for both EDEN-biased
+    // and EDEN-unbiased.
+    float yq_dot = 0; // <y, q>
+    float scale = 0;
+    if (quant_mode == QuantMode::InnerProduct) { // EDEN-unbiased
+        for (size_t i = 0; i < d; ++i) {
+            const uint8_t idx = closest_centroid_index<float>(y[i] * nx, codebook);
+            const float   c_i = codebook[idx];
+            yq_dot += y[i] * c_i;
+            _idx_tmp[i] = idx;
+        }
+        scale = x_norm2 / yq_dot;
+    } else /* MSE/EDEN-biased */ {
+        float q_norm2 = 0; // _squared_ Euclidean norm
+        for (size_t i = 0; i < d; ++i) {
+            const uint8_t idx = closest_centroid_index<float>(y[i] * nx, codebook);
+            const float   c_i = codebook[idx];
+            yq_dot += y[i] * c_i;
+            q_norm2 += c_i * c_i;
+            _idx_tmp[i] = idx;
+        }
+        scale = yq_dot / q_norm2;
+    }
+    with_packer_for_bit_count(_bits, [&](auto bp) {
+        uint8_t* out_bits = q_x.data() + sizeof(float);
+        decltype(bp)::pack(out_bits, _idx_tmp.data(), _dimensions);
+    });
+    memcpy(q_x.data(), &scale, sizeof(float));
+}
+
+void EdenQuantizer::dequantize(std::span<const uint8_t> q_x, std::span<float> dq_x) noexcept {
+    assert(q_x.size() == _quantized_size);
+    assert(dq_x.size() == _dimensions);
+    float scale;
+    memcpy(&scale, q_x.data(), sizeof(float));
+    with_packer_for_bit_count(_bits, [&](auto bp) {
+        const uint8_t* in_bits = q_x.data() + sizeof(float);
+        decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
+    });
+    const auto codebook = my_codebook();
+    for (size_t i = 0; i < _dimensions; ++i) {
+        dq_x[i] = codebook[_idx_tmp[i]] * scale;
+    }
+    _rotator.rotate_inverse(dq_x);
+}
+
+void EdenQuantizer::rotate_vector_inplace(std::span<float> vec) const noexcept {
+    assert(vec.size() == _dimensions);
+    _rotator.rotate_forward(vec);
+}
+
+float EdenQuantizer::pre_rotated_query_dot_product(std::span<const float>   query,
+                                                   std::span<const uint8_t> quant_vec) noexcept {
+    assert(query.size() == _dimensions);
+    assert(quant_vec.size() == _quantized_size);
+    float scale;
+    memcpy(&scale, quant_vec.data(), sizeof(float));
+    with_packer_for_bit_count(_bits, [&](auto bp) {
+        const uint8_t* in_bits = quant_vec.data() + sizeof(float);
+        decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
+    });
+    const auto codebook = my_codebook();
+    float      dot = 0;
+    // TODO shiny happy vectorization time~
+    for (size_t i = 0; i < _dimensions; ++i) {
+        dot += query[i] * codebook[_idx_tmp[i]];
+    }
+    return dot * scale;
+}
+
+} // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/eden.h
+++ b/vespalib/src/vespa/vespalib/quant/eden.h
@@ -1,0 +1,149 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "rotator.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace vespalib::quant {
+
+enum class QuantMode : uint8_t {
+    // Quantization optimized for reconstruction accuracy, aiming to minimize the
+    // mean of squared errors (MSE) between the original vector and its dequantized
+    // representation.
+    MSE,
+    // Quantization optimized for inner product accuracy. MSE-oriented quantization
+    // introduces a bias when used for inner products; `InnerProduct` is designed
+    // to eliminate this bias.
+    InnerProduct
+};
+
+/*
+ * Vector (de-)quantizer using the EDEN ("Efficient Distributed Mean Estimation for
+ * diverse Networks") algorithm, supporting 1-4 bits (inclusive) per coordinate.
+ * See [0] and [1].
+ *
+ * Two distinct quantization "modes" are supported; one optimizing for minimizing
+ * reconstruction mean squared error (MSE) and one optimizing for unbiased inner
+ * product computations. See `QuantMode`.
+ *
+ * An EdenQuantizer instance is bound to a particular vector dimensionality for the
+ * duration of its lifetime.
+ *
+ * Quantization inherently involves pseudo-randomness that is derived from the
+ * seed value provided during construction. The same seed value shall result in the
+ * ~same output (modulo floating point errors) for a given vector across distinct
+ * instances, even across different process lifetimes. Consequently, it is vital
+ * that the same seed value is provided when different vectors are to be used in the
+ * same context. Note that this only applies to a given dimensionality; quantizers
+ * using the same seed but different dimensionality values are not interoperable.
+ *
+ * Assuming `d` dimensions and `b` bits, the footprint of a quantized vector is
+ * d*b bits (rounded up to nearest whole byte) + a single 4-byte f32 scalar value.
+ * Use `quantized_size()` to get the exact value; both quantization and dequantization
+ * expects exact input/output size matches.
+ *
+ * Thread safety: non-const/static methods are NOT thread safe since certain
+ * internal operations require the use of object-level temporary data structures.
+ *
+ * References:
+ *  [0] Shay Vargaftik, Ran Ben Basat, Amit Portnoy, Gal Mendelson, Yaniv Ben-Itzhak
+ *      and Michael Mitzenmacher. EDEN: Communication-Efficient and Robust Distributed
+ *      Mean Estimation for Federated Learning, 2022. https://arxiv.org/abs/2108.08842v3
+ *
+ *  [1] Ran Ben-Basat, Yaniv Ben-Itzhak, Gal Mendelson, Michael Mitzenmacher, Amit
+ *      Portnoy and Shay Vargaftik. A Note on TurboQuant and the Earlier DRIVE/EDEN
+ *      Line of Work, 2026. https://arxiv.org/abs/2604.18555
+ */
+class EdenQuantizer {
+    const size_t         _dimensions;
+    const size_t         _quantized_size;
+    const Rotator        _rotator;
+    std::vector<float>   _rot_tmp;
+    std::vector<uint8_t> _idx_tmp;
+    const uint64_t       _seed;
+    const float          _sqrt_d; // Precomputed sqrt(dimensions)
+    const uint8_t        _bits;
+
+    // Returns the shared, fixed N(0, 1) codebook for the configured quantizer bit count
+    [[nodiscard]] std::span<const float> my_codebook() const noexcept;
+
+public:
+    EdenQuantizer(size_t dimensions, uint8_t bits, uint64_t seed);
+    ~EdenQuantizer();
+
+    [[nodiscard]] size_t dimensions() const noexcept { return _dimensions; }
+    [[nodiscard]] uint8_t bits() const noexcept { return _bits; }
+    [[nodiscard]] uint64_t seed() const noexcept { return _seed; }
+
+    // Number of bytes used by a quantized vector representation.
+    [[nodiscard]] size_t quantized_size() const noexcept { return _quantized_size; }
+
+    /*
+     * Quantize the input vector `x` into the receiving buffer `q_x`.
+     *
+     * `quant_mode` should be chosen based on the context in which the quantized vectors
+     * are expected to be used; MSE for "general" vector reconstruction, InnerProduct for
+     * inner products (perhaps unsurprisingly).
+     *
+     * Preconditions:
+     *  - x.size() == dimensions()
+     *  - q_x.size() == quantized_size()
+     */
+    void quantize(std::span<const float> x, std::span<uint8_t> q_x, QuantMode quant_mode) noexcept;
+    /*
+     * Takes in the quantized vector buffer `q_x` that is the result of a prior call to
+     * `quantize(x, q_x)` and dequantizes an approximation of `x` into `dq_x`.
+     *
+     * It is important that quantize() and dequantize() pairs always happen on quantizer
+     * instances that have been created with the _exact same_ seed value! Otherwise, the
+     * dequantized output will have effectively no correlation with the original vector.
+     *
+     * Preconditions:
+     *  - q_x.size() == quantized_size()
+     *  - dq_x.size() == dimensions()
+     */
+    void dequantize(std::span<const uint8_t> q_x, std::span<float> dq_x) noexcept;
+
+    /*
+     * In-place rotates `vec` so that it is in the same frame of reference as the vectors
+     * quantized by an EdenQuantizer using the same construction seed and dimensionality
+     * as this one.
+     *
+     * Query vectors rotated by this function can be used in `pre_rotated_query_dot_product()`.
+     *
+     * Note: calling this twice on the same vector does _not_ invert the original rotation.
+     * I.e. this is a one-way rotation only. Calling it more than once will further rotate
+     * the vector into some completely uncorrelated goblin space.
+     *
+     * Preconditions:
+     *  - vec.size() == dimensions()
+     */
+    void rotate_vector_inplace(std::span<float> vec) const noexcept;
+
+    /*
+     * Computes the dot product between a quantized vector and a _pre-rotated_ query
+     * vector. This is much more efficient than doing dequantize() followed by an
+     * explicit dot product, as we don't have to perform any expensive rotations.
+     *
+     * `query` must have had a spin in the `rotate_vector_inplace` function prior to use,
+     * i.e. it must be rotated into the same frame of reference as `quant_vec`.
+     *
+     * Only makes sense if `quant_vec` was originally quantized with `QuantMode::InnerProduct`.
+     *
+     * Preconditions:
+     *  - query.size() == dimensions()
+     *  - quant_vec.size() == quantized_size()
+     *
+     * TODO with a vectorized "just in time" bit unpacking that doesn't need a temporary
+     *  buffer we could make this const...
+     */
+    [[nodiscard]] float pre_rotated_query_dot_product(std::span<const float>   query,
+                                                      std::span<const uint8_t> quant_vec) noexcept;
+};
+
+} // namespace vespalib::quant


### PR DESCRIPTION
@havardpe please review
@arnej27959 FYI

This PR forms the "rest of the owl" assembly of the recently added Lloyd-Max codebooks, centroid selection, fast Walsh-Hadamard transforms, pseudo-random sign flipping, randomized vector rotation and multi-bit packing.

This adds a vector (de-)quantizer using the EDEN ("Efficient Distributed Mean Estimation for diverse Networks") algorithm[^1][^2], in our case supporting 1-4 bits (inclusive) per coordinate.

Two distinct quantization "modes" are supported; one optimizing for minimizing vector reconstruction mean squared error (aka. _EDEN-biased_) and one optimizing for unbiased inner product computations (aka. _EDEN-unbiased_). The mode only affects the resulting per-vector scaling factor that is included alongside the bit-packed quantized representation. Dequantization is identical for both modes, as only the scaling factor is used.

The quantizer additionally supports computing the dot product between a full precision vector and a quantized vector, where the full precision vector has been pre-rotated (once) into the same frame of reference as the quantized vectors. This allows for efficiently computing the dot product between one query vector and many candidate vectors, as the candidate vectors do not themselves have to be inverse rotated (as they would need for full dequantization).

This initial implementation focuses on the functional aspects; optimization (vectorization) will follow in subsequent steps.

[^1]: Shay Vargaftik, Ran Ben Basat, Amit Portnoy, Gal Mendelson, Yaniv Ben-Itzhak and Michael Mitzenmacher. EDEN: Communication-Efficient and Robust Distributed Mean Estimation for Federated Learning, 2022. https://arxiv.org/abs/2108.08842v3
[^2]: Ran Ben-Basat, Yaniv Ben-Itzhak, Gal Mendelson, Michael Mitzenmacher, Amit Portnoy and Shay Vargaftik. A Note on TurboQuant and the Earlier DRIVE/EDEN Line of Work, 2026. https://arxiv.org/abs/2604.18555

