### PR TITLE
defaults: write OpenTelemetry host-hostname under conf/, not the mounted var/

### DIFF
--- a/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
+++ b/defaults/src/main/java/com/yahoo/vespa/defaults/Defaults.java
@@ -17,8 +17,12 @@ public class Defaults {
      * Relative path (under $VESPA_HOME) where host-admin writes the local host's hostname for the
      * container's OpenTelemetry exporter to read. Shared between host-admin (writer) and the config-model
      * (which points the container at it) so the two cannot drift.
+     *
+     * Under conf/ (not var/): var/ is a mounted volume, so host-admin cannot stage files there via
+     * container-data; conf/ is part of the container image and is the home for host-admin-generated
+     * startup inputs the container reads (e.g. conf/vespa/transport-security-options.json).
      */
-    public static final String OPENTELEMETRY_HOST_HOSTNAME_FILE = "var/vespa/otel/host-hostname";
+    public static final String OPENTELEMETRY_HOST_HOSTNAME_FILE = "conf/vespa/otel/host-hostname";
 
     private static final Logger log = Logger.getLogger(Defaults.class.getName());
     private static final Defaults defaults = new Defaults();


### PR DESCRIPTION
## Problem

After #37262 and the host-admin writer side deployed, host-admin **fails node convergence**:

```
ERROR node-admin ... NodeAgentImpl ctl2: Cannot add file ctl2:/opt/vespa/var/vespa/otel/host-hostname via container data, it is mounted
```

## Root cause

host-admin writes the host-hostname file via container-data (`containerData.addFile`). That mechanism stages files into the container's **image layer**, before volumes mount, so it **refuses paths under a mounted volume** (the mount would shadow them). `${VESPA_HOME}/var` is a mounted volume (the per-node data disk) — which is exactly why the trust store and TLS options under `var/` are written *directly* rather than via container-data. Our file used `addFile` on `var/`, so it threw and aborted `writeContainerData`.

## Fix

Move the shared path constant `Defaults.OPENTELEMETRY_HOST_HOSTNAME_FILE` from `var/vespa/otel/host-hostname` to **`conf/vespa/otel/host-hostname`**:

- `conf/` is part of the **container image** (not a mounted volume), so `containerData.addFile` works there.
- It's the established home for **host-admin-generated startup inputs the container reads** — e.g. `conf/vespa/transport-security-options.json` (generated TLS config) and `conf/vespa/default-env.txt`. This file is exactly that kind of thing (a generated value the container reads at startup to configure its OTLP exporter), and it's static for the container's lifetime, so writing it once at container creation is correct.
- `config-model` (which sets the config value) and host-admin (which writes the file) both **reference the constant**, so this single change flows to both. The container reader is unchanged — `underVespaHome(...)` resolves the new relative path.

## Tests

- `container-disc` `OpenTelemetrySdkBuilderTest` — 3/3.
- `host-admin` `ContainerDataGeneratorTest` (cloud) — 29/29 against the new value (the `addFile`-to-`var/` failure is gone).
- `defaults` abicheck — green; value-only change, **no ABI change**.

## Related

- #37262 — introduced the shared constant + the container-side reader (this fixes a deploy-time regression from its host-admin writer).
- vespaai/cloud#3160 — the host-admin writer that references this constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)