### PR TITLE
Only call `mallinfo` when we know the malloc library supports it

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/malloc_info_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/malloc_info_explorer.cpp
@@ -4,6 +4,7 @@
 
 #include <vespa/vespalib/data/slime/cursor.h>
 #include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/detect_malloc_impl.h>
 
 #include <cassert>
 #include <cstdio>
@@ -16,9 +17,7 @@
 
 extern "C" {
 
-// Weakly resolved symbols that will be nullptr if they fail to resolve. Used to
-// both detect the presence of a particular malloc implementation and to do the
-// info dumping for it.
+// Weakly resolved debug dumping symbols that will be nullptr if they fail to resolve.
 // Vespamalloc:
 void vespamalloc_dump_info(FILE* out_file) __attribute__((weak));
 // MiMalloc:
@@ -35,32 +34,6 @@ using namespace std::string_view_literals;
 namespace {
 
 #ifdef __linux__
-
-enum class MallocImpl { LibcOrUnknown, VespaMalloc, MiMalloc };
-
-[[nodiscard]]
-MallocImpl detect_malloc_impl() noexcept {
-    if (vespamalloc_dump_info != nullptr) {
-        return MallocImpl::VespaMalloc;
-    }
-    if (mi_stats_print_out != nullptr) {
-        return MallocImpl::MiMalloc;
-    }
-    return MallocImpl::LibcOrUnknown;
-}
-
-[[nodiscard]]
-std::string_view to_string(MallocImpl mi) noexcept {
-    switch (mi) {
-    case MallocImpl::VespaMalloc:
-        return "vespamalloc";
-    case MallocImpl::MiMalloc:
-        return "mimalloc";
-    case MallocImpl::LibcOrUnknown:
-        return "libc_or_unknown";
-    }
-    abort();
-}
 
 [[maybe_unused]]
 void fclose_helper(FILE* f) {
@@ -101,6 +74,7 @@ void my_mimalloc_info_callback(const char* msg, void* aux_arg) {
 
 std::string get_mimalloc_info_dump() {
     std::string info;
+    assert(mi_stats_print_out != nullptr);
     // `mi_stats_print_out` forwards a void* of our choice to the callback.
     mi_stats_print_out(my_mimalloc_info_callback, &info);
     return info;
@@ -156,14 +130,16 @@ void MallocInfoExplorer::get_state(const Inserter& inserter, bool full) const {
         return;
     }
 #ifdef __linux__
-    const auto malloc_impl = detect_malloc_impl();
+    const auto malloc_impl = vespalib::detect_malloc_impl();
     object.setString("malloc_impl", to_string(malloc_impl));
+    if (malloc_impl == vespalib::MallocImpl::VespaMalloc) {
 #ifdef __GLIBC__
-    dump_mallinfo(object);
+        // Only dump mallinfo if we know the underlying malloc impl supports it.
+        // We don't know this with `LibcOrUnknown`.
+        dump_mallinfo(object);
 #endif
-    if (malloc_impl == MallocImpl::VespaMalloc) {
         emit_malloc_internal_info_dump(object, get_vespamalloc_info_dump());
-    } else if (malloc_impl == MallocImpl::MiMalloc) {
+    } else if (malloc_impl == vespalib::MallocImpl::MiMalloc) {
         emit_malloc_internal_info_dump(object, get_mimalloc_info_dump());
     }
 #else

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -57,6 +57,7 @@
 #include <vespa/vespalib/net/http/state_server.h>
 #include <vespa/vespalib/util/blockingthreadstackexecutor.h>
 #include <vespa/vespalib/util/cpu_usage.h>
+#include <vespa/vespalib/util/detect_malloc_impl.h>
 #include <vespa/vespalib/util/host_name.h>
 #include <vespa/vespalib/util/lambdatask.h>
 #include <vespa/vespalib/util/mmap_file_allocator_factory.h>
@@ -868,15 +869,26 @@ void Proton::updateMetrics(const metrics::MetricLockGuard&) {
         metrics.resourceUsage.openFileDescriptors.set(FastOS_File::count_open_files());
         metrics.resourceUsage.feedingBlocked.set((usage_filter.acceptWriteOperation() ? 0.0 : 1.0));
 #ifdef __linux__
+        static const auto malloc_impl = vespalib::detect_malloc_impl();
+        // Only dump mallinfo if we _know_ that the underlying malloc implementation
+        // supports it. We can't tell this for sure with LibcOrUnknown because of the
+        // "unknown" aspect of it. It _could_ be Bob's Artisan Home-Brewed Malloc(tm).
+        // Using a custom (non-glibc) malloc implementation that does _not_ have mallinfo()
+        // and then calling it may trigger internal glibc malloc heap/arena init code, as
+        // glibc erroneously believes malloc is being bootstrapped by the main thread.
+        if (malloc_impl == vespalib::MallocImpl::VespaMalloc) {
 #if __GLIBC_PREREQ(2, 33)
-        struct mallinfo2 mallocInfo = mallinfo2();
-        metrics.resourceUsage.mallocArena.set(mallocInfo.arena);
+            struct mallinfo2 mallocInfo = mallinfo2();
+            metrics.resourceUsage.mallocArena.set(mallocInfo.arena);
 #else
-        struct mallinfo mallocInfo = mallinfo();
-        // Vespamalloc reports arena in 1M blocks as an 'int' is too small.
-        // If we use something else than vespamalloc this must be changed.
-        metrics.resourceUsage.mallocArena.set(uint64_t(mallocInfo.arena) * 1_Mi);
+            struct mallinfo mallocInfo = mallinfo();
+            // Vespamalloc reports arena in 1M blocks as an 'int' is too small.
+            // If we use something else than vespamalloc this must be changed.
+            metrics.resourceUsage.mallocArena.set(uint64_t(mallocInfo.arena) * 1_Mi);
 #endif
+        } else {
+            metrics.resourceUsage.mallocArena.set(UINT64_C(0));
+        }
 #else
         metrics.resourceUsage.mallocArena.set(UINT64_C(0));
 #endif

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -24,6 +24,7 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     crc.cpp
     deadline.cpp
     destructor_callbacks.cpp
+    detect_malloc_impl.cpp
     doom.cpp
     dual_merge_director.cpp
     error.cpp

--- a/vespalib/src/vespa/vespalib/util/detect_malloc_impl.cpp
+++ b/vespalib/src/vespa/vespalib/util/detect_malloc_impl.cpp
@@ -1,0 +1,46 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "detect_malloc_impl.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+
+// Weakly resolved symbols that will be nullptr if they fail to resolve. Used to
+// detect the presence of a particular malloc implementation.
+// Vespamalloc:
+void vespamalloc_dump_info(FILE* out_file) __attribute__((weak));
+// MiMalloc:
+// From https://microsoft.github.io/mimalloc/group__extended.html:
+using mi_output_fun = void(const char* msg, void* aux_arg);
+void mi_stats_print_out(mi_output_fun* out, void* aux_arg) __attribute__((weak));
+}
+
+namespace vespalib {
+
+[[nodiscard]]
+MallocImpl detect_malloc_impl() noexcept {
+    if (vespamalloc_dump_info != nullptr) {
+        return MallocImpl::VespaMalloc;
+    }
+    if (mi_stats_print_out != nullptr) {
+        return MallocImpl::MiMalloc;
+    }
+    return MallocImpl::LibcOrUnknown;
+}
+
+[[nodiscard]]
+std::string_view to_string(MallocImpl mi) noexcept {
+    switch (mi) {
+    case MallocImpl::VespaMalloc:
+        return "vespamalloc";
+    case MallocImpl::MiMalloc:
+        return "mimalloc";
+    case MallocImpl::LibcOrUnknown:
+        return "libc_or_unknown";
+    }
+    abort();
+}
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/detect_malloc_impl.h
+++ b/vespalib/src/vespa/vespalib/util/detect_malloc_impl.h
@@ -1,0 +1,19 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string_view>
+
+namespace vespalib {
+
+enum class MallocImpl { LibcOrUnknown, VespaMalloc, MiMalloc };
+
+// Attempts to deduce the currently running malloc implementation based on particular
+// symbols that are present (or not) in the process runtime. We can currently detect
+// vespamalloc and mimalloc. If neither of these are present, either glibc malloc
+// or some unknown malloc implementation is being used.
+[[nodiscard]] MallocImpl detect_malloc_impl() noexcept;
+
+[[nodiscard]] std::string_view to_string(MallocImpl mi) noexcept;
+
+} // namespace vespalib


### PR DESCRIPTION
@toregge please review. Hypothesis testing time... 👀 
@hmusum FYI

Factor out existing malloc implementation detection code and use it when emitting malloc arena metrics.

Only dump `mallinfo` stats if we _know_ that the underlying malloc implementation supports it. Glibc of course supports it, but we can't tell for sure that we're running it when observing `MallocImpl::LibcOrUnknown` because of the "unknown" aspect of it. We _could_ be running Bob's Artisan Home-Brewed Malloc(tm), which would be subsumed by `LibcOrUnknown`.

Using a custom (non-glibc) malloc implementation that does _not_ have `mallinfo()`, and then calling it, may trigger internal glibc lazy malloc heap/arena init code, as glibc erroneously believes malloc is being bootstrapped by the main thread.

This causes much excitement further down the line.

