### PR TITLE
Log warning on disk capacity changed

### DIFF
--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -72,9 +72,10 @@ struct DiskMemUsageSamplerTest : public ::testing::Test {
           reserved_disk_space_and_memory_provider(std::make_unique<MyReservedDiskSpaceAndMemoryProvider>()),
           sampler(std::make_unique<DiskMemUsageSampler>(".", *write_filter, *notifier,
                                                         *reserved_disk_space_and_memory_provider)) {
-        sampler->setConfig(
-            DiskMemUsageSampler::Config(0.8, 0.8, 0.0, 0.0, AttributeUsageFilterConfig(), 50ms, make_hw_info()),
-            executor);
+        sampler->setConfig(DiskMemUsageSampler::Config(0.8, 0.8, 0.0, 0.0, AttributeUsageFilterConfig(),
+                                                       /* log_warning_on_disk_capacity_change */ false, 50ms,
+                                                       make_hw_info()),
+                           executor);
         sampler->add_resource_usage_provider(std::make_shared<MyProvider>(50, 200));
         sampler->add_resource_usage_provider(std::make_shared<MyProvider>(100, 150));
     }

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -56,9 +56,10 @@ public:
 
         Config(double memoryLimit_in, double diskLimit_in, double reserved_disk_space_factor_in,
                double reserved_memory_factor_in, AttributeUsageFilterConfig attribute_limit_in,
-               vespalib::duration sampleInterval_in, const vespalib::HwInfo& hwInfo_in)
+               bool log_warning_on_disk_capacity_change_in, vespalib::duration sampleInterval_in,
+               const vespalib::HwInfo& hwInfo_in)
             : filterConfig(memoryLimit_in, diskLimit_in, reserved_disk_space_factor_in, reserved_memory_factor_in,
-                           attribute_limit_in),
+                           attribute_limit_in, log_warning_on_disk_capacity_change_in),
               sampleInterval(sampleInterval_in),
               hwInfo(hwInfo_in) {}
     };

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -138,6 +138,7 @@ DiskMemUsageSampler::Config diskMemUsageSamplerConfig(const ProtonConfig& proton
             proton.writefilter.reservedDiskSpaceFactor,
             proton.writefilter.reservedMemoryFactor,
             AttributeUsageFilterConfig(proton.writefilter.attribute.addressSpaceLimit),
+            proton.logWarningOnDiskCapacityChange,
             vespalib::from_s(proton.writefilter.sampleinterval),
             hwInfo};
 }

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -9,6 +9,9 @@
 
 #include <algorithm>
 
