### PR TITLE
Periodically resample disk capacity when disk size is configured to 0

### DIFF
--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -72,9 +72,9 @@ struct DiskMemUsageSamplerTest : public ::testing::Test {
           reserved_disk_space_and_memory_provider(std::make_unique<MyReservedDiskSpaceAndMemoryProvider>()),
           sampler(std::make_unique<DiskMemUsageSampler>(".", *write_filter, *notifier,
                                                         *reserved_disk_space_and_memory_provider)) {
-        sampler->setConfig(
-            DiskMemUsageSampler::Config(0.8, 0.8, 0.0, 0.0, AttributeUsageFilterConfig(), 50ms, make_hw_info()),
-            executor);
+        sampler->setConfig(DiskMemUsageSampler::Config(0.8, 0.8, 0.0, 0.0, AttributeUsageFilterConfig(), 50ms,
+                                                       make_hw_info(), false),
+                           executor);
         sampler->add_resource_usage_provider(std::make_shared<MyProvider>(50, 200));
         sampler->add_resource_usage_provider(std::make_shared<MyProvider>(100, 150));
     }

--- a/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
@@ -129,7 +129,7 @@ TEST_F(ResourceUsageWriteFilterTest, disk_limit_can_be_reached) {
 
 TEST_F(ResourceUsageWriteFilterTest, disk_usage_ratios_follow_resampled_capacity) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{40, 0}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), 100, 200, ReservedDiskSpaceAndMemory(20, 0));
+                                 _notifier.getMemoryStats(), 100, 200, ReservedDiskSpaceAndMemory(20, 0, 0));
     EXPECT_DOUBLE_EQ(0.5, _notifier.usageState().diskState().usage());    // 100 / 200
     EXPECT_DOUBLE_EQ(0.2, _notifier.usageState().transient_disk_usage()); // 40 / 200
     EXPECT_DOUBLE_EQ(0.1, _notifier.usageState().reserved_disk_space());  // 20 / 200
@@ -138,7 +138,7 @@ TEST_F(ResourceUsageWriteFilterTest, disk_usage_ratios_follow_resampled_capacity
 TEST_F(ResourceUsageWriteFilterTest, disk_limit_message_reports_resampled_capacity) {
     EXPECT_TRUE(_notifier.setConfig(Config(1.0, 0.8, 0.0, 0.0, AttributeUsageFilterConfig())));
     _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), 180, 200,
-                                 ReservedDiskSpaceAndMemory(0, 0));
+                                 ReservedDiskSpaceAndMemory(0, 0, 0));
     testWrite("diskLimitReached: { "
               "action: \"add more content nodes\", "
               "reason: \"disk used (0.9) > disk limit (0.8)\", "

--- a/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
@@ -127,6 +127,25 @@ TEST_F(ResourceUsageWriteFilterTest, disk_limit_can_be_reached) {
     assertResourceUsage(0.9, 0.8, 1.125, _notifier.usageState().diskState());
 }
 
+TEST_F(ResourceUsageWriteFilterTest, disk_usage_ratios_follow_resampled_capacity) {
+    _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{40, 0}, zero_size_on_disk},
+                                 _notifier.getMemoryStats(), 100, 200, ReservedDiskSpaceAndMemory(20, 0));
+    EXPECT_DOUBLE_EQ(0.5, _notifier.usageState().diskState().usage());    // 100 / 200
+    EXPECT_DOUBLE_EQ(0.2, _notifier.usageState().transient_disk_usage()); // 40 / 200
+    EXPECT_DOUBLE_EQ(0.1, _notifier.usageState().reserved_disk_space());  // 20 / 200
+}
+
+TEST_F(ResourceUsageWriteFilterTest, disk_limit_message_reports_resampled_capacity) {
+    EXPECT_TRUE(_notifier.setConfig(Config(1.0, 0.8, 0.0, 0.0, AttributeUsageFilterConfig())));
+    _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), 180, 200,
+                                 ReservedDiskSpaceAndMemory(0, 0));
+    testWrite("diskLimitReached: { "
+              "action: \"add more content nodes\", "
+              "reason: \"disk used (0.9) > disk limit (0.8)\", "
+              "stats: { "
+              "capacity: 200, used: 180, diskUsed: 0.9, diskLimit: 0.8}}");
+}
+
 TEST_F(ResourceUsageWriteFilterTest, memory_limit_can_be_reached) {
     EXPECT_TRUE(_notifier.setConfig(Config(0.8, 1.0, 0.0, 0.0, AttributeUsageFilterConfig())));
     assertResourceUsage(0.3, 0.8, 0.375, _notifier.usageState().memoryState());

--- a/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
@@ -61,7 +61,7 @@ struct ResourceUsageWriteFilterTest : public ::testing::Test {
 
     ResourceUsageWriteFilterTest()
         : _filter(HwInfo(HwInfo::Disk(100, false, false), HwInfo::Memory(1000), HwInfo::Cpu(0))), _notifier(_filter) {
-        _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 300), 20,
+        _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 300), 20, 100,
                                      ReservedDiskSpaceAndMemory(0, 0, 0));
     }
 
