### PR TITLE
Add support for quantized squared Euclidean distance computations

### DIFF
--- a/vespalib/src/tests/quant/eden_quantizer_test.cpp
+++ b/vespalib/src/tests/quant/eden_quantizer_test.cpp
@@ -49,6 +49,17 @@ namespace {
     return d;
 }
 
+// Simple non-vectorized squared Euclidean distance
+[[nodiscard]] float squared_euclidean_distance(std::span<const float> a, std::span<const float> b) noexcept {
+    assert(a.size() == b.size());
+    float d = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        const float delta = a[i] - b[i];
+        d += delta * delta;
+    }
+    return d;
+}
+
 void normalize(std::span<float> v) noexcept {
     const float norm_recip = 1.f / l2_norm(v);
     for (auto& c : v) {
@@ -309,6 +320,76 @@ TEST(EdenQuantizerTest, can_compute_dot_product_between_quantized_vectors_3_bits
 
 TEST(EdenQuantizerTest, can_compute_dot_product_between_quantized_vectors_4_bits) {
     do_test_quantized_vectors_dot_product(4);
+}
+
+TEST(EdenQuantizerTest, can_compute_squared_euclidean_distance_with_pre_rotated_vector) {
+    EdenQuantizer        q(16, 4, 0xbeefd00d);
+    std::vector<uint8_t> v_q(q.quantized_size());
+
+    const std::vector v = my_16d_test_vector();
+    q.quantize(v, v_q, QuantMode::MSE);
+
+    const std::vector<float> query = {2, 2, 3, -5, 4, 1, 3, -4, 2, -1, 3, 2, -5, 1, 3, 2};
+
+    std::vector query_rot = query;
+    q.rotate_vector_inplace(query_rot);
+
+    const float real_dist = squared_euclidean_distance(query, v);
+    const float quant_dist = q.pre_rotated_query_squared_euclidean_distance(query_rot, v_q);
+    EXPECT_THAT(quant_dist / real_dist, FloatNear(1.0, 0.021)); // ~2% error
+}
+
+namespace {
+
+void do_test_quantized_vectors_squared_euclidean_distance(const size_t dimensions, const uint8_t bits) {
+    Xoshiro256PlusPlusPrng prng(0x123456789abcdef); // Fixed seed due to floating point testing
+    EdenQuantizer          q(dimensions, bits, prng());
+
+    std::vector<float>   lhs(dimensions), lhs_dq(dimensions);
+    std::vector<float>   rhs(dimensions), rhs_dq(dimensions);
+    std::vector<uint8_t> lhs_q(q.quantized_size());
+    std::vector<uint8_t> rhs_q(q.quantized_size());
+
+    const size_t rounds = 100;
+    for (size_t i = 0; i < rounds; ++i) {
+        fill_random(lhs, prng);
+        fill_random(rhs, prng);
+
+        q.quantize(lhs, lhs_q, QuantMode::MSE);
+        q.quantize(rhs, rhs_q, QuantMode::MSE);
+        q.dequantize(lhs_q, lhs_dq);
+        q.dequantize(rhs_q, rhs_dq);
+
+        const float real_q_eqd = squared_euclidean_distance(lhs_dq, rhs_dq);
+        ASSERT_NE(real_q_eqd, 0.0); // it could theoretically happen...
+        const float q_eqd = q.quantized_lhs_rhs_squared_euclidean_distance(lhs_q, rhs_q);
+        // Normalize for magnitude by computing relative error
+        ASSERT_THAT(q_eqd / real_q_eqd, FloatNear(1.0, 0.00005f));
+    }
+}
+
+void do_test_quantized_vectors_squared_euclidean_distance(const uint8_t bits) {
+    for (size_t dims : {1, 2, 3, 15, 16, 17, 64, 127, 128, 129, 1024}) {
+        ASSERT_NO_FATAL_FAILURE(do_test_quantized_vectors_squared_euclidean_distance(dims, bits));
+    }
+}
+
+} // namespace
+
+TEST(EdenQuantizerTest, can_compute_squared_euclidean_distance_between_quantized_vectors_1_bit) {
+    do_test_quantized_vectors_squared_euclidean_distance(1);
+}
+
+TEST(EdenQuantizerTest, can_compute_squared_euclidean_distance_between_quantized_vectors_2_bits) {
+    do_test_quantized_vectors_squared_euclidean_distance(2);
+}
+
+TEST(EdenQuantizerTest, can_compute_squared_euclidean_distance_between_quantized_vectors_3_bits) {
+    do_test_quantized_vectors_squared_euclidean_distance(3);
+}
+
+TEST(EdenQuantizerTest, can_compute_squared_euclidean_distance_between_quantized_vectors_4_bits) {
+    do_test_quantized_vectors_squared_euclidean_distance(4);
 }
 
 } // namespace vespalib::quant

--- a/vespalib/src/tests/quant/quant_benchmarks.cpp
+++ b/vespalib/src/tests/quant/quant_benchmarks.cpp
@@ -98,6 +98,28 @@ void BM_pre_rotated_dot_product(benchmark::State& state, Args&&... args) {
     }
 }
 
+// Pre-rotated full precision vector vs. quantized vector squared Euclidean distance with args <bits, dimensions>
+template <typename... Args>
+void BM_pre_rotated_squared_euclidean_distance(benchmark::State& state, Args&&... args) {
+    const auto    my_args = std::make_tuple(std::move(args)...);
+    const uint8_t bits = std::get<0>(my_args);
+    const size_t  dims = state.range();
+
+    Xoshiro256PlusPlusPrng prng(gen_true_random());
+    EdenQuantizer          quant(dims, bits, prng());
+    std::vector<float>     v(dims);
+    std::vector<uint8_t>   q_v(quant.quantized_size());
+    fill_random(v, prng);
+
+    quant.quantize(v, q_v, QuantMode::MSE);
+    quant.rotate_vector_inplace(v);
+
+    for (auto _ : state) {
+        float dist = quant.pre_rotated_query_squared_euclidean_distance(v, q_v);
+        benchmark::DoNotOptimize(dist);
+    }
+}
+
 // TODO benchmark non-power of 2 sizes
 
 BENCHMARK_CAPTURE(BM_quantize, 1_bit_mse, 1, QuantMode::MSE)->Range(8, 8192);
@@ -119,6 +141,11 @@ BENCHMARK_CAPTURE(BM_pre_rotated_dot_product, 1_bit, 1)->Range(8, 8192);
 BENCHMARK_CAPTURE(BM_pre_rotated_dot_product, 2_bits, 2)->Range(8, 8192);
 BENCHMARK_CAPTURE(BM_pre_rotated_dot_product, 3_bits, 3)->Range(8, 8192);
 BENCHMARK_CAPTURE(BM_pre_rotated_dot_product, 4_bits, 4)->Range(8, 8192);
+
+BENCHMARK_CAPTURE(BM_pre_rotated_squared_euclidean_distance, 1_bit, 1)->Range(8, 8192);
+BENCHMARK_CAPTURE(BM_pre_rotated_squared_euclidean_distance, 2_bits, 2)->Range(8, 8192);
+BENCHMARK_CAPTURE(BM_pre_rotated_squared_euclidean_distance, 3_bits, 3)->Range(8, 8192);
+BENCHMARK_CAPTURE(BM_pre_rotated_squared_euclidean_distance, 4_bits, 4)->Range(8, 8192);
 
 } // namespace vespalib::quant
 

