### PR TITLE
Improve coverage computation when a node is down in a grouped topology

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/CoverageAggregator.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/CoverageAggregator.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
+import com.yahoo.search.dispatch.searchcluster.DocumentCount;
 import com.yahoo.search.result.Coverage;
 
 import static com.yahoo.container.handler.Coverage.DEGRADED_BY_ADAPTIVE_TIMEOUT;
@@ -63,7 +64,7 @@ public class CoverageAggregator {
         return coverage;
     }
 
-    public CoverageAggregator adjustedDegradedCoverage(int redundancy, TimeoutHandler timeoutHandler) {
+    public CoverageAggregator adjustedDegradedCoverage(int redundancy, TimeoutHandler timeoutHandler, DocumentCount documentCount) {
         int askedAndFailed = askedNodes + failedNodes;
         if (askedAndFailed == answeredNodesParticipated) {
             return this;
@@ -72,13 +73,13 @@ public class CoverageAggregator {
 
         if (timeoutHandler.reason() == DEGRADED_BY_ADAPTIVE_TIMEOUT) {
             CoverageAggregator clone = new CoverageAggregator(this);
-            return clone.adjustActiveDocs(notAnswered);
+            return clone.adjustActiveDocs(notAnswered, documentCount);
         } else {
             if (askedAndFailed > answeredNodesParticipated) {
                 CoverageAggregator clone = new CoverageAggregator(this);
                 int missingNodes = notAnswered - (redundancy - 1);
                 if (missingNodes > 0) {
-                    clone.adjustActiveDocs(missingNodes);
+                    clone.adjustActiveDocs(missingNodes, documentCount);
                 }
                 clone.degradedReason |= timeoutHandler.reason();
                 return clone;
@@ -87,10 +88,17 @@ public class CoverageAggregator {
         return this;
     }
 
-    private CoverageAggregator adjustActiveDocs(int numMissingNodes) {
+    private CoverageAggregator adjustActiveDocs(int numMissingNodes, DocumentCount documentCount) {
         if (answeredNodesParticipated > 0) {
             answeredActiveDocs += (numMissingNodes * answeredActiveDocs / answeredNodesParticipated);
             answeredTargetActiveDocs += (numMissingNodes * answeredTargetActiveDocs / answeredNodesParticipated);
+
+            // Check that the document count is reliable (there was a group with all nodes online)
+            // and that it is not the initial value of 0.
+            if (documentCount.isReliable() && documentCount.getActiveDocuments() > 0 && documentCount.getTargetActiveDocuments() > 0) {
+                answeredActiveDocs = Math.min(answeredActiveDocs, documentCount.getActiveDocuments());
+                answeredTargetActiveDocs = Math.min(answeredTargetActiveDocs, documentCount.getTargetActiveDocuments());
+            }
         }
         return this;
     }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -10,6 +10,7 @@ import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.searchcluster.Group;
 import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.dispatch.searchcluster.DocumentCountSource;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
@@ -44,6 +45,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
     private final Set<SearchInvoker> invokers;
     private final DispatchConfig dispatchConfig;
     private final Group group;
+    private final DocumentCountSource documentCountSource;
     private final LinkedBlockingQueue<SearchInvoker> availableForProcessing;
     private final Set<Integer> alreadyFailedNodes;
     private final CoverageAggregator coverageAggregator;
@@ -55,12 +57,14 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
                                     TopKEstimator hitEstimator,
                                     DispatchConfig dispatchConfig,
                                     Group group,
+                                    DocumentCountSource documentCountSource,
                                     Set<Integer> alreadyFailedNodes) {
         super(Optional.empty());
         this.timer = timer;
         this.invokers = new LinkedHashSet<>(invokers);
         this.dispatchConfig = dispatchConfig;
         this.group = group;
+        this.documentCountSource = documentCountSource;
         this.availableForProcessing = newQueue();
         this.alreadyFailedNodes = alreadyFailedNodes;
         this.coverageAggregator = new CoverageAggregator(invokers.size());
@@ -142,7 +146,8 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         groupingResultAggregator.toAggregatedHit().ifPresent(h -> result.getResult().hits().add(h));
 
         insertNetworkErrors(result.getResult());
-        CoverageAggregator adjusted = coverageAggregator.adjustedDegradedCoverage((int)dispatchConfig.redundancy(), timeoutHandler);
+        CoverageAggregator adjusted = coverageAggregator.adjustedDegradedCoverage((int)dispatchConfig.redundancy(),
+                timeoutHandler, documentCountSource.getDocumentCount());
         result.getResult().setCoverage(adjusted.createCoverage(timeoutHandler));
 
         int needed = query.getOffset() + query.getHits();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
@@ -90,7 +90,7 @@ public abstract class InvokerFactory {
         if (invokers.size() == 1 && failed == null) {
             return Optional.of(invokers.get(0));
         } else {
-            return Optional.of(new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, failed));
+            return Optional.of(new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, cluster, failed));
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/DocumentCount.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/DocumentCount.java
@@ -1,0 +1,36 @@
+package com.yahoo.search.dispatch.searchcluster;
+
+/**
+ * Immutable class that stores the maximum number of documents over all groups in a search cluster.
+ *
+ * @author boeker
+ */
+public final class DocumentCount {
+    // The maximum (target) active documents across all groups in the search cluster.
+    private final long activeDocuments;
+    private final long targetActiveDocuments;
+    // Whether these numbers can be trusted (because they were gathered when all nodes in a group were working).
+    private final boolean reliable;
+
+    public DocumentCount() {
+        this(0L, 0L, false);
+    }
+
+    public DocumentCount(long maximumActiveDocuments, long maximumTargetActiveDocuments, boolean reliable) {
+        this.activeDocuments = maximumActiveDocuments;
+        this.targetActiveDocuments = maximumTargetActiveDocuments;
+        this.reliable = reliable;
+    }
+
+    public long getActiveDocuments() {
+        return activeDocuments;
+    }
+
+    public long getTargetActiveDocuments() {
+        return targetActiveDocuments;
+    }
+
+    public boolean isReliable () {
+        return reliable;
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/DocumentCountSource.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/DocumentCountSource.java
@@ -1,0 +1,10 @@
+package com.yahoo.search.dispatch.searchcluster;
+
+/**
+ * Simple interface for accessing the document count of a search cluster.
+ *
+ * @author boeker
+ */
+public interface DocumentCountSource{
+    DocumentCount getDocumentCount();
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -71,6 +71,13 @@ public class Group {
         return workingNodes().size();
     }
 
+    /**
+     * Returns whether all nodes in this group are working.
+     */
+    public boolean allNodesWorking() {
+        return workingNodesCount() == size();
+    }
+
     /** Called every time, and only when, we have received a ping response from every node in the group. */
     public void aggregateNodeValues() {
         List<Node> workingNodes = workingNodes();
@@ -111,7 +118,7 @@ public class Group {
      * Returns the target active documents in this group.
      * If we have not yet received this information from <i>all</i> nodes in the group, 0 is returned.
      */
-    long targetActiveDocuments() { return targetActiveDocuments; }
+    public long targetActiveDocuments() { return targetActiveDocuments; }
 
     /** Returns whether the nodes in the group have about the same number of documents */
     public boolean isBalanced() { return isBalanced; }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -235,7 +235,7 @@ public class SearchCluster implements NodeManager<Node> {
         groups.groups().forEach(Group::aggregateNodeValues);
         long medianDocuments = groups.medianDocumentCount();
         long maxDocuments = groups.maxDocumentCount();
-        groups.setDocumentCount(new DocumentCount(maxDocuments, groups.maxTargetDocumentCount(), groups.hasAllWorkingGroup()));
+        groups.setDocumentCount(new DocumentCount(maxDocuments, groups.maxTargetDocumentCount(), groups.hasGroupWithAllNodesWorking()));
         for (Group group : groups.groups()) {
             boolean sufficientCoverage = groups.isGroupCoverageSufficient(group.hasSufficientCoverage(),
                                                                           group.activeDocuments(), medianDocuments, maxDocuments);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -222,6 +222,7 @@ public class SearchCluster implements NodeManager<Node> {
     private void pingIterationCompletedSingleGroup(SearchGroupsImpl groups) {
         Group group = groups.groups().iterator().next();
         group.aggregateNodeValues();
+        groups.setDocumentCount(new DocumentCount(group.activeDocuments(), group.targetActiveDocuments(), group.allNodesWorking()));
         // With just one group sufficient coverage may not be the same as full coverage, as the
         // group will always be marked sufficient for use.
         updateSufficientCoverage(group, true);
@@ -234,6 +235,7 @@ public class SearchCluster implements NodeManager<Node> {
         groups.groups().forEach(Group::aggregateNodeValues);
         long medianDocuments = groups.medianDocumentCount();
         long maxDocuments = groups.maxDocumentCount();
+        groups.setDocumentCount(new DocumentCount(maxDocuments, groups.maxTargetDocumentCount(), groups.hasAllWorkingGroup()));
         for (Group group : groups.groups()) {
             boolean sufficientCoverage = groups.isGroupCoverageSufficient(group.hasSufficientCoverage(),
                                                                           group.activeDocuments(), medianDocuments, maxDocuments);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
@@ -13,7 +13,7 @@ import static java.util.stream.Collectors.toCollection;
  *
  * @author baldersheim
  */
-public interface SearchGroups {
+public interface SearchGroups extends DocumentCountSource {
 
     Group get(int id);
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
@@ -14,10 +14,12 @@ public class SearchGroupsImpl implements SearchGroups {
 
     private final AvailabilityPolicy availabilityPolicy;
     private final Map<Integer, Group> groups;
+    private volatile DocumentCount documentCount;
 
     public SearchGroupsImpl(AvailabilityPolicy availabilityPolicy, Map<Integer, Group> groups) {
         this.availabilityPolicy = availabilityPolicy;
         this.groups = Map.copyOf(groups);
+        this.documentCount = new DocumentCount();
     }
 
     @Override public Group get(int id) { return groups.get(id); }
@@ -71,4 +73,19 @@ public class SearchGroupsImpl implements SearchGroups {
         return (long)groups().stream().mapToDouble(Group::activeDocuments).max().orElse(0);
     }
 
+    public long maxTargetDocumentCount() {
+        return (long)groups().stream().mapToDouble(Group::targetActiveDocuments).max().orElse(0);
+    }
+
+    public boolean hasAllWorkingGroup() {
+        return groups().stream().anyMatch(Group::allNodesWorking);
+    }
+
+    public DocumentCount getDocumentCount() {
+        return this.documentCount;
+    }
+
+    public void setDocumentCount(DocumentCount documentCount) {
+        this.documentCount = documentCount;
+    }
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
@@ -77,7 +77,7 @@ public class SearchGroupsImpl implements SearchGroups {
         return (long)groups().stream().mapToDouble(Group::targetActiveDocuments).max().orElse(0);
     }
 
-    public boolean hasAllWorkingGroup() {
+    public boolean hasGroupWithAllNodesWorking() {
         return groups().stream().anyMatch(Group::allNodesWorking);
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/CoverageAggregatorTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/CoverageAggregatorTest.java
@@ -1,0 +1,86 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+import com.yahoo.search.dispatch.searchcluster.DocumentCount;
+import com.yahoo.search.result.Coverage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author boeker
+ */
+public class CoverageAggregatorTest {
+    private MockTimeoutHandler timeoutHandler;
+    private CoverageAggregator aggregator;
+
+    @BeforeEach
+    public void setUp() {
+        timeoutHandler = new MockTimeoutHandler();
+        aggregator = new CoverageAggregator(2);
+        aggregator.add(new Coverage(10_000L, 10_000L, 1));
+    }
+
+    @Test
+    void coverageIsAdjusted() {
+        Coverage coverage = aggregator.adjustedDegradedCoverage(1, timeoutHandler, new DocumentCount()).createCoverage(timeoutHandler);
+        assertEquals(10_000L, coverage.getDocs());
+        assertEquals(20_000L, coverage.getActive());
+        assertEquals(20_000L, coverage.getTargetActive());
+    }
+
+    @Test
+    void adjustedCoverageIsNotClampedAtDocumentCountWhenNotReliable() {
+        DocumentCount count = new DocumentCount(10_000L, 10_000L, false);
+        Coverage coverage = aggregator.adjustedDegradedCoverage(1, timeoutHandler, count).createCoverage(timeoutHandler);
+        assertEquals(10_000L, coverage.getDocs());
+        assertEquals(20_000L, coverage.getActive());
+        assertEquals(20_000L, coverage.getTargetActive());
+    }
+
+    @Test
+    void adjustedCoverageIsClampedAtDocumentCount() {
+        DocumentCount count = new DocumentCount(10_000L, 10_000L, true);
+        Coverage coverage = aggregator.adjustedDegradedCoverage(1, timeoutHandler, count).createCoverage(timeoutHandler);
+        assertEquals(10_000L, coverage.getDocs());
+        assertEquals(10_000L, coverage.getActive());
+        assertEquals(10_000L, coverage.getTargetActive());
+    }
+
+    @Test
+    void adjustedCoverageIsClampedAtDocumentCountWithDifferentTarget() {
+        DocumentCount count = new DocumentCount(12_345L, 16_789L, true);
+        Coverage coverage = aggregator.adjustedDegradedCoverage(1, timeoutHandler, count).createCoverage(timeoutHandler);
+        assertEquals(10_000L, coverage.getDocs());
+        assertEquals(12_345L, coverage.getActive());
+        assertEquals(16_789L, coverage.getTargetActive());
+    }
+
+    @Test
+    void adjustedCoverageIsNotClampedWhenOneCountIsZero() {
+        DocumentCount count = new DocumentCount(0L, 20_000L, true);
+        Coverage coverage = aggregator.adjustedDegradedCoverage(1, timeoutHandler, count).createCoverage(timeoutHandler);
+        assertEquals(10_000L, coverage.getDocs());
+        assertEquals(20_000L, coverage.getActive());
+        assertEquals(20_000L, coverage.getTargetActive());
+
+        count = new DocumentCount(20_000L, 0L, true);
+        coverage = aggregator.adjustedDegradedCoverage(1, timeoutHandler, count).createCoverage(timeoutHandler);
+        assertEquals(10_000L, coverage.getDocs());
+        assertEquals(20_000L, coverage.getActive());
+        assertEquals(20_000L, coverage.getTargetActive());
+    }
+}
+
+class MockTimeoutHandler implements TimeoutHandler {
+    @Override
+    public long nextTimeoutMS(int answeredNodes) {
+        return 1000L;
+    }
+
+    @Override
+    public int reason() {
+        return 0;
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -9,7 +9,10 @@ import com.yahoo.prelude.fastsearch.GroupingListHit;
 import com.yahoo.prelude.query.NearestNeighborItem;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
+import com.yahoo.search.dispatch.searchcluster.DocumentCount;
+import com.yahoo.search.dispatch.searchcluster.DocumentCountSource;
 import com.yahoo.search.dispatch.searchcluster.Group;
+import com.yahoo.search.dispatch.searchcluster.MockDocumentCountSource;
 import com.yahoo.search.dispatch.searchcluster.MockSearchCluster;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.Coverage;
@@ -353,7 +356,8 @@ public class InterleavedSearchInvokerTest {
                         .addAggregationResult(new MinAggregationResult().setMin(new IntegerResultNode(6)).setTag(3))));
         invokers.add(new MockInvoker(0).setHits(List.of(new GroupingListHit(List.of(grouping2)))));
 
-        try (InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, new Group(0, List.of()), Set.of())) {
+        try (InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig,
+                new Group(0, List.of()), new MockDocumentCountSource(), Set.of())) {
             invoker.responseAvailable(invokers.get(0));
             invoker.responseAvailable(invokers.get(1));
             Result result = invoker.search(query, 1.0);
@@ -398,7 +402,8 @@ public class InterleavedSearchInvokerTest {
         List<SearchInvoker> invokers = new ArrayList<>();
         invokers.add(createMockInvoker(a, new Node("test", 0, "?", 0, false)));
         invokers.add(createMockInvoker(b, new Node("test", 1, "?", 0, false)));
-        InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, Set.of());
+        InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig,
+                group, new MockDocumentCountSource(), Set.of());
         invoker.responseAvailable(invokers.get(0));
         invoker.responseAvailable(invokers.get(1));
         return invoker;
@@ -449,16 +454,25 @@ public class InterleavedSearchInvokerTest {
     }
 
     private InterleavedSearchInvoker createInterleavedInvoker(Group group, int numInvokers) {
-        return createInterleavedInvoker(hitEstimator, dispatchConfig, group, numInvokers);
+        return createInterleavedInvoker(hitEstimator, dispatchConfig, group, numInvokers, new MockDocumentCountSource());
+    }
+
+    private InterleavedSearchInvoker createInterleavedInvoker(Group group, int numInvokers, DocumentCountSource documentCountSource) {
+        return createInterleavedInvoker(hitEstimator, dispatchConfig, group, numInvokers, documentCountSource);
     }
 
     private InterleavedSearchInvoker createInterleavedInvoker(TopKEstimator hitEstimator, DispatchConfig dispatchConfig,
                                                               Group group, int numInvokers) {
+        return createInterleavedInvoker(hitEstimator, dispatchConfig, group, numInvokers, new MockDocumentCountSource());
+    }
+
+    private InterleavedSearchInvoker createInterleavedInvoker(TopKEstimator hitEstimator, DispatchConfig dispatchConfig,
+                                                              Group group, int numInvokers, DocumentCountSource documentCountSource) {
         for (int i = 0; i < numInvokers; i++) {
             invokers.add(new MockInvoker(i));
         }
 
-        return new InterleavedSearchInvoker(Timer.wrap(clock), invokers, hitEstimator, dispatchConfig, group,null) {
+        return new InterleavedSearchInvoker(Timer.wrap(clock), invokers, hitEstimator, dispatchConfig, group, documentCountSource, null) {
 
             @Override
             protected LinkedBlockingQueue<SearchInvoker> newQueue() {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -231,6 +231,37 @@ public class InterleavedSearchInvokerTest {
     }
 
     @Test
+    void correctCoverageCalculationWithMultipleGroupsWhenOneNodeIsUnexpectedlyDown() throws IOException {
+        // This one is online and has taken over for the offline node.
+        invokers.add(new MockInvoker(0, createCoverage(100_000, 100_000, 100_000, 1, 1, 0)));
+        // This one is offline.
+        Coverage errorCoverage = new Coverage(0, 0, 0);
+        errorCoverage.setNodesTried(1);
+        invokers.add(new SearchErrorInvoker(ErrorMessage.createBackendCommunicationError("node is down"), errorCoverage));
+        // Group info from another group: There are 100_000 documents
+        DocumentCount count = new DocumentCount(100_000L, 100_000L, true);
+        try (SearchInvoker invoker = createInterleavedInvoker(new Group(1, List.of()), 0, new MockDocumentCountSource(count))) {
+
+            expectedEvents.add(new Event(null, 100, 0));
+            expectedEvents.add(new Event(null, 200, 1));
+
+            Result result = invoker.search(query, 1.0);
+
+            Coverage cov = result.getCoverage(true);
+            assertEquals(100_000L, cov.getDocs());
+            assertEquals(1, cov.getNodes());
+            assertEquals(2, cov.getNodesTried());
+            assertTrue(cov.getFull());
+            assertEquals(100, cov.getResultPercentage());
+            assertEquals(1, cov.getResultSets());
+            assertEquals(1, cov.getFullResultSets());
+            assertFalse(cov.isDegraded());
+            assertFalse(cov.isDegradedByNonIdealState());
+            assertFalse(cov.isDegradedByTimeout());
+        }
+    }
+
+    @Test
     void topKProbabilityOverrideTakesEffect() throws IOException {
         assertTopKProbabilityOverride(null, 8, new Group(0, List.of()));
         assertTopKProbabilityOverride(0.8, 7, new Group(0, List.of()));

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
@@ -21,6 +21,7 @@ import com.yahoo.search.dispatch.InterleavedSearchInvoker;
 import com.yahoo.search.dispatch.SearchInvoker;
 import com.yahoo.search.dispatch.TopKEstimator;
 import com.yahoo.search.dispatch.searchcluster.Group;
+import com.yahoo.search.dispatch.searchcluster.MockDocumentCountSource;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.schema.MatchPhase;
 import com.yahoo.search.schema.RankProfile;
@@ -408,7 +409,7 @@ public class RpcSearchInvokerTest {
         DispatchConfig dispatchConfig = new DispatchConfig.Builder().build();
         TopKEstimator hitEstimator = new TopKEstimator(30, dispatchConfig.topKProbability(), 0.05);
         List<SearchInvoker> invokers = new ArrayList<>(nodeInvokers);
-        return new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, Set.of());
+        return new InterleavedSearchInvoker(Timer.monotonic, invokers, hitEstimator, dispatchConfig, group, new MockDocumentCountSource(), Set.of());
     }
 
     RpcSearchInvoker createRpcInvoker(Node node, int maxHits, Holders holders) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/DocumentCountTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/DocumentCountTest.java
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.searchcluster;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author boeker
+ */
+public class DocumentCountTest {
+
+    @Test
+    void verifyDefaults() {
+        DocumentCount count = new DocumentCount();
+        assertEquals(0, count.getActiveDocuments());
+        assertEquals(0, count.getTargetActiveDocuments());
+        assertFalse(count.isReliable());
+    }
+
+    @Test
+    void documentCountsCanBeRetrieved() {
+        DocumentCount reliable = new DocumentCount(23, 42, true);
+        assertEquals(23, reliable.getActiveDocuments());
+        assertEquals(42, reliable.getTargetActiveDocuments());
+        assertTrue(reliable.isReliable());
+
+        DocumentCount unreliable = new DocumentCount(123, 456, false);
+        assertEquals(123, unreliable.getActiveDocuments());
+        assertEquals(456, unreliable.getTargetActiveDocuments());
+        assertFalse(unreliable.isReliable());
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/MockDocumentCountSource.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/MockDocumentCountSource.java
@@ -1,0 +1,16 @@
+package com.yahoo.search.dispatch.searchcluster;
+
+public class MockDocumentCountSource implements DocumentCountSource {
+    private final DocumentCount documentCount;
+
+    public MockDocumentCountSource() {
+        this.documentCount = new DocumentCount();
+    }
+    public MockDocumentCountSource(DocumentCount documentCount) {
+        this.documentCount = documentCount;
+    }
+
+    public DocumentCount getDocumentCount() {
+        return documentCount;
+    }
+}


### PR DESCRIPTION
Uses the document count (obtained from a group where every node is online) as an upper limit when adjusting the coverage to make up for non-responding nodes in `CoverageAggregator`. This avoids reporting a too-low coverage when a node in a group is down and there is no redundancy within this group.

A limitation of this approach is that this document count is only updated at every ping and, hence, might be a bit outdated. Moreover, when there is no group where all nodes are online, the coverage will still not be reported correctly. However, in practice, this approach seems to be good enough.