### PR TITLE
Fix reply ordering race in SourceSession blocked-message expiry

### DIFF
--- a/messagebus/src/main/java/com/yahoo/messagebus/SourceSession.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/SourceSession.java
@@ -186,8 +186,11 @@ public final class SourceSession implements ReplyHandler, MessageBus.SendBlocked
         boolean notifyIfExpired() {
             if (msg.isExpired()) {
                 Error error = new Error(ErrorCode.TIMEOUT, "Timed out in sendQ");
-                notifyComplete(new Result(error));
+                // Deliver the timeout reply to the reply handler before unblocking the sender.
+                // Otherwise the unblocked sender may race ahead and cause another reply to
+                // be delivered first.
                 replyHandler.handleReply(createSendTimedOutReply(msg, error));
+                notifyComplete(new Result(error));
                 return true;
             }
             return false;


### PR DESCRIPTION
When a blocked message times out in the sendQ, notifyIfExpired() woke the thread waiting in sendBlocking() before delivering the timeout reply to the reply handler. The unblocked sender could then race ahead and cause another reply (e.g. for an earlier in-flight message sharing the same reply handler) to be delivered first, reversing the observed reply order.

Deliver the timeout reply to the reply handler before calling notifyComplete() so the timeout reply is always enqueued before the sender is released. This fixes spurious failures in LocalNetworkTest.requireThatBlockingSendTimeOutInSendQ.
