### PR TITLE
Add tensorFromLabelsWithOffset rank feature

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -163,6 +163,7 @@ vespa_define_module(
     src/tests/features/subqueries
     src/tests/features/tensor
     src/tests/features/tensor_from_labels
+    src/tests/features/tensor_from_labels_with_offset
     src/tests/features/tensor_from_structs
     src/tests/features/tensor_from_weighted_set
     src/tests/features/text_similarity_feature

--- a/searchlib/src/tests/features/tensor_from_labels_with_offset/CMakeLists.txt
+++ b/searchlib/src/tests/features/tensor_from_labels_with_offset/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchlib_tensor_from_labels_with_offset_test_app TEST
+    SOURCES
+    tensor_from_labels_with_offset_test.cpp
+    DEPENDS
+    vespa_searchlib
+    searchlib_test
+)
+vespa_add_test(NAME searchlib_tensor_from_labels_with_offset_test_app COMMAND searchlib_tensor_from_labels_with_offset_test_app)

--- a/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
@@ -174,30 +174,6 @@ TEST(TensorFromLabelsWithOffsetTest, array_integer_attribute_values_are_converte
               f.execute());
 }
 
-// Tests for attribute source — single-value:
-
-TEST(TensorFromLabelsWithOffsetTest, single_value_integer_attribute_produces_single_cell_at_offset_0) {
-    ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})").add({{"dim", "5"}, {"offset", "0"}}, 1)),
-              f.execute());
-}
-
-TEST(TensorFromLabelsWithOffsetTest, single_value_string_attribute_produces_single_cell_at_offset_0) {
-    ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})").add({{"dim", "foo"}, {"offset", "0"}}, 1)),
-              f.execute());
-}
-
-TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_single_value_integer_attribute_is_undefined) {
-    ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute(2));
-}
-
-TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_single_value_string_attribute_is_undefined) {
-    ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute(2));
-}
-
 // Tests for error cases:
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_does_not_exist) {
@@ -207,6 +183,16 @@ TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_does_n
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_type_is_weighted_set) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(wsstr),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_is_single_value_integer) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_is_single_value_string) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
     EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute());
 }
 

--- a/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
@@ -125,7 +125,7 @@ struct ExecFixture {
 TEST(TensorFromLabelsWithOffsetTest, array_string_attribute_produces_2d_tensor_with_label_and_offset_dims) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(astr),dim,offset)");
     // tensor(dim{},offset{}) — 'dim' < 'offset' alphabetically, so dim is index 0 in the type
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})")
                                .add({{"dim", "a"}, {"offset", "0"}}, 1)
                                .add({{"dim", "b"}, {"offset", "1"}}, 1)
                                .add({{"dim", "c"}, {"offset", "2"}}, 1)),
@@ -136,7 +136,7 @@ TEST(TensorFromLabelsWithOffsetTest, duplicate_labels_are_disambiguated_by_offse
     // It's also possible to have duplicate values in the array: [a a b] keeps the
     // two 'a' entries as distinct cells, whereas tensorFromLabels would collide them.
     ExecFixture f("tensorFromLabelsWithOffset(attribute(adup),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})")
                                .add({{"dim", "a"}, {"offset", "0"}}, 1)
                                .add({{"dim", "a"}, {"offset", "1"}}, 1)
                                .add({{"dim", "b"}, {"offset", "2"}}, 1)),
@@ -146,7 +146,7 @@ TEST(TensorFromLabelsWithOffsetTest, duplicate_labels_are_disambiguated_by_offse
 TEST(TensorFromLabelsWithOffsetTest, dimension_order_in_spec_follows_alphabetical_sort) {
     // 'z' > 'a', so offset dim 'z' sorts after label dim 'a' — address ordering must still be correct
     ExecFixture f("tensorFromLabelsWithOffset(attribute(astr),a,z)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(a{},z{})")
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(a{},z{})")
                                .add({{"a", "a"}, {"z", "0"}}, 1)
                                .add({{"a", "b"}, {"z", "1"}}, 1)
                                .add({{"a", "c"}, {"z", "2"}}, 1)),
@@ -156,7 +156,7 @@ TEST(TensorFromLabelsWithOffsetTest, dimension_order_in_spec_follows_alphabetica
 TEST(TensorFromLabelsWithOffsetTest, dimension_order_reversed_when_offset_dim_sorts_first) {
     // offset dim 'aoffset' < label dim 'zlabel' — type has offset first
     ExecFixture f("tensorFromLabelsWithOffset(attribute(astr),zlabel,aoffset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(aoffset{},zlabel{})")
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(aoffset{},zlabel{})")
                                .add({{"zlabel", "a"}, {"aoffset", "0"}}, 1)
                                .add({{"zlabel", "b"}, {"aoffset", "1"}}, 1)
                                .add({{"zlabel", "c"}, {"aoffset", "2"}}, 1)),
@@ -167,7 +167,7 @@ TEST(TensorFromLabelsWithOffsetTest, dimension_order_reversed_when_offset_dim_so
 
 TEST(TensorFromLabelsWithOffsetTest, array_integer_attribute_values_are_converted_to_string_labels) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(aint),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})")
                                .add({{"dim", "3"}, {"offset", "0"}}, 1)
                                .add({{"dim", "5"}, {"offset", "1"}}, 1)
                                .add({{"dim", "7"}, {"offset", "2"}}, 1)),
