### PR TITLE
Add method for getting only tenants with deployed instances

### DIFF
--- a/cloud/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
+++ b/cloud/hosted-api/src/main/java/ai/vespa/hosted/api/ControllerHttpClient.java
@@ -219,24 +219,29 @@ public abstract class ControllerHttpClient {
 
     /** Returns the tenants in this system. */
     public Set<TenantName> tenants() {
-        return tenants(false);
+        return tenants(false, false);
     }
 
     /** Returns the tenants in this system that has applications. */
     public Set<TenantName> tenantsWithApplications() {
-        return tenants(true);
+        return tenants(true, false);
+    }
+
+    /** Returns the tenants in this system that have deployed instances. */
+    public Set<TenantName> tenantsWithDeployedInstances() {
+        return tenants(false, true);
     }
 
     /**
      * Returns the tenants in this system.
      *
-     * @param tenantsWithApplications if true, only return tenants with applications
-     *
+     * @param withApplications if true, only return tenants with applications
+     * @param withDeployedInstances if true, only return tenants with deployed instances
      */
-    public Set<TenantName> tenants(boolean tenantsWithApplications) {
-        return toTenants(send(request(HttpRequest.newBuilder(withQuery(tenantsPath(),
-                                                                       "withApplications",
-                                                                       String.valueOf(tenantsWithApplications)))
+    public Set<TenantName> tenants(boolean withApplications, boolean withDeployedInstances) {
+        URI path = withQuery(tenantsPath(), "withApplications", String.valueOf(withApplications));
+        path = withQuery(path, "withDeployedInstances", String.valueOf(withDeployedInstances));
+        return toTenants(send(request(HttpRequest.newBuilder(path)
                                                  .timeout(Duration.ofSeconds(20)),
                                       GET)));
     }


### PR DESCRIPTION
## Summary
- Add `tenantsWithDeployedInstances()` convenience method
- Extend `tenants(boolean)` to `tenants(boolean, boolean)` to support both `withApplications` and `withDeployedInstances` query parameters
- Follows the same pattern as #37253

---
*Generated by Claude Code*