### PR TITLE
Bump and manage low-level transitive maven dependencies

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -72,6 +72,7 @@
         <bouncycastle.vespa.version>1.84</bouncycastle.vespa.version>
         <byte-buddy.vespa.version>1.18.10</byte-buddy.vespa.version>
         <checker-qual.vespa.version>3.38.0</checker-qual.vespa.version>
+        <classworlds-classworlds.vespa.version>1.1</classworlds-classworlds.vespa.version>
         <commons-beanutils.vespa.version>1.9.4</commons-beanutils.vespa.version>
         <commons-codec.vespa.version>1.22.0</commons-codec.vespa.version>
         <commons-collections.vespa.version>3.2.2</commons-collections.vespa.version>
@@ -142,6 +143,7 @@
         <at.yawk.lz4.vespa.version>1.11.0</at.yawk.lz4.vespa.version>
         <prometheus.client.vespa.version>0.16.0</prometheus.client.vespa.version>
         <plexus-archiver.vespa.version>4.12.0</plexus-archiver.vespa.version>
+        <plexus-component-annotations.vespa.version>2.2.0</plexus-component-annotations.vespa.version>
         <plexus-interpolation.vespa.version>1.29</plexus-interpolation.vespa.version>
         <plexus-io.vespa.version>3.6.0</plexus-io.vespa.version>
         <plexus-utils.vespa.version>4.0.3</plexus-utils.vespa.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -615,6 +615,11 @@
                 <version>${huggingface.vespa.version}</version>
             </dependency>
             <dependency>
+                <groupId>classworlds</groupId>
+                <artifactId>classworlds</artifactId>
+                <version>${classworlds-classworlds.vespa.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.dev-smart</groupId>
                 <artifactId>ubjson</artifactId>
                 <version>${dev-smart-ubjson.vespa.version}</version>
@@ -1214,6 +1219,11 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-classworlds</artifactId>
                 <version>${plexus-classworlds.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-annotations</artifactId>
+                <version>${plexus-component-annotations.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -5,7 +5,7 @@ ai.djl:api:${huggingface.vespa.version}
 aopalliance:aopalliance:${aopalliance.vespa.version}
 at.yawk.lz4:lz4-java:${at.yawk.lz4.vespa.version}
 backport-util-concurrent:backport-util-concurrent:3.1
-classworlds:classworlds:1.1-alpha-2
+classworlds:classworlds:${classworlds-classworlds.vespa.version}
 com.dev-smart:ubjson:${dev-smart-ubjson.vespa.version}
 com.ethlo.time:itu:1.14.0
 com.fasterxml.jackson.core:jackson-annotations:${jackson-annotations.vespa.version}
@@ -161,7 +161,7 @@ org.bouncycastle:bcprov-jdk18on:${bouncycastle.vespa.version}
 org.bouncycastle:bcutil-jdk18on:${bouncycastle.vespa.version}
 org.codehaus.plexus:plexus-archiver:${plexus-archiver.vespa.version}
 org.codehaus.plexus:plexus-classworlds:${plexus-classworlds.vespa.version}
-org.codehaus.plexus:plexus-component-annotations:2.1.0
+org.codehaus.plexus:plexus-component-annotations:${plexus-component-annotations.vespa.version}
 org.codehaus.plexus:plexus-container-default:1.0-alpha-9-stable-1
 org.codehaus.plexus:plexus-interpolation:${plexus-interpolation.vespa.version}
 org.codehaus.plexus:plexus-io:${plexus-io.vespa.version}


### PR DESCRIPTION
These two low-level dependencies (pulled in transitively, e.g. via the plexus/maven tooling stack) were previously pinned to hardcoded versions directly in the enforcer allowlist. Move them under managed version properties so they are declared and bumped in one place like the rest of our dependencies, and update the enforcer allowlist to reference the properties.

While doing so, bump the versions:
  - classworlds:classworlds  1.1-alpha-2 -> 1.1 (use the released version instead of an alpha)
  - org.codehaus.plexus:plexus-component-annotations  2.1.0 -> 2.2.0
