### PR TITLE
Use clock.instant() instead of Instant.EPOCH when lastModified throws

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -702,6 +702,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         List<String> deleted = new ArrayList<>();
         toDelete.forEach(fileReference -> {
             try {
+                // Note that a file reference will only be deleted if it is not in use and is old enough
                 if (fileDirectory.delete(new FileReference(fileReference), this::isFileReferenceInUse, this::isFileReferenceOld))
                     deleted.add(fileReference);
             } catch (UncheckedIOException e) {
@@ -748,8 +749,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                     try {
                         return lastModified(new File(fileReferencesPath, a));
                     } catch (UncheckedIOException e) {
-                        log.log(Level.FINE, "Unable to get last modified time for file reference " + a + ", probably deleted");
-                        return Instant.EPOCH;
+                        log.log(Level.INFO, "Unable to get last modified time for file reference " + a + ", probably deleted");
+                        return clock.instant();
                     }
                 }))
                 // Do max 20 at a time

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -218,7 +218,8 @@ public class FileServer {
                                                                           false);
             file = downloader.getFile(newDownload);
             if (file.isEmpty())
-                log.log(Level.INFO, "Failed downloading '" + fileReferenceDownload + "'");
+                log.log(Level.INFO, "File not available for serving and failed downloading '" +
+                        fileReferenceDownload + "' from another source");
             return file;
         } else {
             log.log(FINE, "File not found, will not download from another source");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -59,6 +59,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -305,6 +306,35 @@ public class ApplicationRepositoryTest {
         assertFalse(new File(fileReferencesDir, "baz0").exists());
         assertFalse(new File(fileReferencesDir, "baz1").exists());
         assertTrue(filereferenceDirNewest.exists());
+    }
+
+    @Test
+    public void deleteUnusedFileReferencesWithConcurrentlyDeletedFileReference() throws IOException {
+        File fileReferencesDir = new File(configserverConfig.fileReferencesDir());
+
+        // Create 20 old file references (more than the limit of 20 to be returned by sortedUnusedFileReferences)
+        IntStream.range(0, 20).forEach(i -> {
+            createFileReferenceOnDisk(new File(fileReferencesDir, "ref" + i));
+            clock.advance(Duration.ofSeconds(1));
+        });
+        clock.advance(Duration.ofMinutes(configserverConfig.keepUnusedFileReferencesMinutes()));
+
+        // Create a broken symlink to simulate a file reference that was concurrently deleted:
+        // it appears in the directory listing but throws UncheckedIOException when lastModified is called.
+        // With the fix (clock.instant()), this sorts as the newest entry and does not take a deletion slot.
+        // Without the fix (Instant.EPOCH), it sorts first and displaces one old file reference.
+        Files.createSymbolicLink(fileReferencesDir.toPath().resolve("concurrently-deleted"),
+                                 java.nio.file.Path.of("/nonexistent/target"));
+
+        applicationRepository = new ApplicationRepository.Builder()
+                .withTenantRepository(tenantRepository)
+                .withClock(clock)
+                .withConfigserverConfig(configserverConfig)
+                .build();
+
+        List<String> deleted = applicationRepository.deleteUnusedFileDistributionReferences(fileDirectory);
+        assertEquals(20, deleted.size());
+        IntStream.range(0, 20).forEach(i -> assertFalse(new File(fileReferencesDir, "ref" + i).exists()));
     }
 
     private File createFileReferenceOnDisk(File filereference) {

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -192,7 +192,8 @@ public class FileReferenceDownloader {
                 return DownloadResult.SUCCESS;
             } else {
                 var error = FileApiErrorCodes.get(errorCode);
-                log.log(logLevel, "Downloading " + fileReference + " from " + address + " failed (" + error + ")");
+                var errorDescription = error == null ? "Unknown error" : error.description();
+                log.log(logLevel, "Downloading " + fileReference + " from " + address + " failed (" + errorDescription + ")");
                 return DownloadResult.FAILURE;
             }
         } else {


### PR DESCRIPTION
## Summary
- When a file reference is deleted between directory listing and the `lastModified` call, the caught `UncheckedIOException` now returns `clock.instant()` as the sort key instead of `Instant.EPOCH`
- This prevents the phantom entry from sorting first (as year 1970) and stealing one of the 20 deletion slots
- Ensures all legitimately old file references are processed for deletion

## Test
Added `deleteUnusedFileReferencesWithConcurrentlyDeletedFileReference` in `ApplicationRepositoryTest`: creates 20 old file references and a broken symlink (simulating a concurrently deleted file), then asserts all 20 old references are deleted. With the old `Instant.EPOCH` behavior only 19 would be deleted.

---
*Generated by Claude Code*