### PR TITLE
Adds ASSIGN_ELEMENT opcode to change vector and assign_element API to attribute vector

### DIFF
--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -847,7 +847,7 @@ void AttributeTest::testSingle(const AttributePtr& ptr, const std::vector<Buffer
     }
     EXPECT_TRUE(!v.remove(ptr->getNumDocs(), values[0], 1));
 
-    // test assign_element() (not supported for single value attributes)
+    // test assign_element()
     for (uint32_t doc = 0; doc < ptr->getNumDocs(); ++doc) {
         EXPECT_TRUE(!v.assign_element(doc, 0, values[0]));
     }

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -890,7 +890,7 @@ void AttributeTest::testSingle() {
         {
             AttributePtr ptr = createAttribute("sv-int32", Config(BasicType::INT32, CollectionType::SINGLE));
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(4224u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(4336u, ptr->getStatus().getAllocated());
             EXPECT_EQ(0u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<IntegerAttribute, AttributeVector::largeint_t, int32_t>(ptr, values);
@@ -905,7 +905,7 @@ void AttributeTest::testSingle() {
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("sv-post-int32", cfg);
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(338972u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(339084u, ptr->getStatus().getAllocated());
             EXPECT_EQ(101512u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<IntegerAttribute, AttributeVector::largeint_t, int32_t>(ptr, values);
@@ -917,7 +917,7 @@ void AttributeTest::testSingle() {
         {
             AttributePtr ptr = createAttribute("sv-float", Config(BasicType::FLOAT, CollectionType::SINGLE));
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(4224u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(4336u, ptr->getStatus().getAllocated());
             EXPECT_EQ(0u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<FloatingPointAttribute, double, float>(ptr, values);
@@ -927,7 +927,7 @@ void AttributeTest::testSingle() {
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("sv-post-float", cfg);
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(338972u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(339084u, ptr->getStatus().getAllocated());
             EXPECT_EQ(101512u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<FloatingPointAttribute, double, float>(ptr, values);
@@ -1112,7 +1112,7 @@ void AttributeTest::testArray() {
         {
             AttributePtr ptr = createAttribute("a-int32", Config(BasicType::INT32, CollectionType::ARRAY));
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(293856u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(293968u, ptr->getStatus().getAllocated());
             EXPECT_EQ(253668u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<IntegerAttribute, AttributeVector::largeint_t>(ptr, values);
@@ -1122,7 +1122,7 @@ void AttributeTest::testArray() {
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("flags", cfg);
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(293856u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(293968u, ptr->getStatus().getAllocated());
             EXPECT_EQ(253668u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<IntegerAttribute, AttributeVector::largeint_t>(ptr, values);
@@ -1132,7 +1132,7 @@ void AttributeTest::testArray() {
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("a-fs-int32", cfg);
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(650492u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(650604u, ptr->getStatus().getAllocated());
             EXPECT_EQ(355200u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<IntegerAttribute, AttributeVector::largeint_t>(ptr, values);
@@ -1151,7 +1151,7 @@ void AttributeTest::testArray() {
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("a-fs-float", cfg);
             ptr->updateStat(CommitParam::UpdateStats::FORCE);
-            EXPECT_EQ(650492u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(650604u, ptr->getStatus().getAllocated());
             EXPECT_EQ(355200u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<FloatingPointAttribute, double>(ptr, values);
@@ -2278,27 +2278,27 @@ void AttributeTest::testPendingCompaction() {
 void AttributeTest::testConditionalCommit() {
     Config cfg(BasicType::INT32, CollectionType::SINGLE);
     cfg.setFastSearch(true);
-    cfg.setMaxUnCommittedMemory(70000);
+    cfg.setMaxUnCommittedMemory(90000);
     AttributePtr v = createAttribute("sfsint32_cc", cfg);
     addClearedDocs(v, 1000);
     auto& iv = static_cast<IntegerAttribute&>(*v.get());
-    EXPECT_EQ(0x8000u, iv.getChangeVectorMemoryUsage().allocatedBytes());
+    EXPECT_EQ(61440u, iv.getChangeVectorMemoryUsage().allocatedBytes());
     EXPECT_EQ(0u, iv.getChangeVectorMemoryUsage().usedBytes());
     AttributeGuard guard1(v);
     populateSimpleUncommitted(iv, 1, 3);
-    EXPECT_EQ(0x8000u, iv.getChangeVectorMemoryUsage().allocatedBytes());
-    EXPECT_EQ(128u, iv.getChangeVectorMemoryUsage().usedBytes());
+    EXPECT_EQ(61440u, iv.getChangeVectorMemoryUsage().allocatedBytes());
+    EXPECT_EQ(160u, iv.getChangeVectorMemoryUsage().usedBytes());
     populateSimpleUncommitted(iv, 1, 1000);
-    EXPECT_EQ(0x10000u, iv.getChangeVectorMemoryUsage().allocatedBytes());
-    EXPECT_EQ(64064u, iv.getChangeVectorMemoryUsage().usedBytes());
+    EXPECT_EQ(122880u, iv.getChangeVectorMemoryUsage().allocatedBytes());
+    EXPECT_EQ(80080u, iv.getChangeVectorMemoryUsage().usedBytes());
     EXPECT_FALSE(v->commitIfChangeVectorTooLarge());
-    EXPECT_EQ(0x10000u, iv.getChangeVectorMemoryUsage().allocatedBytes());
-    EXPECT_EQ(64064u, iv.getChangeVectorMemoryUsage().usedBytes());
+    EXPECT_EQ(122880u, iv.getChangeVectorMemoryUsage().allocatedBytes());
+    EXPECT_EQ(80080u, iv.getChangeVectorMemoryUsage().usedBytes());
     populateSimpleUncommitted(iv, 1, 200);
-    EXPECT_EQ(0x20000u, iv.getChangeVectorMemoryUsage().allocatedBytes());
-    EXPECT_EQ(76800u, iv.getChangeVectorMemoryUsage().usedBytes());
+    EXPECT_EQ(122880u, iv.getChangeVectorMemoryUsage().allocatedBytes());
+    EXPECT_EQ(96000u, iv.getChangeVectorMemoryUsage().usedBytes());
     EXPECT_TRUE(v->commitIfChangeVectorTooLarge());
-    EXPECT_EQ(0x2000u, iv.getChangeVectorMemoryUsage().allocatedBytes());
+    EXPECT_EQ(8160u, iv.getChangeVectorMemoryUsage().allocatedBytes());
     EXPECT_EQ(0u, iv.getChangeVectorMemoryUsage().usedBytes());
 }
 

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -847,6 +847,12 @@ void AttributeTest::testSingle(const AttributePtr& ptr, const std::vector<Buffer
     }
     EXPECT_TRUE(!v.remove(ptr->getNumDocs(), values[0], 1));
 
+    // test assign_element() (not supported for single value attributes)
+    for (uint32_t doc = 0; doc < ptr->getNumDocs(); ++doc) {
+        EXPECT_TRUE(!v.assign_element(doc, 0, values[0]));
+    }
+    EXPECT_TRUE(!v.assign_element(ptr->getNumDocs(), 0, values[0]));
+
     bool smallUInt = isUnsignedSmallIntAttribute(*ptr);
     // test clearDoc()
     for (uint32_t doc = 0; doc < ptr->getNumDocs(); ++doc) {
@@ -1058,6 +1064,43 @@ void AttributeTest::testArray(const AttributePtr& ptr, const std::vector<BufferT
         EXPECT_TRUE(checkCount(ptr, doc, valueCount, valueCount, values[1]));
     }
     EXPECT_TRUE(!v.clearDoc(ptr->getNumDocs()));
+
+    // test assign_element()
+    for (uint32_t doc = 0; doc < ptr->getNumDocs(); ++doc) {
+        ptr->clearDoc(doc);
+
+        // start from a known array: [values[0], values[1], values[2]]
+        for (uint32_t i = 0; i < 3; ++i) {
+            EXPECT_TRUE(v.append(doc, values[i], 1));
+        }
+        ptr->commit();
+        EXPECT_TRUE(checkContent(ptr, doc, 3, 3, values));
+
+        // in-range assign overwrites only the addressed element, size is unchanged
+        EXPECT_TRUE(v.assign_element(doc, 1, values[3]));
+        ptr->commit();
+        {
+            std::vector<BufferType> buffer(3);
+            EXPECT_EQ(3u, ptr->getValueCount(doc));
+            EXPECT_EQ(3u, ptr->get(doc, buffer.data(), buffer.size()));
+            EXPECT_EQ(values[0], buffer[0]);
+            EXPECT_EQ(values[3], buffer[1]);
+            EXPECT_EQ(values[2], buffer[2]);
+        }
+
+        // out-of-range assign is a no-op: the array is neither grown nor modified
+        EXPECT_TRUE(v.assign_element(doc, 3, values[4]));
+        ptr->commit();
+        {
+            std::vector<BufferType> buffer(3);
+            EXPECT_EQ(3u, ptr->getValueCount(doc));
+            EXPECT_EQ(3u, ptr->get(doc, buffer.data(), buffer.size()));
+            EXPECT_EQ(values[0], buffer[0]);
+            EXPECT_EQ(values[3], buffer[1]);
+            EXPECT_EQ(values[2], buffer[2]);
+        }
+    }
+    EXPECT_TRUE(!v.assign_element(ptr->getNumDocs(), 0, values[0]));
 }
 
 void AttributeTest::testArray() {

--- a/searchlib/src/tests/attribute/changevector/changevector_test.cpp
+++ b/searchlib/src/tests/attribute/changevector/changevector_test.cpp
@@ -90,10 +90,10 @@ TEST(ChangeVectorTest, require_that_inserting_empty_vector_does_not_affect_the_v
 TEST(ChangeVectorTest, require_that_we_have_control_over_buffer_construction_size) {
     CV a;
     EXPECT_EQ(0u, a.size());
-    EXPECT_EQ(4u, a.capacity());
+    EXPECT_EQ(6u, a.capacity());
     a.clear();
     EXPECT_EQ(0u, a.size());
-    EXPECT_EQ(4u, a.capacity());
+    EXPECT_EQ(6u, a.capacity());
 }
 
 TEST(ChangeVectorTest, require_that_buffer_can_grow_some) {
@@ -102,27 +102,27 @@ TEST(ChangeVectorTest, require_that_buffer_can_grow_some) {
         a.push_back(Change(Change::NOOP, i, i));
     }
     EXPECT_EQ(1024u, a.size());
-    EXPECT_EQ(1024u, a.capacity());
+    EXPECT_EQ(1536u, a.capacity());
     a.clear();
     EXPECT_EQ(0u, a.size());
-    EXPECT_EQ(1024u, a.capacity());
+    EXPECT_EQ(1536u, a.capacity());
 }
 
 TEST(ChangeVectorTest, require_that_buffer_can_grow_some_but_not_unbound) {
     CV a;
-    for (size_t i(0); i < 1025; i++) {
+    for (size_t i(0); i < 1537; i++) {
         a.push_back(Change(Change::NOOP, i, i));
     }
-    EXPECT_EQ(1025u, a.size());
-    EXPECT_EQ(2048u, a.capacity());
+    EXPECT_EQ(1537u, a.size());
+    EXPECT_EQ(3072u, a.capacity());
     a.clear();
     EXPECT_EQ(0u, a.size());
-    EXPECT_EQ(256u, a.capacity());
+    EXPECT_EQ(204u, a.capacity());
 }
 
 TEST(ChangeVectorTest, Control_Change_size) {
-    EXPECT_EQ(32u, sizeof(ChangeTemplate<NumericChangeData<long>>));
-    EXPECT_EQ(16u + sizeof(std::string), sizeof(ChangeTemplate<StringChangeData>));
+    EXPECT_EQ(40u, sizeof(ChangeTemplate<NumericChangeData<long>>));
+    EXPECT_EQ(24u + sizeof(std::string), sizeof(ChangeTemplate<StringChangeData>));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -746,5 +746,8 @@ template bool AttributeVector::update<StringChangeData>(ChangeVectorT<ChangeTemp
                                                         uint32_t, const StringChangeData&);
 template bool AttributeVector::remove<StringChangeData>(ChangeVectorT<ChangeTemplate<StringChangeData>>& changes,
                                                         uint32_t, const StringChangeData&, int32_t);
+template bool
+AttributeVector::assign_element<StringChangeData>(ChangeVectorT<ChangeTemplate<StringChangeData>>& changes, uint32_t,
+                                                  uint32_t, const StringChangeData&);
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -209,6 +209,9 @@ protected:
     template <typename T> bool remove(ChangeVectorT<ChangeTemplate<T>>& changes, DocId doc, const T& v, int32_t w);
 
     template <typename T>
+    bool assign_element(ChangeVectorT<ChangeTemplate<T>>& changes, DocId doc, uint32_t index, const T& v);
+
+    template <typename T>
     bool adjustWeight(ChangeVectorT<ChangeTemplate<T>>& changes, DocId doc, const T& v,
                       const ArithmeticValueUpdate& wd);
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.hpp
@@ -175,8 +175,8 @@ bool AttributeVector::assign_element(ChangeVectorT<ChangeTemplate<T>>& changes, 
                                      const T& v) {
     bool retval = hasMultiValue() && hasArrayType() && (doc < getNumDocs());
     if (retval) {
-        // Use _weight field to store array index
-        changes.push_back(ChangeTemplate<T>(ChangeBase::ASSIGN_ELEMENT, doc, v, index));
+        changes.push_back(ChangeTemplate<T>(ChangeBase::ASSIGN_ELEMENT, doc, v));
+        changes.back().set_element_index(index);
         _status.incUpdates();
         updateUncommittedDocIdLimit(doc);
         _status.incNonIdempotentUpdates();

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.hpp
@@ -170,4 +170,18 @@ bool AttributeVector::remove(ChangeVectorT<ChangeTemplate<T>>& changes, DocId do
     return retval;
 }
 
+template <typename T>
+bool AttributeVector::assign_element(ChangeVectorT<ChangeTemplate<T>>& changes, DocId doc, uint32_t index,
+                                     const T& v) {
+    bool retval = hasMultiValue() && hasArrayType() && (doc < getNumDocs());
+    if (retval) {
+        // Use _weight field to store array index
+        changes.push_back(ChangeTemplate<T>(ChangeBase::ASSIGN_ELEMENT, doc, v, index));
+        _status.incUpdates();
+        updateUncommittedDocIdLimit(doc);
+        _status.incNonIdempotentUpdates();
+    }
+    return retval;
+}
+
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -46,10 +46,13 @@ struct ChangeBase {
     void set_entry_ref(uint32_t entry_ref) const { _cached_entry_ref = entry_ref; }
     bool has_entry_ref() const { return _cached_entry_ref != UNSET_ENTRY_REF; }
     void clear_entry_ref() const { _cached_entry_ref = UNSET_ENTRY_REF; }
+    [[nodiscard]] uint32_t element_index() const noexcept { return _element_index; }
+    void set_element_index(uint32_t index) noexcept { _element_index = index; }
 
     Type             _type;
     uint32_t         _doc;
     int32_t          _weight;
+    uint32_t         _element_index;
     mutable uint32_t _cached_entry_ref;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -19,6 +19,7 @@ struct ChangeBase {
         UPDATE,
         APPEND,
         REMOVE,
+        ASSIGN_ELEMENT,
         INCREASEWEIGHT,
         MULWEIGHT,
         DIVWEIGHT,

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -32,10 +32,10 @@ struct ChangeBase {
     };
     enum { UNSET_ENTRY_REF = 0 };
 
-    ChangeBase() : _type(NOOP), _doc(0), _weight(1), _cached_entry_ref(UNSET_ENTRY_REF) {}
+    ChangeBase() : _type(NOOP), _doc(0), _weight(1), _element_index(0), _cached_entry_ref(UNSET_ENTRY_REF) {}
 
     ChangeBase(Type type, uint32_t d, int32_t w = 1)
-        : _type(type), _doc(d), _weight(w), _cached_entry_ref(UNSET_ENTRY_REF) {}
+        : _type(type), _doc(d), _weight(w), _element_index(0), _cached_entry_ref(UNSET_ENTRY_REF) {}
 
     int cmp(const ChangeBase& b) const {
         int diff(_doc - b._doc);

--- a/searchlib/src/vespa/searchlib/attribute/floatbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/floatbase.cpp
@@ -99,5 +99,7 @@ template bool AttributeVector::append(FloatingPointAttribute::ChangeVector& chan
                                       const NumericChangeData<double>& v, int32_t w, bool doCount);
 template bool AttributeVector::remove(FloatingPointAttribute::ChangeVector& changes, DocId doc,
                                       const NumericChangeData<double>& v, int32_t w);
+template bool AttributeVector::assign_element(FloatingPointAttribute::ChangeVector& changes, DocId doc,
+                                              uint32_t index, const NumericChangeData<double>& v);
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/floatbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/floatbase.h
@@ -22,6 +22,9 @@ public:
         return AttributeVector::remove(_changes, doc, NumericChangeData<double>(v), weight);
     }
     bool update(DocId doc, double v) { return AttributeVector::update(_changes, doc, NumericChangeData<double>(v)); }
+    bool assign_element(DocId doc, uint32_t index, double v) {
+        return AttributeVector::assign_element(_changes, doc, index, NumericChangeData<double>(v));
+    }
     bool apply(DocId doc, const ArithmeticValueUpdate& op);
     bool applyWeight(DocId doc, const FieldValue& fv, const ArithmeticValueUpdate& wAdjust) override;
     bool applyWeight(DocId doc, const FieldValue& fv, const document::AssignValueUpdate& wAdjust) override;

--- a/searchlib/src/vespa/searchlib/attribute/integerbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/integerbase.cpp
@@ -107,5 +107,7 @@ template bool AttributeVector::append(IntegerAttribute::ChangeVector& changes, D
                                       const NumericChangeData<largeint_t>& v, int32_t w, bool doCount);
 template bool AttributeVector::remove(IntegerAttribute::ChangeVector& changes, DocId doc,
                                       const NumericChangeData<largeint_t>& v, int32_t w);
+template bool AttributeVector::assign_element(IntegerAttribute::ChangeVector& changes, DocId doc, uint32_t index,
+                                              const NumericChangeData<largeint_t>& v);
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/integerbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/integerbase.h
@@ -24,6 +24,9 @@ public:
     bool remove(DocId doc, largeint_t v, int32_t weight) {
         return AttributeVector::remove(_changes, doc, NumericChangeData<largeint_t>(v), weight);
     }
+    bool assign_element(DocId doc, uint32_t index, largeint_t v) {
+        return AttributeVector::assign_element(_changes, doc, index, NumericChangeData<largeint_t>(v));
+    }
     bool apply(DocId doc, const ArithmeticValueUpdate& op);
     bool applyWeight(DocId doc, const FieldValue& fv, const ArithmeticValueUpdate& wAdjust) override;
     bool applyWeight(DocId doc, const FieldValue& fv, const document::AssignValueUpdate& wAdjust) override;

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
@@ -35,7 +35,7 @@ bool MultiValueEnumAttribute<B, M>::extractChangeData(const Change& c, EnumIndex
 
 template <typename B, typename M>
 void MultiValueEnumAttribute<B, M>::considerAttributeChange(const Change& c, EnumStoreBatchUpdater& inserter) {
-    if (c._type == ChangeBase::APPEND ||
+    if (c._type == ChangeBase::APPEND || c._type == ChangeBase::ASSIGN_ELEMENT ||
         (this->getInternalCollectionType().createIfNonExistant() &&
          (c._type >= ChangeBase::INCREASEWEIGHT && c._type <= ChangeBase::SETWEIGHT)))
     {

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -107,6 +107,17 @@ void MultiValueAttribute<B, M>::apply_attribute_changes_to_array(DocumentValues&
                     new_values.emplace_back(
                         multivalue::ValueBuilder<MultiValueType>::build(ValueType(data), current->_weight));
                 }
+            } else if (current->_type == ChangeBase::ASSIGN_ELEMENT) {
+                // Element-wise assignment: arr[index] = value.
+                // The index is stored in the _weight.
+                uint32_t index = current->_weight;
+                if (index < new_values.size()) {
+                    if constexpr (std::is_same_v<ValueType, NonAtomicValueType>) {
+                        new_values[index] = multivalue::ValueBuilder<MultiValueType>::build(data, 1);
+                    } else {
+                        new_values[index] = multivalue::ValueBuilder<MultiValueType>::build(ValueType(data), 1);
+                    }
+                }
             } else if (current->_type == ChangeBase::REMOVE) {
                 // Defer all removals to the very end by tracking when, during value vector build time,
                 // a removal was encountered for a particular value. All values < this index will be ignored.

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -108,9 +108,7 @@ void MultiValueAttribute<B, M>::apply_attribute_changes_to_array(DocumentValues&
                         multivalue::ValueBuilder<MultiValueType>::build(ValueType(data), current->_weight));
                 }
             } else if (current->_type == ChangeBase::ASSIGN_ELEMENT) {
-                // Element-wise assignment: arr[index] = value.
-                // The index is stored in the _weight.
-                uint32_t index = current->_weight;
+                uint32_t index = current->element_index();
                 if (index < new_values.size()) {
                     if constexpr (std::is_same_v<ValueType, NonAtomicValueType>) {
                         new_values[index] = multivalue::ValueBuilder<MultiValueType>::build(data, 1);

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
@@ -265,5 +265,7 @@ template bool AttributeVector::append(StringAttribute::ChangeVector& changes, Do
                                       int32_t w, bool doCount);
 template bool AttributeVector::remove(StringAttribute::ChangeVector& changes, DocId doc, const StringChangeData& v,
                                       int32_t w);
+template bool AttributeVector::assign_element(StringAttribute::ChangeVector& changes, DocId doc, uint32_t index,
+                                              const StringChangeData& v);
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -36,6 +36,9 @@ public:
     bool update(DocId doc, const std::string& v) {
         return AttributeVector::update(_changes, doc, StringChangeData(v));
     }
+    bool assign_element(DocId doc, uint32_t index, std::string_view v) {
+        return AttributeVector::assign_element(_changes, doc, index, StringChangeData(v));
+    }
     bool apply(DocId doc, const ArithmeticValueUpdate& op);
     bool applyWeight(DocId doc, const FieldValue& fv, const ArithmeticValueUpdate& wAdjust) override;
     bool applyWeight(DocId doc, const FieldValue& fv, const document::AssignValueUpdate& wAdjust) override;


### PR DESCRIPTION
Adds `ASSIGN_ELEMENT` opcode to change vector and `assign_element` API to attribute vector that takes an index and the value to assign at that index.

If the index is outside the bounds of the vector that we apply changes to, the ASSIGN_ELEMENT op is dropped silently. This is consistent with the document module (see `array_element_update_for_invalid_index_is_ignored` test).

@toregge please review

*AI has assisted in the development of this PR*