### PR TITLE
metrics-proxy: add osVersion to the alive metric via a config-driven host-dimension mapping

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -203,8 +203,7 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         if (isHostedVespa()) {
             builder.defaultDimension(PublicDimensions.HOSTNAME);
             builder.defaultDimension(PublicDimensions.PARENT_HOSTNAME);
-            builder.mapping(new MetricDimensionMappingConfig.Mapping.Builder()
-                    .service(HOST_LIFE_SERVICE)
+            builder.service(HOST_LIFE_SERVICE, s -> s
                     .dimension(PublicDimensions.HOSTNAME)
                     .dimension(PublicDimensions.PARENT_HOSTNAME)
                     .dimension(PublicDimensions.OS_VERSION));

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -17,6 +17,8 @@ import ai.vespa.metricsproxy.http.yamas.YamasHandler;
 import ai.vespa.metricsproxy.metric.ExternalMetrics;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMapping;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMappingConfig;
 import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import ai.vespa.metricsproxy.rpc.RpcServer;
 import ai.vespa.metricsproxy.service.ConfigSentinelClient;
@@ -65,6 +67,7 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerClus
  */
 public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyContainer> implements
         ApplicationDimensionsConfig.Producer,
+        MetricDimensionMappingConfig.Producer,
         ConsumersConfig.Producer,
         MonitoringConfig.Producer,
         MetricsNodesConfig.Producer
@@ -72,6 +75,9 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
     public static final Logger log = Logger.getLogger(MetricsProxyContainerCluster.class.getName());
 
     public static final String NEW_DEFAULT_CONSUMER_ID = "new-default";
+
+    // The service/application name of the locally generated 'alive' packet; see HostLifeGatherer.
+    private static final String HOST_LIFE_SERVICE = "host_life";
 
     private static final String METRICS_PROXY_NAME = "metrics-proxy";
 
@@ -120,6 +126,7 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         addMetricsProxyComponent(ApplicationDimensions.class);
         addMetricsProxyComponent(ConfigSentinelClient.class);
         addMetricsProxyComponent(ExternalMetrics.class);
+        addMetricsProxyComponent(MetricDimensionMapping.class);
         addMetricsProxyComponent(MetricsConsumers.class);
         addMetricsProxyComponent(MetricsManager.class);
         addMetricsProxyComponent(RpcServer.class);
@@ -188,6 +195,19 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
     public void getConfig(ApplicationDimensionsConfig.Builder builder) {
         if (isHostedVespa()) {
             builder.dimensions(applicationDimensions());
+        }
+    }
+
+    @Override
+    public void getConfig(MetricDimensionMappingConfig.Builder builder) {
+        if (isHostedVespa()) {
+            builder.defaultDimension(PublicDimensions.HOSTNAME);
+            builder.defaultDimension(PublicDimensions.PARENT_HOSTNAME);
+            builder.mapping(new MetricDimensionMappingConfig.Mapping.Builder()
+                    .service(HOST_LIFE_SERVICE)
+                    .dimension(PublicDimensions.HOSTNAME)
+                    .dimension(PublicDimensions.PARENT_HOSTNAME)
+                    .dimension(PublicDimensions.OS_VERSION));
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -7,6 +7,7 @@ import ai.vespa.metricsproxy.http.metrics.MetricsV1Handler;
 import ai.vespa.metricsproxy.http.prometheus.PrometheusHandler;
 import ai.vespa.metricsproxy.http.yamas.YamasHandler;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMappingConfig;
 import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -37,6 +39,7 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.M
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getApplicationDimensionsConfig;
+import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getMetricDimensionMappingConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getMetricsNodesConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getModel;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.servicesWithAdminOnly;
@@ -106,6 +109,28 @@ public class MetricsProxyContainerClusterTest {
         assertEquals(MY_INSTANCE, config.dimensions(AppDimensionNames.INSTANCE));
         assertEquals(MY_TENANT + "." + MY_APPLICATION + "." + MY_INSTANCE, config.dimensions(PublicDimensions.APPLICATION_ID));
         assertEquals(MY_APPLICATION + "." + MY_INSTANCE, config.dimensions(AppDimensionNames.LEGACY_APPLICATION));
+    }
+
+    @Test
+    void hosted_application_propagates_metric_dimension_mapping() {
+        VespaModel hostedModel = getModel(servicesWithAdminOnly(), hosted);
+        MetricDimensionMappingConfig config = getMetricDimensionMappingConfig(hostedModel);
+
+        assertEquals(List.of(PublicDimensions.HOSTNAME, PublicDimensions.PARENT_HOSTNAME), config.defaultDimension());
+
+        assertEquals(1, config.mapping().size());
+        MetricDimensionMappingConfig.Mapping mapping = config.mapping().get(0);
+        assertEquals("host_life", mapping.service());
+        assertEquals(List.of(PublicDimensions.HOSTNAME, PublicDimensions.PARENT_HOSTNAME, PublicDimensions.OS_VERSION),
+                     mapping.dimension());
+    }
+
+    @Test
+    void self_hosted_application_has_empty_metric_dimension_mapping() {
+        VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
+        MetricDimensionMappingConfig config = getMetricDimensionMappingConfig(model);
+        assertTrue(config.defaultDimension().isEmpty());
+        assertTrue(config.mapping().isEmpty());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -118,11 +118,9 @@ public class MetricsProxyContainerClusterTest {
 
         assertEquals(List.of(PublicDimensions.HOSTNAME, PublicDimensions.PARENT_HOSTNAME), config.defaultDimension());
 
-        assertEquals(1, config.mapping().size());
-        MetricDimensionMappingConfig.Mapping mapping = config.mapping().get(0);
-        assertEquals("host_life", mapping.service());
+        assertEquals(Set.of("host_life"), config.service().keySet());
         assertEquals(List.of(PublicDimensions.HOSTNAME, PublicDimensions.PARENT_HOSTNAME, PublicDimensions.OS_VERSION),
-                     mapping.dimension());
+                     config.service("host_life").dimension());
     }
 
     @Test
@@ -130,7 +128,7 @@ public class MetricsProxyContainerClusterTest {
         VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
         MetricDimensionMappingConfig config = getMetricDimensionMappingConfig(model);
         assertTrue(config.defaultDimension().isEmpty());
-        assertTrue(config.mapping().isEmpty());
+        assertTrue(config.service().isEmpty());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
@@ -6,6 +6,7 @@ import ai.vespa.metrics.set.Metric;
 import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.http.application.MetricsNodesConfig;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMappingConfig;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
 import ai.vespa.metricsproxy.rpc.RpcConnectorConfig;
 import ai.vespa.metricsproxy.service.VespaServicesConfig;
@@ -106,6 +107,10 @@ class MetricsProxyModelTester {
 
     static ApplicationDimensionsConfig getApplicationDimensionsConfig(VespaModel model) {
         return model.getConfig(ApplicationDimensionsConfig.class, CLUSTER_CONFIG_ID);
+    }
+
+    static MetricDimensionMappingConfig getMetricDimensionMappingConfig(VespaModel model) {
+        return model.getConfig(MetricDimensionMappingConfig.class, CLUSTER_CONFIG_ID);
     }
 
     static NodeDimensionsConfig getNodeDimensionsConfig(VespaModel model, String configId) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/MetricsManager.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/MetricsManager.java
@@ -7,6 +7,7 @@ import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
+import ai.vespa.metricsproxy.metric.model.ServiceId;
 import ai.vespa.metricsproxy.service.VespaService;
 import ai.vespa.metricsproxy.service.VespaServices;
 
@@ -17,10 +18,12 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static ai.vespa.metricsproxy.metric.ExternalMetrics.extractConfigserverDimensions;
+import static ai.vespa.metricsproxy.metric.ExternalMetrics.extractHostDimensions;
 import static java.util.logging.Level.FINE;
 
 /**
@@ -41,6 +44,7 @@ public class MetricsManager {
     private final NodeDimensions nodeDimensions;
 
     private volatile Map<DimensionId, String> extraDimensions = new HashMap<>();
+    private volatile Map<DimensionId, String> extraHostDimensions = new HashMap<>();
     private volatile Instant externalMetricsUpdateTime = Instant.now();
     private static final Duration EXTERNAL_METRICS_TTL = Duration.ofMinutes(10);
 
@@ -173,12 +177,24 @@ public class MetricsManager {
     public void setExtraMetrics(List<MetricsPacket.Builder> packets) {
         externalMetricsUpdateTime = Instant.now();
         extraDimensions = extractConfigserverDimensions(packets);
+        extraHostDimensions = extractHostDimensions(packets);
         externalMetrics.setExtraMetrics(packets);
     }
 
     public Map<DimensionId, String> getExtraDimensions() {
         purgeStaleMetrics();
         return this.extraDimensions;
+    }
+
+    /** Host-level dimensions (host, parentHostname, osVersion) for the given service, filtered by the metric-to-dimension mapping. */
+    public Map<DimensionId, String> getExtraHostDimensions(ServiceId serviceId) {
+        purgeStaleMetrics();
+        Set<DimensionId> allowed = ExternalMetrics.allowedHostDimensions(serviceId);
+        Map<DimensionId, String> result = new LinkedHashMap<>();
+        extraHostDimensions.forEach((id, value) -> {
+            if (allowed.contains(id)) result.put(id, value);
+        });
+        return result;
     }
 
     private void purgeStaleMetrics() {
@@ -189,6 +205,7 @@ public class MetricsManager {
 
     public void purgeExtraMetrics() {
         extraDimensions = new HashMap<>();
+        extraHostDimensions = new HashMap<>();
         externalMetrics.setExtraMetrics(List.of());
     }
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/MetricsManager.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/MetricsManager.java
@@ -23,7 +23,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static ai.vespa.metricsproxy.metric.ExternalMetrics.extractConfigserverDimensions;
-import static ai.vespa.metricsproxy.metric.ExternalMetrics.extractHostDimensions;
 import static java.util.logging.Level.FINE;
 
 /**
@@ -177,7 +176,7 @@ public class MetricsManager {
     public void setExtraMetrics(List<MetricsPacket.Builder> packets) {
         externalMetricsUpdateTime = Instant.now();
         extraDimensions = extractConfigserverDimensions(packets);
-        extraHostDimensions = extractHostDimensions(packets);
+        extraHostDimensions = externalMetrics.extractHostDimensions(packets);
         externalMetrics.setExtraMetrics(packets);
     }
 
@@ -189,7 +188,7 @@ public class MetricsManager {
     /** Host-level dimensions (host, parentHostname, osVersion) for the given service, filtered by the metric-to-dimension mapping. */
     public Map<DimensionId, String> getExtraHostDimensions(ServiceId serviceId) {
         purgeStaleMetrics();
-        Set<DimensionId> allowed = ExternalMetrics.allowedHostDimensions(serviceId);
+        Set<DimensionId> allowed = externalMetrics.allowedHostDimensions(serviceId);
         Map<DimensionId, String> result = new LinkedHashMap<>();
         extraHostDimensions.forEach((id, value) -> {
             if (allowed.contains(id)) result.put(id, value);

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
@@ -3,6 +3,7 @@ package ai.vespa.metricsproxy.metric;
 
 import ai.vespa.metricsproxy.core.ConfiguredMetric;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
+import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
@@ -37,6 +38,30 @@ public class ExternalMetrics {
     public static final DimensionId ROLE_DIMENSION = toDimensionId("role");
     public static final DimensionId STATE_DIMENSION = toDimensionId("state");
 
+    // Host-level dimensions harvested from host-admin packets, kept separate from the global
+    // {role, state} dimensions above so they can be applied per the metric-to-dimension mapping
+    // rather than globally.
+    public static final DimensionId HOST_DIMENSION = toDimensionId(PublicDimensions.HOSTNAME);
+    public static final DimensionId PARENT_HOSTNAME_DIMENSION = toDimensionId(PublicDimensions.PARENT_HOSTNAME);
+    public static final DimensionId OS_VERSION_DIMENSION = toDimensionId(PublicDimensions.OS_VERSION);
+
+    private static final Set<DimensionId> EXTRA_HOST_DIMENSIONS =
+            Set.of(HOST_DIMENSION, PARENT_HOSTNAME_DIMENSION, OS_VERSION_DIMENSION);
+
+    // Hardcoded metric-to-dimension mapping (chunk E replaces this with config).
+    // Maps a metric packet's serviceId to the host dimensions allowed on it; serviceIds not
+    // listed fall back to DEFAULT_HOST_DIMENSIONS.
+    private static final ServiceId HOST_LIFE_SERVICE_ID = ServiceId.toServiceId("host_life");
+    private static final Map<ServiceId, Set<DimensionId>> HOST_DIMENSIONS_BY_SERVICE =
+            Map.of(HOST_LIFE_SERVICE_ID, EXTRA_HOST_DIMENSIONS);
+    private static final Set<DimensionId> DEFAULT_HOST_DIMENSIONS =
+            Set.of(HOST_DIMENSION, PARENT_HOSTNAME_DIMENSION);
+
+    /** The host dimensions allowed on metrics from the given service (explicit mapping, else default). */
+    public static Set<DimensionId> allowedHostDimensions(ServiceId serviceId) {
+        return HOST_DIMENSIONS_BY_SERVICE.getOrDefault(serviceId, DEFAULT_HOST_DIMENSIONS);
+    }
+
     private volatile List<MetricsPacket.Builder> metrics = new ArrayList<>();
     private final MetricsConsumers consumers;
 
@@ -56,6 +81,7 @@ public class ExternalMetrics {
         externalPackets.forEach(packet -> packet.addConsumers(consumers.getAllConsumers())
                 .retainMetrics(metricsToRetain())
                 .applyOutputNames(outputNamesById()));
+        externalPackets.forEach(ExternalMetrics::stripDisallowedHostDimensions);
         metrics = List.copyOf(externalPackets);
     }
 
@@ -90,6 +116,34 @@ public class ExternalMetrics {
         }
         dimensions.keySet().retainAll(Set.of(ROLE_DIMENSION, STATE_DIMENSION));
         return dimensions;
+    }
+
+    /**
+     * Extracts the host-level dimensions (host, parentHostname, osVersion) from the given packets.
+     * These are harvested separately from {@link #extractConfigserverDimensions} (role, state) so they
+     * can be applied to specific metrics via the metric-to-dimension mapping, rather than globally.
+     * If the same dimension exists in multiple packets, this implementation gives no guarantees
+     * about which value is returned.
+     */
+    public static Map<DimensionId, String> extractHostDimensions(Collection<MetricsPacket.Builder> packets) {
+        Map<DimensionId, String> dimensions = new HashMap<>();
+        for (MetricsPacket.Builder packet : packets) {
+            dimensions.putAll(packet.build().dimensions());
+        }
+        dimensions.keySet().retainAll(EXTRA_HOST_DIMENSIONS);
+        return dimensions;
+    }
+
+    /**
+     * Removes host dimensions not allowed for the packet's service, e.g. strips 'osVersion' from
+     * carrier packets (vespa.node etc.) so it only remains where the mapping allows it (host_life).
+     * Non-host dimensions (role, state, ...) are left untouched.
+     */
+    private static void stripDisallowedHostDimensions(MetricsPacket.Builder packet) {
+        Set<DimensionId> allowed = allowedHostDimensions(packet.getServiceId());
+        Set<DimensionId> retained = packet.getDimensionIds();
+        retained.removeIf(id -> EXTRA_HOST_DIMENSIONS.contains(id) && ! allowed.contains(id));
+        packet.retainDimensions(retained);
     }
 
 }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
@@ -3,7 +3,7 @@ package ai.vespa.metricsproxy.metric;
 
 import ai.vespa.metricsproxy.core.ConfiguredMetric;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
-import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMapping;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
@@ -38,35 +38,18 @@ public class ExternalMetrics {
     public static final DimensionId ROLE_DIMENSION = toDimensionId("role");
     public static final DimensionId STATE_DIMENSION = toDimensionId("state");
 
-    // Host-level dimensions harvested from host-admin packets, kept separate from the global
-    // {role, state} dimensions above so they can be applied per the metric-to-dimension mapping
-    // rather than globally.
-    public static final DimensionId HOST_DIMENSION = toDimensionId(PublicDimensions.HOSTNAME);
-    public static final DimensionId PARENT_HOSTNAME_DIMENSION = toDimensionId(PublicDimensions.PARENT_HOSTNAME);
-    public static final DimensionId OS_VERSION_DIMENSION = toDimensionId(PublicDimensions.OS_VERSION);
-
-    private static final Set<DimensionId> EXTRA_HOST_DIMENSIONS =
-            Set.of(HOST_DIMENSION, PARENT_HOSTNAME_DIMENSION, OS_VERSION_DIMENSION);
-
-    // Hardcoded metric-to-dimension mapping (chunk E replaces this with config).
-    // Maps a metric packet's serviceId to the host dimensions allowed on it; serviceIds not
-    // listed fall back to DEFAULT_HOST_DIMENSIONS.
-    private static final ServiceId HOST_LIFE_SERVICE_ID = ServiceId.toServiceId("host_life");
-    private static final Map<ServiceId, Set<DimensionId>> HOST_DIMENSIONS_BY_SERVICE =
-            Map.of(HOST_LIFE_SERVICE_ID, EXTRA_HOST_DIMENSIONS);
-    private static final Set<DimensionId> DEFAULT_HOST_DIMENSIONS =
-            Set.of(HOST_DIMENSION, PARENT_HOSTNAME_DIMENSION);
-
-    /** The host dimensions allowed on metrics from the given service (explicit mapping, else default). */
-    public static Set<DimensionId> allowedHostDimensions(ServiceId serviceId) {
-        return HOST_DIMENSIONS_BY_SERVICE.getOrDefault(serviceId, DEFAULT_HOST_DIMENSIONS);
-    }
-
     private volatile List<MetricsPacket.Builder> metrics = new ArrayList<>();
     private final MetricsConsumers consumers;
+    private final MetricDimensionMapping dimensionMapping;
 
-    public ExternalMetrics(MetricsConsumers consumers) {
+    public ExternalMetrics(MetricsConsumers consumers, MetricDimensionMapping dimensionMapping) {
         this.consumers = consumers;
+        this.dimensionMapping = dimensionMapping;
+    }
+
+    /** The host dimensions allowed on metrics from the given service (explicit mapping, else default). */
+    public Set<DimensionId> allowedHostDimensions(ServiceId serviceId) {
+        return dimensionMapping.allowedFor(serviceId);
     }
 
     public List<MetricsPacket.Builder> getMetrics() {
@@ -81,7 +64,7 @@ public class ExternalMetrics {
         externalPackets.forEach(packet -> packet.addConsumers(consumers.getAllConsumers())
                 .retainMetrics(metricsToRetain())
                 .applyOutputNames(outputNamesById()));
-        externalPackets.forEach(ExternalMetrics::stripDisallowedHostDimensions);
+        externalPackets.forEach(this::stripDisallowedHostDimensions);
         metrics = List.copyOf(externalPackets);
     }
 
@@ -125,12 +108,12 @@ public class ExternalMetrics {
      * If the same dimension exists in multiple packets, this implementation gives no guarantees
      * about which value is returned.
      */
-    public static Map<DimensionId, String> extractHostDimensions(Collection<MetricsPacket.Builder> packets) {
+    public Map<DimensionId, String> extractHostDimensions(Collection<MetricsPacket.Builder> packets) {
         Map<DimensionId, String> dimensions = new HashMap<>();
         for (MetricsPacket.Builder packet : packets) {
             dimensions.putAll(packet.build().dimensions());
         }
-        dimensions.keySet().retainAll(EXTRA_HOST_DIMENSIONS);
+        dimensions.keySet().retainAll(dimensionMapping.managedDimensions());
         return dimensions;
     }
 
@@ -139,10 +122,11 @@ public class ExternalMetrics {
      * carrier packets (vespa.node etc.) so it only remains where the mapping allows it (host_life).
      * Non-host dimensions (role, state, ...) are left untouched.
      */
-    private static void stripDisallowedHostDimensions(MetricsPacket.Builder packet) {
+    private void stripDisallowedHostDimensions(MetricsPacket.Builder packet) {
         Set<DimensionId> allowed = allowedHostDimensions(packet.getServiceId());
+        Set<DimensionId> managed = dimensionMapping.managedDimensions();
         Set<DimensionId> retained = packet.getDimensionIds();
-        retained.removeIf(id -> EXTRA_HOST_DIMENSIONS.contains(id) && ! allowed.contains(id));
+        retained.removeIf(id -> managed.contains(id) && ! allowed.contains(id));
         packet.retainDimensions(retained);
     }
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMapping.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMapping.java
@@ -1,0 +1,51 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.metricsproxy.metric.dimensions;
+
+import ai.vespa.metricsproxy.metric.model.DimensionId;
+import ai.vespa.metricsproxy.metric.model.ServiceId;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
+import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
+import static java.util.stream.Collectors.toUnmodifiableMap;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+/**
+ * Maps a metric packet's service to the host dimensions allowed on it. Services not explicitly
+ * listed fall back to the default set. Used to harvest host dimensions from external (host-admin)
+ * packets and to keep each such dimension only on the metrics the mapping allows.
+ *
+ * @author onur
+ */
+public class MetricDimensionMapping {
+
+    private final Set<DimensionId> defaultDimensions;
+    private final Map<ServiceId, Set<DimensionId>> dimensionsByService;
+    private final Set<DimensionId> managedDimensions;
+
+    public MetricDimensionMapping(MetricDimensionMappingConfig config) {
+        defaultDimensions = config.defaultDimension().stream()
+                .map(DimensionId::toDimensionId)
+                .collect(toUnmodifiableSet());
+        dimensionsByService = config.mapping().stream().collect(toUnmodifiableMap(
+                mapping -> toServiceId(mapping.service()),
+                mapping -> mapping.dimension().stream().map(DimensionId::toDimensionId).collect(toUnmodifiableSet())));
+        Set<DimensionId> all = new HashSet<>(defaultDimensions);
+        dimensionsByService.values().forEach(all::addAll);
+        managedDimensions = Set.copyOf(all);
+    }
+
+    /** Host dimensions allowed on metrics from the given service (explicit mapping, else default). */
+    public Set<DimensionId> allowedFor(ServiceId serviceId) {
+        return dimensionsByService.getOrDefault(serviceId, defaultDimensions);
+    }
+
+    /** The union of all dimensions the mapping manages; only these are harvested and stripped. */
+    public Set<DimensionId> managedDimensions() {
+        return managedDimensions;
+    }
+
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMapping.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMapping.java
@@ -30,9 +30,9 @@ public class MetricDimensionMapping {
         defaultDimensions = config.defaultDimension().stream()
                 .map(DimensionId::toDimensionId)
                 .collect(toUnmodifiableSet());
-        dimensionsByService = config.mapping().stream().collect(toUnmodifiableMap(
-                mapping -> toServiceId(mapping.service()),
-                mapping -> mapping.dimension().stream().map(DimensionId::toDimensionId).collect(toUnmodifiableSet())));
+        dimensionsByService = config.service().entrySet().stream().collect(toUnmodifiableMap(
+                entry -> toServiceId(entry.getKey()),
+                entry -> entry.getValue().dimension().stream().map(DimensionId::toDimensionId).collect(toUnmodifiableSet())));
         Set<DimensionId> all = new HashSet<>(defaultDimensions);
         dimensionsByService.values().forEach(all::addAll);
         managedDimensions = Set.copyOf(all);

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/PublicDimensions.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/PublicDimensions.java
@@ -38,6 +38,12 @@ public final class PublicDimensions {
     // From host-admin, currently (Jan 2020) only included for 'vespa.node' metrics
     public static final String HOSTNAME = "host";
 
+    // From host-admin. The physical host the node runs on.
+    public static final String PARENT_HOSTNAME = "parentHostname";
+
+    // From host-admin. The OS version of the physical host.
+    public static final String OS_VERSION = "osVersion";
+
 
     /**  Metric specific dimensions  **/
     public static final String API = "api";                                 // feed

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/MetricsPacket.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/MetricsPacket.java
@@ -96,6 +96,8 @@ public class MetricsPacket {
             return this;
         }
 
+        public ServiceId getServiceId() { return service; }
+
         public Builder statusCode(Integer statusCode) {
             if (statusCode != null) this.statusCode = statusCode;
             return this;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/node/NodeMetricGatherer.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/node/NodeMetricGatherer.java
@@ -51,7 +51,8 @@ public class NodeMetricGatherer {
                 .map(metricPacketBuilder ->
                     metricPacketBuilder.putDimensionsIfAbsent(applicationDimensions.getDimensions())
                     .putDimensionsIfAbsent(nodeDimensions.getDimensions())
-                    .putDimensionsIfAbsent(metricsManager.getExtraDimensions()).build()
+                    .putDimensionsIfAbsent(metricsManager.getExtraDimensions())
+                    .putDimensionsIfAbsent(metricsManager.getExtraHostDimensions(metricPacketBuilder.getServiceId())).build()
         ).toList();
     }
 

--- a/metrics-proxy/src/main/resources/configdefinitions/metric-dimension-mapping.def
+++ b/metrics-proxy/src/main/resources/configdefinitions/metric-dimension-mapping.def
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package=ai.vespa.metricsproxy.metric.dimensions
+
+# Host dimensions allowed on metrics whose service is not explicitly listed below.
+defaultDimension[] string
+
+# Per-service overrides: the host dimensions allowed on metrics from this service.
+mapping[].service string
+mapping[].dimension[] string

--- a/metrics-proxy/src/main/resources/configdefinitions/metric-dimension-mapping.def
+++ b/metrics-proxy/src/main/resources/configdefinitions/metric-dimension-mapping.def
@@ -4,6 +4,5 @@ package=ai.vespa.metricsproxy.metric.dimensions
 # Host dimensions allowed on metrics whose service is not explicitly listed below.
 defaultDimension[] string
 
-# Per-service overrides: the host dimensions allowed on metrics from this service.
-mapping[].service string
-mapping[].dimension[] string
+# Per-service overrides, keyed by service name: the host dimensions allowed on metrics from that service.
+service{}.dimension[] string

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
@@ -6,6 +6,8 @@ import ai.vespa.metricsproxy.core.MetricsManager;
 import ai.vespa.metricsproxy.core.VespaMetrics;
 import ai.vespa.metricsproxy.metric.ExternalMetrics;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMapping;
+import ai.vespa.metricsproxy.metric.dimensions.MetricDimensionMappingConfig;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.service.VespaServices;
 
@@ -25,8 +27,24 @@ public class TestUtil {
                                                       ApplicationDimensions applicationDimensions,
                                                       NodeDimensions nodeDimensions) {
         VespaMetrics metrics = new VespaMetrics(consumers);
-        return new MetricsManager(vespaServices, metrics, new ExternalMetrics(consumers),
+        return new MetricsManager(vespaServices, metrics, new ExternalMetrics(consumers, standardDimensionMapping()),
                                   applicationDimensions, nodeDimensions);
+    }
+
+    /**
+     * The metric-to-dimension mapping that config-model generates by default: host_life gets osVersion
+     * in addition to host/parentHostname; services not listed keep only host/parentHostname.
+     */
+    public static MetricDimensionMapping standardDimensionMapping() {
+        return new MetricDimensionMapping(new MetricDimensionMappingConfig.Builder()
+                .defaultDimension("host")
+                .defaultDimension("parentHostname")
+                .mapping(new MetricDimensionMappingConfig.Mapping.Builder()
+                        .service("host_life")
+                        .dimension("host")
+                        .dimension("parentHostname")
+                        .dimension("osVersion"))
+                .build());
     }
 
     public static String getFileContents(String filename) {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/TestUtil.java
@@ -39,8 +39,7 @@ public class TestUtil {
         return new MetricDimensionMapping(new MetricDimensionMappingConfig.Builder()
                 .defaultDimension("host")
                 .defaultDimension("parentHostname")
-                .mapping(new MetricDimensionMappingConfig.Mapping.Builder()
-                        .service("host_life")
+                .service("host_life", s -> s
                         .dimension("host")
                         .dimension("parentHostname")
                         .dimension("osVersion"))

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
@@ -28,11 +28,15 @@ import java.util.Map;
 import static ai.vespa.metricsproxy.core.MetricsManager.VESPA_VERSION;
 import static ai.vespa.metricsproxy.core.VespaMetrics.METRIC_TYPE_DIMENSION_ID;
 import static ai.vespa.metricsproxy.core.VespaMetrics.vespaMetricsConsumerId;
+import static ai.vespa.metricsproxy.metric.ExternalMetrics.HOST_DIMENSION;
+import static ai.vespa.metricsproxy.metric.ExternalMetrics.OS_VERSION_DIMENSION;
+import static ai.vespa.metricsproxy.metric.ExternalMetrics.PARENT_HOSTNAME_DIMENSION;
 import static ai.vespa.metricsproxy.metric.ExternalMetrics.ROLE_DIMENSION;
 import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
 import static ai.vespa.metricsproxy.metric.model.MetricId.toMetricId;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -194,6 +198,33 @@ public class MetricsManagerTest {
         assertEquals("standard", packets.get(0).dimensions().get(METRIC_TYPE_DIMENSION_ID));
         assertEquals("standard", packets.get(1).dimensions().get(METRIC_TYPE_DIMENSION_ID));
         assertEquals("from extraMetrics", packets.get(2).dimensions().get(METRIC_TYPE_DIMENSION_ID));
+    }
+
+    @Test
+    public void osVersion_reaches_alive_but_is_stripped_from_carrier_packets() {
+        // Simulate hostadmin pushing a vespa.node packet carrying all three host dims + role + a whitelisted metric.
+        metricsManager.setExtraMetrics(List.of(
+                new MetricsPacket.Builder(toServiceId("vespa.node"))
+                        .putMetrics(List.of(new Metric(WHITELISTED_METRIC_ID, 0)))
+                        .putDimension(HOST_DIMENSION, "h1")
+                        .putDimension(PARENT_HOSTNAME_DIMENSION, "p1")
+                        .putDimension(OS_VERSION_DIMENSION, "8.4.0")
+                        .putDimension(ROLE_DIMENSION, "tenants")));
+
+        // (a) what the host_life/alive packet would receive — osVersion survived the harvest:
+        Map<DimensionId, String> hostLifeDims = metricsManager.getExtraHostDimensions(toServiceId("host_life"));
+        assertEquals("8.4.0", hostLifeDims.get(OS_VERSION_DIMENSION));
+        assertEquals("h1", hostLifeDims.get(HOST_DIMENSION));
+        assertEquals("p1", hostLifeDims.get(PARENT_HOSTNAME_DIMENSION));
+
+        // (b) the carrier packet kept host/parentHostname/role but lost osVersion:
+        MetricsPacket carrier = metricsManager.getMetrics(testServices, Instant.EPOCH).stream()
+                .filter(p -> p.service().equals(toServiceId("vespa.node")))
+                .findFirst().orElseThrow();
+        assertEquals("h1", carrier.dimensions().get(HOST_DIMENSION));
+        assertEquals("p1", carrier.dimensions().get(PARENT_HOSTNAME_DIMENSION));
+        assertEquals("tenants", carrier.dimensions().get(ROLE_DIMENSION));
+        assertFalse(carrier.dimensions().containsKey(OS_VERSION_DIMENSION));
     }
 
     @Test

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/core/MetricsManagerTest.java
@@ -10,6 +10,7 @@ import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
+import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
@@ -28,9 +29,6 @@ import java.util.Map;
 import static ai.vespa.metricsproxy.core.MetricsManager.VESPA_VERSION;
 import static ai.vespa.metricsproxy.core.VespaMetrics.METRIC_TYPE_DIMENSION_ID;
 import static ai.vespa.metricsproxy.core.VespaMetrics.vespaMetricsConsumerId;
-import static ai.vespa.metricsproxy.metric.ExternalMetrics.HOST_DIMENSION;
-import static ai.vespa.metricsproxy.metric.ExternalMetrics.OS_VERSION_DIMENSION;
-import static ai.vespa.metricsproxy.metric.ExternalMetrics.PARENT_HOSTNAME_DIMENSION;
 import static ai.vespa.metricsproxy.metric.ExternalMetrics.ROLE_DIMENSION;
 import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
 import static ai.vespa.metricsproxy.metric.model.MetricId.toMetricId;
@@ -206,25 +204,25 @@ public class MetricsManagerTest {
         metricsManager.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(toServiceId("vespa.node"))
                         .putMetrics(List.of(new Metric(WHITELISTED_METRIC_ID, 0)))
-                        .putDimension(HOST_DIMENSION, "h1")
-                        .putDimension(PARENT_HOSTNAME_DIMENSION, "p1")
-                        .putDimension(OS_VERSION_DIMENSION, "8.4.0")
+                        .putDimension(toDimensionId(PublicDimensions.HOSTNAME), "h1")
+                        .putDimension(toDimensionId(PublicDimensions.PARENT_HOSTNAME), "p1")
+                        .putDimension(toDimensionId(PublicDimensions.OS_VERSION), "8.4.0")
                         .putDimension(ROLE_DIMENSION, "tenants")));
 
         // (a) what the host_life/alive packet would receive — osVersion survived the harvest:
         Map<DimensionId, String> hostLifeDims = metricsManager.getExtraHostDimensions(toServiceId("host_life"));
-        assertEquals("8.4.0", hostLifeDims.get(OS_VERSION_DIMENSION));
-        assertEquals("h1", hostLifeDims.get(HOST_DIMENSION));
-        assertEquals("p1", hostLifeDims.get(PARENT_HOSTNAME_DIMENSION));
+        assertEquals("8.4.0", hostLifeDims.get(toDimensionId(PublicDimensions.OS_VERSION)));
+        assertEquals("h1", hostLifeDims.get(toDimensionId(PublicDimensions.HOSTNAME)));
+        assertEquals("p1", hostLifeDims.get(toDimensionId(PublicDimensions.PARENT_HOSTNAME)));
 
         // (b) the carrier packet kept host/parentHostname/role but lost osVersion:
         MetricsPacket carrier = metricsManager.getMetrics(testServices, Instant.EPOCH).stream()
                 .filter(p -> p.service().equals(toServiceId("vespa.node")))
                 .findFirst().orElseThrow();
-        assertEquals("h1", carrier.dimensions().get(HOST_DIMENSION));
-        assertEquals("p1", carrier.dimensions().get(PARENT_HOSTNAME_DIMENSION));
+        assertEquals("h1", carrier.dimensions().get(toDimensionId(PublicDimensions.HOSTNAME)));
+        assertEquals("p1", carrier.dimensions().get(toDimensionId(PublicDimensions.PARENT_HOSTNAME)));
         assertEquals("tenants", carrier.dimensions().get(ROLE_DIMENSION));
-        assertFalse(carrier.dimensions().containsKey(OS_VERSION_DIMENSION));
+        assertFalse(carrier.dimensions().containsKey(toDimensionId(PublicDimensions.OS_VERSION)));
     }
 
     @Test

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/ExternalMetricsTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/ExternalMetricsTest.java
@@ -4,16 +4,20 @@ package ai.vespa.metricsproxy.metric;
 import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
+import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
 import ai.vespa.metricsproxy.metric.model.ServiceId;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static ai.vespa.metricsproxy.metric.model.ConsumerId.toConsumerId;
+import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -68,6 +72,61 @@ public class ExternalMetricsTest {
         assertEquals(2, consumerIds.size());
         assertTrue(consumerIds.contains(CUSTOM_CONSUMER_1));
         assertTrue(consumerIds.contains(CUSTOM_CONSUMER_2));
+    }
+
+    @Test
+    public void host_dimensions_are_extracted_and_other_dimensions_dropped() {
+        MetricsPacket.Builder packet = new MetricsPacket.Builder(toServiceId("vespa.node"))
+                .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
+                .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
+                .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")
+                .putDimension(toDimensionId("role"), "tenants")
+                .putDimension(toDimensionId("state"), "active")
+                .putDimension(toDimensionId("zone"), "prod.us-east-1");
+
+        Map<DimensionId, String> hostDimensions = ExternalMetrics.extractHostDimensions(List.of(packet));
+
+        assertEquals(3, hostDimensions.size());
+        assertEquals("host1", hostDimensions.get(ExternalMetrics.HOST_DIMENSION));
+        assertEquals("parent1", hostDimensions.get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
+        assertEquals("8.4.0", hostDimensions.get(ExternalMetrics.OS_VERSION_DIMENSION));
+        assertFalse(hostDimensions.containsKey(toDimensionId("role")));
+        assertFalse(hostDimensions.containsKey(toDimensionId("state")));
+        assertFalse(hostDimensions.containsKey(toDimensionId("zone")));
+    }
+
+    @Test
+    public void osVersion_is_stripped_from_carrier_packets_but_host_and_parentHostname_kept() {
+        MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
+        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
+        externalMetrics.setExtraMetrics(List.of(
+                new MetricsPacket.Builder(toServiceId("vespa.node"))
+                        .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
+                        .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
+                        .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")
+                        .putDimension(toDimensionId("role"), "tenants")));
+
+        Map<DimensionId, String> dims = externalMetrics.getMetrics().get(0).build().dimensions();
+        assertEquals("host1", dims.get(ExternalMetrics.HOST_DIMENSION));
+        assertEquals("parent1", dims.get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
+        assertEquals("tenants", dims.get(toDimensionId("role")));
+        assertFalse(dims.containsKey(ExternalMetrics.OS_VERSION_DIMENSION));
+    }
+
+    @Test
+    public void osVersion_is_kept_on_host_life_packets() {
+        MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
+        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
+        externalMetrics.setExtraMetrics(List.of(
+                new MetricsPacket.Builder(toServiceId("host_life"))
+                        .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
+                        .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
+                        .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")));
+
+        Map<DimensionId, String> dims = externalMetrics.getMetrics().get(0).build().dimensions();
+        assertEquals("8.4.0", dims.get(ExternalMetrics.OS_VERSION_DIMENSION));
+        assertEquals("host1", dims.get(ExternalMetrics.HOST_DIMENSION));
+        assertEquals("parent1", dims.get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
     }
 
 }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/ExternalMetricsTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/ExternalMetricsTest.java
@@ -1,8 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.metric;
 
+import ai.vespa.metricsproxy.TestUtil;
 import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
+import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
@@ -30,7 +32,7 @@ public class ExternalMetricsTest {
     @Test
     public void extra_metrics_are_added() {
         MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
-        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
+        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers, TestUtil.standardDimensionMapping());
 
         externalMetrics.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(toServiceId("foo"))));
@@ -44,7 +46,7 @@ public class ExternalMetricsTest {
         final ServiceId SERVICE_ID = toServiceId("do-not-replace");
 
         MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
-        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
+        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers, TestUtil.standardDimensionMapping());
         externalMetrics.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(SERVICE_ID)));
 
@@ -60,7 +62,7 @@ public class ExternalMetricsTest {
                 .consumer(new ConsumersConfig.Consumer.Builder().name(CUSTOM_CONSUMER_2.id))
                 .build();
         MetricsConsumers consumers = new MetricsConsumers(consumersConfig);
-        ExternalMetrics externalMetrics = new ExternalMetrics(consumers);
+        ExternalMetrics externalMetrics = new ExternalMetrics(consumers, TestUtil.standardDimensionMapping());
 
         externalMetrics.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(toServiceId("foo"))));
@@ -77,19 +79,21 @@ public class ExternalMetricsTest {
     @Test
     public void host_dimensions_are_extracted_and_other_dimensions_dropped() {
         MetricsPacket.Builder packet = new MetricsPacket.Builder(toServiceId("vespa.node"))
-                .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
-                .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
-                .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")
+                .putDimension(toDimensionId(PublicDimensions.HOSTNAME), "host1")
+                .putDimension(toDimensionId(PublicDimensions.PARENT_HOSTNAME), "parent1")
+                .putDimension(toDimensionId(PublicDimensions.OS_VERSION), "8.4.0")
                 .putDimension(toDimensionId("role"), "tenants")
                 .putDimension(toDimensionId("state"), "active")
                 .putDimension(toDimensionId("zone"), "prod.us-east-1");
 
-        Map<DimensionId, String> hostDimensions = ExternalMetrics.extractHostDimensions(List.of(packet));
+        ExternalMetrics externalMetrics = new ExternalMetrics(
+                new MetricsConsumers(new ConsumersConfig.Builder().build()), TestUtil.standardDimensionMapping());
+        Map<DimensionId, String> hostDimensions = externalMetrics.extractHostDimensions(List.of(packet));
 
         assertEquals(3, hostDimensions.size());
-        assertEquals("host1", hostDimensions.get(ExternalMetrics.HOST_DIMENSION));
-        assertEquals("parent1", hostDimensions.get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
-        assertEquals("8.4.0", hostDimensions.get(ExternalMetrics.OS_VERSION_DIMENSION));
+        assertEquals("host1", hostDimensions.get(toDimensionId(PublicDimensions.HOSTNAME)));
+        assertEquals("parent1", hostDimensions.get(toDimensionId(PublicDimensions.PARENT_HOSTNAME)));
+        assertEquals("8.4.0", hostDimensions.get(toDimensionId(PublicDimensions.OS_VERSION)));
         assertFalse(hostDimensions.containsKey(toDimensionId("role")));
         assertFalse(hostDimensions.containsKey(toDimensionId("state")));
         assertFalse(hostDimensions.containsKey(toDimensionId("zone")));
@@ -98,35 +102,35 @@ public class ExternalMetricsTest {
     @Test
     public void osVersion_is_stripped_from_carrier_packets_but_host_and_parentHostname_kept() {
         MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
-        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
+        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers, TestUtil.standardDimensionMapping());
         externalMetrics.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(toServiceId("vespa.node"))
-                        .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
-                        .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
-                        .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")
+                        .putDimension(toDimensionId(PublicDimensions.HOSTNAME), "host1")
+                        .putDimension(toDimensionId(PublicDimensions.PARENT_HOSTNAME), "parent1")
+                        .putDimension(toDimensionId(PublicDimensions.OS_VERSION), "8.4.0")
                         .putDimension(toDimensionId("role"), "tenants")));
 
         Map<DimensionId, String> dims = externalMetrics.getMetrics().get(0).build().dimensions();
-        assertEquals("host1", dims.get(ExternalMetrics.HOST_DIMENSION));
-        assertEquals("parent1", dims.get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
+        assertEquals("host1", dims.get(toDimensionId(PublicDimensions.HOSTNAME)));
+        assertEquals("parent1", dims.get(toDimensionId(PublicDimensions.PARENT_HOSTNAME)));
         assertEquals("tenants", dims.get(toDimensionId("role")));
-        assertFalse(dims.containsKey(ExternalMetrics.OS_VERSION_DIMENSION));
+        assertFalse(dims.containsKey(toDimensionId(PublicDimensions.OS_VERSION)));
     }
 
     @Test
     public void osVersion_is_kept_on_host_life_packets() {
         MetricsConsumers noConsumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
-        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers);
+        ExternalMetrics externalMetrics = new ExternalMetrics(noConsumers, TestUtil.standardDimensionMapping());
         externalMetrics.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(toServiceId("host_life"))
-                        .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
-                        .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
-                        .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")));
+                        .putDimension(toDimensionId(PublicDimensions.HOSTNAME), "host1")
+                        .putDimension(toDimensionId(PublicDimensions.PARENT_HOSTNAME), "parent1")
+                        .putDimension(toDimensionId(PublicDimensions.OS_VERSION), "8.4.0")));
 
         Map<DimensionId, String> dims = externalMetrics.getMetrics().get(0).build().dimensions();
-        assertEquals("8.4.0", dims.get(ExternalMetrics.OS_VERSION_DIMENSION));
-        assertEquals("host1", dims.get(ExternalMetrics.HOST_DIMENSION));
-        assertEquals("parent1", dims.get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
+        assertEquals("8.4.0", dims.get(toDimensionId(PublicDimensions.OS_VERSION)));
+        assertEquals("host1", dims.get(toDimensionId(PublicDimensions.HOSTNAME)));
+        assertEquals("parent1", dims.get(toDimensionId(PublicDimensions.PARENT_HOSTNAME)));
     }
 
 }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMappingTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMappingTest.java
@@ -20,8 +20,7 @@ public class MetricDimensionMappingTest {
                 new MetricDimensionMappingConfig.Builder()
                         .defaultDimension("host")
                         .defaultDimension("parentHostname")
-                        .mapping(new MetricDimensionMappingConfig.Mapping.Builder()
-                                .service("host_life")
+                        .service("host_life", s -> s
                                 .dimension("host")
                                 .dimension("parentHostname")
                                 .dimension("osVersion"))

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMappingTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/metric/dimensions/MetricDimensionMappingTest.java
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.metricsproxy.metric.dimensions;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
+import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author onur
+ */
+public class MetricDimensionMappingTest {
+
+    @Test
+    public void uses_default_for_unmapped_services_and_explicit_mapping_for_listed_services() {
+        MetricDimensionMapping mapping = new MetricDimensionMapping(
+                new MetricDimensionMappingConfig.Builder()
+                        .defaultDimension("host")
+                        .defaultDimension("parentHostname")
+                        .mapping(new MetricDimensionMappingConfig.Mapping.Builder()
+                                .service("host_life")
+                                .dimension("host")
+                                .dimension("parentHostname")
+                                .dimension("osVersion"))
+                        .build());
+
+        assertEquals(Set.of(toDimensionId("host"), toDimensionId("parentHostname"), toDimensionId("osVersion")),
+                mapping.allowedFor(toServiceId("host_life")));
+
+        // A service not in the mapping falls back to the default dimensions.
+        assertEquals(Set.of(toDimensionId("host"), toDimensionId("parentHostname")),
+                mapping.allowedFor(toServiceId("vespa.node")));
+
+        // The managed set is the union of default + all per-service dimensions.
+        assertEquals(Set.of(toDimensionId("host"), toDimensionId("parentHostname"), toDimensionId("osVersion")),
+                mapping.managedDimensions());
+    }
+
+}

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/node/NodeMetricGathererTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/node/NodeMetricGathererTest.java
@@ -5,11 +5,11 @@ import ai.vespa.metricsproxy.TestUtil;
 import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
 import ai.vespa.metricsproxy.core.MetricsManager;
-import ai.vespa.metricsproxy.metric.ExternalMetrics;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
+import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static ai.vespa.metricsproxy.metric.model.json.JacksonUtil.objectMapper;
 import static org.junit.Assert.assertEquals;
@@ -58,9 +59,9 @@ public class NodeMetricGathererTest {
         // host-admin pushes host-level dimensions on its packets; these get harvested.
         metricsManager.setExtraMetrics(List.of(
                 new MetricsPacket.Builder(toServiceId("vespa.node"))
-                        .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
-                        .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
-                        .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")));
+                        .putDimension(toDimensionId(PublicDimensions.HOSTNAME), "host1")
+                        .putDimension(toDimensionId(PublicDimensions.PARENT_HOSTNAME), "parent1")
+                        .putDimension(toDimensionId(PublicDimensions.OS_VERSION), "8.4.0")));
 
         NodeMetricGatherer gatherer = new NodeMetricGatherer(metricsManager, applicationDimensions, nodeDimensions);
 
@@ -68,9 +69,9 @@ public class NodeMetricGathererTest {
                 .filter(p -> p.service().id.equals("host_life"))
                 .findFirst().orElseThrow();
 
-        assertEquals("host1", hostLife.dimensions().get(ExternalMetrics.HOST_DIMENSION));
-        assertEquals("parent1", hostLife.dimensions().get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
-        assertEquals("8.4.0", hostLife.dimensions().get(ExternalMetrics.OS_VERSION_DIMENSION));
+        assertEquals("host1", hostLife.dimensions().get(toDimensionId(PublicDimensions.HOSTNAME)));
+        assertEquals("parent1", hostLife.dimensions().get(toDimensionId(PublicDimensions.PARENT_HOSTNAME)));
+        assertEquals("8.4.0", hostLife.dimensions().get(toDimensionId(PublicDimensions.OS_VERSION)));
     }
 
     private JsonNode generateHostLifePacket() {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/node/NodeMetricGathererTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/node/NodeMetricGathererTest.java
@@ -1,9 +1,19 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.node;
 
+import ai.vespa.metricsproxy.TestUtil;
+import ai.vespa.metricsproxy.core.ConsumersConfig;
+import ai.vespa.metricsproxy.core.MetricsConsumers;
+import ai.vespa.metricsproxy.core.MetricsManager;
+import ai.vespa.metricsproxy.metric.ExternalMetrics;
+import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensions;
+import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
+import ai.vespa.metricsproxy.metric.dimensions.NodeDimensions;
+import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
+import ai.vespa.metricsproxy.service.VespaServices;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
@@ -12,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static ai.vespa.metricsproxy.metric.model.json.JacksonUtil.objectMapper;
 import static org.junit.Assert.assertEquals;
 
@@ -32,6 +43,34 @@ public class NodeMetricGathererTest {
         assertEquals(12L, packet.metrics().get(MetricId.toMetricId("uptime")));
         assertEquals(1L, packet.metrics().get(MetricId.toMetricId("alive")));
         assertEquals(Set.of(ConsumerId.toConsumerId("Vespa")), packet.consumers());
+    }
+
+    @Test
+    public void host_life_packet_gets_extra_host_dimensions() {
+        ApplicationDimensions applicationDimensions =
+                new ApplicationDimensions(new ApplicationDimensionsConfig.Builder().build());
+        NodeDimensions nodeDimensions =
+                new NodeDimensions(new NodeDimensionsConfig.Builder().build());
+        MetricsConsumers consumers = new MetricsConsumers(new ConsumersConfig.Builder().build());
+        MetricsManager metricsManager = TestUtil.createMetricsManager(
+                new VespaServices(List.of()), consumers, applicationDimensions, nodeDimensions);
+
+        // host-admin pushes host-level dimensions on its packets; these get harvested.
+        metricsManager.setExtraMetrics(List.of(
+                new MetricsPacket.Builder(toServiceId("vespa.node"))
+                        .putDimension(ExternalMetrics.HOST_DIMENSION, "host1")
+                        .putDimension(ExternalMetrics.PARENT_HOSTNAME_DIMENSION, "parent1")
+                        .putDimension(ExternalMetrics.OS_VERSION_DIMENSION, "8.4.0")));
+
+        NodeMetricGatherer gatherer = new NodeMetricGatherer(metricsManager, applicationDimensions, nodeDimensions);
+
+        MetricsPacket hostLife = gatherer.gatherMetrics().stream()
+                .filter(p -> p.service().id.equals("host_life"))
+                .findFirst().orElseThrow();
+
+        assertEquals("host1", hostLife.dimensions().get(ExternalMetrics.HOST_DIMENSION));
+        assertEquals("parent1", hostLife.dimensions().get(ExternalMetrics.PARENT_HOSTNAME_DIMENSION));
+        assertEquals("8.4.0", hostLife.dimensions().get(ExternalMetrics.OS_VERSION_DIMENSION));
     }
 
     private JsonNode generateHostLifePacket() {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/IntegrationTester.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/IntegrationTester.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.rpc;
 
+import ai.vespa.metricsproxy.TestUtil;
 import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.core.ConsumersConfig.Consumer;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
@@ -59,7 +60,7 @@ public class IntegrationTester implements  AutoCloseable {
         vespaServices = new VespaServices(servicesConfig(), monitoringConfig(), null);
         MetricsConsumers consumers = new MetricsConsumers(consumersConfig());
         VespaMetrics vespaMetrics = new VespaMetrics(consumers);
-        ExternalMetrics externalMetrics = new ExternalMetrics(consumers);
+        ExternalMetrics externalMetrics = new ExternalMetrics(consumers, TestUtil.standardDimensionMapping());
         ApplicationDimensions appDimensions = new ApplicationDimensions(applicationDimensionsConfig());
         NodeDimensions nodeDimensions = new NodeDimensions(nodeDimensionsConfig());
 


### PR DESCRIPTION
## Why
A tenant (Indeed) needs the host OS version on the `alive` (host_life) metric to correlate host liveness with the OS each host runs on.

`osVersion` is only known on host-admin (Vespa Cloud), but the `host_life` packet is generated locally inside metrics-proxy and carries only `vespaVersion`. Rather than a one-off osVersion hack, this adds a **generic way to attach host-admin-provided dimensions to specific metrics**, keeping cardinality off everything else.

## What
A config-driven mapping deciding which host-level dimensions (provided by host-admin) are allowed on which metric:
- **Harvest** — host-admin pushes host dimensions (`host`, `parentHostname`, now `osVersion`) on its packets via the `setExtraMetrics` RPC; metrics-proxy harvests them into a dedicated store, separate from the global `{role, state}` dimensions.
- **Apply** — the locally-built `alive`/`host_life` packet gets the host dimensions allowed for its service.
- **Strip** — host dimensions not allowed for a packet's service are removed from the carrier packets (`vespa.node`, `vespa.sidecar`, `vespa.routing`).

The allow-list is a config-def (`metric-dimension-mapping.def`) generated by config-model: `default = {host, parentHostname}`, `host_life = {host, parentHostname, osVersion}`.

**Net effect (hosted):** `osVersion` appears only on `alive`; `host`/`parentHostname` added to `alive` and kept where already native; role/state and internal Vespa metrics unchanged. **Self-hosted** emits an empty mapping → full no-op. Adding a host dimension to another metric later is now a config-model change, not source.

## Commits
1. add osVersion (and host/parentHostname) to the alive metric — harvest/apply/strip (mapping initially hardcoded)
2. make the metric-to-dimension mapping config-driven — moves it to the config-def + `MetricDimensionMapping` component

## Cross-repo / deploy order
host-admin must emit `osVersion` — companion cloud change: vespaai/cloud#3154. **Deploy metrics-proxy BEFORE host-admin**, else `osVersion` briefly appears on carriers until the strip is live.

## Tests
ExternalMetricsTest, NodeMetricGathererTest, MetricsManagerTest (within-proxy end-to-end), MetricDimensionMappingTest, config-model MetricsProxyContainerClusterTest. metrics-proxy 155 green, config-model metricsproxy 23 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
