### PR TITLE
Update Jackson to 2.22.0

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -38,8 +38,8 @@
         <guava.vespa.version>33.2.1-jre</guava.vespa.version>
         <guice.vespa.version>6.0.0</guice.vespa.version>
         <j2objc-annotations.vespa.version>3.0.0</j2objc-annotations.vespa.version>
-        <jackson2.vespa.version>2.21.4</jackson2.vespa.version>
-        <jackson-annotations.vespa.version>2.21</jackson-annotations.vespa.version>
+        <jackson2.vespa.version>2.22.0</jackson2.vespa.version>
+        <jackson-annotations.vespa.version>2.22</jackson-annotations.vespa.version>
         <jackson-databind.vespa.version>${jackson2.vespa.version}</jackson-databind.vespa.version>
         <jakarta.inject.vespa.version>2.0.1</jakarta.inject.vespa.version>
         <javax.activation-api.vespa.version>1.2.0</javax.activation-api.vespa.version>

--- a/integration/logstash-plugins/logstash-output-vespa/build.gradle
+++ b/integration/logstash-plugins/logstash-output-vespa/build.gradle
@@ -58,10 +58,10 @@ dependencies {
 
     implementation("com.yahoo.vespa:vespa-feed-client:${VESPA_VERSION}")
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.4'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.21.4'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.21'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.22.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.22.0'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.22'
 
     implementation "org.yaml:snakeyaml:${snakeYamlVersion}"
 
@@ -72,7 +72,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation("com.yahoo.vespa:vespa-feed-client:${VESPA_VERSION}")
     testImplementation fileTree(dir: LOGSTASH_CORE_PATH, include: "**/logstash-core.jar")
-    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.4'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.22.0'
 }
 
 clean {


### PR DESCRIPTION
Bump the shared jackson2 dependency (and the jackson-annotations track to 2.22) in dependency-versions/pom.xml so all Vespa modules pick up the new Jackson release, and align the explicitly pinned Jackson coordinates in the logstash-output-vespa plugin (which builds outside the Maven dependency management) to the same version. Staying current with Jackson keeps us on supported releases and picks up upstream bug/security fixes.