### PR TITLE
Add dedicated 'cluster-deployment-metrics' consumer and metric set

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/ConsumersConfigGenerator.java
@@ -33,6 +33,7 @@ class ConsumersConfigGenerator {
         allConsumers.put(MetricsConsumer.vespa.id(),
                          combineConsumers(defaultConsumer, allConsumers.get(MetricsConsumer.vespa.id())));
         allConsumers.put(MetricsConsumer.autoscaling.id(), MetricsConsumer.autoscaling);
+        allConsumers.put(MetricsConsumer.clusterDeployment.id(), MetricsConsumer.clusterDeployment);
 
         if (systemName.isPublicCloudLike())
             allConsumers.put(MetricsConsumer.vespaCloud.id(), MetricsConsumer.vespaCloud);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/MetricsConsumer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/MetricsConsumer.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static ai.vespa.metrics.set.AutoscalingMetrics.autoscalingMetricSet;
+import static ai.vespa.metrics.set.ClusterDeploymentSet.clusterDeploymentMetricSet;
 import static ai.vespa.metrics.set.DefaultMetrics.defaultMetricSet;
 import static ai.vespa.metrics.set.NetworkMetrics.networkMetricSet;
 import static ai.vespa.metrics.set.SystemMetrics.systemMetricSet;
@@ -37,6 +38,9 @@ public class MetricsConsumer {
     // Referenced from com.yahoo.vespa.hosted.provision.autoscale.NodeMetricsFetcher
     public static final MetricsConsumer autoscaling =
             consumer("autoscaling", autoscalingMetricSet);
+
+    public static final MetricsConsumer clusterDeployment =
+            consumer("cluster-deployment-metrics", clusterDeploymentMetricSet);
 
     public static final MetricsConsumer vespaCloud =
             consumer("vespa-cloud", vespaMetricSet, systemMetricSet, networkMetricSet);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/builder/xml/MetricsBuilder.java
@@ -90,6 +90,9 @@ public class MetricsBuilder {
         if (consumerId.equalsIgnoreCase(MetricsConsumer.autoscaling.id()))
             throw new IllegalArgumentException("'" + MetricsConsumer.autoscaling.id() + " is not allowed as metrics consumer id (case is ignored.)");
 
+        if (consumerId.equalsIgnoreCase(MetricsConsumer.clusterDeployment.id()))
+            throw new IllegalArgumentException("'" + MetricsConsumer.clusterDeployment.id() + " is not allowed as metrics consumer id (case is ignored.)");
+
         if (consumerId.equalsIgnoreCase(MetricsConsumer.vespaCloud.id()))
             throw new IllegalArgumentException("'" + MetricsConsumer.vespaCloud.id() + " is not allowed as metrics consumer id (case is ignored.)");
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsConsumersTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsConsumersTest.java
@@ -45,21 +45,22 @@ public class MetricsConsumersTest {
     @Test
     void default_public_consumers_is_set_up_for_self_hosted() {
         ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), self_hosted);
-        assertEquals(4, config.consumer().size());
-        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(2).name());
+        assertEquals(5, config.consumer().size());
+        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(3).name());
         int numMetricsForPublicDefaultConsumer = defaultMetricSet.getMetrics().size() + numSystemMetrics;
-        assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(2).metric().size());
+        assertEquals(numMetricsForPublicDefaultConsumer, config.consumer(3).metric().size());
     }
 
     @Test
     void consumers_are_set_up_for_hosted() {
         ConsumersConfig config = consumersConfigFromXml(servicesWithAdminOnly(), hosted);
-        assertEquals(5, config.consumer().size());
+        assertEquals(6, config.consumer().size());
         assertEquals(MetricsConsumer.vespa.id(), config.consumer(0).name());
         assertEquals(MetricsConsumer.autoscaling.id(), config.consumer(1).name());
-        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(2).name());
-        assertEquals(MetricsProxyContainerCluster.NEW_DEFAULT_CONSUMER_ID, config.consumer(3).name());
-        assertEquals(MetricsConsumer.vespa9.id(), config.consumer(4).name());
+        assertEquals(MetricsConsumer.clusterDeployment.id(), config.consumer(2).name());
+        assertEquals(MetricsConsumer.defaultConsumer.id(), config.consumer(3).name());
+        assertEquals(MetricsProxyContainerCluster.NEW_DEFAULT_CONSUMER_ID, config.consumer(4).name());
+        assertEquals(MetricsConsumer.vespa9.id(), config.consumer(5).name());
     }
 
     @Test
