### PR TITLE
Add dot product computation between two quantized vectors

### DIFF
--- a/vespalib/src/tests/quant/eden_quantizer_test.cpp
+++ b/vespalib/src/tests/quant/eden_quantizer_test.cpp
@@ -3,10 +3,12 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/quant/eden.h>
+#include <vespa/vespalib/util/xoshiro.h>
 
 #include <gmock/gmock.h>
 
 #include <cmath>
+#include <random>
 #include <ranges>
 #include <span>
 #include <vector>
@@ -35,6 +37,16 @@ namespace {
         l2 += c * c;
     }
     return std::sqrtf(l2);
+}
+
+// Simple non-vectorized dot product (sanity check vs. vectorized functions)
+[[nodiscard]] float dot(std::span<const float> a, std::span<const float> b) noexcept {
+    assert(a.size() == b.size());
+    float d = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        d += a[i] * b[i];
+    }
+    return d;
 }
 
 void normalize(std::span<float> v) noexcept {
@@ -209,6 +221,7 @@ TEST(EdenQuantizerTest, zero_norm_vector_emits_zero_scale_and_quantization_index
     EXPECT_THAT(v_dq, Each(Eq(0.0f)));
 }
 
+// TODO extend this test to all bit widths
 TEST(EdenQuantizerTest, can_compute_dot_product_with_pre_rotated_vector) {
     EdenQuantizer        q(16, 4, 0xbeefd00d);
     std::vector<uint8_t> v_q(q.quantized_size());
@@ -233,6 +246,69 @@ TEST(EdenQuantizerTest, can_compute_dot_product_with_pre_rotated_vector) {
         c = -c;
     }
     EXPECT_THAT(q.pre_rotated_query_dot_product(q_rot, v_q), FloatEq(-1));
+}
+
+namespace {
+
+template <std::uniform_random_bit_generator Rng>
+void fill_random(std::span<float> v, Rng& rng) noexcept {
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::ranges::generate(v, [&]() mutable { return dist(rng); });
+}
+
+void do_test_quantized_vectors_dot_product(const size_t dimensions, const uint8_t bits) {
+    Xoshiro256PlusPlusPrng prng(0x123456789abcdef); // Fixed seed due to floating point testing
+    EdenQuantizer          q(dimensions, bits, prng());
+
+    std::vector<float>   lhs(dimensions), lhs_dq(dimensions);
+    std::vector<float>   rhs(dimensions), rhs_dq(dimensions);
+    std::vector<uint8_t> lhs_q(q.quantized_size());
+    std::vector<uint8_t> rhs_q(q.quantized_size());
+
+    const size_t rounds = 100;
+    for (size_t i = 0; i < rounds; ++i) {
+        fill_random(lhs, prng);
+        fill_random(rhs, prng);
+
+        q.quantize(lhs, lhs_q, QuantMode::InnerProduct);
+        q.quantize(rhs, rhs_q, QuantMode::InnerProduct);
+        q.dequantize(lhs_q, lhs_dq);
+        q.dequantize(rhs_q, rhs_dq);
+
+        // The dot products between the _dequantized_ representations of the vectors and the dot
+        // products between the _quantized_ representations should be very close. There is some
+        // added rounding error due to dequantization requiring a rotation step, as well as any
+        // differences in dot product vectorization. This error is independent of the bit width
+        // used since rotation/dot product happens on values from the centroid codebook, and
+        // these have the same, higher floating point precision.
+        const float real_q_dot = dot(lhs_dq, rhs_dq);
+        const float q_dot = q.quantized_lhs_rhs_dot_product(lhs_q, rhs_q);
+        ASSERT_THAT(q_dot, FloatNear(real_q_dot, 0.00001));
+    }
+}
+
+void do_test_quantized_vectors_dot_product(const uint8_t bits) {
+    for (size_t dims : {1, 2, 3, 15, 16, 17, 64, 127, 128, 129}) {
+        ASSERT_NO_FATAL_FAILURE(do_test_quantized_vectors_dot_product(dims, bits));
+    }
+}
+
+} // namespace
+
+TEST(EdenQuantizerTest, can_compute_dot_product_between_quantized_vectors_1_bit) {
+    do_test_quantized_vectors_dot_product(1);
+}
+
+TEST(EdenQuantizerTest, can_compute_dot_product_between_quantized_vectors_2_bits) {
+    do_test_quantized_vectors_dot_product(2);
+}
+
+TEST(EdenQuantizerTest, can_compute_dot_product_between_quantized_vectors_3_bits) {
+    do_test_quantized_vectors_dot_product(3);
+}
+
+TEST(EdenQuantizerTest, can_compute_dot_product_between_quantized_vectors_4_bits) {
+    do_test_quantized_vectors_dot_product(4);
 }
 
 } // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -29,6 +29,13 @@ namespace {
     return scale_bytes + dim_bytes;
 }
 
