### PR TITLE
Skip VSCode extension publishing temporarily

### DIFF
--- a/.github/workflows/lspDeploy.yml
+++ b/.github/workflows/lspDeploy.yml
@@ -68,12 +68,13 @@ jobs:
           gradle buildPlugin
         working-directory: ./integration/schema-language-server/clients/intellij
 
-      - name: Publish VScode extension
-        if: github.event_name == 'workflow_dispatch'
-        run: npm run publish
-        working-directory: ./integration/schema-language-server/clients/vscode
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      # Disable temporarily
+      #- name: Publish VScode extension
+      #  if: github.event_name == 'workflow_dispatch'
+      #  run: npm run publish
+      #  working-directory: ./integration/schema-language-server/clients/vscode
+      #  env:
+      #    VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish IntelliJ plugin
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
We already published the new version there, so deployment now fails at this step. 🫠 