--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -56,6 +56,34 @@ std::span<const float> EdenQuantizer::my_codebook() const noexcept {
     return {codebooks::unit_norm_centroids_f32[_bits - 1], 1u << _bits};
 }
 
+EdenQuantizer::ScaleAndCentroidsPtr
+EdenQuantizer::unary_unpack_bits_to_scratch_space(std::span<const uint8_t> buf) noexcept {
+    assert(buf.size() == _quantized_size);
+    const float scale = extract_scale_factor(buf.data());
+    with_packer_for_bit_count(_bits, [&](auto bp) {
+        const uint8_t* in_bits = buf.data() + sizeof(float);
+        decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
+    });
+    return {scale, _idx_tmp.data()};
+}
+
+std::pair<EdenQuantizer::ScaleAndCentroidsPtr, EdenQuantizer::ScaleAndCentroidsPtr>
+EdenQuantizer::binary_unpack_bits_to_scratch_space(std::span<const uint8_t> lhs,
+                                                   std::span<const uint8_t> rhs) noexcept {
+    assert(lhs.size() == _quantized_size);
+    assert(rhs.size() == _quantized_size);
+    // We have left room for an additional vector bit unpacking run in _idx_tmp
+    uint8_t* lhs_idx = _idx_tmp.data();
+    uint8_t* rhs_idx = _idx_tmp.data() + _dimensions;
+    with_packer_for_bit_count(_bits, [&](auto bp) {
+        decltype(bp)::unpack(lhs_idx, lhs.data() + sizeof(float), _dimensions);
+        decltype(bp)::unpack(rhs_idx, rhs.data() + sizeof(float), _dimensions);
+    });
+    const float lhs_scale = extract_scale_factor(lhs.data());
+    const float rhs_scale = extract_scale_factor(rhs.data());
+    return {{lhs_scale, lhs_idx}, {rhs_scale, rhs_idx}};
+}
+
 // Note for quantize() and dequantize(): the algorithm implementations try to closely
 // follow the pseudocode outlined in [1], with some additional normalization factor
 // details from [0].
