### PR TITLE
Distinguish unreachable services from config failures in ConfigConvergenceChecker

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ConfigConvergenceChecker.java
@@ -302,7 +302,7 @@ public class ConfigConvergenceChecker extends AbstractComponent {
     private record ServiceGenerationResult(long generation, ConfigStatus configStatus) {
         static ServiceGenerationResult ok(long generation) { return new ServiceGenerationResult(generation, ConfigStatus.ok(generation)); }
         static ServiceGenerationResult configFailed(long generation, String message) { return new ServiceGenerationResult(-1L, ConfigStatus.failed(generation, message)); }
-        static ServiceGenerationResult unreachable(String message) { return new ServiceGenerationResult(-1L, ConfigStatus.failed(-1, message)); }
+        static ServiceGenerationResult unreachable(String message) { return new ServiceGenerationResult(-1L, ConfigStatus.unknown(-1, message)); }
     }
 
     private static URI createApiUri(URI serviceUrl) {
@@ -351,7 +351,7 @@ public class ConfigConvergenceChecker extends AbstractComponent {
 
     public record ConfigStatus(long generation, Status status, String message) {
         public enum Status {
-            OK, FAILED;
+            OK, FAILED, UNKNOWN;
             @Override public String toString() { return name().toLowerCase(); }
         }
         public static ConfigStatus ok(long generation) {
@@ -359,6 +359,9 @@ public class ConfigConvergenceChecker extends AbstractComponent {
         }
         public static ConfigStatus failed(long generation, String message) {
             return new ConfigStatus(generation, Status.FAILED, message);
+        }
+        public static ConfigStatus unknown(long generation, String message) {
+            return new ConfigStatus(generation, Status.UNKNOWN, message);
         }
         public boolean isFailed() { return status == Status.FAILED; }
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ConfigConvergenceCheckerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ConfigConvergenceCheckerTest.java
@@ -26,6 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.yahoo.vespa.config.server.application.ConfigConvergenceChecker.ConfigStatus;
 import static com.yahoo.vespa.config.server.application.ConfigConvergenceChecker.ServiceListResponse;
 import static com.yahoo.vespa.config.server.application.ConfigConvergenceChecker.ServiceResponse;
 import static org.junit.Assert.assertEquals;
@@ -283,6 +284,30 @@ public class ConfigConvergenceCheckerTest {
         assertEquals(-1, service.currentGeneration);
         assertTrue(service.configStatus.isFailed());
         assertEquals("Failed to construct component Foo", service.configStatus.message());
+    }
+
+    @Test
+    public void config_status_unknown_is_not_failed() {
+        ConfigStatus status = ConfigStatus.unknown(-1, "service unreachable");
+        assertEquals(ConfigStatus.Status.UNKNOWN, status.status());
+        assertFalse(status.isFailed());
+        assertEquals("unknown", status.status().toString());
+        assertEquals("service unreachable", status.message());
+    }
+
+    @Test
+    public void service_list_convergence_unreachable_service_has_unknown_status() {
+        wireMock.stubFor(get(urlEqualTo("/state/v1/config")).willReturn(aResponse()
+                .withFixedDelay((int) clientTimeout.plus(Duration.ofSeconds(1)).toMillis())
+                .withBody("response too slow")));
+
+        ServiceListResponse response = checker.checkConvergenceForAllServices(application, Duration.ofMillis(1));
+        assertFalse(response.converged);
+        assertEquals(1, response.services.size());
+        ServiceListResponse.Service service = response.services.get(0);
+        assertEquals(-1, service.currentGeneration);
+        assertFalse(service.configStatus.isFailed());
+        assertEquals(ConfigStatus.Status.UNKNOWN, service.configStatus.status());
     }
 
     private void assertService(URI uri, ServiceListResponse.Service service1, long expectedGeneration) {


### PR DESCRIPTION
## Summary
- Add `ConfigStatus.Status.UNKNOWN` enum value to separate "service unreachable" from "config application failed"
- Add `ConfigStatus.unknown()` factory method
- Use `UNKNOWN` (not `FAILED`) for unreachable services in `ServiceGenerationResult.unreachable()`
- Add tests for `ConfigStatus.unknown()` and unreachable service list convergence

## Benefits
Previously both unreachable services and config application failures mapped to `FAILED`, making it impossible to distinguish between a service that was down/slow and one that had a genuine config error.

---
*Generated by Claude Code*