### PR TITLE
Separate tracking of reserved memory for flush and reserved memory for

### DIFF
--- a/searchcore/src/tests/proton/flushengine/reserved_memory_calculator_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/reserved_memory_calculator_test.cpp
@@ -33,7 +33,7 @@ size_t ReservedMemoryCalculatorTest::calc_reserved_memory(size_t              co
     for (auto transient_memory : transient_memory_sizes) {
         calc.track_transient_memory_for_flush(transient_memory, _type, _component);
     }
-    return calc.get_reserved_memory();
+    return calc.reserved_memory_for_flush() + calc.reserved_memory_for_memory_indexes();
 }
 
 TEST_F(ReservedMemoryCalculatorTest, calc_reserved_memory_for_flush) {

--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -49,7 +49,7 @@ public:
     MyReservedDiskSpaceAndMemoryProvider() noexcept : IReservedDiskSpaceAndMemoryProvider() {}
     ~MyReservedDiskSpaceAndMemoryProvider() override;
     ReservedDiskSpaceAndMemory get_reserved_disk_space_and_memory() const override {
-        return ReservedDiskSpaceAndMemory(42, 0);
+        return ReservedDiskSpaceAndMemory(42, 0, 0);
     }
 };
 

--- a/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
@@ -62,7 +62,7 @@ struct ResourceUsageWriteFilterTest : public ::testing::Test {
     ResourceUsageWriteFilterTest()
         : _filter(HwInfo(HwInfo::Disk(100, false, false), HwInfo::Memory(1000), HwInfo::Cpu(0))), _notifier(_filter) {
         _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 300), 20,
-                                     ReservedDiskSpaceAndMemory(0, 0));
+                                     ReservedDiskSpaceAndMemory(0, 0, 0));
     }
 
     void testWrite(const std::string& exp) {
@@ -81,12 +81,12 @@ struct ResourceUsageWriteFilterTest : public ::testing::Test {
 
     void triggerDiskLimit() {
         _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), 90,
-                                     ReservedDiskSpaceAndMemory(0, 0));
+                                     ReservedDiskSpaceAndMemory(0, 0, 0));
     }
 
     void triggerMemoryLimit() {
         _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(897, 898, 900),
-                                     _notifier.getDiskUsedSize(), ReservedDiskSpaceAndMemory(0, 0));
+                                     _notifier.getDiskUsedSize(), ReservedDiskSpaceAndMemory(0, 0, 0));
     }
 
     void notify_attribute_usage(const AttributeUsageStats& usage) { _notifier.notify_attribute_usage(usage); }
@@ -162,7 +162,7 @@ TEST_F(ResourceUsageWriteFilterTest, both_disk_limit_and_memory_limit_can_be_rea
 TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_disk_usage_tracked_in_usage_state_and_metrics) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{15, 0}, zero_size_on_disk},
                                  _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
-                                 ReservedDiskSpaceAndMemory(0, 0));
+                                 ReservedDiskSpaceAndMemory(0, 0, 0));
     EXPECT_DOUBLE_EQ(0.15, _notifier.usageState().transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.15, _notifier.get_metrics().transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.05, _notifier.usageState().non_transient_disk_usage());
@@ -172,7 +172,7 @@ TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_disk_usage_trac
 TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_memory_usage_tracked_in_usage_state_and_metrics) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{0, 100}, zero_size_on_disk},
                                  _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
-                                 ReservedDiskSpaceAndMemory(0, 0));
+                                 ReservedDiskSpaceAndMemory(0, 0, 0));
     EXPECT_DOUBLE_EQ(0.1, _notifier.usageState().transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.1, _notifier.get_metrics().transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.2, _notifier.usageState().non_transient_memory_usage());

