### PR TITLE
Add memory-dump element to deployment.xml

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -252,7 +252,7 @@
       "final"
     ],
     "methods" : [
-      "public void <init>(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Tags, java.util.List, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, com.yahoo.config.application.api.DeploymentSpec$RevisionTarget, com.yahoo.config.application.api.DeploymentSpec$RevisionChange, com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout, int, int, int, java.util.List, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags, com.yahoo.config.application.api.Notifications, java.util.List, java.util.Map, com.yahoo.config.application.api.Bcp, java.util.Optional, java.time.Instant)",
+      "public void <init>(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Tags, java.util.List, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, com.yahoo.config.application.api.DeploymentSpec$RevisionTarget, com.yahoo.config.application.api.DeploymentSpec$RevisionChange, com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout, int, int, int, java.util.List, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags, java.util.Optional, com.yahoo.config.application.api.Notifications, java.util.List, java.util.Map, com.yahoo.config.application.api.Bcp, java.util.Optional, java.time.Instant)",
       "public com.yahoo.config.provision.InstanceName name()",
       "public com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy upgradePolicy()",
       "public com.yahoo.config.application.api.DeploymentSpec$RevisionTarget revisionTarget()",
@@ -269,6 +269,7 @@
       "public java.util.Map cloudAccounts(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags()",
       "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
+      "public java.util.Optional heapDumpRedaction()",
       "public java.util.Optional hostTTL(com.yahoo.config.provision.Environment, java.util.Optional)",
       "public com.yahoo.config.application.api.Notifications notifications()",
       "public java.util.List endpoints()",
@@ -554,7 +555,7 @@
       "final"
     ],
     "methods" : [
-      "public void <init>(java.util.List, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags, java.util.List, java.lang.String, java.util.List, com.yahoo.config.application.api.DeploymentSpec$DevSpec)",
+      "public void <init>(java.util.List, java.util.Optional, java.util.Optional, java.util.Optional, java.util.Map, java.util.Optional, com.yahoo.config.provision.CloudResourceTags, java.util.Optional, java.util.List, java.lang.String, java.util.List, com.yahoo.config.application.api.DeploymentSpec$DevSpec)",
       "public boolean isEmpty()",
       "public java.util.Optional majorVersion()",
       "public java.util.List steps()",
@@ -566,6 +567,8 @@
       "public java.util.Map cloudAccounts()",
       "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags()",
       "public com.yahoo.config.provision.CloudResourceTags cloudResourceTags(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.zone.ZoneId)",
+      "public java.util.Optional heapDumpRedaction()",
+      "public com.yahoo.config.provision.HeapDumpRedaction heapDumpRedaction(com.yahoo.config.provision.InstanceName)",
       "public com.yahoo.config.provision.Tags tags(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment)",
       "public java.util.Optional hostTTL(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
       "public com.yahoo.config.provision.ZoneEndpoint zoneEndpoint(com.yahoo.config.provision.InstanceName, com.yahoo.config.provision.Zone, com.yahoo.config.provision.ClusterSpec$Id, boolean)",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.HeapDumpRedaction;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Tags;
@@ -62,6 +63,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
     private final Map<CloudName, CloudAccount> cloudAccounts;
     private final Optional<Duration> hostTTL;
     private final CloudResourceTags cloudResourceTags;
+    private final Optional<HeapDumpRedaction> heapDumpRedaction;
     private final Notifications notifications;
     private final List<Endpoint> endpoints;
     private final Map<ClusterSpec.Id, Map<ZoneId, ZoneEndpoint>> zoneEndpoints;
@@ -81,6 +83,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
                                   Map<CloudName, CloudAccount> cloudAccounts,
                                   Optional<Duration> hostTTL,
                                   CloudResourceTags cloudResourceTags,
+                                  Optional<HeapDumpRedaction> heapDumpRedaction,
                                   Notifications notifications,
                                   List<Endpoint> endpoints,
                                   Map<ClusterSpec.Id, Map<ZoneId, ZoneEndpoint>> zoneEndpoints,
@@ -106,6 +109,7 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
         this.cloudAccounts = Map.copyOf(cloudAccounts);
         this.hostTTL = Objects.requireNonNull(hostTTL);
         this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
+        this.heapDumpRedaction = Objects.requireNonNull(heapDumpRedaction);
         this.notifications = Objects.requireNonNull(notifications);
         this.endpoints = List.copyOf(Objects.requireNonNull(endpoints));
         Map<ClusterSpec.Id, Map<ZoneId, ZoneEndpoint>> zoneEndpointsCopy =  new HashMap<>();
@@ -290,6 +294,9 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
                                             .orElse(CloudResourceTags.empty());
         return cloudResourceTags.mergedWith(zoneTags);
     }
