### PR TITLE
Add DiskUsage class without sampling capacity

### DIFF
--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -98,7 +98,7 @@ TEST_F(DiskMemUsageSamplerTest, resource_usage_is_sampled) {
     LOG(info, "Polled %zu times (%zu ms) to get a sample", i, i * 50);
     // Anonymous resident memory used by current process is sampled.
     EXPECT_GT(notifier->getMemoryStats().getAnonymousRss(), 0);
-    EXPECT_GT(notifier->getDiskUsedSize(), 0);
+    EXPECT_GT(notifier->disk_usage().used_bytes(), 0);
     EXPECT_EQ(150, notifier->get_resource_usage().transient_memory());
     EXPECT_EQ(210.0 / memory_size_bytes, notifier->usageState().reserved_memory());
     EXPECT_EQ(150.0 / memory_size_bytes, notifier->usageState().transient_memory_usage());

--- a/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/resource_usage_write_filter/resource_usage_write_filter_test.cpp
@@ -61,7 +61,7 @@ struct ResourceUsageWriteFilterTest : public ::testing::Test {
 
     ResourceUsageWriteFilterTest()
         : _filter(HwInfo(HwInfo::Disk(100, false, false), HwInfo::Memory(1000), HwInfo::Cpu(0))), _notifier(_filter) {
-        _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 300), 20,
+        _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(297, 298, 300), DiskUsage(20, 100),
                                      ReservedDiskSpaceAndMemory());
     }
 
@@ -80,13 +80,13 @@ struct ResourceUsageWriteFilterTest : public ::testing::Test {
     }
 
     void triggerDiskLimit() {
-        _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), 90,
+        _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), DiskUsage(90, 100),
                                      ReservedDiskSpaceAndMemory());
     }
 
     void triggerMemoryLimit() {
         _notifier.set_resource_usage(ResourceUsage(), vespalib::ProcessMemoryStats(897, 898, 900),
-                                     _notifier.getDiskUsedSize(), ReservedDiskSpaceAndMemory());
+                                     _notifier.disk_usage(), ReservedDiskSpaceAndMemory());
     }
 
     void notify_attribute_usage(const AttributeUsageStats& usage) { _notifier.notify_attribute_usage(usage); }
@@ -127,6 +127,26 @@ TEST_F(ResourceUsageWriteFilterTest, disk_limit_can_be_reached) {
     assertResourceUsage(0.9, 0.8, 1.125, _notifier.usageState().diskState());
 }
 
+TEST_F(ResourceUsageWriteFilterTest, disk_usage_ratios_follow_sampled_capacity) {
+    _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{40, 0}, zero_size_on_disk},
+                                 _notifier.getMemoryStats(), DiskUsage(100, 200),
+                                 ReservedDiskSpaceAndMemory(60, 0, 0, 0));
+    EXPECT_DOUBLE_EQ(0.5, _notifier.usageState().diskState().usage());    // 100 / 200
+    EXPECT_DOUBLE_EQ(0.2, _notifier.usageState().transient_disk_usage()); // 40 / 200
+    EXPECT_DOUBLE_EQ(0.3, _notifier.usageState().reserved_disk_space());  // 60 / 200
+}
+
+TEST_F(ResourceUsageWriteFilterTest, disk_limit_message_reports_sampled_capacity) {
+    EXPECT_TRUE(_notifier.setConfig(Config(1.0, 0.8, 0.0, 0.0, AttributeUsageFilterConfig())));
+    _notifier.set_resource_usage(_notifier.get_resource_usage(), _notifier.getMemoryStats(), DiskUsage(180, 200),
+                                 ReservedDiskSpaceAndMemory());
+    testWrite("diskLimitReached: { "
+              "action: \"add more content nodes\", "
+              "reason: \"disk used (0.9) > disk limit (0.8)\", "
+              "stats: { "
+              "capacity: 200, used: 180, diskUsed: 0.9, diskLimit: 0.8}}");
+}
+
 TEST_F(ResourceUsageWriteFilterTest, memory_limit_can_be_reached) {
     EXPECT_TRUE(_notifier.setConfig(Config(0.8, 1.0, 0.0, 0.0, AttributeUsageFilterConfig())));
     assertResourceUsage(0.3, 0.8, 0.375, _notifier.usageState().memoryState());
@@ -161,14 +181,14 @@ TEST_F(ResourceUsageWriteFilterTest, both_disk_limit_and_memory_limit_can_be_rea
 
 TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_disk_usage_tracked_in_usage_state_and_metrics) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{15, 0}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
+                                 _notifier.getMemoryStats(), _notifier.disk_usage(),
                                  ReservedDiskSpaceAndMemory(100, 0, 0, 0));
     EXPECT_DOUBLE_EQ(0.15, _notifier.usageState().transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.15, _notifier.get_metrics().transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.05, _notifier.usageState().non_transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.05, _notifier.get_metrics().non_transient_disk_usage());
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{15, 0}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
+                                 _notifier.getMemoryStats(), _notifier.disk_usage(),
                                  ReservedDiskSpaceAndMemory(10, 0, 0, 0));
     EXPECT_DOUBLE_EQ(0.10, _notifier.usageState().transient_disk_usage());
     EXPECT_DOUBLE_EQ(0.10, _notifier.usageState().non_transient_disk_usage());