--- a/searchcore/src/vespa/searchcore/proton/common/reserved_disk_space_and_memory.h
+++ b/searchcore/src/vespa/searchcore/proton/common/reserved_disk_space_and_memory.h
@@ -12,13 +12,23 @@ namespace proton {
  */
 class ReservedDiskSpaceAndMemory {
     uint64_t _reserved_disk_space;
-    size_t   _reserved_memory;
+    size_t   _reserved_memory_for_flush;
+    size_t   _reserved_memory_for_memory_indexes;
 
 public:
-    ReservedDiskSpaceAndMemory(uint64_t reserved_disk_space_in, size_t reserved_memory_in) noexcept
-        : _reserved_disk_space(reserved_disk_space_in), _reserved_memory(reserved_memory_in) {}
+    ReservedDiskSpaceAndMemory(uint64_t reserved_disk_space_in, size_t reserved_memory_for_flush_in,
+                               size_t reserved_memory_for_memory_indexes_in) noexcept
+        : _reserved_disk_space(reserved_disk_space_in),
+          _reserved_memory_for_flush(reserved_memory_for_flush_in),
+          _reserved_memory_for_memory_indexes(reserved_memory_for_memory_indexes_in) {}
     [[nodiscard]] uint64_t reserved_disk_space() const noexcept { return _reserved_disk_space; }
-    [[nodiscard]] size_t reserved_memory() const noexcept { return _reserved_memory; }
+    [[nodiscard]] size_t reserved_memory_for_flush() const noexcept { return _reserved_memory_for_flush; }
+    [[nodiscard]] size_t reserved_memory_for_memory_indexes() const noexcept {
+        return _reserved_memory_for_memory_indexes;
+    }
+    [[nodiscard]] size_t reserved_memory() const noexcept {
+        return _reserved_memory_for_flush + _reserved_memory_for_memory_indexes;
+    }
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_engine_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_engine_explorer.cpp
@@ -47,6 +47,7 @@ void convertToSlime(const FlushContext::List& allTargets, const vespalib::system
         object.setBool("needUrgentFlush", target->needUrgentFlush());
         object.setLong("last_flush_duration",
                        duration_cast<std::chrono::microseconds>(target->last_flush_duration()).count());
+        object.setLong("reserved-memory-for-flush", target->transient_memory_for_flush());
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -677,7 +677,8 @@ ReservedDiskSpaceAndMemory FlushEngine::get_reserved_disk_space_and_memory() con
                                                    target->getComponent());
         }
     }
-    return ReservedDiskSpaceAndMemory(calc.get_reserved_disk(), mcalc.get_reserved_memory());
+    return ReservedDiskSpaceAndMemory(calc.get_reserved_disk(), mcalc.reserved_memory_for_flush(),
+                                      mcalc.reserved_memory_for_memory_indexes());
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/reserved_memory_calculator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/reserved_memory_calculator.cpp
@@ -34,7 +34,7 @@ void ReservedMemoryCalculator::track_transient_memory_for_flush(size_t          
     }
 }
 
