### PR TITLE
Let coverage-policy:node keep groups with a down node in rotation

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
@@ -105,9 +105,7 @@ public class ClusterControllerConfig extends AnyConfigProducer implements Fleetc
     public ClusterControllerTuning tuning() { return tuning; }
 
     private static CoveragePolicy.Policy coveragePolicy(ModelElement content) {
-        var policy = Optional.ofNullable(content.childAsString("coverage-policy"));
-        return policy.map(s -> new CoveragePolicy(CoveragePolicy.Policy.valueOf(s.toUpperCase(java.util.Locale.ROOT))))
-                     .orElseGet(CoveragePolicy::group).policy();
+        return CoveragePolicy.from(content.childAsString("coverage-policy")).policy();
     }
 
     private static Optional<Integer> maxGroupsAllowedDown(ModelElement tuning,

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/CoveragePolicy.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/CoveragePolicy.java
@@ -2,7 +2,17 @@ package com.yahoo.vespa.model.content;
 
 public record CoveragePolicy(Policy policy) {
 
-    enum Policy { GROUP, NODE }
+    public enum Policy { GROUP, NODE }
+
+    public static CoveragePolicy from(String policy) {
+        if (policy == null || policy.equals("group")) {
+            return new CoveragePolicy(Policy.GROUP);
+        } else if (policy.equals("node")) {
+            return new CoveragePolicy(Policy.NODE);
+        } else {
+            throw new IllegalArgumentException("Unknown policy: " + policy);
+        }
+    }
 
     static CoveragePolicy group() { return new CoveragePolicy(Policy.GROUP); }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -36,6 +36,7 @@ import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.builder.xml.dom.NodesSpecification;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.content.ClusterControllerConfig;
+import com.yahoo.vespa.model.content.CoveragePolicy;
 import com.yahoo.vespa.model.content.ClusterResourceLimits;
 import com.yahoo.vespa.model.content.ContentSearch;
 import com.yahoo.vespa.model.content.ContentSearchCluster;
@@ -219,6 +220,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
             if (index.getTuning() == null)
                 index.setTuning(new Tuning(index));
             index.getTuning().dispatch = DomTuningDispatchBuilder.build(element, logger);
+            index.setCoveragePolicy(CoveragePolicy.from(element.childAsString("coverage-policy")).policy());
         }
 
         private void setupDocumentProcessing(ContentCluster c, ModelElement e) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -7,6 +7,7 @@ import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.config.search.DispatchConfig;
 import com.yahoo.vespa.config.search.DispatchConfig.DistributionPolicy;
 import com.yahoo.vespa.config.search.DispatchNodesConfig;
+import com.yahoo.vespa.model.content.CoveragePolicy;
 import com.yahoo.vespa.model.content.DispatchTuning;
 import com.yahoo.vespa.model.content.Redundancy;
 import com.yahoo.vespa.model.content.SearchCoverage;
@@ -22,6 +23,7 @@ public class IndexedSearchCluster extends SearchCluster {
 
     private Tuning tuning;
     private SearchCoverage searchCoverage;
+    private CoveragePolicy.Policy coveragePolicy = null;
 
     private final Redundancy.Provider redundancyProvider;
 
@@ -51,6 +53,10 @@ public class IndexedSearchCluster extends SearchCluster {
         this.searchCoverage = searchCoverage;
     }
 
+    public void setCoveragePolicy(CoveragePolicy.Policy policy) {
+        this.coveragePolicy = policy;
+    }
+
     private static DistributionPolicy.Enum toDistributionPolicy(DispatchTuning.DispatchPolicy tuning) {
         return switch (tuning) {
             case ADAPTIVE: yield DistributionPolicy.ADAPTIVE;
@@ -77,8 +83,21 @@ public class IndexedSearchCluster extends SearchCluster {
             builder.topKProbability(tuning.dispatch.getTopkProbability());
         if (tuning.dispatch.getPrioritizeAvailability() != null)
             builder.prioritizeAvailability(tuning.dispatch.getPrioritizeAvailability());
-        if (tuning.dispatch.getMinActiveDocsCoverage() != null)
+        if (tuning.dispatch.getMinActiveDocsCoverage() != null) {
             builder.minActivedocsPercentage(tuning.dispatch.getMinActiveDocsCoverage());
+        } else if (coveragePolicy == CoveragePolicy.Policy.NODE && !searchNodes.isEmpty()) {
+            long numGroups = searchNodes.stream()
+                    .mapToInt(n -> n.getNodeSpec().groupIndex())
+                    .distinct()
+                    .count();
+            int nodesPerGroup = (int) (searchNodes.size() / numGroups);
+            if (nodesPerGroup > 1) {
+                // Note: For clusters with small number of docs the " - 0.001" might still make
+                // this limit is too high, but we don't know the document count here
+                // Apps with several groups is not likely to have that few docs in practice
+                builder.minActivedocsPercentage((1.0 - 1.0 / nodesPerGroup) * 100.0 - 0.01);
+            }
+        }
         if (tuning.dispatch.getDispatchPolicy() != null)
             builder.distributionPolicy(toDistributionPolicy(tuning.dispatch.getDispatchPolicy()));
         if (tuning.dispatch.getMaxHitsPerPartition() != null)

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -92,7 +92,7 @@ public class IndexedSearchCluster extends SearchCluster {
                     .count();
             int nodesPerGroup = (int) (searchNodes.size() / numGroups);
             if (nodesPerGroup > 1) {
-                // Note: For clusters with small number of docs the " - 0.001" might still make
+                // Note: For clusters with small number of docs the " - 0.01" might still make
                 // this limit is too high, but we don't know the document count here
                 // Apps with several groups is not likely to have that few docs in practice
                 builder.minActivedocsPercentage((1.0 - 1.0 / nodesPerGroup) * 100.0 - 0.01);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
@@ -128,6 +128,27 @@ public class ClusterTest {
         assertEquals("localhost", nodesConfig.node(2).host());
     }
 
+    @Test
+    void requireThatNodeCoveragePolicyAutoSetsMinActiveDocsCoverage() {
+        // 3 nodes in 1 group, coverage-policy:node gives (1 - 1/3) * 100 - 0.01 = 66.666...
+        ContentCluster cluster = newContentCluster(joinLines("<search>", "</search>"),
+                "", "", false, "node");
+        DispatchConfig.Builder builder = new DispatchConfig.Builder();
+        cluster.getSearch().getConfig(builder);
+        DispatchConfig config = new DispatchConfig(builder);
+        assertEquals(100.0 * (1.0 - 1.0 / 3) - 0.01, config.minActivedocsPercentage(), DELTA);
+    }
+
+    @Test
+    void requireThatExplicitMinActiveDocsCoverageOverridesNodeCoveragePolicy() {
+        ContentCluster cluster = newContentCluster(joinLines("<search>", "</search>"),
+                "", "<min-active-docs-coverage>80</min-active-docs-coverage>", false, "node");
+        DispatchConfig.Builder builder = new DispatchConfig.Builder();
+        cluster.getSearch().getConfig(builder);
+        DispatchConfig config = new DispatchConfig(builder);
+        assertEquals(80.0, config.minActivedocsPercentage(), DELTA);
+    }
+
     private static ContentCluster newContentCluster(String contentSearchXml, String searchNodeTuningXml) {
         return newContentCluster(contentSearchXml, searchNodeTuningXml, "", false);
     }
@@ -143,6 +164,13 @@ public class ClusterTest {
     private static ContentCluster newContentCluster(String contentSearchXml, String searchNodeTuningXml,
                                                     String dispatchTuning, boolean globalDocType)
     {
+        return newContentCluster(contentSearchXml, searchNodeTuningXml, dispatchTuning, globalDocType, "");
+    }
+
+    private static ContentCluster newContentCluster(String contentSearchXml, String searchNodeTuningXml,
+                                                    String dispatchTuning, boolean globalDocType, String coveragePolicy)
+    {
+        String coveragePolicyXml = coveragePolicy.isEmpty() ? "" : "<coverage-policy>" + coveragePolicy + "</coverage-policy>";
         ApplicationPackage app = new MockApplicationPackage.Builder()
                 .withHosts(joinLines(
                         "<hosts>",
@@ -159,6 +187,7 @@ public class ClusterTest {
                         "</container>",
                         "  <content version='1.0'>",
                         "    <redundancy>3</redundancy>",
+                        coveragePolicyXml,
                         "    <documents>",
                         "    " + getDocumentXml(globalDocType),
                         "    </documents>",


### PR DESCRIPTION
## Summary
- When `coverage-policy` is `node`, automatically set `minActivedocsPercentage` in the dispatch config to `(1 - 1/n) * 100` where n is nodes per group
- This ensures a group stays in rotation when exactly one of its n nodes is down, matching the node-level redundancy semantics
- An explicit `min-active-docs-coverage` in `services.xml` takes precedence over the auto-computed value

## Benefits
- Completes the `coverage-policy:node` feature so it also affects container-side group load balancing, not just the fleet controller
- Groups with a single node down are no longer unnecessarily removed from query rotation
- Adds a `CoveragePolicy.from()` factory to simplify parsing in both `ClusterControllerConfig` and `ContentCluster`

*Generated by Claude Code*