### PR TITLE
Provide more information in error message when searching non-existent field

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
@@ -133,9 +133,17 @@ private:
             }
             _result = std::move(se);
         } else {
-            vespalib::Issue::report(
-                "SameElement operator searches in unexpected number of fields. Expected 1 but was %zu",
-                n.numFields());
+            // numFields() == 0 happens if multiple schemas are queried and the current schema does not contain the
+            // searched field. Produce a more meaningful error message in this case.
+            if (n.numFields() == 0) {
+                vespalib::Issue::report(
+                    "SameElement operator does not search in a field. Is '%s' a field of document type '%s'?",
+                    n.getView().c_str(), std::string(_context.get_document_type_name()).c_str());
+            } else if (n.numFields() > 1) {
+                vespalib::Issue::report(
+                    "SameElement operator searches in unexpected number of fields. Expected 1 but was %zu",
+                    n.numFields());
+            }
             _result = std::make_unique<EmptyBlueprint>();
         }
     }

--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
@@ -135,14 +135,15 @@ private:
         } else {
             // numFields() == 0 happens if multiple schemas are queried and the current schema does not contain the
             // searched field. Produce a more meaningful error message in this case.
+            std::string document_type_name(_context.get_document_type_name());
             if (n.numFields() == 0) {
                 vespalib::Issue::report(
                     "SameElement operator does not search in a field. Is '%s' a field of document type '%s'?",
-                    n.getView().c_str(), std::string(_context.get_document_type_name()).c_str());
+                    n.getView().c_str(), document_type_name.c_str());
             } else if (n.numFields() > 1) {
-                vespalib::Issue::report(
-                    "SameElement operator searches in unexpected number of fields. Expected 1 but was %zu",
-                    n.numFields());
+                vespalib::Issue::report("SameElement operator searches in more than one field: '%s' maps to "
+                                        "%zu fields of document type '%s'.",
+                                        n.getView().c_str(), n.numFields(), document_type_name.c_str());
             }
             _result = std::make_unique<EmptyBlueprint>();
         }

--- a/searchcore/src/vespa/searchcore/proton/matching/fakesearchcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/fakesearchcontext.h
@@ -60,6 +60,7 @@ public:
     search::queryeval::Searchable& getAttributes() override { return _attrSearchable; }
 
     uint32_t getDocIdLimit() override { return _docIdLimit; }
+    const std::string_view get_document_type_name() override { return {}; }
     virtual const vespalib::Doom& getDoom() const { return _doom; }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/matching/isearchcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/isearchcontext.h
@@ -60,6 +60,13 @@ public:
     virtual uint32_t getDocIdLimit() = 0;
 
     /**
+     * Obtain the name of the document type.
+     *
+     * @return name of the document type
+     **/
+    virtual const std::string_view get_document_type_name() = 0;
+
+    /**
      * Deleting the context will trigger cleanup in the
      * implementation.
      **/

--- a/searchcore/src/vespa/searchcore/proton/server/matchview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/matchview.cpp
@@ -6,6 +6,7 @@
 
 #include <vespa/searchcore/proton/attribute/i_attribute_manager.h>
 #include <vespa/searchcore/proton/matching/matcher.h>
+#include <vespa/searchlib/engine/request.h>
 #include <vespa/searchlib/engine/searchreply.h>
 #include <vespa/searchlib/engine/searchrequest.h>
 #include <vespa/vespalib/util/exceptions.h>
@@ -53,15 +54,15 @@ std::shared_ptr<Matcher> MatchView::getMatcher(const std::string& rankProfile) c
     return _matchers->lookup(rankProfile);
 }
 
