### PR TITLE
Reapply "Change default value of require-explicit-docproc-cluster to true"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -148,7 +148,7 @@ public class Flags {
             APPLICATION);
 
     public static final UnboundBooleanFlag REQUIRE_EXPLICIT_DOCPROC_CLUSTER = defineFeatureFlag(
-            "require-explicit-docproc-cluster", false,
+            "require-explicit-docproc-cluster", true,
             List.of("hmusum"), "2026-05-26", "2026-12-01",
             "Whether to require an explicit document-processing cluster to be configured in content clusters when there is more than one container cluster",
             "Takes effect at redeployment",


### PR DESCRIPTION
Reverts vespa-engine/vespa#37154

Many tests updated to use just one container cluster, but will probably break some now as well. Will create a revert to have ready after merging this one