### PR TITLE
Use vespa-maven from vespa-build-dependencies [MERGEOK]

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -33,7 +33,7 @@
 %define _defattr_is_vespa_vespa 0
 %define _command_cmake cmake
 %global _vespa_abseil_cpp_version 20250127.1
-%global _vespa_build_depencencies_version 1.16.0
+%global _vespa_build_depencencies_version 1.17.0
 %global _vespa_gtest_version 1.16.0
 %global _vespa_protobuf_version 6.34.1
 %global _vespa_openblas_version 0.3.27
@@ -378,9 +378,6 @@ esac
 %if ! 0%{?installdir:1}
 %if 0%{?_devtoolset_enable:1}
 source %{_devtoolset_enable} || true
-%endif
-%if 0%{?_rhmaven35_enable:1}
-source %{_rhmaven35_enable} || true
 %endif
 %if 0%{?_rhgit227_enable:1}
 source %{_rhgit227_enable} || true


### PR DESCRIPTION
Bump the required vespa-build-dependencies version to 1.17.0, which now provides vespa-maven. Cleanup old rhmaven35 reference.