-MatchContext MatchView::createContext() const {
-    auto searchCtx = std::make_unique<SearchContext>(_indexSearchable, _docIdLimit.get());
+MatchContext MatchView::createContext(const search::engine::Request& req) const {
+    auto searchCtx = std::make_unique<SearchContext>(_indexSearchable, _docIdLimit.get(), req);
     return {_attrMgr->createContext(), std::move(searchCtx)};
 }
 
 std::unique_ptr<SearchReply> MatchView::match(std::shared_ptr<const ISearchHandler> searchHandler,
                                               const SearchRequest& req, vespalib::ThreadBundle& threadBundle) const {
     Matcher::SP                    matcher = getMatcher(req.ranking);
-    SearchSession::OwnershipBundle owned_objects(createContext(), std::move(searchHandler));
+    SearchSession::OwnershipBundle owned_objects(createContext(req), std::move(searchHandler));
     owned_objects.readGuard = _metaStore->getReadGuard();
     ISearchContext&                   search_ctx = owned_objects.context.getSearchContext();
     IAttributeContext&                attribute_ctx = owned_objects.context.getAttributeContext();

--- a/searchcore/src/vespa/searchcore/proton/server/matchview.h
+++ b/searchcore/src/vespa/searchcore/proton/server/matchview.h
@@ -13,6 +13,10 @@ namespace searchcorespi {
 class IndexSearchable;
 }
 
+namespace search::engine {
+class Request;
+}
+
 namespace proton::matching {
 class MatchContext;
 class Matcher;
@@ -59,7 +63,7 @@ public:
         return _matchers->getStats(rankProfile);
     }
 
-    matching::MatchContext createContext() const;
+    matching::MatchContext createContext(const search::engine::Request& req) const;
 
     std::unique_ptr<search::engine::SearchReply> match(std::shared_ptr<const ISearchHandler> searchHandler,
                                                        const search::engine::SearchRequest&  req,

--- a/searchcore/src/vespa/searchcore/proton/server/searchcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchcontext.cpp
@@ -19,8 +19,13 @@ uint32_t SearchContext::getDocIdLimit() {
     return _docIdLimit;
 }
 
-SearchContext::SearchContext(const std::shared_ptr<IndexSearchable>& indexSearchable, uint32_t docIdLimit)
-    : _indexSearchable(indexSearchable), _attributeBlueprintFactory(), _docIdLimit(docIdLimit) {
+const std::string_view SearchContext::get_document_type_name() {
+    return _doc_type_name.getName();
+}
+
+SearchContext::SearchContext(const std::shared_ptr<IndexSearchable>& indexSearchable, uint32_t docIdLimit,
+                             const search::engine::Request& req)
+    : _indexSearchable(indexSearchable), _attributeBlueprintFactory(), _docIdLimit(docIdLimit), _doc_type_name(req) {
 }
 
 SearchContext::~SearchContext() = default;

--- a/searchcore/src/vespa/searchcore/proton/server/searchcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchcontext.h
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <vespa/searchcore/proton/common/doctypename.h>
 #include <vespa/searchcore/proton/matching/isearchcontext.h>
 #include <vespa/searchlib/attribute/attribute_blueprint_factory.h>
 
@@ -18,13 +19,16 @@ private:
     std::shared_ptr<IndexSearchable>  _indexSearchable;
     search::AttributeBlueprintFactory _attributeBlueprintFactory;
     uint32_t                          _docIdLimit;
+    DocTypeName                       _doc_type_name;
 
     IndexSearchable& getIndexes() override;
     Searchable& getAttributes() override;
     uint32_t getDocIdLimit() override;
+    const std::string_view get_document_type_name() override;
 
 public:
-    SearchContext(const std::shared_ptr<IndexSearchable>& indexSearchable, uint32_t docIdLimit);
+    SearchContext(const std::shared_ptr<IndexSearchable>& indexSearchable, uint32_t docIdLimit,
+                  const search::engine::Request& req);
     ~SearchContext() override;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/searchview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchview.cpp
@@ -114,7 +114,7 @@ SearchView::InternalDocsumReply SearchView::getDocsumsInternal(const DocsumReque
 
     convertGidsToLids(req, metaStore, _matchView->getDocIdLimit().get());
     auto store(_summarySetup->createDocsumStore());
-    auto mctx = _matchView->createContext();
+    auto mctx = _matchView->createContext(req);
     auto ctx = std::make_unique<DocsumContext>(
         req, _summarySetup->getDocsumWriter(), *store, _matchView->getMatcher(req.ranking), mctx.getSearchContext(),
         mctx.getAttributeContext(), *_summarySetup->getAttributeManager(), getSessionManager());

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -203,7 +203,9 @@ void FieldSearchSpecMap::addFieldsFromIndex(std::string_view rawIndex, StringFie
                 }
             }
         } else {
-            Issue::report("No valid indexes registered for index %s", std::string(rawIndex).c_str());
+            std::string raw_index_string(rawIndex);
+            Issue::report("No valid indexes registered for index '%s'. Is '%s' a field of document type '%s'?",
+                          raw_index_string.c_str(), raw_index_string.c_str(), dtm.first.c_str());
         }
     }
 }


### PR DESCRIPTION
With `sameElement` in indexed search:
```
     "errors": [
       {
         "code": 8,
         "summary": "Error in search reply.",
         "source": "search",
         "message": "SameElement operator does not search in a field. Is 'custom_fields_string' a field of document type 'withoutfield'?"
       }
     ],
```

and in streaming search:
```
     "errors": [
       {
         "code": 8,
         "summary": "Error in search reply.",
         "source": "search",
         "message": "Could not find a view for index 'custom_fields_string.key'. Ranking no fields."
       },
       {
         "code": 8,
         "summary": "Error in search reply.",
         "source": "search",
         "message": "Could not find a view for index 'custom_fields_string.value'. Ranking no fields."
       },
       {
         "code": 8,
         "summary": "Error in search reply.",
         "source": "search",
         "message": "Could not find a view for index 'custom_fields_string'. Ranking no fields."
       },
       {
         "code": 8,
         "summary": "Error in search reply.",
         "source": "search",
         "message": "No valid indexes registered for index 'custom_fields_string.value'. Is 'custom_fields_string.value' a field of document type 'withoutfield'?"
       },
       {
         "code": 8,
         "summary": "Error in search reply.",
         "source": "search",
         "message": "No valid indexes registered for index 'custom_fields_string.key'. Is 'custom_fields_string.key' a field of document type 'withoutfield'?"
       }
     ],

```

Still a bit ugly, but should make it clear why there is an error message.