@@ -129,16 +157,11 @@ void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, c
 }
 
 void EdenQuantizer::dequantize(std::span<const uint8_t> q_x, std::span<float> dq_x) noexcept {
-    assert(q_x.size() == _quantized_size);
     assert(dq_x.size() == _dimensions);
-    const float scale = extract_scale_factor(q_x.data());
-    with_packer_for_bit_count(_bits, [&](auto bp) {
-        const uint8_t* in_bits = q_x.data() + sizeof(float);
-        decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
-    });
+    const auto [scale, centroid_idx] = unary_unpack_bits_to_scratch_space(q_x);
     const auto codebook = my_codebook();
     for (size_t i = 0; i < _dimensions; ++i) {
-        dq_x[i] = codebook[_idx_tmp[i]] * scale;
+        dq_x[i] = codebook[centroid_idx[i]] * scale;
     }
     _rotator.rotate_inverse(dq_x);
 }
@@ -151,43 +174,55 @@ void EdenQuantizer::rotate_vector_inplace(std::span<float> vec) const noexcept {
 float EdenQuantizer::pre_rotated_query_dot_product(std::span<const float>   query,
                                                    std::span<const uint8_t> quant_vec) noexcept {
     assert(query.size() == _dimensions);
-    assert(quant_vec.size() == _quantized_size);
-    const float scale = extract_scale_factor(quant_vec.data());
-    with_packer_for_bit_count(_bits, [&](auto bp) {
-        const uint8_t* in_bits = quant_vec.data() + sizeof(float);
-        decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
-    });
+    const auto [scale, centroid_idx] = unary_unpack_bits_to_scratch_space(quant_vec);
     const auto codebook = my_codebook();
     // Taunt the auto-vectorizer by explicitly running parallel fp accumulators.
     // 8x is only slightly faster than 4x (on M3 AArch64), but 4x is by itself ~4x
     // faster than the naive scalar loop version.
     // clang-format off: lambda formatting
     return scale * sum_indexed_unrolled<8, float>(_dimensions, [&](size_t idx) noexcept {
-        return query[idx] * codebook[_idx_tmp[idx]];
+        return query[idx] * codebook[centroid_idx[idx]];
     });
     // clang-format on
 }
 
 float EdenQuantizer::quantized_lhs_rhs_dot_product(std::span<const uint8_t> lhs,
                                                    std::span<const uint8_t> rhs) noexcept {
-    assert(lhs.size() == _quantized_size);
-    assert(rhs.size() == _quantized_size);
-    // We have left room for an additional vector bit unpacking run in _idx_tmp
-    uint8_t* lhs_idx = _idx_tmp.data();
-    uint8_t* rhs_idx = _idx_tmp.data() + _dimensions;
-    with_packer_for_bit_count(_bits, [&](auto bp) {
-        decltype(bp)::unpack(lhs_idx, lhs.data() + sizeof(float), _dimensions);
-        decltype(bp)::unpack(rhs_idx, rhs.data() + sizeof(float), _dimensions);
-    });
+    const auto [lhs_unp, rhs_unp] = binary_unpack_bits_to_scratch_space(lhs, rhs);
     const auto codebook = my_codebook();
     // clang-format off: lambda formatting
     const float dot = sum_indexed_unrolled<8, float>(_dimensions, [&](size_t idx) noexcept {
-        return codebook[lhs_idx[idx]] * codebook[rhs_idx[idx]];
+        return codebook[lhs_unp.centroid_idx[idx]] * codebook[rhs_unp.centroid_idx[idx]];
     });
     // clang-format on
-    const float lhs_scale = extract_scale_factor(lhs.data());
-    const float rhs_scale = extract_scale_factor(rhs.data());
-    return lhs_scale * rhs_scale * dot;
+    return lhs_unp.scale * rhs_unp.scale * dot;
+}
+
+// TODO is there a way we can use the fact that squared Euclidean distance == 2*(1 - dot(x, y)) when
+//  x and y are both _unit length_? Raw index-to-centroid vectors are not unit-length, and the scale
+//  factor subsumes both magnitude and normal distribution "fitting" for dimensionality...
+
+float EdenQuantizer::pre_rotated_query_squared_euclidean_distance(std::span<const float>   query,
+                                                                  std::span<const uint8_t> quant_vec) noexcept {
+    assert(query.size() == _dimensions);
+    const auto [scale, centroid_idx] = unary_unpack_bits_to_scratch_space(quant_vec);
+    const auto codebook = my_codebook();
+    return sum_indexed_unrolled<8, float>(_dimensions, [&](size_t idx) noexcept {
+        const float d = query[idx] - (codebook[centroid_idx[idx]] * scale);
+        return d * d;
+    });
+}
+
+float EdenQuantizer::quantized_lhs_rhs_squared_euclidean_distance(std::span<const uint8_t> lhs,
+                                                                  std::span<const uint8_t> rhs) noexcept {
+    const auto [lhs_unp, rhs_unp] = binary_unpack_bits_to_scratch_space(lhs, rhs);
+    const auto codebook = my_codebook();
+    return sum_indexed_unrolled<8, float>(_dimensions, [&](const size_t i) noexcept {
+        const float a = codebook[lhs_unp.centroid_idx[i]] * lhs_unp.scale;
+        const float b = codebook[rhs_unp.centroid_idx[i]] * rhs_unp.scale;
+        const float d = a - b;
+        return d * d;
+    });
 }
 
 } // namespace vespalib::quant