@@ -133,7 +134,7 @@ public class MetricsConsumersTest {
         );
         VespaModel hostedModel = getModel(services, hosted);
         ConsumersConfig config = consumersConfigFromModel(hostedModel);
-        assertEquals(5, config.consumer().size());
+        assertEquals(6, config.consumer().size());
 
         // All default metrics are retained
         ConsumersConfig.Consumer vespaConsumer = config.consumer(0);

--- a/metrics/src/main/java/ai/vespa/metrics/set/ClusterDeploymentSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/ClusterDeploymentSet.java
@@ -1,0 +1,75 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package ai.vespa.metrics.set;
+
+import ai.vespa.metrics.ClusterControllerMetrics;
+import ai.vespa.metrics.ContainerMetrics;
+import ai.vespa.metrics.DistributorMetrics;
+import ai.vespa.metrics.Suffix;
+import ai.vespa.metrics.VespaMetrics;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static ai.vespa.metrics.Suffix.count;
+import static ai.vespa.metrics.Suffix.last;
+import static ai.vespa.metrics.Suffix.max;
+import static ai.vespa.metrics.Suffix.sum;
+
+/**
+ * Service metrics fetched by ClusterDeploymentMetricsRetriever
+ *
+ * @author arnej
+ */
+public class ClusterDeploymentSet {
+
+    public static final MetricSet clusterDeploymentMetricSet = createMetricSet();
+
+    private static MetricSet createMetricSet() {
+        return new MetricSet("cluster-deployment-metrics",
+                             makeMetrics());
+    }
+
+    private static Set<Metric> makeMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        metrics.addAll(getContainerMetrics());
+        metrics.addAll(getDistributorMetrics());
+        metrics.addAll(getClusterControllerMetrics());
+        return Collections.unmodifiableSet(metrics);
+    }
+
+    private static Set<Metric> getContainerMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        addMetric(metrics, ContainerMetrics.FEED_LATENCY, EnumSet.of(sum, count));
+        addMetric(metrics, ContainerMetrics.QUERY_LATENCY, EnumSet.of(sum, count));
+        return metrics;
+    }
+
+    private static Set<Metric> getClusterControllerMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_DISK_LIMIT, EnumSet.of(max, last));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MAX_DISK_UTILIZATION, EnumSet.of(last, max));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MAX_MEMORY_UTILIZATION, EnumSet.of(last, max));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MEMORY_LIMIT, EnumSet.of(max, last));
+        addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_NODES_ABOVE_LIMIT, EnumSet.of(last, max));
+        return metrics;
+    }
+
+    private static Set<Metric> getDistributorMetrics() {
+        Set<Metric> metrics = new LinkedHashSet<>();
+        addMetric(metrics, DistributorMetrics.VDS_DISTRIBUTOR_DOCSSTORED.average());
+        addMetric(metrics, DistributorMetrics.VDS_DISTRIBUTOR_GETS_LATENCY, EnumSet.of(sum, count));
+        return metrics;
+    }
+
+    private static void addMetric(Set<Metric> metrics, String nameWithSuffix) {
+        metrics.add(new Metric(nameWithSuffix));
+    }
+
+    private static void addMetric(Set<Metric> metrics, VespaMetrics metric, EnumSet<Suffix> suffixes) {
+        suffixes.forEach(suffix -> addMetric(metrics, metric.baseName() + "." + suffix.suffix()));
+    }
+
+}


### PR DESCRIPTION
Define ClusterDeploymentSet, a small metric set containing exactly the container, distributor and cluster-controller metrics that the configserver's ClusterDeploymentMetricsRetriever aggregates, and register it as a reserved built-in metrics consumer.

Today the retriever fetches metrics through the default consumer and throws most of the response away; a dedicated consumer makes those requests much cheaper. This redoes the config-model part of #37331 (reverted in #37353), but deliberately leaves the retriever unchanged: the consumer must be present in deployed systems before the retriever can start requesting it, so switching the retriever over is left for a follow-up.
