### PR TITLE
[tracing] container: resolve OpenTelemetry endpoint from host-written file + client mTLS

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -37,6 +37,7 @@ import com.yahoo.search.config.SchemaInfoConfig;
 import com.yahoo.search.pagetemplates.PageTemplatesConfig;
 import com.yahoo.search.query.profile.config.QueryProfilesConfig;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
+import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.PortsMeta;
 import com.yahoo.vespa.model.Service;
 import com.yahoo.vespa.model.VespaModel;
@@ -578,8 +579,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     @Override
     public void getConfig(TelemetryConfig.Builder builder) {
         builder.enabled(opentelemetrySdk.enabled())
-               .endpoint(opentelemetrySdk.endpoint())
-               .samplingRatio(opentelemetrySdk.samplingRatio());
+               .samplingRatio(opentelemetrySdk.samplingRatio())
+               .endpointHostnameFile(Defaults.OPENTELEMETRY_HOST_HOSTNAME_FILE);
         builder.resourceAttribute.putAll(telemetryResourceAttributes);
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/OpenTelemetryConfiguration.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/OpenTelemetryConfiguration.java
@@ -10,14 +10,12 @@ package com.yahoo.config.provision;
 public interface OpenTelemetryConfiguration {
 
     boolean enabled();
-    String endpoint();
     double samplingRatio();
 
     /** The default, disabled configuration: produces a no-op OpenTelemetry. */
     static OpenTelemetryConfiguration disabled() {
         return new OpenTelemetryConfiguration() {
             @Override public boolean enabled() { return false; }
-            @Override public String endpoint() { return ""; }
             @Override public double samplingRatio() { return 1.0; }
         };
     }

--- a/configdefinitions/src/vespa/telemetry.def
+++ b/configdefinitions/src/vespa/telemetry.def
@@ -4,8 +4,11 @@
 package=ai.vespa.telemetry
 
 enabled            bool
-endpoint           string
 samplingRatio      double
+
+# Relative path (under $VESPA_HOME) to the file where host-admin writes the local host's hostname.
+# The container reads it to build the local Alloy OTLP endpoint. Set by the config-model.
+endpointHostnameFile string
 
 # Resource attributes describing the emitting service, filled by the config-model
 # from whatever deployment identity is available (application, tenant, cluster type, cluster id).

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilder.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilder.java
@@ -2,6 +2,10 @@
 package com.yahoo.container.jdisc.telemetry;
 
 import ai.vespa.telemetry.TelemetryConfig;
+import com.yahoo.security.X509SslContext;
+import com.yahoo.security.tls.TlsContext;
+import com.yahoo.security.tls.TransportSecurityUtils;
+import com.yahoo.vespa.defaults.Defaults;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -14,6 +18,11 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
 /**
  * Builds the real OpenTelemetry SDK (OTLP/HTTP exporter, batching, parent-based ratio sampling, W3C trace
  * context propagation) from {@link TelemetryConfig}.
@@ -22,14 +31,50 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
  * provider takes its enabled branch, so the OTel SDK classes are needed on the classpath only when tracing
  * is actually enabled. When disabled, the provider references only the OTel API.</p>
  *
+ * <p>The exporter targets the local host's Alloy OTLP receiver. Its endpoint is host-specific and not known
+ * at deploy time, so it is resolved at startup from the hostname host-admin writes into the container
+ * (see {@code ContainerDataGenerator}); the fixed receiver port matches host-admin's {@code GrafanaAlloyTask}.</p>
+ *
  * @author onur
  */
 class OpenTelemetrySdkBuilder {
 
+    private static final Logger log = Logger.getLogger(OpenTelemetrySdkBuilder.class.getName());
+
+    /** Port the host's Alloy OTLP receiver listens on (HTTP). Must match host-admin's GrafanaAlloyTask. */
+    private static final int ALLOY_OTLP_HTTP_PORT = 4318;
+
     private OpenTelemetrySdkBuilder() {}
 
-    /** Returns the configured SDK as an {@link OpenTelemetry}; the concrete type also implements AutoCloseable. */
+    /**
+     * Returns the configured SDK as an {@link OpenTelemetry}, or {@link OpenTelemetry#noop()} if the local
+     * host's Alloy endpoint cannot be resolved (e.g. the hostname file is absent). The concrete SDK type also
+     * implements AutoCloseable.
+     */
     static OpenTelemetry build(TelemetryConfig config) {
+        Path hostnameFile = Path.of(Defaults.getDefaults().underVespaHome(config.endpointHostnameFile()));
+        String endpoint = resolveEndpoint(hostnameFile);
+        if (endpoint == null) {
+            log.warning("OpenTelemetry tracing is enabled but the host hostname file " + hostnameFile +
+                    " is missing or empty; tracing disabled (no-op).");
+            return OpenTelemetry.noop();
+        }
+
+        // The hop to the host's Alloy receiver is mutual TLS: present the container's own system TLS
+        // identity and trust the host's cert via the same Vespa Athenz CA. The SSLContext is backed by
+        // auto-reloading key/trust managers, so SIA cert rotation is picked up without rebuilding the exporter.
+        // Server hostname verification is intentionally off: the container's system TLS config sets
+        // hostnameValidationDisabled, and reusing the system trust manager (PeerAuthorizerTrustManager) disables
+        // endpoint identification for client connections. So the endpoint host (the parent-host name written by
+        // host-admin) need not match the host cert's SAN -- the same posture as the Alloy->gateway hop.
+        TlsContext tlsContext = TransportSecurityUtils.getSystemTlsContext().orElse(null);
+        if (tlsContext == null) {
+            log.warning("OpenTelemetry tracing is enabled but no system TLS context is available " +
+                    "(system TLS not configured); tracing disabled (no-op).");
+            return OpenTelemetry.noop();
+        }
+        X509SslContext ssl = tlsContext.sslContext();
+
         AttributesBuilder attributes = Attributes.builder();
         config.resourceAttribute().forEach(attributes::put);
         Resource resource = Resource.getDefault().merge(Resource.create(attributes.build()));
@@ -39,10 +84,27 @@ class OpenTelemetrySdkBuilder {
                         .setResource(resource)
                         .setSampler(Sampler.parentBased(Sampler.traceIdRatioBased(config.samplingRatio())))
                         .addSpanProcessor(BatchSpanProcessor.builder(
-                                OtlpHttpSpanExporter.builder().setEndpoint(config.endpoint()).build()).build())
+                                OtlpHttpSpanExporter.builder()
+                                        .setEndpoint(endpoint)
+                                        .setSslContext(ssl.context(), ssl.trustManager())
+                                        .build()).build())
                         .build())
                 .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
+    }
+
+    /**
+     * Builds the local host's Alloy OTLP endpoint from the hostname host-admin wrote into the container,
+     * or {@code null} if the file is missing, unreadable or empty.
+     */
+    static String resolveEndpoint(Path hostnameFile) {
+        try {
+            String hostname = Files.readString(hostnameFile).trim();
+            if (hostname.isEmpty()) return null;
+            return "https://" + hostname + ":" + ALLOY_OTLP_HTTP_PORT;
+        } catch (IOException e) {
+            return null;
+        }
     }
 
 }

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilderTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilderTest.java
@@ -1,0 +1,38 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.container.jdisc.telemetry;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author onur
+ */
+class OpenTelemetrySdkBuilderTest {
+
+    @Test
+    void builds_endpoint_from_hostname_file(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("host-hostname");
+        Files.writeString(file, "host1.example.com\n");
+        assertEquals("https://host1.example.com:4318", OpenTelemetrySdkBuilder.resolveEndpoint(file));
+    }
+
+    @Test
+    void returns_null_when_file_missing(@TempDir Path dir) {
+        assertNull(OpenTelemetrySdkBuilder.resolveEndpoint(dir.resolve("absent")));
+    }
+
+    @Test
+    void returns_null_when_file_blank(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("host-hostname");
+        Files.writeString(file, "  \n");
+        assertNull(OpenTelemetrySdkBuilder.resolveEndpoint(file));
+    }
+
+}

