### PR TITLE
refactor: do not assume warning log level in ValidationOverrides

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
@@ -134,7 +134,7 @@ public class HostSystem extends TreeConfigProducer<Host> {
         var builder = new ProvisionContext.Builder();
         builder.setLogger(new ProvisionDeployLogger(deployState.getDeployLogger()));
         var validation = builder.validationOverrides();
-        validation.setWarnOnly(deployState.warnOnlyOnValidationFailure());
+        validation.setLogOnly(deployState.warnOnlyOnValidationFailure());
         validation.setOverrideResourcesReduction(deployState.validationOverrides().allows(ValidationId.resourcesReduction, deployState.now()));
         return builder.build();
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ProvisionContext.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ProvisionContext.java
@@ -49,16 +49,16 @@ public class ProvisionContext {
      */
     public static class ValidationOverrides {
 
-        private final boolean warnOnly;
+        private final boolean logOnly;
         private final boolean overrideResourcesReduction;
 
         public ValidationOverrides(Builder builder) {
-            this.warnOnly = builder.warnOnly;
+            this.logOnly = builder.logOnly;
             this.overrideResourcesReduction = builder.overrideResourcesReduction;
         }
 
-        /** True to warn instead of throwing on validation failures. */
-        public boolean warnOnly() { return warnOnly; }
+        /** True to log instead of throwing on validation failures. */
+        public boolean logOnly() { return logOnly; }
 
         /** True if the resources reduction validation is overridden. */
         public boolean overrideResourcesReduction() {
@@ -67,11 +67,11 @@ public class ProvisionContext {
 
         public static class Builder {
 
-            private boolean warnOnly                   = false;
+            private boolean logOnly = false;
             private boolean overrideResourcesReduction = false;
 
-            public Builder setWarnOnly(boolean warnOnly) {
-                this.warnOnly = warnOnly;
+            public Builder setLogOnly(boolean logOnly) {
+                this.logOnly = logOnly;
                 return this;
             }
 


### PR DESCRIPTION
## What

simple refactor: rename `setWarnOnly` to `setLogOnly`

## Why

do not assume the log level which will be used at the end.


---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