@@ -80,13 +80,13 @@ struct ResourceUsageWriteFilterTest : public ::testing::Test {
     }
 
     void triggerDiskLimit() {
-        _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), 90,
+        _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), 90, 100,
                                      ReservedDiskSpaceAndMemory(0, 0, 0));
     }
 
     void triggerMemoryLimit() {
         _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(897, 898, 900),
-                                     _notifier.getDiskUsedSize(), ReservedDiskSpaceAndMemory(0, 0, 0));
+                                     _notifier.getDiskUsedSize(), 100, ReservedDiskSpaceAndMemory(0, 0, 0));
     }
 
     void notify_attribute_usage(const AttributeUsageStats& usage) { _notifier.notify_attribute_usage(usage); }
@@ -161,7 +161,7 @@ TEST_F(ResourceUsageWriteFilterTest, both_disk_limit_and_memory_limit_can_be_rea
 
 TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_disk_usage_tracked_in_usage_state_and_metrics) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{15, 0}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
+                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(), 100,
                                  ReservedDiskSpaceAndMemory(0, 0, 0));
     EXPECT_DOUBLE_EQ(0.15, _notifier.usageState().transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.15, _notifier.get_metrics().transient_disk_usage());
@@ -171,7 +171,7 @@ TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_disk_usage_trac
 
 TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_memory_usage_tracked_in_usage_state_and_metrics) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{0, 100}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
