### PR TITLE
Re-enable heap dump redaction store call

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -230,7 +230,9 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
 
         // Heap dump redaction applies in all environments, and falls back to the root level
         // when the instance is not declared in the spec (e.g. manually deployed environments).
-        //deploymentConfigStore.get().storeHeapDumpRedaction(applicationId, spec.heapDumpRedaction(applicationId.instance()));
+        // The store must tolerate applications without an application record in the node repository,
+        // e.g. infrastructure applications; this is called for every activation, including bootstrap.
+        deploymentConfigStore.get().storeHeapDumpRedaction(applicationId, spec.heapDumpRedaction(applicationId.instance()));
 
         if ( ! Environment.from(applicationRepository.configserverConfig().environment()).isProduction()) return;
 


### PR DESCRIPTION
Reverts the mitigation in #37356, which commented out the `storeHeapDumpRedaction` call after it made config server bootstrap fail on infrastructure applications.

---
*AI-assisted PR (Claude Fable 5) - all changes verified by the author before submission*