### PR TITLE
Comment out call to storeHeapDumpRedaction

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -230,7 +230,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
 
         // Heap dump redaction applies in all environments, and falls back to the root level
         // when the instance is not declared in the spec (e.g. manually deployed environments).
-        deploymentConfigStore.get().storeHeapDumpRedaction(applicationId, spec.heapDumpRedaction(applicationId.instance()));
+        //deploymentConfigStore.get().storeHeapDumpRedaction(applicationId, spec.heapDumpRedaction(applicationId.instance()));
 
         if ( ! Environment.from(applicationRepository.configserverConfig().environment()).isProduction()) return;
 


### PR DESCRIPTION
This change was enough to bootstrap config server, nothing uses this feature yet.

Fails when bootstrapping config server:

[2026-07-06 07:01:40.269] WARNING configserver     Container.com.yahoo.vespa.config.server.ConfigServerBootstrap
	Redeploying hosted-vespa.routing.default failed, will retry
	exception=
	java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: No application 'hosted-vespa.routing.default' was found
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.getDeploymentStatus(ConfigServerBootstrap.java:284)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.lambda$checkDeployments$7(ConfigServerBootstrap.java:253)
	at java.base/java.util.HashMap.forEach(HashMap.java:1421)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.checkDeployments(ConfigServerBootstrap.java:250)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.redeployApplications(ConfigServerBootstrap.java:230)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.redeployAllApplications(ConfigServerBootstrap.java:197)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.start(ConfigServerBootstrap.java:136)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.<init>(ConfigServerBootstrap.java:107)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.<init>(ConfigServerBootstrap.java:84)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at com.yahoo.container.di.componentgraph.core.ComponentNode.newInstance(ComponentNode.java:156)
	at com.yahoo.container.di.componentgraph.core.Node.constructInstance(Node.java:44)
	at com.yahoo.container.di.componentgraph.core.Node.component(Node.java:52)
	at com.yahoo.container.di.componentgraph.core.ComponentRegistryNode.lambda$newInstance$0(ComponentRegistryNode.java:39)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at com.yahoo.container.di.componentgraph.core.ComponentRegistryNode.newInstance(ComponentRegistryNode.java:39)
	at com.yahoo.container.di.componentgraph.core.Node.constructInstance(Node.java:44)
	at com.yahoo.container.di.componentgraph.core.Node.component(Node.java:52)
	at com.yahoo.container.di.componentgraph.core.ComponentNode.newInstance(ComponentNode.java:144)
	at com.yahoo.container.di.componentgraph.core.Node.constructInstance(Node.java:44)
	at com.yahoo.container.di.Container.lambda$constructComponents$0(Container.java:136)
	at java.base/java.util.HashMap$Values.forEach(HashMap.java:1065)
	at com.yahoo.container.di.Container.constructComponents(Container.java:133)
	at com.yahoo.container.di.Container.waitForNextGraphGeneration(Container.java:105)
	at com.yahoo.container.core.config.HandlersConfigurerDi.waitForNextGraphGeneration(HandlersConfigurerDi.java:158)
	at com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:79)
	at com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:65)
	at com.yahoo.container.jdisc.ConfiguredApplication.createConfigurer(ConfiguredApplication.java:453)
	at com.yahoo.container.jdisc.ConfiguredApplication.start(ConfiguredApplication.java:178)
	at com.yahoo.container.standalone.StandaloneContainerApplication.start(StandaloneContainerApplication.java:158)
	at com.yahoo.jdisc.core.ApplicationLoader.start(ApplicationLoader.java:158)
	Caused by: java.lang.IllegalArgumentException: No application 'hosted-vespa.routing.default' was found
	at com.yahoo.vespa.hosted.provision.applications.Applications.lambda$require$1(Applications.java:50)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at com.yahoo.vespa.hosted.provision.applications.Applications.require(Applications.java:50)
	at com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryDeploymentConfigStore.storeHeapDumpRedaction(NodeRepositoryDeploymentConfigStore.java:48)
	at com.yahoo.vespa.config.server.deploy.Deployment.storeDeploymentConfig(Deployment.java:233)
	at com.yahoo.vespa.config.server.deploy.Deployment.activate(Deployment.java:154)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at com.yahoo.vespa.config.server.ConfigServerBootstrap.lambda$redeployApplications$4(ConfigServerBootstrap.java:225)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
