### PR TITLE
Package vespa-crypto-cli-standalone as RPM subpackage

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -330,6 +330,24 @@ Requires: %{name}-base-libs = %{version}-%{release}
 
 Vespa - The open big data serving engine - devel package
 
+%package crypto-cli-standalone
+
+Summary: Vespa - standalone crypto CLI
+
+# Self-contained: the fat JAR bundles all provided-scope deps, so no Vespa install is required.
+# Mirrors the java requirement conditional in %package base, but pulls the headless runtime
+# instead of the full JDK since this is a runtime-only CLI.
+%if 0%{?amzn2023}
+Requires: java-17-amazon-corretto-headless
+%else
+Requires: java-%{_vespa_java_version}-openjdk-headless
+%endif
+
+%description crypto-cli-standalone
+
+The vespa-crypto-cli-standalone tool for key/secret operations (e.g. core dump
+resealing), runnable without a full Vespa installation.
+
 %prep
 %if 0%{?installdir:1}
 %if 0%{?source_base:1}
@@ -507,6 +525,7 @@ fi
 %dir %{_prefix}
 %{_prefix}/bin
 %exclude %{_prefix}/bin/vespa
+%exclude %{_prefix}/bin/vespa-crypto-cli-standalone
 %exclude %{_prefix}/bin/vespa-curl
 %exclude %{_prefix}/bin/vespa-destination
 %exclude %{_prefix}/bin/vespa-fbench
@@ -766,5 +785,16 @@ fi
 %dir %{_prefix}
 %{_prefix}/include
 %{_prefix}/share/cmake
+
+%files crypto-cli-standalone
+%if %{_defattr_is_vespa_vespa}
+%defattr(-,%{_vespa_user},%{_vespa_group},-)
+%endif
+%dir %{_prefix}
+%dir %{_prefix}/bin
+%{_prefix}/bin/vespa-crypto-cli-standalone
+%dir %{_prefix}/lib
+%dir %{_prefix}/lib/jars
+%{_prefix}/lib/jars/vespaclient-java-fat-with-provided.jar
 
 %changelog

--- a/vespaclient-java/CMakeLists.txt
+++ b/vespaclient-java/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_jar(vespaclient-java-jar-with-dependencies.jar)
+# Fat JAR bundling all deps (incl. provided scope), for the standalone crypto CLI (no Vespa install required)
+install_jar(vespaclient-java-fat-with-provided.jar)
 
 vespa_install_script(src/main/sh/vespa-crypto-cli.sh vespa-crypto-cli bin)
+vespa_install_script(src/main/sh/vespa-crypto-cli-standalone.sh vespa-crypto-cli-standalone bin)
 vespa_install_script(src/main/sh/vespa-stat.sh vespa-stat bin)
 vespa_install_script(src/main/sh/vespa-query-profile-dump-tool.sh vespa-query-profile-dump-tool bin)
 vespa_install_script(src/main/sh/vespa-summary-benchmark.sh vespa-summary-benchmark bin)

--- a/vespaclient-java/src/main/sh/vespa-crypto-cli-standalone.sh
+++ b/vespaclient-java/src/main/sh/vespa-crypto-cli-standalone.sh
@@ -4,11 +4,35 @@
 # Resolve symlink (if any) and normalize path
 program=$(readlink -f "$0")
 program_dir=$(dirname "$program")
-jarfile=$(readlink -f "$program_dir"/../../../target/vespaclient-java-fat-with-provided.jar)
 
-if ! test -e "$jarfile"
+jar_name=vespaclient-java-fat-with-provided.jar
+
+# Locate the fat JAR, in priority order:
+#   1. $VESPA_CRYPTO_CLI_JAR, if set (explicit override)
+#   2. installed location, relative to this script (RPM: bin/ and lib/jars/ are siblings)
+#   3. target/ in the Maven build tree (local dev)
+jarfile=""
+if [ -n "$VESPA_CRYPTO_CLI_JAR" ]; then
+    jarfile=$VESPA_CRYPTO_CLI_JAR
+else
+    for candidate in \
+        "$program_dir/../lib/jars/$jar_name" \
+        "$program_dir/../../../target/$jar_name"
+    do
+        if [ -e "$candidate" ]; then
+            jarfile=$(readlink -f "$candidate")
+            break
+        fi
+    done
+fi
+
+if [ -z "$jarfile" ] || ! test -e "$jarfile"
 then
-    echo "No such file: '$jarfile'" >&2
+    if [ -n "$VESPA_CRYPTO_CLI_JAR" ]; then
+        echo "VESPA_CRYPTO_CLI_JAR is set to '$VESPA_CRYPTO_CLI_JAR' but no such file exists." >&2
+    else
+        echo "Could not locate '$jar_name'. Set VESPA_CRYPTO_CLI_JAR to its path." >&2
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
Makes the standalone crypto CLI installable as an RPM so it can run without a full Vespa installation.

- `vespa-crypto-cli-standalone.sh`: resolve the fat JAR via a fallback chain (`$VESPA_CRYPTO_CLI_JAR`, then the installed `lib/jars/` location relative to the script, then `target/` for local dev) instead of the hardcoded `target/` path. 
- `vespaclient-java/CMakeLists.txt`: install the `fat-with-provided` JAR and the standalone launcher script.
- `dist/vespa.spec`: add a `vespa-crypto-cli-standalone` subpackage containing only the script and the fat JAR, requires only a headless JRE.

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*