+// Precondition: buf must be valid for at least sizeof(float) bytes
+[[nodiscard]] float extract_scale_factor(const uint8_t* buf) noexcept {
+    float scale;
+    memcpy(&scale, buf, sizeof(float));
+    return scale;
+}
+
 } // namespace
 
 EdenQuantizer::EdenQuantizer(const size_t dimensions, const uint8_t bits, const uint64_t seed)
@@ -36,7 +43,7 @@ EdenQuantizer::EdenQuantizer(const size_t dimensions, const uint8_t bits, const 
       _quantized_size(compute_quantized_buffer_size(dimensions, bits)),
       _rotator(dimensions, seed),
       _rot_tmp(dimensions),
-      _idx_tmp(dimensions),
+      _idx_tmp(dimensions * 2), // also leave room for rhs bit unpacking storage
       _seed(seed),
       _sqrt_d(std::sqrtf(static_cast<float>(dimensions))),
       _bits(bits) {
@@ -124,8 +131,7 @@ void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, c
 void EdenQuantizer::dequantize(std::span<const uint8_t> q_x, std::span<float> dq_x) noexcept {
     assert(q_x.size() == _quantized_size);
     assert(dq_x.size() == _dimensions);
-    float scale;
-    memcpy(&scale, q_x.data(), sizeof(float));
+    const float scale = extract_scale_factor(q_x.data());
     with_packer_for_bit_count(_bits, [&](auto bp) {
         const uint8_t* in_bits = q_x.data() + sizeof(float);
         decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
@@ -146,8 +152,7 @@ float EdenQuantizer::pre_rotated_query_dot_product(std::span<const float>   quer
                                                    std::span<const uint8_t> quant_vec) noexcept {
     assert(query.size() == _dimensions);
     assert(quant_vec.size() == _quantized_size);
-    float scale;
-    memcpy(&scale, quant_vec.data(), sizeof(float));
+    const float scale = extract_scale_factor(quant_vec.data());
     with_packer_for_bit_count(_bits, [&](auto bp) {
         const uint8_t* in_bits = quant_vec.data() + sizeof(float);
         decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
@@ -161,6 +166,28 @@ float EdenQuantizer::pre_rotated_query_dot_product(std::span<const float>   quer
         return query[idx] * codebook[_idx_tmp[idx]];
     });
     // clang-format on
+}
+
+float EdenQuantizer::quantized_lhs_rhs_dot_product(std::span<const uint8_t> lhs,
+                                                   std::span<const uint8_t> rhs) noexcept {
+    assert(lhs.size() == _quantized_size);
+    assert(rhs.size() == _quantized_size);
+    // We have left room for an additional vector bit unpacking run in _idx_tmp
+    uint8_t* lhs_idx = _idx_tmp.data();
+    uint8_t* rhs_idx = _idx_tmp.data() + _dimensions;
+    with_packer_for_bit_count(_bits, [&](auto bp) {
+        decltype(bp)::unpack(lhs_idx, lhs.data() + sizeof(float), _dimensions);
+        decltype(bp)::unpack(rhs_idx, rhs.data() + sizeof(float), _dimensions);
+    });
+    const auto codebook = my_codebook();
+    // clang-format off: lambda formatting
+    const float dot = sum_indexed_unrolled<8, float>(_dimensions, [&](size_t idx) noexcept {
+        return codebook[lhs_idx[idx]] * codebook[rhs_idx[idx]];
+    });
+    // clang-format on
+    const float lhs_scale = extract_scale_factor(lhs.data());
+    const float rhs_scale = extract_scale_factor(rhs.data());
+    return lhs_scale * rhs_scale * dot;
 }
 
 } // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/eden.h
+++ b/vespalib/src/vespa/vespalib/quant/eden.h
@@ -144,6 +144,25 @@ public:
      */
     [[nodiscard]] float pre_rotated_query_dot_product(std::span<const float>   query,
                                                       std::span<const uint8_t> quant_vec) noexcept;
+
+    /*
+     * Computes the dot product between two quantized vectors that were both quantized
+     * using the (logically) same quantizer as `this`. This is more efficient than
+     * explicitly dequantizing the vectors (and then running a float32 dot product) since
+     * it does not involve any rotations.
+     *
+     * Only makes sense if `lhs` and `rhs` were originally both quantized with
+     * `QuantMode::InnerProduct`.
+     *
+     * Preconditions:
+     *  - lhs.size() == quantized_size()
+     *  - rhs.size() == quantized_size()
+     *
+     * TODO with a vectorized "just in time" bit unpacking that doesn't need a temporary
+     *  buffer we could make this const...
+     */
+    [[nodiscard]] float quantized_lhs_rhs_dot_product(std::span<const uint8_t> lhs,
+                                                      std::span<const uint8_t> rhs) noexcept;
 };
 
 } // namespace vespalib::quant


### PR DESCRIPTION
@havardpe please review

This is more efficient than explicitly dequantizing the vectors (and then running a float32 dot product) since it does not involve any inverse rotations. Vectors must have been quantized using the _logically_ same quantizer and using `InnerProduct` mode for the output to make sense.

Same `const`-ness/thread-safety caveats apply as other quantizer functions due to the current need for scratch space for unpacking of bits.

