### PR TITLE
Reuse prebuilt base image in build-container.sh when available

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -57,6 +57,13 @@ select_dockerfile() {
     fi
 }
 
+target_option=""
+if [ "${PREBUILT_BASE_IMAGE:-}" != "" ]; then
+    VESPA_BASE_IMAGE="${PREBUILT_BASE_IMAGE}:${VESPA_BUILDOS_LABEL}"
+    SYSTEM_TEST_BASE_IMAGE=${VESPA_BASE_IMAGE}
+    target_option="--target vespa"
+fi
+
 echo "--- Building Vespa preview container"
 GHCR_PREVIEW_TAG=ghcr.io/vespa-engine/vespa-preview-${ARCH}:${VESPA_VERSION}${VESPA_CONTAINER_IMAGE_VERSION_TAG_SUFFIX}
 echo "Building container with tag: ${GHCR_PREVIEW_TAG}"
@@ -66,6 +73,7 @@ docker build --progress plain \
              --build-arg VESPA_BASE_IMAGE="$VESPA_BASE_IMAGE" \
              --tag vespaengine/vespa \
              --tag "${GHCR_PREVIEW_TAG}" \
+             ${target_option} \
              --file "$(select_dockerfile)" .
 
 declare -r GITREF="${GITREF_SYSTEM_TEST:-HEAD}"


### PR DESCRIPTION
The container build previously always built the Vespa base layer from scratch on every run. When a PREBUILT_BASE_IMAGE is provided, point the build at "<PREBUILT_BASE_IMAGE>:<VESPA_BUILDOS_LABEL>" instead and build only the final "vespa" target (--target vespa), skipping the expensive base-image build. This skips downloading many 3rdparty packages. The same image is also used as the system-test base image.