@@ -178,36 +178,36 @@ TEST(TensorFromLabelsWithOffsetTest, array_integer_attribute_values_are_converte
 
 TEST(TensorFromLabelsWithOffsetTest, single_value_integer_attribute_produces_single_cell_at_offset_0) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})").add({{"dim", "5"}, {"offset", "0"}}, 1)),
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})").add({{"dim", "5"}, {"offset", "0"}}, 1)),
               f.execute());
 }
 
 TEST(TensorFromLabelsWithOffsetTest, single_value_string_attribute_produces_single_cell_at_offset_0) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})").add({{"dim", "foo"}, {"offset", "0"}}, 1)),
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor<float>(dim{},offset{})").add({{"dim", "foo"}, {"offset", "0"}}, 1)),
               f.execute());
 }
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_single_value_integer_attribute_is_undefined) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute(2));
+    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute(2));
 }
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_single_value_string_attribute_is_undefined) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute(2));
+    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute(2));
 }
 
 // Tests for error cases:
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_does_not_exist) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(null),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
+    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute());
 }
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_type_is_weighted_set) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(wsstr),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
+    EXPECT_EQ(*make_empty("tensor<float>(dim{},offset{})"), f.execute());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
@@ -1,6 +1,5 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/eval/eval/function.h>
 #include <vespa/eval/eval/simple_value.h>
 #include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/test/value_compare.h>
@@ -24,7 +23,6 @@ using namespace search::features;
 using search::AttributeFactory;
 using search::IntegerAttribute;
 using search::StringAttribute;
-using vespalib::eval::Function;
 using vespalib::eval::SimpleValue;
 using vespalib::eval::TensorSpec;
 using vespalib::eval::Value;
@@ -65,10 +63,9 @@ TEST(TensorFromLabelsWithOffsetTest, require_that_setup_succeeds_with_attribute_
                      StringList(), StringList().add("tensor"));
 }
 
-TEST(TensorFromLabelsWithOffsetTest, require_that_setup_succeeds_with_query_source) {
+TEST(TensorFromLabelsWithOffsetTest, require_that_setup_fails_with_query_source) {
     SetupFixture f;
-    FTA::FT_SETUP_OK(f.blueprint, f.indexEnv, StringList().add("query(foo)").add("dim").add("offset"), StringList(),
-                     StringList().add("tensor"));
+    FTA::FT_SETUP_FAIL(f.blueprint, f.indexEnv, StringList().add("query(foo)").add("dim").add("offset"));
 }
 
 struct ExecFixture {
@@ -77,7 +74,6 @@ struct ExecFixture {
     ExecFixture(const std::string& feature) : factory(), test(factory, feature) {
         setup_search_features(factory);
         setupAttributeVectors();
-        setupQueryEnvironment();
         EXPECT_TRUE(test.setup());
     }
     void setupAttributeVectors() {
@@ -120,7 +116,6 @@ struct ExecFixture {
             attr->commit();
         }
     }
-    void setupQueryEnvironment() { test.getQueryEnv().getProperties().add("astr_query", "[d e f]"); }
     const Value& extractTensor(uint32_t docid) { return test.resolveObjectFeature(docid); }
     const Value& execute(uint32_t docid = 1) { return extractTensor(docid); }
 };
@@ -212,22 +207,6 @@ TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_does_n
 
 TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_type_is_weighted_set) {
     ExecFixture f("tensorFromLabelsWithOffset(attribute(wsstr),dim,offset)");
-    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
-}
-
-// Tests for query source:
-
-TEST(TensorFromLabelsWithOffsetTest, string_array_from_query_produces_2d_tensor_with_indices_as_offsets) {
-    ExecFixture f("tensorFromLabelsWithOffset(query(astr_query),dim,offset)");
-    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
-                               .add({{"dim", "d"}, {"offset", "0"}}, 1)
-                               .add({{"dim", "e"}, {"offset", "1"}}, 1)
-                               .add({{"dim", "f"}, {"offset", "2"}}, 1)),
-              f.execute());
-}
-
-TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_query_parameter_is_not_found) {
-    ExecFixture f("tensorFromLabelsWithOffset(query(null),dim,offset)");
     EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
 }
 

