### PR TITLE
added -show-cost-analysis option to compare planning with profiling

### DIFF
--- a/client/go/internal/cli/cmd/inspect.go
+++ b/client/go/internal/cli/cmd/inspect.go
@@ -16,6 +16,7 @@ type inspectProfileOptions struct {
 	showMedianNode      bool
 	showDispatchedQuery bool
 	showNnsDetails      bool
+	showCostAnalysis    bool
 	makePrompt          bool
 	showQueryNodes      []int
 }
@@ -48,6 +49,9 @@ func inspectProfile(cli *CLI, opts *inspectProfileOptions) error {
 	if opts.showNnsDetails {
 		context.ShowNnsDetails()
 	}
+	if opts.showCostAnalysis {
+		context.ShowCostAnalysis()
+	}
 	if opts.makePrompt {
 		context.MakePrompt()
 	}
@@ -74,6 +78,7 @@ func newInspectProfileCmd(cli *CLI) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.showMedianNode, "show-median-node", false, "Show median node analysis")
 	cmd.Flags().BoolVar(&opts.showDispatchedQuery, "show-dispatched-query", false, "Show query sent to search nodes")
 	cmd.Flags().BoolVar(&opts.showNnsDetails, "show-nns-details", false, "Show more details related to nearest neighbor search")
+	cmd.Flags().BoolVar(&opts.showCostAnalysis, "show-cost-analysis", false, "Compare query plan abs_cost against measured time per query node")
 	cmd.Flags().BoolVar(&opts.makePrompt, "make-prompt", false, "Output an LLM prompt instead of human-readable analysis")
 	cmd.Flags().IntSliceVar(&opts.showQueryNodes, "show-query-nodes", nil, "Show detailed information for specific query node IDs")
 	return cmd

--- a/client/go/internal/vespa/tracedoctor/cost_analysis.go
+++ b/client/go/internal/vespa/tracedoctor/cost_analysis.go
@@ -1,0 +1,113 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package tracedoctor
+
+import (
+	"fmt"
+
+	"github.com/vespa-engine/vespa/client/go/internal/vespa/slime"
+)
+
+type costAnalysis struct {
+	queryTree    *queryTree
+	maxTimeMs    float64
+	maxCost      float64
+	foundSamples int64
+	usedSamples  int64
+}
+
+func newCostAnalysis(p protonTrace) *costAnalysis {
+	q := p.extractQuery()
+	c := &costAnalysis{queryTree: q}
+	applySample := func(sample perfSample) {
+		if q.applySample(sample) {
+			c.usedSamples += sample.count()
+		}
+	}
+	for _, thread := range p.findThreadTraces() {
+		slime.Select(thread.source, hasTag("match_profiling"), func(_ *slime.Path, v slime.Value) {
+			eachSample(v, func(sample perfSample) {
+				c.foundSamples += sample.count()
+			})
+			walkSamples(v, func(sample perfSample, inSeek bool) bool {
+				if sample.isUnpackSample() && !inSeek {
+					// Cost estimate covers unpack only as part of seek.
+					return false
+				}
+				applySample(sample)
+				return true
+			})
+		})
+	}
+	slime.Select(p.source, hasTag("setup_profiling"), func(_ *slime.Path, v slime.Value) {
+		eachSample(v, func(sample perfSample) {
+			c.foundSamples += sample.count()
+		})
+		walkSamples(v, func(sample perfSample, inSeek bool) bool {
+			if !sample.isFetchPostingsSample() || sample.count() != 1 {
+				// Repeated fetch-postings samples mix multiple optimization iterations;
+				// the latest setup cost cannot be isolated reliably.
+				return false
+			}
+			applySample(sample)
+			return true
+		})
+	})
+	c.maxTimeMs = q.root.totalTimeMs
+	c.maxCost = q.root.absCost
+	return c
+}
+
+func (c *costAnalysis) useful() bool {
+	return c.maxCost != 0
+}
+
+func (c *costAnalysis) analyze(n *queryNode) string {
+	if c.maxTimeMs == 0 || c.maxCost == 0 {
+		return ""
+	}
+	relTime := n.totalTimeMs / c.maxTimeMs
+	relCost := n.absCost / c.maxCost
+	// + means more expensive than expected, - means less; more symbols = bigger deviation.
+	diff := relTime - relCost
+	switch {
+	case diff > 0.20:
+		return "+++"
+	case diff > 0.10:
+		return "++"
+	case diff > 0.05:
+		return "+"
+	case diff < -0.20:
+		return "---"
+	case diff < -0.10:
+		return "--"
+	case diff < -0.05:
+		return "-"
+	}
+	return ""
+}
+
+func (c *costAnalysis) render(output *output) {
+	c.queryTree.makeTable([]queryColumn{
+		{"cost %", func(n *queryNode) string {
+			if c.maxCost == 0 {
+				return "-"
+			}
+			return fmt.Sprintf("%.3f", 100.0*n.absCost/c.maxCost)
+		}},
+		{"time %", func(n *queryNode) string {
+			if c.maxTimeMs == 0 {
+				return "-"
+			}
+			return fmt.Sprintf("%.3f", 100.0*n.totalTimeMs/c.maxTimeMs)
+		}},
+		{"ms/cost", func(n *queryNode) string {
+			if n.absCost == 0 {
+				return "-"
+			}
+			return fmt.Sprintf("%.3f", n.totalTimeMs/n.absCost)
+		}},
+		{"eval", func(n *queryNode) string { return n.evalMode() }},
+		{"diff", func(n *queryNode) string { return c.analyze(n) }},
+	}).render(output)
+}

