### PR TITLE
Set service.name and service.version on container telemetry resource

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -592,6 +592,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         var applicationId = deployState.getProperties().applicationId();
 
         Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("service.name", applicationId.application().value() + "." + clusterId);
+        attributes.put("service.version", deployState.getWantedNodeVespaVersion().toFullString());
         attributes.put("application", applicationId.application().value());
         attributes.put("tenant", applicationId.tenant().value());
         attributes.put("zone", this.zone.systemLocalValue());

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container;
 
+import ai.vespa.telemetry.TelemetryConfig;
 import com.yahoo.cloud.config.ClusterInfoConfig;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.cloud.config.CuratorConfig;
@@ -372,6 +373,22 @@ public class ContainerClusterTest {
                            new ContainerEndpoint("search-cluster", application, List.of("app-rotation.x.y.z"), OptionalInt.of(3), sharedLayer4),
                            new ContainerEndpoint("search-cluster", zone, List.of("search-cluster.a1.t1.endpoint.suffix"), OptionalInt.empty(), sharedLayer4)),
                 List.of("search-cluster.a1.t1.endpoint.suffix", "rotation-1.x.y.z", "rotation-2.x.y.z", "app-rotation.x.y.z"));
+    }
+
+    @Test
+    void telemetryResourceAttributesIncludeServiceIdentity() {
+        DeployState state = new DeployState.Builder()
+                .properties(new TestProperties().setApplicationId(ApplicationId.from("t1", "a1", "i1")))
+                .build();
+        MockRoot root = new MockRoot("foo", state);
+        ApplicationContainerCluster cluster = new ApplicationContainerCluster(root, "container", "search-cluster", state);
+
+        TelemetryConfig.Builder builder = new TelemetryConfig.Builder();
+        cluster.getConfig(builder);
+        TelemetryConfig config = builder.build();
+
+        assertEquals("a1.search-cluster", config.resourceAttribute("service.name"));
+        assertEquals(state.getWantedNodeVespaVersion().toFullString(), config.resourceAttribute("service.version"));
     }
 
     private void assertNames(SystemName systemName, ApplicationId appId, Set<ContainerEndpoint> globalEndpoints, List<String> expectedSharedL4Names) {


### PR DESCRIPTION
## Problem

The OpenTelemetry `Resource` built for the container had no `service.name`, so `Resource.getDefault()` kept OTel's `unknown_service:java` default. Exported traces therefore showed up as **`unknown_service`** in Grafana/Tempo.

## Fix

Fill `service.name` and `service.version` from the deployment identity in the container telemetry resource attributes (`ContainerCluster.telemetryResourceAttributes`):

- `service.name = {application}.{cluster.id}` — application-qualified so the service map / RED metrics are per-application (not collapsed across tenants); the existing `application`/`tenant`/`cluster.id` attributes remain individually filterable.
- `service.version = deployState.getWantedNodeVespaVersion()` — the wanted node Vespa version.

These flow through `TelemetryConfig.resourceAttribute` into `OpenTelemetrySdkBuilder`, where `Resource.getDefault().merge(Resource.create(...))` gives our attributes precedence — so they override the `unknown_service` default.

## Test

`ContainerClusterTest.telemetryResourceAttributesIncludeServiceIdentity` builds a container cluster and asserts the produced `TelemetryConfig` carries the expected `service.name` and `service.version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)