### PR TITLE
turn off ASLR for verify_feature test

### DIFF
--- a/searchlib/src/tests/ranksetup/verify_feature/CMakeLists.txt
+++ b/searchlib/src/tests/ranksetup/verify_feature/CMakeLists.txt
@@ -6,4 +6,4 @@ vespa_add_executable(searchlib_verify_feature_test_app TEST
     vespa_searchlib
     GTest::gtest
 )
-vespa_add_test(NAME searchlib_verify_feature_test_app COMMAND searchlib_verify_feature_test_app)
+vespa_add_test(NAME searchlib_verify_feature_test_app COMMAND run.sh)

--- a/searchlib/src/tests/ranksetup/verify_feature/run.sh
+++ b/searchlib/src/tests/ranksetup/verify_feature/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+setarch $(arch) -R ./searchlib_verify_feature_test_app


### PR DESCRIPTION
this test failed with address sanitizer, probably caused by interference from ASLR.