-size_t ReservedMemoryCalculator::get_reserved_memory() {
+size_t ReservedMemoryCalculator::reserved_memory_for_flush() {
     if (_concurrent < _candidates.size()) {
         /*
          * Retain the _concurrent biggest candidates. They are later used to calculate reserved
@@ -47,7 +47,6 @@ size_t ReservedMemoryCalculator::get_reserved_memory() {
     for (auto& candidate : _candidates) {
         reserved_memory += candidate.reserved();
     }
-    reserved_memory += reserved_memory_for_memory_indexes();
     return reserved_memory;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/reserved_memory_calculator.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/reserved_memory_calculator.h
@@ -30,15 +30,14 @@ class ReservedMemoryCalculator {
     uint32_t               _memory_indexes;
     std::vector<Candidate> _candidates; // Used to calculate worst case for concurrent flushes
 
-    [[nodiscard]] size_t reserved_memory_for_memory_indexes() const noexcept;
-
 public:
     using IFlushTarget = searchcorespi::IFlushTarget;
     ReservedMemoryCalculator(size_t concurrent, size_t each_max_memory, size_t global_max_memory) noexcept;
     ~ReservedMemoryCalculator();
     void track_transient_memory_for_flush(size_t transient_memory_for_flush, IFlushTarget::Type type,
                                           IFlushTarget::Component component);
-    [[nodiscard]] size_t get_reserved_memory();
+    [[nodiscard]] size_t reserved_memory_for_flush();
+    [[nodiscard]] size_t reserved_memory_for_memory_indexes() const noexcept;
 };
 
 } // namespace proton::flushengine

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
@@ -56,7 +56,15 @@ void ResourceUsageExplorer::get_state(const vespalib::slime::Inserter& inserter,
         memory.setDouble("transient", usageState.transient_memory_usage());
         memory.setDouble("non-transient", usageState.non_transient_memory_usage());
         memory.setDouble("reported", usageState.reported_memory_usage());
-        memory.setLong("physicalMemory", _usage_notifier.getHwInfo().memory().sizeBytes());
+        auto physical_memory = _usage_notifier.getHwInfo().memory().sizeBytes();
+        memory.setLong("physicalMemory", physical_memory);
+        auto reserved_disk_space_and_memory = _usage_notifier.reserved_disk_space_and_memory();
+        memory.setDouble("reserved-for-flush",
+                         static_cast<double>(reserved_disk_space_and_memory.reserved_memory_for_flush()) /
+                             physical_memory);
+        memory.setDouble("reserved-for-memory-indexes",
+                         static_cast<double>(reserved_disk_space_and_memory.reserved_memory_for_memory_indexes()) /
+                             physical_memory);
         convertMemoryStatsToSlime(_usage_notifier.getMemoryStats(), memory.setObject("stats"));
 
         Cursor& address_space = object.setObject("attribute_address_space");

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -18,7 +18,7 @@ ResourceUsageNotifier::ResourceUsageNotifier(ResourceUsageWriteFilter& filter)
       _hwInfo(filter.get_hw_info()),
       _memoryStats(),
       _diskUsedSizeBytes(),
-      _reserved_disk_space_and_memory(0, 0),
+      _reserved_disk_space_and_memory(0, 0, 0),
       _resource_usage(),
       _attribute_usage(),
       _config(),
@@ -78,10 +78,10 @@ double ResourceUsageNotifier::get_relative_transient_disk_usage(const Guard&) co
 
 void ResourceUsageNotifier::set_resource_usage(const ResourceUsage&         resource_usage,
                                                vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes,
-                                               ReservedDiskSpaceAndMemory reserved_disk_space_and_memory) {
+                                               ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_) {
     Guard guard(_lock);
     _resource_usage = resource_usage;
-    _reserved_disk_space_and_memory = reserved_disk_space_and_memory;
+    _reserved_disk_space_and_memory = reserved_disk_space_and_memory_;
     _memoryStats = memoryStats;
     _diskUsedSizeBytes = diskUsedSizeBytes;
     recalcState(guard, true);
@@ -110,6 +110,11 @@ vespalib::ProcessMemoryStats ResourceUsageNotifier::getMemoryStats() const {
 uint64_t ResourceUsageNotifier::getDiskUsedSize() const {
     Guard guard(_lock);
     return _diskUsedSizeBytes;
+}
+
+ReservedDiskSpaceAndMemory ResourceUsageNotifier::reserved_disk_space_and_memory() const noexcept {
+    Guard guard(_lock);
+    return _reserved_disk_space_and_memory;
 }
 
 ResourceUsage ResourceUsageNotifier::get_resource_usage() const {

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
@@ -87,10 +87,11 @@ public:
 
     void set_resource_usage(const searchcorespi::common::ResourceUsage& resource_usage,
                             vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes,
-                            ReservedDiskSpaceAndMemory reserved_disk_space_and_memory);
+                            ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_);
     [[nodiscard]] bool setConfig(Config config);
     vespalib::ProcessMemoryStats getMemoryStats() const;
     uint64_t getDiskUsedSize() const;
+    [[nodiscard]] ReservedDiskSpaceAndMemory reserved_disk_space_and_memory() const noexcept;
     searchcorespi::common::ResourceUsage get_resource_usage() const;
     Config getConfig() const;
     const vespalib::HwInfo& getHwInfo() const noexcept { return _hwInfo; }


### PR DESCRIPTION
memory indexes. Show both in resource usage state explorer.

@vekterli : please review
