### PR TITLE
fix(CI): ensure we get a SHA for a container, or fail out if we do not [MERGEOK]

### DIFF
--- a/.buildkite/publish-container.sh
+++ b/.buildkite/publish-container.sh
@@ -31,6 +31,10 @@ docker push "$VESPA_PREVIEW_CONTAINER_URI"
 
 echo "Signing container image..."
 IMAGE_SHA256=$(crane digest "$VESPA_PREVIEW_CONTAINER_URI")
+if [ "${IMAGE_SHA256}na" = "na" ]; then
+    echo "Failed getting IMAGE_SHA256 from $VESPA_PREVIEW_CONTAINER_URI"
+    exit 1
+fi
 cosign sign -y --oidc-provider=buildkite-agent "${VESPA_PREVIEW_CONTAINER_URI}@${IMAGE_SHA256}"
 
 echo "Setting Buildkite metadata for Vespa container..."
@@ -42,8 +46,7 @@ SYSTEMTEST_PREVIEW_CONTAINER_URI=docker.io/vespaengine/vespa-systemtest-preview-
 echo "Pushing container: ${SYSTEMTEST_PREVIEW_CONTAINER_URI}"
 docker push "$SYSTEMTEST_PREVIEW_CONTAINER_URI"
 IMAGE_SHA256=$(crane digest "$SYSTEMTEST_PREVIEW_CONTAINER_URI")
-
-if [ "${IMAGE_SHA256}" = "" ]; then
+if [ "${IMAGE_SHA256}na" = "na" ]; then
     echo "Failed getting IMAGE_SHA256 from $SYSTEMTEST_PREVIEW_CONTAINER_URI"
     exit 1
 fi

--- a/.buildkite/publish-container.sh
+++ b/.buildkite/publish-container.sh
@@ -31,8 +31,8 @@ docker push "$VESPA_PREVIEW_CONTAINER_URI"
 
 echo "Signing container image..."
 IMAGE_SHA256=$(crane digest "$VESPA_PREVIEW_CONTAINER_URI")
-if [ "${IMAGE_SHA256}na" = "na" ]; then
-    echo "Failed getting IMAGE_SHA256 from $VESPA_PREVIEW_CONTAINER_URI"
+if [[ -z "${IMAGE_SHA256}" ]]; then
+    echo "Failed getting IMAGE_SHA256 from ${VESPA_PREVIEW_CONTAINER_URI}"
     exit 1
 fi
 cosign sign -y --oidc-provider=buildkite-agent "${VESPA_PREVIEW_CONTAINER_URI}@${IMAGE_SHA256}"
@@ -46,8 +46,8 @@ SYSTEMTEST_PREVIEW_CONTAINER_URI=docker.io/vespaengine/vespa-systemtest-preview-
 echo "Pushing container: ${SYSTEMTEST_PREVIEW_CONTAINER_URI}"
 docker push "$SYSTEMTEST_PREVIEW_CONTAINER_URI"
 IMAGE_SHA256=$(crane digest "$SYSTEMTEST_PREVIEW_CONTAINER_URI")
-if [ "${IMAGE_SHA256}na" = "na" ]; then
-    echo "Failed getting IMAGE_SHA256 from $SYSTEMTEST_PREVIEW_CONTAINER_URI"
+if [[ -z "${IMAGE_SHA256}" ]]; then
+    echo "Failed getting IMAGE_SHA256 from ${SYSTEMTEST_PREVIEW_CONTAINER_URI}"
     exit 1
 fi
 


### PR DESCRIPTION
## What

- Catch the situation where a SHA is NOT returned by crane.

## Why

- Return code is not consistent and the script would progress eitherway. Now we fail out early.


---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