--- a/vespalib/src/vespa/vespalib/quant/eden.cpp
+++ b/vespalib/src/vespa/vespalib/quant/eden.cpp
@@ -36,6 +36,17 @@ namespace {
     return scale;
 }
 
+// Given an input ptr `buf` that is at the start of the "raw" quantized buffer, returns
+// an adjusted ptr that points to the first byte of the sequence of quantized bits.
+// Precondition: buf must be valid for at least sizeof(float) bytes
+[[nodiscard]] const uint8_t* packed_bits_buf(const uint8_t* buf) noexcept {
+    return buf + sizeof(float); // Just skip past the scale factor
+}
+
+[[nodiscard]] uint8_t* packed_bits_buf(uint8_t* buf) noexcept {
+    return buf + sizeof(float);
+}
+
 } // namespace
 
 EdenQuantizer::EdenQuantizer(const size_t dimensions, const uint8_t bits, const uint64_t seed)
@@ -56,28 +67,28 @@ std::span<const float> EdenQuantizer::my_codebook() const noexcept {
     return {codebooks::unit_norm_centroids_f32[_bits - 1], 1u << _bits};
 }
 
-EdenQuantizer::ScaleAndCentroidsPtr
+EdenQuantizer::ScaleAndCentroidIndexesPtr
 EdenQuantizer::unary_unpack_bits_to_scratch_space(std::span<const uint8_t> buf) noexcept {
     assert(buf.size() == _quantized_size);
     const float scale = extract_scale_factor(buf.data());
     with_packer_for_bit_count(_bits, [&](auto bp) {
-        const uint8_t* in_bits = buf.data() + sizeof(float);
-        decltype(bp)::unpack(_idx_tmp.data(), in_bits, _dimensions);
+        const uint8_t* in_bits = packed_bits_buf(buf.data());
+        decltype(bp)::unpack(lhs_scratch_idx_space(), in_bits, _dimensions);
     });
-    return {scale, _idx_tmp.data()};
+    return {scale, lhs_scratch_idx_space()};
 }
 
