### PR TITLE
Add OpenTelemetry API to the in-process container test classpath - MERGEOK

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -151,7 +151,10 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>testutil</artifactId>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -219,6 +219,9 @@
                                         <include>org.json:json:${org.json.vespa.version}:test</include> <!-- TODO: Remove on Vespa 9 -->
                                         <include>at.yawk.lz4:lz4-java:${at.yawk.lz4.vespa.version}:test</include>
                                         <include>xerces:xercesImpl:${xerces.vespa.version}:test</include>
+                                        <include>io.opentelemetry:opentelemetry-api:jar:${opentelemetry.vespa.version}:test</include>
+                                        <include>io.opentelemetry:opentelemetry-common:jar:${opentelemetry.vespa.version}:test</include>
+                                        <include>io.opentelemetry:opentelemetry-context:jar:${opentelemetry.vespa.version}:test</include>
                                     </allowed>
                                 </enforceDependencies>
                             </rules>


### PR DESCRIPTION
## Problem

`OpenTelemetryProvider` (`implements Provider<OpenTelemetry>`) is registered in **every** container's component graph. Building any in-process container graph (e.g. via `com.yahoo.application.Application`, used by sample-app and tenant tests) makes `ComponentGraph` reflect the provider's generic interface — `ComponentNode.componentType()` → `Class.getGenericInterfaces()` — which must load `io.opentelemetry.api.OpenTelemetry`.

The API was added to `container-dev` (so vespa's own in-process tests pass) but **not** to the user-facing in-process test framework, the `application` module. So tenant / sample-app tests that boot a container fail:

```
TypeNotPresentException: Type io.opentelemetry.api.OpenTelemetry not present
Caused by: ClassNotFoundException: io.opentelemetry.api.OpenTelemetry
```

(In a real deployment the `container-opentelemetry` pre-installed bundle supplies the API via OSGi; the flat in-process test classpath has no such mechanism.)

## Fix

- `application/pom.xml`: add `opentelemetry-api` to the test-visible dependencies (it transitively brings `-context` and `-common`).
- `container-dependencies-enforcer/pom.xml`: allow `opentelemetry-api`/`-common`/`-context` at `test` scope.

The enforcer allow-list is kept **in sync** with the cloud and hosted tenant-base dependency enforcers (the poms note this requirement). Those companion PRs are listed below and should merge together with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs (merge together)
- vespa: https://github.com/vespa-engine/vespa/pull/37251
- cloud: https://github.com/vespaai/cloud/pull/3151
- hosted (yahoo-vespa-yahoo): https://github.com/vespaai/yahoo-vespa-yahoo/pull/815