### PR TITLE
Hard-link ONNX external data files instead of symlinking

### DIFF
--- a/model-integration/src/main/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolver.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolver.java
@@ -8,6 +8,7 @@ import com.yahoo.config.UrlReference;
 import com.yahoo.text.Text;
 
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -20,7 +21,7 @@ import java.util.logging.Logger;
 
 /**
  * Resolves external data files for an ONNX models.
- * Files are retrieved using {@link ModelPathHelper} and symlinked into a temporary directory together with the ONNX model file.
+ * Files are retrieved using {@link ModelPathHelper} and hard-linked into a temporary directory together with the ONNX model file.
  *
  * @author bjorncs
  */
@@ -44,7 +45,7 @@ public class OnnxExternalDataResolver {
 
     /**
      * Resolves the ONNX model file and its external data files.
-     * @return Path to the ONNX model file, which may be a symbolic link to the actual file.
+     * @return Path to the ONNX model file, which may be a hard link to the actual file.
      */
     public Path resolveOnnxModel(ModelReference ref) {
         var localPath = modelPathHelper.getModelPathResolvingIfNecessary(ref);
@@ -99,11 +100,11 @@ public class OnnxExternalDataResolver {
     }
 
     /**
-     * Creates a temporary directory where the ONNX model file and all external data files are symlinked in.
+     * Creates a temporary directory where the ONNX model file and all external data files are hard-linked in.
      *
      * @param model The ONNX model file.
      * @param externalDataFiles Mapping of relative location from model file to the path of the actual for external files.
-     * @return path to the newly created directory containing symlinks to model and files.
+     * @return path to the newly created directory containing hard links to model and files.
      */
     static Path createDirectoryWithExternalDataFiles(Path model, Map<Path, Path> externalDataFiles) throws IOException {
         var tempDir = Files.createTempDirectory("onnx-model-");
@@ -112,10 +113,10 @@ public class OnnxExternalDataResolver {
             throw new IllegalArgumentException("Model file does not exist: " + model);
 
         var targetModelPath = tempDir.resolve(model.getFileName());
-        log.fine(() -> Text.format("Creating symlink for '%s' to '%s'", model, targetModelPath));
-        Files.createSymbolicLink(targetModelPath, model.toAbsolutePath());
+        log.fine(() -> Text.format("Linking '%s' into '%s'", model, targetModelPath));
+        linkOrCopy(model, targetModelPath);
 
-        // Create symlinks for all external data files
+        // Link all external data files next to the model
         for (var entry : externalDataFiles.entrySet()) {
             var relativeLocation = entry.getKey();
             var dataFile = entry.getValue().toAbsolutePath();
@@ -127,14 +128,35 @@ public class OnnxExternalDataResolver {
             var targetPath = tempDir.resolve(relativeLocation);
             var parentDir = targetPath.getParent();
             if (parentDir != null && !Files.exists(parentDir, LinkOption.NOFOLLOW_LINKS)) {
-                log.fine(() -> Text.format("Creating parent directory for symlink: '%s'", parentDir));
+                log.fine(() -> Text.format("Creating parent directory for external data file: '%s'", parentDir));
                 Files.createDirectories(parentDir);
             }
 
-            // Create the symlink to the external data file
-            log.fine(() -> Text.format("Creating symlink for external data file '%s' to '%s'", dataFile, targetPath));
-            Files.createSymbolicLink(targetPath, dataFile);
+            log.fine(() -> Text.format("Linking external data file '%s' into '%s'", dataFile, targetPath));
+            linkOrCopy(dataFile, targetPath);
         }
         return tempDir;
+    }
+
+    /**
+     * Hard-links {@code source} to {@code target}, falling back to a plain copy if hard linking is not possible
+     * (e.g. source and target reside on different filesystems).
+     *
+     * <p>Hard links are used rather than symbolic links because onnxruntime (>= 1.24) validates that external data
+     * paths resolve (via {@code weakly_canonical}, which follows symlinks) to a location contained within the model
+     * directory. Symlinking the downloaded files — which live in separate per-URL download directories — makes the
+     * resolved paths escape the model directory and fail validation. Hard links have no symlink to follow, so they
+     * resolve to their own path inside the temporary model directory.
+     */
+    private static void linkOrCopy(Path source, Path target) throws IOException {
+        // Resolve to the real file so we link/copy the underlying inode, not a symlink in the download directory.
+        var src = source.toRealPath();
+        try {
+            Files.createLink(target, src);
+        } catch (UnsupportedOperationException | FileSystemException e) {
+            log.fine(() -> Text.format(
+                    "Hard link from '%s' to '%s' failed (%s); copying instead", src, target, e.getMessage()));
+            Files.copy(src, target);
+        }
     }
 }

--- a/model-integration/src/main/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolver.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolver.java
@@ -20,8 +20,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Resolves external data files for an ONNX models.
- * Files are retrieved using {@link ModelPathHelper} and hard-linked into a temporary directory together with the ONNX model file.
+ * Resolves external data files for ONNX models.
+ * Files are retrieved using {@link ModelPathHelper} and hard-linked (or copied, when hard-linking is not possible)
+ * into a temporary directory together with the ONNX model file.
  *
  * @author bjorncs
  */
@@ -45,7 +46,9 @@ public class OnnxExternalDataResolver {
 
     /**
      * Resolves the ONNX model file and its external data files.
-     * @return Path to the ONNX model file, which may be a hard link to the actual file.
+     * @return Path to the ONNX model file. When the model has external data files, this is a path inside a temporary
+     *         directory where the model and its data files are hard-linked (or copied); otherwise it is the resolved
+     *         local path of the model itself.
      */
     public Path resolveOnnxModel(ModelReference ref) {
         var localPath = modelPathHelper.getModelPathResolvingIfNecessary(ref);
@@ -107,10 +110,10 @@ public class OnnxExternalDataResolver {
      * @return path to the newly created directory containing hard links to model and files.
      */
     static Path createDirectoryWithExternalDataFiles(Path model, Map<Path, Path> externalDataFiles) throws IOException {
-        var tempDir = Files.createTempDirectory("onnx-model-");
+        if (!Files.isRegularFile(model))
+            throw new IllegalArgumentException("Model file does not exist or is not a regular file: " + model);
 
-        if (!Files.exists(model, LinkOption.NOFOLLOW_LINKS) && !Files.isRegularFile(model))
-            throw new IllegalArgumentException("Model file does not exist: " + model);
+        var tempDir = Files.createTempDirectory("onnx-model-");
 
         var targetModelPath = tempDir.resolve(model.getFileName());
         log.fine(() -> Text.format("Linking '%s' into '%s'", model, targetModelPath));

--- a/model-integration/src/main/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolver.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolver.java
@@ -12,6 +12,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -114,31 +115,50 @@ public class OnnxExternalDataResolver {
             throw new IllegalArgumentException("Model file does not exist or is not a regular file: " + model);
 
         var tempDir = Files.createTempDirectory("onnx-model-");
+        try {
+            var targetModelPath = tempDir.resolve(model.getFileName());
+            log.fine(() -> Text.format("Linking '%s' into '%s'", model, targetModelPath));
+            linkOrCopy(model, targetModelPath);
 
-        var targetModelPath = tempDir.resolve(model.getFileName());
-        log.fine(() -> Text.format("Linking '%s' into '%s'", model, targetModelPath));
-        linkOrCopy(model, targetModelPath);
+            // Link all external data files next to the model
+            for (var entry : externalDataFiles.entrySet()) {
+                var relativeLocation = entry.getKey();
+                var dataFile = entry.getValue().toAbsolutePath();
 
-        // Link all external data files next to the model
-        for (var entry : externalDataFiles.entrySet()) {
-            var relativeLocation = entry.getKey();
-            var dataFile = entry.getValue().toAbsolutePath();
+                if (!Files.exists(dataFile, LinkOption.NOFOLLOW_LINKS) || !Files.isRegularFile(dataFile))
+                    throw new IllegalArgumentException("External data file does not exist: " + dataFile);
 
-            if (!Files.exists(dataFile, LinkOption.NOFOLLOW_LINKS) || !Files.isRegularFile(dataFile))
-                throw new IllegalArgumentException("External data file does not exist: " + dataFile);
+                // Handle data files in subdirectories
+                var targetPath = tempDir.resolve(relativeLocation);
+                var parentDir = targetPath.getParent();
+                if (parentDir != null && !Files.exists(parentDir, LinkOption.NOFOLLOW_LINKS)) {
+                    log.fine(() -> Text.format("Creating parent directory for external data file: '%s'", parentDir));
+                    Files.createDirectories(parentDir);
+                }
 
-            // Handle data files in subdirectories
-            var targetPath = tempDir.resolve(relativeLocation);
-            var parentDir = targetPath.getParent();
-            if (parentDir != null && !Files.exists(parentDir, LinkOption.NOFOLLOW_LINKS)) {
-                log.fine(() -> Text.format("Creating parent directory for external data file: '%s'", parentDir));
-                Files.createDirectories(parentDir);
+                log.fine(() -> Text.format("Linking external data file '%s' into '%s'", dataFile, targetPath));
+                linkOrCopy(dataFile, targetPath);
             }
-
-            log.fine(() -> Text.format("Linking external data file '%s' into '%s'", dataFile, targetPath));
-            linkOrCopy(dataFile, targetPath);
+            return tempDir;
+        } catch (RuntimeException | IOException e) {
+            // Avoid leaking a partially populated temp directory (which may contain large copied files) on failure.
+            deleteRecursivelyQuietly(tempDir);
+            throw e;
         }
-        return tempDir;
+    }
+
+    private static void deleteRecursivelyQuietly(Path dir) {
+        try (var paths = Files.walk(dir)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    log.log(Level.FINE, e, () -> Text.format("Failed to delete '%s' during cleanup", p));
+                }
+            });
+        } catch (IOException e) {
+            log.log(Level.FINE, e, () -> Text.format("Failed to clean up temporary directory '%s'", dir));
+        }
     }
 
     /**

--- a/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluatorTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluatorTest.java
@@ -2,6 +2,10 @@
 
 package ai.vespa.modelintegration.evaluator;
 
+import ai.vespa.modelintegration.utils.ModelPathHelper;
+import ai.vespa.modelintegration.utils.OnnxExternalDataResolver;
+import com.yahoo.config.ModelReference;
+import com.yahoo.config.UrlReference;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import org.junit.Test;
@@ -13,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,6 +27,8 @@ import java.util.logging.LogRecord;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author lesters
@@ -72,6 +79,35 @@ public class EmbeddedOnnxEvaluatorTest {
         Map<String, Tensor> inputs = new HashMap<>();
         inputs.put("input", Tensor.from("tensor<float>(d0[2],d1[3]):[[0.1, 0.2, 0.3],[0.4,0.5,0.6]]"));
         assertEquals(evaluator.evaluate(inputs, "output"), Tensor.from("tensor<float>(d0[2],d1[1]):[0.6393113,0.67574286]"));
+    }
+
+    @Test
+    public void testModelWithExternalData() {
+        assumeTrue(OnnxRuntime.isRuntimeAvailable());
+        // Resolve the model and its external data file the same way the embedders do. onnxruntime (>= 1.24)
+        // validates that external data paths don't escape the model directory, so the resolver must place the
+        // model and its data file together as hard links (or copies) rather than symlinks into the download dir.
+        var model = Paths.get("src/test/models/onnx/external_data/add_with_external_data.onnx");
+        var dataFile = Paths.get("src/test/models/onnx/external_data/external_data.bin");
+        var modelRef = ModelReference.unresolved(
+                Optional.empty(), Optional.of(new UrlReference("https://my.website/add_with_external_data.onnx")),
+                Optional.empty(), Optional.empty());
+        var dataRef = ModelReference.unresolved(
+                Optional.empty(), Optional.of(new UrlReference("https://my.website/external_data.bin")),
+                Optional.empty(), Optional.empty());
+        var modelPathHelper = mock(ModelPathHelper.class);
+        when(modelPathHelper.getModelPathResolvingIfNecessary(modelRef)).thenReturn(model);
+        when(modelPathHelper.getModelPathResolvingIfNecessary(dataRef)).thenReturn(dataFile);
+        var resolvedPath = new OnnxExternalDataResolver(modelPathHelper).resolveOnnxModel(modelRef);
+
+        var runtime = EmbeddedOnnxRuntime.createTestInstance();
+        // Creating the session triggers onnxruntime's external data path validation.
+        OnnxEvaluator evaluator = runtime.evaluatorOf(resolvedPath.toString());
+        Map<String, Tensor> inputs = new HashMap<>();
+        inputs.put("input1", Tensor.from("tensor<float>(d0[1]):[1]"));
+        inputs.put("input2", Tensor.from("tensor<float>(d0[1]):[2]"));
+        // output = input1 + input2 + constant_value (5.0, stored as external data)
+        assertEquals(Tensor.from("tensor<float>(d0[1]):[8]"), evaluator.evaluate(inputs, "output"));
     }
 
     @Test

--- a/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluatorTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluatorTest.java
@@ -100,6 +100,8 @@ public class EmbeddedOnnxEvaluatorTest {
         when(modelPathHelper.getModelPathResolvingIfNecessary(dataRef)).thenReturn(dataFile);
         var resolvedPath = new OnnxExternalDataResolver(modelPathHelper).resolveOnnxModel(modelRef);
         var tempDir = resolvedPath.getParent();
+        // Guard against accidentally deleting the source tree if resolveOnnxModel ever falls back to the local path.
+        assertTrue(tempDir.getFileName().toString().startsWith("onnx-model-"));
 
         var runtime = EmbeddedOnnxRuntime.createTestInstance();
         try {

--- a/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluatorTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/EmbeddedOnnxEvaluatorTest.java
@@ -82,7 +82,7 @@ public class EmbeddedOnnxEvaluatorTest {
     }
 
     @Test
-    public void testModelWithExternalData() {
+    public void testModelWithExternalData() throws IOException {
         assumeTrue(OnnxRuntime.isRuntimeAvailable());
         // Resolve the model and its external data file the same way the embedders do. onnxruntime (>= 1.24)
         // validates that external data paths don't escape the model directory, so the resolver must place the
@@ -99,15 +99,25 @@ public class EmbeddedOnnxEvaluatorTest {
         when(modelPathHelper.getModelPathResolvingIfNecessary(modelRef)).thenReturn(model);
         when(modelPathHelper.getModelPathResolvingIfNecessary(dataRef)).thenReturn(dataFile);
         var resolvedPath = new OnnxExternalDataResolver(modelPathHelper).resolveOnnxModel(modelRef);
+        var tempDir = resolvedPath.getParent();
 
         var runtime = EmbeddedOnnxRuntime.createTestInstance();
-        // Creating the session triggers onnxruntime's external data path validation.
-        OnnxEvaluator evaluator = runtime.evaluatorOf(resolvedPath.toString());
-        Map<String, Tensor> inputs = new HashMap<>();
-        inputs.put("input1", Tensor.from("tensor<float>(d0[1]):[1]"));
-        inputs.put("input2", Tensor.from("tensor<float>(d0[1]):[2]"));
-        // output = input1 + input2 + constant_value (5.0, stored as external data)
-        assertEquals(Tensor.from("tensor<float>(d0[1]):[8]"), evaluator.evaluate(inputs, "output"));
+        try {
+            // Creating the session triggers onnxruntime's external data path validation.
+            try (OnnxEvaluator evaluator = runtime.evaluatorOf(resolvedPath.toString())) {
+                Map<String, Tensor> inputs = new HashMap<>();
+                inputs.put("input1", Tensor.from("tensor<float>(d0[1]):[1]"));
+                inputs.put("input2", Tensor.from("tensor<float>(d0[1]):[2]"));
+                // output = input1 + input2 + constant_value (5.0, stored as external data)
+                assertEquals(Tensor.from("tensor<float>(d0[1]):[8]"), evaluator.evaluate(inputs, "output"));
+            }
+        } finally {
+            try (var paths = Files.walk(tempDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                    try { Files.deleteIfExists(p); } catch (IOException e) { throw new java.io.UncheckedIOException(e); }
+                });
+            }
+        }
     }
 
     @Test

--- a/model-integration/src/test/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolverTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolverTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -25,7 +26,7 @@ import static org.mockito.Mockito.when;
  */
 class OnnxExternalDataResolverTest {
     @Test
-    void downloads_external_data_files_for_onnx_model_referred_by_url() {
+    void downloads_external_data_files_for_onnx_model_referred_by_url() throws IOException {
         var model = Paths.get("src/test/models/onnx/external_data/add_with_external_data.onnx");
         var externalDataFile = Paths.get("src/test/models/onnx/external_data/external_data.bin");
         var modelRef = ModelReference.unresolved(
@@ -47,13 +48,18 @@ class OnnxExternalDataResolverTest {
         var resolver = new OnnxExternalDataResolver(modelPathHelper);
         var modelPath = resolver.resolveOnnxModel(modelRef);
 
+        // Files are hard-linked (or copied, on a different filesystem) rather than symlinked, so that
+        // onnxruntime's external data path validation sees them inside the model directory.
         assertTrue(Files.exists(modelPath));
-        assertTrue(Files.isSymbolicLink(modelPath));
+        assertFalse(Files.isSymbolicLink(modelPath));
+        assertTrue(Files.isRegularFile(modelPath));
         assertEquals("add_with_external_data.onnx", modelPath.getFileName().toString());
 
         var parentDir = modelPath.getParent();
-        assertTrue(Files.exists(parentDir.resolve("external_data.bin")));
-        assertTrue(Files.isSymbolicLink(parentDir.resolve("external_data.bin")));
+        var linkedDataFile = parentDir.resolve("external_data.bin");
+        assertTrue(Files.exists(linkedDataFile));
+        assertFalse(Files.isSymbolicLink(linkedDataFile));
+        assertTrue(Files.isRegularFile(linkedDataFile));
 
         verify(modelPathHelper, times(1)).getModelPathResolvingIfNecessary(externalDataFileRef);
     }
@@ -66,9 +72,14 @@ class OnnxExternalDataResolverTest {
 
         var tempDir = OnnxExternalDataResolver.createDirectoryWithExternalDataFiles(model, externalDataFiles);
 
-        assertTrue(Files.exists(tempDir.resolve("add_with_external_data.onnx")));
-        assertTrue(Files.isSymbolicLink(tempDir.resolve("add_with_external_data.onnx")));
-        assertTrue(Files.exists(tempDir.resolve("external_files/external_data.bin")));
-        assertTrue(Files.isSymbolicLink(tempDir.resolve("external_files/external_data.bin")));
+        var linkedModel = tempDir.resolve("add_with_external_data.onnx");
+        assertTrue(Files.exists(linkedModel));
+        assertFalse(Files.isSymbolicLink(linkedModel));
+        assertTrue(Files.isRegularFile(linkedModel));
+
+        var linkedDataFile = tempDir.resolve("external_files/external_data.bin");
+        assertTrue(Files.exists(linkedDataFile));
+        assertFalse(Files.isSymbolicLink(linkedDataFile));
+        assertTrue(Files.isRegularFile(linkedDataFile));
     }
 }

--- a/model-integration/src/test/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolverTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolverTest.java
@@ -7,9 +7,11 @@ import com.yahoo.config.UrlReference;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 
@@ -47,21 +49,24 @@ class OnnxExternalDataResolverTest {
 
         var resolver = new OnnxExternalDataResolver(modelPathHelper);
         var modelPath = resolver.resolveOnnxModel(modelRef);
+        var tempDir = modelPath.getParent();
+        try {
+            // Files are hard-linked (or copied, on a different filesystem) rather than symlinked, so that
+            // onnxruntime's external data path validation sees them inside the model directory.
+            assertTrue(Files.exists(modelPath));
+            assertFalse(Files.isSymbolicLink(modelPath));
+            assertTrue(Files.isRegularFile(modelPath));
+            assertEquals("add_with_external_data.onnx", modelPath.getFileName().toString());
 
-        // Files are hard-linked (or copied, on a different filesystem) rather than symlinked, so that
-        // onnxruntime's external data path validation sees them inside the model directory.
-        assertTrue(Files.exists(modelPath));
-        assertFalse(Files.isSymbolicLink(modelPath));
-        assertTrue(Files.isRegularFile(modelPath));
-        assertEquals("add_with_external_data.onnx", modelPath.getFileName().toString());
+            var linkedDataFile = tempDir.resolve("external_data.bin");
+            assertTrue(Files.exists(linkedDataFile));
+            assertFalse(Files.isSymbolicLink(linkedDataFile));
+            assertTrue(Files.isRegularFile(linkedDataFile));
 
-        var parentDir = modelPath.getParent();
-        var linkedDataFile = parentDir.resolve("external_data.bin");
-        assertTrue(Files.exists(linkedDataFile));
-        assertFalse(Files.isSymbolicLink(linkedDataFile));
-        assertTrue(Files.isRegularFile(linkedDataFile));
-
-        verify(modelPathHelper, times(1)).getModelPathResolvingIfNecessary(externalDataFileRef);
+            verify(modelPathHelper, times(1)).getModelPathResolvingIfNecessary(externalDataFileRef);
+        } finally {
+            deleteRecursively(tempDir);
+        }
     }
 
     @Test
@@ -71,15 +76,31 @@ class OnnxExternalDataResolverTest {
         var externalDataFiles = Map.of(Path.of("external_files/external_data.bin"), externalDataFile);
 
         var tempDir = OnnxExternalDataResolver.createDirectoryWithExternalDataFiles(model, externalDataFiles);
+        try {
+            var linkedModel = tempDir.resolve("add_with_external_data.onnx");
+            assertTrue(Files.exists(linkedModel));
+            assertFalse(Files.isSymbolicLink(linkedModel));
+            assertTrue(Files.isRegularFile(linkedModel));
 
-        var linkedModel = tempDir.resolve("add_with_external_data.onnx");
-        assertTrue(Files.exists(linkedModel));
-        assertFalse(Files.isSymbolicLink(linkedModel));
-        assertTrue(Files.isRegularFile(linkedModel));
+            var linkedDataFile = tempDir.resolve("external_files/external_data.bin");
+            assertTrue(Files.exists(linkedDataFile));
+            assertFalse(Files.isSymbolicLink(linkedDataFile));
+            assertTrue(Files.isRegularFile(linkedDataFile));
+        } finally {
+            deleteRecursively(tempDir);
+        }
+    }
 
-        var linkedDataFile = tempDir.resolve("external_files/external_data.bin");
-        assertTrue(Files.exists(linkedDataFile));
-        assertFalse(Files.isSymbolicLink(linkedDataFile));
-        assertTrue(Files.isRegularFile(linkedDataFile));
+    private static void deleteRecursively(Path dir) throws IOException {
+        if (dir == null || !Files.exists(dir)) return;
+        try (var paths = Files.walk(dir)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
     }
 }

--- a/model-integration/src/test/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolverTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/utils/OnnxExternalDataResolverTest.java
@@ -50,6 +50,8 @@ class OnnxExternalDataResolverTest {
         var resolver = new OnnxExternalDataResolver(modelPathHelper);
         var modelPath = resolver.resolveOnnxModel(modelRef);
         var tempDir = modelPath.getParent();
+        // Guard against accidentally deleting the source tree if resolveOnnxModel ever falls back to the local path.
+        assertTrue(tempDir.getFileName().toString().startsWith("onnx-model-"));
         try {
             // Files are hard-linked (or copied, on a different filesystem) rather than symlinked, so that
             // onnxruntime's external data path validation sees them inside the model directory.
@@ -92,7 +94,8 @@ class OnnxExternalDataResolverTest {
     }
 
     private static void deleteRecursively(Path dir) throws IOException {
-        if (dir == null || !Files.exists(dir)) return;
+        // Only ever delete a generated temp directory, never the checked-in source tree.
+        if (dir == null || !dir.getFileName().toString().startsWith("onnx-model-") || !Files.exists(dir)) return;
         try (var paths = Files.walk(dir)) {
             paths.sorted(Comparator.reverseOrder()).forEach(p -> {
                 try {


### PR DESCRIPTION
onnxruntime >= 1.24 validates that external data paths resolve (via weakly_canonical, which follows symlinks) to a location contained within the model directory, and there is no flag to disable this. Symlinking the downloaded model and its external data files - which live in separate per-URL download directories - made the resolved paths escape the model directory and fail with ORT_FAIL "External data path validation failed".

Hard links have no symlink for weakly_canonical to follow, so they resolve to their own path inside the temporary model directory and pass validation, without copying the (potentially multi-GB) data files. Fall back to a plain copy when hard linking is not possible (e.g. across filesystems).
