### PR TITLE
Add FieldPathTarget to parse field path for partial update in attributes

### DIFF
--- a/searchcore/src/tests/proton/common/CMakeLists.txt
+++ b/searchcore/src/tests/proton/common/CMakeLists.txt
@@ -18,6 +18,7 @@ vespa_add_executable(searchcore_proton_common_gtest_test_app TEST
     selectpruner_test.cpp
     state_reporter_utils_test.cpp
     statusreport_test.cpp
+    field_path_target_test.cpp
     DEPENDS
     searchcore_feedoperation
     searchcore_pcommon

--- a/searchcore/src/tests/proton/common/field_path_target_test.cpp
+++ b/searchcore/src/tests/proton/common/field_path_target_test.cpp
@@ -1,0 +1,57 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/document/repo/newconfigbuilder.h>
+#include <vespa/searchcore/proton/common/field_path_target.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+#include <vector>
+
+using document::DocumentTypeRepo;
+using document::new_config_builder::NewConfigBuilder;
+
+namespace proton {
+
+std::unique_ptr<DocumentTypeRepo> make_document_type_repo() {
+    NewConfigBuilder builder;
+    auto&            doc = builder.document("testdoc", 222);
+    auto             int_array = doc.createArray(builder.intTypeRef()).ref();
+    auto             int_wset = doc.createWset(builder.intTypeRef()).ref();
+    doc.addField("aint", int_array).addField("wsint", int_wset);
+    return std::make_unique<DocumentTypeRepo>(builder.config());
+}
+
+std::unique_ptr<DocumentTypeRepo> repo = make_document_type_repo();
+
+TEST(FieldPathTargetTest, make_unsupported) {
+    auto target = FieldPathTarget::unsupported();
+    EXPECT_EQ(target.kind(), FieldPathTarget::Kind::UNSUPPORTED);
+}
+
+TEST(FieldPathTargetTest, make_array_index) {
+    auto target = FieldPathTarget::array_index("attr_name", 5);
+    EXPECT_EQ(target.kind(), FieldPathTarget::Kind::ARRAY_INDEX);
+    EXPECT_EQ(target.attribute_name(), "attr_name");
+    EXPECT_EQ(target.index(), 5);
+}
+
+TEST(FieldPathTargetTest, parse_array_index) {
+    const auto& doc_type = *repo->getDocumentType("testdoc");
+
+    auto target = FieldPathTarget::parse("aint[32]", doc_type);
+    EXPECT_EQ(target.kind(), FieldPathTarget::Kind::ARRAY_INDEX);
+    EXPECT_EQ(target.attribute_name(), "aint");
+    EXPECT_EQ(target.index(), 32);
+}
+
+TEST(FieldPathTargetTest, parse_unsupported) {
+    const auto& doc_type = *repo->getDocumentType("testdoc");
+
+    std::vector<std::string> unsupported_field_paths = {"abc", "bogus[0]", "wsint{5}", "aint[$x]", "aint[0].foo"};
+    for (const auto& field_path : unsupported_field_paths) {
+        auto target = FieldPathTarget::parse(field_path, doc_type);
+        EXPECT_TRUE(target.is_unsupported());
+    }
+}
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/common/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/common/CMakeLists.txt
@@ -13,6 +13,7 @@ vespa_add_library(searchcore_pcommon STATIC
     eventlogger.cpp
     feeddebugger.cpp
     feedtoken.cpp
+    field_path_target.cpp
     hw_info_sampler.cpp
     indexschema_inspector.cpp
     ipendinglidtracker.cpp

--- a/searchcore/src/vespa/searchcore/proton/common/field_path_target.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/field_path_target.cpp
@@ -1,0 +1,58 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "field_path_target.h"
+
+#include <vespa/document/base/exceptions.h>
+#include <vespa/document/base/fieldpath.h>
+#include <vespa/document/datatype/documenttype.h>
+
+using document::DocumentType;
+using document::FieldNotFoundException;
+using document::FieldPath;
+using document::FieldPathEntry;
+using vespalib::IllegalArgumentException;
+
+namespace proton {
+
+FieldPathTarget FieldPathTarget::unsupported() {
+    FieldPathTarget target;
+    target._kind = Kind::UNSUPPORTED;
+    return target;
+}
+
+FieldPathTarget FieldPathTarget::array_index(std::string attribute_name, uint32_t index) {
+    FieldPathTarget target;
+    target._kind = Kind::ARRAY_INDEX;
+    target._attribute_name = std::move(attribute_name);
+    target._index = index;
+    return target;
+}
+
+namespace {
+
+// my_arr [index]
+bool is_simple_array_lookup(const FieldPath& field_path) {
+    return field_path.size() == 2 && field_path[0].getType() == FieldPathEntry::Type::STRUCT_FIELD &&
+           field_path[1].getType() == FieldPathEntry::Type::ARRAY_INDEX;
+}
+
+} // namespace
+
+FieldPathTarget FieldPathTarget::parse(const std::string& original_field_path, const DocumentType& doc_type) {
+    FieldPath field_path;
+    try {
+        doc_type.buildFieldPath(field_path, original_field_path);
+    } catch (FieldNotFoundException&) {
+        return unsupported();
+    } catch (vespalib::IllegalArgumentException&) {
+        return unsupported();
+    }
+
+    if (is_simple_array_lookup(field_path)) {
+        return array_index(field_path[0].getFieldRef().getName(), field_path[1].getIndex());
+    }
+
+    return unsupported();
+}
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/common/field_path_target.h
+++ b/searchcore/src/vespa/searchcore/proton/common/field_path_target.h
@@ -1,0 +1,49 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace document {
+class DocumentType;
+}
+
+namespace proton {
+
+/**
+ * A parsed FieldPath for partial update of attribute vector using
+ * field paths.
+ */
+class FieldPathTarget {
+public:
+    using DocumentType = document::DocumentType;
+
+    enum class Kind : uint8_t {
+        UNSUPPORTED = 0,
+        ARRAY_INDEX,
+    };
+
+private:
+    Kind        _kind;
+    std::string _attribute_name;
+    uint32_t    _index;
+
+    FieldPathTarget() : _kind(Kind::UNSUPPORTED), _attribute_name(), _index(0) {}
+
+public:
+    [[nodiscard]] Kind kind() const noexcept { return _kind; }
+    [[nodiscard]] std::string_view attribute_name() const noexcept { return _attribute_name; }
+    [[nodiscard]] uint32_t index() const noexcept { return _index; }
+
+    [[nodiscard]] bool is_unsupported() const noexcept { return _kind == Kind::UNSUPPORTED; }
+
+    static FieldPathTarget unsupported();
+    static FieldPathTarget array_index(std::string attribute_name, uint32_t index);
+
+    // parse does not throw, malformed or unsupported field paths become Kind::UNSUPPORTED.
+    static FieldPathTarget parse(const std::string& original_field_path, const DocumentType& doc_type);
+};
+
+} // namespace proton


### PR DESCRIPTION
Adds FieldPathUpdate, which does not throw but catches known exceptions. Currently, it only parses `array[index]` syntax. Later, we will add, e.g., wset.

This will be used to parse field paths in partial updates for attribute vectors.

@toregge please review