### PR TITLE
build-container: use PREBUILT_BASE_IMAGE verbatim [MERGEOK]

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -59,7 +59,7 @@ select_dockerfile() {
 
 target_option=""
 if [ "${PREBUILT_BASE_IMAGE:-}" != "" ]; then
-    VESPA_BASE_IMAGE="${PREBUILT_BASE_IMAGE}:${VESPA_BUILDOS_LABEL}"
+    VESPA_BASE_IMAGE=${PREBUILT_BASE_IMAGE}
     SYSTEM_TEST_BASE_IMAGE=${VESPA_BASE_IMAGE}
     target_option="--target vespa"
 fi


### PR DESCRIPTION
When PREBUILT_BASE_IMAGE is provided by the pipeline it already carries its OS tag (e.g. ":alma8"), so appending ":${VESPA_BUILDOS_LABEL}" produced an invalid double-tagged reference like "repo:alma8:alma8". Use the value as-is instead.
