### PR TITLE
Reduce _prevActive lifetime in LogDataStore, clear it when previous

### DIFF
--- a/searchlib/src/tests/docstore/file_chunk/file_chunk_test.cpp
+++ b/searchlib/src/tests/docstore/file_chunk/file_chunk_test.cpp
@@ -107,6 +107,7 @@ struct WriteFixture : public FixtureBase {
         : FixtureBase(baseName, dirCleanup),
           chunk(executor, FileChunk::FileId(0), FileChunk::NameId(1234), baseName, serialNum, docIdLimit,
                 {CompressionConfig(), 0x1000}, tuneFile, fileHeaderCtx, &bucketizer) {
+        chunk.enable_flush_pending_chunks();
         dir.cleanup(dirCleanup);
     }
     void flush() {

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -1086,7 +1086,8 @@ TEST_F(LogDataStoreTest, require_that_there_is_control_of_static_memory_usage) {
     auto                  tmp7 = build_testdata() + "/tmp7";
     Fixture               f(tmp7);
     vespalib::MemoryUsage usage = f.store.getMemoryUsage();
-    EXPECT_EQ(464u + 2 * sizeof(LogDataStore::NameIdSet) + sizeof(std::mutex) + sizeof(std::string),
+    EXPECT_EQ(480u + 2 * sizeof(LogDataStore::NameIdSet) + sizeof(std::mutex) + sizeof(std::condition_variable) +
+                  sizeof(std::string),
               sizeof(LogDataStore));
     EXPECT_EQ(73924u + 3 * sizeof(std::string), usage.allocatedBytes());
     EXPECT_EQ(200u + 3 * sizeof(std::string), usage.usedBytes());

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -87,6 +87,8 @@ LogDataStore::LogDataStore(vespalib::Executor& executor, const std::string& dirN
       _holdFileChunks(),
       _active(0),
       _prevActive(FileId::active()),
+      _updateLock(),
+      _update_cond(),
       _readOnly(readOnly),
       _executor(executor),
       _initFlushSyncToken(0),
@@ -94,7 +96,9 @@ LogDataStore::LogDataStore(vespalib::Executor& executor, const std::string& dirN
       _bucketizer(std::move(bucketizer)),
       _currentlyCompacting(),
       _compactLidSpaceGeneration(),
-      _last_name_id(0) {
+      _last_name_id(0),
+      _frozen_prev_modification_time(),
+      _frozen_prev_persisted_serial_num(0) {
     // Reserve space for 1TB summary in order to avoid locking.
     // Even if we have reserved 16 bits for file id there is no chance that we will even get close to that.
     // Size of files grows with disk size, so 8k files should be more than sufficient.
@@ -105,6 +109,7 @@ LogDataStore::LogDataStore(vespalib::Executor& executor, const std::string& dirN
     preload();
     updateLidMap(getLastFileChunkDocIdLimit());
     updateSerialNum();
+    on_freeze_prev_active();
 }
 
 void LogDataStore::reconfigure(const Config& config) {
@@ -118,6 +123,32 @@ void LogDataStore::updateSerialNum() {
             getActive(guard).setSerialNum(getPrevActive(guard)->getLastPersistedSerialNum());
         }
     }
+}
+
+void LogDataStore::on_freeze_prev_active() {
+    std::unique_lock guard(_updateLock);
+    auto*            prev = getPrevActive(guard);
+    if (prev != nullptr) {
+        _frozen_prev_modification_time = prev->getModificationTime();
+        _frozen_prev_persisted_serial_num = prev->getLastPersistedSerialNum();
+    }
+    if (!isReadOnly()) {
+        getActive(guard).enable_flush_pending_chunks();
+    }
+    _prevActive = FileId::active();
+    _update_cond.notify_all();
+}
+
+bool LogDataStore::waited_for_prev_active(MonitorGuard& guard) {
+    if (_prevActive != FileId::active()) {
+        // Wait for previous active chunk to be flushed and frozen
+        auto wait_start_prev_active = _prevActive;
+        while (wait_start_prev_active == _prevActive) {
+            _update_cond.wait(guard);
+        }
+        return true;
+    }
+    return false;
 }
 
 LogDataStore::~LogDataStore() {
@@ -212,6 +243,9 @@ void LogDataStore::requireSpace(MonitorGuard guard, WriteableFileChunk& active, 
     LOG(spam, "Checking file %s size %ld < %ld AND #lids %u < %u", active.getName().c_str(), oldSz,
         _config.getMaxFileSize(), active.getNumLids(), _config.getMaxNumLids());
     if ((oldSz > _config.getMaxFileSize()) || (active.getNumLids() >= _config.getMaxNumLids())) {
+        if (waited_for_prev_active(guard)) {
+            return; // Active file chunk might have changed.
+        }
         FileId fileId = allocateFileId(guard);
         setNewFileChunk(guard, createWritableFile(fileId, active.getSerialNum()));
         setActive(guard, fileId);
@@ -226,6 +260,7 @@ void LogDataStore::requireSpace(MonitorGuard guard, WriteableFileChunk& active, 
         // and sync old .idx file to disk.
         active.flushPendingChunks(active.getSerialNum());
         active.freeze(cpu_category);
+        on_freeze_prev_active();
         // TODO: Delay create of new file
         LOG(debug, "Closed file %s of size %ld and %u lids due to maxsize of %ld or maxlids %u reached. Bloat is %ld",
             active.getName().c_str(), active.getDiskFootprint(), active.getNumLids(), _config.getMaxFileSize(),
@@ -240,6 +275,9 @@ uint64_t LogDataStore::lastSyncToken() const {
         const FileChunk* prev = getPrevActive(guard);
         if (prev != nullptr) {
             lastSerial = prev->getLastPersistedSerialNum();
+        }
+        if (lastSerial == 0) {
+            lastSerial = _frozen_prev_persisted_serial_num;
         }
     }
     return lastSerial;
@@ -260,6 +298,9 @@ vespalib::system_time LogDataStore::getLastFlushTime() const {
         const FileChunk* prev = getPrevActive(guard);
         if (prev != nullptr) {
             timeStamp = prev->getModificationTime();
+        }
+        if (timeStamp == vespalib::system_time()) {
+            timeStamp = _frozen_prev_modification_time;
         }
     }
     // TODO Needs to change when we decide on Flush time reference
@@ -449,6 +490,8 @@ void LogDataStore::compactFile(FileId fileId) {
             destinationFileId = allocateFileId(guard);
             setNewFileChunk(guard, createWritableFile(destinationFileId, fc->getLastPersistedSerialNum(),
                                                       fc->getNameId().next()));
+            auto& compact_to = dynamic_cast<WriteableFileChunk&>(*_fileChunks[destinationFileId.getId()]);
+            compact_to.enable_flush_pending_chunks();
         }
         guard.unlock();
         size_t numSignificantBucketBits = computeNumberOfSignificantBucketIdBits(*_bucketizer, fc->getFileId());

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -139,7 +139,7 @@ void LogDataStore::on_freeze_prev_active() {
     _update_cond.notify_all();
 }
 
-bool LogDataStore::waited_for_prev_active(MonitorGuard& guard) {
+bool LogDataStore::wait_for_prev_active(MonitorGuard& guard) {
     if (_prevActive != FileId::active()) {
         // Wait for previous active chunk to be flushed and frozen
         auto wait_start_prev_active = _prevActive;
@@ -243,7 +243,7 @@ void LogDataStore::requireSpace(MonitorGuard guard, WriteableFileChunk& active, 
     LOG(spam, "Checking file %s size %ld < %ld AND #lids %u < %u", active.getName().c_str(), oldSz,
         _config.getMaxFileSize(), active.getNumLids(), _config.getMaxNumLids());
     if ((oldSz > _config.getMaxFileSize()) || (active.getNumLids() >= _config.getMaxNumLids())) {
-        if (waited_for_prev_active(guard)) {
+        if (wait_for_prev_active(guard)) {
             return; // Active file chunk might have changed.
         }
         FileId fileId = allocateFileId(guard);

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -245,7 +245,7 @@ private:
     bool isReadOnly() const { return _readOnly; }
     void updateSerialNum();
     void on_freeze_prev_active();
-    bool waited_for_prev_active(MonitorGuard& guard);
+    [[nodiscard]] bool wait_for_prev_active(MonitorGuard& guard);
 
     size_t computeNumberOfSignificantBucketIdBits(const IBucketizer& bucketizer, FileId fileId) const;
 

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -244,6 +244,8 @@ private:
     void requireSpace(MonitorGuard guard, WriteableFileChunk& active, vespalib::CpuUsage::Category cpu_category);
     bool isReadOnly() const { return _readOnly; }
     void updateSerialNum();
+    void on_freeze_prev_active();
+    bool waited_for_prev_active(MonitorGuard& guard);
 
     size_t computeNumberOfSignificantBucketIdBits(const IBucketizer& bucketizer, FileId fileId) const;
 
@@ -280,6 +282,7 @@ private:
     FileId                                   _active;
     FileId                                   _prevActive;
     mutable std::mutex                       _updateLock;
+    std::condition_variable                  _update_cond;
     bool                                     _readOnly;
     vespalib::Executor&                      _executor;
     SerialNum                                _initFlushSyncToken;
@@ -288,6 +291,8 @@ private:
     NameIdSet                                _currentlyCompacting;
     vespalib::Generation                     _compactLidSpaceGeneration;
     NameId                                   _last_name_id;
+    vespalib::system_time                    _frozen_prev_modification_time;
+    SerialNum                                _frozen_prev_persisted_serial_num;
 };
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
@@ -85,6 +85,7 @@ WriteableFileChunk::WriteableFileChunk(vespalib::Executor& executor, FileId file
       _cond(),
       _writeLock(),
       _flushLock(),
+      _flush_cond(),
       _dataFile(_dataFileName.c_str()),
       _chunkMap(),
       _pendingChunks(),
@@ -101,6 +102,7 @@ WriteableFileChunk::WriteableFileChunk(vespalib::Executor& executor, FileId file
       _maxChunkSize(0x100000),
       _firstChunkIdToBeWritten(0),
       _writeTaskIsRunning(false),
+      _enable_flush_pending_chunks(false),
       _writeMonitor(),
       _writeCond(),
       _executor(executor),
@@ -797,6 +799,12 @@ uint64_t WriteableFileChunk::writeIdxHeader(const FileHeaderContext& fileHeaderC
     return h.writeFile(file);
 }
 
+void WriteableFileChunk::enable_flush_pending_chunks() {
+    std::unique_lock flush_guard(_flushLock);
+    _enable_flush_pending_chunks = true;
+    _flush_cond.notify_all();
+}
+
 bool WriteableFileChunk::needFlushPendingChunks(uint64_t serialNum, uint64_t datFileLen) {
     std::unique_lock guard(_lock);
     return needFlushPendingChunks(guard, serialNum, datFileLen);
@@ -828,8 +836,13 @@ void WriteableFileChunk::updateCurrentDiskFootprint(const std::lock_guard<std::m
  */
 void WriteableFileChunk::flushPendingChunks(uint64_t serialNum) {
     std::unique_lock flushGuard(_flushLock);
-    if (frozen())
+    while (!_enable_flush_pending_chunks) {
+        // Block until previous file chunk has been flushed and frozen.
+        _flush_cond.wait(flushGuard);
+    }
+    if (frozen()) {
         return;
+    }
     uint64_t              datFileLen = _dataFile.getSize();
     vespalib::system_time timeStamp(vespalib::system_clock::now());
     if (needFlushPendingChunks(serialNum, datFileLen)) {

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -72,6 +72,7 @@ public:
 
     static uint64_t writeIdxHeader(const common::FileHeaderContext& fileHeaderContext, uint32_t docIdLimit,
                                    FastOS_FileInterface& file);
+    void enable_flush_pending_chunks();
 
 private:
     using ProcessedChunkUP = std::unique_ptr<ProcessedChunk>;
@@ -117,6 +118,7 @@ private:
     mutable std::condition_variable _cond;
     std::mutex                      _writeLock;
     std::mutex                      _flushLock;
+    std::condition_variable         _flush_cond;
     FastOS_File                     _dataFile;
     using ChunkMap = std::map<uint32_t, Chunk::UP>;
     ChunkMap _chunkMap;
@@ -139,6 +141,7 @@ private:
     size_t                  _maxChunkSize;
     uint32_t                _firstChunkIdToBeWritten;
     bool                    _writeTaskIsRunning;
+    bool                    _enable_flush_pending_chunks;
     std::mutex              _writeMonitor;
     std::condition_variable _writeCond;
     ProcessedChunkQ         _writeQ;


### PR DESCRIPTION
active file has been flushed and frozen. Block flush of new active file until previous active file has been flushed and frozen.

@vekterli : please review