--- a/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
+++ b/searchlib/src/tests/features/tensor_from_labels_with_offset/tensor_from_labels_with_offset_test.cpp
@@ -1,0 +1,234 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/eval/eval/function.h>
+#include <vespa/eval/eval/simple_value.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/test/value_compare.h>
+#include <vespa/eval/eval/value.h>
+#include <vespa/searchcommon/attribute/config.h>
+#include <vespa/searchlib/attribute/attributefactory.h>
+#include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/integerbase.h>
+#include <vespa/searchlib/attribute/stringbase.h>
+#include <vespa/searchlib/features/setup.h>
+#include <vespa/searchlib/features/tensor_from_labels_with_offset_feature.h>
+#include <vespa/searchlib/fef/fef.h>
+#include <vespa/searchlib/fef/test/indexenvironment.h>
+#include <vespa/searchlib/test/ft_test_app_base.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using search::feature_t;
+using namespace search::fef;
+using namespace search::fef::test;
+using namespace search::features;
+using search::AttributeFactory;
+using search::IntegerAttribute;
+using search::StringAttribute;
+using vespalib::eval::Function;
+using vespalib::eval::SimpleValue;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::Value;
+
+using AVC = search::attribute::Config;
+using AVBT = search::attribute::BasicType;
+using AVCT = search::attribute::CollectionType;
+using AttributePtr = search::AttributeVector::SP;
+using FTA = FtTestAppBase;
+
+Value::UP make_tensor(const TensorSpec& spec) {
+    return SimpleValue::from_spec(spec);
+}
+
+Value::UP make_empty(const std::string& type) {
+    return make_tensor(TensorSpec(type));
+}
+
+struct SetupFixture {
+    TensorFromLabelsWithOffsetBlueprint blueprint;
+    IndexEnvironment                    indexEnv;
+    SetupFixture() : blueprint(), indexEnv() {}
+};
+
+TEST(TensorFromLabelsWithOffsetTest, require_that_blueprint_can_be_created_from_factory) {
+    SetupFixture f;
+    EXPECT_TRUE(FTA::assertCreateInstance(f.blueprint, "tensorFromLabelsWithOffset"));
+}
+
+TEST(TensorFromLabelsWithOffsetTest, require_that_setup_fails_if_source_spec_is_invalid) {
+    SetupFixture f;
+    FTA::FT_SETUP_FAIL(f.blueprint, f.indexEnv, StringList().add("source(foo)").add("dim").add("offset"));
+}
+
+TEST(TensorFromLabelsWithOffsetTest, require_that_setup_succeeds_with_attribute_source) {
+    SetupFixture f;
+    FTA::FT_SETUP_OK(f.blueprint, f.indexEnv, StringList().add("attribute(foo)").add("dim").add("offset"),
+                     StringList(), StringList().add("tensor"));
+}
+
+TEST(TensorFromLabelsWithOffsetTest, require_that_setup_succeeds_with_query_source) {
+    SetupFixture f;
+    FTA::FT_SETUP_OK(f.blueprint, f.indexEnv, StringList().add("query(foo)").add("dim").add("offset"), StringList(),
+                     StringList().add("tensor"));
+}
+
+struct ExecFixture {
+    BlueprintFactory factory;
+    FtFeatureTest    test;
+    ExecFixture(const std::string& feature) : factory(), test(factory, feature) {
+        setup_search_features(factory);
+        setupAttributeVectors();
+        setupQueryEnvironment();
+        EXPECT_TRUE(test.setup());
+    }
+    void setupAttributeVectors() {
+        std::vector<AttributePtr> attrs;
+        attrs.push_back(AttributeFactory::createAttribute("astr", AVC(AVBT::STRING, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("aint", AVC(AVBT::INT32, AVCT::ARRAY)));
+        attrs.push_back(AttributeFactory::createAttribute("wsstr", AVC(AVBT::STRING, AVCT::WSET)));
+        attrs.push_back(AttributeFactory::createAttribute("sint", AVC(AVBT::INT32, AVCT::SINGLE)));
+        attrs.push_back(AttributeFactory::createAttribute("sstr", AVC(AVBT::STRING, AVCT::SINGLE)));
+        attrs.push_back(AttributeFactory::createAttribute("adup", AVC(AVBT::STRING, AVCT::ARRAY)));
+
+        for (const auto& attr : attrs) {
+            attr->addReservedDoc();
+            attr->addDocs(2);
+            test.getIndexEnv().getAttributeMap().add(attr);
+        }
+
+        StringAttribute& astr = dynamic_cast<StringAttribute&>(*attrs[0]);
+        astr.append(1, "a", 0);
+        astr.append(1, "b", 0);
+        astr.append(1, "c", 0);
+
+        IntegerAttribute& aint = dynamic_cast<IntegerAttribute&>(*attrs[1]);
+        aint.append(1, 3, 0);
+        aint.append(1, 5, 0);
+        aint.append(1, 7, 0);
+
+        IntegerAttribute& sint = dynamic_cast<IntegerAttribute&>(*attrs[3]);
+        sint.update(1, 5);
+
+        StringAttribute& sstr = dynamic_cast<StringAttribute&>(*attrs[4]);
+        sstr.update(1, "foo");
+
+        StringAttribute& adup = dynamic_cast<StringAttribute&>(*attrs[5]);
+        adup.append(1, "a", 0);
+        adup.append(1, "a", 0);
+        adup.append(1, "b", 0);
+
+        for (const auto& attr : attrs) {
+            attr->commit();
+        }
+    }
+    void setupQueryEnvironment() { test.getQueryEnv().getProperties().add("astr_query", "[d e f]"); }
+    const Value& extractTensor(uint32_t docid) { return test.resolveObjectFeature(docid); }
+    const Value& execute(uint32_t docid = 1) { return extractTensor(docid); }
+};
+
+// Tests for attribute source — string array:
+
+TEST(TensorFromLabelsWithOffsetTest, array_string_attribute_produces_2d_tensor_with_label_and_offset_dims) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(astr),dim,offset)");
+    // tensor(dim{},offset{}) — 'dim' < 'offset' alphabetically, so dim is index 0 in the type
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+                               .add({{"dim", "a"}, {"offset", "0"}}, 1)
+                               .add({{"dim", "b"}, {"offset", "1"}}, 1)
+                               .add({{"dim", "c"}, {"offset", "2"}}, 1)),
+              f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, duplicate_labels_are_disambiguated_by_offset) {
+    // It's also possible to have duplicate values in the array: [a a b] keeps the
+    // two 'a' entries as distinct cells, whereas tensorFromLabels would collide them.
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(adup),dim,offset)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+                               .add({{"dim", "a"}, {"offset", "0"}}, 1)
+                               .add({{"dim", "a"}, {"offset", "1"}}, 1)
+                               .add({{"dim", "b"}, {"offset", "2"}}, 1)),
+              f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, dimension_order_in_spec_follows_alphabetical_sort) {
+    // 'z' > 'a', so offset dim 'z' sorts after label dim 'a' — address ordering must still be correct
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(astr),a,z)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(a{},z{})")
+                               .add({{"a", "a"}, {"z", "0"}}, 1)
+                               .add({{"a", "b"}, {"z", "1"}}, 1)
+                               .add({{"a", "c"}, {"z", "2"}}, 1)),
+              f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, dimension_order_reversed_when_offset_dim_sorts_first) {
+    // offset dim 'aoffset' < label dim 'zlabel' — type has offset first
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(astr),zlabel,aoffset)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(aoffset{},zlabel{})")
+                               .add({{"zlabel", "a"}, {"aoffset", "0"}}, 1)
+                               .add({{"zlabel", "b"}, {"aoffset", "1"}}, 1)
+                               .add({{"zlabel", "c"}, {"aoffset", "2"}}, 1)),
+              f.execute());
+}
+
+// Tests for attribute source — integer array:
+
+TEST(TensorFromLabelsWithOffsetTest, array_integer_attribute_values_are_converted_to_string_labels) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(aint),dim,offset)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+                               .add({{"dim", "3"}, {"offset", "0"}}, 1)
+                               .add({{"dim", "5"}, {"offset", "1"}}, 1)
+                               .add({{"dim", "7"}, {"offset", "2"}}, 1)),
+              f.execute());
+}
+
+// Tests for attribute source — single-value:
+
+TEST(TensorFromLabelsWithOffsetTest, single_value_integer_attribute_produces_single_cell_at_offset_0) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})").add({{"dim", "5"}, {"offset", "0"}}, 1)),
+              f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, single_value_string_attribute_produces_single_cell_at_offset_0) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})").add({{"dim", "foo"}, {"offset", "0"}}, 1)),
+              f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_single_value_integer_attribute_is_undefined) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(sint),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute(2));
+}
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_single_value_string_attribute_is_undefined) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(sstr),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute(2));
+}
+
+// Tests for error cases:
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_does_not_exist) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(null),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_attribute_type_is_weighted_set) {
+    ExecFixture f("tensorFromLabelsWithOffset(attribute(wsstr),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
+}
+
+// Tests for query source:
+
+TEST(TensorFromLabelsWithOffsetTest, string_array_from_query_produces_2d_tensor_with_indices_as_offsets) {
+    ExecFixture f("tensorFromLabelsWithOffset(query(astr_query),dim,offset)");
+    EXPECT_EQ(*make_tensor(TensorSpec("tensor(dim{},offset{})")
+                               .add({{"dim", "d"}, {"offset", "0"}}, 1)
+                               .add({{"dim", "e"}, {"offset", "1"}}, 1)
+                               .add({{"dim", "f"}, {"offset", "2"}}, 1)),
+              f.execute());
+}
+
+TEST(TensorFromLabelsWithOffsetTest, empty_tensor_is_created_if_query_parameter_is_not_found) {
+    ExecFixture f("tensorFromLabelsWithOffset(query(null),dim,offset)");
+    EXPECT_EQ(*make_empty("tensor(dim{},offset{})"), f.execute());
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/features/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/features/CMakeLists.txt
@@ -72,6 +72,7 @@ vespa_add_library(searchlib_features OBJECT
     tensor_attribute_executor.cpp
     tensor_factory_blueprint.cpp
     tensor_from_labels_feature.cpp
+    tensor_from_labels_with_offset_feature.cpp
     tensor_from_structs_feature.cpp
     tensor_from_weighted_set_feature.cpp
     term_field_md_feature.cpp

--- a/searchlib/src/vespa/searchlib/features/setup.cpp
+++ b/searchlib/src/vespa/searchlib/features/setup.cpp
@@ -56,6 +56,7 @@
 #include "second_phase_feature.h"
 #include "subqueries_feature.h"
 #include "tensor_from_labels_feature.h"
+#include "tensor_from_labels_with_offset_feature.h"
 #include "tensor_from_structs_feature.h"
 #include "tensor_from_weighted_set_feature.h"
 #include "term_field_md_feature.h"
@@ -121,6 +122,7 @@ void setup_search_features(fef::IBlueprintRegistry& registry) {
     registry.addPrototype(std::make_shared<SecondPhaseBlueprint>());
     registry.addPrototype(std::make_shared<SubqueriesBlueprint>());
     registry.addPrototype(std::make_shared<TensorFromLabelsBlueprint>());
+    registry.addPrototype(std::make_shared<TensorFromLabelsWithOffsetBlueprint>());
     registry.addPrototype(std::make_shared<TensorFromStructsBlueprint>());
     registry.addPrototype(std::make_shared<TensorFromWeightedSetBlueprint>());
     registry.addPrototype(std::make_shared<TermBlueprint>());

--- a/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
@@ -73,7 +73,6 @@ private:
     std::unique_ptr<vespalib::eval::Value>     _tensor;
     size_t                                     _label_idx;
     size_t                                     _offset_idx;
-    bool                                       _is_single_value;
 
 public:
     TensorFromLabelsWithOffsetAttributeExecutor(const search::attribute::IAttributeVector* attribute,
@@ -85,8 +84,7 @@ public:
           _addr_ref(2),
           _tensor(),
           _label_idx(0),
-          _offset_idx(1),
-          _is_single_value(attribute->getCollectionType() == search::attribute::CollectionType::SINGLE) {
+          _offset_idx(1) {
         _attrBuffer.allocate(_attribute->getMaxValueCount());
         const auto& dims = _type.dimensions();
         for (size_t d = 0; d < dims.size(); ++d) {
@@ -105,8 +103,7 @@ void TensorFromLabelsWithOffsetAttributeExecutor<WeightedBufferType>::execute(ui
     _attrBuffer.fill(*_attribute, docId);
     auto factory = FastValueBuilderFactory::get();
     auto builder = factory.create_value_builder<float>(_type, 2, 1, _attrBuffer.size());
-    bool ignore = _is_single_value && _attribute->isUndefined(docId);
-    for (size_t i = 0; i < _attrBuffer.size() && !ignore; ++i) {
+    for (size_t i = 0; i < _attrBuffer.size(); ++i) {
         std::string label(_attrBuffer[i].value());
         std::string index_str = std::to_string(i);
         _addr_ref[_label_idx] = label;
@@ -123,20 +120,26 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
                                          const std::string& offset_dim, vespalib::Stash& stash) {
     const IAttributeVector* attribute = env.getAttributeContext().getAttribute(attrName);
     if (attribute == nullptr) {
-        Issue::report("tensor_from_labels_with_offset feature: The attribute vector '%s' was not found."
+        Issue::report("tensorFromLabelsWithOffset feature: The attribute vector '%s' was not found."
                       " Returning empty tensor.",
                       attrName.c_str());
         return ConstantTensorExecutor::createEmpty(valueType, stash);
     }
     if (attribute->isFloatingPointType()) {
-        Issue::report("tensor_from_labels_with_offset feature: The attribute vector '%s' must have basic type"
+        Issue::report("tensorFromLabelsWithOffset feature: The attribute vector '%s' must have basic type"
                       " string or integer. Returning empty tensor.",
                       attrName.c_str());
         return ConstantTensorExecutor::createEmpty(valueType, stash);
     }
     if (attribute->getCollectionType() == search::attribute::CollectionType::WSET) {
-        Issue::report("tensor_from_labels_with_offset feature: The attribute vector '%s' is a weighted set - use"
+        Issue::report("tensorFromLabelsWithOffset feature: The attribute vector '%s' is a weighted set - use"
                       " tensorFromWeightedSet instead. Returning empty tensor.",
+                      attrName.c_str());
+        return ConstantTensorExecutor::createEmpty(valueType, stash);
+    }
+    if (attribute->getCollectionType() == search::attribute::CollectionType::SINGLE) {
+        Issue::report("tensorFromLabelsWithOffset feature: The attribute vector '%s' is single-valued - this"
+                      " feature requires an array attribute. Returning empty tensor.",
                       attrName.c_str());
         return ConstantTensorExecutor::createEmpty(valueType, stash);
     }

--- a/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
@@ -2,7 +2,6 @@
 
 #include "tensor_from_labels_with_offset_feature.h"
 
-#include "array_parser.hpp"
 #include "constant_tensor_executor.h"
 
 #include <vespa/eval/eval/fast_value.h>
@@ -10,7 +9,6 @@
 #include <vespa/searchcommon/attribute/attributecontent.h>
 #include <vespa/searchcommon/attribute/iattributevector.h>
 #include <vespa/searchlib/fef/feature_type.h>
-#include <vespa/searchlib/fef/properties.h>
 #include <vespa/vespalib/util/issue.h>
 
 #include <vespa/log/log.h>
@@ -38,12 +36,15 @@ TensorFromLabelsWithOffsetBlueprint::~TensorFromLabelsWithOffsetBlueprint() = de
 bool TensorFromLabelsWithOffsetBlueprint::setup(const search::fef::IIndexEnvironment& env,
                                                 const search::fef::ParameterList&     params) {
     (void)env;
-    // _params[0] = source ('attribute(name)' OR 'query(param)');
+    // _params[0] = source ('attribute(name)');
     // _params[1] = dimension name for label values;
     // _params[2] = dimension name for array indices (offset);
     bool validSource = extractSource(params[0].getValue());
     if (!validSource) {
         return fail("invalid source: '%s'", params[0].getValue().c_str());
+    }
+    if (_sourceType != ATTRIBUTE_SOURCE) {
+        return fail("invalid source: '%s', only 'attribute(name)' is supported", params[0].getValue().c_str());
     }
     _dimension = params[1].getValue();
     _offset_dimension = params[2].getValue();
@@ -147,47 +148,12 @@ FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& e
                                                                                                label_dim, offset_dim);
 }
 
-FeatureExecutor& createQueryExecutor(const search::fef::IQueryEnvironment& env, const std::string& queryKey,
-                                     const ValueType& valueType, const std::string& label_dim,
-                                     const std::string& offset_dim, vespalib::Stash& stash) {
-    search::fef::Property prop = env.getProperties().lookup(queryKey);
-    if (prop.found() && !prop.get().empty()) {
-        std::vector<std::string> vector;
-        ArrayParser::parse(prop.get(), vector);
-
-        size_t      label_idx = 0, offset_idx = 1;
-        const auto& dims = valueType.dimensions();
-        for (size_t d = 0; d < dims.size(); ++d) {
-            if (dims[d].name == label_dim)
-                label_idx = d;
-            if (dims[d].name == offset_dim)
-                offset_idx = d;
-        }
-
-        auto factory = FastValueBuilderFactory::get();
-        auto builder = factory.create_value_builder<double>(valueType, 2, 1, vector.size());
-
-        std::vector<std::string_view> addr_ref(2);
-        for (size_t i = 0; i < vector.size(); ++i) {
-            std::string index_str = std::to_string(i);
-            addr_ref[label_idx] = vector[i];
-            addr_ref[offset_idx] = index_str;
-            auto cell_array = builder->add_subspace(addr_ref);
-            cell_array[0] = 1.0;
-        }
-        return ConstantTensorExecutor::create(builder->build(std::move(builder)), stash);
-    }
-    return ConstantTensorExecutor::createEmpty(valueType, stash);
-}
-
 } // namespace
 
 FeatureExecutor& TensorFromLabelsWithOffsetBlueprint::createExecutor(const search::fef::IQueryEnvironment& env,
                                                                      vespalib::Stash& stash) const {
     if (_sourceType == ATTRIBUTE_SOURCE) {
         return createAttributeExecutor(env, _sourceParam, _valueType, _dimension, _offset_dimension, stash);
-    } else if (_sourceType == QUERY_SOURCE) {
-        return createQueryExecutor(env, _sourceParam, _valueType, _dimension, _offset_dimension, stash);
     }
     return ConstantTensorExecutor::createEmpty(_valueType, stash);
 }

--- a/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
@@ -1,0 +1,196 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "tensor_from_labels_with_offset_feature.h"
+
+#include "array_parser.hpp"
+#include "constant_tensor_executor.h"
+
+#include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/value_type.h>
+#include <vespa/searchcommon/attribute/attributecontent.h>
+#include <vespa/searchcommon/attribute/iattributevector.h>
+#include <vespa/searchlib/fef/feature_type.h>
+#include <vespa/searchlib/fef/properties.h>
+#include <vespa/vespalib/util/issue.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".features.tensor_from_labels_with_offset_feature");
+
+using namespace search::fef;
+using search::attribute::IAttributeVector;
+using search::attribute::WeightedConstCharContent;
+using search::attribute::WeightedStringContent;
+using search::fef::FeatureType;
+using vespalib::Issue;
+using vespalib::eval::CellType;
+using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::ValueType;
+
+namespace search {
+namespace features {
+
+TensorFromLabelsWithOffsetBlueprint::TensorFromLabelsWithOffsetBlueprint()
+    : TensorFactoryBlueprint("tensorFromLabelsWithOffset"), _offset_dimension() {
+}
+
+TensorFromLabelsWithOffsetBlueprint::~TensorFromLabelsWithOffsetBlueprint() = default;
+
+bool TensorFromLabelsWithOffsetBlueprint::setup(const search::fef::IIndexEnvironment& env,
+                                                const search::fef::ParameterList&     params) {
+    (void)env;
+    // _params[0] = source ('attribute(name)' OR 'query(param)');
+    // _params[1] = dimension name for label values;
+    // _params[2] = dimension name for array indices (offset);
+    bool validSource = extractSource(params[0].getValue());
+    if (!validSource) {
+        return fail("invalid source: '%s'", params[0].getValue().c_str());
+    }
+    _dimension = params[1].getValue();
+    _offset_dimension = params[2].getValue();
+    auto vt = ValueType::make_type(CellType::DOUBLE, {{_dimension}, {_offset_dimension}});
+    _valueType = ValueType::from_spec(vt.to_spec());
+    if (_valueType.is_error()) {
+        return fail("invalid dimension names: '%s', '%s'", _dimension.c_str(), _offset_dimension.c_str());
+    }
+    describeOutput("tensor",
+                   "The tensor created from the given source with label values and array-index offset dimensions",
+                   FeatureType::object(_valueType));
+    return true;
+}
+
+namespace {
+
+// ValueType::make_type sorts dimensions alphabetically; this executor resolves
+// the correct address slot for each dimension at construction time.
+template <typename WeightedBufferType>
+class TensorFromLabelsWithOffsetAttributeExecutor : public fef::FeatureExecutor {
+private:
+    const search::attribute::IAttributeVector* _attribute;
+    vespalib::eval::ValueType                  _type;
+    WeightedBufferType                         _attrBuffer;
+    std::vector<std::string_view>              _addr_ref;
+    std::unique_ptr<vespalib::eval::Value>     _tensor;
+    size_t                                     _label_idx;
+    size_t                                     _offset_idx;
+    bool                                       _is_single_value;
+
+public:
+    TensorFromLabelsWithOffsetAttributeExecutor(const search::attribute::IAttributeVector* attribute,
+                                                const vespalib::eval::ValueType&           valueType,
+                                                const std::string& label_dim, const std::string& offset_dim)
+        : _attribute(attribute),
+          _type(valueType),
+          _attrBuffer(),
+          _addr_ref(2),
+          _tensor(),
+          _label_idx(0),
+          _offset_idx(1),
+          _is_single_value(attribute->getCollectionType() == search::attribute::CollectionType::SINGLE) {
+        _attrBuffer.allocate(_attribute->getMaxValueCount());
+        const auto& dims = _type.dimensions();
+        for (size_t d = 0; d < dims.size(); ++d) {
+            if (dims[d].name == label_dim)
+                _label_idx = d;
+            if (dims[d].name == offset_dim)
+                _offset_idx = d;
+        }
+    }
+
+    void execute(uint32_t docId) override;
+};
+
+template <typename WeightedBufferType>
+void TensorFromLabelsWithOffsetAttributeExecutor<WeightedBufferType>::execute(uint32_t docId) {
+    _attrBuffer.fill(*_attribute, docId);
+    auto factory = FastValueBuilderFactory::get();
+    auto builder = factory.create_value_builder<double>(_type, 2, 1, _attrBuffer.size());
+    bool ignore = _is_single_value && _attribute->isUndefined(docId);
+    for (size_t i = 0; i < _attrBuffer.size() && !ignore; ++i) {
+        std::string label(_attrBuffer[i].value());
+        std::string index_str = std::to_string(i);
+        _addr_ref[_label_idx] = label;
+        _addr_ref[_offset_idx] = index_str;
+        auto cell_array = builder->add_subspace(_addr_ref);
+        cell_array[0] = 1.0;
+    }
+    _tensor = builder->build(std::move(builder));
+    outputs().set_object(0, *_tensor);
+}
+
+FeatureExecutor& createAttributeExecutor(const search::fef::IQueryEnvironment& env, const std::string& attrName,
+                                         const ValueType& valueType, const std::string& label_dim,
+                                         const std::string& offset_dim, vespalib::Stash& stash) {
+    const IAttributeVector* attribute = env.getAttributeContext().getAttribute(attrName);
+    if (attribute == nullptr) {
+        Issue::report("tensor_from_labels_with_offset feature: The attribute vector '%s' was not found."
+                      " Returning empty tensor.",
+                      attrName.c_str());
+        return ConstantTensorExecutor::createEmpty(valueType, stash);
+    }
+    if (attribute->isFloatingPointType()) {
+        Issue::report("tensor_from_labels_with_offset feature: The attribute vector '%s' must have basic type"
+                      " string or integer. Returning empty tensor.",
+                      attrName.c_str());
+        return ConstantTensorExecutor::createEmpty(valueType, stash);
+    }
+    if (attribute->getCollectionType() == search::attribute::CollectionType::WSET) {
+        Issue::report("tensor_from_labels_with_offset feature: The attribute vector '%s' is a weighted set - use"
+                      " tensorFromWeightedSet instead. Returning empty tensor.",
+                      attrName.c_str());
+        return ConstantTensorExecutor::createEmpty(valueType, stash);
+    }
+    if (attribute->isIntegerType()) {
+        return stash.create<TensorFromLabelsWithOffsetAttributeExecutor<WeightedStringContent>>(
+            attribute, valueType, label_dim, offset_dim);
+    }
+    return stash.create<TensorFromLabelsWithOffsetAttributeExecutor<WeightedConstCharContent>>(attribute, valueType,
+                                                                                               label_dim, offset_dim);
+}
+
+FeatureExecutor& createQueryExecutor(const search::fef::IQueryEnvironment& env, const std::string& queryKey,
+                                     const ValueType& valueType, const std::string& label_dim,
+                                     const std::string& offset_dim, vespalib::Stash& stash) {
+    search::fef::Property prop = env.getProperties().lookup(queryKey);
+    if (prop.found() && !prop.get().empty()) {
+        std::vector<std::string> vector;
+        ArrayParser::parse(prop.get(), vector);
+
+        size_t      label_idx = 0, offset_idx = 1;
+        const auto& dims = valueType.dimensions();
+        for (size_t d = 0; d < dims.size(); ++d) {
+            if (dims[d].name == label_dim)
+                label_idx = d;
+            if (dims[d].name == offset_dim)
+                offset_idx = d;
+        }
+
+        auto factory = FastValueBuilderFactory::get();
+        auto builder = factory.create_value_builder<double>(valueType, 2, 1, vector.size());
+
+        std::vector<std::string_view> addr_ref(2);
+        for (size_t i = 0; i < vector.size(); ++i) {
+            std::string index_str = std::to_string(i);
+            addr_ref[label_idx] = vector[i];
+            addr_ref[offset_idx] = index_str;
+            auto cell_array = builder->add_subspace(addr_ref);
+            cell_array[0] = 1.0;
+        }
+        return ConstantTensorExecutor::create(builder->build(std::move(builder)), stash);
+    }
+    return ConstantTensorExecutor::createEmpty(valueType, stash);
+}
+
+} // namespace
+
+FeatureExecutor& TensorFromLabelsWithOffsetBlueprint::createExecutor(const search::fef::IQueryEnvironment& env,
+                                                                     vespalib::Stash& stash) const {
+    if (_sourceType == ATTRIBUTE_SOURCE) {
+        return createAttributeExecutor(env, _sourceParam, _valueType, _dimension, _offset_dimension, stash);
+    } else if (_sourceType == QUERY_SOURCE) {
+        return createQueryExecutor(env, _sourceParam, _valueType, _dimension, _offset_dimension, stash);
+    }
+    return ConstantTensorExecutor::createEmpty(_valueType, stash);
+}
+
+} // namespace features
+} // namespace search

--- a/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.cpp
@@ -48,7 +48,7 @@ bool TensorFromLabelsWithOffsetBlueprint::setup(const search::fef::IIndexEnviron
     }
     _dimension = params[1].getValue();
     _offset_dimension = params[2].getValue();
-    auto vt = ValueType::make_type(CellType::DOUBLE, {{_dimension}, {_offset_dimension}});
+    auto vt = ValueType::make_type(CellType::FLOAT, {{_dimension}, {_offset_dimension}});
     _valueType = ValueType::from_spec(vt.to_spec());
     if (_valueType.is_error()) {
         return fail("invalid dimension names: '%s', '%s'", _dimension.c_str(), _offset_dimension.c_str());
@@ -104,7 +104,7 @@ template <typename WeightedBufferType>
 void TensorFromLabelsWithOffsetAttributeExecutor<WeightedBufferType>::execute(uint32_t docId) {
     _attrBuffer.fill(*_attribute, docId);
     auto factory = FastValueBuilderFactory::get();
-    auto builder = factory.create_value_builder<double>(_type, 2, 1, _attrBuffer.size());
+    auto builder = factory.create_value_builder<float>(_type, 2, 1, _attrBuffer.size());
     bool ignore = _is_single_value && _attribute->isUndefined(docId);
     for (size_t i = 0; i < _attrBuffer.size() && !ignore; ++i) {
         std::string label(_attrBuffer[i].value());

--- a/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.h
@@ -14,7 +14,7 @@ namespace search::features {
  * array indices ("0", "1", ...) are used as labels in an offset dimension.
  * The tensor cells all get the value 1.0.
  *
- * The array source can be either an attribute vector or query parameter.
+ * The array source is an attribute vector.
  */
 class TensorFromLabelsWithOffsetBlueprint : public TensorFactoryBlueprint {
 private:

--- a/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.h
+++ b/searchlib/src/vespa/searchlib/features/tensor_from_labels_with_offset_feature.h
@@ -1,0 +1,36 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "tensor_factory_blueprint.h"
+
+#include <string>
+
+namespace search::features {
+
+/**
+ * Blueprint for a rank feature that creates a tensor from an array
+ * where the elements are used as labels in one dimension and the
+ * array indices ("0", "1", ...) are used as labels in an offset dimension.
+ * The tensor cells all get the value 1.0.
+ *
+ * The array source can be either an attribute vector or query parameter.
+ */
+class TensorFromLabelsWithOffsetBlueprint : public TensorFactoryBlueprint {
+private:
+    std::string _offset_dimension;
+
+public:
+    TensorFromLabelsWithOffsetBlueprint();
+    ~TensorFromLabelsWithOffsetBlueprint() override;
+    fef::Blueprint::UP createInstance() const override {
+        return Blueprint::UP(new TensorFromLabelsWithOffsetBlueprint());
+    }
+    fef::ParameterDescriptions getDescriptions() const override {
+        return fef::ParameterDescriptions().desc().string().string().string();
+    }
+    bool setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) override;
+    fef::FeatureExecutor& createExecutor(const fef::IQueryEnvironment& env, vespalib::Stash& stash) const override;
+};
+
+} // namespace search::features


### PR DESCRIPTION
Creates a 2D sparse tensor from an array attribute (or query param) where one dimension holds the element values as labels and a second "offset" dimension holds the array indices ("0", "1", ...) as labels. Each cell gets value 1.0, matching the tensorFromLabels convention.

@dainiusjocas FYI
