### PR TITLE
Fix NPE when a replacing semantic rule empties a composite

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/semantics/engine/Evaluation.java
+++ b/container-search/src/main/java/com/yahoo/prelude/semantics/engine/Evaluation.java
@@ -21,8 +21,10 @@ import com.yahoo.search.Query;
 import com.yahoo.search.query.QueryTree;
 
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -37,6 +39,9 @@ public class Evaluation {
     private ParameterNameSpace parameterNameSpace = null;
 
     private final Query query;
+
+    /** A composite emptied by a replacing rule mapped to its replacement, so the rule's later targets accumulate there. */
+    private final Map<Item, CompositeItem> replacementForEmptied = new IdentityHashMap<>();
 
     /** The current index into the flattened item list */
     private int currentIndex = 0;
@@ -276,6 +281,14 @@ public class Evaluation {
             return;
         }
 
+        // Earlier in this rule a production emptied (and detached) parent; redirect later targets onto its
+        // replacement and fall through, so each keeps its own type (NOT, OR, ...) and none is lost in the orphan.
+        CompositeItem replaced = replacementForEmptied.get(parent);
+        if (replaced != null) {
+            parent = replaced;
+            index = parent.getItemCount();
+        }
+
         if (parent.getItemCount() > 0 && parent instanceof QueryTree && parent.getItem(0) instanceof CompositeItem) {
             // combine with the existing root instead
             parent = (CompositeItem)parent.getItem(0);
@@ -291,10 +304,17 @@ public class Evaluation {
                 addItem(parent, index, item, desiredParentType);
         }
         else if (parent.items().isEmpty()) {
+            // A replacing rule emptied this composite (removed its sole matched child). Replace it with one of
+            // the desired type (at the query root if it had no parent) and remember it for later targets above;
+            // replacing it in place previously NPE'd at the root and threw a ClassCastException when nested.
+            CompositeItem replacement = newParent(desiredParentType);
+            items.forEach(replacement::addItem);
             CompositeItem parentsParent = parent.getParent();
-            CompositeItem newParent = newParent(desiredParentType);
-            items.forEach(item -> newParent.addItem(item));
-            parentsParent.setItem(parentsParent.getItemIndex(parent), newParent);
+            if (parentsParent != null)
+                parentsParent.setItem(parentsParent.getItemIndex(parent), replacement);
+            else
+                query.getModel().getQueryTree().setRoot(replacement);
+            replacementForEmptied.put(parent, replacement);
         }
         else if (items.size() == 1 && desiredParentType.hasItemClass(items.get(0).getClass())) {
             addItem(parent, index, items.get(0), desiredParentType);

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/WeakAndTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/WeakAndTestCase.java
@@ -29,6 +29,79 @@ public class WeakAndTestCase {
         tester.assertSemantics("AND (WEAKAND tva taxe sur la valeur ajoutée tva) hostname:'www legifrance gouv fr'", query);
     }
 
+    /** The case that used to NPE: a replacing EQUIV rule on the matched term that is the root weakAnd's lone child. */
+    @Test
+    public void testReplacingEquivRuleOnSingleTermWeakAndRoot() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("EQUIV ig instagram", "ig", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testSingleTargetReplacingEquivOnSingleTermWeakAndRoot() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("facebook", "fbb", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testThreeTargetReplacingEquivOnSingleTermWeakAndRoot() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("EQUIV a3 b3 c3", "q3", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testPhraseTargetReplacingEquivOnSingleTermWeakAndRoot() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("EQUIV nyc \"new york\"", "nyc", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testReplacingEquivOnSingleTermOrRoot() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("EQUIV ig instagram", "ig", 0, Query.Type.ANY);
+    }
+
+    /** Pre-existing: with siblings the weakAnd isn't emptied, so targets are added flat, not grouped. */
+    @Test
+    public void testReplacingEquivWithSiblingTermsIsFlattened() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("WEAKAND design ig instagram", "ig design", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testReplacingEquivInNestedSoleChildWeakAnd() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        var query = new Query("?yql=" + QueryTestCase.httpEncode("select * from webpages where (userQuery() and (hostname contains 'site'))") + "&query=ig");
+        search(new SimpleLinguistics(), new IndexModel(Map.of(), List.of()), query);
+        tester.assertSemantics("AND (EQUIV ig instagram) hostname:site", query);
+    }
+
+    /** A later target of a different type joins the first target's container instead of being lost. */
+    @Test
+    public void testMixedTypeReplacingRuleGroupsAllTargets() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("EQUIV foo bar", "mix", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testReplacingRuleNotTargetKeepsNegation() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("+foo -bar", "neg", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testReplacingRuleOrTargetKeepsOrContainer() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        tester.assertSemantics("OR foo bar", "orthr", 0, Query.Type.WEAKAND);
+    }
+
+    @Test
+    public void testSingleTargetReplacingEquivInNestedSoleChildWeakAnd() {
+        var tester = new RuleBaseTester("weakAnd.sr", null);
+        var query = new Query("?yql=" + QueryTestCase.httpEncode("select * from webpages where (userQuery() and (hostname contains 'site'))") + "&query=fbb");
+        search(new SimpleLinguistics(), new IndexModel(Map.of(), List.of()), query);
+        tester.assertSemantics("AND facebook hostname:site", query);
+    }
+
     private Result search(Linguistics linguistics, IndexModel indexModel, Query query) {
         return new Execution(new Chain<>(new MinimalQueryInserter(linguistics) /*, new StemmingSearcher(linguistics)*/),
                              Execution.Context.createContextStub(new IndexFacts(indexModel), linguistics)).search(query);

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/weakAnd.sr
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/rulebases/weakAnd.sr
@@ -2,3 +2,12 @@
 
 # Abbreviation expansions
 tva +> taxe sur la valeur ajoutée; taxe sur la valeur ajoutée +> tva;
+
+# Replacing EQUIV rules exercising an emptied single-term weakAnd root, incl. mixed target types
+ig -> =ig =instagram;
+fbb -> =facebook;
+q3 -> =a3 =b3 =c3;
+nyc -> =nyc ="new york";
+mix -> =foo bar;
+neg -> =foo -bar;
+orthr -> =foo ?bar;


### PR DESCRIPTION
A replacing rule (e.g. `a -> =a =b`) removes the matched term before adding its targets. When that term is a composite's only child the composite is emptied; replacing it then dereferenced a null parent at the query root (NPE/500) and mis-placed later targets when nested.

Replace the emptied composite once and remember it, so the rule's remaining targets accumulate into that replacement.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


Written by AI, reviewed by me
