### PR TITLE
Generalized (de-)quantization of indexed and mixed float32 tensors

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/tensorattribute/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_executable(searchlib_tensorattribute_test_app TEST
     SOURCES
+    tensor_quantization_test.cpp
     tensorattribute_test.cpp
     DEPENDS
     vespa_searchlib
-    GTest::gtest
+    GTest::gmock_main
 )
 vespa_add_test(NAME searchlib_tensorattribute_test_app COMMAND searchlib_tensorattribute_test_app)

--- a/searchlib/src/tests/attribute/tensorattribute/tensor_quantization_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensor_quantization_test.cpp
@@ -1,0 +1,127 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/simple_value.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/value.h>
+#include <vespa/eval/eval/value_codec.h>
+#include <vespa/searchlib/tensor/tensor_quantization.h>
+#include <vespa/vespalib/quant/eden.h>
+
+#include <gmock/gmock.h>
+
+#include <iostream>
+
+using vespalib::eval::CellType;
+using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::Value;
+using vespalib::eval::ValueType;
+using vespalib::quant::EdenQuantizer;
+using vespalib::quant::QuantMode;
+
+using namespace ::testing;
+
+namespace search::tensor {
+
+namespace {
+
+Value::UP create_tensor(const TensorSpec& spec) {
+    return value_from_spec(spec, FastValueBuilderFactory::get());
+}
+
+std::unique_ptr<EdenQuantizer> make_quantizer_from_type(const ValueType& type, const uint8_t bits) {
+    const size_t   dimensions = type.dense_subspace_size();
+    const uint64_t seed = 0x1234567890;
+    return std::make_unique<EdenQuantizer>(dimensions, bits, seed);
+}
+
+std::string to_quant_spec(const std::string& spec, uint8_t bits) {
+    auto in_type = ValueType::from_spec(spec);
+    auto q = make_quantizer_from_type(in_type, bits);
+    return to_quantized_tensor_type(in_type, *q).to_spec();
+}
+
+} // namespace
+
+TEST(TensorQuantizationTest, quantized_type_conversion_flattens_indexed_dimensions) {
+    EXPECT_EQ(to_quant_spec("tensor<float>(x[16])", 1), "tensor<int8>(x[6])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(x[17])", 1), "tensor<int8>(x[7])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(x[16])", 4), "tensor<int8>(x[12])");
+    // For multiple indexed dimensions we choose the name of the last dimension (in lexicographic order)
+    EXPECT_EQ(to_quant_spec("tensor<float>(x[2],y[3])", 4), "tensor<int8>(y[7])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(x[2],y[3],z[4])", 4), "tensor<int8>(z[16])");
+
+    EXPECT_EQ(to_quant_spec("tensor<float>(a{},x[16])", 1), "tensor<int8>(a{},x[6])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(a{},x[16])", 4), "tensor<int8>(a{},x[12])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(a{},b{},x[16])", 4), "tensor<int8>(a{},b{},x[12])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(a{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(a{},b{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},b{},z[16])");
+
+    // Tensor dimensions are normalized to lexicographic order, so we must not be
+    // ordering-dependent in our type conversion.
+    EXPECT_EQ(to_quant_spec("tensor<float>(z[4],y[2],x[3])", 4), "tensor<int8>(z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(y[4],z[2],x[3])", 4), "tensor<int8>(z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(x{},a[16])", 4), "tensor<int8>(a[12],x{})");
+    EXPECT_EQ(to_quant_spec("tensor<float>(a[16],x{})", 4), "tensor<int8>(a[12],x{})");
+    EXPECT_EQ(to_quant_spec("tensor<float>(x{},y{},a[2],b[3],c[4])", 4), "tensor<int8>(c[16],x{},y{})");
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_indexed_tensors) {
+    constexpr uint8_t q_bits = 4;
+
+    auto t = create_tensor(
+        TensorSpec("tensor<float>(x[2],y[3])").add({{"x", 0}, {"y", 1}}, 12).add({{"x", 1}, {"y", 2}}, 9));
+    auto q = make_quantizer_from_type(t->type(), q_bits);
+    auto q_type = to_quantized_tensor_type(t->type(), *q);
+
+    auto qt_mse = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::MSE);
+    auto dqt_mse = search::tensor::dequantize_tensor(*qt_mse, t->type(), *q);
+    auto qt_ip = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::InnerProduct);
+    auto dqt_ip = search::tensor::dequantize_tensor(*qt_ip, t->type(), *q);
+
+    EXPECT_EQ(qt_mse->type(), q_type);
+    EXPECT_EQ(qt_ip->type(), q_type);
+
+    // OG vector
+    EXPECT_THAT(t->cells().typify<float>(), ElementsAre(/*x=0*/ 0, 12, 0, /*x=1*/ 0, 0, 9));
+    // we have vector at home, MSE edition:
+    std::vector<float> mse_expected = {-0.364243, 11.9888, 1.24358, -0.301369, -0.404984, 8.79533};
+    EXPECT_THAT(dqt_mse->cells().typify<float>(), Pointwise(FloatNear(0.0001), mse_expected));
+    // Inner-product edition:
+    std::vector<float> ip_expected = {-0.36747, 12.0951, 1.2546, -0.304039, -0.408572, 8.87325};
+    EXPECT_THAT(dqt_ip->cells().typify<float>(), Pointwise(FloatNear(0.0001), ip_expected));
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_mixed_tensors) {
+    constexpr uint8_t q_bits = 4;
+
+    auto t = create_tensor(TensorSpec("tensor<float>(a{},x[2],y[3])")
+                               .add({{"a", "foo"}, {"x", 0}, {"y", 1}}, 12)
+                               .add({{"a", "foo"}, {"x", 1}, {"y", 2}}, 9)
+                               .add({{"a", "bar"}, {"x", 0}, {"y", 1}}, 5)
+                               .add({{"a", "bar"}, {"x", 1}, {"y", 1}}, 3));
+    auto q = make_quantizer_from_type(t->type(), q_bits);
+    auto q_type = to_quantized_tensor_type(t->type(), *q);
+
+    auto qt_mse = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::MSE);
+    auto dqt_mse = search::tensor::dequantize_tensor(*qt_mse, t->type(), *q);
+    auto qt_ip = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::InnerProduct);
+    auto dqt_ip = search::tensor::dequantize_tensor(*qt_ip, t->type(), *q);
+
+    EXPECT_EQ(qt_mse->type(), q_type);
+    EXPECT_EQ(qt_ip->type(), q_type);
+
+    // OG vector. Arranged as bar=[0, 5, 0, 0, 3, 0], foo=[0, 12, 0, 0, 0, 9]
+    EXPECT_THAT(t->cells().typify<float>(), ElementsAre(0, 5, 0, 0, 3, 0, 0, 12, 0, 0, 0, 9));
+
+    std::vector<float> mse_expected = {-0.00648499, 4.85099, 0.384633, -0.0835068, 3.1499,    -0.309387,
+                                       -0.364243,   11.9888, 1.24358,  -0.301369,  -0.404984, 8.79533};
+    EXPECT_THAT(dqt_mse->cells().typify<float>(), Pointwise(FloatNear(0.0001), mse_expected));
+
+    std::vector<float> ip_expected = {-0.00654173, 4.8935,  0.388003, -0.0842385, 3.1775,    -0.312098,
+                                      -0.36747,    12.0951, 1.2546,   -0.304039,  -0.408572, 8.87325};
+    EXPECT_THAT(dqt_ip->cells().typify<float>(), Pointwise(FloatNear(0.0001), ip_expected));
+}
+
+} // namespace search::tensor

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1719,5 +1719,3 @@ TEST_F(SparseTensorAttributeTest, size_on_disk_factor_is_calculated_and_used) {
     EXPECT_EQ(dynamic_memory_usage, attr2.getStatus().get_used_minus_dead_and_onhold() - initial_memory_usage);
     EXPECT_EQ(attr.getEstimatedSaveByteSize(), attr2.getEstimatedSaveByteSize());
 }