-std::pair<EdenQuantizer::ScaleAndCentroidsPtr, EdenQuantizer::ScaleAndCentroidsPtr>
+std::pair<EdenQuantizer::ScaleAndCentroidIndexesPtr, EdenQuantizer::ScaleAndCentroidIndexesPtr>
 EdenQuantizer::binary_unpack_bits_to_scratch_space(std::span<const uint8_t> lhs,
                                                    std::span<const uint8_t> rhs) noexcept {
     assert(lhs.size() == _quantized_size);
     assert(rhs.size() == _quantized_size);
     // We have left room for an additional vector bit unpacking run in _idx_tmp
-    uint8_t* lhs_idx = _idx_tmp.data();
-    uint8_t* rhs_idx = _idx_tmp.data() + _dimensions;
+    uint8_t* lhs_idx = lhs_scratch_idx_space();
+    uint8_t* rhs_idx = rhs_scratch_idx_space();
     with_packer_for_bit_count(_bits, [&](auto bp) {
-        decltype(bp)::unpack(lhs_idx, lhs.data() + sizeof(float), _dimensions);
-        decltype(bp)::unpack(rhs_idx, rhs.data() + sizeof(float), _dimensions);
+        decltype(bp)::unpack(lhs_idx, packed_bits_buf(lhs.data()), _dimensions);
+        decltype(bp)::unpack(rhs_idx, packed_bits_buf(rhs.data()), _dimensions);
     });
     const float lhs_scale = extract_scale_factor(lhs.data());
     const float rhs_scale = extract_scale_factor(rhs.data());
@@ -128,14 +139,15 @@ void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, c
     // pack), but we maintain a running dot product of it vs. the unquantized (but
     // rotated) vector, which is used to derive a scale factor for both EDEN-biased
     // and EDEN-unbiased.
-    float yq_dot = 0; // <y, q>
-    float scale = 0;
+    float    yq_dot = 0; // <y, q>
+    float    scale = 0;
+    uint8_t* idx_buf = lhs_scratch_idx_space();
     if (quant_mode == QuantMode::InnerProduct) { // EDEN-unbiased
         for (size_t i = 0; i < d; ++i) {
             const uint8_t idx = closest_centroid_index<float>(y[i] * nx, codebook);
             const float   c_i = codebook[idx];
             yq_dot += y[i] * c_i;
-            _idx_tmp[i] = idx;
+            idx_buf[i] = idx;
         }
         scale = x_norm2 / yq_dot;
     } else /* MSE/EDEN-biased */ {
@@ -145,13 +157,13 @@ void EdenQuantizer::quantize(std::span<const float> x, std::span<uint8_t> q_x, c
             const float   c_i = codebook[idx];
             yq_dot += y[i] * c_i;
             q_norm2 += c_i * c_i;
-            _idx_tmp[i] = idx;
+            idx_buf[i] = idx;
         }
         scale = yq_dot / q_norm2;
     }
     with_packer_for_bit_count(_bits, [&](auto bp) {
-        uint8_t* out_bits = q_x.data() + sizeof(float);
-        decltype(bp)::pack(out_bits, _idx_tmp.data(), _dimensions);
+        uint8_t* out_bits = packed_bits_buf(q_x.data());
+        decltype(bp)::pack(out_bits, idx_buf, _dimensions);
     });
     memcpy(q_x.data(), &scale, sizeof(float));
 }
@@ -197,10 +209,6 @@ float EdenQuantizer::quantized_lhs_rhs_dot_product(std::span<const uint8_t> lhs,
     // clang-format on
     return lhs_unp.scale * rhs_unp.scale * dot;
 }
