### PR TITLE
Generate compile_commands.json for clangd/LSP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ install_manifest.txt
 .metadata
 /maven-wrapper
 /compile_commands.json
+/.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ vespa_detect_build_platform()
 message("-- Vespa build platform is ${VESPA_OS_DISTRO} ${VESPA_OS_DISTRO_VERSION}")
 vespa_use_default_cxx_compiler()
 
+# Emit compile_commands.json so editors/LSP servers (e.g. clangd) can find
+# per-file compile flags and include paths.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 project(vespa CXX C)
 vespa_use_default_vespa_unprivileged()
 vespa_use_default_cmake_install_prefix()


### PR DESCRIPTION
Enable CMAKE_EXPORT_COMPILE_COMMANDS so CMake emits a compile_commands.json describing the per-file compile flags and include paths. This lets editors and LSP servers such as clangd resolve symbols, includes and diagnostics correctly across the C++ codebase without hand-maintained configuration.

The variable is set before project() so it takes effect for all enabled languages. Also ignore clangd's /.cache index directory (compile_commands.json is already ignored).