+                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(), 100,
                                  ReservedDiskSpaceAndMemory(0, 0, 0));
     EXPECT_DOUBLE_EQ(0.1, _notifier.usageState().transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.1, _notifier.get_metrics().transient_memory_usage());

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -28,6 +28,7 @@ DiskMemUsageSampler::DiskMemUsageSampler(
       _notifier(resource_usage_notifier),
       _reserved_disk_space_and_memory_provider(reserved_disk_space_and_memory_provider),
       _path(path_in),
+      _should_resample_disk_capacity(false),
       _sampleInterval(60s),
       _lastSampleTime(),
       _lock(),
@@ -46,6 +47,7 @@ bool DiskMemUsageSampler::timeToSampleAgain() const noexcept {
 }
 
 void DiskMemUsageSampler::setConfig(const Config& config, IScheduledExecutor& executor) {
+    _should_resample_disk_capacity = config.should_resample_disk_capacity;
     bool wasChanged = _notifier.setConfig(config.filterConfig);
     if (_periodicHandle && (_sampleInterval == config.sampleInterval) && !wasChanged) {
         return;
@@ -77,10 +79,11 @@ void DiskMemUsageSampler::sampleAndReportUsage() {
      * and a short period of allowed feed. The latter will be very rare as you are rarely feed blocked anyway.
      */
     vespalib::ProcessMemoryStats memoryStats = sampleMemoryUsage();
-    uint64_t                     diskUsage = sampleDiskUsage(resource_usage);
+    DiskUsage                    diskUsage = sampleDiskUsage(resource_usage);
     auto                         reserved_disk_space_and_memory =
         _reserved_disk_space_and_memory_provider.get_reserved_disk_space_and_memory();
-    _notifier.set_resource_usage(resource_usage, memoryStats, diskUsage, reserved_disk_space_and_memory);
+    _notifier.set_resource_usage(resource_usage, memoryStats, diskUsage.used_bytes(), diskUsage.capacity_bytes(),
+                                 reserved_disk_space_and_memory);
     _lastSampleTime = vespalib::steady_clock::now();
 }
 
@@ -88,21 +91,23 @@ namespace {
 
 namespace fs = std::filesystem;
 
-uint64_t sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk) {
+DiskUsage sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk,
+                                      bool should_resample_disk_capacity) {
     auto     space_info = fs::space(path);
-    uint64_t result = (space_info.capacity - space_info.available);
-    if (result > disk.sizeBytes()) {
-        return disk.sizeBytes();
+    uint64_t capacity = should_resample_disk_capacity ? space_info.capacity : disk.sizeBytes();
+    uint64_t used = (space_info.capacity - space_info.available);
+    if (used > capacity) {
+        used = capacity;
     }
-    return result;
+    return {used, capacity};
 }
 
 } // namespace
 
-uint64_t DiskMemUsageSampler::sampleDiskUsage(const ResourceUsage& resource_usage) {
+DiskUsage DiskMemUsageSampler::sampleDiskUsage(const ResourceUsage& resource_usage) {
     const auto& disk = _notifier.getHwInfo().disk();
-    return disk.shared() ? (resource_usage.disk() + resource_usage.transient().disk())
-                         : sampleDiskUsageOnFileSystem(_path, disk);
+    return disk.shared() ? DiskUsage(resource_usage.disk() + resource_usage.transient().disk(), disk.sizeBytes())
+                         : sampleDiskUsageOnFileSystem(_path, disk, _should_resample_disk_capacity);
 }
 
 vespalib::ProcessMemoryStats DiskMemUsageSampler::sampleMemoryUsage() {

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -24,6 +24,20 @@ namespace proton {
 
 class IReservedDiskSpaceAndMemoryProvider;
 
+/**
+ * Disk usage sample.
+ */
+class DiskUsage {
+    uint64_t _used_bytes;
+    uint64_t _capacity_bytes;
+
+public:
+    DiskUsage(uint64_t used_bytes, uint64_t capacity_bytes) noexcept
+        : _used_bytes(used_bytes), _capacity_bytes(capacity_bytes) {}
+    [[nodiscard]] uint64_t used_bytes() const noexcept { return _used_bytes; }
+    [[nodiscard]] uint64_t capacity_bytes() const noexcept { return _capacity_bytes; }
+};
+
 /*
  * Class to sample disk and memory usage used for filtering write operations.
  */
@@ -32,6 +46,7 @@ class DiskMemUsageSampler {
     ResourceUsageNotifier&                     _notifier;
     const IReservedDiskSpaceAndMemoryProvider& _reserved_disk_space_and_memory_provider;
     std::filesystem::path                      _path;
+    bool                                       _should_resample_disk_capacity;
     vespalib::duration                         _sampleInterval;
     vespalib::steady_time                      _lastSampleTime;
     std::mutex                                 _lock;
@@ -39,7 +54,7 @@ class DiskMemUsageSampler {
     std::unique_ptr<vespalib::IDestructorCallback>                                    _periodicHandle;
 
     void sampleAndReportUsage();
-    uint64_t sampleDiskUsage(const searchcorespi::common::ResourceUsage& resource_usage);
+    [[nodiscard]] DiskUsage sampleDiskUsage(const searchcorespi::common::ResourceUsage& resource_usage);
     vespalib::ProcessMemoryStats sampleMemoryUsage();
     searchcorespi::common::ResourceUsage sample_resource_usage();
     [[nodiscard]] bool timeToSampleAgain() const noexcept;
@@ -50,16 +65,19 @@ public:
         ResourceUsageNotifier::Config filterConfig;
         vespalib::duration            sampleInterval;
         vespalib::HwInfo              hwInfo;
+        bool                          should_resample_disk_capacity;
 
-        Config() : filterConfig(), sampleInterval(60s), hwInfo() {}
+        Config() : filterConfig(), sampleInterval(60s), hwInfo(), should_resample_disk_capacity(false) {}
 
         Config(double memoryLimit_in, double diskLimit_in, double reserved_disk_space_factor_in,
                double reserved_memory_factor_in, AttributeUsageFilterConfig attribute_limit_in,
-               vespalib::duration sampleInterval_in, const vespalib::HwInfo& hwInfo_in)
+               vespalib::duration sampleInterval_in, const vespalib::HwInfo& hwInfo_in,
+               bool should_resample_disk_capacity_in)
             : filterConfig(memoryLimit_in, diskLimit_in, reserved_disk_space_factor_in, reserved_memory_factor_in,
                            attribute_limit_in),
               sampleInterval(sampleInterval_in),
-              hwInfo(hwInfo_in) {}
+              hwInfo(hwInfo_in),
+              should_resample_disk_capacity(should_resample_disk_capacity_in) {}
     };
 
     DiskMemUsageSampler(const std::string& path_in, ResourceUsageWriteFilter& filter,

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -133,13 +133,16 @@ void setFS4Compression(const ProtonConfig& proton) {
 }
 
 DiskMemUsageSampler::Config diskMemUsageSamplerConfig(const ProtonConfig& proton, const vespalib::HwInfo& hwInfo) {
+    // If user configures disk size to be 0, let proton resample the disk size periodically.
+    bool should_resample_disk_capacity = (proton.hwinfo.disk.size == 0);
     return {proton.writefilter.memorylimit,
             proton.writefilter.disklimit,
             proton.writefilter.reservedDiskSpaceFactor,
             proton.writefilter.reservedMemoryFactor,
             AttributeUsageFilterConfig(proton.writefilter.attribute.addressSpaceLimit),
             vespalib::from_s(proton.writefilter.sampleinterval),
-            hwInfo};
+            hwInfo,
+            should_resample_disk_capacity};
 }
 
 uint32_t computeRpcTransportThreads(const ProtonConfig& cfg, const vespalib::HwInfo::Cpu& cpuInfo) {

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
@@ -14,8 +14,8 @@ using storage::spi::AttributeResourceUsage;
 
 namespace proton {
 
-void convertDiskStatsToSlime(const vespalib::HwInfo& hwInfo, uint64_t diskUsedSizeBytes, Cursor& object) {
-    object.setLong("capacity", hwInfo.disk().sizeBytes());
+void convertDiskStatsToSlime(uint64_t disk_capacity_bytes, uint64_t diskUsedSizeBytes, Cursor& object) {
+    object.setLong("capacity", disk_capacity_bytes);
     object.setLong("used", diskUsedSizeBytes);
 }
 
@@ -44,7 +44,7 @@ void ResourceUsageExplorer::get_state(const vespalib::slime::Inserter& inserter,
         disk.setDouble("transient", usageState.transient_disk_usage());
         disk.setDouble("non-transient", usageState.non_transient_disk_usage());
         disk.setDouble("reported", usageState.reported_disk_usage());
-        convertDiskStatsToSlime(_usage_notifier.getHwInfo(), _usage_notifier.getDiskUsedSize(),
+        convertDiskStatsToSlime(_usage_notifier.disk_capacity_bytes(), _usage_notifier.getDiskUsedSize(),
                                 disk.setObject("stats"));
 
         Cursor& memory = object.setObject("memory");

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -118,6 +118,11 @@ ReservedDiskSpaceAndMemory ResourceUsageNotifier::reserved_disk_space_and_memory
     return _reserved_disk_space_and_memory;
 }
 
+uint64_t ResourceUsageNotifier::disk_capacity_bytes() const {
+    Guard guard(_lock);
+    return _disk_capacity_bytes;
+}
+
 ResourceUsage ResourceUsageNotifier::get_resource_usage() const {
     Guard guard(_lock);
     return _resource_usage;
@@ -163,7 +168,7 @@ void ResourceUsageNotifier::notify_resource_usage(const Guard& guard, ResourceUs
     if (disk_mem_sample) {
         _disk_mem_usage_metrics.merge(state);
     }
-    _filter.notify_resource_usage(_usage_state, _memoryStats, _diskUsedSizeBytes);
+    _filter.notify_resource_usage(_usage_state, _memoryStats, _diskUsedSizeBytes, _disk_capacity_bytes);
     for (const auto& listener : _listeners) {
         listener->notify_resource_usage(_usage_state);
     }

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -18,6 +18,7 @@ ResourceUsageNotifier::ResourceUsageNotifier(ResourceUsageWriteFilter& filter)
       _hwInfo(filter.get_hw_info()),
       _memoryStats(),
       _diskUsedSizeBytes(),
+      _disk_capacity_bytes(_hwInfo.disk().sizeBytes()),
       _reserved_disk_space_and_memory(0, 0, 0),
       _resource_usage(),
       _attribute_usage(),
@@ -55,9 +56,7 @@ double ResourceUsageNotifier::getMemoryUsedRatio(const Guard&) const {
 }
 
 double ResourceUsageNotifier::getDiskUsedRatio(const Guard&) const {
-    double usedDiskSpaceRatio =
-        static_cast<double>(_diskUsedSizeBytes) / static_cast<double>(_hwInfo.disk().sizeBytes());
-    return usedDiskSpaceRatio;
+    return static_cast<double>(_diskUsedSizeBytes) / static_cast<double>(_disk_capacity_bytes);
 }
 
 double ResourceUsageNotifier::get_relative_reserved_disk_space(const Guard&) const {
@@ -78,12 +77,14 @@ double ResourceUsageNotifier::get_relative_transient_disk_usage(const Guard&) co
 
 void ResourceUsageNotifier::set_resource_usage(const ResourceUsage&         resource_usage,
                                                vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes,
+                                               uint64_t                   disk_capacity_bytes,
                                                ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_) {
     Guard guard(_lock);
     _resource_usage = resource_usage;
     _reserved_disk_space_and_memory = reserved_disk_space_and_memory_;
     _memoryStats = memoryStats;
     _diskUsedSizeBytes = diskUsedSizeBytes;
+    _disk_capacity_bytes = disk_capacity_bytes;
     recalcState(guard, true);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -60,7 +60,7 @@ double ResourceUsageNotifier::getDiskUsedRatio(const Guard&) const {
 }
 
 double ResourceUsageNotifier::get_relative_reserved_disk_space(const Guard&) const {
-    return static_cast<double>(_reserved_disk_space_and_memory.reserved_disk_space()) / _hwInfo.disk().sizeBytes();
+    return static_cast<double>(_reserved_disk_space_and_memory.reserved_disk_space()) / _disk_capacity_bytes;
 }
 
 double ResourceUsageNotifier::get_relative_reserved_memory(const Guard&) const {
@@ -72,7 +72,7 @@ double ResourceUsageNotifier::get_relative_transient_memory_usage(const Guard&) 
 }
 
 double ResourceUsageNotifier::get_relative_transient_disk_usage(const Guard&) const {
-    return static_cast<double>(_resource_usage.transient_disk()) / _hwInfo.disk().sizeBytes();
+    return static_cast<double>(_resource_usage.transient_disk()) / _disk_capacity_bytes;
 }
 
 void ResourceUsageNotifier::set_resource_usage(const ResourceUsage&         resource_usage,

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
@@ -93,6 +93,7 @@ public:
     vespalib::ProcessMemoryStats getMemoryStats() const;
     uint64_t getDiskUsedSize() const;
     [[nodiscard]] ReservedDiskSpaceAndMemory reserved_disk_space_and_memory() const noexcept;
+    [[nodiscard]] uint64_t disk_capacity_bytes() const;
     searchcorespi::common::ResourceUsage get_resource_usage() const;
     Config getConfig() const;
     const vespalib::HwInfo& getHwInfo() const noexcept { return _hwInfo; }

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
@@ -63,6 +63,7 @@ private:
     // Following member variables are protected by _lock
     vespalib::ProcessMemoryStats         _memoryStats;
     uint64_t                             _diskUsedSizeBytes;
+    uint64_t                             _disk_capacity_bytes;
     ReservedDiskSpaceAndMemory           _reserved_disk_space_and_memory;
     searchcorespi::common::ResourceUsage _resource_usage;
     AttributeUsageStats                  _attribute_usage;
@@ -87,7 +88,7 @@ public:
 
     void set_resource_usage(const searchcorespi::common::ResourceUsage& resource_usage,
                             vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes,
-                            ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_);
+                            uint64_t disk_capacity_bytes, ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_);
     [[nodiscard]] bool setConfig(Config config);
     vespalib::ProcessMemoryStats getMemoryStats() const;
     uint64_t getDiskUsedSize() const;

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.cpp
@@ -40,21 +40,21 @@ void makeMemoryLimitMessage(std::ostream& os, double memoryUsed, double memoryLi
     os << "}";
 }
 
-void makeDiskStatsMessage(std::ostream& os, double diskUsed, double diskLimit, const HwInfo& hwInfo,
+void makeDiskStatsMessage(std::ostream& os, double diskUsed, double diskLimit, uint64_t disk_capacity_bytes,
                           uint64_t usedDiskSizeBytes) {
     os << "stats: { ";
-    os << "capacity: " << hwInfo.disk().sizeBytes() << ", ";
+    os << "capacity: " << disk_capacity_bytes << ", ";
     os << "used: " << usedDiskSizeBytes << ", ";
     os << "diskUsed: " << diskUsed << ", ";
     os << "diskLimit: " << diskLimit << "}";
 }
 
-void makeDiskLimitMessage(std::ostream& os, double diskUsed, double diskLimit, const HwInfo& hwInfo,
+void makeDiskLimitMessage(std::ostream& os, double diskUsed, double diskLimit, uint64_t disk_capacity_bytes,
                           uint64_t usedDiskSizeBytes) {
     os << "diskLimitReached: { ";
     os << "action: \"add more content nodes\", ";
     os << "reason: \"disk used (" << diskUsed << ") > disk limit (" << diskLimit << ")\", ";
-    makeDiskStatsMessage(os, diskUsed, diskLimit, hwInfo, usedDiskSizeBytes);
+    makeDiskStatsMessage(os, diskUsed, diskLimit, disk_capacity_bytes, usedDiskSizeBytes);
     os << "}";
 }
 
@@ -91,13 +91,13 @@ void make_attribute_address_space_error_message(std::ostream& os, double used, d
 
 std::string makeUnblockingMessage(double memoryUsed, double memoryLimit, const ProcessMemoryStats& memoryStats,
                                   const HwInfo& hwInfo, double diskUsed, double diskLimit,
-                                  uint64_t usedDiskSizeBytes) {
+                                  uint64_t disk_capacity_bytes, uint64_t usedDiskSizeBytes) {
     std::ostringstream os;
     os << "memoryLimitOK: { ";
     makeMemoryStatsMessage(os, memoryUsed, memoryLimit, memoryStats, hwInfo.memory().sizeBytes());
     os << "}, ";
     os << "diskLimitOK: { ";
-    makeDiskStatsMessage(os, diskUsed, diskLimit, hwInfo, usedDiskSizeBytes);
+    makeDiskStatsMessage(os, diskUsed, diskLimit, disk_capacity_bytes, usedDiskSizeBytes);
     os << "}";
     return os.str();
 }
@@ -111,6 +111,7 @@ ResourceUsageWriteFilter::ResourceUsageWriteFilter(const HwInfo& hwInfo)
       _acceptWrite(true),
       _memoryStats(),
       _diskUsedSizeBytes(0),
+      _disk_capacity_bytes(_hwInfo.disk().sizeBytes()),
       _state(),
       _usage_state() {
 }
@@ -131,8 +132,8 @@ void ResourceUsageWriteFilter::recalc_state(const Guard& guard) {
             message << ", ";
         }
         hasMessage = true;
-        makeDiskLimitMessage(message, _usage_state.diskState().usage(), _usage_state.diskState().limit(), _hwInfo,
-                             _diskUsedSizeBytes);
+        makeDiskLimitMessage(message, _usage_state.diskState().usage(), _usage_state.diskState().limit(),
+                             _disk_capacity_bytes, _diskUsedSizeBytes);
     }
     {
         const auto& max_attribute_address_space_state = _usage_state.max_attribute_address_space_state();
@@ -154,9 +155,10 @@ void ResourceUsageWriteFilter::recalc_state(const Guard& guard) {
         _acceptWrite = false;
     } else {
         if (!_acceptWrite) {
-            std::string unblockMsg = makeUnblockingMessage(
-                _usage_state.memoryState().usage(), _usage_state.memoryState().limit(), _memoryStats, _hwInfo,
-                _usage_state.diskState().usage(), _usage_state.diskState().limit(), _diskUsedSizeBytes);
+            std::string unblockMsg =
+                makeUnblockingMessage(_usage_state.memoryState().usage(), _usage_state.memoryState().limit(),
+                                      _memoryStats, _hwInfo, _usage_state.diskState().usage(),
+                                      _usage_state.diskState().limit(), _disk_capacity_bytes, _diskUsedSizeBytes);
             LOG(info, "Write operations are now un-blocked: '%s'", unblockMsg.c_str());
         }
         _state = State();
@@ -175,11 +177,12 @@ ResourceUsageWriteFilter::State ResourceUsageWriteFilter::getAcceptState() const
 
 void ResourceUsageWriteFilter::notify_resource_usage(const ResourceUsageState&           state,
                                                      const vespalib::ProcessMemoryStats& memoryStats,
-                                                     uint64_t                            diskUsedSizeBytes) {
+                                                     uint64_t diskUsedSizeBytes, uint64_t disk_capacity_bytes) {
     std::lock_guard guard(_lock);
     _usage_state = state;
     _memoryStats = memoryStats;
     _diskUsedSizeBytes = diskUsedSizeBytes;
+    _disk_capacity_bytes = disk_capacity_bytes;
     recalc_state(guard);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.h
@@ -33,6 +33,7 @@ private:
     // Following member variables are protected by _lock
     vespalib::ProcessMemoryStats _memoryStats;
     uint64_t                     _diskUsedSizeBytes;
+    uint64_t                     _disk_capacity_bytes;
     State                        _state;
     ResourceUsageState           _usage_state;
 
@@ -45,7 +46,7 @@ public:
     State getAcceptState() const override;
     const vespalib::HwInfo& get_hw_info() const noexcept { return _hwInfo; }
     void notify_resource_usage(const ResourceUsageState& state, const vespalib::ProcessMemoryStats& memoryStats,
-                               uint64_t diskUsedSizeBytes);
+                               uint64_t diskUsedSizeBytes, uint64_t disk_capacity_bytes);
 };
 
 } // namespace proton


### PR DESCRIPTION
- **Periodically resample disk capacity when disk size configured to 0**
- **Use resampled disk capacity for all disk usage ratios**
- **Show capacity in /resourceusage and logs**

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
