### PR TITLE
Add quantized bound angular distance function

### DIFF
--- a/searchlib/src/tests/tensor/distance_functions/CMakeLists.txt
+++ b/searchlib/src/tests/tensor/distance_functions/CMakeLists.txt
@@ -4,7 +4,7 @@ vespa_add_executable(searchlib_distance_functions_test_app TEST
     distance_functions_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::gtest
+    GTest::gmock
 )
 vespa_add_test(NAME searchlib_distance_functions_test_app COMMAND searchlib_distance_functions_test_app)
 

--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
@@ -5,7 +5,11 @@
 #include <vespa/searchlib/tensor/distance_function_factory.h>
 #include <vespa/searchlib/tensor/distance_functions.h>
 #include <vespa/searchlib/tensor/mips_distance_transform.h>
+#include <vespa/searchlib/tensor/temporary_vector_store.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/quant/eden.h>
+
+#include <gmock/gmock.h>
 
 #include <numbers>
 #include <vector>
@@ -14,6 +18,7 @@
 LOG_SETUP("distance_function_test");
 
 using namespace search::tensor;
+using namespace testing;
 using search::attribute::DistanceMetric;
 using vespalib::BFloat16;
 using vespalib::eval::CellType;
@@ -74,10 +79,11 @@ double computeEuclideanChecked(TypedCells a, TypedCells b) {
     static EuclideanDistanceFunctionFactory<Int8Float> i8f_dff;
     static EuclideanDistanceFunctionFactory<float>     flt_dff;
     static EuclideanDistanceFunctionFactory<double>    dbl_dff;
-    auto                                               d_n = dbl_dff.for_query_vector(a);
-    auto                                               d_f = flt_dff.for_query_vector(a);
-    auto                                               d_r = dbl_dff.for_query_vector(b);
-    auto                                               d_i = dbl_dff.for_insertion_vector(a);
+
+    auto d_n = dbl_dff.for_query_vector(a);
+    auto d_f = flt_dff.for_query_vector(a);
+    auto d_r = dbl_dff.for_query_vector(b);
+    auto d_i = dbl_dff.for_insertion_vector(a);
     // normal:
     double result = d_n->calc(b);
     // insert is exactly same:
@@ -174,13 +180,50 @@ TEST(DistanceFunctionsTest, euclidean_int8_smoketest) {
     EXPECT_DOUBLE_EQ(14.0, computeEuclideanChecked(t(p5), t(p7)));
 }
 
+TypedCells retype_to_i8f(const std::vector<uint8_t>& v) {
+    static_assert(sizeof(Int8Float) == 1);
+    auto as_i8f = std::span<const Int8Float>(reinterpret_cast<const Int8Float*>(v.data()), v.size());
+    return TypedCells(as_i8f);
+}
+
+void check_quantized_angular(TypedCells a, TypedCells b, const double expected_result) {
+    constexpr uint64_t seed = 0x123456789;
+    // The test vectors have such low dimensionality that anything less than 4-bit
+    // quantization causes hilarious precision loss.
+    constexpr uint8_t bits = 4;
+
+    QuantizedAngularDistanceFunctionFactory q_dff(a.size, bits, seed);
+
+    vespalib::quant::EdenQuantizer quantizer(a.size, bits, seed);
+    std::vector<uint8_t>           a_q(quantizer.quantized_size());
+    std::vector<uint8_t>           b_q(quantizer.quantized_size());
+    // (Ab)use TemporaryVectorStore for auto-conversion to float
+    TemporaryVectorStore<float> tmp_float_store(a.size);
+    quantizer.quantize(tmp_float_store.convertRhs(a), a_q, vespalib::quant::QuantMode::InnerProduct);
+    quantizer.quantize(tmp_float_store.convertRhs(b), b_q, vespalib::quant::QuantMode::InnerProduct);
+
+    // Query vectors are always full precision
+    auto d_n = q_dff.for_query_vector(a);
+    auto d_r = q_dff.for_query_vector(b);
+    // Insertion vectors must always be in quantized form (must compare apples to apples in a HNSW index)
+    auto d_i = q_dff.for_insertion_vector(retype_to_i8f(a_q));
+    // f32 `a` vs quantized `b`;
+    double result = d_n->calc(retype_to_i8f(b_q));
+    EXPECT_THAT(result, DoubleNear(expected_result, 0.1));
+    // quantized vs. quantized; worst-case for precision loss
+    EXPECT_THAT(d_i->calc(retype_to_i8f(b_q)), DoubleNear(expected_result, 0.13));
+    // reverse (f32 `b` vs quantized `a`):
+    EXPECT_THAT(d_r->calc(retype_to_i8f(a_q)), DoubleNear(expected_result, 0.108));
+}
+
 double computeAngularChecked(TypedCells a, TypedCells b) {
     static AngularDistanceFunctionFactory<float>  flt_dff;
     static AngularDistanceFunctionFactory<double> dbl_dff;
-    auto                                          d_n = dbl_dff.for_query_vector(a);
-    auto                                          d_f = flt_dff.for_query_vector(a);
-    auto                                          d_r = dbl_dff.for_query_vector(b);
-    auto                                          d_i = dbl_dff.for_insertion_vector(a);
+
+    auto d_n = dbl_dff.for_query_vector(a);
+    auto d_f = flt_dff.for_query_vector(a);
+    auto d_r = dbl_dff.for_query_vector(b);
+    auto d_i = dbl_dff.for_insertion_vector(a);
     // normal:
     double result = d_n->calc(b);
     // insert is exactly same:
@@ -189,6 +232,7 @@ double computeAngularChecked(TypedCells a, TypedCells b) {
     EXPECT_DOUBLE_EQ(d_r->calc(a), result);
     // float factory:
     EXPECT_FLOAT_EQ(d_f->calc(b), result);
+    check_quantized_angular(a, b, result);
     return result;
 }
 
@@ -293,10 +337,11 @@ TEST(DistanceFunctionsTest, conversion_to_internal_distance_threshold_is_capped)
 double computePrenormalizedAngularChecked(TypedCells a, TypedCells b) {
     static PrenormalizedAngularDistanceFunctionFactory<float>  flt_dff;
     static PrenormalizedAngularDistanceFunctionFactory<double> dbl_dff;
-    auto                                                       d_n = dbl_dff.for_query_vector(a);
-    auto                                                       d_f = flt_dff.for_query_vector(a);
-    auto                                                       d_r = dbl_dff.for_query_vector(b);
-    auto                                                       d_i = dbl_dff.for_insertion_vector(a);
+
+    auto d_n = dbl_dff.for_query_vector(a);
+    auto d_f = flt_dff.for_query_vector(a);
+    auto d_r = dbl_dff.for_query_vector(b);
+    auto d_i = dbl_dff.for_insertion_vector(a);
     // normal:
     double result = d_n->calc(b);
     // insert is exactly same:

--- a/searchlib/src/vespa/searchlib/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/CMakeLists.txt
@@ -36,6 +36,7 @@ vespa_add_library(vespa_searchlib
     INSTALL lib64
     DEPENDS
     vespalib
+    vespalib_quant
     ICU::i18n
     ICU::uc
     protobuf::libprotobuf

--- a/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
@@ -5,11 +5,13 @@
 #include "temporary_vector_store.h"
 
 #include <vespa/vespalib/hwaccelerated/functions.h>
+#include <vespa/vespalib/quant/eden.h>
 
 #include <cmath>
 #include <numbers>
 
 using vespalib::typify_invoke;
+using vespalib::eval::CellType;
 using vespalib::eval::Int8Float;
 using vespalib::eval::TypedCells;
 using vespalib::eval::TypifyCellType;
@@ -17,7 +19,32 @@ namespace hwaccelerated = vespalib::hwaccelerated;
 
 namespace search::tensor {
 
-template <typename VectorStoreType> class BoundAngularDistance final : public BoundDistanceFunction {
+class BoundAngularDistanceBase : public BoundDistanceFunction {
+public:
+    double convert_threshold(double threshold) const noexcept override {
+        if (threshold < 0.0) {
+            return 0.0;
+        }
+        if (threshold > std::numbers::pi) {
+            return 2.0;
+        }
+        double cosine_similarity = cos(threshold);
+        return 1.0 - cosine_similarity;
+    }
+    double to_rawscore(double distance) const noexcept override {
+        double cosine_similarity = 1.0 - distance;
+        // should be in the range [-1,1] but roundoff may cause problems:
+        cosine_similarity = std::min(1.0, cosine_similarity);
+        cosine_similarity = std::max(-1.0, cosine_similarity);
+        double angle_distance = acos(cosine_similarity); // in range [0,pi]
+        double score = 1.0 / (1.0 + angle_distance);
+        return score;
+    }
+    double calc_with_limit(TypedCells rhs, double) const noexcept override { return calc(rhs); }
+};
+
+template <typename VectorStoreType>
+class BoundAngularDistance final : public BoundAngularDistanceBase {
     using FloatType = VectorStoreType::FloatType;
     mutable VectorStoreType          _tmpSpace;
     const std::span<const FloatType> _lhs;
@@ -41,26 +68,6 @@ public:
         double                     distance = 1.0 - cosine_similarity; // in range [0,2]
         return distance;
     }
-    double convert_threshold(double threshold) const noexcept override {
-        if (threshold < 0.0) {
-            return 0.0;
-        }
-        if (threshold > std::numbers::pi) {
-            return 2.0;
-        }
-        double cosine_similarity = cos(threshold);
-        return 1.0 - cosine_similarity;
-    }
-    double to_rawscore(double distance) const noexcept override {
-        double cosine_similarity = 1.0 - distance;
-        // should be in the range [-1,1] but roundoff may cause problems:
-        cosine_similarity = std::min(1.0, cosine_similarity);
-        cosine_similarity = std::max(-1.0, cosine_similarity);
-        double angle_distance = acos(cosine_similarity); // in range [0,pi]
-        double score = 1.0 / (1.0 + angle_distance);
-        return score;
-    }
-    double calc_with_limit(TypedCells rhs, double) const noexcept override { return calc(rhs); }
 };
 
 template class BoundAngularDistance<TemporaryVectorStore<float>>;
@@ -89,9 +96,110 @@ BoundDistanceFunction::UP AngularDistanceFunctionFactory<FloatType>::for_inserti
     }
 }
 
+namespace {
+
+struct Float32LhsQuantizedRhs {
+    using VectorStoreType = MutableSingleTemporaryVectorStore<float>;
+    using LhsFloatType = float;
+    constexpr static bool pre_quantized_lhs = false;
+};
+
+struct QuantizedLhsAndRhs {
+    using VectorStoreType = ReferenceVectorStore<Int8Float>;
+    using LhsFloatType = Int8Float;
+    constexpr static bool pre_quantized_lhs = true;
+};
+
+} // namespace
+
+// TODO generalize for other quantized bound distance functions?
+template <typename QuantTraits>
+class BoundQuantizedAngularDistance final : public BoundAngularDistanceBase {
+    using LhsVectorStoreType = typename QuantTraits::VectorStoreType;
+    using LhsFloatType = typename QuantTraits::LhsFloatType;
+    // A distance function instance shall only be used by one thread at a time,
+    // so this can be mutable without violating constness assumptions.
+    // FIXME this one is relatively expensive to create and keep around...!
+    //  Make as much as possible into free-standing functions and only create quantizer
+    //  when pre-rotating.
+    mutable vespalib::quant::EdenQuantizer _quantizer;
+    LhsVectorStoreType                     _tmp_space;
+    const std::span<const LhsFloatType>    _lhs;
+    double                                 _lhs_norm_sq;
+
+public:
+    BoundQuantizedAngularDistance(TypedCells lhs, size_t dimensions, uint8_t bits, uint64_t seed)
+        : _quantizer(dimensions, bits, seed), _tmp_space(lhs.size), _lhs(_tmp_space.storeLhs(lhs)) {
+        if constexpr (!QuantTraits::pre_quantized_lhs) { // full precision format
+            assert(lhs.size == _quantizer.dimensions());
+            // Quantized vectors are all in rotated space, so pre-rotate the query vector once
+            // so that it is in the same frame of reference. This avoids having to rotate the
+            // _quantized_ vectors when performing dot products. Note: this aliases `_lhs`.
+            _quantizer.rotate_vector_inplace(_tmp_space.mutable_lhs_buf());
+        } else {
+            static_assert(std::is_same_v<LhsFloatType, Int8Float>);
+            assert(lhs.size == _quantizer.quantized_size());
+        }
+        const auto* a = _lhs.data();
+        _lhs_norm_sq = dot(cast(a), cast(a)); // TODO dedicated L2 norm function
+    }
+    ~BoundQuantizedAngularDistance() override;
+
+    // rhs is always a quantized vector representation
+    double calc(TypedCells rhs) const noexcept override {
+        assert(rhs.type == CellType::INT8);
+        assert(rhs.size == _quantizer.quantized_size());
+        auto   rhs_vector = rhs.unsafe_typify<Int8Float>();
+        auto*  a = _lhs.data(); // f32 (raw query vector) or i8 (quantized insertion vector)
+        auto*  b = rhs_vector.data();
+        double b_norm_sq = dot(cast(b), cast(b)); // TODO dedicated L2 norm function (avoids 2x codebook lookups)
+        double squared_norms = _lhs_norm_sq * b_norm_sq;
+        double dot_product = dot(cast(a), cast(b));
+        double div = (squared_norms > 0) ? sqrt(squared_norms) : 1.0;
+        double cosine_similarity = dot_product / div;
+        double distance = 1.0 - cosine_similarity; // in range [0,2]
+        return distance;
+    }
+
+private:
+    [[nodiscard]] float dot(const int8_t* lhs, const int8_t* rhs) const noexcept {
+        auto lhs_u8 = std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(lhs), _quantizer.quantized_size());
+        auto rhs_u8 = std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(rhs), _quantizer.quantized_size());
+        return _quantizer.quantized_lhs_rhs_dot_product(lhs_u8, rhs_u8);
+    }
+
+    [[nodiscard]] float dot(const float* lhs, const int8_t* rhs) const noexcept {
+        auto lhs_f32 = std::span<const float>(lhs, _quantizer.dimensions());
+        auto rhs_u8 = std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(rhs), _quantizer.quantized_size());
+        return _quantizer.pre_rotated_query_dot_product(lhs_f32, rhs_u8);
+    }
+
+    [[nodiscard]] float dot(const float* lhs, const float* rhs) const noexcept {
+        return hwaccelerated::dot_product(lhs, rhs, _quantizer.dimensions());
+    }
+};
+
+template <typename LhsVectorStoreType>
+BoundQuantizedAngularDistance<LhsVectorStoreType>::~BoundQuantizedAngularDistance() = default;
+
+BoundDistanceFunction::UP QuantizedAngularDistanceFunctionFactory::for_query_vector(TypedCells lhs) const {
+    using DFT = BoundQuantizedAngularDistance<Float32LhsQuantizedRhs>;
+    return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
+}
+
+BoundDistanceFunction::UP QuantizedAngularDistanceFunctionFactory::for_insertion_vector(TypedCells lhs) const {
+    // Insertion vectors are always in quantized int8 form
+    using DFT = BoundQuantizedAngularDistance<QuantizedLhsAndRhs>;
+    assert(lhs.type == CellType::INT8);
+    return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
+}
+
 template class AngularDistanceFunctionFactory<float>;
 template class AngularDistanceFunctionFactory<double>;
 template class AngularDistanceFunctionFactory<Int8Float>;
 template class AngularDistanceFunctionFactory<vespalib::BFloat16>;