-
-// TODO is there a way we can use the fact that squared Euclidean distance == 2*(1 - dot(x, y)) when
-//  x and y are both _unit length_? Raw index-to-centroid vectors are not unit-length, and the scale
-//  factor subsumes both magnitude and normal distribution "fitting" for dimensionality...
 
 float EdenQuantizer::pre_rotated_query_squared_euclidean_distance(std::span<const float>   query,
                                                                   std::span<const uint8_t> quant_vec) noexcept {

--- a/vespalib/src/vespa/vespalib/quant/eden.h
+++ b/vespalib/src/vespa/vespalib/quant/eden.h
@@ -73,16 +73,23 @@ class EdenQuantizer {
     // Returns the shared, fixed N(0, 1) codebook for the configured quantizer bit count
     [[nodiscard]] std::span<const float> my_codebook() const noexcept;
 
-    struct ScaleAndCentroidsPtr {
+    // We allocate space for 2 vectors worth of centroid index runs. The first run is used for
+    // quantized left hand side arguments, or when there's only a single vector. The second
+    // run is for when we need to unpack a right hand side argument as well.
+    [[nodiscard]] uint8_t* lhs_scratch_idx_space() noexcept { return _idx_tmp.data(); }
+    [[nodiscard]] uint8_t* rhs_scratch_idx_space() noexcept { return _idx_tmp.data() + _dimensions; }
+
+    struct ScaleAndCentroidIndexesPtr {
         float          scale;
         const uint8_t* centroid_idx;
     };
     // Precondition: `bits.size() == quantized_size()`
     // Returns [scale factor, unpacked centroid index ptr]
-    [[nodiscard]] ScaleAndCentroidsPtr unary_unpack_bits_to_scratch_space(std::span<const uint8_t> bits) noexcept;
+    [[nodiscard]] ScaleAndCentroidIndexesPtr
+    unary_unpack_bits_to_scratch_space(std::span<const uint8_t> bits) noexcept;
     // Precondition: `lhs.size() == rhs.size() == quantized_size()`
     // Returns [[lhs scale, lhs unpacked index ptr], [rhs scale, rhs unpacked index ptr]]
-    [[nodiscard]] std::pair<ScaleAndCentroidsPtr, ScaleAndCentroidsPtr>
+    [[nodiscard]] std::pair<ScaleAndCentroidIndexesPtr, ScaleAndCentroidIndexesPtr>
     binary_unpack_bits_to_scratch_space(std::span<const uint8_t> lhs, std::span<const uint8_t> rhs) noexcept;
 
 public:

--- a/vespalib/src/vespa/vespalib/quant/eden.h
+++ b/vespalib/src/vespa/vespalib/quant/eden.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <utility>
 #include <vector>
 
 namespace vespalib::quant {
@@ -71,6 +72,18 @@ class EdenQuantizer {
 
     // Returns the shared, fixed N(0, 1) codebook for the configured quantizer bit count
     [[nodiscard]] std::span<const float> my_codebook() const noexcept;
+
+    struct ScaleAndCentroidsPtr {
+        float          scale;
+        const uint8_t* centroid_idx;
+    };
+    // Precondition: `bits.size() == quantized_size()`
+    // Returns [scale factor, unpacked centroid index ptr]
+    [[nodiscard]] ScaleAndCentroidsPtr unary_unpack_bits_to_scratch_space(std::span<const uint8_t> bits) noexcept;
+    // Precondition: `lhs.size() == rhs.size() == quantized_size()`
+    // Returns [[lhs scale, lhs unpacked index ptr], [rhs scale, rhs unpacked index ptr]]
+    [[nodiscard]] std::pair<ScaleAndCentroidsPtr, ScaleAndCentroidsPtr>
+    binary_unpack_bits_to_scratch_space(std::span<const uint8_t> lhs, std::span<const uint8_t> rhs) noexcept;
 
 public:
     EdenQuantizer(size_t dimensions, uint8_t bits, uint64_t seed);
@@ -163,6 +176,37 @@ public:
      */
     [[nodiscard]] float quantized_lhs_rhs_dot_product(std::span<const uint8_t> lhs,
                                                       std::span<const uint8_t> rhs) noexcept;
+
+    /*
+     * Computes the squared Euclidean distance between a quantized vector and a
+     * _pre-rotated_ query vector. This is much more efficient than doing dequantize()
+     * followed by an explicit float32 squared Euclidean distance computation, as we
+     * don't have to perform any expensive rotations.
+     *
+     * `query` must have had a spin in the `rotate_vector_inplace` function prior to use,
+     * i.e. it must be rotated into the same frame of reference as `quant_vec`.
+     *
+     * TODO determine the best quantization mode for Euclidean distance.
+     *
+     * Preconditions:
+     *  - query.size() == dimensions()
+     *  - quant_vec.size() == quantized_size()
+     */
+    [[nodiscard]] float pre_rotated_query_squared_euclidean_distance(std::span<const float>   query,
+                                                                     std::span<const uint8_t> quant_vec) noexcept;
+
+    /*
+     * Computes the squared Euclidean distance between two quantized vectors that were both
+     * quantized using the (logically) same quantizer as `this`. This is more efficient than
+     * explicitly dequantizing the vectors (and then running a float32 squared Euclidean
+     * distance) since it does not involve any rotations.
+     *
+     * Preconditions:
+     *  - lhs.size() == quantized_size()
+     *  - rhs.size() == quantized_size()
+     */
+    [[nodiscard]] float quantized_lhs_rhs_squared_euclidean_distance(std::span<const uint8_t> lhs,
+                                                                     std::span<const uint8_t> rhs) noexcept;
 };
 
 } // namespace vespalib::quant


### PR DESCRIPTION
@arnej27959 please review

This adds two new distance functions to `EdenQuantizer`, mirroring what we have for quantized dot product computations:

 - Squared Euclidean distance between a pre-rotated `float` vector and a quantized vector.
 - Squared Euclidean distance between two quantized vectors.

Also adds a microbenchmark for pre-rotated vector squared Euclidean distance. Will add microbenchmarks for quantized lhs _and_ rhs at a later point, since that's also missing for the dot product case right now.