### PR TITLE
container: OTLP traces endpoint must include the /v1/traces path

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilder.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilder.java
@@ -96,12 +96,16 @@ class OpenTelemetrySdkBuilder {
     /**
      * Builds the local host's Alloy OTLP endpoint from the hostname host-admin wrote into the container,
      * or {@code null} if the file is missing, unreadable or empty.
+     *
+     * <p>The endpoint must be the full OTLP/HTTP traces URL including the {@code /v1/traces} path:
+     * {@code OtlpHttpSpanExporter.setEndpoint} uses it verbatim (it does not append the signal path), so a
+     * bare {@code https://host:4318} would POST to {@code /} and the receiver answers 404.</p>
      */
     static String resolveEndpoint(Path hostnameFile) {
         try {
             String hostname = Files.readString(hostnameFile).trim();
             if (hostname.isEmpty()) return null;
-            return "https://" + hostname + ":" + ALLOY_OTLP_HTTP_PORT;
+            return "https://" + hostname + ":" + ALLOY_OTLP_HTTP_PORT + "/v1/traces";
         } catch (IOException e) {
             return null;
         }

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilderTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/telemetry/OpenTelemetrySdkBuilderTest.java
@@ -20,7 +20,7 @@ class OpenTelemetrySdkBuilderTest {
     void builds_endpoint_from_hostname_file(@TempDir Path dir) throws IOException {
         Path file = dir.resolve("host-hostname");
         Files.writeString(file, "host1.example.com\n");
-        assertEquals("https://host1.example.com:4318", OpenTelemetrySdkBuilder.resolveEndpoint(file));
+        assertEquals("https://host1.example.com:4318/v1/traces", OpenTelemetrySdkBuilder.resolveEndpoint(file));
     }
 
     @Test


### PR DESCRIPTION
## Problem

With tracing enabled, the container's OTLP exporter fails every export against the host Alloy receiver:

```
WARNING container io.opentelemetry.exporter.otlp.internal.HttpExporter
  Failed to export spans. Server responded with HTTP status code 404.
```

Everything else in the hop is healthy — the 404 (an HTTP response, not a TLS error) shows the hostname file is read, the endpoint resolves, **mTLS succeeds**, and the Alloy receiver is up. Only the request path is wrong.

## Root cause

`OtlpHttpSpanExporter.setEndpoint(...)` takes the **full URL verbatim** and does **not** append the OTLP signal path — the exporter's own default is `http://localhost:4318/v1/traces`. `OpenTelemetrySdkBuilder.resolveEndpoint` produced a bare `https://<host>:4318`, so the exporter POSTed to `/`, and Alloy's OTLP receiver (which serves `/v1/traces`) answered **404**.

Confirmed against the docs: the endpoint *"must … include the full HTTP path"* and the default value itself contains `/v1/traces` ([OTLP exporter config](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/), [OtlpHttpSpanExporterBuilder javadoc](https://javadoc.io/static/io.opentelemetry/opentelemetry-exporter-otlp-http-trace/1.14.0/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.html)).

## Fix

```diff
- return "https://" + hostname + ":" + ALLOY_OTLP_HTTP_PORT;
+ return "https://" + hostname + ":" + ALLOY_OTLP_HTTP_PORT + "/v1/traces";
```

`OpenTelemetrySdkBuilderTest` updated; 3/3.

## Related
- #37262 — introduced the endpoint builder.
- #37276 — `conf/` host-hostname path fix.
- vespaai/cloud#3160 — host-admin Alloy receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)