### PR TITLE
Treat an empty chunk from a ByteSource as end-of-input

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/slime/BufferedInput.java
+++ b/vespajlib/src/main/java/com/yahoo/slime/BufferedInput.java
@@ -13,11 +13,11 @@ final class BufferedInput {
 
     private Bytes current;
     private Bytes previous = null;
-    private ByteSource sources;
+    private ByteSource byteSource;
     private int position;
     private String failReason = null;
     private int failPos = -1;
-    private int lost = 0;
+    private int discarded = 0;
 
     void fail(String reason) {
         if (failed()) {
@@ -26,7 +26,7 @@ final class BufferedInput {
         failReason = reason;
         failPos = position;
         position = current.end();
-        sources = null;
+        byteSource = null;
     }
 
     BufferedInput(byte[] bytes) {
@@ -36,31 +36,28 @@ final class BufferedInput {
     BufferedInput(byte[] bytes, int offset, int length) {
         this.current = new Bytes(bytes, offset, offset + length);
         this.position = offset;
-        this.sources = null;
+        this.byteSource = null;
     }
 
-    BufferedInput(ByteSource sources) {
+    BufferedInput(ByteSource byteSource) {
         // Start empty; the first chunk is fetched lazily
         this.current = new Bytes(new byte[0], 0, 0);
         this.position = 0;
-        this.sources = sources;
+        this.byteSource = byteSource;
     }
 
     private boolean getMore() {
-        if (sources == null) {
+        if (byteSource == null) {
             return false;
         }
         try {
-            byte[] next;
-            do {
-                next = sources.next();
-                if (next == null) {
-                    sources = null;
-                    return false;
-                }
-            } while (next.length == 0); // Skip empty chunks
+            byte[] next = byteSource.next();
+            if (next == null || next.length == 0) {
+                byteSource = null;
+                return false;
+            }
             if (previous != null) {
-                lost += previous.size();
+                discarded += previous.size();
             }
             if (current.size() > 0) {
                 previous = current;
@@ -101,7 +98,7 @@ final class BufferedInput {
         if (failed()) {
             return 0;
         }
-        int consumed = lost;
+        int consumed = discarded;
         if (previous != null) {
             consumed += previous.size();
         }
@@ -116,8 +113,8 @@ final class BufferedInput {
             System.arraycopy(current.data(), current.start(), ret, 0, fromCurr);
             return ret;
         }
-        byte[] prefix = (lost > 0)
-                ? ("[... " + lost + " bytes ...]").getBytes(StandardCharsets.UTF_8)
+        byte[] prefix = (discarded > 0)
+                ? ("[... " + discarded + " bytes ...]").getBytes(StandardCharsets.UTF_8)
                 : new byte[0];
         int fromPrev = previous.size();
         byte[] ret = new byte[prefix.length + fromPrev + fromCurr];
@@ -151,11 +148,7 @@ final class BufferedInput {
             fail("underflow");
             return new byte[0];
         }
-        if (sources == null) {
-            if (size > current.end() - position) {
-                fail("underflow");
-                return new byte[0];
-            }
+        if (size <= current.end() - position) {
             byte[] ret = new byte[size];
             System.arraycopy(current.data(), position, ret, 0, size);
             skip(size);

--- a/vespajlib/src/test/java/com/yahoo/slime/BufferedInputTest.java
+++ b/vespajlib/src/test/java/com/yahoo/slime/BufferedInputTest.java
@@ -132,26 +132,30 @@ public class BufferedInputTest {
     }
 
     /**
-     * A source that hands out (arbitrarily many) empty chunks must be skipped over without
-     * recursing, so it can neither blow the stack nor be mistaken for end-of-input.
+     * Check that an empty chunk as input signals EOF.
      */
     @Test
-    public void emptyChunksAreSkippedWithoutRecursing() {
+    public void emptyChunksSignalsEOF() {
         byte[] data = sequence(10);
         ByteSource manyEmpties = new ByteSource() {
             private int emitted = 0;
             private int pos = 0;
             @Override public byte[] next() {
-                if (emitted++ < 100_000) return new byte[0];
-                if (pos >= data.length) return null;
-                return new byte[] { data[pos++] };
+                if (emitted++ < 3) {
+                    return new byte[] { data[pos++] };
+                } else {
+                    return new byte[0];
+                }
             }
         };
         BufferedInput in = new BufferedInput(manyEmpties);
         byte[] got = new byte[data.length];
         int i = 0;
         while ( ! in.eof()) got[i++] = in.getByte();
-        assertArrayEquals(data, got);
+        assertEquals(i, 3);
+        assertEquals(data[0], got[0]);
+        assertEquals(data[1], got[1]);
+        assertEquals(data[2], got[2]);
         assertFalse(in.failed());
     }
 


### PR DESCRIPTION
Previously BufferedInput.getMore() skipped empty chunks in a loop, fetching again until it saw a non-empty chunk or null. A ByteSource that keeps returning empty arrays without ever returning null would make that loop spin forever. Treat an empty chunk the same as null: it signals end-of-input. This gives a well-defined termination and removes the skip loop, with empty and null handled by a single check.

While here, take the in-current-chunk fast path in getBytes() whenever the request fits the current chunk, regardless of whether we are in streaming mode, instead of only when there is no ByteSource. Underflow in non-streaming mode now falls through to the streaming loop, which fails with "underflow" once the (absent) source is exhausted, so the behavior is unchanged.

Also rename two fields for clarity (no behavioral change): 'sources' to 'byteSource', since it holds a single ByteSource rather than a collection, and 'lost' to 'discarded', to better describe bytes dropped from earlier chunks once they can no longer be referenced.
