### PR TITLE
Add nodiscard and noexcept to change vector header, remove dead comparison operators

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/changevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.cpp
@@ -8,7 +8,7 @@ LOG_SETUP(".searchlib.attribute.changevector");
 
 namespace search {
 
-StringChangeData::StringChangeData(std::string s) noexcept : _s(std::move(s)) {
+StringChangeData::StringChangeData(std::string s) : _s(std::move(s)) {
     if (StringAttribute::countZero(_s.data(), _s.size()) > 0) {
         LOG(warning, "StringChangeData(): "
                      "Input string contains <null> byte(s); "

--- a/searchlib/src/vespa/searchlib/attribute/changevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.cpp
@@ -8,7 +8,7 @@ LOG_SETUP(".searchlib.attribute.changevector");
 
 namespace search {
 
-StringChangeData::StringChangeData(std::string s) : _s(std::move(s)) {
+StringChangeData::StringChangeData(std::string s) noexcept : _s(std::move(s)) {
     if (StringAttribute::countZero(_s.data(), _s.size()) > 0) {
         LOG(warning, "StringChangeData(): "
                      "Input string contains <null> byte(s); "

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -68,7 +68,6 @@ public:
     [[nodiscard]] T raw() const noexcept { return _v; }
     operator T() const noexcept { return _v; }
     operator T&() noexcept { return _v; }
-    [[nodiscard]] bool operator<(const NumericChangeData<T>& rhs) const noexcept { return _v < rhs._v; }
 };
 
 class StringChangeData {
@@ -83,7 +82,6 @@ public:
     [[nodiscard]] const char* raw() const noexcept { return _s.c_str(); }
     operator const DataType&() const noexcept { return _s; }
     operator DataType&() noexcept { return _s; }
-    [[nodiscard]] bool operator<(const StringChangeData& rhs) const noexcept { return _s < rhs._s; }
 
 private:
     DataType _s;
@@ -101,17 +99,6 @@ template <typename T> struct ChangeTemplate : public ChangeBase {
 template <>
 inline NumericChangeData<double>::NumericChangeData(double v)
     : _v(attribute::isUndefined<double>(v) ? attribute::getUndefined<double>() : v) {
-}
-
-template <> [[nodiscard]] inline bool
-NumericChangeData<double>::operator<(const NumericChangeData<double>& rhs) const noexcept {
-    if (std::isnan(_v)) {
-        return !std::isnan(rhs._v);
-    }
-    if (std::isnan(rhs._v)) {
-        return false;
-    }
-    return _v < rhs._v;
 }
 
 /**

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -37,15 +37,11 @@ struct ChangeBase {
     ChangeBase(Type type, uint32_t d, int32_t w = 1)
         : _type(type), _doc(d), _weight(w), _element_index(0), _cached_entry_ref(UNSET_ENTRY_REF) {}
 
-    int cmp(const ChangeBase& b) const {
-        int diff(_doc - b._doc);
-        return diff;
-    }
-    bool operator<(const ChangeBase& b) const { return cmp(b) < 0; }
-    uint32_t get_entry_ref() const { return _cached_entry_ref; }
-    void set_entry_ref(uint32_t entry_ref) const { _cached_entry_ref = entry_ref; }
-    bool has_entry_ref() const { return _cached_entry_ref != UNSET_ENTRY_REF; }
-    void clear_entry_ref() const { _cached_entry_ref = UNSET_ENTRY_REF; }
+    [[nodiscard]] bool operator<(const ChangeBase& b) const noexcept { return _doc < b._doc; }
+    [[nodiscard]] uint32_t get_entry_ref() const noexcept { return _cached_entry_ref; }
+    void set_entry_ref(uint32_t entry_ref) const noexcept { _cached_entry_ref = entry_ref; }
+    [[nodiscard]] bool has_entry_ref() const noexcept { return _cached_entry_ref != UNSET_ENTRY_REF; }
+    void clear_entry_ref() const noexcept { _cached_entry_ref = UNSET_ENTRY_REF; }
     [[nodiscard]] uint32_t element_index() const noexcept { return _element_index; }
     void set_element_index(uint32_t index) noexcept { _element_index = index; }
 

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -37,7 +37,6 @@ struct ChangeBase {
     ChangeBase(Type type, uint32_t d, int32_t w = 1)
         : _type(type), _doc(d), _weight(w), _element_index(0), _cached_entry_ref(UNSET_ENTRY_REF) {}
 
-    [[nodiscard]] bool operator<(const ChangeBase& b) const noexcept { return _doc < b._doc; }
     [[nodiscard]] uint32_t get_entry_ref() const noexcept { return _cached_entry_ref; }
     void set_entry_ref(uint32_t entry_ref) const noexcept { _cached_entry_ref = entry_ref; }
     [[nodiscard]] bool has_entry_ref() const noexcept { return _cached_entry_ref != UNSET_ENTRY_REF; }
@@ -63,28 +62,28 @@ public:
     NumericChangeData(T v) : _arithOperand(0), _v(v) {}
     NumericChangeData() : _arithOperand(0), _v(T()) {}
 
-    double getArithOperand() const { return _arithOperand; }
-    void setArithOperand(double operand) { _arithOperand = operand; }
-    T get() const { return _v; }
-    T raw() const { return _v; }
-    operator T() const { return _v; }
-    operator T&() { return _v; }
-    bool operator<(const NumericChangeData<T>& rhs) const { return _v < rhs._v; }
+    [[nodiscard]] double getArithOperand() const noexcept { return _arithOperand; }
+    void setArithOperand(double operand) noexcept { _arithOperand = operand; }
+    [[nodiscard]] T get() const noexcept { return _v; }
+    [[nodiscard]] T raw() const noexcept { return _v; }
+    operator T() const noexcept { return _v; }
+    operator T&() noexcept { return _v; }
+    [[nodiscard]] bool operator<(const NumericChangeData<T>& rhs) const noexcept { return _v < rhs._v; }
 };
 
 class StringChangeData {
 public:
     using DataType = std::string;
 
-    StringChangeData(std::string_view s) noexcept : StringChangeData(DataType(s)) {}
-    StringChangeData(DataType s) noexcept;
+    StringChangeData(std::string_view s) : StringChangeData(DataType(s)) {}
+    StringChangeData(DataType s);
     StringChangeData() noexcept : _s() {}
 
-    const DataType& get() const { return _s; }
-    const char* raw() const { return _s.c_str(); }
-    operator const DataType&() const { return _s; }
-    operator DataType&() { return _s; }
-    bool operator<(const StringChangeData& rhs) const { return _s < rhs._s; }
+    [[nodiscard]] const DataType& get() const noexcept { return _s; }
+    [[nodiscard]] const char* raw() const noexcept { return _s.c_str(); }
+    operator const DataType&() const noexcept { return _s; }
+    operator DataType&() noexcept { return _s; }
+    [[nodiscard]] bool operator<(const StringChangeData& rhs) const noexcept { return _s < rhs._s; }
 
 private:
     DataType _s;
@@ -104,7 +103,8 @@ inline NumericChangeData<double>::NumericChangeData(double v)
     : _v(attribute::isUndefined<double>(v) ? attribute::getUndefined<double>() : v) {
 }
 
-template <> inline bool NumericChangeData<double>::operator<(const NumericChangeData<double>& rhs) const {
+template <> [[nodiscard]] inline bool
+NumericChangeData<double>::operator<(const NumericChangeData<double>& rhs) const noexcept {
     if (std::isnan(_v)) {
         return !std::isnan(rhs._v);
     }
@@ -129,16 +129,16 @@ public:
     ~ChangeVectorT();
     void push_back(const T& c);
     template <typename Accessor> void push_back(uint32_t doc, Accessor& ac);
-    T& back() { return _v.back(); }
-    size_t size() const { return _v.size(); }
-    size_t capacity() const { return _v.capacity(); }
-    bool empty() const { return _v.empty(); }
+    [[nodiscard]] T& back() { return _v.back(); }
+    [[nodiscard]] size_t size() const noexcept { return _v.size(); }
+    [[nodiscard]] size_t capacity() const noexcept { return _v.capacity(); }
+    [[nodiscard]] bool empty() const noexcept { return _v.empty(); }
     void clear();
     class InsertOrder {
     public:
         InsertOrder(const Vector& v) : _v(v) {}
-        const_iterator begin() const { return _v.begin(); }
-        const_iterator end() const { return _v.end(); }
+        const_iterator begin() const noexcept { return _v.begin(); }
+        const_iterator end() const noexcept { return _v.end(); }
 
     private:
         const Vector& _v;
@@ -151,8 +151,12 @@ public:
         public:
             const_iterator(const Vector& vector, const AdjacentDocIds& order, uint32_t cur)
                 : _v(&vector), _o(&order), _cur(cur) {}
-            bool operator==(const const_iterator& rhs) const { return _v == rhs._v && _cur == rhs._cur; }
-            bool operator!=(const const_iterator& rhs) const { return _v != rhs._v || _cur != rhs._cur; }
+            [[nodiscard]] bool operator==(const const_iterator& rhs) const noexcept {
+                return _v == rhs._v && _cur == rhs._cur;
+            }
+            [[nodiscard]] bool operator!=(const const_iterator& rhs) const noexcept {
+                return _v != rhs._v || _cur != rhs._cur;
+            }
             const_iterator& operator++() {
                 _cur++;
                 return *this;
@@ -162,8 +166,8 @@ public:
                 _cur++;
                 return other;
             }
-            const T& operator*() const { return v(); }
-            const T* operator->() const { return &v(); }
+            [[nodiscard]] const T& operator*() const { return v(); }
+            [[nodiscard]] const T* operator->() const { return &v(); }
 
         private:
             const T& v() const { return (*_v)[(*_o)[_cur] & 0xffffffff]; }
@@ -172,16 +176,16 @@ public:
             uint32_t              _cur;
         };
         DocIdInsertOrder(const Vector& v);
-        const_iterator begin() const { return const_iterator(_v, _adjacent, 0); }
-        const_iterator end() const { return const_iterator(_v, _adjacent, _v.size()); }
+        const_iterator begin() const noexcept { return const_iterator(_v, _adjacent, 0); }
+        const_iterator end() const noexcept { return const_iterator(_v, _adjacent, _v.size()); }
 
     private:
         const Vector&  _v;
         AdjacentDocIds _adjacent;
     };
-    InsertOrder getInsertOrder() const { return InsertOrder(_v); }
-    DocIdInsertOrder getDocIdInsertOrder() const { return DocIdInsertOrder(_v); }
-    vespalib::MemoryUsage getMemoryUsage() const;
+    [[nodiscard]] InsertOrder getInsertOrder() const noexcept { return InsertOrder(_v); }
+    [[nodiscard]] DocIdInsertOrder getDocIdInsertOrder() const { return DocIdInsertOrder(_v); }
+    [[nodiscard]] vespalib::MemoryUsage getMemoryUsage() const;
 
 private:
     Vector _v;

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -75,7 +75,7 @@ public:
     using DataType = std::string;
 
     StringChangeData(std::string_view s) : StringChangeData(DataType(s)) {}
-    StringChangeData(DataType s);
+    StringChangeData(DataType s) noexcept;
     StringChangeData() noexcept : _s() {}
 
     [[nodiscard]] const DataType& get() const noexcept { return _s; }


### PR DESCRIPTION
Began by adding noexcept and nodiscard to trivial methods in ChangeBase.

Removed the dead `<` operators.

@toregge please review