### PR TITLE
Revert "Upgrade protobuf-java from 3.25.9 to 4.35.1 (major version bump)"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -148,7 +148,7 @@
         <plexus-xml.vespa.version>4.1.1</plexus-xml.vespa.version>
         <plexus-classworlds.vespa.version>2.12.0</plexus-classworlds.vespa.version>
         <proto-google-common-protos.vespa.version>2.71.0</proto-google-common-protos.vespa.version>
-        <protobuf.vespa.version>4.35.1</protobuf.vespa.version>
+        <protobuf.vespa.version>3.25.9</protobuf.vespa.version>
         <questdb.vespa.version>7.4.2</questdb.vespa.version>
         <re2j.vespa.version>1.8</re2j.vespa.version>
         <reactor-core.vespa.version>3.8.5</reactor-core.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#37225

if integration tests still hang mysteriously, let's try reverting this one