### PR TITLE
Add back endpoint() method to OpenTelemetryConfiguration [MERGEOK]

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/OpenTelemetryConfiguration.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/OpenTelemetryConfiguration.java
@@ -10,6 +10,7 @@ package com.yahoo.config.provision;
 public interface OpenTelemetryConfiguration {
 
     boolean enabled();
+    default String endpoint() { return ""; }; // TODO: Remove after 8.711 is oldest version in use
     double samplingRatio();
 
     /** The default, disabled configuration: produces a no-op OpenTelemetry. */


### PR DESCRIPTION
Needed by older versions when generating config, so cannot be removed until older versions are gone
