### PR TITLE
Hardcode simpleAnnotations to always-on; prepare flag for removal

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/ContainerDocproc.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/ContainerDocproc.java
@@ -29,7 +29,6 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
 
     public final Options options;
     private final Map<Pair<String, String>, String> fieldNameSchemaMap = new HashMap<>();
-    private final boolean useSimpleAnnotations;
 
     public ContainerDocproc(ContainerCluster<?> cluster, DocprocChains chains) {
         this(cluster, chains, Options.empty(), null);
@@ -53,7 +52,6 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
         super(chains);
         assert (options != null) : "Null Options for " + this + " under cluster " + cluster.getName();
         this.options = options;
-        this.useSimpleAnnotations = deployState == null || deployState.featureFlags().useSimpleAnnotations();
 
         if (addSourceClientProvider) {
             addSource(cluster, "source", SessionConfig.Type.SOURCE);
@@ -86,7 +84,7 @@ public class ContainerDocproc extends ContainerSubsystem<DocprocChains> implemen
         if (getMaxQueueTimeMs() != null) {
             builder.maxqueuetimems(getMaxQueueTimeMs());
         }
-        builder.simpleAnnotations(useSimpleAnnotations);
+        builder.simpleAnnotations(true);
     }
 
     @Override

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
@@ -110,9 +110,8 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                      .setContainerDocumentConfig(containerDocConfig),
                 threadPool);
 
-        // Set simple annotations flag based on config
-        com.yahoo.document.annotation.internal.SimpleIndexingAnnotations.setEnabled(
-                docprocConfig.simpleAnnotations());
+        // Set simple annotations flag
+        com.yahoo.document.annotation.internal.SimpleIndexingAnnotations.setEnabled(true);
 
         docprocServiceRegistry.freeze();
     }

--- a/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
+++ b/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
@@ -9,6 +9,6 @@ maxqueuetimems int default=-1
 # numthreads no longer has an effect.
 numthreads int default=-1
 
-# Enable lightweight annotation representation for StringFieldValue.
+# Not used - always enabled.
 # When enabled, uses SimpleIndexingAnnotations (flat arrays) instead of full SpanTree objects.
 simpleAnnotations bool default=true

--- a/document/src/main/java/com/yahoo/document/annotation/internal/SimpleIndexingAnnotations.java
+++ b/document/src/main/java/com/yahoo/document/annotation/internal/SimpleIndexingAnnotations.java
@@ -30,7 +30,7 @@ public final class SimpleIndexingAnnotations {
      * Global feature flag to enable/disable simple annotations representation.
      * When enabled, uses SimpleIndexingAnnotations (flat arrays) instead of full SpanTree objects.
      */
-    private static volatile boolean enabled = false;
+    private static volatile boolean enabled = true;
 
     /**
      * Returns whether simple annotations are enabled.


### PR DESCRIPTION
The lightweight SimpleIndexingAnnotations representation (flat arrays instead of full SpanTree objects) has been validated as the only supported behavior, so stop threading the useSimpleAnnotations feature flag / docproc config through the code and hardcode the enabled path.