--- a/defaults/abi-spec.json
+++ b/defaults/abi-spec.json
@@ -18,6 +18,8 @@
       "public int vespaConfigProxyRpcPort()",
       "public static com.yahoo.vespa.defaults.Defaults getDefaults()"
     ],
-    "fields" : [ ]
+    "fields" : [
+      "public static final java.lang.String OPENTELEMETRY_HOST_HOSTNAME_FILE"
+    ]
   }
 }

--- a/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
+++ b/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
@@ -13,6 +13,13 @@ import java.util.logging.Logger;
  */
 public class Defaults {
 
+    /**
+     * Relative path (under $VESPA_HOME) where host-admin writes the local host's hostname for the
+     * container's OpenTelemetry exporter to read. Shared between host-admin (writer) and the config-model
+     * (which points the container at it) so the two cannot drift.
+     */
+    public static final String OPENTELEMETRY_HOST_HOSTNAME_FILE = "var/vespa/otel/host-hostname";
+
     private static final Logger log = Logger.getLogger(Defaults.class.getName());
     private static final Defaults defaults = new Defaults();
 

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -151,7 +151,7 @@ public class Flags {
     public static final UnboundJacksonFlag<OpenTelemetrySettings> OPENTELEMETRY_SDK = defineJacksonFlag(
             "opentelemetry-sdk", OpenTelemetrySettings.createDisabled(), OpenTelemetrySettings.class,
             List.of("onur"), "2026-06-16", "2026-12-31",
-            "Configuration for Vespa's OpenTelemetry SDK (tracing) in the container: enabled, endpoint, samplingRatio. When disabled the provider hands out a no-op OpenTelemetry that produces nothing",
+            "Configuration for Vespa's OpenTelemetry SDK (tracing) in the container: enabled, samplingRatio. When disabled the provider hands out a no-op OpenTelemetry that produces nothing",
             "Takes effect at redeployment",
             __ -> true,
             APPLICATION, INSTANCE_ID);

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/OpenTelemetrySettings.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/OpenTelemetrySettings.java
@@ -20,24 +20,20 @@ import com.yahoo.config.provision.OpenTelemetryConfiguration;
 public class OpenTelemetrySettings implements OpenTelemetryConfiguration {
 
     private final boolean enabled;
-    private final String endpoint;
     private final double samplingRatio;
 
     public static OpenTelemetrySettings createDisabled() {
-        return new OpenTelemetrySettings(false, null, null);
+        return new OpenTelemetrySettings(false, null);
     }
 
     @JsonCreator
     public OpenTelemetrySettings(@JsonProperty("enabled") Boolean enabled,
-                                 @JsonProperty("endpoint") String endpoint,
                                  @JsonProperty("samplingRatio") Double samplingRatio) {
         this.enabled = enabled != null && enabled;
-        this.endpoint = endpoint != null ? endpoint : "";
         this.samplingRatio = samplingRatio != null ? samplingRatio : 1.0;
     }
 
     @JsonGetter("enabled")       @Override public boolean enabled()      { return enabled; }
-    @JsonGetter("endpoint")      @Override public String endpoint()      { return endpoint; }
     @JsonGetter("samplingRatio") @Override public double samplingRatio() { return samplingRatio; }
 
 }


### PR DESCRIPTION
## What

The **container (jdisc) side** of Vespa Cloud OpenTelemetry tracing. The container's OTel SDK exports spans over OTLP/HTTP to a Grafana **Alloy** receiver running on the **local physical host**, which forwards them on to the otel-gateway.

Because the target Alloy runs on whichever host the container lands on, the exporter endpoint is **per-physical-host and only known at runtime** — it cannot be a static deploy-time flag/config value. So host-admin writes the host's hostname into the container, and the container builds its endpoint from it.

## How it fits together

```mermaid
flowchart TB
    subgraph host["Vespa host (physical machine)"]
        ha["host-admin<br/>(cloud #3160)"]
        alloy["Grafana Alloy<br/>otelcol.receiver.otlp · :4318 · mTLS<br/>(cloud #3160)"]
        subgraph pod["podman — Vespa container"]
            file["file: var/vespa/otel/host-hostname<br/>= host FQDN"]
            exp["OTel SDK exporter<br/>(this PR)"]
        end
    end
    gw["otel-gateway"]

    ha -- "① writes host FQDN" --> file
    ha -- "② installs receiver + firewall :4318" --> alloy
    file -. "③ read → builds https://HOST:4318" .-> exp
    exp == "④ OTLP spans · mTLS" ==> alloy
    alloy == "⑤ OTLP · mTLS" ==> gw
```

1. **host-admin** (cloud #3160) writes the host's FQDN into `var/vespa/otel/host-hostname` inside each container, installs the Alloy OTLP receiver, and opens the firewall to its port.
2. The container's **OTel exporter** (this PR) reads that file at startup and builds the endpoint `https://<host>:4318`.
3. It exports spans to the host-local Alloy over **mutual TLS**; Alloy forwards them to the otel-gateway.

## What this PR changes

- **Drop the static `endpoint`** — removed from `telemetry.def`, the `opentelemetry-sdk` flag (`OpenTelemetrySettings`), `OpenTelemetryConfiguration`, the flag description, and `ContainerCluster.getConfig`. The endpoint is per-host, so it can't live in a flag.
- **Resolve the endpoint from the host file** (`OpenTelemetrySdkBuilder`) — read the hostname, build `https://<hostname>:4318` (fixed OTLP HTTP port, constant in the builder). Missing/blank file **or** no system TLS context → log + `OpenTelemetry.noop()`. The provider is fail-safe: enabled-but-unprovisioned degrades to a no-op and never throws.
- **Shared path constant** — `Defaults.OPENTELEMETRY_HOST_HOSTNAME_FILE = "var/vespa/otel/host-hostname"`, referenced by config-model here and by host-admin in cloud #3160, so the writer and reader can't drift. config-model sets it via the new `endpointHostnameFile` config field; the container resolves it under `$VESPA_HOME` (the `VipStatusHandler` pattern). `abi-spec.json` regenerated for the new public field.
- **Client mTLS** — the exporter presents the container's **own** system TLS identity and trusts the host cert via the same Vespa Athenz CA, using `setSslContext(...)` from `TransportSecurityUtils.getSystemTlsContext()`. The `SSLContext` is backed by auto-reloading key/trust managers, so SIA cert rotation is handled without rebuilding the exporter. Server hostname verification is disabled via the system trust manager (`PeerAuthorizerTrustManager`), since Athenz certs don't carry the connection FQDN as a SAN — same posture as the Alloy→gateway hop.

## Related (for reviewers)

- **cloud [#3160](https://github.com/vespaai/cloud/pull/3160)** — host-admin writer side: writes the hostname file, installs the Alloy OTLP trace receiver, opens the firewall. **Depends on this PR** for the `Defaults.OPENTELEMETRY_HOST_HOSTNAME_FILE` constant.
- **#37257** — Jetty server-span instrumentation (the code that actually *creates* the spans). Complementary; touches disjoint files.

No traces flow until all of these land **and** tracing is enabled — tracing is **disabled by default**.

## Tests
- `OpenTelemetrySdkBuilderTest` — endpoint resolution (present / missing / blank).
- Verified green: `defaults` (+ abicheck), `flags`, `config-model` `ContainerModelBuilderTest`, `container-disc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)