+
+template class BoundQuantizedAngularDistance<Float32LhsQuantizedRhs>;
+template class BoundQuantizedAngularDistance<QuantizedLhsAndRhs>;
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
@@ -113,10 +113,10 @@ struct QuantizedLhsAndRhs {
 } // namespace
 
 // TODO generalize for other quantized bound distance functions?
-template <typename QuantTraits>
+template <typename QuantParams>
 class BoundQuantizedAngularDistance final : public BoundAngularDistanceBase {
-    using LhsVectorStoreType = typename QuantTraits::VectorStoreType;
-    using LhsFloatType = typename QuantTraits::LhsFloatType;
+    using LhsVectorStoreType = typename QuantParams::VectorStoreType;
+    using LhsFloatType = typename QuantParams::LhsFloatType;
     // A distance function instance shall only be used by one thread at a time,
     // so this can be mutable without violating constness assumptions.
     // FIXME this one is relatively expensive to create and keep around...!
@@ -130,7 +130,7 @@ class BoundQuantizedAngularDistance final : public BoundAngularDistanceBase {
 public:
     BoundQuantizedAngularDistance(TypedCells lhs, size_t dimensions, uint8_t bits, uint64_t seed)
         : _quantizer(dimensions, bits, seed), _tmp_space(lhs.size), _lhs(_tmp_space.storeLhs(lhs)) {
-        if constexpr (!QuantTraits::pre_quantized_lhs) { // full precision format
+        if constexpr (!QuantParams::pre_quantized_lhs) { // full precision format
             assert(lhs.size == _quantizer.dimensions());
             // Quantized vectors are all in rotated space, so pre-rotate the query vector once
             // so that it is in the same frame of reference. This avoids having to rotate the

--- a/searchlib/src/vespa/searchlib/tensor/angular_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/angular_distance.h
@@ -29,4 +29,28 @@ public:
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };
 
+/**
+ * Calculates angular distance between vectors, where the left hand side may be
+ * either a float32 (full precision) vector or a quantized vector in int8 format,
+ * and the right hand side is always a quantized vector in int8 format.
+ *
+ * Query vectors are always converted to float32 form. That means a _query_ vector
+ * of int8 values will be elementwise promoted to float and will _not_ be treated
+ * as the quantized representation of a query vector.
+ *
+ * Insertion vectors are expected to be in pre-quantized int8 format.
+ */
+class QuantizedAngularDistanceFunctionFactory : public DistanceFunctionFactory {
+    const size_t   _dimensions;
+    const uint64_t _seed;
+    const uint8_t  _bits;
+
+public:
+    QuantizedAngularDistanceFunctionFactory(size_t dimensions, uint8_t bits, uint64_t seed) noexcept
+        : _dimensions(dimensions), _seed(seed), _bits(bits) {}
+    BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
+    // Only supports int8 insertion vectors
+    BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
+};
+
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
@@ -49,9 +49,20 @@ std::span<const FloatType> TemporaryVectorStore<FloatType>::internal_convert(Typ
     return result;
 }
 
+template <typename FloatType>
+std::span<const FloatType> MutableSingleTemporaryVectorStore<FloatType>::internal_convert(TypedCells cells) noexcept {
+    std::span<FloatType> where(_tmp_space.data(), cells.size);
+    using MyTypify = vespalib::eval::TypifyCellType;
+    using MySelector = ConvertCellsSelector<FloatType>;
+    return vespalib::typify_invoke<1, MyTypify, MySelector>(cells.type, where, cells);
+}
+
 template class TemporaryVectorStore<vespalib::eval::Int8Float>;
 template class TemporaryVectorStore<vespalib::BFloat16>;
 template class TemporaryVectorStore<float>;
 template class TemporaryVectorStore<double>;
+
+template class MutableSingleTemporaryVectorStore<float>;
+template class MutableSingleTemporaryVectorStore<vespalib::eval::Int8Float>;
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.h
@@ -31,6 +31,26 @@ public:
 };
 
 /**
+ * Helper class for explicitly storing (and exposing a mutable view of) a single vector.
+ * Only useful when the right hand side is always known to not require temporary storage.
+ */
+template <typename FloatTypeT>
+class MutableSingleTemporaryVectorStore {
+public:
+    using FloatType = FloatTypeT;
+
+private:
+    using TypedCells = vespalib::eval::TypedCells;
+    std::vector<FloatType> _tmp_space;
+    std::span<const FloatType> internal_convert(TypedCells cells) noexcept;
+
+public:
+    explicit MutableSingleTemporaryVectorStore(size_t vector_size) noexcept : _tmp_space(vector_size) {}
+    [[nodiscard]] std::span<const FloatType> storeLhs(TypedCells cells) noexcept { return internal_convert(cells); }
+    [[nodiscard]] std::span<FloatType> mutable_lhs_buf() noexcept { return _tmp_space; }
+};
+
+/**
  * Helper class used when TypedCells vector memory is just referenced,
  * and used directly in calculations without any transforms.
  */

--- a/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/quant/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(vespalib_quant
     codebooks.cpp
     eden.cpp
     rotator.cpp
+    INSTALL lib64
     DEPENDS
     vespa_hwaccelerated
 )


### PR DESCRIPTION
@havardpe @arnej27959 please review

This is an adaptation of the existing bound angular distance function, but which supports transparently operating on pre- quantized vectors (using the EDEN algorithm).

Angular was chosen as the first quantized distance function since we have thus far focused on dot product evaluation for quantized vectors.

The _right_ hand side argument to the distance function is expected to always be a pre-quantized vector encapsulated in an opaque `int8` array.

The type of the _left_ hand side argument depends on the factory function invoked; _query_ vectors will use `float` precision, HNSW _insertion_ vectors must be pre-quantized as `int8`.

This means we evaluate query-to-candidate distances with asymmetric types, significantly increasing the evaluation precision over doing this with both sides quantized.

For the `float` query vector case, we always store a copy of the input query vector, as we have to explicitly rotate it into the same frame of reference as that used by the quantized vectors. Query inputs that are not `float` will be implicitly converted to this type. An `int8` input in this case will be element-wise _widened_ to `float` and will _not_ be treated as pre-quantized input.

