### PR TITLE
Test that activation stores heap dump redaction

### DIFF
--- a/configserver/src/test/apps/hosted-without-memory-dump/deployment.xml
+++ b/configserver/src/test/apps/hosted-without-memory-dump/deployment.xml
@@ -1,8 +1,5 @@
 <!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <deployment version='1.0'>
-  <backup frequency='24h' granularity='cluster' />
-  <block-change revision='true' version='false' days='mon,tue' hours='8-10' time-zone='UTC' />
-  <memory-dump heap-dump-redaction='basic' />
   <prod>
     <region>us-north-1</region>
   </prod>

--- a/configserver/src/test/apps/hosted-without-memory-dump/services.xml
+++ b/configserver/src/test/apps/hosted-without-memory-dump/services.xml
@@ -1,0 +1,6 @@
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+  <container id="container" version="1.0">
+    <nodes count="2"/>
+  </container>
+</services>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeploymentConfigStoreTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeploymentConfigStoreTest.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.BackupConfig;
 import com.yahoo.config.provision.BlockWindow;
 import com.yahoo.config.provision.DeploymentConfigStore;
 import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.HeapDumpRedaction;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.TelemetryExporterConfiguration;
 import com.yahoo.config.provision.Zone;
@@ -30,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests that Deployment.activate() stores backup config and block windows via DeploymentConfigStore
  * when activated in a production environment, and does nothing in non-production environments.
+ * Heap dump redaction is stored in all environments.
  *
  * @author olaa
  */
@@ -126,6 +128,54 @@ public class DeploymentConfigStoreTest {
     }
 
     @Test
+    public void stores_heap_dump_redaction_for_prod_deployment() {
+        CapturingDeploymentConfigStore store = new CapturingDeploymentConfigStore();
+        Zone prodZone = new Zone(Environment.prod, RegionName.from("us-north-1"));
+
+        DeployTester tester = new DeployTester.Builder(temporaryFolder)
+                .hostedConfigserverConfig(prodZone)
+                .modelFactory(createHostedModelFactory())
+                .deploymentConfigStore(store)
+                .build();
+
+        tester.deployApp("src/test/apps/hosted-with-backup/");
+
+        assertEquals(List.of(HeapDumpRedaction.basic), store.redactionCalls);
+    }
+
+    @Test
+    public void stores_heap_dump_redaction_also_for_non_prod_deployment() {
+        CapturingDeploymentConfigStore store = new CapturingDeploymentConfigStore();
+        Zone devZone = new Zone(Environment.dev, RegionName.defaultName());
+
+        DeployTester tester = new DeployTester.Builder(temporaryFolder)
+                .hostedConfigserverConfig(devZone)
+                .modelFactory(createHostedModelFactory())
+                .deploymentConfigStore(store)
+                .build();
+
+        tester.deployApp("src/test/apps/hosted-with-backup/");
+
+        assertEquals(List.of(HeapDumpRedaction.basic), store.redactionCalls);
+    }
+
+    @Test
+    public void stores_heap_dump_redaction_none_when_not_declared() {
+        CapturingDeploymentConfigStore store = new CapturingDeploymentConfigStore();
+        Zone prodZone = new Zone(Environment.prod, RegionName.from("us-north-1"));
+
+        DeployTester tester = new DeployTester.Builder(temporaryFolder)
+                .hostedConfigserverConfig(prodZone)
+                .modelFactory(createHostedModelFactory())
+                .deploymentConfigStore(store)
+                .build();
+
+        tester.deployApp("src/test/apps/hosted-without-memory-dump/");
+
+        assertEquals(List.of(HeapDumpRedaction.none), store.redactionCalls);
+    }
+
+    @Test
     public void does_not_store_config_when_no_store_configured() {
         Zone prodZone = new Zone(Environment.prod, RegionName.from("us-north-1"));
 
@@ -142,6 +192,7 @@ public class DeploymentConfigStoreTest {
     private static class CapturingDeploymentConfigStore implements DeploymentConfigStore {
 
         final List<Call> calls = new ArrayList<>();
+        final List<HeapDumpRedaction> redactionCalls = new ArrayList<>();
 
         @Override
         public void store(ApplicationId applicationId,
@@ -149,6 +200,11 @@ public class DeploymentConfigStoreTest {
                           List<BlockWindow> blockWindows,
                           TelemetryExporterConfiguration telemetryExporterConfiguration) {
             calls.add(new Call(applicationId, backup, blockWindows, telemetryExporterConfiguration));
+        }
+
+        @Override
+        public void storeHeapDumpRedaction(ApplicationId applicationId, HeapDumpRedaction heapDumpRedaction) {
+            redactionCalls.add(heapDumpRedaction);
         }
 
         record Call(ApplicationId applicationId,


### PR DESCRIPTION
The activation -> storeHeapDumpRedaction link had no test coverage: 
* The test store inherited the interface's no-op default, so disabling the call (#37356) kept every suite green. 
* Adds recording of storeHeapDumpRedaction to DeploymentConfigStoreTest with three cases: 
    * declared level stored in prod
    * declared level stored in non-prod (unlike backup config, which is prod-only)
    * none stored when the element is absent.

Test-only change; DeploymentConfigStoreTest passes 7/7.

---
*AI-assisted PR (Claude Fable 5) - all changes verified by the author before submission*