### PR TITLE
Make uri tokenization in query identical to uri field

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -1765,7 +1765,7 @@ public class YqlParser implements Parser {
             uriItem.addStartAnchorItem();
 
         String uriString = ast.<List<OperatorNode<ExpressionOperator>>> getArgument(1).get(0).getArgument(0);
-        for (String token : segmenter.segment(uriString, new LinguisticsParameters(linguisticsProfileFor(field), Language.ENGLISH, StemMode.NONE, false, false)))
+        for (String token : tokenizeUri(uriString))
             uriItem.addItem(new WordItem(token, field, true));
 
         if (getAnnotation(ast, END_ANCHOR, Boolean.class, endAnchorDefault,
@@ -1778,6 +1778,34 @@ public class YqlParser implements Parser {
         uriItem.setSourceString(uriString);
 
         return uriItem;
+    }
+
+    /**
+     * Tokenize uri query argument the same way the uri field is tokenized at indexing time
+     * (searchlib URL::IsTokenChar): token characters are ASCII alphanumerics, '-' and '_';
+     * everything else (incl. '.', '/', ':', '?' and any non-ASCII char) is a separator.
+     * Note: Not using {@link com.yahoo.net.UrlTokenizer} because it decodes %xx
+     * escapes before tokenizing, which is not what searchlib URL does.
+     */
+    static List<String> tokenizeUri(String uriString) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (int i = 0; i < uriString.length(); i++) {
+            char c = uriString.charAt(i);
+
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+                current.append(c);
+            } else if (current.length() > 0) {
+                tokens.add(current.toString());
+                current.setLength(0);
+            }
+        }
+
+        if (current.length() > 0)
+            tokens.add(current.toString());
+
+        return tokens;
     }
 
     private Item instantiateWordItem(String field, OperatorNode<ExpressionOperator> ast, Class<?> parent) {

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -1437,6 +1437,26 @@ public class YqlParserTestCase {
         yql.properties().set("yql", "select * from sources * where urlfield.hostname contains uri(\"google.com\")");
         assertUrlQuery("urlfield.hostname", yql, false, true, true);
     }
+    
+    @Test
+    void testUriTokenization() {
+        //Tokenizer should match searchlib URL::IsTokenChar
+        
+        // '-' or '_' are token characters, not separators
+        assertEquals(List.of("my-subdomain", "example", "com"), YqlParser.tokenizeUri("my-subdomain.example.com"));
+        assertEquals(List.of("foo_bar", "example", "com"), YqlParser.tokenizeUri("foo_bar.example.com"));
+
+        // %xx escapes are not decoded: '%' is a separator and the hex chars are token chars
+        assertEquals(List.of("my", "2dsub", "example", "com"), YqlParser.tokenizeUri("my%2dsub.example.com"));
+
+        // Non-ASCII char stay a separator
+        assertEquals(List.of("a", "b", "example", "com"), YqlParser.tokenizeUri("a\u212Ab.example.com"));
+
+        // Leading/trailing/repeated separators produce no empty tokens.
+        assertEquals(List.of("example", "com"), YqlParser.tokenizeUri("://example..com/"));
+        assertEquals(List.of(), YqlParser.tokenizeUri(""));
+        assertEquals(List.of(), YqlParser.tokenizeUri("..."));
+    }
 
     @Test
     void testUrlHostSearchingNoAnchors() {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This is to fix asymmetry in how URIs are tokenized during indexing vs query that caused mismatch of identical URIs containing "_" and "-".