### PR TITLE
Use newer vespa-valgrind package on EL8 for systemtest valgrind runs

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -310,7 +310,11 @@ Summary: Vespa - The open big data serving engine - tools for system tests
 
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-base-libs = %{version}-%{release}
+%if 0%{?el8}
+Requires: vespa-valgrind
+%else
 Requires: valgrind
+%endif
 Requires: perf
 
 %description systemtest-tools


### PR DESCRIPTION
The valgrind shipped with EL8 is too old to correctly instrument current Vespa binaries, causing system tests run under valgrind to fail or report spurious errors. Depend on the separately built vespa-valgrind RPM (a newer valgrind) on EL8, while keeping the distro-provided valgrind on EL9/EL10 and other platforms where it is recent enough.

