### PR TITLE
Add another valgrind suppression for GCC 15 optimized string scanning

### DIFF
--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -868,13 +868,21 @@
    ...
 }
 {
+   for GCC 15 optimized string scanning in pagedict4 version 2
+   Memcheck:Cond
+   fun:_ZN6search14bitcompression16PageDict4PWriter9addCountsESt17basic_string_viewIcSt11char_traitsIcEERKNS_5index17PostingListCountsE
+   fun:_ZN6search9diskindex11FieldWriter5flushEv
+   fun:_ZN6search9diskindex11FieldWriter7newWordEmSt17basic_string_viewIcSt11char_traitsIcEE
+   ...
+}
+{
    for new openssl on EL8/arm64 (optimized strlcpy)
    Memcheck:Cond
    fun:OPENSSL_strlcpy
    ...
 }
 {
-   for new openssl on EL8/arm64 (optimized strlat)
+   for new openssl on EL8/arm64 (optimized strlcat)
    Memcheck:Cond
    fun:OPENSSL_strlcat
    ...


### PR DESCRIPTION
GCC 15 emits vectorized string scanning code that reads memory in word-sized chunks, which can touch a few bytes past the end of a std::string_view's data. Those trailing bytes are uninitialized but never affect the result, so valgrind reports a spurious Memcheck:Cond (use of uninitialised value) inside PageDict4PWriter::addCounts when called from FieldWriter::flush/newWord.

This is the same false positive already suppressed for the testWords path; add a second suppression covering the FieldWriter writer path so the valgrind test runs clean. Also fix a typo in a neighbouring openssl suppression comment (strlat -> strlcat).