@@ -176,14 +196,14 @@ TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_disk_usage_trac
 
 TEST_F(ResourceUsageWriteFilterTest, transient_and_non_transient_memory_usage_tracked_in_usage_state_and_metrics) {
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{0, 100}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
+                                 _notifier.getMemoryStats(), _notifier.disk_usage(),
                                  ReservedDiskSpaceAndMemory(100, 0, 0, 100));
     EXPECT_DOUBLE_EQ(0.1, _notifier.usageState().transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.1, _notifier.get_metrics().transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.2, _notifier.usageState().non_transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.2, _notifier.get_metrics().non_transient_memory_usage());
     _notifier.set_resource_usage(ResourceUsage{TransientResourceUsage{0, 100}, zero_size_on_disk},
-                                 _notifier.getMemoryStats(), _notifier.getDiskUsedSize(),
+                                 _notifier.getMemoryStats(), _notifier.disk_usage(),
                                  ReservedDiskSpaceAndMemory(100, 0, 0, 50));
     EXPECT_DOUBLE_EQ(0.05, _notifier.usageState().transient_memory_usage());
     EXPECT_DOUBLE_EQ(0.25, _notifier.usageState().non_transient_memory_usage());

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -77,7 +77,7 @@ void DiskMemUsageSampler::sampleAndReportUsage() {
      * and a short period of allowed feed. The latter will be very rare as you are rarely feed blocked anyway.
      */
     vespalib::ProcessMemoryStats memoryStats = sampleMemoryUsage();
-    uint64_t                     diskUsage = sampleDiskUsage(resource_usage);
+    DiskUsage                    diskUsage = sampleDiskUsage(resource_usage);
     auto                         reserved_disk_space_and_memory =
         _reserved_disk_space_and_memory_provider.get_reserved_disk_space_and_memory();
     _notifier.set_resource_usage(resource_usage, memoryStats, diskUsage, reserved_disk_space_and_memory);
@@ -88,20 +88,21 @@ namespace {
 
 namespace fs = std::filesystem;
 
-uint64_t sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk) {
+DiskUsage sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk) {
     auto     space_info = fs::space(path);
-    uint64_t result = (space_info.capacity - space_info.available);
-    if (result > disk.sizeBytes()) {
-        return disk.sizeBytes();
+    uint64_t capacity = disk.sizeBytes();
+    uint64_t used = (space_info.capacity - space_info.available);
+    if (used > capacity) {
+        used = capacity;
     }
-    return result;
+    return {used, capacity};
 }
 
 } // namespace
 
-uint64_t DiskMemUsageSampler::sampleDiskUsage(const ResourceUsage& resource_usage) {
+DiskUsage DiskMemUsageSampler::sampleDiskUsage(const ResourceUsage& resource_usage) {
     const auto& disk = _notifier.getHwInfo().disk();
-    return disk.shared() ? (resource_usage.disk() + resource_usage.transient().disk())
+    return disk.shared() ? DiskUsage(resource_usage.disk() + resource_usage.transient().disk(), disk.sizeBytes())
                          : sampleDiskUsageOnFileSystem(_path, disk);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "disk_usage.h"
 #include "resource_usage_notifier.h"
 
 #include <vespa/searchcore/proton/attribute/attribute_usage_filter_config.h>
@@ -39,7 +40,7 @@ class DiskMemUsageSampler {
     std::unique_ptr<vespalib::IDestructorCallback>                                    _periodicHandle;
 
     void sampleAndReportUsage();
-    uint64_t sampleDiskUsage(const searchcorespi::common::ResourceUsage& resource_usage);
+    [[nodiscard]] DiskUsage sampleDiskUsage(const searchcorespi::common::ResourceUsage& resource_usage);
     vespalib::ProcessMemoryStats sampleMemoryUsage();
     searchcorespi::common::ResourceUsage sample_resource_usage();
     [[nodiscard]] bool timeToSampleAgain() const noexcept;

--- a/searchcore/src/vespa/searchcore/proton/server/disk_usage.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_usage.h
@@ -1,0 +1,23 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+
+namespace proton {
+
+/**
+ * Disk usage sample.
+ */
+class DiskUsage {
+    uint64_t _used_bytes;
+    uint64_t _capacity_bytes;
+
+public:
+    DiskUsage(uint64_t used_bytes, uint64_t capacity_bytes) noexcept
+        : _used_bytes(used_bytes), _capacity_bytes(capacity_bytes) {}
+    [[nodiscard]] uint64_t used_bytes() const noexcept { return _used_bytes; }
+    [[nodiscard]] uint64_t capacity_bytes() const noexcept { return _capacity_bytes; }
+};
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
@@ -14,9 +14,9 @@ using storage::spi::AttributeResourceUsage;
 
 namespace proton {
 
-void convertDiskStatsToSlime(const vespalib::HwInfo& hwInfo, uint64_t diskUsedSizeBytes, Cursor& object) {
-    object.setLong("capacity", hwInfo.disk().sizeBytes());
-    object.setLong("used", diskUsedSizeBytes);
+void convertDiskStatsToSlime(const DiskUsage& disk_usage, Cursor& object) {
+    object.setLong("capacity", disk_usage.capacity_bytes());
+    object.setLong("used", disk_usage.used_bytes());
 }
 
 void convertMemoryStatsToSlime(const vespalib::ProcessMemoryStats& stats, Cursor& object) {
@@ -45,15 +45,14 @@ void ResourceUsageExplorer::get_state(const vespalib::slime::Inserter& inserter,
         disk.setDouble("non-transient", usageState.non_transient_disk_usage());
         disk.setDouble("reported", usageState.reported_disk_usage());
         auto reserved_disk_space_and_memory = _usage_notifier.reserved_disk_space_and_memory();
-        auto disk_capacity_bytes = _usage_notifier.getHwInfo().disk().sizeBytes();
+        auto disk_usage = _usage_notifier.disk_usage();
         disk.setDouble("reserved-for-flush",
                        static_cast<double>(reserved_disk_space_and_memory.reserved_disk_space_for_flush()) /
-                           disk_capacity_bytes);
+                           disk_usage.capacity_bytes());
         disk.setDouble("reserved-for-growth",
                        static_cast<double>(reserved_disk_space_and_memory.reserved_disk_space_for_growth()) /
-                           disk_capacity_bytes);
-        convertDiskStatsToSlime(_usage_notifier.getHwInfo(), _usage_notifier.getDiskUsedSize(),
-                                disk.setObject("stats"));
+                           disk_usage.capacity_bytes());
+        convertDiskStatsToSlime(disk_usage, disk.setObject("stats"));
 
         Cursor& memory = object.setObject("memory");
         memory.setDouble("usage", usageState.memoryState().usage());

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -17,7 +17,7 @@ ResourceUsageNotifier::ResourceUsageNotifier(ResourceUsageWriteFilter& filter)
     : _lock(),
       _hwInfo(filter.get_hw_info()),
       _memoryStats(),
-      _diskUsedSizeBytes(),
+      _disk_usage(0, _hwInfo.disk().sizeBytes()),
       _reserved_disk_space_and_memory(),
       _resource_usage(),
       _attribute_usage(),
@@ -58,13 +58,11 @@ double ResourceUsageNotifier::getMemoryUsedRatio(const Guard&) const {
 }
 
 double ResourceUsageNotifier::getDiskUsedRatio(const Guard&) const {
-    double usedDiskSpaceRatio =
-        static_cast<double>(_diskUsedSizeBytes) / static_cast<double>(_hwInfo.disk().sizeBytes());
-    return usedDiskSpaceRatio;
+    return static_cast<double>(_disk_usage.used_bytes()) / static_cast<double>(_disk_usage.capacity_bytes());
 }
 
 double ResourceUsageNotifier::get_relative_reserved_disk_space(const Guard&) const {
-    return static_cast<double>(_reserved_disk_space_and_memory.reserved_disk_space()) / _hwInfo.disk().sizeBytes();
+    return static_cast<double>(_reserved_disk_space_and_memory.reserved_disk_space()) / _disk_usage.capacity_bytes();
 }
 
 double ResourceUsageNotifier::get_relative_reserved_memory(const Guard&) const {
@@ -76,17 +74,17 @@ double ResourceUsageNotifier::get_relative_transient_memory_usage(const Guard&) 
 }
 
 double ResourceUsageNotifier::get_relative_transient_disk_usage(const Guard&) const {
-    return static_cast<double>(_resource_usage.transient_disk()) / _hwInfo.disk().sizeBytes();
+    return static_cast<double>(_resource_usage.transient_disk()) / _disk_usage.capacity_bytes();
 }
 
 void ResourceUsageNotifier::set_resource_usage(const ResourceUsage&         resource_usage,
-                                               vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes,
+                                               vespalib::ProcessMemoryStats memoryStats, const DiskUsage& disk_usage,
                                                ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_) {
     Guard guard(_lock);
     _resource_usage = resource_usage;
     _reserved_disk_space_and_memory = reserved_disk_space_and_memory_;
     _memoryStats = memoryStats;
-    _diskUsedSizeBytes = diskUsedSizeBytes;
+    _disk_usage = disk_usage;
     recalcState(guard, true);
 }
 
@@ -110,9 +108,9 @@ vespalib::ProcessMemoryStats ResourceUsageNotifier::getMemoryStats() const {
     return _memoryStats;
 }
 
-uint64_t ResourceUsageNotifier::getDiskUsedSize() const {
+DiskUsage ResourceUsageNotifier::disk_usage() const {
     Guard guard(_lock);
-    return _diskUsedSizeBytes;
+    return _disk_usage;
 }
 
 ReservedDiskSpaceAndMemory ResourceUsageNotifier::reserved_disk_space_and_memory() const noexcept {
@@ -165,7 +163,7 @@ void ResourceUsageNotifier::notify_resource_usage(const Guard& guard, ResourceUs
     if (disk_mem_sample) {
         _disk_mem_usage_metrics.merge(state);
     }
-    _filter.notify_resource_usage(_usage_state, _memoryStats, _diskUsedSizeBytes);
+    _filter.notify_resource_usage(_usage_state, _memoryStats, _disk_usage);
     for (const auto& listener : _listeners) {
         listener->notify_resource_usage(_usage_state);
     }

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "disk_mem_usage_metrics.h"
+#include "disk_usage.h"
 #include "i_resource_usage_notifier.h"
 #include "resource_usage_state.h"
 
@@ -62,7 +63,7 @@ private:
     vespalib::HwInfo _hwInfo;
     // Following member variables are protected by _lock
     vespalib::ProcessMemoryStats         _memoryStats;
-    uint64_t                             _diskUsedSizeBytes;
+    DiskUsage                            _disk_usage;
     ReservedDiskSpaceAndMemory           _reserved_disk_space_and_memory;
     searchcorespi::common::ResourceUsage _resource_usage;
     AttributeUsageStats                  _attribute_usage;
@@ -86,11 +87,11 @@ public:
     ~ResourceUsageNotifier() override;
 
     void set_resource_usage(const searchcorespi::common::ResourceUsage& resource_usage,
-                            vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes,
+                            vespalib::ProcessMemoryStats memoryStats, const DiskUsage& disk_usage,
                             ReservedDiskSpaceAndMemory reserved_disk_space_and_memory_);
     [[nodiscard]] bool setConfig(Config config);
     vespalib::ProcessMemoryStats getMemoryStats() const;
-    uint64_t getDiskUsedSize() const;
+    [[nodiscard]] DiskUsage disk_usage() const;
     [[nodiscard]] ReservedDiskSpaceAndMemory reserved_disk_space_and_memory() const noexcept;
     searchcorespi::common::ResourceUsage get_resource_usage() const;
     Config getConfig() const;

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.cpp
@@ -40,21 +40,19 @@ void makeMemoryLimitMessage(std::ostream& os, double memoryUsed, double memoryLi
     os << "}";
 }
 
-void makeDiskStatsMessage(std::ostream& os, double diskUsed, double diskLimit, const HwInfo& hwInfo,
-                          uint64_t usedDiskSizeBytes) {
+void makeDiskStatsMessage(std::ostream& os, double diskUsed, double diskLimit, const DiskUsage& disk_usage) {
     os << "stats: { ";
-    os << "capacity: " << hwInfo.disk().sizeBytes() << ", ";
-    os << "used: " << usedDiskSizeBytes << ", ";
+    os << "capacity: " << disk_usage.capacity_bytes() << ", ";
+    os << "used: " << disk_usage.used_bytes() << ", ";
     os << "diskUsed: " << diskUsed << ", ";
     os << "diskLimit: " << diskLimit << "}";
 }
 
-void makeDiskLimitMessage(std::ostream& os, double diskUsed, double diskLimit, const HwInfo& hwInfo,
-                          uint64_t usedDiskSizeBytes) {
+void makeDiskLimitMessage(std::ostream& os, double diskUsed, double diskLimit, const DiskUsage& disk_usage) {
     os << "diskLimitReached: { ";
     os << "action: \"add more content nodes\", ";
     os << "reason: \"disk used (" << diskUsed << ") > disk limit (" << diskLimit << ")\", ";
-    makeDiskStatsMessage(os, diskUsed, diskLimit, hwInfo, usedDiskSizeBytes);
+    makeDiskStatsMessage(os, diskUsed, diskLimit, disk_usage);
     os << "}";
 }
 
@@ -91,13 +89,13 @@ void make_attribute_address_space_error_message(std::ostream& os, double used, d
 
 std::string makeUnblockingMessage(double memoryUsed, double memoryLimit, const ProcessMemoryStats& memoryStats,
                                   const HwInfo& hwInfo, double diskUsed, double diskLimit,
-                                  uint64_t usedDiskSizeBytes) {
+                                  const DiskUsage& disk_usage) {
     std::ostringstream os;
     os << "memoryLimitOK: { ";
     makeMemoryStatsMessage(os, memoryUsed, memoryLimit, memoryStats, hwInfo.memory().sizeBytes());
     os << "}, ";
     os << "diskLimitOK: { ";
-    makeDiskStatsMessage(os, diskUsed, diskLimit, hwInfo, usedDiskSizeBytes);
+    makeDiskStatsMessage(os, diskUsed, diskLimit, disk_usage);
     os << "}";
     return os.str();
 }
@@ -110,7 +108,7 @@ ResourceUsageWriteFilter::ResourceUsageWriteFilter(const HwInfo& hwInfo)
       _hwInfo(hwInfo),
       _acceptWrite(true),
       _memoryStats(),
-      _diskUsedSizeBytes(0),
+      _disk_usage(0, _hwInfo.disk().sizeBytes()),
       _state(),
       _usage_state() {
 }
@@ -131,8 +129,8 @@ void ResourceUsageWriteFilter::recalc_state(const Guard& guard) {
             message << ", ";
         }
         hasMessage = true;
-        makeDiskLimitMessage(message, _usage_state.diskState().usage(), _usage_state.diskState().limit(), _hwInfo,
-                             _diskUsedSizeBytes);
+        makeDiskLimitMessage(message, _usage_state.diskState().usage(), _usage_state.diskState().limit(),
+                             _disk_usage);
     }
     {
         const auto& max_attribute_address_space_state = _usage_state.max_attribute_address_space_state();
@@ -156,7 +154,7 @@ void ResourceUsageWriteFilter::recalc_state(const Guard& guard) {
         if (!_acceptWrite) {
             std::string unblockMsg = makeUnblockingMessage(
                 _usage_state.memoryState().usage(), _usage_state.memoryState().limit(), _memoryStats, _hwInfo,
-                _usage_state.diskState().usage(), _usage_state.diskState().limit(), _diskUsedSizeBytes);
+                _usage_state.diskState().usage(), _usage_state.diskState().limit(), _disk_usage);
             LOG(info, "Write operations are now un-blocked: '%s'", unblockMsg.c_str());
         }
         _state = State();
@@ -175,11 +173,11 @@ ResourceUsageWriteFilter::State ResourceUsageWriteFilter::getAcceptState() const
 
 void ResourceUsageWriteFilter::notify_resource_usage(const ResourceUsageState&           state,
                                                      const vespalib::ProcessMemoryStats& memoryStats,
-                                                     uint64_t                            diskUsedSizeBytes) {
+                                                     const DiskUsage&                    disk_usage) {
     std::lock_guard guard(_lock);
     _usage_state = state;
     _memoryStats = memoryStats;
-    _diskUsedSizeBytes = diskUsedSizeBytes;
+    _disk_usage = disk_usage;
     recalc_state(guard);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_write_filter.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "disk_usage.h"
 #include "resource_usage_state.h"
 
 #include <vespa/searchcore/proton/attribute/attribute_usage_filter_config.h>
@@ -32,7 +33,7 @@ private:
     std::atomic<bool>      _acceptWrite;
     // Following member variables are protected by _lock
     vespalib::ProcessMemoryStats _memoryStats;
-    uint64_t                     _diskUsedSizeBytes;
+    DiskUsage                    _disk_usage;
     State                        _state;
     ResourceUsageState           _usage_state;
 
@@ -45,7 +46,7 @@ public:
     State getAcceptState() const override;
     const vespalib::HwInfo& get_hw_info() const noexcept { return _hwInfo; }
     void notify_resource_usage(const ResourceUsageState& state, const vespalib::ProcessMemoryStats& memoryStats,
-                               uint64_t diskUsedSizeBytes);
+                               const DiskUsage& disk_usage);
 };
 
 } // namespace proton


### PR DESCRIPTION
This PR partially reapplies #37338.

We refactor disk usage and disk capacity numbers into the `DiskUsage` class. It is initialized only with `hwInfo.disk().sizeBytes(),` and we set capacity to `getHwInfo().disk()` when sampling the disk, ensuring the capacity remains constant.

No functional changes.

@toregge ptal