-
-GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/tensor/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/tensor/CMakeLists.txt
@@ -47,6 +47,7 @@ vespa_add_library(searchlib_tensor OBJECT
     tensor_buffer_type_mapper.cpp
     tensor_deserialize.cpp
     tensor_ext_attribute.cpp
+    tensor_quantization.cpp
     tensor_store.cpp
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
@@ -1,0 +1,125 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "tensor_quantization.h"
+
+#include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/value.h>
+#include <vespa/vespalib/quant/eden.h>
+
+#include <cassert>
+#include <type_traits>
+
+using vespalib::eval::CellType;
+using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::Int8Float;
+using vespalib::eval::ValueType;
+
+namespace search::tensor {
+
+namespace {
+
+template <typename T, typename T2>
+[[nodiscard]] constexpr std::span<T> cast_span(const std::span<T2> in) noexcept { // TODO or span_cast...?
+    static_assert(sizeof(T) == sizeof(T2));
+    static_assert(alignof(T) == alignof(T2));
+    static_assert(std::has_unique_object_representations_v<T> && std::has_unique_object_representations_v<T2>);
+    return std::span<T>(reinterpret_cast<T*>(in.data()), in.size());
+}
+
+} // namespace
+
+// TODO consider if we should just pass the number of bits rather than a full quantizer...
+//  - could make size computation a static public function in EdenQuantizer
+
+ValueType to_quantized_tensor_type(const ValueType&                      f32_tensor_type,
+                                   const vespalib::quant::EdenQuantizer& quantizer) {
+    std::vector<ValueType::Dimension> q_dims = f32_tensor_type.mapped_dimensions();
+    assert(!f32_tensor_type.is_sparse()); // Must have at least 1 indexed dimension
+    assert(f32_tensor_type.dense_subspace_size() == quantizer.dimensions());
+    // Leave all sparse dimensions untouched and replace all indexed dimensions with a single
+    // quantized "aggregate" dimension. We cheekily reuse the name of the last indexed dimension
+    // to ensure we use a name that is unique within the tensor type.
+    q_dims.emplace_back(f32_tensor_type.indexed_dimensions().back().name, quantizer.quantized_size());
+    return ValueType::make_type(CellType::INT8, std::move(q_dims));
+}
+
+// These functions have been cooked on firewood stol- uh, borrowed, from vespalib::eval::CopyValue. Yes. yes.
+
+std::unique_ptr<vespalib::eval::Value> quantize_f32_tensor(const vespalib::eval::Value&     f32_in_tensor,
+                                                           const vespalib::eval::ValueType& quantized_type,
+                                                           vespalib::quant::EdenQuantizer&  quantizer,
+                                                           const vespalib::quant::QuantMode quantization_mode) {
+    // We expect that the number of mapped dimensions is the same for both tensor types
+    const size_t num_mapped = quantized_type.count_mapped_dimensions();
+    const size_t input_dense_size = f32_in_tensor.type().dense_subspace_size();
+    const size_t quantized_dense_size = quantized_type.dense_subspace_size();
+    const auto&  idx = f32_in_tensor.index();
+    auto         input_cells = f32_in_tensor.cells().typify<float>();
+    assert(input_dense_size == quantizer.dimensions());
+    assert(quantized_dense_size == quantizer.quantized_size());
+    assert(num_mapped == quantized_type.dimensions().size() - 1); // Indexed must be reduced down to 1 dimension
+    auto builder = FastValueBuilderFactory::get().create_value_builder<Int8Float>(quantized_type, num_mapped,
+                                                                                  quantized_dense_size, idx.size());
+    std::vector<vespalib::string_id> addr(num_mapped);
+    if (num_mapped == 0) {
+        assert(idx.size() == 1);
+        auto i8f_array_ref = builder->add_subspace(addr);
+        auto u8_array_ref = cast_span<uint8_t>(i8f_array_ref);
+        quantizer.quantize(input_cells, u8_array_ref, quantization_mode);
+    } else {
+        auto view = idx.create_view({});
+        view->lookup({});
+        std::vector<vespalib::string_id*> addr_fetch;
+        addr_fetch.reserve(num_mapped);
+        for (auto& label : addr) {
+            addr_fetch.emplace_back(&label);
+        }
+        size_t subspace_idx;
+        while (view->next_result(addr_fetch, subspace_idx)) {
+            auto i8f_array_ref = builder->add_subspace(addr);
+            auto u8_array_ref = cast_span<uint8_t>(i8f_array_ref);
+            auto input = input_cells.subspan(input_dense_size * subspace_idx, input_dense_size);
+            quantizer.quantize(input, u8_array_ref, quantization_mode);
+        }
+    }
+    return builder->build(std::move(builder));
+}
+
+std::unique_ptr<vespalib::eval::Value> dequantize_tensor(const vespalib::eval::Value&     quantized_in_tensor,
+                                                         const vespalib::eval::ValueType& out_f32_tensor_type,
+                                                         vespalib::quant::EdenQuantizer&  quantizer) {
+    // We expect that the number of mapped dimensions is the same for both tensor types
+    const size_t num_mapped = out_f32_tensor_type.count_mapped_dimensions();
+    const size_t quantized_dense_size = quantizer.quantized_size();
+    const size_t dense_size = out_f32_tensor_type.dense_subspace_size();
+    const auto&  idx = quantized_in_tensor.index();
+    auto         input_cells = quantized_in_tensor.cells().typify<Int8Float>();
+    assert(dense_size == quantizer.dimensions());
+    auto builder = FastValueBuilderFactory::get().create_value_builder<float>(out_f32_tensor_type, num_mapped,
+                                                                              dense_size, idx.size());
+    std::vector<vespalib::string_id> addr(num_mapped);
+    if (num_mapped == 0) {
+        assert(idx.size() == 1);
+        auto f32_array_ref = builder->add_subspace(addr);
+        auto input_as_u8 = cast_span<const uint8_t>(input_cells);
+        quantizer.dequantize(input_as_u8, f32_array_ref);
+    } else {
+        auto view = idx.create_view({});
+        view->lookup({});
+        std::vector<vespalib::string_id*> addr_fetch;
+        addr_fetch.reserve(num_mapped);
+        for (auto& label : addr) {
+            addr_fetch.emplace_back(&label);
+        }
+        size_t subspace_idx;
+        while (view->next_result(addr_fetch, subspace_idx)) {
+            auto f32_array_ref = builder->add_subspace(addr);
+            auto input = input_cells.subspan(quantized_dense_size * subspace_idx, quantized_dense_size);
+            auto input_as_u8 = cast_span<const uint8_t>(input);
+            quantizer.dequantize(input_as_u8, f32_array_ref);
+        }
+    }
+    return builder->build(std::move(builder));
+}
+
+} // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
@@ -22,7 +22,7 @@ template <typename T, typename T2>
 [[nodiscard]] constexpr std::span<T> cast_span(const std::span<T2> in) noexcept { // TODO or span_cast...?
     static_assert(sizeof(T) == sizeof(T2));
     static_assert(alignof(T) == alignof(T2));
-    static_assert(std::has_unique_object_representations_v<T> && std::has_unique_object_representations_v<T2>);
+    static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_copyable_v<T2>);
     return std::span<T>(reinterpret_cast<T*>(in.data()), in.size());
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
@@ -19,7 +19,7 @@ namespace search::tensor {
 namespace {
 
 template <typename T, typename T2>
-[[nodiscard]] constexpr std::span<T> cast_span(const std::span<T2> in) noexcept { // TODO or span_cast...?
+[[nodiscard]] constexpr std::span<T> span_cast(const std::span<T2> in) noexcept {
     static_assert(sizeof(T) == sizeof(T2));
     static_assert(alignof(T) == alignof(T2));
     static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_copyable_v<T2>);
@@ -64,7 +64,7 @@ std::unique_ptr<vespalib::eval::Value> quantize_f32_tensor(const vespalib::eval:
     if (num_mapped == 0) {
         assert(idx.size() == 1);
         auto i8f_array_ref = builder->add_subspace(addr);
-        auto u8_array_ref = cast_span<uint8_t>(i8f_array_ref);
+        auto u8_array_ref = span_cast<uint8_t>(i8f_array_ref);
         quantizer.quantize(input_cells, u8_array_ref, quantization_mode);
     } else {
         auto view = idx.create_view({});
@@ -77,7 +77,7 @@ std::unique_ptr<vespalib::eval::Value> quantize_f32_tensor(const vespalib::eval:
         size_t subspace_idx;
         while (view->next_result(addr_fetch, subspace_idx)) {
             auto i8f_array_ref = builder->add_subspace(addr);
-            auto u8_array_ref = cast_span<uint8_t>(i8f_array_ref);
+            auto u8_array_ref = span_cast<uint8_t>(i8f_array_ref);
             auto input = input_cells.subspan(input_dense_size * subspace_idx, input_dense_size);
             quantizer.quantize(input, u8_array_ref, quantization_mode);
         }
@@ -101,7 +101,7 @@ std::unique_ptr<vespalib::eval::Value> dequantize_tensor(const vespalib::eval::V
     if (num_mapped == 0) {
         assert(idx.size() == 1);
         auto f32_array_ref = builder->add_subspace(addr);
-        auto input_as_u8 = cast_span<const uint8_t>(input_cells);
+        auto input_as_u8 = span_cast<const uint8_t>(input_cells);
         quantizer.dequantize(input_as_u8, f32_array_ref);
     } else {
         auto view = idx.create_view({});
@@ -115,7 +115,7 @@ std::unique_ptr<vespalib::eval::Value> dequantize_tensor(const vespalib::eval::V
         while (view->next_result(addr_fetch, subspace_idx)) {
             auto f32_array_ref = builder->add_subspace(addr);
             auto input = input_cells.subspan(quantized_dense_size * subspace_idx, quantized_dense_size);
-            auto input_as_u8 = cast_span<const uint8_t>(input);
+            auto input_as_u8 = span_cast<const uint8_t>(input);
             quantizer.dequantize(input_as_u8, f32_array_ref);
         }
     }

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.h
@@ -1,0 +1,69 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/eval/eval/value_type.h>
+#include <vespa/vespalib/quant/eden.h>
+
+#include <memory>
+
+/*
+ * Generalized support for quantizing and dequantizing indexed and mixed float32 tensors.
+ *
+ * We quantize each dense subspace individually, treating each such subspace as if it's logically
+ * a single vector whose size is the product of all indexed dimension sizes. This allows for
+ * maximally dense bit packing _across_ indexed dimensions (for one particular dense subspace),
+ * and also allows for selectively dequantizing individual _mapped_ subspaces.
+ *
+ * This packing means that a quantized tensor has a differently shaped type than the original
+ * float tensor. All mapped dimensions are preserved as-is, but all indexed dimensions are
+ * replaced with a single "aggregate" int8 indexed dimension whose size is equal to the number
+ * of bytes required to store a single full, dense subspace. The number of bytes required
+ * is proportional to the number of quantization bits used. To ensure dimension name uniqueness
+ * within the transformed type, we reuse the name of the last (in lexicographic order) indexed
+ * dimension.
+ *
+ * Quantization of fully sparse tensors is not supported.
+ */
+
+namespace vespalib::eval {
+struct Value;
+} // namespace vespalib::eval
+
+namespace search::tensor {
+
+/*
+ * Returns a transformed ValueType that can be used to store a quantized representation of `tensor_type`
+ * using the quantization parameters specified by `quantizer`.
+ *
+ * The tensor type must contain at least 1 indexed dimension.
+ */
+[[nodiscard]] vespalib::eval::ValueType to_quantized_tensor_type(const vespalib::eval::ValueType& f32_tensor_type,
+                                                                 const vespalib::quant::EdenQuantizer& quantizer);
+
+/*
+ * Returns a quantized representation of the input `f32_in_tensor`, using the specified quantization mode.
+ *
+ * Preconditions:
+ *   - `quantizer` must be logically the same as that provided as input to `to_quantized_tensor_type()`
+ *      (i.e. it must have the same construction parameters, but need not be the same actual instance).
+ *   - `f32_in_tensor.type()` must be the same as that provided as input to `to_quantized_tensor_type()`.
+ *   - `quantized_type` must be the same as the output of `to_quantized_tensor_type()`.
+ */
+[[nodiscard]] std::unique_ptr<vespalib::eval::Value>
+quantize_f32_tensor(const vespalib::eval::Value& f32_in_tensor, const vespalib::eval::ValueType& quantized_type,
+                    vespalib::quant::EdenQuantizer& quantizer, vespalib::quant::QuantMode quantization_mode);
+
+/*
+ * Preconditions:
+ *   - `quantized_in_tensor` must contain tensor data that was produced by a prior call to
+ *     `quantize_f32_tensor()`.
+ *   - `out_f32_tensor_type` must match the type of the tensor that was originally provided
+ *      as `f32_in_tensor` to the `quantize_f32_tensor` function.
+ *   - `quantizer` must be logically the same as the one used in the prior `quantize_f32_tensor` call.
+ */
+[[nodiscard]] std::unique_ptr<vespalib::eval::Value>
+dequantize_tensor(const vespalib::eval::Value&     quantized_in_tensor,
+                  const vespalib::eval::ValueType& out_f32_tensor_type, vespalib::quant::EdenQuantizer& quantizer);
+
+} // namespace search::tensor


### PR DESCRIPTION
@havardpe please review

We quantize each dense subspace individually, treating each such subspace as if it's logically a single vector whose size is the product of all indexed dimension sizes. This allows for maximally dense bit packing _across_ indexed dimensions (for one particular dense subspace), and also allows for selectively dequantizing individual _mapped_ subspaces.

This packing means that a quantized tensor has a differently shaped type than the original float tensor. All _mapped_ dimensions are preserved as-is, but all _indexed_ dimensions are replaced with a single "aggregate" `int8` indexed dimension whose size is equal to the number of bytes required to store a single full, dense subspace. The number of bytes required is proportional to the number of quantization bits used. To ensure dimension name uniqueness within the transformed type, we reuse the name of the last (in lexicographic order) indexed dimension.

Quantization of fully sparse tensors is not supported.

