### PR TITLE
Write more NNS information to trace

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -204,6 +204,22 @@ void traceQuery(uint32_t traceLevel, Trace& trace, const Query& query) {
     }
 }
 
+void trace_setup_stats(uint32_t trace_level, Trace& trace, const search::queryeval::QuerySetupStats& setup_stats) {
+    if (trace_level <= trace.getLevel()) {
+        // Tag is the existing "query_setup" tag plus "_stats"
+        vespalib::slime::ObjectInserter inserter(trace.createCursor("query_setup_stats"), "stats");
+        setup_stats.as_slime(inserter);
+    }
+}
+
+void trace_eval_stats(uint32_t trace_level, Trace& trace, const search::queryeval::QueryEvalStats& eval_stats) {
+    if (trace_level <= trace.getLevel()) {
+        // Tag is the existing "query_execution" tag plus "_stats"
+        vespalib::slime::ObjectInserter inserter(trace.createCursor("query_execution_stats"), "stats");
+        eval_stats.as_slime(inserter);
+    }
+}
+
 void updateCoverage(Coverage& coverage, const MaybeMatchPhaseLimiter& limiter, const MatchingStats& my_stats,
                     const search::IDocumentMetaStore& metaStore, const bucketdb::BucketDBOwner& bucketdb) {
     size_t spaceEstimate = (my_stats.softDoomed()) ? my_stats.docidSpaceCovered() : limiter.getDocIdSpaceEstimate();
@@ -296,6 +312,7 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
             request, searchContext, attrContext, metaStore, *feature_overrides, threadBundle,
             &owned_objects.readGuard, setup_stats, searchContext.getDocIdLimit(), true);
         isDoomExplicit = mtf->get_request_context().getDoom().isExplicitSoftDoom();
+        trace_setup_stats(6, request.trace(), setup_stats);
         traceQuery(6, request.trace(), mtf->query());
 
         if (!mtf->valid()) {
@@ -356,6 +373,7 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
         }
     }
     // Destructors of search iterators have written stats to queryeval_stats
