### PR TITLE
Allow some undefined symbols when creating vespalib shared library.

### DIFF
--- a/vespalib/src/vespa/vespalib/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/CMakeLists.txt
@@ -62,3 +62,6 @@ vespa_add_library(vespalib
 
 vespa_add_target_package_dependency(vespalib OpenSSL)
 vespa_add_target_package_dependency(vespalib RE2)
+if (APPLE)
+    target_link_options(vespalib PRIVATE "-Wl,-U,_vespamalloc_dump_info,-U,_mi_stats_print_out")
+endif()


### PR DESCRIPTION
This tracks changes from #37175
