### PR TITLE
Allow configuring optimization for ONNX models in services.xml

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -925,6 +925,10 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             onnxModel.setStatelessExecutionMode(getStringValue(modelElement, "execution-mode", null));
             onnxModel.setStatelessInterOpThreads(getIntValue(modelElement, "interop-threads", -1));
             onnxModel.setStatelessIntraOpThreads(getIntValue(modelElement, "intraop-threads", -1));
+            Element optimizeModelElement = XML.getChild(modelElement, "optimize-model");
+            if (optimizeModelElement != null) {
+                onnxModel.setOptimizeModel(Boolean.parseBoolean(optimizeModelElement.getTextContent()));
+            }
             Element gpuDeviceElement = XML.getChild(modelElement, "gpu-device");
             if (gpuDeviceElement != null) {
                 int gpuDevice = Integer.parseInt(gpuDeviceElement.getTextContent());

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -119,6 +119,7 @@ ModelEvaluation = element model-evaluation {
                 element intraop-threads { xsd:nonNegativeInteger }? &
                 element interop-threads { xsd:nonNegativeInteger }? &
                 element execution-mode { string "sequential" | string "parallel" }? &
+                element optimize-model { xsd:boolean }? &
                 element gpu-device {
                   xsd:nonNegativeInteger
                 }?

--- a/config-model/src/test/cfg/application/onnx_cluster_specific/services.xml
+++ b/config-model/src/test/cfg/application/onnx_cluster_specific/services.xml
@@ -8,6 +8,7 @@
         <models>
           <model name="mul">
             <intraop-threads>2</intraop-threads>
+            <optimize-model>true</optimize-model>
             <gpu-device>0</gpu-device>
           </model>
         </models>

--- a/config-model/src/test/java/com/yahoo/vespa/model/ml/ModelEvaluationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ml/ModelEvaluationTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,6 +97,8 @@ public class ModelEvaluationTest {
             OnnxModelsConfig.Model c2Model = getOnnxModelsConfig(model.getContainerClusters().get("c2"));
             assertEquals(2, c1Model.stateless_intraop_threads());
             assertEquals(4, c2Model.stateless_intraop_threads());
+            assertTrue(c1Model.optimize_model());
+            assertFalse(c2Model.optimize_model());
             assertEquals(0, c1Model.gpu_device());
             assertEquals(1, c2Model.gpu_device());
         } finally {


### PR DESCRIPTION
Add an "optimize-model" element to the model-evaluation/onnx/models/model block in services.xml. This lets each container cluster control ONNX graph optimization for models not declared in a schema.

