### PR TITLE
Consolidate Kotlin dependencies to a single managed version

### DIFF
--- a/cloud/hosted-tenant-base/pom.xml
+++ b/cloud/hosted-tenant-base/pom.xml
@@ -156,7 +156,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
-                <version>1.9.25</version>
+                <version>${kotlin-stdlib-common.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/cloud/hosted-tenant-base/pom.xml
+++ b/cloud/hosted-tenant-base/pom.xml
@@ -141,6 +141,34 @@
                 <artifactId>hamcrest-core</artifactId>
                 <version>${hamcrest.vespa.version}</version>
             </dependency>
+
+            <!-- Transitive dependencies of openai-java -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>${kotlin.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>1.9.25</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk7</artifactId>
+                <version>${kotlin.vespa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${kotlin.vespa.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -212,7 +212,7 @@
                                         <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-reflect:${kotlin.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-stdlib:${kotlin.vespa.version}:test</include>
-                                        <include>org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin.vespa.version}:test</include>
+                                        <include>org.jetbrains.kotlin:kotlin-stdlib-common:1.9.25:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin.vespa.version}:test</include>
                                         <include>org.jspecify:jspecify:1.0.0:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -212,7 +212,7 @@
                                         <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-reflect:${kotlin.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-stdlib:${kotlin.vespa.version}:test</include>
-                                        <include>org.jetbrains.kotlin:kotlin-stdlib-common:1.9.25:test</include>
+                                        <include>org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin-stdlib-common.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin.vespa.version}:test</include>
                                         <include>org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin.vespa.version}:test</include>
                                         <include>org.jspecify:jspecify:1.0.0:test</include>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -118,7 +118,8 @@
         <junit.platform.vespa.version>1.10.2</junit.platform.vespa.version>
         <junit4.vespa.version>4.13.2</junit4.vespa.version>
         <jllama.vespa.version>4.7.10</jllama.vespa.version>
-        <kotlin.vespa.version>1.9.25</kotlin.vespa.version>
+        <kotlin.vespa.version>2.1.21</kotlin.vespa.version>
+        <kotlin-stdlib-common.vespa.version>1.9.25</kotlin-stdlib-common.vespa.version>
         <luben.zstd.vespa.version>1.5.7-9</luben.zstd.vespa.version>
         <lucene.vespa.version>9.12.3</lucene.vespa.version>
         <maven-archiver.vespa.version>3.6.6</maven-archiver.vespa.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1398,7 +1398,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${kotlin.vespa.version}</version>
+                <version>${kotlin-stdlib-common.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -190,15 +190,10 @@ org.hamcrest:hamcrest-core:${hamcrest.vespa.version}
 org.hamcrest:hamcrest:${hamcrest.vespa.version}
 org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}
 org.jetbrains.kotlin:kotlin-reflect:${kotlin.vespa.version}
-org.jetbrains.kotlin:kotlin-reflect:2.1.21
-org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin.vespa.version}
-org.jetbrains.kotlin:kotlin-stdlib-common:1.8.0
+org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin-stdlib-common.vespa.version}
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin.vespa.version}
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin.vespa.version}
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0
 org.jetbrains.kotlin:kotlin-stdlib:${kotlin.vespa.version}
-org.jetbrains.kotlin:kotlin-stdlib:1.8.0
 org.jetbrains:annotations:17.0.0
 org.json:json:${org.json.vespa.version}
 org.jspecify:jspecify:1.0.0


### PR DESCRIPTION
Adding openai-java pulled in jackson-module-kotlin, which depends on kotlin-reflect 2.1.21, so the build ended up with several Kotlin versions (1.8.0, 1.9.25 and 2.1.21) on the dependency tree and in the enforcer allowlist.

Bump kotlin.vespa.version to 2.1.21 so all Kotlin artifacts are managed at one version. The exception is kotlin-stdlib-common, which is not published for major version 2, so keep it at 1.9.25 via a separate kotlin-stdlib-common.vespa.version property.

Also add dependency management for the openai-java transitive Kotlin artifacts in hosted-tenant-base, and prune the now-redundant Kotlin version entries from the dependency enforcer allowlist.
