### PR TITLE
Import netty-bom for consistent netty versions

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -131,7 +131,7 @@
         <mockito.vespa.version>5.23.0</mockito.vespa.version>
         <mojo-executor.vespa.version>2.4.1</mojo-executor.vespa.version>
         <netty.vespa.version>4.2.15.Final</netty.vespa.version>
-        <netty-tcnative.vespa.version>2.0.78.Final</netty-tcnative.vespa.version>
+        <netty-tcnative.vespa.version>2.0.77.Final</netty-tcnative.vespa.version>
         <okhttp.vespa.version>4.12.0</okhttp.vespa.version>
         <onnxruntime.vespa.version>1.26.0</onnxruntime.vespa.version>
         <openai-java.vespa.version>1.6.1</openai-java.vespa.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -798,6 +798,13 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.vespa.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject-api</artifactId>
                 <version>${jakarta.inject.vespa.version}</version>


### PR DESCRIPTION
Add io.netty:netty-bom (at ${netty.vespa.version}) as an imported BOM in the parent dependencyManagement. The BOM centrally pins all netty artifacts, including the netty-tcnative version that the netty release was built and tested against, so we no longer risk mixing a netty-tcnative release that doesn't match our netty version.

Align netty-tcnative.vespa.version with the version declared by the BOM (2.0.77.Final instead of 2.0.78.Final) so the property reflects what is actually resolved.
