### PR TITLE
[opentelemetry] add missing javax.net.ssl import in container-openetelemetry

### DIFF
--- a/container-opentelemetry/pom.xml
+++ b/container-opentelemetry/pom.xml
@@ -113,6 +113,8 @@
                              (grpc/okhttp sender, incubator, autoconfigure, guava, jspecify, sun.misc). -->
                         <Import-Package>
                             com.fasterxml.jackson.core
+                            javax.net.ssl,
+                            *;resolution:=optional
                         </Import-Package>
                         <_nouses>true</_nouses>
                     </instructions>

--- a/container-opentelemetry/pom.xml
+++ b/container-opentelemetry/pom.xml
@@ -112,7 +112,7 @@
                              the bundle resolves without unavailable deps it never exercises
                              (grpc/okhttp sender, incubator, autoconfigure, guava, jspecify, sun.misc). -->
                         <Import-Package>
-                            com.fasterxml.jackson.core
+                            com.fasterxml.jackson.core,
                             javax.net.ssl,
                             *;resolution:=optional
                         </Import-Package>


### PR DESCRIPTION
…

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
