### PR TITLE
Rewrite BufferedInput to support incremental (streamed) input

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
@@ -14,7 +14,6 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import com.yahoo.text.Text;
@@ -157,8 +156,7 @@ public class ClusterDeploymentMetricsRetriever {
     private static Slime doMetricsRequest(URI hostURI) {
         HttpGet get = new HttpGet(hostURI);
         try (CloseableHttpResponse response = httpClient.execute(get)) {
-            byte[] body = EntityUtils.toByteArray(response.getEntity());
-            return SlimeUtils.jsonToSlime(body);
+            return SlimeUtils.jsonToSlime(response.getEntity().getContent());
         } catch (IOException e) {
             log.info("Was unable to fetch metrics from " + hostURI + " : " + Exceptions.toMessageString(e));
             return new Slime();

--- a/vespajlib/src/main/java/com/yahoo/slime/BinaryDecoder.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/BinaryDecoder.java
@@ -129,12 +129,10 @@ final class BinaryDecoder {
 
     static void decodeSymbolTable(BufferedInput input, SymbolTable names) {
         int numSymbols = input.read_cmpr_int();
-        final byte[] backing = input.getBacking();
         for (int i = 0; i < numSymbols; ++i) {
             int size = input.read_cmpr_int();
-            int offset = input.getPosition();
-            input.skip(size);
-            int symbol = names.insert(Utf8Codec.decode(backing, offset, size));
+            var bytes = input.getBytesView(size);
+            int symbol = names.insert(Utf8Codec.decode(bytes.data(), bytes.start(), size));
             if (symbol != i) {
                 input.fail("duplicate symbols in symbol table");
                 return;

--- a/vespajlib/src/main/java/com/yahoo/slime/BinaryDecoder.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/BinaryDecoder.java
@@ -132,7 +132,7 @@ final class BinaryDecoder {
         for (int i = 0; i < numSymbols; ++i) {
             int size = input.read_cmpr_int();
             var bytes = input.getBytesView(size);
-            int symbol = names.insert(Utf8Codec.decode(bytes.data(), bytes.start(), size));
+            int symbol = names.insert(Utf8Codec.decode(bytes.data(), bytes.start(), bytes.size()));
             if (symbol != i) {
                 input.fail("duplicate symbols in symbol table");
                 return;

--- a/vespajlib/src/main/java/com/yahoo/slime/BinaryView.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/BinaryView.java
@@ -284,12 +284,12 @@ public final class BinaryView implements Inspector {
         var input = new BufferedInput(data);
         var names = new SymbolTable();
         BinaryDecoder.decodeSymbolTable(input, names);
-        var index = new DecodeIndex(input.getBacking().length, input.getPosition());
+        var index = new DecodeIndex(data.length, input.getPosition());
         buildIndex(input, index, 0, 0);
         if (input.failed()) {
             throw new IllegalArgumentException("bad input: " + input.getErrorMessage());
         }
-        return new BinaryView(input.getBacking(), names, index.getBacking(), 0);
+        return new BinaryView(data, names, index.getBacking(), 0);
     }
 
     static int peek_cmpr_int_for_testing(byte[] data, int idx) {

--- a/vespajlib/src/main/java/com/yahoo/slime/BufferedInput.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/BufferedInput.java
@@ -110,11 +110,7 @@ final class BufferedInput {
     }
 
     byte[] getOffending() {
-        if (failPos < current.start()) {
-            // this should not happen, but handle it anyway
-            failPos = current.start();
-        }
-        int fromCurr = failPos - current.start();
+        int fromCurr = (failPos < current.start()) ? 0 : (failPos - current.start());
         if (previous == null) {
             byte[] ret = new byte[fromCurr];
             System.arraycopy(current.data(), current.start(), ret, 0, fromCurr);

--- a/vespajlib/src/main/java/com/yahoo/slime/BufferedInput.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/BufferedInput.java
@@ -1,14 +1,23 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.slime;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
 final class BufferedInput {
 
-    private final byte[] source;
-    private final int end;
-    private final int start;
+    record Bytes(byte[] data, int start, int end) {
+        int size() { return end - start; }
+    }
+
+    private Bytes current;
+    private Bytes previous = null;
+    private ByteSource sources;
     private int position;
-    private String failReason;
-    private int failPos;
+    private String failReason = null;
+    private int failPos = -1;
+    private int lost = 0;
 
     void fail(String reason) {
         if (failed()) {
@@ -16,7 +25,8 @@ final class BufferedInput {
         }
         failReason = reason;
         failPos = position;
-        position = end;
+        position = current.end();
+        sources = null;
     }
 
     BufferedInput(byte[] bytes) {
@@ -24,17 +34,53 @@ final class BufferedInput {
     }
 
     BufferedInput(byte[] bytes, int offset, int length) {
-        this.source = bytes;
-        this.start = offset;
-        position = offset;
-        this.end = offset + length;
+        this.current = new Bytes(bytes, offset, offset + length);
+        this.position = offset;
+        this.sources = null;
     }
+
+    BufferedInput(ByteSource sources) {
+        // Start empty; the first chunk is fetched lazily
+        this.current = new Bytes(new byte[0], 0, 0);
+        this.position = 0;
+        this.sources = sources;
+    }
+
+    private boolean getMore() {
+        if (sources == null) {
+            return false;
+        }
+        try {
+            byte[] next;
+            do {
+                next = sources.next();
+                if (next == null) {
+                    sources = null;
+                    return false;
+                }
+            } while (next.length == 0); // Skip empty chunks
+            if (previous != null) {
+                lost += previous.size();
+            }
+            if (current.size() > 0) {
+                previous = current;
+            }
+            current = new Bytes(next, 0, next.length);
+            position = current.start();
+            return true;
+        } catch (IOException e) {
+            fail("IO error reading input: " + e);
+            return false;
+        }
+    }
+
     byte getByte() {
-        if (position == end) {
+        // Fetch the next chunk when the current one is exhausted
+        if (position == current.end() && ! getMore()) {
             fail("underflow");
             return 0;
         }
-        return source[position++];
+        return current.data()[position++];
     }
 
     boolean failed() {
@@ -42,7 +88,9 @@ final class BufferedInput {
     }
 
     boolean eof() {
-        return this.position == this.end;
+        // Pull the next chunk on demand: we are at end-of-input only if the current
+        // chunk is exhausted and no more chunks can be fetched.
+        return position == current.end() && ! getMore();
     }
 
     String getErrorMessage() {
@@ -50,35 +98,101 @@ final class BufferedInput {
     }
 
     int getConsumedSize() {
-        return failed() ? 0 : position - start;
+        if (failed()) {
+            return 0;
+        }
+        int consumed = lost;
+        if (previous != null) {
+            consumed += previous.size();
+        }
+        consumed += position - current.start();
+        return consumed;
     }
 
     byte[] getOffending() {
-        byte[] ret = new byte[failPos-start];
-        System.arraycopy(source, start, ret, 0, failPos-start);
+        if (failPos < current.start()) {
+            // this should not happen, but handle it anyway
+            failPos = current.start();
+        }
+        int fromCurr = failPos - current.start();
+        if (previous == null) {
+            byte[] ret = new byte[fromCurr];
+            System.arraycopy(current.data(), current.start(), ret, 0, fromCurr);
+            return ret;
+        }
+        byte[] prefix = (lost > 0)
+                ? ("[... " + lost + " bytes ...]").getBytes(StandardCharsets.UTF_8)
+                : new byte[0];
+        int fromPrev = previous.size();
+        byte[] ret = new byte[prefix.length + fromPrev + fromCurr];
+        System.arraycopy(prefix, 0, ret, 0, prefix.length);
+        System.arraycopy(previous.data(), previous.start(), ret, prefix.length, fromPrev);
+        System.arraycopy(current.data(), current.start(), ret, prefix.length + fromPrev, fromCurr);
         return ret;
     }
 
-    byte[] getBacking() { return source; }
     int getPosition() { return position; }
+
     void skip(int size) {
-        if (position + size > end) {
+        if (size < 0) {
             fail("underflow");
-        }  else {
-            position += size;
+            return;
         }
+        // Compare with subtraction so a bogus huge 'size' cannot cause overflow.
+        while (size > current.end() - position) {
+            size -= (current.end() - position);
+            position = current.end();
+            if (! getMore()) {
+                fail("underflow");
+                return;
+            }
+        }
+        position += size;
     }
 
     byte[] getBytes(int size) {
-        if (position + size > end) {
+        if (size < 0) {
             fail("underflow");
             return new byte[0];
         }
-        byte[] ret = new byte[size];
+        if (sources == null) {
+            if (size > current.end() - position) {
+                fail("underflow");
+                return new byte[0];
+            }
+            byte[] ret = new byte[size];
+            System.arraycopy(current.data(), position, ret, 0, size);
+            skip(size);
+            return ret;
+        }
+        // Streaming: the total length of the input is unknown up
+        // front, so grow the buffer as bytes actually arrive rather
+        // than trusting 'size'. A bogus large size fails with
+        // underflow once the stream ends instead of OOM-ing on
+        // allocation.
+        byte[] ret = new byte[Math.min(size, 4096)];
         for (int i = 0; i < size; i++) {
-            ret[i] = source[position++];
+            if (eof()) {
+                fail("underflow");
+                return new byte[0];
+            }
+            if (i == ret.length) {
+                ret = Arrays.copyOf(ret, (int) Math.min((long) size, ret.length * 2L));
+            }
+            ret[i] = getByte();
         }
         return ret;
+    }
+
+    Bytes getBytesView(int size) {
+        if (size >= 0 && size <= current.end() - position) {
+            var ret = new Bytes(current.data(), position, position + size);
+            skip(size);
+            return ret;
+        } else {
+            var data = getBytes(size);
+            return new Bytes(data, 0, data.length);
+        }
     }
 
     int read_cmpr_int() {

--- a/vespajlib/src/main/java/com/yahoo/slime/ByteSource.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/ByteSource.java
@@ -1,0 +1,16 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.slime;
+
+import java.io.IOException;
+
+/**
+ * A source of successive byte arrays, used by {@link BufferedInput} to consume
+ * input incrementally without buffering everything into a single array first.
+ */
+@FunctionalInterface
+interface ByteSource {
+
+    /** Returns the next chunk of bytes, or null when there are no more. */
+    byte[] next() throws IOException;
+
+}

--- a/vespajlib/src/main/java/com/yahoo/slime/JsonDecoder.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/JsonDecoder.java
@@ -33,11 +33,8 @@ public class JsonDecoder {
 
     public JsonDecoder() {}
 
-    public Slime decode(Slime slime, byte[] bytes) {
-        return decode(slime, ByteBuffer.wrap(bytes));
-    }
-    public Slime decode(Slime slime, ByteBuffer buf) {
-        in = new BufferedInput(buf.array(), buf.arrayOffset()+buf.position(), buf.remaining());
+    Slime decode(Slime slime, BufferedInput input) {
+        in = input;
         next();
         decodeValue(slimeInserter.adjust(slime));
         if (in.failed()) {
@@ -46,6 +43,14 @@ public class JsonDecoder {
             slime.get().setString("error_message", in.getErrorMessage());
         }
         return slime;
+    }
+
+    public Slime decode(Slime slime, byte[] bytes) {
+        return decode(slime, new BufferedInput(bytes));
+    }
+
+    public Slime decode(Slime slime, ByteBuffer buf) {
+        return decode(slime, new BufferedInput(buf.array(), buf.arrayOffset()+buf.position(), buf.remaining()));
     }
 
     /** Decode bytes as a UTF-8 JSON into Slime, or throw {@link JsonParseException} on invalid JSON. */

--- a/vespajlib/src/main/java/com/yahoo/slime/SlimeUtils.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/SlimeUtils.java
@@ -3,6 +3,7 @@ package com.yahoo.slime;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -101,6 +102,31 @@ public class SlimeUtils {
     public static Slime jsonToSlime(byte[] json) {
         Slime slime = new Slime();
         new JsonDecoder().decode(slime, json);
+        return slime;
+    }
+
+    /**
+     * Decodes UTF-8 JSON read incrementally from the given stream into Slime, without
+     * buffering the whole input into a single array first. The stream is read in chunks
+     * on demand as the parser consumes bytes.
+     * <p>
+     * Invalid JSON (or an {@link IOException} while reading the stream) does not throw;
+     * it produces a Slime wrapping a {@code partial_result} object with {@code error_message}
+     * and {@code offending_input} fields, the same as the other {@code jsonToSlime} overloads.
+     * Note that when the error occurs after several chunks have been read, the offending
+     * input only covers the most recently buffered bytes (see {@link BufferedInput#getOffending}).
+     * <p>
+     * The caller retains ownership of the stream and is responsible for closing it.
+     */
+    public static Slime jsonToSlime(InputStream json) {
+        var in = new BufferedInput(() -> {
+            byte[] buffer = new byte[8192];
+            int read = json.read(buffer);
+            if (read < 0) return null;
+            return read == buffer.length ? buffer : Arrays.copyOf(buffer, read);
+        });
+        Slime slime = new Slime();
+        new JsonDecoder().decode(slime, in);
         return slime;
     }
 

--- a/vespajlib/src/test/java/com/yahoo/slime/BufferedInputTest.java
+++ b/vespajlib/src/test/java/com/yahoo/slime/BufferedInputTest.java
@@ -1,0 +1,301 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.slime;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the sequential read operations on {@link BufferedInput} (getByte, eof, skip,
+ * getBytes, getConsumedSize) behave identically whether reading a single backing array or a
+ * {@link ByteSource} that hands out the input in small chunks.
+ */
+public class BufferedInputTest {
+
+    /** Hands out the input in fixed-size chunks to force chunk boundaries mid-token. */
+    private static final class ChunkedByteSource implements ByteSource {
+        private final byte[] data;
+        private final int chunk;
+        private int pos = 0;
+        ChunkedByteSource(byte[] data, int chunk) { this.data = data; this.chunk = chunk; }
+        @Override public byte[] next() {
+            if (pos >= data.length) return null;
+            int n = Math.min(chunk, data.length - pos);
+            byte[] b = Arrays.copyOfRange(data, pos, pos + n);
+            pos += n;
+            return b;
+        }
+    }
+
+    private static byte[] sequence(int n) {
+        byte[] b = new byte[n];
+        for (int i = 0; i < n; i++) b[i] = (byte) i;
+        return b;
+    }
+
+    @Test
+    public void getByteAndEofWorkAcrossChunks() {
+        byte[] data = sequence(50);
+        for (int chunk : new int[] {1, 2, 3, 7, 50, 1000}) {
+            BufferedInput in = new BufferedInput(new ChunkedByteSource(data, chunk));
+            byte[] got = new byte[data.length];
+            int i = 0;
+            while ( ! in.eof()) {
+                got[i++] = in.getByte();
+            }
+            assertEquals("chunk " + chunk, data.length, i);
+            assertArrayEquals("chunk " + chunk, data, got);
+            assertTrue(in.eof());
+            assertFalse(in.failed());
+        }
+    }
+
+    @Test
+    public void getBytesWorksAcrossChunks() {
+        byte[] data = sequence(50);
+        for (int chunk : new int[] {1, 3, 7, 50}) {
+            BufferedInput in = new BufferedInput(new ChunkedByteSource(data, chunk));
+            assertArrayEquals("chunk " + chunk, Arrays.copyOfRange(data, 0, 10), in.getBytes(10));
+            assertArrayEquals("chunk " + chunk, Arrays.copyOfRange(data, 10, 50), in.getBytes(40));
+            assertTrue(in.eof());
+            assertFalse(in.failed());
+        }
+    }
+
+    @Test
+    public void skipWorksAcrossChunks() {
+        byte[] data = sequence(50);
+        for (int chunk : new int[] {1, 3, 7, 50}) {
+            BufferedInput in = new BufferedInput(new ChunkedByteSource(data, chunk));
+            in.skip(20);
+            assertArrayEquals("chunk " + chunk, Arrays.copyOfRange(data, 20, 50), in.getBytes(30));
+            assertTrue(in.eof());
+            assertFalse(in.failed());
+        }
+    }
+
+    @Test
+    public void consumedSizeTracksTotalAcrossChunks() {
+        byte[] data = sequence(50);
+        BufferedInput in = new BufferedInput(new ChunkedByteSource(data, 3));
+        in.getByte();
+        in.skip(9);
+        in.getBytes(20);
+        assertEquals(30, in.getConsumedSize());
+    }
+
+    @Test
+    public void getBytesUnderflowFails() {
+        BufferedInput in = new BufferedInput(new ChunkedByteSource(sequence(5), 2));
+        assertArrayEquals(new byte[0], in.getBytes(10));
+        assertTrue(in.failed());
+        assertEquals(0, in.getConsumedSize());
+    }
+
+    /**
+     * An IOException from the underlying source while fetching a chunk surfaces as a failed
+     * decode (it does not propagate), with the exception text folded into the error message.
+     */
+    @Test
+    public void ioExceptionWhileReadingFailsTheDecode() {
+        ByteSource throwing = () -> { throw new IOException("disconnected"); };
+        BufferedInput in = new BufferedInput(throwing);
+        assertEquals(0, in.getByte());
+        assertTrue(in.failed());
+        assertTrue("got: " + in.getErrorMessage(), in.getErrorMessage().contains("IO error reading input"));
+        assertTrue("got: " + in.getErrorMessage(), in.getErrorMessage().contains("disconnected"));
+    }
+
+    /** An IOException raised partway through the stream still surfaces as a failure, not a throw. */
+    @Test
+    public void ioExceptionMidStreamFailsTheDecode() {
+        ByteSource throwing = new ByteSource() {
+            private boolean first = true;
+            @Override public byte[] next() throws IOException {
+                if (first) { first = false; return sequence(4); }
+                throw new IOException("disconnected");
+            }
+        };
+        BufferedInput in = new BufferedInput(throwing);
+        for (int i = 0; i < 4; i++) assertEquals((byte) i, in.getByte()); // first chunk reads fine
+        assertFalse(in.failed());
+        in.getByte(); // forces the next fetch, which throws
+        assertTrue(in.failed());
+        assertTrue("got: " + in.getErrorMessage(), in.getErrorMessage().contains("IO error reading input"));
+    }
+
+    /**
+     * A source that hands out (arbitrarily many) empty chunks must be skipped over without
+     * recursing, so it can neither blow the stack nor be mistaken for end-of-input.
+     */
+    @Test
+    public void emptyChunksAreSkippedWithoutRecursing() {
+        byte[] data = sequence(10);
+        ByteSource manyEmpties = new ByteSource() {
+            private int emitted = 0;
+            private int pos = 0;
+            @Override public byte[] next() {
+                if (emitted++ < 100_000) return new byte[0];
+                if (pos >= data.length) return null;
+                return new byte[] { data[pos++] };
+            }
+        };
+        BufferedInput in = new BufferedInput(manyEmpties);
+        byte[] got = new byte[data.length];
+        int i = 0;
+        while ( ! in.eof()) got[i++] = in.getByte();
+        assertArrayEquals(data, got);
+        assertFalse(in.failed());
+    }
+
+    @Test
+    public void skipUnderflowFails() {
+        BufferedInput in = new BufferedInput(new ChunkedByteSource(sequence(5), 2));
+        in.skip(10);
+        assertTrue(in.failed());
+    }
+
+    /**
+     * A bogus huge size (as can appear in a corrupt length prefix) must fail with
+     * underflow rather than attempt to allocate the array up front and OOM. The tiny
+     * input here would never satisfy the request, so allocating Integer.MAX_VALUE
+     * bytes would be both wrong and fatal.
+     * <p>
+     * The position is advanced first so that {@code position + size} would overflow a
+     * naive bounds check (wrapping to a negative value that slips past {@code > end}):
+     * the check must use subtraction so the bogus size is still rejected.
+     */
+    @Test
+    public void getBytesWithHugeSizeFailsWithoutAllocating() {
+        for (int size : new int[] {Integer.MAX_VALUE, Integer.MAX_VALUE - 4}) {
+            BufferedInput array = new BufferedInput(sequence(10));
+            array.skip(8); // position past zero, so 8 + (MAX-4) overflows int
+            assertArrayEquals(new byte[0], array.getBytes(size));
+            assertTrue("size " + size, array.failed());
+
+            BufferedInput stream = new BufferedInput(new ChunkedByteSource(sequence(10), 4));
+            stream.skip(8);
+            assertArrayEquals(new byte[0], stream.getBytes(size));
+            assertTrue("size " + size, stream.failed());
+
+            // getBytesView and skip share the same overflow-prone bounds check.
+            BufferedInput view = new BufferedInput(sequence(10));
+            view.skip(8);
+            var got = view.getBytesView(size);
+            assertEquals("size " + size, 0, got.size());
+            assertTrue("size " + size, view.failed());
+
+            BufferedInput skip = new BufferedInput(sequence(10));
+            skip.skip(8);
+            skip.skip(size);
+            assertTrue("size " + size, skip.failed());
+        }
+    }
+
+    @Test
+    public void getBytesViewWorksWithinAndAcrossChunks() {
+        byte[] data = sequence(50);
+        for (int chunk : new int[] {1, 3, 7, 50}) {
+            BufferedInput in = new BufferedInput(new ChunkedByteSource(data, chunk));
+            var first = in.getBytesView(5);
+            assertArrayEquals("chunk " + chunk,
+                              Arrays.copyOfRange(data, 0, 5),
+                              Arrays.copyOfRange(first.data(), first.start(), first.end()));
+            var second = in.getBytesView(45);
+            assertArrayEquals("chunk " + chunk,
+                              Arrays.copyOfRange(data, 5, 50),
+                              Arrays.copyOfRange(second.data(), second.start(), second.end()));
+            assertTrue(in.eof());
+            assertFalse(in.failed());
+        }
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] ret = new byte[a.length + b.length];
+        System.arraycopy(a, 0, ret, 0, a.length);
+        System.arraycopy(b, 0, ret, a.length, b.length);
+        return ret;
+    }
+
+    /** In byte[] mode the whole input is retained, so getOffending is exactly what was consumed. */
+    @Test
+    public void getOffendingReturnsConsumedBytesInArrayMode() {
+        BufferedInput in = new BufferedInput(sequence(10));
+        in.skip(4);
+        in.fail("boom");
+        assertTrue(in.failed());
+        assertEquals("boom", in.getErrorMessage());
+        assertArrayEquals(new byte[] {0, 1, 2, 3}, in.getOffending());
+    }
+
+    /** getOffending honours the start offset of a windowed byte[] input. */
+    @Test
+    public void getOffendingRespectsOffsetInArrayMode() {
+        BufferedInput in = new BufferedInput(sequence(10), 2, 6); // window over bytes 2..7
+        in.skip(3);
+        in.fail("x");
+        assertArrayEquals(new byte[] {2, 3, 4}, in.getOffending());
+    }
+
+    /** When the whole input still fits in the current chunk, nothing is dropped and no marker is added. */
+    @Test
+    public void getOffendingHasNoMarkerWhenNothingDropped() {
+        BufferedInput in = new BufferedInput(new ChunkedByteSource(sequence(10), 100));
+        in.skip(4);
+        in.fail("boom");
+        assertArrayEquals(new byte[] {0, 1, 2, 3}, in.getOffending());
+    }
+
+    /**
+     * Once earlier chunks have been discarded, getOffending can only report the last two buffers,
+     * prefixed by a "[... N bytes ...]" marker accounting for the dropped prefix.
+     */
+    @Test
+    public void getOffendingAcrossChunksIncludesDroppedBytesMarker() {
+        BufferedInput in = new BufferedInput(new ChunkedByteSource(sequence(20), 4));
+        in.skip(14);
+        in.fail("boom");
+
+        // bytes 0..7 fell out of the two retained buffers; bytes 8..13 remain
+        byte[] marker = "[... 8 bytes ...]".getBytes(StandardCharsets.UTF_8);
+        byte[] expected = concat(marker, new byte[] {8, 9, 10, 11, 12, 13});
+        assertArrayEquals(expected, in.getOffending());
+    }
+
+    private static Slime streamingBinaryDecode(byte[] bytes, int chunk) {
+        BinaryDecoder dec = new BinaryDecoder();
+        Slime out = new Slime();
+        dec.in = new BufferedInput(new ChunkedByteSource(bytes, chunk));
+        BinaryDecoder.decodeSymbolTable(dec.in, out.symbolTable());
+        dec.decodeValue(new SlimeInserter(out));
+        assertFalse(dec.in.failed());
+        return out;
+    }
+
+    @Test
+    public void binaryDecodeFromChunkedSourceMatchesInMemory() {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+        root.setString("name", "a fairly long string value 佳 with some utf8 content");
+        root.setLong("count", 1234567);
+        root.setDouble("ratio", 3.14159);
+        root.setData("blob", sequence(40));
+        Cursor arr = root.setArray("items");
+        for (int i = 0; i < 30; i++) arr.addString("item-number-" + i);
+        byte[] bytes = BinaryFormat.encode(slime);
+        assertTrue("input should span several small chunks", bytes.length > 20);
+
+        byte[] reference = BinaryFormat.encode(new BinaryDecoder().decode(bytes));
+        for (int chunk : new int[] {1, 2, 3, 7, 13, bytes.length, 100000}) {
+            byte[] streamed = BinaryFormat.encode(streamingBinaryDecode(bytes, chunk));
+            assertArrayEquals("chunk " + chunk, reference, streamed);
+        }
+    }
+}

--- a/vespajlib/src/test/java/com/yahoo/slime/JsonFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/slime/JsonFormatTestCase.java
@@ -4,11 +4,16 @@ package com.yahoo.slime;
 import com.yahoo.text.Utf8;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class JsonFormatTestCase {
@@ -228,6 +233,148 @@ public class JsonFormatTestCase {
 
     private void verifyEncoding(Slime slime, String expected) {
         verifyEncoding(slime, expected, true);
+    }
+
+    /** An InputStream that hands out at most maxChunk bytes per read, to force chunk boundaries. */
+    private static class ChunkedInputStream extends InputStream {
+        private final byte[] data;
+        private final int maxChunk;
+        private int pos = 0;
+        ChunkedInputStream(byte[] data, int maxChunk) { this.data = data; this.maxChunk = maxChunk; }
+        @Override public int read() { return pos < data.length ? data[pos++] & 0xff : -1; }
+        @Override public int read(byte[] b, int off, int len) {
+            if (pos >= data.length) return -1;
+            int n = Math.min(Math.min(len, maxChunk), data.length - pos);
+            System.arraycopy(data, pos, b, off, n);
+            pos += n;
+            return n;
+        }
+    }
+
+    /** Delivers a few valid bytes, then fails the read, to exercise the IOException-while-streaming path. */
+    private static class FailingInputStream extends InputStream {
+        private final byte[] prefix;
+        private int pos = 0;
+        FailingInputStream(byte[] prefix) { this.prefix = prefix; }
+        @Override public int read() throws IOException {
+            if (pos < prefix.length) return prefix[pos++] & 0xff;
+            throw new IOException("connection reset");
+        }
+        @Override public int read(byte[] b, int off, int len) throws IOException {
+            if (pos < prefix.length) {
+                int n = Math.min(len, prefix.length - pos);
+                System.arraycopy(prefix, pos, b, off, n);
+                pos += n;
+                return n;
+            }
+            throw new IOException("connection reset");
+        }
+    }
+
+    /**
+     * An IOException while reading the stream does not propagate: it is turned into a failed
+     * decode and surfaces as a partial_result Slime with an error_message, the same shape the
+     * other jsonToSlime overloads produce for invalid JSON.
+     */
+    @Test
+    public void testStreamingDecodeIoErrorBecomesPartialResult() {
+        byte[] validPrefix = Utf8.toBytesStd("{\"a\": 1, ");
+        Slime slime = SlimeUtils.jsonToSlime(new FailingInputStream(validPrefix));
+        String error = slime.get().field("error_message").asString();
+        assertTrue("expected a non-empty error message", error.length() > 0);
+        assertTrue("expected IO error in: " + error, error.contains("IO error reading input"));
+        assertTrue("expected cause in: " + error, error.contains("connection reset"));
+    }
+
+    private void verifyStreamingDecode(String json, int maxChunk) {
+        byte[] bytes = Utf8.toBytesStd(json);
+        Slime fromBytes = SlimeUtils.jsonToSlime(bytes);
+        Slime fromStream = SlimeUtils.jsonToSlime(new ChunkedInputStream(bytes, maxChunk));
+        ByteArrayOutputStream a = new ByteArrayOutputStream();
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        try {
+            new JsonFormat(true).encode(a, fromBytes);
+            new JsonFormat(true).encode(b, fromStream);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        assertArrayEquals("chunk size " + maxChunk, a.toByteArray(), b.toByteArray());
+    }
+
+    @Test
+    public void testStreamingDecodeAcrossChunkBoundaries() {
+        StringBuilder sb = new StringBuilder("{\"items\":[");
+        for (int i = 0; i < 2000; i++) {
+            if (i > 0) sb.append(',');
+            sb.append("{\"key\":\"value佳").append(i).append("\",\"n\":").append(i).append("}");
+        }
+        sb.append("]}");
+        String json = sb.toString();
+        assertTrue("input must span multiple 8K read buffers", Utf8.toBytesStd(json).length > 8192);
+
+        // tokens, strings and numbers all straddle boundaries at these chunk sizes
+        verifyStreamingDecode(json, 1);
+        verifyStreamingDecode(json, 3);
+        verifyStreamingDecode(json, 8192);
+        verifyStreamingDecode(json, Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testStreamingDecodeError() {
+        String json = "{\"a\": 1 \"b\": 2}"; // missing comma
+        byte[] bytes = Utf8.toBytesStd(json);
+        Slime fromBytes = SlimeUtils.jsonToSlime(bytes);
+        Slime fromStream = SlimeUtils.jsonToSlime(new ByteArrayInputStream(bytes));
+
+        // The whole input fits in a single read buffer, so no bytes are dropped and the streaming
+        // path reports the failure identically to the in-memory path.
+        assertTrue(fromBytes.get().field("error_message").asString().length() > 0);
+        assertEquals(fromBytes.get().field("error_message").asString(),
+                     fromStream.get().field("error_message").asString());
+        assertArrayEquals(fromBytes.get().field("offending_input").asData(),
+                          fromStream.get().field("offending_input").asData());
+    }
+
+    @Test
+    public void testStreamingDecodeErrorAcrossChunkBoundaries() {
+        // A long valid prefix forces the failure to occur many chunks into the stream, so the
+        // offending input cannot be reconstructed from a single buffer.
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < 500; i++) sb.append("\"k").append(i).append("\":").append(i).append(',');
+        sb.append("\"a\": 1 \"b\": 2}"); // missing comma
+        byte[] bytes = Utf8.toBytesStd(sb.toString());
+
+        Slime fromBytes = SlimeUtils.jsonToSlime(bytes);
+        Slime fromStream = SlimeUtils.jsonToSlime(new ChunkedInputStream(bytes, 3));
+
+        // The error message is parser state, so it must match regardless of chunking.
+        assertTrue(fromBytes.get().field("error_message").asString().length() > 0);
+        assertEquals(fromBytes.get().field("error_message").asString(),
+                     fromStream.get().field("error_message").asString());
+
+        // The full input is not retained when streaming, so the offending input only covers the
+        // last buffers read, prefixed with a "[... N bytes ...]" marker for the dropped prefix.
+        byte[] offendingBytes = fromBytes.get().field("offending_input").asData();
+        byte[] offendingStream = fromStream.get().field("offending_input").asData();
+        String streamStr = new String(offendingStream, StandardCharsets.UTF_8);
+        assertTrue("expected dropped-bytes marker, got: " + streamStr, streamStr.startsWith("[... "));
+
+        int markerEnd = indexOf(offendingStream, (byte) ']') + 1;
+        byte[] retainedTail = Arrays.copyOfRange(offendingStream, markerEnd, offendingStream.length);
+
+        // Whatever was retained is a non-empty suffix of what the in-memory path reports.
+        assertTrue(retainedTail.length > 0);
+        assertTrue("streaming offending input must drop the bulk of the prefix",
+                   retainedTail.length < offendingBytes.length);
+        byte[] tailOfBytes = Arrays.copyOfRange(offendingBytes,
+                                                offendingBytes.length - retainedTail.length,
+                                                offendingBytes.length);
+        assertArrayEquals(tailOfBytes, retainedTail);
+    }
+
+    private static int indexOf(byte[] data, byte b) {
+        for (int i = 0; i < data.length; i++) if (data[i] == b) return i;
+        return -1;
     }
 
     @Test


### PR DESCRIPTION
Why: decoding Slime from a stream (e.g. an HTTP response body) used to require slurping the whole payload into one byte[] before parsing.

What: BufferedInput can now optionally pull its input lazily from a ByteSource - a supplier of successive byte[] chunks.  This is exposed via a new SlimeUtils.jsonToSlime(InputStream) overload, and ClusterDeploymentMetricsRetriever now decodes the response body straight from the stream, dropping the EntityUtils.toByteArray() copy.

Behavior change in ClusterDeploymentMetricsRetriever: an IOException while reading the body now surfaces inside the decoder instead of out of EntityUtils.toByteArray(), so it is returned as a partial_result Slime with an error_message field. getHostMetrics() already checks error_message, so the failure is still observed and logged.

Implementation notes:
- BufferedInput keeps the current and previous chunk plus a count of dropped bytes so getConsumedSize() and getOffending stay correct across chunk boundaries (prepending a "[... N bytes ...]" marker when earlier chunks are gone).
- Chunks are fetched only when the current one is exhausted and a byte is actually needed; we never read ahead, so a consumer reading a known number of bytes does not trigger a blocking read past its input.
- Added getBytesView() for a zero-copy view within the current chunk; BinaryDecoder/BinaryView use it and the original data array instead of getBacking()/a single backing array.

Tests cover the ByteSource-backed path against the contiguous byte[] path across chunk boundaries (getByte/eof, getBytes, skip, getConsumedSize, getBytesView, full binary decode, underflow, bogus size), the three getOffending paths, and streaming JSON decode.