--- a/client/go/internal/vespa/tracedoctor/cost_analysis_test.go
+++ b/client/go/internal/vespa/tracedoctor/cost_analysis_test.go
@@ -1,0 +1,26 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package tracedoctor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCostAnalysisUseful(t *testing.T) {
+	assert.True(t, (&costAnalysis{maxCost: 100}).useful())
+	assert.False(t, (&costAnalysis{maxTimeMs: 100}).useful())
+}
+
+func TestCostAnalysisDiff(t *testing.T) {
+	c := &costAnalysis{maxTimeMs: 100, maxCost: 100}
+	assert.Equal(t, "", c.analyze(&queryNode{totalTimeMs: 10, absCost: 10}))
+	assert.Equal(t, "+", c.analyze(&queryNode{totalTimeMs: 16, absCost: 10}))
+	assert.Equal(t, "++", c.analyze(&queryNode{totalTimeMs: 21, absCost: 10}))
+	assert.Equal(t, "+++", c.analyze(&queryNode{totalTimeMs: 31, absCost: 10}))
+	assert.Equal(t, "-", c.analyze(&queryNode{totalTimeMs: 10, absCost: 16}))
+	assert.Equal(t, "--", c.analyze(&queryNode{totalTimeMs: 10, absCost: 21}))
+	assert.Equal(t, "---", c.analyze(&queryNode{totalTimeMs: 10, absCost: 31}))
+	assert.Equal(t, "", (&costAnalysis{}).analyze(&queryNode{totalTimeMs: 10, absCost: 10}))
+}