+    trace_eval_stats(6, request.trace(), *queryeval_stats);
     // We can now merge the stats into my_stats
     my_stats.add_query_eval_stats(*queryeval_stats);
     queryeval_stats.reset(); // Manually reset pointer to include object tear-down in measured time

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -64,14 +64,17 @@ namespace proton::matching {
 
 namespace {
 
-void trace_global_filter_decision(uint32_t trace_level, search::engine::Trace* trace, double estimated_hit_ratio,
-                                  double lower_limit, double upper_limit) {
+void trace_global_filter_decision(uint32_t trace_level, search::engine::Trace* trace, const std::string& decision,
+                                  double estimated_hit_ratio, double lower_limit, double upper_limit) {
     if (trace && trace_level <= trace->getLevel()) {
-        vespalib::slime::ObjectInserter inserter(trace->createCursor("global_filter_decision"), "parameters");
-        vespalib::slime::Cursor&        cursor = inserter.insertObject();
-        cursor.setDouble("estimated_hit_ratio", estimated_hit_ratio);
-        cursor.setDouble("lower_limit", lower_limit);
-        cursor.setDouble("upper_limit", upper_limit);
+        vespalib::slime::Cursor& cursor = trace->createCursor("global_filter_decision");
+        cursor.setString("decision", decision);
+
+        vespalib::slime::ObjectInserter inserter(cursor, "parameters");
+        vespalib::slime::Cursor&        param_cursor = inserter.insertObject();
+        param_cursor.setDouble("estimated_hit_ratio", estimated_hit_ratio);
+        param_cursor.setDouble("lower_limit", lower_limit);
+        param_cursor.setDouble("upper_limit", upper_limit);
     }
 }
 
@@ -294,12 +297,13 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
     // Use overrides from blueprint if provided
     double effective_lower_limit = limits.lower_limit.value_or(global_filter_lower_limit);
     double effective_upper_limit = limits.upper_limit.value_or(global_filter_upper_limit);
-    trace_global_filter_decision(5, trace, estimated_hit_ratio, effective_lower_limit, effective_upper_limit);
 
     if (estimated_hit_ratio < effective_lower_limit) {
         if (trace && trace->shouldTrace(5)) {
             trace->addEvent(5, "Skip calculate global filter");
         }
+        trace_global_filter_decision(5, trace, "Skip", estimated_hit_ratio, effective_lower_limit,
+                                     effective_upper_limit);
         return false;
     }
 
@@ -316,6 +320,8 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
         if (trace && trace->shouldTrace(5)) {
             trace->addEvent(5, "Calculate global filter");
         }
+        trace_global_filter_decision(5, trace, "Calculate", estimated_hit_ratio, effective_lower_limit,
+                                     effective_upper_limit);
         global_filter = GlobalFilter::create(blueprint, docid_limit, thread_bundle, trace);
         if (!global_filter->is_active()) {
             estimated_hit_ratio = 1.0;
@@ -327,6 +333,8 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
         if (trace && trace->shouldTrace(5)) {
             trace->addEvent(5, "Create match everything global filter");
         }
+        trace_global_filter_decision(5, trace, "Match everything", estimated_hit_ratio, effective_lower_limit,
+                                     effective_upper_limit);
         global_filter = GlobalFilter::create();
     }
     if (use_lazy_filter) {

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -341,13 +341,13 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
         trace->addEvent(5, "Handle global filter in query execution plan");
     }
     blueprint.set_global_filter(*global_filter, estimated_hit_ratio);
-    perform_ann_searches(blueprint, doom, ann_deadline_config, setup_stats);
+    perform_ann_searches(blueprint, doom, ann_deadline_config, setup_stats, trace);
     return true;
 }
 
 void Query::perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doom,
                                  const AnnDeadlineConfiguration&     ann_deadline_config,
-                                 search::queryeval::QuerySetupStats& setup_stats) {
+                                 search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace* trace) {
     std::queue<search::queryeval::NearestNeighborBlueprint*> ann_blueprints;
     blueprint.each_node_post_order([&ann_blueprints](Blueprint& bp) {
         if (auto nearest_neighbor = bp.asNearestNeighbor()) {
@@ -356,6 +356,9 @@ void Query::perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doo
             }
         }
     });
+    if (trace && !ann_blueprints.empty()) {
+        trace->addEvent(5, ann_blueprints.size() > 1 ? "Perform ann searches" : "Perform ann search");
+    }
     while (!ann_blueprints.empty()) {
         const vespalib::Deadline deadline = ann_deadline_config.make_ann_deadline(doom, ann_blueprints.size());
         ann_blueprints.front()->perform_index_search(deadline, setup_stats);

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -64,6 +64,17 @@ namespace proton::matching {
 
 namespace {
 
+void trace_global_filter_decision(uint32_t trace_level, search::engine::Trace* trace, double estimated_hit_ratio,
+                                  double lower_limit, double upper_limit) {
+    if (trace && trace_level <= trace->getLevel()) {
+        vespalib::slime::ObjectInserter inserter(trace->createCursor("global_filter_decision"), "parameters");
+        vespalib::slime::Cursor&        cursor = inserter.insertObject();
+        cursor.setDouble("estimated_hit_ratio", estimated_hit_ratio);
+        cursor.setDouble("lower_limit", lower_limit);
+        cursor.setDouble("upper_limit", upper_limit);
+    }
+}
+
 Node::UP inject(Node::UP query, Node::UP to_inject) {
     if (auto* my_and = dynamic_cast<search::query::And*>(query.get())) {
         my_and->append(std::move(to_inject));
@@ -283,12 +294,11 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
     // Use overrides from blueprint if provided
     double effective_lower_limit = limits.lower_limit.value_or(global_filter_lower_limit);
     double effective_upper_limit = limits.upper_limit.value_or(global_filter_upper_limit);
+    trace_global_filter_decision(5, trace, estimated_hit_ratio, effective_lower_limit, effective_upper_limit);
 
     if (estimated_hit_ratio < effective_lower_limit) {
         if (trace && trace->shouldTrace(5)) {
-            trace->addEvent(
-                5, vespalib::make_string("Skip calculate global filter (estimated_hit_ratio (%f) < lower_limit (%f))",
-                                         estimated_hit_ratio, effective_lower_limit));
+            trace->addEvent(5, "Skip calculate global filter");
         }
         return false;
     }
@@ -304,9 +314,7 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
     std::shared_ptr<GlobalFilter> global_filter;
     if (estimated_hit_ratio <= effective_upper_limit) {
         if (trace && trace->shouldTrace(5)) {
-            trace->addEvent(
-                5, vespalib::make_string("Calculate global filter (estimated_hit_ratio (%f) <= upper_limit (%f))",
-                                         estimated_hit_ratio, effective_upper_limit));
+            trace->addEvent(5, "Calculate global filter");
         }
         global_filter = GlobalFilter::create(blueprint, docid_limit, thread_bundle, trace);
         if (!global_filter->is_active()) {
@@ -317,21 +325,14 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
         }
     } else {
         if (trace && trace->shouldTrace(5)) {
-            trace->addEvent(5,
-                            vespalib::make_string(
-                                "Create match everything global filter (estimated_hit_ratio (%f) > upper_limit (%f))",
-                                estimated_hit_ratio, effective_upper_limit));
+            trace->addEvent(5, "Create match everything global filter");
         }
         global_filter = GlobalFilter::create();
     }
     if (use_lazy_filter) {
         if (lazy_filter->is_active()) {
             if (trace && trace->shouldTrace(5)) {
-                trace->addEvent(
-                    5, vespalib::make_string("Apply active lazy filter (estimate is %f)",
-                                             lazy_filter->size() > 0
-                                                 ? static_cast<double>(lazy_filter->count()) / lazy_filter->size()
-                                                 : 1.0));
+                trace->addEvent(5, "Apply active lazy filter");
             }
             blueprint.set_lazy_filter(*lazy_filter);
         }

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -365,7 +365,7 @@ void Query::perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doo
         }
     });
     if (trace && !ann_blueprints.empty()) {
-        trace->addEvent(5, "Perform ANN searches");
+        trace->addEvent(5, "Perform ANN search(es)");
     }
     while (!ann_blueprints.empty()) {
         const vespalib::Deadline deadline = ann_deadline_config.make_ann_deadline(doom, ann_blueprints.size());

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -357,7 +357,7 @@ void Query::perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doo
         }
     });
     if (trace && !ann_blueprints.empty()) {
-        trace->addEvent(5, ann_blueprints.size() > 1 ? "Perform ann searches" : "Perform ann search");
+        trace->addEvent(5, "Perform ANN searches");
     }
     while (!ann_blueprints.empty()) {
         const vespalib::Deadline deadline = ann_deadline_config.make_ann_deadline(doom, ann_blueprints.size());

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -138,7 +138,7 @@ public:
 
     static void perform_ann_searches(Blueprint& blueprint, const vespalib::Doom& doom,
                                      const AnnDeadlineConfiguration&     ann_deadline_config,
-                                     search::queryeval::QuerySetupStats& setup_stats);
+                                     search::queryeval::QuerySetupStats& setup_stats, search::engine::Trace* trace);
 
     void freeze();
     void set_matching_phase(search::queryeval::MatchingPhase matching_phase) const noexcept;

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -257,7 +257,17 @@ void NearestNeighborBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) co
     visitor.visitString("query_tensor", _query_tensor.type().to_spec());
     visitor.visitInt("target_hits", _target_hits);
     visitor.visitInt("adjusted_target_hits", _adjusted_target_hits);
+
+    // Dump parameters
     visitor.visitInt("explore_additional_hits", _hnsw_params.explore_additional_hits);
+    visitor.visitFloat("distance_threshold", _hnsw_params.distance_threshold);
+    // global_filter_lower_limit and global_filter_upper_limit are included in global_filter struct below
+    visitor.visitFloat("filter_first_upper_limit", _hnsw_params.filter_first_upper_limit);
+    visitor.visitFloat("filter_first_exploration", _hnsw_params.filter_first_exploration);
+    visitor.visitFloat("exploration_slack", _hnsw_params.exploration_slack);
+    visitor.visitBool("prefetch_tensors", _hnsw_params.prefetch_tensors);
+    visitor.visitFloat("target_hits_max_adjustment_factor", _hnsw_params.target_hits_max_adjustment_factor);
+
     visitor.visitBool("wanted_approximate", _approximate);
     visitor.visitBool("has_index", _attr_tensor.nearest_neighbor_index());
     visitor.visitString("algorithm", to_string(_algorithm));

--- a/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
+++ b/searchlib/src/vespa/searchlib/queryeval/queryeval_stats.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/util/time.h>
 
 #include <atomic>
@@ -49,6 +50,16 @@ public:
 
     size_t approximate_nns_timeouts_hit() const noexcept { return _approximate_nns_timeouts_hit; }
     void add_to_approximate_nns_timeouts_hit(size_t value) noexcept { _approximate_nns_timeouts_hit += value; }
+
+    vespalib::slime::Cursor& as_slime(const vespalib::slime::Inserter& inserter) const {
+        vespalib::slime::Cursor& cursor = inserter.insertObject();
+        cursor.setLong("approximate_nns_distances_computed", approximate_nns_distances_computed());
+        cursor.setLong("approximate_nns_nodes_visited", approximate_nns_nodes_visited());
+        cursor.setLong("approximate_nns_searches_performed", approximate_nns_searches_performed());
+        cursor.setDouble("approximate_nns_time_used_ms", vespalib::count_ns(approximate_nns_time_used()) / 1000000.0);
+        cursor.setLong("approximate_nns_timeouts_hit", approximate_nns_timeouts_hit());
+        return cursor;
+    }
 };
 
 /**
@@ -74,6 +85,12 @@ public:
     }
     void add_to_exact_nns_distances_computed(size_t value) noexcept {
         _exact_nns_distances_computed.fetch_add(value, std::memory_order_relaxed);
+    }
+
+    vespalib::slime::Cursor& as_slime(const vespalib::slime::Inserter& inserter) const {
+        vespalib::slime::Cursor& cursor = inserter.insertObject();
+        cursor.setLong("exact_nns_distances_computed", exact_nns_distances_computed());
+        return cursor;
     }
 };
 


### PR DESCRIPTION
Writes

- the stats from `QuerySetupStats`,
- the stats from `QueryEvalStats`,
- the parameters deciding whether to compute the global filter,
- a new message `Perform ann search`/`Perform ann searches`, and
- the HNSW parameters from the `NearestNeighborBlueprint`

to the trace. The values deciding whether to compute the global filter are removed from the event messages. In addition, the estimate for the lazy filter is removed. Probably not needed.

A follow-up PR will make use of this information. Abbreviated Proton sample trace with the stats and the filter decision:
```
{
  "distribution-key": 0,
  "document-type": "test",
  "duration_ms": 20.684177,
  "start_time": "2026-06-02 07:45:33.712 UTC",
  "traces": [
    {
      "event": "searching for 100 hits at offset 0",
      "tag": "query_start",
      "timestamp_ms": 0.199917
    },
    {
      "tag": "query_setup",
      "timestamp_ms": 20.372509,
      "traces": [
        {
          "event": "Start query setup",
          "timestamp_ms": 0.227834
        },
        {
          "parameters": {
            "estimated_hit_ratio": 0.49995000499950004,
            "lower_limit": 0.05,
            "upper_limit": 1
          },
          "tag": "global_filter_decision",
          "timestamp_ms": 0.541543
        },
        {
          "event": "Complete query setup",
          "timestamp_ms": 20.371842
        }
      ]
    },
    {
      "stats": {
        "approximate_nns_distances_computed": 1739,
        "approximate_nns_nodes_visited": 1739,
        "approximate_nns_searches_performed": 1,
        "approximate_nns_time_used_ms": 3.309966,
        "approximate_nns_timeouts_hit": 0
      },
      "tag": "query_setup_stats",
      "timestamp_ms": 20.444093
    },
    {
      "optimized": {
      },
      "tag": "query_execution_plan",
      "timestamp_ms": 20.386342
    },
    {
      "tag": "query_execution",
      "threads": [
        {
          "traces": [
            {
              "event": "Start MatchThread::run",
              "timestamp_ms": 20.454676
            },
            {
              "event": "MatchThread::run Done",
              "timestamp_ms": 20.592885
            },
            {
              "depth": 100,
              "profiler": "tree",
              "roots": [
              ],
              "tag": "match_profiling",
              "timestamp_ms": 20.592968,
              "total_time_ms": 0.028308
            },
            {
              "depth": 100,
              "profiler": "tree",
              "roots": [
              ],
              "tag": "first_phase_profiling",
              "timestamp_ms": 20.598926,
              "total_time_ms": 0.002466
            },
            {
              "depth": 100,
              "profiler": "tree",
              "tag": "second_phase_profiling",
              "timestamp_ms": 20.603426,
              "total_time_ms": 0
            }
          ]
        }
      ],
      "timestamp_ms": 20.641968
    },
    {
      "stats": {
        "exact_nns_distances_computed": 0
      },
      "tag": "query_execution_stats",
      "timestamp_ms": 20.67151
    },
    {
      "event": "returning 100 hits from total 100",
      "tag": "query_reply",
      "timestamp_ms": 20.68201
    }
  ]
}

```