### PR TITLE
Auto-vectorize the lowest hanging quantization fruits

### DIFF
--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -15,6 +15,32 @@ namespace vespalib::quant {
 
 namespace {
 
+// Invokes `fn(i)` once for every value `i` in [0, sz) and adds each result to one
+// of N partial sums. The sum of partial sums is then returned as the final value.
+// For floating point sums, this is explicitly and intentionally _not_ guaranteed
+// to yield the exact same result as if the output of `fn` had been sequentially
+// summed to a single accumulator. And that's why the compiler dares not optimize
+// loops in such a way in general (modulo `-ffast-math`, which is yolo-mode).
+template <size_t N, typename SumT, typename Fn>
+[[nodiscard]] SumT sum_indexed_unrolled(const size_t sz, Fn fn) noexcept(noexcept(fn(0))) {
+    SumT   partial[N] = {};
+    size_t i = 0;
+    for (; (i + N) <= sz; i += N) {
+        for (size_t j = 0; j < N; ++j) {
+            partial[j] += fn(i + j);
+        }
+    }
+    SumT sum{};
+    for (; i < sz; ++i) {
+        sum += fn(i);
+    }
+    // A "proper" vectorized version would use an N-way reduction tree, but this will do.
+    for (size_t j = 0; j < N; ++j) {
+        sum += partial[j];
+    }
+    return sum;
+}
+
 [[nodiscard]] size_t compute_quantized_buffer_size(const size_t dimensions, const uint8_t bits) noexcept {
     (void)bits;
     constexpr size_t scale_bytes = sizeof(float); // TODO configurable scale factor precision (f16 vs f32)?
@@ -57,12 +83,7 @@ void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, c
     // the magnitude by sqrt(d), which is then subsequently divided away in a subsequent
     // normalization step. Changes in magnitude are more likely to cause precision loss
     // since exponent adjustments can truncate mantissa LSBs.
-    // TODO add explicitly vectorized squared L2 norm functionality. Multiple parallel
-    //  accumulators will also likely _reduce_ accumulated floating point error.
-    float x_norm2 = 0;
-    for (size_t i = 0; i < d; ++i) {
-        x_norm2 += x[i] * x[i];
-    }
+    float x_norm2 = sum_indexed_unrolled<8, float>(d, [&](size_t idx) noexcept { return x[idx] * x[idx]; });
     if (x_norm2 == 0) [[unlikely]] {
         // Zero norm vectors must be special-cased, or we'll end up dividing by zero
         // when computing `nx` below. Set the scale explicitly to zero. For consistency,

--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -173,12 +173,14 @@ float EdenQuantizer::pre_rotated_query_dot_product(std::span<const float>   quer
         decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
     });
     const auto codebook = my_codebook();
-    float      dot = 0;
-    // TODO shiny happy vectorization time~
-    for (size_t i = 0; i < _dimensions; ++i) {
-        dot += query[i] * codebook[_idx_tmp[i]];
-    }
-    return dot * scale;
+    // Taunt the auto-vectorizer by explicitly running parallel fp accumulators.
+    // 8x is only slightly faster than 4x (on M3 AArch64), but 4x is by itself ~4x
+    // faster than the naive scalar loop version.
+    // clang-format off: lambda formatting
+    return scale * sum_indexed_unrolled<8, float>(_dimensions, [&](size_t idx) noexcept {
+        return query[idx] * codebook[_idx_tmp[idx]];
+    });
+    // clang-format on
 }
 
 } // namespace vespalib::quant


### PR DESCRIPTION
@arnej27959 please review
@havardpe FYI

I intentionally did not do anything special with the naïve scalar floating point accumulator loops for L2 norms or dot products in the initial implementation, as I wanted to wait until we had some microbenchmarks. Now that we do, these are minor changes to give the auto-vectorizer some freedom to tinker by running parallel partial sums.

Approximate improvement numbers (as measured on an M3 Max):
- Quantization performance increased 10-18% for <= 2 bits. For greater bit widths the time saved is dwarfed by the current naïve _O(n)_ centroid distance argmin.
- Pre-rotated quantized dot product performance increased by ~4x for longer vectors