### PR TITLE
Add reserveMemory flag to CustomerRpmService.

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/CustomerRpmService.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/CustomerRpmService.java
@@ -78,6 +78,13 @@ public class CustomerRpmService {
     @JsonProperty("disabled")
     private final Boolean disabled;
 
+    /**
+     * Optional flag that determines whether {@code memoryLimitMib} is subtracted
+     * from the Vespa node container. Defaults to false.
+     */
+    @JsonProperty("reserveMemory")
+    private final Boolean reserveMemory;
+
     @JsonCreator
     public CustomerRpmService(
         @JsonProperty(value = "unit") String unit,
@@ -87,7 +94,8 @@ public class CustomerRpmService {
         @JsonProperty(value = "memory") Double memoryLimitMib,
         @JsonProperty("cpu") Double cpuLimitCores,
         @JsonProperty("repositories") List<String> repositories,
-        @JsonProperty("disabled") Boolean disabled
+        @JsonProperty("disabled") Boolean disabled,
+        @JsonProperty("reserveMemory") Boolean reserveMemory
     ) {
         this.unit = Objects.requireNonNull(unit);
         this.packageName = packageName;
@@ -97,6 +105,7 @@ public class CustomerRpmService {
         this.cpuLimitCores = cpuLimitCores == null || cpuLimitCores <= 0.0 ? null : cpuLimitCores;
         this.repositories = repositories == null ? List.of() : repositories;
         this.disabled = disabled != null && disabled;
+        this.reserveMemory = reserveMemory != null && reserveMemory;
     }
 
     public String unitName() {
@@ -123,6 +132,10 @@ public class CustomerRpmService {
         return disabled;
     }
 
+    public boolean reserveMemory() {
+        return reserveMemory;
+    }
+
     public Optional<Double> cpuLimitCores() {
         return Optional.ofNullable(cpuLimitCores);
     }
@@ -144,21 +157,23 @@ public class CustomerRpmService {
             packageRelease().equals(other.packageRelease()) &&
             repositories().equals(other.repositories()) &&
             cpuLimitCores().equals(other.cpuLimitCores()) &&
-            disabled() == other.disabled();
+            disabled() == other.disabled() &&
+            reserveMemory() == other.reserveMemory();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(unitName(), packageName(), packageVersion(), packageRelease(), memoryLimitMib(), cpuLimitCores(), repositories(), disabled());
+        return Objects.hash(unitName(), packageName(), packageVersion(), packageRelease(), memoryLimitMib(), cpuLimitCores(), repositories(), disabled(), reserveMemory());
     }
 
     @Override
     public String toString() {
-        return Text.format("{ unit: %s, package: %s, memory: %s MiB, cpu: %s, repositories: %s, disabled: %s }",
+        return Text.format("{ unit: %s, package: %s, memory: %s MiB, cpu: %s, repositories: %s, disabled: %s, reserveMemory: %s }",
                         unitName(), packageName(), memoryLimitMib(),
                         cpuLimitCores().map(Object::toString).orElse("unlimited"),
                         String.join(", ", repositories()),
-                        disabled()
+                        disabled(),
+                        reserveMemory()
                 );
     }
 

--- a/flags/src/test/java/com/yahoo/vespa/flags/custom/CustomerRpmServiceTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/custom/CustomerRpmServiceTest.java
@@ -34,7 +34,8 @@ public class CustomerRpmServiceTest {
                             "unit": "example3",
                             "package": "package3",
                             "memory": 400.0,
-                            "disabled": true
+                            "disabled": true,
+                            "reserveMemory": true
                         },
                         {
                             "unit": "example4",
@@ -58,6 +59,7 @@ public class CustomerRpmServiceTest {
         assertEquals(200.0, service1.get().memoryLimitMib());
         assertEquals(List.of(), service1.get().repositories());
         assertFalse(service1.get().disabled());
+        assertFalse(service1.get().reserveMemory());
 
         Optional<CustomerRpmService> service2 = serviceList.services().stream()
                 .filter(r -> r.unitName().equals("example2"))
@@ -75,6 +77,7 @@ public class CustomerRpmServiceTest {
         assertEquals(400.0, service3.get().memoryLimitMib());
         assertEquals(List.of(), service3.get().repositories());
         assertTrue(service3.get().disabled());
+        assertTrue(service3.get().reserveMemory());
 
         Optional<CustomerRpmService> service4 = serviceList.services().stream()
                 .filter(r -> r.unitName().equals("example4"))
@@ -107,10 +110,10 @@ public class CustomerRpmServiceTest {
 
     @Test
     void customer_rpm_services_serialize() throws JsonProcessingException {
-        CustomerRpmService service1 = new CustomerRpmService("foo", null, null, null, 123.4, null, List.of(), false);
-        CustomerRpmService service2 = new CustomerRpmService("bar",  null, "1.0", "3", 567.8, 1.0, List.of(), true);
-        CustomerRpmService service3 = new CustomerRpmService("dog",  "pack", null, null, 500.0, 0.3, List.of(), false);
-        CustomerRpmService service4 = new CustomerRpmService("hi",  "there", null, null, 450.0, 0.4, List.of("repo1", "repo2"), false);
+        CustomerRpmService service1 = new CustomerRpmService("foo", null, null, null, 123.4, null, List.of(), false, false);
+        CustomerRpmService service2 = new CustomerRpmService("bar",  null, "1.0", "3", 567.8, 1.0, List.of(), true, true);
+        CustomerRpmService service3 = new CustomerRpmService("dog",  "pack", null, null, 500.0, 0.3, List.of(), false, true);
+        CustomerRpmService service4 = new CustomerRpmService("hi",  "there", null, null, 450.0, 0.4, List.of("repo1", "repo2"), false, false);
         CustomerRpmServiceList serviceList = new CustomerRpmServiceList(List.of(service1, service2, service3, service4));
         var mapper = Jackson.mapper();
         String serialized = mapper.writeValueAsString(serviceList);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This is needed so we can add memory used by RPM services to host memory.