### PR TITLE
Add quantized Euclidean and prenormalized angular distance functions

### DIFF
--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
@@ -75,6 +75,43 @@ template <typename T> void verifyInvalidQueryVector(DistanceFunctionFactory& dff
                     dff.for_query_vector(t(origo))->calc(e<vespalib::BFloat16>(origo.size()).cells));
 }
 
+TypedCells retype_to_i8f(const std::vector<uint8_t>& v) {
+    static_assert(sizeof(Int8Float) == 1);
+    auto as_i8f = std::span<const Int8Float>(reinterpret_cast<const Int8Float*>(v.data()), v.size());
+    return TypedCells(as_i8f);
+}
+
+constexpr static uint64_t quant_seed = 0x123456789;
+// The test vectors have such low dimensionality that anything less than 4-bit
+// quantization causes hilarious precision loss.
+constexpr static uint8_t quant_bits = 4;
+
+void check_quantized_distance_function(const DistanceFunctionFactory& dff, TypedCells a, TypedCells b,
+                                       const double expected_result, const double max_result_delta,
+                                       const vespalib::quant::QuantMode quant_mode) {
+    vespalib::quant::EdenQuantizer quantizer(a.size, quant_bits, quant_seed);
+    std::vector<uint8_t>           a_q(quantizer.quantized_size());
+    std::vector<uint8_t>           b_q(quantizer.quantized_size());
+    // (Ab)use TemporaryVectorStore for auto-conversion to float
+    TemporaryVectorStore<float> tmp_float_store(a.size);
+    quantizer.quantize(tmp_float_store.convertRhs(a), a_q, quant_mode);
+    quantizer.quantize(tmp_float_store.convertRhs(b), b_q, quant_mode);
+
+    // Query vectors are always full precision
+    auto d_n = dff.for_query_vector(a);
+    auto d_r = dff.for_query_vector(b);
+    // Insertion vectors must always be in quantized form (must compare apples to apples in a HNSW index)
+    auto d_i = dff.for_insertion_vector(retype_to_i8f(a_q));
+    // f32 `a` vs quantized `b`;
+    double result = d_n->calc(retype_to_i8f(b_q));
+    // TODO magnitude-relative max delta
+    EXPECT_THAT(result, DoubleNear(expected_result, max_result_delta));
+    // quantized vs. quantized; worst-case for precision loss
+    EXPECT_THAT(d_i->calc(retype_to_i8f(b_q)), DoubleNear(expected_result, max_result_delta));
+    // reverse (f32 `b` vs quantized `a`):
+    EXPECT_THAT(d_r->calc(retype_to_i8f(a_q)), DoubleNear(expected_result, max_result_delta));
+}
+
 double computeEuclideanChecked(TypedCells a, TypedCells b) {
     static EuclideanDistanceFunctionFactory<Int8Float> i8f_dff;
     static EuclideanDistanceFunctionFactory<float>     flt_dff;
@@ -96,6 +133,9 @@ double computeEuclideanChecked(TypedCells a, TypedCells b) {
         auto d_8 = i8f_dff.for_query_vector(a);
         EXPECT_DOUBLE_EQ(d_8->calc(b), result);
     }
+    QuantizedEuclideanDistanceFunctionFactory q_dff(a.size, quant_bits, quant_seed);
+    check_quantized_distance_function(q_dff, a, b, result, 0.65, vespalib::quant::QuantMode::MSE);
+
     return result;
 }
 
@@ -180,42 +220,6 @@ TEST(DistanceFunctionsTest, euclidean_int8_smoketest) {
     EXPECT_DOUBLE_EQ(14.0, computeEuclideanChecked(t(p5), t(p7)));
 }
 
