### PR TITLE
Force patched brace-expansion 2.1.1 in schema-language-server VSCode client (Mend HIGH CVE-2026-13149)

### DIFF
--- a/integration/schema-language-server/clients/vscode/package-lock.json
+++ b/integration/schema-language-server/clients/vscode/package-lock.json
@@ -5795,9 +5795,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/integration/schema-language-server/clients/vscode/package.json
+++ b/integration/schema-language-server/clients/vscode/package.json
@@ -100,5 +100,10 @@
   "dependencies": {
     "hasbin": "^1.2.3",
     "vscode-languageclient": "^9.0.1"
+  },
+  "overrides": {
+    "vscode-languageclient": {
+      "brace-expansion": "2.1.1"
+    }
   }
 }


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**
>
> **Once approved, please merge it** — this is an automated dependency-update PR and merging is the final step that closes out the linked Mend/Jira findings.

## Summary
Forces the transitive `brace-expansion` pulled into the schema-language-server VSCode client to the patched **2.1.1** maintenance release, clearing Mend HIGH **CVE-2026-13149** (ReDoS-class). No production/runtime code is affected — this is the editor-extension build only.

## Changed Files

**`integration/schema-language-server/clients/vscode/package.json`** — added a scoped npm `overrides` block:
- `vscode-languageclient` → `brace-expansion`: `2.1.1`

**`integration/schema-language-server/clients/vscode/package-lock.json`** — regenerated via `npm install --package-lock-only`:
- `node_modules/vscode-languageclient/node_modules/brace-expansion`: `2.0.3` → `2.1.1`

## CVEs Addressed

| Package | CVE(s) | Severity | Fix version reached |
|---|---|---|---|
| brace-expansion | CVE-2026-13149 | HIGH | 2.1.1 (`maintenance-v2` dist-tag) |

## Implementation Notes
- **Scoped, not blanket.** This lockfile has three `brace-expansion` instances: the flagged `2.0.3` (via `vscode-languageclient` → `minimatch ^2.0.1`), a dev `1.1.13` (via `@vscode/vsce` → `minimatch`), and a top-level dev `5.0.5`. A blanket `"brace-expansion": "2.1.1"` would force-downgrade the `5.x` instance and break `minimatch ^5.0.2`, so the override is deliberately scoped to the `vscode-languageclient` subtree only. `2.1.1` satisfies `minimatch`'s `^2.0.1`, so no consumer breaks.
- Mend flagged only the `2.0.3` instance on this ticket. Separately, `npm audit` reports the top-level dev `brace-expansion 5.0.5` as HIGH (a *different*, un-ticketed advisory patched in `5.0.6`/`5.0.7`). It's out of scope for VESPANG-3662 and not tracked by Mend, so it's left untouched here — flagging for maintainer awareness.
- CVE-2026-13149 is not yet indexed in OSV / the GitHub Advisory DB (published ~2026-06-30; public-DB lag is normal). The fix target `2.1.1` is corroborated by npm's `maintenance-v2` dist-tag and matches the patched-version choice used in the sibling `vespaai/*` fixes (athenz-ui, marketplace, habitat).

## Verification
- `npm install --package-lock-only` resolves cleanly; the `vscode-languageclient` brace-expansion node is now `2.1.1` (verified in `package-lock.json`).
- No `npm test` script exists for this extension. CI (`.github/workflows/lspDeploy.yml`) runs `npm ci` → build; the regenerated lockfile is consistent with the manifest so `npm ci` will succeed.
- Re-run the Mend scan after merge to confirm the CVE clears.
