### PR TITLE
Add JSON summary output for inspect profile

### DIFF
--- a/client/go/internal/cli/cmd/inspect.go
+++ b/client/go/internal/cli/cmd/inspect.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,8 @@ import (
 
 type inspectProfileOptions struct {
 	profileFile         string
+	format              string
+	outputFile          string
 	showMedianNode      bool
 	showDispatchedQuery bool
 	showNnsDetails      bool
@@ -63,7 +66,33 @@ func inspectProfile(cli *CLI, opts *inspectProfileOptions) error {
 	if len(opts.showQueryNodes) > 0 {
 		context.ShowQueryNodes(opts.showQueryNodes)
 	}
-	return context.Analyze(cli.Stdout)
+
+	switch opts.format {
+	case "human", "json":
+	default:
+		return fmt.Errorf("invalid format: %s", opts.format)
+	}
+
+	out := cli.Stdout
+	var f *os.File
+	if opts.outputFile != "" {
+		var err error
+		f, err = os.Create(opts.outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file '%s': %w", opts.outputFile, err)
+		}
+		defer f.Close()
+		out = f
+	}
+	switch opts.format {
+	case "human":
+		return context.Analyze(out)
+	case "json":
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(context.Summary())
+	}
+	return nil
 }
 
 func newInspectProfileCmd(cli *CLI) *cobra.Command {
@@ -80,6 +109,8 @@ func newInspectProfileCmd(cli *CLI) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.profileFile, "profile-file", "f", "vespa_query_profile_result.json", "Name of the profile file to inspect. Use '-' for stdin.")
+	cmd.Flags().StringVar(&opts.format, "format", "human", "Output format. Must be 'human' or 'json'")
+	cmd.Flags().StringVarP(&opts.outputFile, "output", "o", "", "Write output to a file instead of stdout")
 	cmd.Flags().BoolVar(&opts.showMedianNode, "show-median-node", false, "Show median node analysis")
 	cmd.Flags().BoolVar(&opts.showDispatchedQuery, "show-dispatched-query", false, "Show query sent to search nodes")
 	cmd.Flags().BoolVar(&opts.showNnsDetails, "show-nns-details", false, "Show more details related to nearest neighbor search")

--- a/client/go/internal/cli/cmd/inspect_test.go
+++ b/client/go/internal/cli/cmd/inspect_test.go
@@ -1,0 +1,69 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeProfileResult(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profile.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "timing": {
+    "querytime": 0.5,
+    "summaryfetchtime": 0.25,
+    "searchtime": 1.0
+  }
+}`), 0o600))
+	return path
+}
+
+func TestInspectProfileJSONFormat(t *testing.T) {
+	cli, stdout, stderr := newTestCLI(t)
+
+	assert.NoError(t, cli.Run("inspect", "profile", "--profile-file", writeProfileResult(t), "--format", "json"))
+	assert.Equal(t, "", stderr.String())
+
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	assert.Equal(t, float64(1), output["schemaVersion"])
+	timing := output["timing"].(map[string]any)
+	assert.Equal(t, float64(1000), timing["totalMs"])
+	assert.Equal(t, float64(500), timing["queryMs"])
+	assert.Equal(t, float64(250), timing["summaryMs"])
+	assert.Equal(t, float64(250), timing["otherMs"])
+}
+
+func TestInspectProfileJSONOutputFile(t *testing.T) {
+	cli, stdout, stderr := newTestCLI(t)
+	outputPath := filepath.Join(t.TempDir(), "summary.json")
+
+	assert.NoError(t, cli.Run("inspect", "profile", "--profile-file", writeProfileResult(t), "--format", "json", "--output", outputPath))
+	assert.Equal(t, "", stderr.String())
+	assert.Equal(t, "", stdout.String())
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(content, &output))
+	assert.Equal(t, float64(1), output["schemaVersion"])
+}
+
+func TestInspectProfileInvalidFormatDoesNotTruncateOutputFile(t *testing.T) {
+	cli, _, _ := newTestCLI(t)
+	outputPath := filepath.Join(t.TempDir(), "summary.json")
+	require.NoError(t, os.WriteFile(outputPath, []byte("keep me"), 0o600))
+
+	assert.Error(t, cli.Run("inspect", "profile", "--profile-file", writeProfileResult(t), "--format", "jsn", "--output", outputPath))
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "keep me", string(content))
+}

--- a/client/go/internal/vespa/tracedoctor/summary.go
+++ b/client/go/internal/vespa/tracedoctor/summary.go
@@ -1,0 +1,120 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package tracedoctor
+
+const profileSummarySchemaVersion = 1
+const profileSummaryTopComponents = 10
+
+// ProfileSummary is a stable, machine-readable summary of the profile data
+// analyzed by tracedoctor. It intentionally does not expose the full trace tree.
+type ProfileSummary struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	Timing        ProfileTiming   `json:"timing"`
+	Searches      []SearchSummary `json:"searches,omitempty"`
+	Warnings      []string        `json:"warnings,omitempty"`
+}
+
+// ProfileTiming summarizes the top-level timing reported by the query result.
+type ProfileTiming struct {
+	TotalMs   float64 `json:"totalMs"`
+	QueryMs   float64 `json:"queryMs"`
+	SummaryMs float64 `json:"summaryMs"`
+	OtherMs   float64 `json:"otherMs"`
+}
+
+// SearchSummary summarizes one dispatched search across its backend nodes.
+type SearchSummary struct {
+	ID            int           `json:"id"`
+	DocumentType  string        `json:"documentType,omitempty"`
+	Nodes         int           `json:"nodes"`
+	BackendTimeMs float64       `json:"backendTimeMs"`
+	NodeSummaries []NodeSummary `json:"nodeSummaries,omitempty"`
+}
+
+// NodeSummary summarizes the most useful profile information for one backend node.
+type NodeSummary struct {
+	Name                     string             `json:"name"`
+	DurationMs               float64            `json:"durationMs"`
+	Tasks                    ProfileTasks       `json:"tasks"`
+	TopFirstPhaseComponents  []ProfileComponent `json:"topFirstPhaseComponents,omitempty"`
+	TopSecondPhaseComponents []ProfileComponent `json:"topSecondPhaseComponents,omitempty"`
+}
+
+// ProfileTasks contains the node-level task timings extracted by tracedoctor.
+type ProfileTasks struct {
+	GlobalFilterMs float64 `json:"globalFilterMs"`
+	AnnSetupMs     float64 `json:"annSetupMs"`
+	MatchingMs     float64 `json:"matchingMs"`
+	FirstPhaseMs   float64 `json:"firstPhaseMs"`
+	SecondPhaseMs  float64 `json:"secondPhaseMs"`
+}
+
+// ProfileComponent contains accumulated self time for a profiled rank component or function.
+type ProfileComponent struct {
+	Name       string  `json:"name"`
+	Count      int64   `json:"count"`
+	SelfTimeMs float64 `json:"selfTimeMs"`
+}
+
+// Summary returns a compact machine-readable profile summary.
+func (ctx *Context) Summary() ProfileSummary {
+	summary := ProfileSummary{
+		SchemaVersion: profileSummarySchemaVersion,
+	}
+	if ctx.timing != nil {
+		summary.Timing = ProfileTiming{
+			TotalMs:   ctx.timing.totalMs,
+			QueryMs:   ctx.timing.queryMs,
+			SummaryMs: ctx.timing.summaryMs,
+			OtherMs:   ctx.timing.totalMs - ctx.timing.queryMs - ctx.timing.summaryMs,
+		}
+	}
+	for _, group := range groupProtonTraces(findProtonTraces(ctx.root)) {
+		search := SearchSummary{
+			ID:            group.id,
+			DocumentType:  group.documentType(),
+			Nodes:         len(group.traces),
+			BackendTimeMs: group.durationMs(),
+		}
+		for _, trace := range group.traces {
+			search.NodeSummaries = append(search.NodeSummaries, summarizeNode(trace))
+		}
+		summary.Searches = append(summary.Searches, search)
+	}
+	return summary
+}
+
+func summarizeNode(trace protonTrace) NodeSummary {
+	proton := trace.extractSummary()
+	node := NodeSummary{
+		Name:       trace.desc(),
+		DurationMs: trace.durationMs(),
+		Tasks: ProfileTasks{
+			GlobalFilterMs: proton.filterMs,
+			AnnSetupMs:     proton.annMs,
+			MatchingMs:     proton.matchMs,
+			FirstPhaseMs:   proton.firstPhaseMs,
+			SecondPhaseMs:  proton.secondPhaseMs,
+		},
+	}
+	if thread, _ := selectSlowestThread(trace.findThreadTraces()); thread != nil {
+		node.TopFirstPhaseComponents = summarizeComponents(thread.firstPhasePerf())
+		node.TopSecondPhaseComponents = summarizeComponents(thread.secondPhasePerf())
+	}
+	return node
+}
+
+func summarizeComponents(perf *topNPerf) []ProfileComponent {
+	if perf == nil {
+		return nil
+	}
+	var components []ProfileComponent
+	for _, entry := range perf.topN(profileSummaryTopComponents) {
+		components = append(components, ProfileComponent{
+			Name:       entry.name,
+			Count:      entry.count,
+			SelfTimeMs: entry.selfTimeMs,
+		})
+	}
+	return components
+}

--- a/client/go/internal/vespa/tracedoctor/tracedoctor_test.go
+++ b/client/go/internal/vespa/tracedoctor/tracedoctor_test.go
@@ -28,3 +28,82 @@ func TestExtractTiming(t *testing.T) {
 	assert.Equal(t, 250.0, timing.summaryMs)
 	assert.Equal(t, 1000.0, timing.totalMs)
 }
+
+func makeProfileSummaryResult() slime.Value {
+	root := makeExampleResult()
+	root.Set("trace", slime.MakeObject(func(obj slime.Value) {
+		obj.Set("children", slime.MakeArray(func(arr slime.Value) {
+			arr.Add(slime.MakeObject(func(obj slime.Value) {
+				obj.Set("document-type", slime.String("music"))
+				obj.Set("distribution-key", slime.Long(7))
+				obj.Set("duration_ms", slime.Double(123.0))
+				obj.Set("traces", slime.MakeArray(func(arr slime.Value) {
+					arr.Add(slime.MakeObject(func(obj slime.Value) {
+						obj.Set("tag", slime.String("query_execution"))
+						obj.Set("threads", slime.MakeArray(func(arr slime.Value) {
+							arr.Add(slime.MakeObject(func(obj slime.Value) {
+								obj.Set("traces", slime.MakeArray(func(arr slime.Value) {
+									arr.Add(slime.MakeObject(func(obj slime.Value) {
+										obj.Set("tag", slime.String("match_profiling"))
+										obj.Set("total_time_ms", slime.Double(11.0))
+									}))
+									arr.Add(slime.MakeObject(func(obj slime.Value) {
+										obj.Set("tag", slime.String("first_phase_profiling"))
+										obj.Set("total_time_ms", slime.Double(22.0))
+										obj.Set("roots", slime.MakeArray(func(arr slime.Value) {
+											arr.Add(slime.MakeObject(func(obj slime.Value) {
+												obj.Set("name", slime.String("nativeRank(title)"))
+												obj.Set("count", slime.Long(3))
+												obj.Set("self_time_ms", slime.Double(7.5))
+											}))
+										}))
+									}))
+									arr.Add(slime.MakeObject(func(obj slime.Value) {
+										obj.Set("tag", slime.String("second_phase_profiling"))
+										obj.Set("total_time_ms", slime.Double(33.0))
+										obj.Set("roots", slime.MakeArray(func(arr slime.Value) {
+											arr.Add(slime.MakeObject(func(obj slime.Value) {
+												obj.Set("name", slime.String("onnx(model)"))
+												obj.Set("count", slime.Long(2))
+												obj.Set("self_time_ms", slime.Double(9.5))
+											}))
+										}))
+									}))
+								}))
+							}))
+						}))
+					}))
+				}))
+			}))
+		}))
+	}))
+	return root
+}
+
+func TestProfileSummaryExtractsStableTimingAndPhaseData(t *testing.T) {
+	summary := NewContext(makeProfileSummaryResult()).Summary()
+
+	assert.Equal(t, 1, summary.SchemaVersion)
+	assert.Equal(t, 1000.0, summary.Timing.TotalMs)
+	assert.Equal(t, 500.0, summary.Timing.QueryMs)
+	assert.Equal(t, 250.0, summary.Timing.SummaryMs)
+	assert.Equal(t, 250.0, summary.Timing.OtherMs)
+
+	assert.Equal(t, 1, len(summary.Searches))
+	search := summary.Searches[0]
+	assert.Equal(t, 0, search.ID)
+	assert.Equal(t, "music", search.DocumentType)
+	assert.Equal(t, 1, search.Nodes)
+	assert.Equal(t, 123.0, search.BackendTimeMs)
+
+	assert.Equal(t, 1, len(search.NodeSummaries))
+	node := search.NodeSummaries[0]
+	assert.Equal(t, "music[7]", node.Name)
+	assert.Equal(t, 123.0, node.DurationMs)
+	assert.Equal(t, 11.0, node.Tasks.MatchingMs)
+	assert.Equal(t, 22.0, node.Tasks.FirstPhaseMs)
+	assert.Equal(t, 33.0, node.Tasks.SecondPhaseMs)
+
+	assert.Equal(t, []ProfileComponent{{Name: "nativeRank(title)", Count: 3, SelfTimeMs: 7.5}}, node.TopFirstPhaseComponents)
+	assert.Equal(t, []ProfileComponent{{Name: "onnx(model)", Count: 2, SelfTimeMs: 9.5}}, node.TopSecondPhaseComponents)
+}


### PR DESCRIPTION
Fixes #33701

## Summary

- Adds `--format human|json` and `--output/-o` to `vespa inspect profile`.
- Adds a compact `tracedoctor.ProfileSummary` model with `schemaVersion: 1`.
- Exposes the stable timing values already extracted by tracedoctor: top-level query timing, per-search backend time, per-node task timing, and top first/second phase profiled components.

This intentionally does not expose the full dynamic profile/trace tree as a stable API.

## Tests

- `go test ./internal/cli/cmd ./internal/vespa/tracedoctor`
- `go test ./...`
