### PR TITLE
Allow configuring ONNX graph optimization for ONNX embedders

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1717,7 +1717,7 @@
     "methods" : [
       "public void <init>(java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional)",
       "public void <init>(java.lang.String, int, int, com.yahoo.config.model.api.OnnxModelOptions$GpuDevice)",
-      "public void <init>(java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional)",
+      "public void <init>(java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Optional)",
       "public static com.yahoo.config.model.api.OnnxModelOptions empty()",
       "public com.yahoo.config.model.api.OnnxModelOptions withExecutionMode(java.lang.String)",
       "public com.yahoo.config.model.api.OnnxModelOptions withInterOpThreads(java.lang.Integer)",
@@ -1728,6 +1728,7 @@
       "public com.yahoo.config.model.api.OnnxModelOptions withConcurrencyFactorType(java.lang.String)",
       "public com.yahoo.config.model.api.OnnxModelOptions withConcurrencyFactor(java.lang.Double)",
       "public com.yahoo.config.model.api.OnnxModelOptions withModelConfigOverride(com.yahoo.config.FileReference)",
+      "public com.yahoo.config.model.api.OnnxModelOptions withOptimizeModel(java.lang.Boolean)",
       "public final java.lang.String toString()",
       "public final int hashCode()",
       "public final boolean equals(java.lang.Object)",
@@ -1739,7 +1740,8 @@
       "public java.util.Optional batchingMaxDelay()",
       "public java.util.Optional concurrencyFactorType()",
       "public java.util.Optional concurrencyFactor()",
-      "public java.util.Optional modelConfigOverride()"
+      "public java.util.Optional modelConfigOverride()",
+      "public java.util.Optional optimizeModel()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelOptions.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelOptions.java
@@ -22,7 +22,8 @@ public record OnnxModelOptions(
         Optional<Duration> batchingMaxDelay,
         Optional<String> concurrencyFactorType,
         Optional<Double> concurrencyFactor,
-        Optional<FileReference> modelConfigOverride) {
+        Optional<FileReference> modelConfigOverride,
+        Optional<Boolean> optimizeModel) {
     public OnnxModelOptions(
             Optional<String> executionMode,
             Optional<Integer> interOpThreads,
@@ -53,7 +54,8 @@ public record OnnxModelOptions(
                 builder.batchingMaxDelay,
                 builder.concurrencyFactorType,
                 builder.concurrencyFactor,
-                builder.modelConfigOverride);
+                builder.modelConfigOverride,
+                builder.optimizeModel);
     }
 
     public static OnnxModelOptions empty() {
@@ -96,6 +98,10 @@ public record OnnxModelOptions(
         return toBuilder().modelConfigOverride(modelConfigOverride).build();
     }
 
+    public OnnxModelOptions withOptimizeModel(Boolean optimizeModel) {
+        return toBuilder().optimizeModel(optimizeModel).build();
+    }
+
     private Builder toBuilder() {
         return new Builder(this);
     }
@@ -110,6 +116,7 @@ public record OnnxModelOptions(
         private Optional<String> concurrencyFactorType = Optional.empty();
         private Optional<Double> concurrencyFactor = Optional.empty();
         private Optional<FileReference> modelConfigOverride = Optional.empty();
+        private Optional<Boolean> optimizeModel = Optional.empty();
 
         Builder() {}
 
@@ -123,6 +130,7 @@ public record OnnxModelOptions(
             this.concurrencyFactorType = options.concurrencyFactorType;
             this.concurrencyFactor = options.concurrencyFactor;
             this.modelConfigOverride = options.modelConfigOverride;
+            this.optimizeModel = options.optimizeModel;
         }
 
         Builder executionMode(String executionMode) {
@@ -167,6 +175,11 @@ public record OnnxModelOptions(
 
         Builder modelConfigOverride(FileReference modelConfigOverride) {
             this.modelConfigOverride = Optional.ofNullable(modelConfigOverride);
+            return this;
+        }
+
+        Builder optimizeModel(Boolean optimizeModel) {
+            this.optimizeModel = Optional.ofNullable(optimizeModel);
             return this;
         }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/OnnxEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/OnnxEmbedder.java
@@ -46,6 +46,11 @@ abstract class OnnxEmbedder extends TypedComponent implements OnnxEvaluatorConfi
                 .map(opts::withGpuDevice)
                 .orElse(opts);
 
+        opts = getChildValue(xml, "onnx-optimize-model")
+                .map(Boolean::parseBoolean)
+                .map(opts::withOptimizeModel)
+                .orElse(opts);
+
         var batchingConfig = EmbedderBatchingConfig.parseBatchingElement(xml);
         if (batchingConfig != null) {
             opts = opts.withBatchingMaxSize(batchingConfig.maxSize());
@@ -91,6 +96,7 @@ abstract class OnnxEmbedder extends TypedComponent implements OnnxEvaluatorConfi
                         builder.concurrency.factorType(OnnxEvaluatorConfig.Concurrency.FactorType.Enum.valueOf(value)));
         onnxModelOptions.concurrencyFactor().ifPresent(builder.concurrency::factor);
         builder.modelConfigOverride(onnxModelOptions.modelConfigOverride());
+        onnxModelOptions.optimizeModel().ifPresent(builder::optimizeModel);
     }
 
 

--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -187,6 +187,7 @@ OnnxModelExecutionParams =
     element onnx-interop-threads { xsd:integer }? &
     element onnx-intraop-threads { xsd:integer }? &
     element onnx-gpu-device { xsd:integer }? &
+    element onnx-optimize-model { xsd:boolean }? &
     EmbedderBatchingParams &
     element concurrency {
         attribute type { "absolute" | "relative" }? &

--- a/config-model/src/test/cfg/application/embed/services.xml
+++ b/config-model/src/test/cfg/application/embed/services.xml
@@ -20,6 +20,7 @@
       <onnx-intraop-threads>10</onnx-intraop-threads>
       <onnx-interop-threads>8</onnx-interop-threads>
       <onnx-gpu-device>1</onnx-gpu-device>
+      <onnx-optimize-model>true</onnx-optimize-model>
       <pooling-strategy>mean</pooling-strategy>
       <batching max-size="16" max-delay="100ms"/>
       <concurrency type="relative">2.0</concurrency>

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/EmbedderTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/EmbedderTestCase.java
@@ -122,6 +122,7 @@ public class EmbedderTestCase {
         assertEquals(2.0, onnxCfg.concurrency().factor(), 0.001);
         assertTrue(onnxCfg.modelConfigOverride().isPresent());
         assertEquals("files/hf_config.pbtxt", onnxCfg.modelConfigOverride().get().toString());
+        assertTrue(onnxCfg.optimizeModel());
     }
 
     @Test

--- a/configdefinitions/src/vespa/onnx-evaluator.def
+++ b/configdefinitions/src/vespa/onnx-evaluator.def
@@ -7,6 +7,9 @@ intraOpThreads int default=-4
 # GPU device id, -1 for CPU
 gpuDevice int default=0
 
+# Controls ONNX graph optimization. Default is off.
+optimizeModel bool default=false
+
 # Controls dynamic batching that combines up to `maxSize` requests within `maxDelayMillis` into a single inference call.
 # This increases throughput at the cost of latency.
 # This is especially effective for generating embeddings during feeding on GPU.

--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
@@ -59,7 +59,8 @@ public record OnnxEvaluatorOptions(
                 .setThreadsFromFactors(config.interOpThreads(), config.intraOpThreads())
                 .setBatchingMaxSize(config.batching().maxSize())
                 .setConcurrency(config.concurrency().factor(), concurrencyFactorType)
-                .setModelConfigOverride(config.modelConfigOverride());
+                .setModelConfigOverride(config.modelConfigOverride())
+                .setOptimizeModel(config.optimizeModel());
 
         if (config.gpuDevice() >= 0) {
             builder.setGpuDevice(config.gpuDevice());


### PR DESCRIPTION
Add an "onnx-optimize-model" element to the ONNX embedder config in services.xml, giving ONNX-based embedders (HuggingFace, Splade, ColBert, Bert, ...) the same per-model graph-optimization control that schema and model-evaluation ONNX models already have.

Wired through the stateless evaluator path:
- onnx-evaluator.def: new optimizeModel bool default=false
- OnnxModelOptions gains an optional optimizeModel field
- OnnxEmbedder parses onnx-optimize-model and emits it in getConfig
- common.rnc accepts the new element for all ONNX embedders
- OnnxEvaluatorOptions.of reads optimizeModel from config, so EmbeddedOnnxRuntime honors it (ALL_OPT vs NO_OPT)

Default is off, matching the existing behavior.
