### PR TITLE
Ignore tag suffix in DockerImage.tagAsVersion

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
@@ -49,9 +49,16 @@ public class DockerImage {
         return tag;
     }
 
-    /** Returns the tag as a {@link Version}, {@link Version#emptyVersion} if tag is not set */
+    /**
+     * Returns the tag as a {@link Version}, {@link Version#emptyVersion} if tag is not set.
+     * Any tag suffix, such as the OS suffix in "8.703.17-alma9", is ignored.
+     */
     public Version tagAsVersion() {
-        return tag.map(Version::new).orElse(Version.emptyVersion);
+        return tag.map(t -> {
+                       int suffixStart = t.indexOf('-');
+                       return new Version(suffixStart < 0 ? t : t.substring(0, suffixStart));
+                   })
+                  .orElse(Version.emptyVersion);
     }
 
     /** Returns a copy of this tagged with the given version */

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.provision;
 
+import com.yahoo.component.Version;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -35,6 +36,16 @@ public class DockerImageTest {
                                    : expected.registry() + "/" + expected.repository();
             assertEquals(untagged, parsed.untagged());
         });
+    }
+
+    @Test
+    void tag_as_version() {
+        Map<String, Version> tests = Map.of(
+                "registry.example.com/vespa/vespa:8.703.17", new Version(8, 703, 17),
+                "registry.example.com/vespa/vespa:8.703.17-alma9", new Version(8, 703, 17),
+                "registry.example.com/vespa/vespa", Version.emptyVersion
+        );
+        tests.forEach((value, expected) -> assertEquals(expected, DockerImage.fromString(value).tagAsVersion()));
     }
 
     @Test


### PR DESCRIPTION
## What
- Strip any `-` suffix (e.g. `-alma9`) from the image tag before parsing it as a `Version` in `DockerImage.tagAsVersion()`.
- Add `tag_as_version` test covering plain, suffixed, and missing tags.

## Why
- Image tags can now carry an OS suffix (`8.703.17-alma9` via `CONTAINER_IMAGE_TAG_SUFFIX`), which `Version` cannot parse, crashing `ReportOomKillTask` in host-admin every tick.

## How to test
- `mvn test -pl config-provisioning -Dtest=DockerImageTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)