### PR TITLE
bootstrap: skip maven wrapper when a matching mvn is already installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,19 +58,27 @@ echo "Using maven command: ${MAVEN_CMD}"
 echo "Using maven extra opts: ${MAVEN_EXTRA_OPTS}"
 echo "Using maven target: ${MAVEN_TARGET}"
 
-# Set up maven wrapper.
-echo "Setting up maven wrapper in $(pwd)"
-# shellcheck disable=SC2086 # allow word splitting for maven extra opts
-mvn -B wrapper:wrapper -Dmaven=3.9.16 -N ${MAVEN_EXTRA_OPTS}
+wanted_mvn_version=3.9.16
 
-# Proxy allowing you to put $(pwd)/maven-wrapper/bin first in PATH
-# to redirect any plain "mvn" commands so they use the wrapper
-wbdir=maven-wrapper/bin
-rm -rf ${wbdir}
-mkdir -p ${wbdir}
-printf '#!/bin/sh\nexec %s/mvnw "$@"\n' "$(pwd)" > ${wbdir}/mvn
-chmod +x ${wbdir}/mvn
-unset wbdir
+current_mvn_version=$(/usr/bin/mvn -version 2>/dev/null | awk '$1 == "Apache" && $2 == "Maven" { print $3; exit }' || true)
+if [ "$current_mvn_version" = "$wanted_mvn_version" ]; then
+    # we already have the correct version installed, skip the wrapper
+    ln -sf /usr/bin/mvn mvnw
+else
+    # Set up maven wrapper.
+    echo "Setting up maven wrapper ${wanted_mvn_version} in $(pwd)"
+    # shellcheck disable=SC2086 # allow word splitting for maven extra opts
+    mvn -B wrapper:wrapper -Dmaven="${wanted_mvn_version}" -N ${MAVEN_EXTRA_OPTS}
+
+    # Proxy allowing you to put $(pwd)/maven-wrapper/bin first in PATH
+    # to redirect any plain "mvn" commands so they use the wrapper
+    wbdir=maven-wrapper/bin
+    rm -rf ${wbdir}
+    mkdir -p ${wbdir}
+    printf '#!/bin/sh\nexec %s/mvnw "$@"\n' "$(pwd)" > ${wbdir}/mvn
+    chmod +x ${wbdir}/mvn
+    unset wbdir
+fi
 
 ${MAVEN_CMD} -v
 


### PR DESCRIPTION
Previously bootstrap.sh unconditionally ran "mvn wrapper:wrapper" to built a maven-wrapper proxy. This downloads the wrapper even on machines that already have the desired Maven version.

Now we first detect the installed Maven version and, when it already matches the wanted version (currently 3.9.16), simply symlink mvnw to the existing mvn and skip the wrapper machinery entirely.
