### PR TITLE
Bump concurrent-ruby 1.3.6 → 1.3.7 (clears Mend HIGH CVE-2026-54904)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     console (1.35.1)
       fiber-annotation
       fiber-local (~> 1.1)


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**
>
> **Once approved, please merge it** — this is an automated dependency-update PR and merging closes out the linked Mend/Jira finding (VESPANG-3585).

## Summary
Minimal lockfile bump of the transitive `concurrent-ruby` gem (Jekyll docs-site deps) to clear a Mend HIGH finding. `concurrent-ruby` comes in via `i18n (~> 1.0)`; `1.3.7` satisfies that constraint, so only `Gemfile.lock` changes — no `Gemfile` edit.

## Changed Files
**`Gemfile.lock`** — single line:
- `concurrent-ruby`: `1.3.6` → `1.3.7` — **CVE-2026-54904**

No other gems changed; `BUNDLED WITH` unchanged (2.4.19).

## CVEs Addressed
Verified against OSV.dev:

| Package | CVE(s) | Severity | Fix version reached |
|---|---|---|---|
| concurrent-ruby | CVE-2026-54904 | high | 1.3.7 |

(`1.3.7` also clears CVE-2026-54905 / CVE-2026-54906 on the same gem.)

## Implementation Notes
- Targeted `bundle lock --update concurrent-ruby` (bundler 2.4.19, in an ephemeral `ruby:3.3` container since local ruby is 2.6). Originally swept all gems, but narrowed to concurrent-ruby only after the first Buildkite run went red — keeping the diff to exactly the security fix so the build surface is minimal.

## Verification
- `Gemfile.lock` pins `concurrent-ruby (1.3.7)`; no other deltas vs `master`.
- Re-run the Mend scan after merge to confirm CVE-2026-54904 clears.