### PR TITLE
add new suppressions for optimized string handling in openssl [MERGEOK]

### DIFF
--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -867,3 +867,15 @@
    fun:_ZN16PageDict4TestApp9testWordsEv
    ...
 }
+{
+   for new openssl on EL8/arm64 (optimized strlcpy)
+   Memcheck:Cond
+   fun:OPENSSL_strlcpy
+   ...
+}
+{
+   for new openssl on EL8/arm64 (optimized strlat)
+   Memcheck:Cond
+   fun:OPENSSL_strlcat
+   ...
+}


### PR DESCRIPTION
I think we can safely assume that these are now optimized  to load 8 bytes at a time, like the other string functions we've seen.