### PR TITLE
Make vespa-crypto-cli-standalone RPM noarch

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -331,6 +331,8 @@ Vespa - The open big data serving engine - devel package
 %package crypto-cli-standalone
 
 Summary: Vespa - standalone crypto CLI
+# Launcher script + pure-Java fat JAR, no native code: build once, not per-arch.
+BuildArch: noarch
 
 # Self-contained: the fat JAR bundles all provided-scope deps, so no Vespa install is required.
 # Mirrors the java requirement conditional in %package base, but pulls the headless runtime


### PR DESCRIPTION
The `vespa-crypto-cli-standalone` subpackage contains only a launcher script and the pure java `vespaclient-java-fat-with-provided.jar`, so it doesn't need to be built per architecture.

Mark it `BuildArch: noarch` so a single package is produced instead of one per architecture. The package remains EL-specific via its JRE `Requires` (set by the distro conditional).

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*