### PR TITLE
Fix out-of-bounds read in UTF8SubStringFieldSearcher::matchTerms

### DIFF
--- a/streamingvisitors/src/vespa/vsm/searcher/utf8substringsearcher.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8substringsearcher.cpp
@@ -32,7 +32,7 @@ size_t UTF8SubStringFieldSearcher::matchTerms(const FieldRef& f, const size_t mi
             termsize_t       tsz = qt->term(term);
 
             const cmptype_t *tt = term, *et = term + tsz, *fnt = fn;
-            for (; (tt < et) && (*tt == *fnt); tt++, fnt++)
+            for (; (tt < et) && (fnt < fe) && (*tt == *fnt); tt++, fnt++)
                 ;
             if (tt == et) {
                 addHit(*qt, words);


### PR DESCRIPTION
matchTerms bounds its outer scan by fre = fe - mintsz, where mintsz is the shortest query term length, but compares each query term using that term's own length tsz. For any term longer than the shortest, the inner comparison could advance fnt up to (tsz - mintsz) characters past fe, the end of the decoded field data, whenever the preceding characters matched. This reads beyond the valid decoded data and can read beyond the allocated scratch buffer.

Guard the comparison with fnt < fe so it never reads past the end of the decoded field, matching the invariant already held by the single-term matchTermSubstring (which bounds with fe - tsz).
