### PR TITLE
Add vectorized squared Euclidean length kernel

### DIFF
--- a/vespalib/src/tests/hwaccelerated/data_utils.h
+++ b/vespalib/src/tests/hwaccelerated/data_utils.h
@@ -2,7 +2,12 @@
 
 #pragma once
 
+#include <vespa/vespalib/util/xoshiro.h>
+
+#include <algorithm>
+#include <concepts>
 #include <random>
+#include <ranges>
 #include <vector>
 
 namespace vespalib::hwaccelerated {
@@ -17,7 +22,8 @@ template <> constexpr auto choose_distribution<size_t>() noexcept {
     return std::uniform_int_distribution<size_t>(0ULL, UINT64_MAX);
 }
 
-template <typename T, std::uniform_random_bit_generator Rng> std::vector<T> create_and_fill(Rng& rng, size_t sz) {
+template <typename T, std::uniform_random_bit_generator Rng>
+std::vector<T> create_and_fill(Rng& rng, size_t sz) {
     auto           dist = choose_distribution<T>();
     std::vector<T> v(sz);
     for (size_t i(0); i < sz; i++) {
@@ -26,9 +32,17 @@ template <typename T, std::uniform_random_bit_generator Rng> std::vector<T> crea
     return v;
 }
 
+template <std::floating_point T, std::uniform_random_bit_generator Rng>
+std::vector<T> create_and_fill_float(Rng& rng, size_t sz) {
+    std::uniform_real_distribution<T> dist(-1, 1);
+    std::vector<T>                    v(sz);
+    std::ranges::generate(v, [&]() mutable { return dist(rng); });
+    return v;
+}
+
 template <typename T> std::pair<std::vector<T>, std::vector<T>> create_and_fill_lhs_rhs(size_t sz) {
-    std::minstd_rand prng;
-    prng.seed(1234567);
+    Xoshiro256PlusPlusPrng prng(1234567);
+
     std::vector<T> a = create_and_fill<T>(prng, sz);
     std::vector<T> b = create_and_fill<T>(prng, sz);
     return {std::move(a), std::move(b)};

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_bench.cpp
@@ -101,6 +101,13 @@ void register_all_benchmark_suites() {
     register_benchmarks<int8_t>("Squared Euclidean Distance", FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_I8,
                                 euclidean_dist_fn);
 
+    auto euclidean_length_fn = [](const auto* lhs, const auto* rhs, size_t my_sz) {
+        (void)rhs; // ... a little bit sneaky; overestimates bytes processed/sec by 2x
+        return squared_euclidean_length(lhs, my_sz);
+    };
+    register_benchmarks<float>("Squared Euclidean Length", FnTable::FnId::SQUARED_EUCLIDEAN_LENGTH_F32,
+                               euclidean_length_fn);
+
     auto dot_product_fn = [](const auto* lhs, const auto* rhs, size_t my_sz) { return dot_product(lhs, rhs, my_sz); };
     register_benchmarks<double>("Dot Product", FnTable::FnId::DOT_PRODUCT_F64, dot_product_fn);
     register_benchmarks<float>("Dot Product", FnTable::FnId::DOT_PRODUCT_F32, dot_product_fn);

--- a/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/hwaccelerated_test.cpp
@@ -47,6 +47,25 @@ void verify_euclidean_distance(std::span<const IAccelerated*> accels, size_t tes
     }
 }
 
+template <std::floating_point T>
+void verify_euclidean_length(std::span<const IAccelerated*> accels, size_t test_length, double approx_factor) {
+    Xoshiro256PlusPlusPrng prng(1234567);
+    std::vector<T>         v = create_and_fill_float<T>(prng, test_length);
+    for (size_t j = 0; j < 32; j++) {
+        float sum = 0;
+        for (size_t i = j; i < test_length; i++) {
+            sum += v[i] * v[i];
+        }
+        for (const auto* accel : accels) {
+            LOG(spam, "verify_euclidean_length(accel=%s, len=%zu, offset=%zu)",
+                accel->target_info().to_string().c_str(), test_length, j);
+            ScopedFnTableOverride fn_scope(accel->fn_table());
+            float                 computed = squared_euclidean_length(&v[j], test_length - j);
+            ASSERT_NEAR(sum, computed, sum * approx_factor) << accel->target_info().to_string();
+        }
+    }
+}
+
 template <typename T>
 void verify_dot_product(std::span<const IAccelerated*> accels, size_t test_length, double approx_factor) {
     auto [a, b] = create_and_fill_lhs_rhs<T>(test_length);
@@ -94,6 +113,10 @@ void verify_euclidean_distance(std::span<const IAccelerated*> accelerators, size
     verify_euclidean_distance<double>(accelerators, testLength, 0.0);
 }
 
+void verify_euclidean_length(std::span<const IAccelerated*> accelerators, size_t testLength) {
+    verify_euclidean_length<float>(accelerators, testLength, 0.0001);
+}
+
 // Max number of elements that can be covered in one computed_chunked_sum() call
 // for our current chunked use cases (dot product + Euclidean distance).
 constexpr uint32_t euclidean_max_chunk_i32_boundary = INT32_MAX / (-255 * -255);
@@ -131,6 +154,13 @@ TEST_F(HwAcceleratedTest, euclidean_distance_impls_match_source_of_truth) {
     for (size_t test_length : test_lengths()) {
         ASSERT_NO_FATAL_FAILURE(verify_euclidean_distance(accelerators, test_length))
             << "with length " << test_length;
+    }
+}
+
+TEST_F(HwAcceleratedTest, euclidean_length_impls_match_source_of_truth) {
+    auto accelerators = all_accelerators_to_test();
+    for (size_t test_length : test_lengths()) {
+        ASSERT_NO_FATAL_FAILURE(verify_euclidean_length(accelerators, test_length)) << "with length " << test_length;
     }
 }
 

--- a/vespalib/src/tests/quant/CMakeLists.txt
+++ b/vespalib/src/tests/quant/CMakeLists.txt
@@ -9,6 +9,7 @@ vespa_add_executable(vespalib_quant_test_app TEST
     sign_flip_test.cpp
     DEPENDS
     vespalib
+    vespalib_quant
     GTest::gtest
     GTest::gmock
 )
@@ -19,6 +20,7 @@ vespa_add_executable(vespalib_quant_benchmark_app
     quant_benchmarks.cpp
     DEPENDS
     vespalib
+    vespalib_quant
 )
 vespa_add_target_external_dependency(vespalib_quant_benchmark_app benchmark)
 vespa_add_test(NAME vespalib_quant_benchmark_app COMMAND vespalib_quant_benchmark_app BENCHMARK)

--- a/vespalib/src/vespa/vespalib/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/CMakeLists.txt
@@ -44,7 +44,6 @@ vespa_add_library(vespalib
     $<TARGET_OBJECTS:vespalib_vespalib_objects>
     $<TARGET_OBJECTS:vespalib_vespalib_portal>
     $<TARGET_OBJECTS:vespalib_vespalib_process>
-    $<TARGET_OBJECTS:vespalib_vespalib_quant>
     $<TARGET_OBJECTS:vespalib_vespalib_regex>
     $<TARGET_OBJECTS:vespalib_vespalib_stllike>
     $<TARGET_OBJECTS:vespalib_vespalib_test>

--- a/vespalib/src/vespa/vespalib/hwaccelerated/autovec_unrolled.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/autovec_unrolled.h
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstddef>
+
+namespace vespalib::hwaccelerated {
+
+// Invokes `fn(i)` once for every value `i` in [0, sz) and adds each result to one
+// of N partial sums. The sum of partial sums is then returned as the final value.
+// For floating point sums, this is explicitly and intentionally _not_ guaranteed
+// to yield the exact same result as if the output of `fn` had been sequentially
+// summed to a single accumulator. And that's why the compiler dares not optimize
+// loops in such a way in general (modulo `-ffast-math`, which is yolo-mode).
+template <size_t N, typename SumT, typename Fn>
+[[nodiscard]] SumT sum_indexed_unrolled(const size_t sz, Fn fn) noexcept(noexcept(fn(0))) {
+    SumT   partial[N] = {};
+    size_t i = 0;
+    for (; (i + N) <= sz; i += N) {
+        for (size_t j = 0; j < N; ++j) {
+            partial[j] += fn(i + j);
+        }
+    }
+    SumT sum{};
+    for (; i < sz; ++i) {
+        sum += fn(i);
+    }
+    // A "proper" vectorized version would use an N-way reduction tree, but this will do.
+    for (size_t j = 0; j < N; ++j) {
+        sum += partial[j];
+    }
+    return sum;
+}
+
+} // namespace vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/fn_table.h
@@ -32,6 +32,8 @@ using SquaredEuclideanDistanceBF16Fn = double (*)(const BFloat16* a, const BFloa
 using SquaredEuclideanDistanceF32Fn = double (*)(const float* a, const float* b, size_t sz) noexcept;
 using SquaredEuclideanDistanceF64Fn = double (*)(const double* a, const double* b, size_t sz) noexcept;
 
+using SquaredEuclideanLengthF32Fn = float (*)(const float* v, size_t sz) noexcept;
+
 using BinaryHammingDistanceFn = size_t (*)(const void* lhs, const void* rhs, size_t sz) noexcept;
 
 using PopulationCountFn = size_t (*)(const uint64_t* buf, size_t sz) noexcept;
@@ -74,6 +76,8 @@ struct FnTable {
     SquaredEuclideanDistanceF32Fn  squared_euclidean_distance_f32 = nullptr;
     SquaredEuclideanDistanceF64Fn  squared_euclidean_distance_f64 = nullptr;
 
+    SquaredEuclideanLengthF32Fn squared_euclidean_length_f32 = nullptr;
+
     BinaryHammingDistanceFn binary_hamming_distance = nullptr;
 
     PopulationCountFn population_count = nullptr;
@@ -100,6 +104,7 @@ struct FnTable {
         SQUARED_EUCLIDEAN_DISTANCE_BF16,
         SQUARED_EUCLIDEAN_DISTANCE_F32,
         SQUARED_EUCLIDEAN_DISTANCE_F64,
+        SQUARED_EUCLIDEAN_LENGTH_F32,
         BINARY_HAMMING_DISTANCE,
         POPULATION_COUNT,
         CONVERT_BFLOAT16_TO_FLOAT,
@@ -163,30 +168,31 @@ struct FnTable {
 // all places that need to poke at the fields of a function table. The `VISITOR` argument
 // is invoked with 3 args; the function ptr type, the function ptr name and its ID used
 // by the "is this function suboptimal for this target"-mask and the target info array.
-#define VESPA_HWACCEL_VISIT_FN_TABLE(VISITOR)                                                              \
-    VISITOR(DotProductI8Fn, dot_product_i8, FnTable::FnId::DOT_PRODUCT_I8)                                 \
-    VISITOR(DotProductI16Fn, dot_product_i16, FnTable::FnId::DOT_PRODUCT_I16)                              \
-    VISITOR(DotProductI32Fn, dot_product_i32, FnTable::FnId::DOT_PRODUCT_I32)                              \
-    VISITOR(DotProductI64Fn, dot_product_i64, FnTable::FnId::DOT_PRODUCT_I64)                              \
-    VISITOR(DotProductBF16Fn, dot_product_bf16, FnTable::FnId::DOT_PRODUCT_BF16)                           \
-    VISITOR(DotProductF32Fn, dot_product_f32, FnTable::FnId::DOT_PRODUCT_F32)                              \
-    VISITOR(DotProductF64Fn, dot_product_f64, FnTable::FnId::DOT_PRODUCT_F64)                              \
-    VISITOR(SquaredEuclideanDistanceI8Fn, squared_euclidean_distance_i8,                                   \
-            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_I8)                                                  \
-    VISITOR(SquaredEuclideanDistanceBF16Fn, squared_euclidean_distance_bf16,                               \
-            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_BF16)                                                \
-    VISITOR(SquaredEuclideanDistanceF32Fn, squared_euclidean_distance_f32,                                 \
-            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_F32)                                                 \
-    VISITOR(SquaredEuclideanDistanceF64Fn, squared_euclidean_distance_f64,                                 \
-            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_F64)                                                 \
-    VISITOR(BinaryHammingDistanceFn, binary_hamming_distance, FnTable::FnId::BINARY_HAMMING_DISTANCE)      \
-    VISITOR(PopulationCountFn, population_count, FnTable::FnId::POPULATION_COUNT)                          \
-    VISITOR(ConvertBFloat16ToFloatFn, convert_bfloat16_to_float, FnTable::FnId::CONVERT_BFLOAT16_TO_FLOAT) \
-    VISITOR(OrBitFn, or_bit, FnTable::FnId::OR_BIT)                                                        \
-    VISITOR(AndBitFn, and_bit, FnTable::FnId::AND_BIT)                                                     \
-    VISITOR(AndNotBitFn, and_not_bit, FnTable::FnId::AND_NOT_BIT)                                          \
-    VISITOR(NotBitFn, not_bit, FnTable::FnId::NOT_BIT)                                                     \
-    VISITOR(And128Fn, and_128, FnTable::FnId::AND_128)                                                     \
+#define VESPA_HWACCEL_VISIT_FN_TABLE(VISITOR)                                                                       \
+    VISITOR(DotProductI8Fn, dot_product_i8, FnTable::FnId::DOT_PRODUCT_I8)                                          \
+    VISITOR(DotProductI16Fn, dot_product_i16, FnTable::FnId::DOT_PRODUCT_I16)                                       \
+    VISITOR(DotProductI32Fn, dot_product_i32, FnTable::FnId::DOT_PRODUCT_I32)                                       \
+    VISITOR(DotProductI64Fn, dot_product_i64, FnTable::FnId::DOT_PRODUCT_I64)                                       \
+    VISITOR(DotProductBF16Fn, dot_product_bf16, FnTable::FnId::DOT_PRODUCT_BF16)                                    \
+    VISITOR(DotProductF32Fn, dot_product_f32, FnTable::FnId::DOT_PRODUCT_F32)                                       \
+    VISITOR(DotProductF64Fn, dot_product_f64, FnTable::FnId::DOT_PRODUCT_F64)                                       \
+    VISITOR(SquaredEuclideanDistanceI8Fn, squared_euclidean_distance_i8,                                            \
+            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_I8)                                                           \
+    VISITOR(SquaredEuclideanDistanceBF16Fn, squared_euclidean_distance_bf16,                                        \
+            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_BF16)                                                         \
+    VISITOR(SquaredEuclideanDistanceF32Fn, squared_euclidean_distance_f32,                                          \
+            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_F32)                                                          \
+    VISITOR(SquaredEuclideanDistanceF64Fn, squared_euclidean_distance_f64,                                          \
+            FnTable::FnId::SQUARED_EUCLIDEAN_DISTANCE_F64)                                                          \
+    VISITOR(SquaredEuclideanLengthF32Fn, squared_euclidean_length_f32, FnTable::FnId::SQUARED_EUCLIDEAN_LENGTH_F32) \
+    VISITOR(BinaryHammingDistanceFn, binary_hamming_distance, FnTable::FnId::BINARY_HAMMING_DISTANCE)               \
+    VISITOR(PopulationCountFn, population_count, FnTable::FnId::POPULATION_COUNT)                                   \
+    VISITOR(ConvertBFloat16ToFloatFn, convert_bfloat16_to_float, FnTable::FnId::CONVERT_BFLOAT16_TO_FLOAT)          \
+    VISITOR(OrBitFn, or_bit, FnTable::FnId::OR_BIT)                                                                 \
+    VISITOR(AndBitFn, and_bit, FnTable::FnId::AND_BIT)                                                              \
+    VISITOR(AndNotBitFn, and_not_bit, FnTable::FnId::AND_NOT_BIT)                                                   \
+    VISITOR(NotBitFn, not_bit, FnTable::FnId::NOT_BIT)                                                              \
+    VISITOR(And128Fn, and_128, FnTable::FnId::AND_128)                                                              \
     VISITOR(Or128Fn, or_128, FnTable::FnId::OR_128)
 
 // Freestanding global dispatch function pointers declarations.

--- a/vespalib/src/vespa/vespalib/hwaccelerated/functions.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/functions.h
@@ -56,6 +56,10 @@ namespace vespalib::hwaccelerated {
     return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(squared_euclidean_distance_f64)(a, b, sz);
 }
 
+[[nodiscard]] inline float squared_euclidean_length(const float* v, size_t sz) noexcept {
+    return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(squared_euclidean_length_f32)(v, sz);
+}
+
 [[nodiscard]] inline size_t binary_hamming_distance(const void* a, const void* b, size_t sz) noexcept {
     return dispatch::VESPA_HWACCEL_DISPATCH_FN_PTR_NAME(binary_hamming_distance)(a, b, sz);
 }

--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic-inl.hpp
@@ -7,6 +7,7 @@
 #error "VESPA_HWACCEL_INCLUDE_DEFINITIONS not set"
 #endif
 
+#include "autovec_unrolled.h"
 #include "fn_table.h"
 #include "private_helpers.hpp"
 
@@ -123,6 +124,9 @@ double my_squared_euclidean_distance_f32(const float* a, const float* b, size_t 
 }
 double my_squared_euclidean_distance_f64(const double* a, const double* b, size_t sz) noexcept {
     return squaredEuclideanDistanceT<double, double, 16>(a, b, sz);
+}
+float my_squared_euclidean_length_f32(const float* v, size_t sz) noexcept {
+    return sum_indexed_unrolled<16, float>(sz, [&](size_t idx) noexcept { return v[idx] * v[idx]; });
 }
 size_t my_binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) noexcept {
     return helper::autovec_binary_hamming_distance(lhs, rhs, sz);

--- a/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/highway.cpp
@@ -104,18 +104,21 @@ float my_hwy_dot_bf16(const BFloat16* HWY_RESTRICT a, const BFloat16* HWY_RESTRI
     const hn::Repartition<float, decltype(dbf16)> df32;
     // Since we're widening the element type, loading e.g. 8 lanes of BF16 in a single
     // 128-bit vector requires us to process 2 vectors of 4 lanes of float32.
-    auto kernel_fn = [df32](auto lhs, auto rhs, auto& acc0, auto& acc1)
-                         VESPA_HWY_LAMBDA { acc0 = hn::ReorderWidenMulAccumulate(df32, lhs, rhs, acc0, acc1); };
+    auto kernel_fn = [df32](auto lhs, auto rhs, auto& acc0, auto& acc1) VESPA_HWY_LAMBDA {
+        // f32 += bf16 * bf16
+        acc0 = hn::ReorderWidenMulAccumulate(df32, lhs, rhs, acc0, acc1);
+    };
     using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<4>, HasAccumulatorArity<2>>;
     return MyKernel::pairwise(dbf16, df32, a_bf16, b_bf16, sz, hn::Zero(df32), kernel_fn, VecAdd(), LaneReduceSum());
 }
 
 template <typename T>
     requires(hwy::IsFloat<T>())
-HWY_INLINE double my_hwy_square_euclidean_distance(const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
-                                                   const size_t sz) noexcept {
+HWY_INLINE double my_hwy_squared_euclidean_distance(const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+                                                    const size_t sz) noexcept {
     const hn::ScalableTag<T> d;
-    const auto               kernel_fn = [](auto lhs, auto rhs, auto& accu) VESPA_HWY_LAMBDA {
+
+    const auto kernel_fn = [](auto lhs, auto rhs, auto& accu) VESPA_HWY_LAMBDA {
         const auto sub = hn::Sub(lhs, rhs);
         accu = hn::MulAdd(sub, sub, accu); // note: using fused multiply-add
     };
@@ -124,8 +127,8 @@ HWY_INLINE double my_hwy_square_euclidean_distance(const T* HWY_RESTRICT a, cons
 }
 
 HWY_INLINE
-double my_hwy_square_euclidean_distance_bf16(const BFloat16* HWY_RESTRICT a, const BFloat16* HWY_RESTRICT b,
-                                             const size_t sz) noexcept {
+double my_hwy_squared_euclidean_distance_bf16(const BFloat16* HWY_RESTRICT a, const BFloat16* HWY_RESTRICT b,
+                                              const size_t sz) noexcept {
     static_assert(sizeof(BFloat16) == sizeof(hwy::bfloat16_t));
     static_assert(alignof(BFloat16) == alignof(hwy::bfloat16_t));
 
@@ -174,6 +177,18 @@ double my_hwy_square_euclidean_distance_int8(const int8_t* HWY_RESTRICT a, const
     return compute_chunked_sum<max_n_per_chunk, double>(sub_mul_add_i8_to_i32, a, b, sz);
 }
 
+template <typename T>
+    requires(hwy::IsFloat<T>())
+HWY_INLINE T my_hwy_squared_euclidean_length(const T* a, const size_t sz) noexcept {
+    const hn::ScalableTag<T> d;
+
+    const auto kernel_fn = [](auto v, auto& accu) VESPA_HWY_LAMBDA {
+        accu = hn::MulAdd(v, v, accu); // accu += v*v
+    };
+    using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<8>, HasAccumulatorArity<1>>;
+    return MyKernel::elementwise(d, d, a, sz, hn::Zero(d), kernel_fn, VecAdd(), LaneReduceSum());
+}
+
 // Performance note: AVX2 and AVX3 do not have dedicated vector popcount instructions,
 // so the Highway "emulation" ends up being slower in practice than the baseline one
 // using 4x pipelined POPCNT.
@@ -219,7 +234,7 @@ int32_t mul_add_i8_to_i32(const int8_t* HWY_RESTRICT a, const int8_t* HWY_RESTRI
     const hn::ScalableTag<int8_t> d8;
 #if HWY_TARGET != HWY_NEON
     const hn::Repartition<int32_t, decltype(d8)> d32;
-    const auto                                   kernel_fn = [d32](auto lhs_i8, auto rhs_i8, auto& accu)
+    const auto kernel_fn = [d32](auto lhs_i8, auto rhs_i8, auto& accu)
                                VESPA_HWY_LAMBDA { accu = hn::SumOfMulQuadAccumulate(d32, lhs_i8, rhs_i8, accu); };
     using MyKernel = HwyReduceKernel<UsesNAccumulators<8>, UnrolledBy<8>, HasAccumulatorArity<1>>;
     return MyKernel::pairwise(d8, d32, a, b, sz, hn::Zero(d32), kernel_fn, VecAdd(), LaneReduceSum());
@@ -289,13 +304,16 @@ double my_squared_euclidean_distance_i8(const int8_t* a, const int8_t* b, size_t
     return my_hwy_square_euclidean_distance_int8(a, b, sz);
 }
 double my_squared_euclidean_distance_bf16(const BFloat16* a, const BFloat16* b, size_t sz) noexcept {
-    return my_hwy_square_euclidean_distance_bf16(a, b, sz);
+    return my_hwy_squared_euclidean_distance_bf16(a, b, sz);
 }
 double my_squared_euclidean_distance_f32(const float* a, const float* b, size_t sz) noexcept {
-    return my_hwy_square_euclidean_distance(a, b, sz);
+    return my_hwy_squared_euclidean_distance(a, b, sz);
 }
 double my_squared_euclidean_distance_f64(const double* a, const double* b, size_t sz) noexcept {
-    return my_hwy_square_euclidean_distance(a, b, sz);
+    return my_hwy_squared_euclidean_distance(a, b, sz);
+}
+float my_squared_euclidean_length_f32(const float* a, size_t sz) noexcept {
+    return my_hwy_squared_euclidean_length(a, sz);
 }
 size_t my_binary_hamming_distance(const void* lhs, const void* rhs, size_t sz) noexcept {
     return my_hwy_binary_hamming_distance(lhs, rhs, sz);
@@ -326,6 +344,7 @@ public:
         ft.squared_euclidean_distance_bf16 = my_squared_euclidean_distance_bf16;
         ft.squared_euclidean_distance_f32 = my_squared_euclidean_distance_f32;
         ft.squared_euclidean_distance_f64 = my_squared_euclidean_distance_f64;
+        ft.squared_euclidean_length_f32 = my_squared_euclidean_length_f32;
         ft.binary_hamming_distance = my_binary_hamming_distance;
         ft.population_count = my_population_count;
 #if HWY_TARGET == HWY_AVX2 || HWY_TARGET == HWY_AVX3

--- a/vespalib/src/vespa/vespalib/hwaccelerated/hwy_kernel-inl.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/hwy_kernel-inl.h
@@ -437,7 +437,8 @@ template <size_t UnrollFactor> struct KernelBody {
                                               const T* HWY_RESTRICT b, const size_t n_elems, const KernelFn kernel_fn,
                                               Accumulators&&... accumulators) noexcept {
         HWY_LANES_CONSTEXPR const size_t N = hn::Lanes(d);
-        size_t                           i = 0;
+
+        size_t i = 0;
         for (; (i + UnrollFactor * N) <= n_elems; i += UnrollFactor * N) {
             UnrolledLoopBody<UnrollFactor>::pairwise_load_and_dispatch(arity, d, a, b, i, N, kernel_fn,
                                                                        std::forward<Accumulators>(accumulators)...);
@@ -462,7 +463,8 @@ template <size_t UnrollFactor> struct KernelBody {
                                                  const size_t n_elems, const KernelFn kernel_fn,
                                                  Accumulators&&... accumulators) noexcept {
         HWY_LANES_CONSTEXPR const size_t N = hn::Lanes(d);
-        size_t                           i = 0;
+
+        size_t i = 0;
         for (; (i + UnrollFactor * N) <= n_elems; i += UnrollFactor * N) {
             UnrolledLoopBody<UnrollFactor>::elementwise_load_and_dispatch(
                 arity, d, a, i, N, kernel_fn, std::forward<Accumulators>(accumulators)...);

--- a/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
@@ -1,8 +1,9 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_library(vespalib_vespalib_quant OBJECT
+vespa_add_library(vespalib_quant
     SOURCES
     codebooks.cpp
     eden.cpp
     rotator.cpp
     DEPENDS
+    vespa_hwaccelerated
 )

--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -7,39 +7,19 @@
 #include "hadamard.h"
 #include "multi_bit_packer.h"
 
+#include <vespa/vespalib/hwaccelerated/autovec_unrolled.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
+
 #include <cassert>
 #include <cmath>
 #include <cstring>
 
 namespace vespalib::quant {
 
-namespace {
+using hwaccelerated::squared_euclidean_length;
+using hwaccelerated::sum_indexed_unrolled;
 
-// Invokes `fn(i)` once for every value `i` in [0, sz) and adds each result to one
-// of N partial sums. The sum of partial sums is then returned as the final value.
-// For floating point sums, this is explicitly and intentionally _not_ guaranteed
-// to yield the exact same result as if the output of `fn` had been sequentially
-// summed to a single accumulator. And that's why the compiler dares not optimize
-// loops in such a way in general (modulo `-ffast-math`, which is yolo-mode).
-template <size_t N, typename SumT, typename Fn>
-[[nodiscard]] SumT sum_indexed_unrolled(const size_t sz, Fn fn) noexcept(noexcept(fn(0))) {
-    SumT   partial[N] = {};
-    size_t i = 0;
-    for (; (i + N) <= sz; i += N) {
-        for (size_t j = 0; j < N; ++j) {
-            partial[j] += fn(i + j);
-        }
-    }
-    SumT sum{};
-    for (; i < sz; ++i) {
-        sum += fn(i);
-    }
-    // A "proper" vectorized version would use an N-way reduction tree, but this will do.
-    for (size_t j = 0; j < N; ++j) {
-        sum += partial[j];
-    }
-    return sum;
-}
+namespace {
 
 [[nodiscard]] size_t compute_quantized_buffer_size(const size_t dimensions, const uint8_t bits) noexcept {
     (void)bits;
@@ -83,7 +63,7 @@ void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, c
     // the magnitude by sqrt(d), which is then subsequently divided away in a subsequent
     // normalization step. Changes in magnitude are more likely to cause precision loss
     // since exponent adjustments can truncate mantissa LSBs.
-    float x_norm2 = sum_indexed_unrolled<8, float>(d, [&](size_t idx) noexcept { return x[idx] * x[idx]; });
+    float x_norm2 = squared_euclidean_length(x.data(), d);
     if (x_norm2 == 0) [[unlikely]] {
         // Zero norm vectors must be special-cased, or we'll end up dividing by zero
         // when computing `nx` below. Set the scale explicitly to zero. For consistency,


### PR DESCRIPTION
@havardpe please review

Add a `squared_euclidean_length` entry to the accelerated function table. Only supporting the `float` type for now.

Move utility code for auto-vectorized parallel partial sums to its own header and use this in the generic implementation.

The Highway vector kernel is a very simple fused multiply-add, using our existing fixture for elementwise kernels. Since the kernel is so simple we use 8-way unrolling with each unrolled instance updating its own accumulator register.

This kernel has 2x the performance of the auto-vectorized code according to the added microbenchmark (on AArch64 M3 Max).

Have tested with QEMU for all relevant dynamic SVE/SVE2 vector widths on AArch64.