+#include <vespa/log/log.h>
+LOG_SETUP(".proton.server.resource_usage_notifier");
+
 using searchcorespi::common::ResourceUsage;
 
 namespace proton {
@@ -90,8 +93,17 @@ void ResourceUsageNotifier::set_resource_usage(const ResourceUsage&         reso
     _resource_usage = resource_usage;
     _reserved_disk_space_and_memory = reserved_disk_space_and_memory_;
     _memoryStats = memoryStats;
+    warn_on_disk_capacity_changed(disk_usage);
     _disk_usage = disk_usage;
     recalcState(guard, true);
+}
+
+void ResourceUsageNotifier::warn_on_disk_capacity_changed(const DiskUsage& disk_usage) const noexcept {
+    const DiskUsage& previous = _disk_usage;
+    if (previous.capacity_bytes() != disk_usage.capacity_bytes()) {
+        LOG(warning, "Disk capacity changed from %zu bytes to %zu bytes.", previous.capacity_bytes(),
+            disk_usage.capacity_bytes());
+    }
 }
 
 void ResourceUsageNotifier::notify_attribute_usage(const AttributeUsageStats& attribute_usage) {

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -99,6 +99,10 @@ void ResourceUsageNotifier::set_resource_usage(const ResourceUsage&         reso
 }
 
 void ResourceUsageNotifier::warn_on_disk_capacity_changed(const DiskUsage& disk_usage) const noexcept {
+    if (!_config._log_warning_on_disk_capacity_change) {
+        return;
+    }
+
     const DiskUsage& previous = _disk_usage;
     if (previous.capacity_bytes() != disk_usage.capacity_bytes()) {
         LOG(warning, "Disk capacity changed from %zu bytes to %zu bytes.", previous.capacity_bytes(),

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -8,6 +8,7 @@
 #include <vespa/vespalib/util/hw_info.h>
 
 #include <algorithm>
+#include <cinttypes>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.server.resource_usage_notifier");
@@ -105,7 +106,7 @@ void ResourceUsageNotifier::warn_on_disk_capacity_changed(const DiskUsage& disk_
 
     const DiskUsage& previous = _disk_usage;
     if (previous.capacity_bytes() != disk_usage.capacity_bytes()) {
-        LOG(warning, "Disk capacity changed from %zu bytes to %zu bytes.", previous.capacity_bytes(),
+        LOG(warning, "Disk capacity changed from %" PRIu64 " bytes to %" PRIu64 " bytes.", previous.capacity_bytes(),
             disk_usage.capacity_bytes());
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.cpp
@@ -106,7 +106,7 @@ void ResourceUsageNotifier::warn_on_disk_capacity_changed(const DiskUsage& disk_
 
     const DiskUsage& previous = _disk_usage;
     if (previous.capacity_bytes() != disk_usage.capacity_bytes()) {
-        LOG(warning, "Disk capacity changed from %" PRIu64 " bytes to %" PRIu64 " bytes.", previous.capacity_bytes(),
+        LOG(info, "Disk capacity changed from %" PRIu64 " bytes to %" PRIu64 " bytes.", previous.capacity_bytes(),
             disk_usage.capacity_bytes());
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
@@ -81,6 +81,7 @@ private:
     double get_relative_transient_memory_usage(const Guard& guard) const;
     double get_relative_transient_disk_usage(const Guard& guard) const;
     void notify_resource_usage(const Guard& guard, ResourceUsageState state, bool disk_mem_sample);
+    void warn_on_disk_capacity_changed(const DiskUsage& disk_usage) const noexcept;
 
 public:
     ResourceUsageNotifier(ResourceUsageWriteFilter& filter);

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_notifier.h
@@ -39,21 +39,25 @@ public:
         double                     _reserved_disk_space_factor;
         double                     _reserved_memory_factor;
         AttributeUsageFilterConfig _attribute_limit;
+        bool                       _log_warning_on_disk_capacity_change;
 
-        Config() : Config(1.0, 1.0, 0.0, 0.0, AttributeUsageFilterConfig()) {}
+        Config() : Config(1.0, 1.0, 0.0, 0.0, AttributeUsageFilterConfig(), false) {}
 
         Config(double memoryLimit_in, double diskLimit_in, double reserved_disk_space_factor_in,
-               double reserved_memory_factor_in, AttributeUsageFilterConfig attribute_limit_in)
+               double reserved_memory_factor_in, AttributeUsageFilterConfig attribute_limit_in,
+               bool log_warning_on_disk_capacity_change_in = false)
             : _memoryLimit(memoryLimit_in),
               _diskLimit(diskLimit_in),
               _reserved_disk_space_factor(reserved_disk_space_factor_in),
               _reserved_memory_factor(reserved_memory_factor_in),
-              _attribute_limit(attribute_limit_in) {}
+              _attribute_limit(attribute_limit_in),
+              _log_warning_on_disk_capacity_change(log_warning_on_disk_capacity_change_in) {}
         bool operator==(const Config& rhs) const noexcept {
             return (_memoryLimit == rhs._memoryLimit) && (_diskLimit == rhs._diskLimit) &&
                    (_reserved_disk_space_factor == rhs._reserved_disk_space_factor) &&
                    (_reserved_memory_factor == rhs._reserved_memory_factor) &&
-                   (_attribute_limit == rhs._attribute_limit);
+                   (_attribute_limit == rhs._attribute_limit) &&
+                   (_log_warning_on_disk_capacity_change == rhs._log_warning_on_disk_capacity_change);
         }
         bool operator!=(const Config& rhs) const noexcept { return !(*this == rhs); }
     };


### PR DESCRIPTION
Log a message when disk capacity changes. This is only the logging part, not the resampling.

```
[2026-07-06 11:06:06.627952] 2968698/63800 (.proton.server.resource_usage_notifier) info: Disk capacity changed from 100 bytes to 200 bytes.
```

This is controlled by the feature flag `proton-log-warning-on-disk-capacity-change` added in #37359.

@toregge please review