--- a/client/go/internal/vespa/tracedoctor/extract.go
+++ b/client/go/internal/vespa/tracedoctor/extract.go
@@ -17,15 +17,18 @@ type queryTree struct {
 }
 
 type queryNode struct {
-	source      slime.Value
-	class       string
-	fieldName   string
-	queryTerm   string
-	strict      string
-	seeks       int64
-	selfTimeMs  float64
-	totalTimeMs float64
-	children    []*queryNode
+	source         slime.Value
+	class          string
+	fieldName      string
+	queryTerm      string
+	strict         bool
+	termwise       bool
+	multiBitVector bool
+	count          int64
+	selfTimeMs     float64
+	totalTimeMs    float64
+	absCost        float64
+	children       []*queryNode
 }
 
 func (q *queryNode) each(f func(q *queryNode)) {
@@ -51,27 +54,44 @@ func (q *queryNode) desc() string {
 
 var treePad = [][]string{{"", ""}, {"├── ", "│   "}, {"└── ", "    "}}
 
-func (q *queryNode) makeTable(tab *table, prefix string, pad int) {
-	tab.str(fmt.Sprintf("%d", q.seeks))
-	tab.str(fmt.Sprintf("%.3f", q.totalTimeMs))
-	tab.str(fmt.Sprintf("%.3f", q.selfTimeMs))
-	tab.str(q.strict)
+type queryColumn struct {
+	name    string
+	extract func(*queryNode) string
+}
+
+func (q *queryNode) makeRows(tab *table, columns []queryColumn, prefix string, pad int) {
+	for _, col := range columns {
+		tab.str(col.extract(q))
+	}
 	tab.str(fmt.Sprintf(" %s%s%s ", prefix, treePad[pad][0], q.desc()))
 	tab.commit()
 	childPrefix := prefix + treePad[pad][1]
 	for i, child := range q.children {
 		if i+1 < len(q.children) {
-			child.makeTable(tab, childPrefix, 1)
+			child.makeRows(tab, columns, childPrefix, 1)
 		} else {
-			child.makeTable(tab, childPrefix, 2)
+			child.makeRows(tab, columns, childPrefix, 2)
 		}
 	}
 }
 
+func (q *queryTree) makeTable(columns []queryColumn) *table {
+	tab := newTable()
+	for _, col := range columns {
+		tab.str(col.name)
+	}
+	tab.str("query tree").commit().line()
+	q.root.makeRows(tab, columns, "", 0)
+	return tab
+}
+
 func (q *queryTree) render(output *output) {
-	tab := newTable().str("seeks").str("total_ms").str("self_ms").str("step").str("query tree").commit().line()
-	q.root.makeTable(tab, "", 0)
-	tab.render(output)
+	q.makeTable([]queryColumn{
+		{"count", func(n *queryNode) string { return fmt.Sprintf("%d", n.count) }},
+		{"total_ms", func(n *queryNode) string { return fmt.Sprintf("%.3f", n.totalTimeMs) }},
+		{"self_ms", func(n *queryNode) string { return fmt.Sprintf("%.3f", n.selfTimeMs) }},
+		{"eval", func(n *queryNode) string { return n.evalMode() }},
+	}).render(output)
 }
 
 func (q *queryNode) asTable() *table {
@@ -126,11 +146,7 @@ func newQueryNode(obj slime.Value, t *queryTree) *queryNode {
 	if id := int(obj.Field("id").AsLong()); id > 0 {
 		t.index[id] = res
 	}
-	if obj.Field("strict").AsBool() {
-		res.strict = "S"
-	} else {
-		res.strict = "N"
-	}
+	res.strict = obj.Field("strict").AsBool()
 	if class := obj.Field("[type]"); class.Valid() {
 		res.class = stripClassName(class.AsString())
 	} else {
@@ -152,6 +168,7 @@ func newQueryNode(obj slime.Value, t *queryTree) *queryNode {
 			res.fieldName = obj.Field("field_name").AsString()
 		}
 	}
+	res.absCost = obj.Field("abs_cost").AsDouble()
 	res.class = strings.TrimSuffix(res.class, "Blueprint")
 	eachObjectArrayElem(obj.Field("children"), func(child slime.Value) {
 		res.children = append(res.children, newQueryNode(child, t))
@@ -163,6 +180,22 @@ func newQueryTree(query slime.Value) *queryTree {
 	res := &queryTree{index: make(map[int]*queryNode)}
 	res.root = newQueryNode(query, res)
 	return res
+}
+
+func (q *queryNode) evalMode() string {
+	var mode string
+	if q.strict {
+		mode = "eager"
+	} else {
+		mode = "lazy"
+	}
+	if q.multiBitVector {
+		mode += " mbv"
+	}
+	if q.termwise {
+		mode += " taat"
+	}
+	return mode
 }
 
 func stripClassName(name string) string {
@@ -252,22 +285,39 @@ func (p perfSample) name() string {
 }
 
 func (p perfSample) isLegacySample() bool {
-	return strings.HasPrefix(p.source.Field("name").AsString(), "/")
+	return strings.HasPrefix(p.name(), "/")
 }
 
 func (p perfSample) isEnumSample() bool {
-	return strings.HasPrefix(p.source.Field("name").AsString(), "[")
+	return strings.HasPrefix(p.name(), "[")
 }
 
 func (p perfSample) isSeekSample() bool {
-	name := p.source.Field("name").AsString()
-	if strings.HasPrefix(name, "/") {
-		return strings.HasSuffix(name, "/seek")
-	}
-	if strings.HasPrefix(name, "[") {
-		return strings.HasSuffix(name, "::doSeek")
-	}
-	return false
+	name := p.name()
+	return strings.HasSuffix(name, "/seek") ||
+		strings.HasSuffix(name, "::doSeek")
+}
+
+func (p perfSample) isUnpackSample() bool {
+	name := p.name()
+	return strings.HasSuffix(name, "/unpack") ||
+		strings.HasSuffix(name, "::doUnpack")
+}
+
+func (p perfSample) isTermwiseSample() bool {
+	name := p.name()
+	return strings.HasSuffix(name, "/termwise") ||
+		strings.HasSuffix(name, "::get_hits") ||
+		strings.HasSuffix(name, "::and_hits_into") ||
+		strings.HasSuffix(name, "::or_hits_into")
+}
+
+func (p perfSample) isMultiBitVectorSample() bool {
+	return strings.Contains(p.name(), "MultiBitVector")
+}
+
+func (p perfSample) isFetchPostingsSample() bool {
+	return strings.HasSuffix(p.name(), "::fetchPostings")
 }
 
 func (p perfSample) count() int64 {
@@ -286,40 +336,49 @@ func (p perfSample) selfTimeMs() float64 {
 }
 
 func (q *queryNode) applySampleStats(sample perfSample, factor float64) {
-	if sample.isSeekSample() {
-		q.seeks += sample.count()
+	if sample.isTermwiseSample() {
+		q.termwise = true
 	}
+	if sample.isMultiBitVectorSample() {
+		q.multiBitVector = true
+	}
+	q.count += sample.count()
 	q.totalTimeMs += sample.totalTimeMs() * factor
 	q.selfTimeMs += sample.selfTimeMs() * factor
 }
 
-func (q *queryTree) applyLegacySample(sample perfSample) {
+func (q *queryTree) applyLegacySample(sample perfSample) bool {
 	node := q.root
 	path := parseNumList(sample.name(), 1, '/')
 	for _, child := range path {
 		if child < len(node.children) {
 			node = node.children[child]
 		} else {
-			return
+			return false
 		}
 	}
 	node.applySampleStats(sample, 1.0)
+	return true
 }
 
-func (q *queryTree) applySample(sample perfSample) {
+func (q *queryTree) applySample(sample perfSample) bool {
 	if sample.isEnumSample() {
+		applied := 0
 		list := parseNumList(sample.name(), 1, ',')
 		if len(list) > 0 {
 			factor := 1.0 / float64(len(list))
 			for _, id := range list {
 				if node, ok := q.index[id]; ok {
 					node.applySampleStats(sample, factor)
+					applied++
 				}
 			}
 		}
+		return applied > 0
 	} else if sample.isLegacySample() {
-		q.applyLegacySample(sample)
+		return q.applyLegacySample(sample)
 	}
+	return false
 }
 
 func hasTag(tag string) func(p *slime.Path, v slime.Value) bool {
@@ -343,6 +402,19 @@ func eachSampleList(list slime.Value, f func(sample perfSample)) {
 
 func eachSample(prof slime.Value, f func(sample perfSample)) {
 	eachSampleList(prof.Field("roots"), f)
+}
+
+func walkSampleList(list slime.Value, inSeek bool, f func(sample perfSample, inSeek bool) bool) {
+	list.EachEntry(func(_ int, v slime.Value) {
+		sample := perfSample{source: v}
+		if f(sample, inSeek) {
+			walkSampleList(v.Field("children"), inSeek || sample.isSeekSample(), f)
+		}
+	})
+}
+
+func walkSamples(prof slime.Value, f func(sample perfSample, inSeek bool) bool) {
+	walkSampleList(prof.Field("roots"), false, f)
 }
 
 func (q *queryTree) importMatchPerf(t threadTrace) {

--- a/client/go/internal/vespa/tracedoctor/extract_test.go
+++ b/client/go/internal/vespa/tracedoctor/extract_test.go
@@ -131,19 +131,45 @@ func TestPerfSample(t *testing.T) {
 		assert.Equal(t, total, p.totalTimeMs())
 		assert.Equal(t, self, p.selfTimeMs())
 	}
-	checkSampleFlags := func(p perfSample, legacy bool, enum bool, seek bool) {
-		assert.Equal(t, enum, p.isEnumSample())
-		assert.Equal(t, legacy, p.isLegacySample())
-		assert.Equal(t, seek, p.isSeekSample())
-	}
 	checkSample(f.flatSample("my_name", 10, 5), "my_name", 10, 0, 5)
 	checkSample(f.treeSample("my_name", 10, 20, 5), "my_name", 10, 20, 5)
 	checkSample(f.leafSample("my_name", 10, 5), "my_name", 10, 5, 5)
-	checkSampleFlags(f.dummySample("/1/2/And/seek"), true, false, true)
-	checkSampleFlags(f.dummySample("/1/2/And/unpack"), true, false, false)
-	checkSampleFlags(f.dummySample("[3]And::doSeek"), false, true, true)
-	checkSampleFlags(f.dummySample("[3]And::doUnpack"), false, true, false)
-	checkSampleFlags(f.dummySample("bogus"), false, false, false)
+	type sampleFlags struct {
+		legacy, enum, seek, unpack, termwise, mbv bool
+	}
+	flagCases := []struct {
+		name string
+		want sampleFlags
+	}{
+		{"/1/2/And/seek", sampleFlags{legacy: true, seek: true}},
+		{"/1/2/And/unpack", sampleFlags{legacy: true, unpack: true}},
+		{"/1/2/And/termwise", sampleFlags{legacy: true, termwise: true}},
+		{"[3]And::doSeek", sampleFlags{enum: true, seek: true}},
+		{"[3]And::doUnpack", sampleFlags{enum: true, unpack: true}},
+		{"[3]And::get_hits", sampleFlags{enum: true, termwise: true}},
+		{"[3]And::and_hits_into", sampleFlags{enum: true, termwise: true}},
+		{"[3]And::or_hits_into", sampleFlags{enum: true, termwise: true}},
+		{"[3]MultiBitVectorIterator::doSeek", sampleFlags{enum: true, seek: true, mbv: true}},
+		{"bogus", sampleFlags{}},
+	}
+	for _, c := range flagCases {
+		p := f.dummySample(c.name)
+		got := sampleFlags{
+			legacy:   p.isLegacySample(),
+			enum:     p.isEnumSample(),
+			seek:     p.isSeekSample(),
+			unpack:   p.isUnpackSample(),
+			termwise: p.isTermwiseSample(),
+			mbv:      p.isMultiBitVectorSample(),
+		}
+		assert.Equal(t, c.want, got, c.name)
+	}
+}
+
+func TestQuerySetupPerfSample(t *testing.T) {
+	f := testFactory{}
+	assert.False(t, f.dummySample("[3]And::create").isFetchPostingsSample())
+	assert.True(t, f.dummySample("[3]And::fetchPostings").isFetchPostingsSample())
 }
 
 func TestParseNumList(t *testing.T) {
@@ -158,20 +184,20 @@ func TestParseNumList(t *testing.T) {
 func TestApplyLegacySample(t *testing.T) {
 	f := testFactory{}
 	query := newQueryTree(f.simpleQuery())
-	query.applySample(f.treeSample("/X/seek", 3, 11, 3))
-	query.applySample(f.treeSample("/X/unpack", 7, 9, 7))
-	query.applySample(f.leafSample("/0/X/init", 10, 12))
-	query.applySample(f.leafSample("/0/X/termwise", 20, 18))
-	query.applySample(f.flatSample("/1/1/X/seek", 5, 10))
-	query.applySample(f.flatSample("/1/1/X/seek", 10, 5))
-	query.applySample(f.treeSample("/100/X/seek", 10, 20, 10)) // out of bounds
-	var seeks []int64
+	assert.True(t, query.applySample(f.treeSample("/X/seek", 3, 11, 3)))
+	assert.True(t, query.applySample(f.treeSample("/X/unpack", 7, 9, 7)))
+	assert.True(t, query.applySample(f.leafSample("/0/X/init", 10, 12)))
+	assert.True(t, query.applySample(f.leafSample("/0/X/termwise", 20, 18)))
+	assert.True(t, query.applySample(f.flatSample("/1/1/X/seek", 5, 10)))
+	assert.True(t, query.applySample(f.flatSample("/1/1/X/seek", 10, 5)))
+	assert.False(t, query.applySample(f.treeSample("/100/X/seek", 10, 20, 10))) // out of bounds
+	var counts []int64
 	var totals []float64
 	var selfs []float64
-	query.root.each(func(q *queryNode) { seeks = append(seeks, q.seeks) })
+	query.root.each(func(q *queryNode) { counts = append(counts, q.count) })
 	query.root.each(func(q *queryNode) { totals = append(totals, q.totalTimeMs) })
 	query.root.each(func(q *queryNode) { selfs = append(selfs, q.selfTimeMs) })
-	assert.Equal(t, []int64{3, 0, 0, 0, 15}, seeks)
+	assert.Equal(t, []int64{10, 30, 0, 0, 15}, counts)
 	assert.Equal(t, []float64{20, 30, 0, 0, 0}, totals)
 	assert.Equal(t, []float64{10, 30, 0, 0, 15}, selfs)
 }
@@ -179,40 +205,72 @@ func TestApplyLegacySample(t *testing.T) {
 func TestApplySample(t *testing.T) {
 	f := testFactory{}
 	query := newQueryTree(f.simpleQuery())
-	query.applySample(f.treeSample("[5]X::doSeek", 3, 11, 3))
-	query.applySample(f.treeSample("[5]X::doUnpack", 7, 9, 7))
-	query.applySample(f.leafSample("[4]X::initRange", 10, 12))
-	query.applySample(f.leafSample("[4]X::or_hits_into", 20, 18))
-	query.applySample(f.flatSample("[1]X::doSeek", 5, 10))
-	query.applySample(f.flatSample("[1]X::doSeek", 10, 5))
-	query.applySample(f.treeSample("[100]X::doSeek", 10, 20, 10)) // not found
-	query.applySample(f.treeSample("[]X::doSeek", 10, 20, 10))    // empty enum list
-	var seeks []int64
+	assert.True(t, query.applySample(f.treeSample("[5]X::doSeek", 3, 11, 3)))
+	assert.True(t, query.applySample(f.treeSample("[5]X::doUnpack", 7, 9, 7)))
+	assert.True(t, query.applySample(f.leafSample("[4]X::initRange", 10, 12)))
+	assert.True(t, query.applySample(f.leafSample("[4]X::or_hits_into", 20, 18)))
+	assert.True(t, query.applySample(f.flatSample("[1]X::doSeek", 5, 10)))
+	assert.True(t, query.applySample(f.flatSample("[1]X::doSeek", 10, 5)))
+	assert.False(t, query.applySample(f.treeSample("[100]X::doSeek", 10, 20, 10))) // not found
+	assert.False(t, query.applySample(f.treeSample("[]X::doSeek", 10, 20, 10)))    // empty enum list
+	var counts []int64
 	var totals []float64
 	var selfs []float64
-	query.root.each(func(q *queryNode) { seeks = append(seeks, q.seeks) })
+	query.root.each(func(q *queryNode) { counts = append(counts, q.count) })
 	query.root.each(func(q *queryNode) { totals = append(totals, q.totalTimeMs) })
 	query.root.each(func(q *queryNode) { selfs = append(selfs, q.selfTimeMs) })
-	assert.Equal(t, []int64{3, 0, 0, 0, 15}, seeks)
+	assert.Equal(t, []int64{10, 30, 0, 0, 15}, counts)
 	assert.Equal(t, []float64{20, 30, 0, 0, 0}, totals)
 	assert.Equal(t, []float64{10, 30, 0, 0, 15}, selfs)
+}
+
+func TestApplySampleFlags(t *testing.T) {
+	f := testFactory{}
+	query := newQueryTree(f.simpleQuery())
+	assert.True(t, query.applySample(f.flatSample("[4]X::or_hits_into", 1, 0)))
+	assert.True(t, query.applySample(f.flatSample("[2]MultiBitVectorIterator::doSeek", 1, 0)))
+	assert.True(t, query.index[4].termwise)
+	assert.False(t, query.index[4].multiBitVector)
+	assert.True(t, query.index[2].multiBitVector)
+	assert.False(t, query.index[2].termwise)
+	assert.False(t, query.index[5].termwise)
+	assert.False(t, query.index[5].multiBitVector)
+}
+
+func TestEvalMode(t *testing.T) {
+	cases := []struct {
+		strict, mbv, taat bool
+		want              string
+	}{
+		{false, false, false, "lazy"},
+		{true, false, false, "eager"},
+		{true, true, false, "eager mbv"},
+		{true, false, true, "eager taat"},
+		{true, true, true, "eager mbv taat"},
+		{false, true, true, "lazy mbv taat"},
+	}
+	for _, c := range cases {
+		n := &queryNode{strict: c.strict, multiBitVector: c.mbv, termwise: c.taat}
+		assert.Equal(t, c.want, n.evalMode())
+	}
 }
 
 func TestApplyMultiSample(t *testing.T) {
 	f := testFactory{}
 	query := newQueryTree(f.simpleQuery())
-	query.applySample(f.treeSample("[1,2]X::doSeek", 3, 10, 2))
-	query.applySample(f.treeSample("[2,3]X::doSeek", 5, 20, 4))
-	query.applySample(f.treeSample("[2,3]X::doUnpack", 7, 30, 6))
-	var seeks []int64
+	assert.True(t, query.applySample(f.treeSample("[1,2]X::doSeek", 3, 10, 2)))
+	assert.True(t, query.applySample(f.treeSample("[2,3]X::doSeek", 5, 20, 4)))
+	assert.True(t, query.applySample(f.treeSample("[2,3]X::doUnpack", 7, 30, 6)))
+	assert.True(t, query.applySample(f.treeSample("[5,100]X::doSeek", 10, 10, 10))) // partial
+	var counts []int64
 	var totals []float64
 	var selfs []float64
-	query.root.each(func(q *queryNode) { seeks = append(seeks, q.seeks) })
+	query.root.each(func(q *queryNode) { counts = append(counts, q.count) })
 	query.root.each(func(q *queryNode) { totals = append(totals, q.totalTimeMs) })
 	query.root.each(func(q *queryNode) { selfs = append(selfs, q.selfTimeMs) })
-	assert.Equal(t, []int64{0, 0, 5, 8, 3}, seeks)
-	assert.Equal(t, []float64{0, 0, 25, 30, 5}, totals)
-	assert.Equal(t, []float64{0, 0, 5, 6, 1}, selfs)
+	assert.Equal(t, []int64{10, 0, 12, 15, 3}, counts)
+	assert.Equal(t, []float64{5, 0, 25, 30, 5}, totals)
+	assert.Equal(t, []float64{5, 0, 5, 6, 1}, selfs)
 }
 
 func TestStripNameSpacesKeepSuffix(t *testing.T) {

--- a/client/go/internal/vespa/tracedoctor/multi_line.go
+++ b/client/go/internal/vespa/tracedoctor/multi_line.go
@@ -1,3 +1,5 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 package tracedoctor
 
 import "github.com/mattn/go-runewidth"

--- a/client/go/internal/vespa/tracedoctor/multi_line_test.go
+++ b/client/go/internal/vespa/tracedoctor/multi_line_test.go
@@ -1,3 +1,5 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 package tracedoctor
 
 import (

--- a/client/go/internal/vespa/tracedoctor/prompt.go
+++ b/client/go/internal/vespa/tracedoctor/prompt.go
@@ -1,3 +1,5 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 package tracedoctor
 
 const introPromptStr = `
@@ -156,6 +158,16 @@ const slowToMedianPromptStr = `<AI>The report for the slowest node is complete.
 The following section reports the median node for comparison.
 Some variance between nodes is expected.</AI>`
 
+const costAnalysisPromptStr = `<AI>The following table compares estimated cost per query-plan node with measured time spent in that node.
+Columns:
+cost %: Percentage of total query-plan cost assigned to this subtree.
+time %: Percentage of total query time spent in this subtree.
+        This includes profiling samples from multiple match threads and query setup.
+        Some samples are filtered out because they are not covered by the cost model.
+ms/cost: Milliseconds per cost unit for this subtree.
+diff: Visual clue for spotting where the query took more (+) or less (-) time than expected.
+More symbols indicate a larger deviation. A blank diff means cost and time are aligned.</AI>`
+
 func promptSetup(ctx *Context, out *output) {
 	if ctx.makePrompt {
 		ctx.showMedianNode = true
@@ -273,5 +285,11 @@ func secondPhaseProfilingPrompt(ctx *Context, out *output) {
 func slowToMedianPrompt(ctx *Context, out *output) {
 	if ctx.makePrompt {
 		out.fmt("%s\n", slowToMedianPromptStr)
+	}
+}
+
+func costAnalysisPrompt(ctx *Context, out *output) {
+	if ctx.makePrompt {
+		out.fmt("%s\n", costAnalysisPromptStr)
 	}
 }

--- a/client/go/internal/vespa/tracedoctor/tracedoctor.go
+++ b/client/go/internal/vespa/tracedoctor/tracedoctor.go
@@ -62,6 +62,7 @@ type Context struct {
 	showMedianNode      bool
 	showDispatchedQuery bool
 	showNnsDetails      bool
+	showCostAnalysis    bool
 	makePrompt          bool
 	showQueryNodes      []int
 }
@@ -76,6 +77,10 @@ func (ctx *Context) ShowDispatchedQuery() {
 
 func (ctx *Context) ShowNnsDetails() {
 	ctx.showNnsDetails = true
+}
+
+func (ctx *Context) ShowCostAnalysis() {
+	ctx.showCostAnalysis = true
 }
 
 func (ctx *Context) MakePrompt() {
@@ -162,6 +167,15 @@ func (ctx *Context) analyzeProtonTrace(trace protonTrace, peer *protonTrace, out
 			median = nil
 		}
 		ctx.analyzeThread(trace, *worst, median, out)
+	}
+	if ctx.showCostAnalysis {
+		if ca := newCostAnalysis(trace); ca.useful() {
+			out.fmt("query plan cost vs measured time (used %d of %d samples)\n", ca.usedSamples, ca.foundSamples)
+			costAnalysisPrompt(ctx, out)
+			ca.render(out)
+		} else {
+			out.fmt("cost analysis requested by user but no cost information found\n")
+		}
 	}
 	if len(ctx.showQueryNodes) > 0 {
 		renderQueryNodes(trace.extractQuery(), ctx.showQueryNodes, out)


### PR DESCRIPTION
Collect all profiling samples correlating to the estimated cost. Compare percent of total cost with percent of total time. Give visual hints for large differences and also print the ms/cost metric that we use in the iterator benchmark.

some tweaks to normal profiling:
- seeks -> count (count all samples, not just seeks)
- S -> eager, N -> lazy
- new tags: mbv (multi bit vector) and taat (term at a time)

@arnej27959 please review
