### PR TITLE
Tolerate metric-updater failures during container shutdown

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MetricUpdater.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MetricUpdater.java
@@ -154,6 +154,22 @@ public class MetricUpdater extends AbstractComponent {
 
         @Override
         public void run() {
+            try {
+                updateMetrics();
+            } catch (NoClassDefFoundError e) {
+                // During container shutdown the OSGi bundle wiring may be invalidated, so loading
+                // classes such as TlsMetrics fails with a NoClassDefFoundError (note: not an
+                // Exception). Tolerate the first such failure quietly, but rethrow if it persists.
+                if (gotException) {
+                    throw e;
+                }
+                gotException = true;
+            }
+        }
+
+        private boolean gotException = false;
+
+        private void updateMetrics() {
             long freeMemory = runtime.freeMemory();
             long totalMemory = runtime.totalMemory();
             long usedMemory = totalMemory - freeMemory;
@@ -201,4 +217,3 @@ public class MetricUpdater extends AbstractComponent {
     }
 
 }
-


### PR DESCRIPTION
The periodic MetricUpdater task calls tlsMetrics(), which references TlsMetrics. During container shutdown the OSGi bundle wiring for container-disc is invalidated, so loading that class fails with:

  Unable to load class 'com.yahoo.security.tls.TlsMetrics' because the
  bundle wiring for container-disc is no longer valid

Wrap the task body in a guard that swallows the first such failure and only rethrows if it keeps failing, so a transient shutdown-time error does not surface as noise while a genuine persistent problem is still propagated.
