### PR TITLE
Set customer tag limit to 20

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudResourceTags.java
@@ -28,8 +28,8 @@ public class CloudResourceTags {
     private static final int MAX_VALUE_LENGTH = 256;  // AWS/Azure hard limit (max across clouds)
     private static final int MAX_TAGS = 64;           // GCP hard limit (max across clouds)
 
-    /** Tags reserved for platform/system use; subtracted from each cloud's hard limit to derive the per-cloud customer {@code MAX_TAGS}. */
-    private static final int MAX_SYSTEM_TAGS = 15;
+    /** Maximum number of customer-provided tags allowed per cloud. */
+    private static final int MAX_CUSTOMER_TAGS = 20;
 
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\$\\{[^}]+\\}");
 
@@ -192,10 +192,9 @@ public class CloudResourceTags {
         private static final String ALLOWED = "letters, digits, spaces, and + - = . _ : / @";
         private static final int MAX_KEY_LENGTH = 128;
         private static final int MAX_VALUE_LENGTH = 256;
-        private static final int MAX_TAGS = 50 - MAX_SYSTEM_TAGS; // AWS allows 50 tags total
 
         static void validate(Map<String, String> tags) {
-            checkTagCount(tags.size(), MAX_TAGS, NAME);
+            checkTagCount(tags.size(), MAX_CUSTOMER_TAGS, NAME);
             for (var entry : tags.entrySet()) {
                 checkLength(entry.getKey(),   MAX_KEY_LENGTH,   "key",   NAME);
                 checkLength(entry.getValue(), MAX_VALUE_LENGTH, "value", NAME);
@@ -213,10 +212,9 @@ public class CloudResourceTags {
         private static final String VALUE_ALLOWED = "lowercase letters, digits, underscores, and hyphens";
         private static final int MAX_KEY_LENGTH = 63;
         private static final int MAX_VALUE_LENGTH = 63;
-        private static final int MAX_TAGS = 64 - MAX_SYSTEM_TAGS; // GCP allows 64 tags total
 
         static void validate(Map<String, String> tags) {
-            checkTagCount(tags.size(), MAX_TAGS, NAME);
+            checkTagCount(tags.size(), MAX_CUSTOMER_TAGS, NAME);
             for (var entry : tags.entrySet()) {
                 checkLength(entry.getKey(),   MAX_KEY_LENGTH,   "key",   NAME);
                 checkLength(entry.getValue(), MAX_VALUE_LENGTH, "value", NAME);
@@ -234,10 +232,9 @@ public class CloudResourceTags {
         private static final Pattern FORBIDDEN_KEY_CHARS = Pattern.compile("[<>%&\\\\?/]");
         private static final int MAX_KEY_LENGTH = 512;
         private static final int MAX_VALUE_LENGTH = 256;
-        private static final int MAX_TAGS = 50 - MAX_SYSTEM_TAGS; // Azure allows 50 tags total
 
         static void validate(Map<String, String> tags) {
-            checkTagCount(tags.size(), MAX_TAGS, NAME);
+            checkTagCount(tags.size(), MAX_CUSTOMER_TAGS, NAME);
             for (var entry : tags.entrySet()) {
                 checkLength(entry.getKey(),   MAX_KEY_LENGTH,   "key",   NAME);
                 checkLength(entry.getValue(), MAX_VALUE_LENGTH, "value", NAME);
@@ -251,8 +248,7 @@ public class CloudResourceTags {
     private static void checkTagCount(int count, int max, String cloud) {
         if (count > max)
             throw new IllegalArgumentException("Too many cloud resource tags (" + count +
-                                               "): " + cloud + " allows at most " + max +
-                                               " customer tags (" + MAX_SYSTEM_TAGS + " of the provider limit are reserved for system tags)");
+                                               "): " + cloud + " allows at most " + max + " customer tags");
     }
 
     private static void checkLength(String value, int max, String field, String cloud) {

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudResourceTagsTest.java
@@ -315,10 +315,10 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void aws_rejects_more_than_35_tags() {
-        Map<String, String> tags36 = IntStream.rangeClosed(1, 36).boxed()
+    void aws_rejects_more_than_20_tags() {
+        Map<String, String> tags21 = IntStream.rangeClosed(1, 21).boxed()
                 .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(tags36);
+        var tags = CloudResourceTags.from(tags21);
         var e = assertThrows(IllegalArgumentException.class, () -> tags.validateFor(CloudName.AWS));
         assertTrue(e.getMessage().contains("AWS"));
     }
@@ -364,10 +364,10 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void gcp_rejects_more_than_49_tags() {
-        Map<String, String> tags50 = IntStream.rangeClosed(1, 50).boxed()
+    void gcp_rejects_more_than_20_tags() {
+        Map<String, String> tags21 = IntStream.rangeClosed(1, 21).boxed()
                 .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(tags50);
+        var tags = CloudResourceTags.from(tags21);
         var e = assertThrows(IllegalArgumentException.class, () -> tags.validateFor(CloudName.GCP));
         assertTrue(e.getMessage().contains("GCP"));
     }
@@ -449,10 +449,10 @@ class CloudResourceTagsTest {
     }
 
     @Test
-    void azure_rejects_more_than_35_tags() {
-        Map<String, String> tags36 = IntStream.rangeClosed(1, 36).boxed()
+    void azure_rejects_more_than_20_tags() {
+        Map<String, String> tags21 = IntStream.rangeClosed(1, 21).boxed()
                 .collect(toMap(i -> "key" + i, i -> "val" + i));
-        var tags = CloudResourceTags.from(tags36);
+        var tags = CloudResourceTags.from(tags21);
         var e = assertThrows(IllegalArgumentException.class, () -> tags.validateFor(CloudName.AZURE));
         assertTrue(e.getMessage().contains("Azure"));
     }
@@ -465,6 +465,16 @@ class CloudResourceTagsTest {
         assertDoesNotThrow(() -> empty.validateFor(CloudName.AWS));
         assertDoesNotThrow(() -> empty.validateFor(CloudName.GCP));
         assertDoesNotThrow(() -> empty.validateFor(CloudName.AZURE));
+    }
+
+    @Test
+    void twenty_customer_tags_accepted_for_all_clouds() {
+        Map<String, String> tags20 = IntStream.rangeClosed(1, 20).boxed()
+                .collect(toMap(i -> "key" + i, i -> "val" + i));
+        var tags = CloudResourceTags.from(tags20);
+        assertDoesNotThrow(() -> tags.validateFor(CloudName.AWS));
+        assertDoesNotThrow(() -> tags.validateFor(CloudName.GCP));
+        assertDoesNotThrow(() -> tags.validateFor(CloudName.AZURE));
     }
 
     @Test


### PR DESCRIPTION
Set the cloud resource tag count model to a fixed 20 customer tags for AWS, GCP, and Azure.

- Replace the system-tag headroom calculation with a shared customer tag limit.

---
*AI-assisted PR (GPT 5.5) - all changes verified by the author before submission*