### PR TITLE
Add dedicated cluster-deployment-metrics consumer

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
@@ -33,6 +33,7 @@ class ConsumersConfigGenerator {
         allConsumers.put(MetricsConsumer.vespa.id(),
                          combineConsumers(defaultConsumer, allConsumers.get(MetricsConsumer.vespa.id())));
         allConsumers.put(MetricsConsumer.autoscaling.id(), MetricsConsumer.autoscaling);
+        allConsumers.put(MetricsConsumer.clusterDeployment.id(), MetricsConsumer.clusterDeployment);
 
         if (systemName.isPublicCloudLike())
             allConsumers.put(MetricsConsumer.vespaCloud.id(), MetricsConsumer.vespaCloud);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/MetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/MetricsConsumer.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static ai.vespa.metrics.set.AutoscalingMetrics.autoscalingMetricSet;
+import static ai.vespa.metrics.set.ClusterDeploymentSet.clusterDeploymentMetricSet;
 import static ai.vespa.metrics.set.DefaultMetrics.defaultMetricSet;
 import static ai.vespa.metrics.set.NetworkMetrics.networkMetricSet;
 import static ai.vespa.metrics.set.SystemMetrics.systemMetricSet;
@@ -37,6 +38,9 @@ public class MetricsConsumer {
     // Referenced from com.yahoo.vespa.hosted.provision.autoscale.NodeMetricsFetcher
     public static final MetricsConsumer autoscaling =
             consumer("autoscaling", autoscalingMetricSet);
+
+    public static final MetricsConsumer clusterDeployment =
+            consumer("cluster-deployment-metrics", clusterDeploymentMetricSet);
 
     public static final MetricsConsumer vespaCloud =
             consumer("vespa-cloud", vespaMetricSet, systemMetricSet, networkMetricSet);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
@@ -90,6 +90,9 @@ public class MetricsBuilder {
         if (consumerId.equalsIgnoreCase(MetricsConsumer.autoscaling.id()))
             throw new IllegalArgumentException("'" + MetricsConsumer.autoscaling.id() + " is not allowed as metrics consumer id (case is ignored.)");
 
+        if (consumerId.equalsIgnoreCase(MetricsConsumer.clusterDeployment.id()))
+            throw new IllegalArgumentException("'" + MetricsConsumer.clusterDeployment.id() + " is not allowed as metrics consumer id (case is ignored.)");
+
         if (consumerId.equalsIgnoreCase(MetricsConsumer.vespaCloud.id()))
             throw new IllegalArgumentException("'" + MetricsConsumer.vespaCloud.id() + " is not allowed as metrics consumer id (case is ignored.)");
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsConsumersTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsConsumersTest.java
@@ -45,21 +45,22 @@ public class MetricsConsumersTest {
     @Test
     void default_public_consumers_is_set_up_for_self_hosted() {
         ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), self_hosted);
-        assertEquals(4, config.consumer().size());
-        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(2).name());
+        assertEquals(5, config.consumer().size());
+        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(3).name());
         int numMetricsForPublicDefaultConsumer = defaultMetricSet.getMetrics().size() + numSystemMetrics;
-        assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(2).metric().size());
+        assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(3).metric().size());
     }
 
     @Test
     void consumers_are_set_up_for_hosted() {
         ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), hosted);
-        assertEquals(5, config.consumer().size());
+        assertEquals(6, config.consumer().size());
         assertEquals(MetricsConsumer.vespa.id(), config.consumer(0).name());
         assertEquals(MetricsConsumer.autoscaling.id(), config.consumer(1).name());
-        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(2).name());
-        assertEquals(MetricsProxyContainerCluster.NEW_DEFAULT_CONSUMER_ID, config.consumer(3).name());
-        assertEquals(MetricsConsumer.vespa9.id(), config.consumer(4).name());
+        assertEquals(MetricsConsumer.clusterDeployment.id(), config.consumer(2).name());
+        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(3).name());
+        assertEquals(MetricsProxyContainerCluster.NEW_DEFAULT_CONSUMER_ID, config.consumer(4).name());
+        assertEquals(MetricsConsumer.vespa9.id(), config.consumer(5).name());
     }
 
     @Test
@@ -133,7 +134,7 @@ public class MetricsConsumersTest {
         );
         VespaModel hostedModel = getModel(services, hosted);
         ConsumersConfig config = consumersConfigFromModel(hostedModel);
-        assertEquals(5, config.consumer().size());
+        assertEquals(6, config.consumer().size());
 
         // All default metrics are retained
         ConsumersConfig.Consumer vespaConsumer = config.consumer(0);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
@@ -152,9 +152,19 @@ public class ClusterDeploymentMetricsRetriever {
         return new ClusterInfo(dimensions.field("clusterid").asString(), dimensions.field("clustertype").asString());
     }
 
