### PR TITLE
Use session ID in remove application barrier path

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -636,7 +636,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                 } catch (NotFoundException e) {
                     log.log(Level.INFO, TenantRepository.logPre(applicationId) + "Active session exists, but has not been deleted properly. Trying to cleanup");
                 }
-                waiter = tenantApplications.createRemoveApplicationWaiter(applicationId);
+                waiter = tenantApplications.createRemoveApplicationWaiter(activeSession.get());
             } else {
                 // If there's no active session, we still want to clean up any resources created in a failing prepare
                 waiter = new NoopCompletionWaiter();

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -226,7 +226,8 @@ public class TenantApplications implements RequestHandler, HostValidator {
                     break;
                 // Event CHILD_REMOVED will be triggered on all config servers if deleteApplication() above is called on one of them
                 case CHILD_REMOVED:
-                    removeApplication(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()));
+                    removeApplication(ApplicationId.fromSerializedForm(Path.fromString(event.getData().getPath()).getName()),
+                                      parseSessionId(event.getData().getData()));
                     break;
                 case CHILD_UPDATED:
                     // do nothing, application just got redeployed
@@ -235,6 +236,18 @@ public class TenantApplications implements RequestHandler, HostValidator {
                     break;
             }
         });
+    }
+
+    private OptionalLong parseSessionId(byte[] data) {
+        if (data == null || data.length == 0) return OptionalLong.empty();
+        try {
+            return ApplicationData.fromBytes(data).activeSession()
+                                  .map(OptionalLong::of)
+                                  .orElse(OptionalLong.empty());
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Could not parse application data when removing application", e);
+            return OptionalLong.empty();
+        }
     }
 
     /**
@@ -267,7 +280,7 @@ public class TenantApplications implements RequestHandler, HostValidator {
     // Note: Assumes that caller already holds the application lock
     // (when getting event from zookeeper to remove application,
     // the lock should be held by the thread that causes the event to happen)
-    public void removeApplication(ApplicationId applicationId) {
+    public void removeApplication(ApplicationId applicationId, OptionalLong sessionId) {
         log.log(Level.FINE, () -> "Removing application " + applicationId);
         if (exists(applicationId)) {
             log.log(Level.INFO, "Tried removing application " + applicationId + ", but it seems to have been deployed again");
@@ -279,7 +292,7 @@ public class TenantApplications implements RequestHandler, HostValidator {
             configActivationListenersOnRemove(applicationId);
             tenantMetricUpdater.setApplications(applicationMapper.numApplications());
             metrics.removeMetricUpdater(Metrics.createDimensions(applicationId));
-            getRemoveApplicationWaiter(applicationId).notifyCompletion();
+            sessionId.ifPresent(id -> getRemoveApplicationWaiter(id).notifyCompletion());
             log.log(Level.INFO, "Application removed: " + applicationId);
         }
     }
@@ -292,7 +305,7 @@ public class TenantApplications implements RequestHandler, HostValidator {
         for (ApplicationId activeApplication : applicationMapper.listApplicationIds()) {
             if ( ! applications.contains(activeApplication)) {
                 try (@SuppressWarnings("unused") var applicationLock = lock(activeApplication)){
-                    removeApplication(activeApplication);
+                    removeApplication(activeApplication, OptionalLong.empty());
                 }
             }
         }
@@ -428,18 +441,20 @@ public class TenantApplications implements RequestHandler, HostValidator {
 
     public TenantFileSystemDirs getTenantFileSystemDirs() { return tenantFileSystemDirs; }
 
-    public CompletionWaiter createRemoveApplicationWaiter(ApplicationId applicationId) {
-        return curator.createCompletionWaiter(barrierPath(applicationId), serverId, waitForAll);
+    public CompletionWaiter createRemoveApplicationWaiter(long sessionId) {
+        Path path = deleteApplicationBarrierPath(sessionId);
+        curator.create(path);
+        return curator.getCompletionWaiter(path, serverId, waitForAll);
     }
 
-    public CompletionWaiter getRemoveApplicationWaiter(ApplicationId applicationId) {
-        return curator.getCompletionWaiter(barrierPath(applicationId), serverId, waitForAll);
+    public CompletionWaiter getRemoveApplicationWaiter(long sessionId) {
+        return curator.getCompletionWaiter(deleteApplicationBarrierPath(sessionId), serverId, waitForAll);
     }
 
-    private static Path barrierPath(ApplicationId applicationId) {
-        return TenantRepository.getBarriersPath().append(applicationId.tenant().value())
-                .append("delete-application")
-                .append(applicationId.serializedForm());
+    private Path deleteApplicationBarrierPath(long sessionId) {
+        return TenantRepository.getBarriersPath().append(tenant.value())
+                .append("delete-session")
+                .append(String.valueOf(sessionId));
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/TenantApplicationsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/TenantApplicationsTest.java
@@ -261,7 +261,9 @@ public class TenantApplicationsTest {
     }
 
     private Thread setupWaiter(TenantApplications applications) {
-        Curator.CompletionWaiter waiter = applications.getRemoveApplicationWaiter(createApplicationId());
+        long sessionId = 1L;
+        applications.createRemoveApplicationWaiter(sessionId);
+        Curator.CompletionWaiter waiter = applications.getRemoveApplicationWaiter(sessionId);
         Thread t1 = new Thread(() -> {
             try {
                 waiter.awaitCompletion(Duration.ofSeconds(120));
@@ -274,9 +276,9 @@ public class TenantApplicationsTest {
     }
 
     private void notifyCompletion(TenantApplications applications, int respondentCount) {
+        long sessionId = 1L;
         IntStream.range(0, respondentCount)
-                 .forEach(i -> applications.createRemoveApplicationWaiter(createApplicationId())
-                                           .notifyCompletion());
+                 .forEach(i -> applications.getRemoveApplicationWaiter(sessionId).notifyCompletion());
     }
 
     private TenantApplications createZKAppRepo() {
@@ -285,10 +287,6 @@ public class TenantApplicationsTest {
 
     private TenantApplications createZKAppRepo(InMemoryFlagSource flagSource) {
         return createTenantApplications(tenantName, curator, configserverConfig, new MockConfigActivationListener(), flagSource);
-    }
-
-    private static ApplicationId createApplicationId() {
-        return createApplicationId("foo");
     }
 
     private static ApplicationId createApplicationId(String name) {


### PR DESCRIPTION
## Summary
- Change removal barrier path from `/config/v2/barriers/<tenant>/delete-application/<appId>` to `/config/v2/barriers/<tenant>/delete-session/<sessionId>`
- Since session IDs are unique per deletion, no delete-before-create step is needed — `curator.create()` on a fresh path is sufficient
- Extract session ID from the CHILD_REMOVED event's `ApplicationData` to notify the correct barrier on other config servers
- Skip barrier notification in `removeApplicationsExcept()` (local cleanup, no barrier involved)

## Benefits
- Eliminates the non-atomic delete-before-create race in `createAndInitialize()` that caused the revert in #37319
- Each removal operation gets a unique, fresh barrier path — no stale state to clean up
- Cleaner separation: activation barriers live under the session path, removal barriers are keyed by session ID under `/config/v2/barriers/`

Generated by Claude Code