-TypedCells retype_to_i8f(const std::vector<uint8_t>& v) {
-    static_assert(sizeof(Int8Float) == 1);
-    auto as_i8f = std::span<const Int8Float>(reinterpret_cast<const Int8Float*>(v.data()), v.size());
-    return TypedCells(as_i8f);
-}
-
-void check_quantized_angular(TypedCells a, TypedCells b, const double expected_result) {
-    constexpr uint64_t seed = 0x123456789;
-    // The test vectors have such low dimensionality that anything less than 4-bit
-    // quantization causes hilarious precision loss.
-    constexpr uint8_t bits = 4;
-
-    QuantizedAngularDistanceFunctionFactory q_dff(a.size, bits, seed);
-
-    vespalib::quant::EdenQuantizer quantizer(a.size, bits, seed);
-    std::vector<uint8_t>           a_q(quantizer.quantized_size());
-    std::vector<uint8_t>           b_q(quantizer.quantized_size());
-    // (Ab)use TemporaryVectorStore for auto-conversion to float
-    TemporaryVectorStore<float> tmp_float_store(a.size);
-    quantizer.quantize(tmp_float_store.convertRhs(a), a_q, vespalib::quant::QuantMode::InnerProduct);
-    quantizer.quantize(tmp_float_store.convertRhs(b), b_q, vespalib::quant::QuantMode::InnerProduct);
-
-    // Query vectors are always full precision
-    auto d_n = q_dff.for_query_vector(a);
-    auto d_r = q_dff.for_query_vector(b);
-    // Insertion vectors must always be in quantized form (must compare apples to apples in a HNSW index)
-    auto d_i = q_dff.for_insertion_vector(retype_to_i8f(a_q));
-    // f32 `a` vs quantized `b`;
-    double result = d_n->calc(retype_to_i8f(b_q));
-    EXPECT_THAT(result, DoubleNear(expected_result, 0.1));
-    // quantized vs. quantized; worst-case for precision loss
-    EXPECT_THAT(d_i->calc(retype_to_i8f(b_q)), DoubleNear(expected_result, 0.13));
-    // reverse (f32 `b` vs quantized `a`):
-    EXPECT_THAT(d_r->calc(retype_to_i8f(a_q)), DoubleNear(expected_result, 0.108));
-}
-
 double computeAngularChecked(TypedCells a, TypedCells b) {
     static AngularDistanceFunctionFactory<float>  flt_dff;
     static AngularDistanceFunctionFactory<double> dbl_dff;
@@ -232,7 +236,10 @@ double computeAngularChecked(TypedCells a, TypedCells b) {
     EXPECT_DOUBLE_EQ(d_r->calc(a), result);
     // float factory:
     EXPECT_FLOAT_EQ(d_f->calc(b), result);
-    check_quantized_angular(a, b, result);
+
+    QuantizedAngularDistanceFunctionFactory q_dff(a.size, quant_bits, quant_seed);
+    check_quantized_distance_function(q_dff, a, b, result, 0.13, vespalib::quant::QuantMode::InnerProduct);
+
     return result;
 }
 
@@ -360,6 +367,10 @@ double computePrenormalizedAngularChecked(TypedCells a, TypedCells b) {
     EXPECT_DOUBLE_EQ(closeness_n, closeness_i);
     EXPECT_GT(closeness_n, 0.0);
     EXPECT_LE(closeness_n, 1.0);
+
+    QuantizedPrenormalizedAngularDistanceFunctionFactory q_dff(a.size, quant_bits, quant_seed);
+    check_quantized_distance_function(q_dff, a, b, result, 0.65, vespalib::quant::QuantMode::InnerProduct);
+
     return result;
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/angular_distance.cpp
@@ -2,10 +2,8 @@
 
 #include "angular_distance.h"
 
+#include "distance_function_vector_access.h"
 #include "temporary_vector_store.h"
-
-#include <vespa/vespalib/hwaccelerated/functions.h>
-#include <vespa/vespalib/quant/eden.h>
 
 #include <cmath>
 #include <numbers>
@@ -15,12 +13,34 @@ using vespalib::eval::CellType;
 using vespalib::eval::Int8Float;
 using vespalib::eval::TypedCells;
 using vespalib::eval::TypifyCellType;
-namespace hwaccelerated = vespalib::hwaccelerated;
 
 namespace search::tensor {
 
-class BoundAngularDistanceBase : public BoundDistanceFunction {
+template <typename VectorAccessType>
+class BoundAngularDistance final : public BoundDistanceFunction {
+    mutable VectorAccessType _access;
+    double                   _lhs_norm_sq;
+
 public:
+    template <typename... AccessArgs>
+    explicit BoundAngularDistance(AccessArgs&&... access_args) : _access(std::forward<AccessArgs>(access_args)...) {
+        const auto* a = _access.lhs().data();
+        _lhs_norm_sq = _access.dot_product(cast(a), cast(a)); // TODO dedicated squared L2 norm function
+    }
+    ~BoundAngularDistance() override;
+
+    double calc(TypedCells rhs) const noexcept override {
+        auto        rhs_vector = _access.convert_rhs(rhs);
+        const auto* a = _access.lhs().data();
+        const auto* b = rhs_vector.data();
+        double      b_norm_sq = _access.dot_product(cast(b), cast(b));
+        double      squared_norms = _lhs_norm_sq * b_norm_sq;
+        double      dot_product = _access.dot_product(cast(a), cast(b));
+        double      div = (squared_norms > 0) ? sqrt(squared_norms) : 1.0;
+        double      cosine_similarity = dot_product / div;
+        double      distance = 1.0 - cosine_similarity; // in range [0,2]
+        return distance;
+    }
     double convert_threshold(double threshold) const noexcept override {
         if (threshold < 0.0) {
             return 0.0;
@@ -43,154 +63,42 @@ public:
     double calc_with_limit(TypedCells rhs, double) const noexcept override { return calc(rhs); }
 };
 
-template <typename VectorStoreType>
-class BoundAngularDistance final : public BoundAngularDistanceBase {
-    using FloatType = VectorStoreType::FloatType;
-    mutable VectorStoreType          _tmpSpace;
-    const std::span<const FloatType> _lhs;
-    double                           _lhs_norm_sq;
+template <typename VectorAccessType>
+BoundAngularDistance<VectorAccessType>::~BoundAngularDistance() = default;
 
-public:
-    explicit BoundAngularDistance(TypedCells lhs) : _tmpSpace(lhs.size), _lhs(_tmpSpace.storeLhs(lhs)) {
-        auto a = _lhs.data();
-        _lhs_norm_sq = hwaccelerated::dot_product(cast(a), cast(a), lhs.size);
-    }
-    double calc(TypedCells rhs) const noexcept override {
-        size_t                     sz = _lhs.size();
-        std::span<const FloatType> rhs_vector = _tmpSpace.convertRhs(rhs);
-        auto                       a = _lhs.data();
-        auto                       b = rhs_vector.data();
-        double                     b_norm_sq = hwaccelerated::dot_product(cast(b), cast(b), sz);
-        double                     squared_norms = _lhs_norm_sq * b_norm_sq;
-        double                     dot_product = hwaccelerated::dot_product(cast(a), cast(b), sz);
-        double                     div = (squared_norms > 0) ? sqrt(squared_norms) : 1.0;
-        double                     cosine_similarity = dot_product / div;
-        double                     distance = 1.0 - cosine_similarity; // in range [0,2]
-        return distance;
-    }
-};
-
-template class BoundAngularDistance<TemporaryVectorStore<float>>;
-template class BoundAngularDistance<TemporaryVectorStore<double>>;
-template class BoundAngularDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundAngularDistance<TemporaryVectorStore<vespalib::BFloat16>>;
-template class BoundAngularDistance<ReferenceVectorStore<float>>;
-template class BoundAngularDistance<ReferenceVectorStore<double>>;
-template class BoundAngularDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundAngularDistance<ReferenceVectorStore<vespalib::BFloat16>>;
+template class BoundAngularDistance<TemporaryVectorAccess<float>>;
+template class BoundAngularDistance<TemporaryVectorAccess<double>>;
+template class BoundAngularDistance<TemporaryVectorAccess<Int8Float>>;
+template class BoundAngularDistance<TemporaryVectorAccess<vespalib::BFloat16>>;
+template class BoundAngularDistance<ReferenceVectorAccess<float>>;
+template class BoundAngularDistance<ReferenceVectorAccess<double>>;
+template class BoundAngularDistance<ReferenceVectorAccess<Int8Float>>;
+template class BoundAngularDistance<ReferenceVectorAccess<vespalib::BFloat16>>;
 
 template <typename FloatType>
 BoundDistanceFunction::UP AngularDistanceFunctionFactory<FloatType>::for_query_vector(TypedCells lhs) const {
-    using DFT = BoundAngularDistance<TemporaryVectorStore<FloatType>>;
+    using DFT = BoundAngularDistance<TemporaryVectorAccess<FloatType>>;
     return std::make_unique<DFT>(lhs);
 }
 
 template <typename FloatType>
 BoundDistanceFunction::UP AngularDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) const {
     if (_reference_insertion_vector) {
-        using DFT = BoundAngularDistance<ReferenceVectorStore<FloatType>>;
+        using DFT = BoundAngularDistance<ReferenceVectorAccess<FloatType>>;
         return std::make_unique<DFT>(lhs);
     } else {
-        using DFT = BoundAngularDistance<TemporaryVectorStore<FloatType>>;
+        using DFT = BoundAngularDistance<TemporaryVectorAccess<FloatType>>;
         return std::make_unique<DFT>(lhs);
     }
 }
 
-namespace {
-
-struct Float32LhsQuantizedRhs {
-    using VectorStoreType = MutableSingleTemporaryVectorStore<float>;
-    using LhsFloatType = float;
-    constexpr static bool pre_quantized_lhs = false;
-};
-
-struct QuantizedLhsAndRhs {
-    using VectorStoreType = ReferenceVectorStore<Int8Float>;
-    using LhsFloatType = Int8Float;
-    constexpr static bool pre_quantized_lhs = true;
-};
-
-} // namespace
-
-// TODO generalize for other quantized bound distance functions?
-template <typename QuantParams>
-class BoundQuantizedAngularDistance final : public BoundAngularDistanceBase {
-    using LhsVectorStoreType = typename QuantParams::VectorStoreType;
-    using LhsFloatType = typename QuantParams::LhsFloatType;
-    // A distance function instance shall only be used by one thread at a time,
-    // so this can be mutable without violating constness assumptions.
-    // FIXME this one is relatively expensive to create and keep around...!
-    //  Make as much as possible into free-standing functions and only create quantizer
-    //  when pre-rotating.
-    mutable vespalib::quant::EdenQuantizer _quantizer;
-    LhsVectorStoreType                     _tmp_space;
-    const std::span<const LhsFloatType>    _lhs;
-    double                                 _lhs_norm_sq;
-
-public:
-    BoundQuantizedAngularDistance(TypedCells lhs, size_t dimensions, uint8_t bits, uint64_t seed)
-        : _quantizer(dimensions, bits, seed), _tmp_space(lhs.size), _lhs(_tmp_space.storeLhs(lhs)) {
-        if constexpr (!QuantParams::pre_quantized_lhs) { // full precision format
-            assert(lhs.size == _quantizer.dimensions());
-            // Quantized vectors are all in rotated space, so pre-rotate the query vector once
-            // so that it is in the same frame of reference. This avoids having to rotate the
-            // _quantized_ vectors when performing dot products. Note: this aliases `_lhs`.
-            _quantizer.rotate_vector_inplace(_tmp_space.mutable_lhs_buf());
-        } else {
-            static_assert(std::is_same_v<LhsFloatType, Int8Float>);
-            assert(lhs.size == _quantizer.quantized_size());
-        }
-        const auto* a = _lhs.data();
-        _lhs_norm_sq = dot(cast(a), cast(a)); // TODO dedicated L2 norm function
-    }
-    ~BoundQuantizedAngularDistance() override;
-
-    // rhs is always a quantized vector representation
-    double calc(TypedCells rhs) const noexcept override {
-        assert(rhs.type == CellType::INT8);
-        assert(rhs.size == _quantizer.quantized_size());
-        auto   rhs_vector = rhs.unsafe_typify<Int8Float>();
-        auto*  a = _lhs.data(); // f32 (raw query vector) or i8 (quantized insertion vector)
-        auto*  b = rhs_vector.data();
-        double b_norm_sq = dot(cast(b), cast(b)); // TODO dedicated L2 norm function (avoids 2x codebook lookups)
-        double squared_norms = _lhs_norm_sq * b_norm_sq;
-        double dot_product = dot(cast(a), cast(b));
-        double div = (squared_norms > 0) ? sqrt(squared_norms) : 1.0;
-        double cosine_similarity = dot_product / div;
-        double distance = 1.0 - cosine_similarity; // in range [0,2]
-        return distance;
-    }
-
-private:
-    [[nodiscard]] float dot(const int8_t* lhs, const int8_t* rhs) const noexcept {
-        auto lhs_u8 = std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(lhs), _quantizer.quantized_size());
-        auto rhs_u8 = std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(rhs), _quantizer.quantized_size());
-        return _quantizer.quantized_lhs_rhs_dot_product(lhs_u8, rhs_u8);
-    }
-
-    [[nodiscard]] float dot(const float* lhs, const int8_t* rhs) const noexcept {
-        auto lhs_f32 = std::span<const float>(lhs, _quantizer.dimensions());
-        auto rhs_u8 = std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(rhs), _quantizer.quantized_size());
-        return _quantizer.pre_rotated_query_dot_product(lhs_f32, rhs_u8);
-    }
-
-    [[nodiscard]] float dot(const float* lhs, const float* rhs) const noexcept {
-        return hwaccelerated::dot_product(lhs, rhs, _quantizer.dimensions());
-    }
-};
-
-template <typename LhsVectorStoreType>
-BoundQuantizedAngularDistance<LhsVectorStoreType>::~BoundQuantizedAngularDistance() = default;
-
 BoundDistanceFunction::UP QuantizedAngularDistanceFunctionFactory::for_query_vector(TypedCells lhs) const {
-    using DFT = BoundQuantizedAngularDistance<Float32LhsQuantizedRhs>;
+    using DFT = BoundAngularDistance<Float32LhsQuantizedRhsVectorAccess>;
     return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
 }
 
 BoundDistanceFunction::UP QuantizedAngularDistanceFunctionFactory::for_insertion_vector(TypedCells lhs) const {
-    // Insertion vectors are always in quantized int8 form
-    using DFT = BoundQuantizedAngularDistance<QuantizedLhsAndRhs>;
-    assert(lhs.type == CellType::INT8);
+    using DFT = BoundAngularDistance<QuantizedLhsAndRhsVectorAccess>;
     return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
 }
 
@@ -198,8 +106,5 @@ template class AngularDistanceFunctionFactory<float>;
 template class AngularDistanceFunctionFactory<double>;
 template class AngularDistanceFunctionFactory<Int8Float>;
 template class AngularDistanceFunctionFactory<vespalib::BFloat16>;
-
-template class BoundQuantizedAngularDistance<Float32LhsQuantizedRhs>;
-template class BoundQuantizedAngularDistance<QuantizedLhsAndRhs>;
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_vector_access.h
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_vector_access.h
@@ -1,0 +1,165 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "temporary_vector_store.h"
+
+#include <vespa/eval/eval/int8float.h>
+#include <vespa/eval/eval/typed_cells.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
+#include <vespa/vespalib/quant/eden.h>
+
+#include <type_traits>
+
+namespace search::tensor {
+
+// Wrappers around temporary vector stores that further abstract away how distance functions
+// deal with type conversions and low-level distance computations. This is an indirection
+// created in the honor of vector quantization, as efficient distance computations on
+// quantized vectors require operating (in a quantization-aware manner) on the bitwise
+// representation without needing to go via an explicit (and expensive) dequantization step.
+// It also allows for heterogeneous types for the left and right hand sides of the
+// comparison, which means a full precision query can be compared with a reduced precision
+// internal representation. This is currently only implemented for quantized vectors,
+// and in that case double-precision queries will be narrowed to full (float) precision.
+
+// Simple wrapper around the provided VectorStoreType with homogenous lhs/rhs types
+// (via implicit conversion of the input lhs vector).
+template <typename VectorStoreType>
+class DefaultDistanceFunctionVectorAccess {
+    using FloatType = VectorStoreType::FloatType;
+
+    VectorStoreType                  _tmp_space;
+    const std::span<const FloatType> _lhs;
+
+public:
+    explicit DefaultDistanceFunctionVectorAccess(vespalib::eval::TypedCells lhs)
+        : _tmp_space(lhs.size), _lhs(_tmp_space.storeLhs(lhs)) {}
+
+    [[nodiscard]] std::span<const FloatType> lhs() const noexcept { return _lhs; }
+    [[nodiscard]] std::span<const FloatType> convert_rhs(vespalib::eval::TypedCells rhs) noexcept {
+        return _tmp_space.convertRhs(rhs);
+    }
+    template <typename T>
+    [[nodiscard]] double dot_product(const T* a, const T* b) const noexcept {
+        return vespalib::hwaccelerated::dot_product(a, b, _lhs.size());
+    }
+    template <typename T>
+    [[nodiscard]] double squared_euclidean_distance(const T* a, const T* b) const noexcept {
+        return vespalib::hwaccelerated::squared_euclidean_distance(a, b, _lhs.size());
+    }
+};
+
+template <typename FloatType>
+using TemporaryVectorAccess = DefaultDistanceFunctionVectorAccess<TemporaryVectorStore<FloatType>>;
+template <typename FloatType>
+using ReferenceVectorAccess = DefaultDistanceFunctionVectorAccess<ReferenceVectorStore<FloatType>>;
+
+// Wrapper used when operating on a quantized tensor where the right hand (tensor) side is
+// always quantized, but the left hand side may be either quantized or a full precision
+// float vector.
+template <typename QuantAccessParams>
+class QuantizedDistanceFunctionVectorAccess {
+    using LhsVectorStoreType = typename QuantAccessParams::VectorStoreType;
+    using LhsFloatType = typename QuantAccessParams::LhsFloatType;
+
+    // A distance function instance shall only be used by one thread at a time,
+    // so this can be mutable without violating constness assumptions.
+    // FIXME this one is relatively expensive to create and keep around...!
+    //  Make as much as possible into free-standing functions and only create quantizer
+    //  when pre-rotating.
+    mutable vespalib::quant::EdenQuantizer _quantizer;
+    LhsVectorStoreType                     _tmp_space;
+    const std::span<const LhsFloatType>    _lhs;
+
+public:
+    QuantizedDistanceFunctionVectorAccess(vespalib::eval::TypedCells lhs, const size_t dimensions, const uint8_t bits,
+                                          const uint64_t seed)
+        : _quantizer(dimensions, bits, seed), _tmp_space(lhs.size), _lhs(_tmp_space.storeLhs(lhs)) {
+        if constexpr (!QuantAccessParams::pre_quantized_lhs) { // full precision format
+            assert(lhs.size == _quantizer.dimensions());
+            // Quantized vectors are all in rotated space, so pre-rotate the query vector once
+            // so that it is in the same frame of reference. This avoids having to rotate the
+            // _quantized_ vectors when performing distance calcs. Note: this aliases `_lhs`.
+            _quantizer.rotate_vector_inplace(_tmp_space.mutable_lhs_buf());
+        } else {
+            static_assert(std::is_same_v<LhsFloatType, vespalib::eval::Int8Float>);
+            assert(lhs.type == vespalib::eval::CellType::INT8);
+            assert(lhs.size == _quantizer.quantized_size());
+        }
+    }
+    ~QuantizedDistanceFunctionVectorAccess();
+
+    [[nodiscard]] size_t dimensions() const noexcept { return _quantizer.dimensions(); }
+    [[nodiscard]] size_t quantized_size() const noexcept { return _quantizer.quantized_size(); }
+
+    // Lhs is _either_ a f32 (raw query vector) or an i8 (quantized insertion vector)
+    [[nodiscard]] std::span<const LhsFloatType> lhs() const noexcept { return _lhs; }
+    // Rhs is always a quantized i8 vector
+    [[nodiscard]] std::span<const vespalib::eval::Int8Float>
+    convert_rhs(vespalib::eval::TypedCells rhs) const noexcept {
+        assert(rhs.size == quantized_size());
+        return rhs.typify<vespalib::eval::Int8Float>();
+    }
+
+    // These overloads are used for selecting the appropriate quantizer function
+    // based on whether the lhs is quantized (i8) or not (float). The float vs float
+    // overload is a convenience function to handle squared L2 norm computation of
+    // a float query vector.
+    // The functions make assumptions on vector lengths that should transitively hold
+    // from the assertions present on the lhs/rhs conversions.
+    // Note: all functions that operate on quantized representations will implicitly
+    // mutate the underlying _quantizer instance.
+    [[nodiscard]] float dot_product(const int8_t* lhs, const int8_t* rhs) const noexcept {
+        return _quantizer.quantized_lhs_rhs_dot_product(as_quantized_u8_vec(lhs), as_quantized_u8_vec(rhs));
+    }
+    [[nodiscard]] float dot_product(const float* lhs, const int8_t* rhs) const noexcept {
+        return _quantizer.pre_rotated_query_dot_product(as_unquantized_f32_vec(lhs), as_quantized_u8_vec(rhs));
+    }
+    [[nodiscard]] float dot_product(const float* lhs, const float* rhs) const noexcept {
+        return vespalib::hwaccelerated::dot_product(lhs, rhs, dimensions());
+    }
+    [[nodiscard]] float squared_euclidean_distance(const int8_t* lhs, const int8_t* rhs) const noexcept {
+        return _quantizer.quantized_lhs_rhs_squared_euclidean_distance(as_quantized_u8_vec(lhs),
+                                                                       as_quantized_u8_vec(rhs));
+    }
+    [[nodiscard]] float squared_euclidean_distance(const float* lhs, const int8_t* rhs) const noexcept {
+        return _quantizer.pre_rotated_query_squared_euclidean_distance(as_unquantized_f32_vec(lhs),
+                                                                       as_quantized_u8_vec(rhs));
+    }
+
+private:
+    [[nodiscard]] std::span<const float> as_unquantized_f32_vec(const float* buf) const noexcept {
+        return std::span<const float>(buf, dimensions());
+    }
+    [[nodiscard]] std::span<const uint8_t> as_quantized_u8_vec(const int8_t* buf) const noexcept {
+        return std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(buf), quantized_size());
+    }
+};
+
+template <typename QuantAccessParams>
+QuantizedDistanceFunctionVectorAccess<QuantAccessParams>::~QuantizedDistanceFunctionVectorAccess() = default;
+
+struct Float32LhsQuantizedRhs {
+    using VectorStoreType = MutableSingleTemporaryVectorStore<float>;
+    using LhsFloatType = float;
+    constexpr static bool pre_quantized_lhs = false;
+};
+// To be used when the left hand (query) side of the distance calculation is a full precision
+// float vector. We need mutable storage for this since the query vector must be rotated into
+// the same frame of reference as the one used by the quantized vectors. Note that we use a
+// custom temporary vector store that only allocates room for a single float vector since we
+// know that the right hand side is always quantized.
+using Float32LhsQuantizedRhsVectorAccess = QuantizedDistanceFunctionVectorAccess<Float32LhsQuantizedRhs>;
+
+struct QuantizedLhsAndRhs {
+    using VectorStoreType = ReferenceVectorStore<vespalib::eval::Int8Float>;
+    using LhsFloatType = vespalib::eval::Int8Float;
+    constexpr static bool pre_quantized_lhs = true;
+};
+// To be used when both the left and right hand sides of the distance calculation are quantized.
+// In this case we can directly reference the left hand side vector, as no rotation or conversion
+// is needed.
+using QuantizedLhsAndRhsVectorAccess = QuantizedDistanceFunctionVectorAccess<QuantizedLhsAndRhs>;
+
+} // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/euclidean_distance.cpp
@@ -2,9 +2,8 @@
 
 #include "euclidean_distance.h"
 
+#include "distance_function_vector_access.h"
 #include "temporary_vector_store.h"
-
-#include <vespa/vespalib/hwaccelerated/functions.h>
 
 #include <cmath>
 
@@ -16,18 +15,20 @@ namespace search::tensor {
 
 using vespalib::eval::Int8Float;
 
-template <typename VectorStoreType> class BoundEuclideanDistance final : public BoundDistanceFunction {
-    using FloatType = VectorStoreType::FloatType;
-    mutable VectorStoreType          _tmpSpace;
-    const std::span<const FloatType> _lhs_vector;
+template <typename VectorAccessType>
+class BoundEuclideanDistance final : public BoundDistanceFunction {
+    mutable VectorAccessType _access;
 
 public:
-    explicit BoundEuclideanDistance(TypedCells lhs) : _tmpSpace(lhs.size), _lhs_vector(_tmpSpace.storeLhs(lhs)) {}
+    template <typename... AccessArgs>
+    explicit BoundEuclideanDistance(AccessArgs&&... access_args)
+        : _access(std::forward<AccessArgs>(access_args)...) {}
+
     double calc(TypedCells rhs) const noexcept override {
-        std::span<const FloatType> rhs_vector = _tmpSpace.convertRhs(rhs);
-        auto                       a = _lhs_vector.data();
-        auto                       b = rhs_vector.data();
-        return vespalib::hwaccelerated::squared_euclidean_distance(cast(a), cast(b), _lhs_vector.size());
+        auto        rhs_vector = _access.convert_rhs(rhs);
+        const auto* a = _access.lhs().data();
+        const auto* b = rhs_vector.data();
+        return _access.squared_euclidean_distance(cast(a), cast(b));
     }
     double convert_threshold(double threshold) const noexcept override { return threshold * threshold; }
     double to_rawscore(double distance) const noexcept override {
@@ -38,28 +39,28 @@ public:
     double calc_with_limit(TypedCells rhs, double) const noexcept override { return calc(rhs); }
 };
 
-template class BoundEuclideanDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundEuclideanDistance<TemporaryVectorStore<vespalib::BFloat16>>;
-template class BoundEuclideanDistance<TemporaryVectorStore<float>>;
-template class BoundEuclideanDistance<TemporaryVectorStore<double>>;
-template class BoundEuclideanDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundEuclideanDistance<ReferenceVectorStore<vespalib::BFloat16>>;
-template class BoundEuclideanDistance<ReferenceVectorStore<float>>;
-template class BoundEuclideanDistance<ReferenceVectorStore<double>>;
+template class BoundEuclideanDistance<TemporaryVectorAccess<Int8Float>>;
+template class BoundEuclideanDistance<TemporaryVectorAccess<vespalib::BFloat16>>;
+template class BoundEuclideanDistance<TemporaryVectorAccess<float>>;
+template class BoundEuclideanDistance<TemporaryVectorAccess<double>>;
+template class BoundEuclideanDistance<ReferenceVectorAccess<Int8Float>>;
+template class BoundEuclideanDistance<ReferenceVectorAccess<vespalib::BFloat16>>;
+template class BoundEuclideanDistance<ReferenceVectorAccess<float>>;
+template class BoundEuclideanDistance<ReferenceVectorAccess<double>>;
 
 template <typename FloatType>
 BoundDistanceFunction::UP EuclideanDistanceFunctionFactory<FloatType>::for_query_vector(TypedCells lhs) const {
-    using DFT = BoundEuclideanDistance<TemporaryVectorStore<FloatType>>;
+    using DFT = BoundEuclideanDistance<TemporaryVectorAccess<FloatType>>;
     return std::make_unique<DFT>(lhs);
 }
 
 template <typename FloatType>
 BoundDistanceFunction::UP EuclideanDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) const {
     if (_reference_insertion_vector) {
-        using DFT = BoundEuclideanDistance<ReferenceVectorStore<FloatType>>;
+        using DFT = BoundEuclideanDistance<ReferenceVectorAccess<FloatType>>;
         return std::make_unique<DFT>(lhs);
     } else {
-        using DFT = BoundEuclideanDistance<TemporaryVectorStore<FloatType>>;
+        using DFT = BoundEuclideanDistance<TemporaryVectorAccess<FloatType>>;
         return std::make_unique<DFT>(lhs);
     }
 }
@@ -68,5 +69,15 @@ template class EuclideanDistanceFunctionFactory<Int8Float>;
 template class EuclideanDistanceFunctionFactory<vespalib::BFloat16>;
 template class EuclideanDistanceFunctionFactory<float>;
 template class EuclideanDistanceFunctionFactory<double>;
+
+BoundDistanceFunction::UP QuantizedEuclideanDistanceFunctionFactory::for_query_vector(TypedCells lhs) const {
+    using DFT = BoundEuclideanDistance<Float32LhsQuantizedRhsVectorAccess>;
+    return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
+}
+
+BoundDistanceFunction::UP QuantizedEuclideanDistanceFunctionFactory::for_insertion_vector(TypedCells lhs) const {
+    using DFT = BoundEuclideanDistance<QuantizedLhsAndRhsVectorAccess>;
+    return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
+}
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/euclidean_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/euclidean_distance.h
@@ -29,4 +29,28 @@ public:
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };
 
+/**
+ * Calculates squared Euclidean distance between vectors, where the left hand side
+ * may be either a float32 (full precision) vector or a quantized vector in int8
+ * format, and the right hand side is always a quantized vector in int8 format.
+ *
+ * Query vectors are always converted to float32 form. That means a _query_ vector
+ * of int8 values will be elementwise promoted to float and will _not_ be treated
+ * as the quantized representation of a query vector.
+ *
+ * Insertion vectors are expected to be in pre-quantized int8 format.
+ */
+class QuantizedEuclideanDistanceFunctionFactory : public DistanceFunctionFactory {
+    const size_t   _dimensions;
+    const uint64_t _seed;
+    const uint8_t  _bits;
+
+public:
+    QuantizedEuclideanDistanceFunctionFactory(size_t dimensions, uint8_t bits, uint64_t seed) noexcept
+        : _dimensions(dimensions), _seed(seed), _bits(bits) {}
+    BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
+    // Only supports int8 insertion vectors
+    BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
+};
+
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.cpp
@@ -2,37 +2,36 @@
 
 #include "prenormalized_angular_distance.h"
 
+#include "distance_function_vector_access.h"
 #include "temporary_vector_store.h"
-
-#include <vespa/vespalib/hwaccelerated/functions.h>
 
 using vespalib::typify_invoke;
 using vespalib::eval::Int8Float;
 using vespalib::eval::TypifyCellType;
-namespace hwaccelerated = vespalib::hwaccelerated;
 
 namespace search::tensor {
 
-template <typename VectorStoreType> class BoundPrenormalizedAngularDistance final : public BoundDistanceFunction {
-    using FloatType = VectorStoreType::FloatType;
-    mutable VectorStoreType          _tmpSpace;
-    const std::span<const FloatType> _lhs;
-    double                           _lhs_norm_sq;
+template <typename VectorAccessType>
+class BoundPrenormalizedAngularDistance final : public BoundDistanceFunction {
+    mutable VectorAccessType _access;
+    double                   _lhs_norm_sq;
 
 public:
-    explicit BoundPrenormalizedAngularDistance(TypedCells lhs) : _tmpSpace(lhs.size), _lhs(_tmpSpace.storeLhs(lhs)) {
-        auto a = _lhs.data();
-        _lhs_norm_sq = hwaccelerated::dot_product(cast(a), cast(a), lhs.size);
+    template <typename... AccessArgs>
+    explicit BoundPrenormalizedAngularDistance(AccessArgs&&... access_args)
+        : _access(std::forward<AccessArgs>(access_args)...) {
+        const auto* a = _access.lhs().data();
+        _lhs_norm_sq = _access.dot_product(cast(a), cast(a)); // TODO dedicated squared L2 norm function
         if (_lhs_norm_sq <= 0.0) {
             _lhs_norm_sq = 1.0;
         }
     }
     double calc(TypedCells rhs) const noexcept override {
-        std::span<const FloatType> rhs_vector = _tmpSpace.convertRhs(rhs);
-        auto                       a = _lhs.data();
-        auto                       b = rhs_vector.data();
-        double                     dot_product = hwaccelerated::dot_product(cast(a), cast(b), _lhs.size());
-        double                     distance = _lhs_norm_sq - dot_product;
+        auto        rhs_vector = _access.convert_rhs(rhs);
+        const auto* a = _access.lhs().data();
+        const auto* b = rhs_vector.data();
+        double      dot_product = _access.dot_product(cast(a), cast(b));
+        double      distance = _lhs_norm_sq - dot_product;
         return distance;
     }
     double convert_threshold(double threshold) const noexcept override {
@@ -54,19 +53,19 @@ public:
     double calc_with_limit(TypedCells rhs, double) const noexcept override { return calc(rhs); }
 };
 
-template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<float>>;
-template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<double>>;
-template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<Int8Float>>;
-template class BoundPrenormalizedAngularDistance<TemporaryVectorStore<vespalib::BFloat16>>;
-template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<float>>;
-template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<double>>;
-template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<Int8Float>>;
-template class BoundPrenormalizedAngularDistance<ReferenceVectorStore<vespalib::BFloat16>>;
+template class BoundPrenormalizedAngularDistance<TemporaryVectorAccess<float>>;
+template class BoundPrenormalizedAngularDistance<TemporaryVectorAccess<double>>;
+template class BoundPrenormalizedAngularDistance<TemporaryVectorAccess<Int8Float>>;
+template class BoundPrenormalizedAngularDistance<TemporaryVectorAccess<vespalib::BFloat16>>;
+template class BoundPrenormalizedAngularDistance<ReferenceVectorAccess<float>>;
+template class BoundPrenormalizedAngularDistance<ReferenceVectorAccess<double>>;
+template class BoundPrenormalizedAngularDistance<ReferenceVectorAccess<Int8Float>>;
+template class BoundPrenormalizedAngularDistance<ReferenceVectorAccess<vespalib::BFloat16>>;
 
 template <typename FloatType>
 BoundDistanceFunction::UP
 PrenormalizedAngularDistanceFunctionFactory<FloatType>::for_query_vector(TypedCells lhs) const {
-    using DFT = BoundPrenormalizedAngularDistance<TemporaryVectorStore<FloatType>>;
+    using DFT = BoundPrenormalizedAngularDistance<TemporaryVectorAccess<FloatType>>;
     return std::make_unique<DFT>(lhs);
 }
 
@@ -74,10 +73,10 @@ template <typename FloatType>
 BoundDistanceFunction::UP
 PrenormalizedAngularDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) const {
     if (_reference_insertion_vector) {
-        using DFT = BoundPrenormalizedAngularDistance<ReferenceVectorStore<FloatType>>;
+        using DFT = BoundPrenormalizedAngularDistance<ReferenceVectorAccess<FloatType>>;
         return std::make_unique<DFT>(lhs);
     } else {
-        using DFT = BoundPrenormalizedAngularDistance<TemporaryVectorStore<FloatType>>;
+        using DFT = BoundPrenormalizedAngularDistance<TemporaryVectorAccess<FloatType>>;
         return std::make_unique<DFT>(lhs);
     }
 }
@@ -86,5 +85,17 @@ template class PrenormalizedAngularDistanceFunctionFactory<float>;
 template class PrenormalizedAngularDistanceFunctionFactory<double>;
 template class PrenormalizedAngularDistanceFunctionFactory<Int8Float>;
 template class PrenormalizedAngularDistanceFunctionFactory<vespalib::BFloat16>;
+
+BoundDistanceFunction::UP
+QuantizedPrenormalizedAngularDistanceFunctionFactory::for_query_vector(TypedCells lhs) const {
+    using DFT = BoundPrenormalizedAngularDistance<Float32LhsQuantizedRhsVectorAccess>;
+    return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
+}
+
+BoundDistanceFunction::UP
+QuantizedPrenormalizedAngularDistanceFunctionFactory::for_insertion_vector(TypedCells lhs) const {
+    using DFT = BoundPrenormalizedAngularDistance<QuantizedLhsAndRhsVectorAccess>;
+    return std::make_unique<DFT>(lhs, _dimensions, _bits, _seed);
+}
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.h
@@ -28,4 +28,29 @@ public:
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };
 
+/**
+ * Calculates inner-product "distance" between vectors assuming a common norm,
+ * where the left hand side may be either a float32 (full precision) vector or
+ * a quantized vector in int8 format, and the right hand side is always a quantized
+ * vector in int8 format.
+ *
+ * Query vectors are always converted to float32 form. That means a _query_ vector
+ * of int8 values will be elementwise promoted to float and will _not_ be treated
+ * as the quantized representation of a query vector.
+ *
+ * Insertion vectors are expected to be in pre-quantized int8 format.
+ */
+class QuantizedPrenormalizedAngularDistanceFunctionFactory : public DistanceFunctionFactory {
+    const size_t   _dimensions;
+    const uint64_t _seed;
+    const uint8_t  _bits;
+
+public:
+    QuantizedPrenormalizedAngularDistanceFunctionFactory(size_t dimensions, uint8_t bits, uint64_t seed) noexcept
+        : _dimensions(dimensions), _seed(seed), _bits(bits) {}
+    BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
+    // Only supports int8 insertion vectors
+    BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
+};
+
 } // namespace search::tensor


### PR DESCRIPTION
@arnej27959 please review. Most of this diff is code-plumbing that hides quantization sausage-making from the actual distance function algorithms.

As with the previous quantized angular implementation, this allows for a left hand side that is either a float32 (full precision) vector or a quantized vector in int8 format. The right hand side must always be a quantized vector in int8 format.

Query vectors are always converted to float32 form. That means a _query_ vector of int8 values will be element-wise promoted to float and will _not_ be treated as the quantized representation of a query vector. Insertion vectors are expected to be in pre-quantized int8 format.

This introduces a new abstraction™ around low-level distance computations that unifies the existing temporary/reference vector stores and the formerly explicitly specialized quantized distance function types.

The new abstraction means that the actual distance algorithm code only has to be written once instead of having to be partially duplicated. As part of this, the previously explicitly quantized angular distance function subclass has been removed, as it's now subsumed into the regular distance function.

