### PR TITLE
[tracing] Add per-request OpenTelemetry server span at the Jetty layer

### DIFF
--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -433,6 +433,12 @@
 
     <!-- TEST scope dependencies -->
     <dependency>
+      <!-- InMemorySpanExporter for asserting on emitted spans; version managed by opentelemetry-bom -->
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -15,6 +15,7 @@ import com.yahoo.jdisc.service.ServerProvider;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.metrics.simple.MetricSettings;
 import com.yahoo.text.Text;
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.jetty.jmx.ConnectorServer;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
@@ -63,7 +64,8 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
                            ServerConfig serverConfig,
                            ComponentRegistry<ConnectorFactory> connectorFactories,
                            RequestLog requestLog,
-                           ConnectionLog connectionLog) {
+                           ConnectionLog connectionLog,
+                           OpenTelemetry openTelemetry) {
         if (connectorFactories.allComponents().isEmpty())
             throw new IllegalArgumentException("No connectors configured.");
 
@@ -115,13 +117,16 @@ public class JettyHttpServer extends AbstractResource implements ServerProvider 
         var connectionMetricAggregator = new ConnectionMetricAggregator(serverConfig, metric, statisticsHandler);
 
 
+        Handler topHandler;
         if (!(connectionLog instanceof VoidConnectionLog)) {
             var connectionLogger = new JettyConnectionLogger(serverConfig.connectionLog(), connectionLog, connectionMetricAggregator);
             server.addBeanToAllConnectors(connectionLogger);
-            server.setHandler(connectionLogger);
+            topHandler = connectionLogger;
         } else {
-            server.setHandler(connectionMetricAggregator);
+            topHandler = connectionMetricAggregator;
         }
+        // Server span handler is outermost so the span encloses the entire request handling.
+        server.setHandler(new JettyServerSpanHandler(openTelemetry, topHandler));
 
         server.addBeanToAllConnectors(connectionMetricAggregator);
 

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandler.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandler.java
@@ -1,0 +1,188 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.jdisc.http.server.jetty;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.EventsHandler;
+
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Jetty integration that creates an OpenTelemetry {@link SpanKind#SERVER server span} per HTTP request.
+ *
+ * <p>The span is started when request handling begins ({@link #onBeforeHandling}) and ended when the
+ * request and response are fully processed ({@link #onComplete}). The owning {@link Context} (the
+ * incoming W3C trace context with this server span set) is stored as a Jetty request attribute under
+ * {@link #OTEL_CONTEXT_REQUEST_ATTRIBUTE}, so downstream code can create child spans and propagate it.</p>
+ *
+ * <p>{@link #onBeforeHandling} and {@link #onComplete} are not guaranteed to run on the same thread
+ * (async requests), so the span is carried explicitly in the request attribute rather than via a
+ * thread-local {@link io.opentelemetry.context.Scope}.</p>
+ *
+ * <p>Always installed; when telemetry is disabled the injected {@link OpenTelemetry} is
+ * {@link OpenTelemetry#noop()}, so all spans are non-recording and effectively free.</p>
+ *
+ * @author onur
+ */
+class JettyServerSpanHandler extends EventsHandler {
+
+    /** Request attribute holding the {@link Context} (incoming context + server span) for this request. */
+    static final String OTEL_CONTEXT_REQUEST_ATTRIBUTE = "jdisc.request.otel.context";
+
+    private static final Logger log = Logger.getLogger(JettyServerSpanHandler.class.getName());
+    private static final String INSTRUMENTATION_SCOPE_NAME = "com.yahoo.jdisc.http.server.jetty";
+
+    // OpenTelemetry HTTP-server semantic-convention attribute keys. Hardcoded here (rather than depending
+    // on the alpha opentelemetry-semconv artifact) so this stays on the API-only classpath.
+    private static final AttributeKey<String> HTTP_REQUEST_METHOD       = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<Long>   HTTP_RESPONSE_STATUS_CODE = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<String> HTTP_ROUTE                = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> URL_SCHEME                = AttributeKey.stringKey("url.scheme");
+    private static final AttributeKey<String> SERVER_ADDRESS            = AttributeKey.stringKey("server.address");
+    private static final AttributeKey<Long>   SERVER_PORT               = AttributeKey.longKey("server.port");
+    private static final AttributeKey<String> CLIENT_ADDRESS            = AttributeKey.stringKey("client.address");
+    private static final AttributeKey<String> NETWORK_PROTOCOL_VERSION  = AttributeKey.stringKey("network.protocol.version");
+    private static final AttributeKey<String> USER_AGENT_ORIGINAL       = AttributeKey.stringKey("user_agent.original");
+    private static final AttributeKey<String> ERROR_TYPE                = AttributeKey.stringKey("error.type");
+
+    private static final TextMapGetter<Request> HEADER_GETTER = new TextMapGetter<>() {
+        @Override public Iterable<String> keys(Request request) {
+            return request.getHeaders().getFieldNamesCollection();
+        }
+        @Override public String get(Request request, String key) {
+            if (request == null) return null;
+            return request.getHeaders().get(key);
+        }
+    };
+
+    private final Tracer tracer;
+    private final TextMapPropagator propagator;
+
+    JettyServerSpanHandler(OpenTelemetry openTelemetry, Handler handler) {
+        super(handler);
+        this.tracer = openTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
+        this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
+    }
+
+    @Override
+    protected void onBeforeHandling(Request request) {
+        try {
+            Context parentContext = propagator.extract(Context.current(), request, HEADER_GETTER);
+            Span span = tracer.spanBuilder(spanName(request))
+                    .setSpanKind(SpanKind.SERVER)
+                    .setParent(parentContext)
+                    .startSpan();
+            // Store the context before setting attributes so onComplete can always end the span,
+            // even if an attribute getter below throws.
+            request.setAttribute(OTEL_CONTEXT_REQUEST_ATTRIBUTE, parentContext.with(span));
+            setRequestAttributes(span, request);
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Failed to start server span", e);
+        }
+    }
+
+    @Override
+    protected void onComplete(Request request, int status, HttpFields headers, Throwable failure) {
+        try {
+            if (!(request.getAttribute(OTEL_CONTEXT_REQUEST_ATTRIBUTE) instanceof Context context)) return;
+            Span span = Span.fromContext(context);
+            span.setAttribute(HTTP_RESPONSE_STATUS_CODE, status);
+            if (failure != null) {
+                span.recordException(failure);
+                span.setStatus(StatusCode.ERROR);
+                span.setAttribute(ERROR_TYPE, failure.getClass().getName());
+            } else if (status >= 500) {
+                span.setStatus(StatusCode.ERROR);
+                span.setAttribute(ERROR_TYPE, Integer.toString(status));
+            }
+            span.end();
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Failed to end server span", e);
+        }
+    }
+
+    /**
+     * No real {@code http.route} is available at this layer (the jdisc handler binding is resolved further
+     * down the chain), so we use the first path segment as a cheap, low-cardinality pseudo-route:
+     * {@code "{method} /{first-segment}"}, e.g. {@code "GET /document"}. Falls back to the method alone
+     * when no path is available.
+     */
+    private static String spanName(Request request) {
+        try {
+            String method = request.getMethod();
+            if (method == null) method = "HTTP";
+            String segment = firstPathSegment(pathOf(request));
+            return segment != null ? method + " " + segment : method;
+        } catch (RuntimeException e) {
+            return "HTTP";
+        }
+    }
+
+    private static String firstPathSegment(String path) {
+        if (path == null || path.isEmpty()) return null;
+        if (!path.startsWith("/")) path = "/" + path;
+        int next = path.indexOf('/', 1);
+        return next < 0 ? path : path.substring(0, next);
+    }
+
+    private static void setRequestAttributes(Span span, Request request) {
+        setAttribute(span, HTTP_REQUEST_METHOD, request::getMethod);
+        // Coarse first-path-segment pseudo-route (the real http.route is not known at this layer); low cardinality.
+        setAttribute(span, HTTP_ROUTE, () -> firstPathSegment(pathOf(request)));
+        setAttribute(span, URL_SCHEME, () -> schemeOf(request));
+        setAttribute(span, SERVER_ADDRESS, () -> Request.getServerName(request));
+        setAttribute(span, SERVER_PORT, () -> Request.getServerPort(request));
+        setAttribute(span, CLIENT_ADDRESS, () -> Request.getRemoteAddr(request));
+        setAttribute(span, NETWORK_PROTOCOL_VERSION, () -> protocolVersion(request));
+        setAttribute(span, USER_AGENT_ORIGINAL, () -> request.getHeaders().get("User-Agent"));
+    }
+
+    /** Each Jetty getter is isolated: a getter that throws is skipped, leaving the other attributes intact. */
+    private static void setAttribute(Span span, AttributeKey<String> key, Supplier<String> getter) {
+        try {
+            String value = getter.get();
+            if (value != null) span.setAttribute(key, value);
+        } catch (RuntimeException ignored) {
+            // best-effort: a single failing getter must not abort span instrumentation
+        }
+    }
+
+    private static void setAttribute(Span span, AttributeKey<Long> key, IntSupplier getter) {
+        try {
+            span.setAttribute(key, getter.getAsInt());
+        } catch (RuntimeException ignored) {
+            // best-effort: a single failing getter must not abort span instrumentation
+        }
+    }
+
+    private static String pathOf(Request request) {
+        var uri = request.getHttpURI();
+        return uri != null ? uri.getPath() : null;
+    }
+
+    private static String schemeOf(Request request) {
+        var uri = request.getHttpURI();
+        return uri != null ? uri.getScheme() : null;
+    }
+
+    private static String protocolVersion(Request request) {
+        String protocol = request.getConnectionMetaData().getProtocol(); // e.g. "HTTP/1.1"
+        if (protocol == null) return null;
+        int slash = protocol.indexOf('/');
+        return slash >= 0 ? protocol.substring(slash + 1) : protocol;
+    }
+
+}

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/testutils/TestDriver.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/testutils/TestDriver.java
@@ -18,6 +18,7 @@ import com.yahoo.jdisc.http.server.jetty.VoidConnectionLog;
 import com.yahoo.jdisc.http.server.jetty.VoidRequestLog;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.security.SslContextBuilder;
+import io.opentelemetry.api.OpenTelemetry;
 
 import javax.net.ssl.SSLContext;
 import java.nio.file.Paths;
@@ -96,6 +97,7 @@ public class TestDriver implements AutoCloseable {
                         bind(ConnectionLog.class).toInstance(new VoidConnectionLog());
                         bind(RequestLog.class).toInstance(new VoidRequestLog());
                         bind(MetricReceiver.class).toInstance(MetricReceiver.nullImplementation);
+                        bind(OpenTelemetry.class).toInstance(OpenTelemetry.noop());
                     }
                 },
                 new ConnectorFactoryRegistryModule(connectorConfig));

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerConformanceIT.java
@@ -12,6 +12,7 @@ import com.yahoo.jdisc.http.ServerConfig;
 import com.yahoo.jdisc.http.server.jetty.testutils.ConnectorFactoryRegistryModule;
 import com.yahoo.jdisc.test.ServerProviderConformanceTest;
 import com.yahoo.metrics.simple.MetricReceiver;
+import io.opentelemetry.api.OpenTelemetry;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpGet;
@@ -778,6 +779,7 @@ public class HttpServerConformanceIT extends ServerProviderConformanceTest {
                             bind(ConnectionLog.class).toInstance(new VoidConnectionLog());
                             bind(RequestLog.class).toInstance(new VoidRequestLog());
                             bind(MetricReceiver.class).toInstance(MetricReceiver.nullImplementation);
+                            bind(OpenTelemetry.class).toInstance(OpenTelemetry.noop());
                         }
                     },
                     new ConnectorFactoryRegistryModule());

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandlerTest.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandlerTest.java
@@ -1,0 +1,143 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.jdisc.http.server.jetty;
+
+import com.google.inject.Module;
+import com.yahoo.jdisc.Request;
+import com.yahoo.jdisc.Response;
+import com.yahoo.jdisc.handler.AbstractRequestHandler;
+import com.yahoo.jdisc.handler.ContentChannel;
+import com.yahoo.jdisc.handler.ResponseHandler;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
+import static com.yahoo.jdisc.Response.Status.OK;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link JettyServerSpanHandler} produces an OpenTelemetry server span per HTTP request,
+ * with the expected semantic-convention attributes and remote-parent extraction.
+ *
+ * @author onur
+ */
+class JettyServerSpanHandlerTest {
+
+    private static final AttributeKey<String> HTTP_REQUEST_METHOD       = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<Long>   HTTP_RESPONSE_STATUS_CODE = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<String> HTTP_ROUTE                = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> URL_SCHEME                = AttributeKey.stringKey("url.scheme");
+    private static final AttributeKey<String> SERVER_ADDRESS            = AttributeKey.stringKey("server.address");
+    private static final AttributeKey<String> NETWORK_PROTOCOL_VERSION  = AttributeKey.stringKey("network.protocol.version");
+    private static final AttributeKey<String> ERROR_TYPE                = AttributeKey.stringKey("error.type");
+
+    @Test
+    void serverSpanIsCreatedWithSemconvAttributes() throws IOException, InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        JettyTestDriver driver = JettyTestDriver.newInstance(new EchoRequestHandler(), otelModule(exporter));
+
+        driver.client().newGet("/search/").execute().expectStatusCode(is(OK));
+
+        SpanData span = awaitSingleSpan(exporter);
+        assertEquals(SpanKind.SERVER, span.getKind());
+        assertEquals("GET /search", span.getName());
+        Attributes attrs = span.getAttributes();
+        assertEquals("GET", attrs.get(HTTP_REQUEST_METHOD));
+        assertEquals("/search", attrs.get(HTTP_ROUTE));
+        assertEquals("http", attrs.get(URL_SCHEME));
+        assertEquals(Long.valueOf(200), attrs.get(HTTP_RESPONSE_STATUS_CODE));
+        assertNotNull(attrs.get(SERVER_ADDRESS));
+        assertNotNull(attrs.get(NETWORK_PROTOCOL_VERSION));
+
+        assertTrue(driver.close());
+    }
+
+    @Test
+    void serverSpanExtractsRemoteParent() throws IOException, InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        JettyTestDriver driver = JettyTestDriver.newInstance(new EchoRequestHandler(), otelModule(exporter));
+
+        String traceId = "0af7651916cd43dd8448eb211c80319c";
+        String parentSpanId = "b7ad6b7169203331";
+        driver.client().newGet("/search/")
+                .addHeader("traceparent", "00-" + traceId + "-" + parentSpanId + "-01")
+                .execute().expectStatusCode(is(OK));
+
+        SpanData span = awaitSingleSpan(exporter);
+        assertEquals(traceId, span.getSpanContext().getTraceId());
+        assertEquals(parentSpanId, span.getParentSpanContext().getSpanId());
+
+        assertTrue(driver.close());
+    }
+
+    @Test
+    void serverSpanMarksErrorOnServerError() throws IOException, InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        JettyTestDriver driver = JettyTestDriver.newInstance(new ServerErrorRequestHandler(), otelModule(exporter));
+
+        driver.client().newGet("/search/").execute().expectStatusCode(is(INTERNAL_SERVER_ERROR));
+
+        SpanData span = awaitSingleSpan(exporter);
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals("500", span.getAttributes().get(ERROR_TYPE));
+        assertEquals(Long.valueOf(500), span.getAttributes().get(HTTP_RESPONSE_STATUS_CODE));
+
+        assertTrue(driver.close());
+    }
+
+    @Test
+    void requestSucceedsWithNoopOpenTelemetry() throws IOException {
+        // No OpenTelemetry override, so TestDriver's OpenTelemetry.noop() binding is used (telemetry disabled).
+        // The handler is still installed but produces no spans; the request must be unaffected.
+        JettyTestDriver driver = JettyTestDriver.newInstance(new EchoRequestHandler());
+
+        driver.client().newGet("/search/").execute().expectStatusCode(is(OK));
+
+        assertTrue(driver.close());
+    }
+
+    private static Module otelModule(InMemorySpanExporter exporter) {
+        OpenTelemetry sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        return binder -> binder.bind(OpenTelemetry.class).toInstance(sdk);
+    }
+
+    /** {@code onComplete} fires just after the client receives the response, so poll briefly for the span. */
+    private static SpanData awaitSingleSpan(InMemorySpanExporter exporter) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        List<SpanData> spans;
+        while ((spans = exporter.getFinishedSpanItems()).isEmpty() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        assertEquals(1, spans.size(), "expected exactly one server span");
+        return spans.get(0);
+    }
+
+    private static class ServerErrorRequestHandler extends AbstractRequestHandler {
+        @Override
+        public ContentChannel handleRequest(Request request, ResponseHandler handler) {
+            return handler.handleResponse(new Response(INTERNAL_SERVER_ERROR));
+        }
+    }
+
+}

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -97,6 +97,7 @@ io.opentelemetry:opentelemetry-exporter-sender-jdk:${opentelemetry.vespa.version
 io.opentelemetry:opentelemetry-sdk-common:${opentelemetry.vespa.version}
 io.opentelemetry:opentelemetry-sdk-logs:${opentelemetry.vespa.version}
 io.opentelemetry:opentelemetry-sdk-metrics:${opentelemetry.vespa.version}
+io.opentelemetry:opentelemetry-sdk-testing:${opentelemetry.vespa.version}
 io.opentelemetry:opentelemetry-sdk-trace:${opentelemetry.vespa.version}
 io.opentelemetry:opentelemetry-sdk:${opentelemetry.vespa.version}
 io.perfmark:perfmark-api:0.27.0


### PR DESCRIPTION
## What

Adds `JettyServerSpanHandler`, a Jetty `EventsHandler` installed as the **outermost** handler in the jdisc container's Jetty server, that creates one OpenTelemetry `SERVER` span per HTTP request:

- **Start** on request begin (`onBeforeHandling`): extract the incoming **W3C trace context** from request headers, start the span as its child.
- **Carry**: store the resulting `Context` (incoming context + server span) in a Jetty request attribute (`jdisc.request.otel.context`) for downstream child-span creation / propagation. `onBeforeHandling` and `onComplete` may run on different threads (async requests), so the span is carried explicitly via the request attribute rather than a thread-local `Scope`.
- **End** on completion (`onComplete`): set `http.response.status_code`, mark `StatusCode.ERROR` + `error.type` on failure or 5xx, then end the span.

## Span shape

- **Name:** `{method} {first-path-segment}` (e.g. `GET /document`) — a low-cardinality pseudo-route, since the real `http.route` is not known at this layer (the jdisc handler binding resolves further down the chain). `http.route` carries the same first segment.
- **Attributes** (OTel HTTP-server semconv): `http.request.method`, `http.route`, `url.scheme`, `server.address`, `server.port`, `network.protocol.version`, `client.address`, `user_agent.original`, `http.response.status_code`, `error.type`. Attribute keys are hardcoded constants to avoid pulling in the alpha `opentelemetry-semconv` artifact.

## Behavior when disabled

The handler is **always installed**; when telemetry is disabled the injected `OpenTelemetry` is `OpenTelemetry.noop()`, so spans are non-recording and effectively free. Each attribute getter is isolated in try/catch so a single failing Jetty getter cannot abort instrumentation, and the callbacks never propagate failures into request handling.

## Tests

`JettyServerSpanHandlerTest` (using a real SDK + `InMemorySpanExporter`): semconv attributes, remote-parent extraction from `traceparent`, 5xx → `ERROR` + `error.type`, and request still succeeds under `OpenTelemetry.noop()`.

`opentelemetry-sdk-testing` is added as a test-scope dependency (version managed by the existing `opentelemetry-bom`) and to the dependency-enforcer allow-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)