+
+    /** Returns the heap dump redaction level set on this instance, if any. */
+    public Optional<HeapDumpRedaction> heapDumpRedaction() { return heapDumpRedaction; }
 
     /** Returns the host TTL to use for given environment and region, if any */
     public Optional<Duration> hostTTL(Environment environment, Optional<RegionName> region) {

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.HeapDumpRedaction;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Tags;
@@ -57,6 +58,7 @@ public final class DeploymentSpec {
                                                                   Map.of(),
                                                                   Optional.empty(),
                                                                   CloudResourceTags.empty(),
+                                                                  Optional.empty(),
                                                                   List.of(),
                                                                   "<deployment version='1.0'/>",
                                                                   List.of(),
@@ -71,6 +73,7 @@ public final class DeploymentSpec {
     private final Map<CloudName, CloudAccount> cloudAccounts;
     private final Optional<Duration> hostTTL;
     private final CloudResourceTags cloudResourceTags;
+    private final Optional<HeapDumpRedaction> heapDumpRedaction;
     private final List<Endpoint> endpoints;
     private final List<DeprecatedElement> deprecatedElements;
     private final DevSpec devSpec;
@@ -84,6 +87,7 @@ public final class DeploymentSpec {
                           Map<CloudName, CloudAccount> cloudAccounts,
                           Optional<Duration> hostTTL,
                           CloudResourceTags cloudResourceTags,
+                          Optional<HeapDumpRedaction> heapDumpRedaction,
                           List<Endpoint> endpoints,
                           String xmlForm,
                           List<DeprecatedElement> deprecatedElements,
@@ -95,6 +99,7 @@ public final class DeploymentSpec {
         this.cloudAccounts = Map.copyOf(cloudAccounts);
         this.hostTTL = Objects.requireNonNull(hostTTL);
         this.cloudResourceTags = Objects.requireNonNull(cloudResourceTags);
+        this.heapDumpRedaction = Objects.requireNonNull(heapDumpRedaction);
         this.xmlForm = Objects.requireNonNull(xmlForm);
         this.endpoints = List.copyOf(Objects.requireNonNull(endpoints));
         this.deprecatedElements = List.copyOf(Objects.requireNonNull(deprecatedElements));
@@ -238,6 +243,16 @@ public final class DeploymentSpec {
                 : instance(instance).map(spec -> spec.cloudResourceTags(zone.environment(), zone.region()))
                                     .orElse(CloudResourceTags.empty());
         return cloudResourceTags.mergedWith(specificTags);
+    }
+
+    /** Returns the heap dump redaction level set on the root tag, if any. */
+    public Optional<HeapDumpRedaction> heapDumpRedaction() { return heapDumpRedaction; }
+
+    /** The most specific heap dump redaction level for the given instance. Instance level takes precedence over root. */
+    public HeapDumpRedaction heapDumpRedaction(InstanceName instance) {
+        return instance(instance).flatMap(DeploymentInstanceSpec::heapDumpRedaction)
+                                 .or(this::heapDumpRedaction)
+                                 .orElse(HeapDumpRedaction.none);
     }
 
     public Tags tags(InstanceName instance, Environment environment) {

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -31,6 +31,7 @@ import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.HeapDumpRedaction;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Tags;
@@ -101,6 +102,8 @@ public class DeploymentSpecXmlReader {
     private static final String cloudAccountAttribute = "cloud-account";
     private static final String hostTTLAttribute = "empty-host-ttl";
     private static final String cloudResourceTagsTag = "resource-tags";
+    private static final String memoryDumpTag = "memory-dump";
+    private static final String heapDumpRedactionAttribute = "heap-dump-redaction";
     private static final String availabilityZoneTag = "availability-zone";
     private static final String skipAttribute = "skip"; // Undocumented on purpose
 
@@ -177,6 +180,7 @@ public class DeploymentSpecXmlReader {
                                   readCloudAccounts(root),
                                   readHostTTL(root),
                                   readCloudResourceTags(root),
+                                  readHeapDumpRedaction(root),
                                   applicationEndpoints,
                                   xmlForm,
                                   deprecatedElements,
@@ -220,6 +224,7 @@ public class DeploymentSpecXmlReader {
         Map<CloudName, CloudAccount> cloudAccounts = readCloudAccounts(instanceElement);
         Optional<Duration> hostTTL = readHostTTL(instanceElement);
         CloudResourceTags cloudResourceTags = readCloudResourceTags(instanceElement);
+        Optional<HeapDumpRedaction> heapDumpRedaction = readHeapDumpRedaction(instanceElement);
         Notifications notifications = readNotifications(instanceElement, parentTag);
 
         // Values where there is no default
@@ -250,6 +255,7 @@ public class DeploymentSpecXmlReader {
                                                              cloudAccounts,
                                                              hostTTL,
                                                              cloudResourceTags,
+                                                             heapDumpRedaction,
                                                              notifications,
                                                              endpoints,
                                                              zoneEndpoints,
@@ -781,6 +787,20 @@ public class DeploymentSpecXmlReader {
                     return CloudResourceTags.from(tags);
                 })
                 .orElse(CloudResourceTags.empty());
+    }
+
+    private Optional<HeapDumpRedaction> readHeapDumpRedaction(Element parent) {
+        Element memoryDumpElement = XML.getChild(parent, memoryDumpTag);
+        if (memoryDumpElement == null) return Optional.empty();
+
+        String value = requireStringAttribute(heapDumpRedactionAttribute, memoryDumpElement);
+        return Optional.of(switch (value) {
+            case "none" -> HeapDumpRedaction.none;
+            case "basic" -> HeapDumpRedaction.basic;
+            case "full" -> HeapDumpRedaction.full;
+            default -> throw new IllegalArgumentException("Illegal " + heapDumpRedactionAttribute + " '" + value +
+                                                          "': Must be one of 'none', 'basic', 'full'");
+        });
     }
 
     private List<DeploymentSpec.ChangeBlocker> readChangeBlockers(Element parent, Element globalBlockersParent) {

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.CloudResourceTags;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.HeapDumpRedaction;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Tags;
@@ -2404,6 +2405,113 @@ public class DeploymentSpecTest {
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         assertEquals("${environment}", spec.cloudResourceTags().asMap().get("env"));
         assertEquals("prefix-${region}", spec.cloudResourceTags().asMap().get("location"));
+    }
+
+    @Test
+    public void memoryDumpAtRootLevel() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <memory-dump heap-dump-redaction='basic'/>
+                    <instance id='default'>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                </deployment>
+                """;
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        assertEquals(Optional.of(HeapDumpRedaction.basic), spec.heapDumpRedaction());
+        assertEquals(HeapDumpRedaction.basic, spec.heapDumpRedaction(InstanceName.from("default")));
+        // The root level also applies to instances not declared in the spec (e.g. manually deployed instances)
+        assertEquals(HeapDumpRedaction.basic, spec.heapDumpRedaction(InstanceName.from("unknown")));
+    }
+
+    @Test
+    public void memoryDumpAtInstanceLevelOverridesRoot() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <memory-dump heap-dump-redaction='basic'/>
+                    <instance id='alpha'>
+                        <memory-dump heap-dump-redaction='full'/>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                    <instance id='beta'>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                    <instance id='gamma'>
+                        <memory-dump heap-dump-redaction='none'/>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                </deployment>
+                """;
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        assertEquals(HeapDumpRedaction.full, spec.heapDumpRedaction(InstanceName.from("alpha")));
+        assertEquals(HeapDumpRedaction.basic, spec.heapDumpRedaction(InstanceName.from("beta")));
+        // Explicit none at instance level opts out of a root-level default
+        assertEquals(HeapDumpRedaction.none, spec.heapDumpRedaction(InstanceName.from("gamma")));
+    }
+
+    @Test
+    public void memoryDumpInImplicitInstance() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <memory-dump heap-dump-redaction='full'/>
+                    <prod>
+                        <region>us-east-1</region>
+                    </prod>
+                </deployment>
+                """;
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        assertEquals(HeapDumpRedaction.full, spec.heapDumpRedaction(InstanceName.from("default")));
+    }
+
+    @Test
+    public void memoryDumpDefaultsToNone() {
+        String r = "<deployment version='1.0'><instance id='default'><prod><region>us-east-1</region></prod></instance></deployment>";
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        assertEquals(Optional.empty(), spec.heapDumpRedaction());
+        assertEquals(HeapDumpRedaction.none, spec.heapDumpRedaction(InstanceName.from("default")));
+    }
+
+    @Test
+    public void memoryDumpWithUnknownRedactionLevelRejected() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <memory-dump heap-dump-redaction='everything'/>
+                    <instance id='default'>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                </deployment>
+                """;
+        assertInvalid(r, "Illegal heap-dump-redaction 'everything'");
+    }
+
+    @Test
+    public void memoryDumpWithMissingRedactionAttributeRejected() {
+        String r =
+                """
+                <deployment version='1.0'>
+                    <memory-dump/>
+                    <instance id='default'>
+                        <prod>
+                            <region>us-east-1</region>
+                        </prod>
+                    </instance>
+                </deployment>
+                """;
+        assertInvalid(r, "Missing required attribute 'heap-dump-redaction'");
     }
 
     private void assertCloudResourceTags(Map<String, String> expected, DeploymentSpec spec,

--- a/config-model/src/main/resources/schema/deployment.rnc
+++ b/config-model/src/main/resources/schema/deployment.rnc
@@ -12,6 +12,7 @@ start = element deployment {
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
    CloudResourceTags? &
+   MemoryDump? &
    Step &
    Dev?
 }
@@ -45,6 +46,7 @@ Instance = element instance {
    attribute cloud-account { xsd:string }? &
    attribute empty-host-ttl { xsd:string }? &
    CloudResourceTags? &
+   MemoryDump? &
    StepExceptInstance
 }
 
@@ -222,6 +224,10 @@ MemberRegion = element region {
 
 CloudResourceTags = element resource-tags {
     CloudResourceTag*
+}
+
+MemoryDump = element memory-dump {
+    attribute heap-dump-redaction { xsd:string }
 }
 
 CloudResourceTag = element tag {

--- a/config-model/src/test/schema-test-files/deployment-with-instances.xml
+++ b/config-model/src/test/schema-test-files/deployment-with-instances.xml
@@ -8,6 +8,7 @@
     <block-change revision='true' version='false' days="mon,tue" hours="14,15"/>
 
     <instance id="one,two">
+      <memory-dump heap-dump-redaction='full'/>
       <block-change days="mon,tue" hours="14,15" time-zone="CET"/>
       <prod athenz-service='other-service'>
           <region>us-west-1</region>

--- a/config-model/src/test/schema-test-files/deployment.xml
+++ b/config-model/src/test/schema-test-files/deployment.xml
@@ -1,6 +1,7 @@
 <!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <deployment version='1.0' major-version='6' athenz-domain='vespa' athenz-service='service'>
     <upgrade policy='canary'/>
+    <memory-dump heap-dump-redaction='basic'/>
     <test/>
     <staging/>
     <block-change revision='true' version='false' days="mon,tue" hours="14,15"/>

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DeploymentConfigStore.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DeploymentConfigStore.java
@@ -18,4 +18,7 @@ public interface DeploymentConfigStore {
                List<BlockWindow> blockWindows,
                TelemetryExporterConfiguration telemetryExportConfig);
 
+    /** Stores the heap dump redaction level for the given application, replacing any previously stored level. */
+    default void storeHeapDumpRedaction(ApplicationId applicationId, HeapDumpRedaction heapDumpRedaction) { }
+
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/HeapDumpRedaction.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/HeapDumpRedaction.java
@@ -1,0 +1,21 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+/**
+ * Redaction level for Java heap dumps, from the memory-dump element in deployment.xml.
+ * Redaction is applied on the node before a heap dump is uploaded to remote storage.
+ *
+ * @author gjoranv
+ */
+public enum HeapDumpRedaction {
+
+    /** No redaction (the default) */
+    none,
+
+    /** Redact the contents of byte and char arrays (strings, buffers, key material) */
+    basic,
+
+    /** Redact all primitive values */
+    full
+
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -225,9 +225,15 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
 
     private void storeDeploymentConfig(ApplicationId applicationId) {
         if (deploymentConfigStore.isEmpty()) return;
-        if ( ! Environment.from(applicationRepository.configserverConfig().environment()).isProduction()) return;
 
         DeploymentSpec spec = session.getApplicationPackage().getDeploymentSpec();
+
+        // Heap dump redaction applies in all environments, and falls back to the root level
+        // when the instance is not declared in the spec (e.g. manually deployed environments).
+        deploymentConfigStore.get().storeHeapDumpRedaction(applicationId, spec.heapDumpRedaction(applicationId.instance()));
+
+        if ( ! Environment.from(applicationRepository.configserverConfig().environment()).isProduction()) return;
+
         Optional<DeploymentInstanceSpec> instanceSpec = spec.instance(applicationId.instance());
         if (instanceSpec.isEmpty()) return;
 


### PR DESCRIPTION
## What
Adds an optional `<memory-dump heap-dump-redaction="none|basic|full"/>` element to deployment.xml, at deployment and instance scope (instance overrides root; default `none`). The level is stored at activation via a new default method on `DeploymentConfigStore`, following the existing backup-config pattern, and is stored in all environments (heap dump upload from nodes is not restricted to production). Unknown values and a missing attribute are rejected at parse time.

## Why
Lets applications in enclave accounts opt in to redaction of PII from Java heap dumps before the dumps leave the node. This PR adds the customer-facing configuration and its propagation to the node repository.

## Tested
Unit tests for parsing (root/instance scope, override, defaults, rejection) in DeploymentSpecTest; schema test files extended to cover the new element; configserver deploy tests pass. The DeploymentConfigStore addition is a default method, so existing implementations are source compatible.

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*