### PR TITLE
Reject dense tensor 'values' array with wrong element count

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
@@ -139,6 +139,7 @@ public class TensorReader {
         if ( ! (builder instanceof IndexedTensor.BoundBuilder indexedBuilder))
             throw new IllegalArgumentException("The 'values' field can only be used with dense tensors. " +
                                                "Use 'cells' or 'blocks' instead");
+        long expectedSize = expectedDenseSize(indexedBuilder);
         if (buffer.current() == JsonToken.VALUE_STRING) {
             if (buffer.currentText().isEmpty())
                 throw new IllegalArgumentException("The 'values' string does not contain any values");
@@ -156,6 +157,8 @@ public class TensorReader {
         }
         if (index == 0)
             throw new IllegalArgumentException("The 'values' array does not contain any values");
+        if (index != expectedSize)
+            throw new IllegalArgumentException("Expected " + expectedSize + " values, but got " + index);
         expectCompositeEnd(buffer.current());
     }
 
@@ -279,6 +282,13 @@ public class TensorReader {
         catch (NumberFormatException e) {
             throw new IllegalArgumentException("Expected a number but got '" + buffer.currentText() + "'");
         }
+    }
+
+    private static long expectedDenseSize(IndexedTensor.BoundBuilder builder) {
+        long size = 1;
+        for (var dim : builder.type().dimensions())
+            size *= dim.size().get();
+        return size;
     }
 
     private static TensorAddress asAddress(String label, TensorType type) {

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -1928,6 +1928,13 @@ public class JsonReaderTestCase {
     }
 
     @Test
+    public void testDisallowedDenseTensorWithWrongNumberOfValues() {
+        // dense_tensor is tensor(x[2],y[3]) = 6 values
+        assertCreatePutFails(inputJson("{ 'values': [1.0, 2.0] }"), "dense_tensor",
+                "Expected 6 values, but got 2");
+    }
+
+    @Test
     public void testDisallowedMixedTensorShortFormWithoutValues() {
         assertCreatePutFails(inputJson("{\"blocks\":{ \"a\": [] } }"),
                 "mixed_tensor", "Expected 3 values, but got 0");


### PR DESCRIPTION
## Summary
- Writing a dense tensor `"values"` array with fewer elements than the declared dimension size was silently accepted, with missing positions defaulting to 0
- This was never an intentional design decision and can mask bugs (truncated embeddings, wrong tensor length, etc.)
- Adds a check in `TensorReader.readTensorValues()` that the provided element count matches the declared tensor size
- Hex-encoded values were already validated by `HexEncoding.decodeHex`; this closes the gap for the JSON array format

_Generated with Claude Code_