### PR TITLE
Make Central metadata look like mirror metadata [MERGEOK]

### DIFF
--- a/.buildkite/build-container.sh
+++ b/.buildkite/build-container.sh
@@ -104,6 +104,10 @@ cd docker
 echo "Copying Maven repository and RPMs for system-test container..."
 rm -rf maven-repo
 cp -a "$HOME/.m2/repository" maven-repo
+find maven-repo -type f -name 'maven-metadata-central.xml*' | while read -r fn; do
+    cp -a "$fn" "${fn/maven-metadata-central./maven-metadata.}"
+done
+
 rm -rf rpms
 mv "$WORKDIR/docker-image/rpms" rpms
 


### PR DESCRIPTION
When building the offline Maven repository for the system-test container, artifacts resolved directly from Maven Central produce metadata files named maven-metadata-central.xml (plus .sha1/.md5 checksums). Inside the container Maven resolves against the bundled repo as if from a mirror, where the metadata is expected to be named maven-metadata.xml. Copy each maven-metadata-central.xml* file to its maven-metadata.xml* counterpart so the metadata is found regardless of whether the original artifact came from Central or a mirror, avoiding re-downloads.
