### PR TITLE
Drop unneeded vespaclient-container-plugin dependency

### DIFF
--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -142,7 +142,6 @@
                                         <include>com.yahoo.vespa:searchsummary:*:test</include>
                                         <include>com.yahoo.vespa:standalone-container:*:test</include>
                                         <include>com.yahoo.vespa:storage:*:test</include>
-                                        <include>com.yahoo.vespa:vespaclient-container-plugin:*:test</include>
                                         <include>com.yahoo.vespa:vespaclient-core:*:test</include>
                                         <include>com.yahoo.vespa:vsm:*:test</include>
 

--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -39,12 +39,6 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
-    <dependency>
-      <!-- Not sure if this is needed, added after removing it from 'container' to ensure unchanged test classpath-->
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespaclient-container-plugin</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- All dependencies that should be visible in test classpath, but not compile classpath,
          for user projects must be added in compile scope here. These dependencies are explicitly excluded


### PR DESCRIPTION
This test dependency was added to container-test in 2023 (commit 39a774d8f35) as a precaution when the plugin stopped being provided via 'container', to keep the test classpath unchanged -- with a comment that it was unclear whether it was actually needed.  Nothing should use the plugin from the test classpath. Remove it, and correspondingly drop it from the allowed test-classpath includes.