+    private static URI withParam(URI uri) {
+        try {
+            String extra = "consumer=cluster-deployment-metrics";
+            String query = uri.getQuery() == null ? extra : uri.getQuery() + "&" + extra;
+            return new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), query, uri.getFragment());
+        } catch(java.net.URISyntaxException ex) {
+            return uri;
+        }
+    }
+
     @SuppressWarnings("deprecation")
     private static Slime doMetricsRequest(URI hostURI) {
-        HttpGet get = new HttpGet(hostURI);
+        HttpGet get = new HttpGet(withParam(hostURI));
         try (CloseableHttpResponse response = httpClient.execute(get)) {
             return SlimeUtils.jsonToSlime(response.getEntity().getContent());
         } catch (IOException e) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetrieverTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetrieverTest.java
@@ -40,22 +40,22 @@ public class ClusterDeploymentMetricsRetrieverTest {
                 .map(item -> URI.create("http://localhost:" + wireMock.port() + "/" + item))
                 .toList();
 
-        stubFor(get(urlEqualTo("/1"))
+        stubFor(get(urlEqualTo("/1?consumer=cluster-deployment-metrics"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(contentMetrics())));
 
-        stubFor(get(urlEqualTo("/2"))
+        stubFor(get(urlEqualTo("/2?consumer=cluster-deployment-metrics"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(contentMetrics())));
 
-        stubFor(get(urlEqualTo("/3"))
+        stubFor(get(urlEqualTo("/3?consumer=cluster-deployment-metrics"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(containerMetrics())));
 
-        stubFor(get(urlEqualTo("/4"))
+        stubFor(get(urlEqualTo("/4?consumer=cluster-deployment-metrics"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(clustercontrollerMetrics())));
@@ -94,12 +94,12 @@ public class ClusterDeploymentMetricsRetrieverTest {
                 .map(item -> URI.create("http://localhost:" + wireMock.port() + "/" + item))
                 .toList();
 
-        stubFor(get(urlEqualTo("/1"))
+        stubFor(get(urlEqualTo("/1?consumer=cluster-deployment-metrics"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(contentMetrics())));
 
-        stubFor(get(urlEqualTo("/2"))
+        stubFor(get(urlEqualTo("/2?consumer=cluster-deployment-metrics"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(clustercontrollerMetricsWithFeedBlocked())));

--- a/metrics/src/main/java/ai/vespa/metrics/set/ClusterDeploymentSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/ClusterDeploymentSet.java
@@ -1,0 +1,77 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package ai.vespa.metrics.set;
+
+import ai.vespa.metrics.ClusterControllerMetrics;
+import ai.vespa.metrics.ContainerMetrics;
+import ai.vespa.metrics.DistributorMetrics;
+import ai.vespa.metrics.Suffix;
+import ai.vespa.metrics.VespaMetrics;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static ai.vespa.metrics.Suffix.average;
+import static ai.vespa.metrics.Suffix.count;
+import static ai.vespa.metrics.Suffix.last;
+import static ai.vespa.metrics.Suffix.max;
+import static ai.vespa.metrics.Suffix.sum;
+
+/**
+ * Service metrics fetched by ClusterDeploymentMetricsRetriever
+ *
+ * @author arnej
+ */
+public class ClusterDeploymentSet {
+
+    public static final MetricSet clusterDeploymentMetricSet = createMetricSet();
+
+    private static MetricSet createMetricSet() {
+        return new MetricSet("cluster-deployment-metrics",
+                             makeMetrics());
+    }
+
+    private static Set<Metric> makeMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        metrics.addAll(getContainerMetrics());
+        metrics.addAll(getDistributorMetrics());
+        metrics.addAll(getClusterControllerMetrics());
+        return Collections.unmodifiableSet(metrics);
+    }
+
+    private static Set<Metric> getContainerMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        addMetric(metrics, ContainerMetrics.FEED_LATENCY, EnumSet.of(sum, count));
+        addMetric(metrics, ContainerMetrics.QUERY_LATENCY, EnumSet.of(sum, count));
+        return metrics;
+    }
+
+    private static Set<Metric> getClusterControllerMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_DISK_LIMIT, EnumSet.of(max, last));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MAX_DISK_UTILIZATION, EnumSet.of(last, max));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MAX_MEMORY_UTILIZATION, EnumSet.of(last, max));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MEMORY_LIMIT, EnumSet.of(max, last));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_NODES_ABOVE_LIMIT, EnumSet.of(last, max));
+        return metrics;
+    }
+
+    private static Set<Metric> getDistributorMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        addMetric(metrics, DistributorMetrics.VDS_DISTRIBUTOR_DOCSSTORED.average());
+        addMetric(metrics, DistributorMetrics.VDS_DISTRIBUTOR_GETS_LATENCY, EnumSet.of(sum, count));
+        return metrics;
+    }
+
+    private static void addMetric(Set<Metric> metrics, String nameWithSuffix) {
+        metrics.add(new Metric(nameWithSuffix));
+    }
+
+    private static void addMetric(Set<Metric> metrics, VespaMetrics metric, EnumSet<Suffix> suffixes) {
+        suffixes.forEach(suffix -> addMetric(metrics, metric.baseName() + "." + suffix.suffix()));
+    }
+
+}


### PR DESCRIPTION
The configserver's ClusterDeploymentMetricsRetriever reaches out to every node in a deployment and aggregates a small, fixed set of deployment-level values: query/feed latency, stored document count, read latency, and content-cluster resource usage (disk/memory utilization and limits, and feed-blocked node count). Until now it requested each node's full default metric set and picked out only the handful of fields it needs, transferring far more metric data than necessary.

Introduce a "cluster-deployment-metrics" metric set that contains exactly the metrics the retriever consumes, expose it as a built-in MetricsConsumer, and have the retriever request it via the consumer=cluster-deployment-metrics query parameter. This narrows each per-node request to just the required metrics.