### PR TITLE
Only call mallopt() when vespamalloc is the active allocator

### DIFF
--- a/vespalib/src/vespa/vespalib/util/malloc_mmap_guard.cpp
+++ b/vespalib/src/vespa/vespalib/util/malloc_mmap_guard.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "malloc_mmap_guard.h"
 
+#include <vespa/vespalib/util/detect_malloc_impl.h>
 #include <vespa/vespalib/util/size_literals.h>
 #ifdef __linux__
 #include <malloc.h>
@@ -12,8 +13,10 @@ namespace vespalib {
 
 MallocMmapGuard::MallocMmapGuard(size_t mmapLimit) : _threadId(std::this_thread::get_id()) {
 #ifdef __linux__
-    int limit = mmapLimit <= std::numeric_limits<int>::max() ? mmapLimit : std::numeric_limits<int>::max();
-    mallopt(M_MMAP_THRESHOLD, limit);
+    if (vespalib::detect_malloc_impl() == vespalib::MallocImpl::VespaMalloc) {
+        int limit = mmapLimit <= std::numeric_limits<int>::max() ? mmapLimit : std::numeric_limits<int>::max();
+        mallopt(M_MMAP_THRESHOLD, limit);
+    }
 #else
     (void)mmapLimit;
 #endif
@@ -22,7 +25,9 @@ MallocMmapGuard::MallocMmapGuard(size_t mmapLimit) : _threadId(std::this_thread:
 MallocMmapGuard::~MallocMmapGuard() {
     assert(_threadId == std::this_thread::get_id());
 #ifdef __linux__
-    mallopt(M_MMAP_THRESHOLD, 1_Gi);
+    if (vespalib::detect_malloc_impl() == vespalib::MallocImpl::VespaMalloc) {
+        mallopt(M_MMAP_THRESHOLD, 1_Gi);
+    }
 #endif
 }
 


### PR DESCRIPTION
MallocMmapGuard used mallopt(M_MMAP_THRESHOLD) unconditionally on Linux. Calling it with other non-standard allocators (mimalloc) has no meaningful effect at best, and may cause unexpected behavior. Guard the calls with detect_malloc_impl() so mallopt is only invoked when vespamalloc is actually in use.
