### PR TITLE
be more careful parsing and combining cluster deployment metrics

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
@@ -138,13 +138,19 @@ public class ClusterDeploymentMetricsRetriever {
                         aggregator.get().addReadLatency(rlSum, values.field("vds.distributor.gets.latency.count").asDouble()));
             }
 
-            case VESPA_CONTAINER_CLUSTERCONTROLLER ->
-                    optionalDouble(values.field(ClusterControllerMetrics.RESOURCE_USAGE_MAX_MEMORY_UTILIZATION.max())).ifPresent(memoryUtil ->
-                            aggregator.get()
-                                    .addMemoryUsage(memoryUtil, values.field(ClusterControllerMetrics.RESOURCE_USAGE_MEMORY_LIMIT.last()).asDouble())
-                                    .addDiskUsage(values.field(ClusterControllerMetrics.RESOURCE_USAGE_MAX_DISK_UTILIZATION.max()).asDouble(),
-                                            values.field(ClusterControllerMetrics.RESOURCE_USAGE_DISK_LIMIT.last()).asDouble())
-                                    .setFeedBlockedNodes((int) values.field(ClusterControllerMetrics.RESOURCE_USAGE_NODES_ABOVE_LIMIT.last()).asLong()));
+            case VESPA_CONTAINER_CLUSTERCONTROLLER -> {
+                var memUtil = optionalDouble(values.field(ClusterControllerMetrics.RESOURCE_USAGE_MAX_MEMORY_UTILIZATION.max()));
+                var memLimit = optionalDouble(values.field(ClusterControllerMetrics.RESOURCE_USAGE_MEMORY_LIMIT.last()));
+                var diskUtil = optionalDouble(values.field(ClusterControllerMetrics.RESOURCE_USAGE_MAX_DISK_UTILIZATION.max()));
+                var diskLimit = optionalDouble(values.field(ClusterControllerMetrics.RESOURCE_USAGE_DISK_LIMIT.last()));
+                memUtil.ifPresent(util -> memLimit.ifPresent(limit -> aggregator.get().addMemoryUsage(util, limit)));
+                diskUtil.ifPresent(util -> diskLimit.ifPresent(limit -> aggregator.get().addDiskUsage(util, limit)));
+                var fbnField = values.field(ClusterControllerMetrics.RESOURCE_USAGE_NODES_ABOVE_LIMIT.last());
+                if (fbnField.valid()) {
+                    long feedBlockedNodes = fbnField.asLong();
+                    aggregator.get().setFeedBlockedNodes((int) feedBlockedNodes);
+                }
+            }
         }
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsAggregator.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsAggregator.java
@@ -97,10 +97,12 @@ public class DeploymentMetricsAggregator {
     }
 
     private static LatencyMetrics combineLatency(LatencyMetrics metricsOrNull, double sum, double count) {
+        if (count == 0) return metricsOrNull;
         return Optional.ofNullable(metricsOrNull).orElseGet(LatencyMetrics::new).combine(sum, count);
     }
 
     private static ResourceUsage combineResourceUtil(ResourceUsage resourceUsageOrNull, double util, double limit) {
+        if (limit <= 0.0) return resourceUsageOrNull;
         return Optional.ofNullable(resourceUsageOrNull).orElseGet(ResourceUsage::new).combine(util, limit);
     }
 


### PR DESCRIPTION
When aggregating deployment metrics scraped from the nodes of a cluster, missing data used to be turned into fabricated zeros:

- for cluster controllers, presence of the memory utilization metric caused memory limit, disk utilization/limit and the feed-blocked node count to be read unconditionally, defaulting to 0 when absent.
- latency samples with zero count and resource usage with a non-positive limit were still combined into the aggregate, so missing data could show up as a rate of 0 or a resource limit of 0.

Instead, only record values that are actually present and meaningful: memory/disk usage requires both utilization and limit, feed-blocked nodes requires that metric to be reported, latency samples require a non-zero count, and resource usage requires a positive limit. Missing metrics now show up as "no data" rather than misleading zeros in the aggregated cluster view.
