### PR TITLE
Raise stack multiplier for AddressSanitizer builds to 100

### DIFF
--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
@@ -293,7 +293,7 @@ bool BlueprintResolver::compile() {
     }
 
     size_t stack_usage = compiler.stack_usage();
-    if (stack_usage > (1UL * STACK_MULTIPLIER * 128_Ki)) {
+    if (stack_usage > (STACK_MULTIPLIER * 128_Ki)) {
         _warnings.emplace_back(fmt("high stack usage: %zu bytes", stack_usage));
     }
     return !compiler.failed();

--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
@@ -272,7 +272,7 @@ void BlueprintResolver::addSeed(std::string_view feature) {
 
 namespace {
 #if defined(VESPA_USE_ADDRESS_SANITIZER)
-constexpr size_t STACK_MULTIPLIER = 10;
+constexpr size_t STACK_MULTIPLIER = 100;
 #else
 constexpr size_t STACK_MULTIPLIER = 1;
 #endif
@@ -293,7 +293,7 @@ bool BlueprintResolver::compile() {
     }
 
     size_t stack_usage = compiler.stack_usage();
-    if (stack_usage > (STACK_MULTIPLIER * 128_Ki)) {
+    if (stack_usage > (1UL * STACK_MULTIPLIER * 128_Ki)) {
         _warnings.emplace_back(fmt("high stack usage: %zu bytes", stack_usage));
     }
     return !compiler.failed();


### PR DESCRIPTION
The compile() check warns about "high stack usage" once feature resolution exceeds STACK_MULTIPLIER * 128 KiB. AddressSanitizer adds substantial per-frame overhead (redzones, shadow bookkeeping), so the ASan-only multiplier needs more headroom to avoid spurious warnings on normal rank-feature graphs. Bump it from 10 to 100. Non-ASan builds are unaffected (multiplier stays 1).
