### PR TITLE
Periodically resample disk capacity in proton

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -100,11 +100,8 @@ namespace fs = std::filesystem;
 DiskUsage sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk,
                                       bool resample_disk_capacity) {
     auto     space_info = fs::space(path);
-    uint64_t capacity = disk.sizeBytes();
+    uint64_t capacity = resample_disk_capacity ? space_info.capacity : disk.sizeBytes();
     uint64_t used = (space_info.capacity - space_info.available);
-    if (resample_disk_capacity) {
-        capacity = space_info.capacity;
-    }
     if (used > capacity) {
         used = capacity;
     }

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -31,6 +31,8 @@ DiskMemUsageSampler::DiskMemUsageSampler(
       _sampleInterval(60s),
       _lastSampleTime(),
       _lock(),
+      _should_resample_disk_capacity(false),
+      _resample_disk_capacity_feature_flag(false),
       _resource_usage_providers(),
       _periodicHandle() {
 }
@@ -47,9 +49,16 @@ bool DiskMemUsageSampler::timeToSampleAgain() const noexcept {
 
 void DiskMemUsageSampler::setConfig(const Config& config, IScheduledExecutor& executor) {
     bool wasChanged = _notifier.setConfig(config.filterConfig);
+    if ((_should_resample_disk_capacity != config.should_resample_disk_capacity) ||
+        (_resample_disk_capacity_feature_flag != config.resample_disk_capacity))
+    {
+        wasChanged = true;
+    }
     if (_periodicHandle && (_sampleInterval == config.sampleInterval) && !wasChanged) {
         return;
     }
+    _should_resample_disk_capacity = config.should_resample_disk_capacity;
+    _resample_disk_capacity_feature_flag = config.resample_disk_capacity;
     restart(config.sampleInterval, executor);
 }
 
@@ -88,10 +97,14 @@ namespace {
 
 namespace fs = std::filesystem;
 
-DiskUsage sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk) {
+DiskUsage sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwInfo::Disk& disk,
+                                      bool resample_disk_capacity) {
     auto     space_info = fs::space(path);
     uint64_t capacity = disk.sizeBytes();
     uint64_t used = (space_info.capacity - space_info.available);
+    if (resample_disk_capacity) {
+        capacity = space_info.capacity;
+    }
     if (used > capacity) {
         used = capacity;
     }
@@ -102,8 +115,9 @@ DiskUsage sampleDiskUsageOnFileSystem(const fs::path& path, const vespalib::HwIn
 
 DiskUsage DiskMemUsageSampler::sampleDiskUsage(const ResourceUsage& resource_usage) {
     const auto& disk = _notifier.getHwInfo().disk();
+    bool        resample_disk_capacity = _should_resample_disk_capacity && _resample_disk_capacity_feature_flag;
     return disk.shared() ? DiskUsage(resource_usage.disk() + resource_usage.transient().disk(), disk.sizeBytes())
-                         : sampleDiskUsageOnFileSystem(_path, disk);
+                         : sampleDiskUsageOnFileSystem(_path, disk, resample_disk_capacity);
 }
 
 vespalib::ProcessMemoryStats DiskMemUsageSampler::sampleMemoryUsage() {

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -36,6 +36,8 @@ class DiskMemUsageSampler {
     vespalib::duration                         _sampleInterval;
     vespalib::steady_time                      _lastSampleTime;
     std::mutex                                 _lock;
+    bool                                       _should_resample_disk_capacity;
+    bool                                       _resample_disk_capacity_feature_flag;
     std::vector<std::shared_ptr<const searchcorespi::common::IResourceUsageProvider>> _resource_usage_providers;
     std::unique_ptr<vespalib::IDestructorCallback>                                    _periodicHandle;
 
@@ -51,17 +53,27 @@ public:
         ResourceUsageNotifier::Config filterConfig;
         vespalib::duration            sampleInterval;
         vespalib::HwInfo              hwInfo;
+        bool                          should_resample_disk_capacity;
+        bool                          resample_disk_capacity;
 
-        Config() : filterConfig(), sampleInterval(60s), hwInfo() {}
+        Config()
+            : filterConfig(),
+              sampleInterval(60s),
+              hwInfo(),
+              should_resample_disk_capacity(false),
+              resample_disk_capacity(false) {}
 
         Config(double memoryLimit_in, double diskLimit_in, double reserved_disk_space_factor_in,
                double reserved_memory_factor_in, AttributeUsageFilterConfig attribute_limit_in,
                bool log_warning_on_disk_capacity_change_in, vespalib::duration sampleInterval_in,
-               const vespalib::HwInfo& hwInfo_in)
+               const vespalib::HwInfo& hwInfo_in, bool should_resample_disk_capacity_in = false,
+               bool resample_disk_capacity_in = false)
             : filterConfig(memoryLimit_in, diskLimit_in, reserved_disk_space_factor_in, reserved_memory_factor_in,
                            attribute_limit_in, log_warning_on_disk_capacity_change_in),
               sampleInterval(sampleInterval_in),
-              hwInfo(hwInfo_in) {}
+              hwInfo(hwInfo_in),
+              should_resample_disk_capacity(should_resample_disk_capacity_in),
+              resample_disk_capacity(resample_disk_capacity_in) {}
     };
 
     DiskMemUsageSampler(const std::string& path_in, ResourceUsageWriteFilter& filter,

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -133,6 +133,8 @@ void setFS4Compression(const ProtonConfig& proton) {
 }
 
 DiskMemUsageSampler::Config diskMemUsageSamplerConfig(const ProtonConfig& proton, const vespalib::HwInfo& hwInfo) {
+    // If user configures disk size to be 0, let proton resample the disk size periodically.
+    bool should_resample_disk_capacity = (proton.hwinfo.disk.size == 0);
     return {proton.writefilter.memorylimit,
             proton.writefilter.disklimit,
             proton.writefilter.reservedDiskSpaceFactor,
@@ -140,7 +142,9 @@ DiskMemUsageSampler::Config diskMemUsageSamplerConfig(const ProtonConfig& proton
             AttributeUsageFilterConfig(proton.writefilter.attribute.addressSpaceLimit),
             proton.logWarningOnDiskCapacityChange,
             vespalib::from_s(proton.writefilter.sampleinterval),
-            hwInfo};
+            hwInfo,
+            should_resample_disk_capacity,
+            proton.resampleDiskCapacity};
 }
 
 uint32_t computeRpcTransportThreads(const ProtonConfig& cfg, const vespalib::HwInfo::Cpu& cpuInfo) {


### PR DESCRIPTION
Re-applies #37338 part 2.

If the user sets the disk size to 0, let proton resample it periodically. 

This is controlled by the feature flag `proton-resample-disk-capacity` added in #37359.

@toregge please review