### PR TITLE
Label support for bm25 rank feature

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/CJKSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/CJKSearcher.java
@@ -20,6 +20,7 @@ import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.PhraseItem;
 import com.yahoo.prelude.query.PhraseSegmentItem;
 import com.yahoo.prelude.query.SegmentItem;
+import com.yahoo.prelude.query.TaggableItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.query.QueryTree;
@@ -68,19 +69,19 @@ public class CJKSearcher extends Searcher {
                 if (child instanceof WordItem)
                     replacement.addItem(child);
                 else if (child instanceof PhraseSegmentItem asSegment)
-                    replacement.addItem(new AndSegmentItem(asSegment));
+                    replacement.addItem(propagateLabelToLeaves(asSegment, new AndSegmentItem(asSegment)));
                 else
                     replacement.addItem(child); // should never get here
             }
             modified[0] = true;
-            return replacement;
+            return propagateLabelToLeaves(phrase, replacement);
         }
         else if (item instanceof PhraseSegmentItem segment) {
             if ( ! language.isCjk()) return item;
             if (segment.isExplicit() || hasOverlappingTokens(segment))
                 return item;
             modified[0] = true;
-            return new AndSegmentItem(segment);
+            return propagateLabelToLeaves(segment, new AndSegmentItem(segment));
         }
         else if (item instanceof SegmentItem) {
             return item; // avoid descending into AndSegmentItems and similar
@@ -95,6 +96,30 @@ public class CJKSearcher extends Searcher {
             return item;
         }
         return item;
+    }
+
+    /**
+     * The source items replaced here are taggable ranking leaves, while their replacements are plain
+     * composites whose taggable leaves are the words inside them. A label on the source must therefore
+     * move to those words to remain addressable from rank features, the same way YQL label annotations
+     * on composites are inherited by each taggable leaf. Existing (more specific) labels are kept.
+     */
+    private Item propagateLabelToLeaves(Item source, Item replacement) {
+        String label = source.getLabel();
+        if (label != null)
+            setLabelIfUnset(replacement, label);
+        return replacement;
+    }
+
+    private void setLabelIfUnset(Item item, String label) {
+        if (item instanceof TaggableItem) { // tested before descending, as in Model.collectTaggableItems
+            if (item.getLabel() == null)
+                item.setLabel(label);
+        }
+        else if (item instanceof CompositeItem composite) {
+            for (Iterator<Item> i = composite.getItemIterator(); i.hasNext(); )
+                setLabelIfUnset(i.next(), label);
+        }
     }
 
     private boolean hasOverlappingTokens(PhraseItem phrase) {

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/PhrasingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/PhrasingSearcher.java
@@ -73,9 +73,20 @@ public class PhrasingSearcher extends Searcher {
         // the start index of each replace phrase until replacement
         for (int i = phrases.size()-1; i >= 0; i--) {
             PhraseMatcher.Phrase phrase = phrases.get(i);
-            if (phrase.getLength() > 1)
+            if (phrase.getLength() > 1 && ! hasLabeledItem(phrase))
                 phrase.replace();
         }
+    }
+
+    /**
+     * Words inside a phrase are not individually addressable as ranking terms, so phrasing a span
+     * where a word carries an explicit rank label would silently disable that label.
+     * Such spans are left as individual words.
+     */
+    private static boolean hasLabeledItem(PhraseMatcher.Phrase phrase) {
+        for (int i = 0; i < phrase.getLength(); i++)
+            if (phrase.getItem(i).getLabel() != null) return true;
+        return false;
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/StemmingSearcher.java
@@ -437,6 +437,9 @@ public class StemmingSearcher extends Searcher {
         replacement.setFilter(blockAsItem.isFilter());
         replacement.setRanked(blockAsItem.isRanked());
         replacement.setPositionData(blockAsItem.usePositionData());
+        if (blockAsItem.getLabel() != null) {
+            replacement.setLabel(blockAsItem.getLabel());
+        }
     }
 
     private void copyWeight(Item block, Item replacement) {

--- a/container-search/src/test/java/com/yahoo/prelude/query/ItemLabelTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/ItemLabelTestCase.java
@@ -86,4 +86,23 @@ public class ItemLabelTestCase {
         assertNull(query.getRanking().getProperties().get("vespa.label.missing.id"));
     }
 
+    @Test
+    final void testSharedLabelEncodesAllUniqueIds() {
+        WordItem w1 = new WordItem("w1");
+        WordItem w2 = new WordItem("w2");
+        AndItem and = new AndItem();
+        Query query = new Query();
+
+        w1.setLabel("shared");
+        w2.setLabel("shared");
+        and.addItem(w1);
+        and.addItem(w2);
+        query.getModel().getQueryTree().setRoot(and);
+        query.prepare();
+        var values = query.getRanking().getProperties().get("vespa.label.shared.id");
+        assertEquals(2, values.size());
+        assertEquals(String.valueOf(w1.getUniqueID()), values.get(0));
+        assertEquals(String.valueOf(w2.getUniqueID()), values.get(1));
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/CJKSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/CJKSearcherTestCase.java
@@ -6,9 +6,12 @@ import com.yahoo.language.Language;
 import com.yahoo.language.Linguistics;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexFactsFactory;
+import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.AndSegmentItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.NullItem;
 import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.PhraseItem;
 import com.yahoo.prelude.query.PhraseSegmentItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.prelude.query.parser.TestLinguistics;
@@ -25,6 +28,8 @@ import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.test.QueryTestCase;
 import com.yahoo.search.yql.MinimalQueryInserter;
 import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -186,6 +191,55 @@ public class CJKSearcherTestCase {
         String trace = query.getContext(false).getTrace().toString();
         assertFalse(trace.contains("Rewriting for CJK behavior for implicit phrases"),
                 "Trace should NOT contain CJK rewriting message when no CJK items: " + trace);
+    }
+
+    @Test
+    void testLabelIsPropagatedToSegmentWords() {
+        PhraseSegmentItem segment = createSegmentedItem(Language.CHINESE_SIMPLIFIED);
+        segment.setLabel("t1");
+
+        Query query = new Query("?language=zh-hans");
+        query.getModel().getQueryTree().setRoot(segment);
+
+        new Execution(new Chain<Searcher>(new CJKSearcher()),
+                      Execution.Context.createContextStub(indexFacts, TestLinguistics.INSTANCE)).search(query);
+
+        Item root = query.getModel().getQueryTree().getRoot();
+        assertTrue(root instanceof AndSegmentItem, "Segment should be transformed to SAND: " + root);
+        AndSegmentItem sand = (AndSegmentItem) root;
+        assertEquals(2, sand.getItemCount());
+        for (Iterator<Item> i = sand.getItemIterator(); i.hasNext(); )
+            assertEquals("t1", i.next().getLabel(), "Words should inherit the segment label");
+
+        // The label must resolve to the words' unique ids when the query is prepared
+        query.prepare();
+        var values = query.getRanking().getProperties().get("vespa.label.t1.id");
+        assertEquals(2, values.size(), "Both words should be addressable through the label");
+        assertEquals(String.valueOf(((WordItem) sand.getItem(0)).getUniqueID()), values.get(0));
+        assertEquals(String.valueOf(((WordItem) sand.getItem(1)).getUniqueID()), values.get(1));
+    }
+
+    @Test
+    void testLabelIsPropagatedFromImplicitPhrase() {
+        PhraseItem phrase = new PhraseItem();
+        phrase.setIndexName("default");
+        phrase.addItem(new WordItem("e", "default"));
+        phrase.addItem(new WordItem("fg", "default"));
+        phrase.setLanguage(Language.CHINESE_SIMPLIFIED);
+        phrase.setLabel("t1");
+
+        Query query = new Query("?language=zh-hans");
+        query.getModel().getQueryTree().setRoot(phrase);
+
+        new Execution(new Chain<Searcher>(new CJKSearcher()),
+                      Execution.Context.createContextStub(indexFacts, TestLinguistics.INSTANCE)).search(query);
+
+        Item root = query.getModel().getQueryTree().getRoot();
+        assertTrue(root instanceof AndItem, "Implicit phrase should be transformed to AND: " + root);
+        AndItem and = (AndItem) root;
+        assertEquals(2, and.getItemCount());
+        for (Iterator<Item> i = and.getItemIterator(); i.hasNext(); )
+            assertEquals("t1", i.next().getLabel(), "Words should inherit the phrase label");
     }
 
     private void assertTransformed(String queryString, String expected, Query.Type mode, Language actualLanguage,

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/PhrasingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/PhrasingSearcherTestCase.java
@@ -46,6 +46,61 @@ public class PhrasingSearcherTestCase {
     }
 
     @Test
+    void testNoPhrasingWhenWordHasLabel() {
+        Searcher searcher =
+                new PhrasingSearcher("src/test/java/com/yahoo/prelude/querytransform/test/test-fsa.fsa");
+
+        Query query = new Query();
+        AndItem andItem = new AndItem();
+        WordItem labeled = new WordItem("tudor", "someindex");
+        labeled.setLabel("t1");
+        andItem.addItem(labeled);
+        andItem.addItem(new WordItem("vidor", "someindex"));
+        query.getModel().getQueryTree().setRoot(andItem);
+
+        new Execution(searcher, Execution.Context.createContextStub()).search(query);
+
+        // The span is not phrased: a word inside a phrase is not addressable from rank
+        // features, so phrasing would silently disable the label
+        CompositeItem root = (CompositeItem) query.getModel().getQueryTree().getRoot();
+        assertEquals(2, root.getItemCount());
+        assertEquals("tudor", ((WordItem) root.getItem(0)).getWord());
+        assertEquals("t1", root.getItem(0).getLabel());
+        assertEquals("vidor", ((WordItem) root.getItem(1)).getWord());
+    }
+
+    @Test
+    void testLabeledSpanIsSkippedWhileUnlabeledSpanIsPhrased() {
+        Searcher searcher =
+                new PhrasingSearcher("src/test/java/com/yahoo/prelude/querytransform/test/test-fsa.fsa");
+
+        Query query = new Query();
+        AndItem labeledBranch = new AndItem();
+        WordItem labeled = new WordItem("tudor", "someindex");
+        labeled.setLabel("t1");
+        labeledBranch.addItem(labeled);
+        labeledBranch.addItem(new WordItem("vidor", "someindex"));
+
+        AndItem unlabeledBranch = new AndItem();
+        unlabeledBranch.addItem(new WordItem("tudor", "someindex"));
+        unlabeledBranch.addItem(new WordItem("vidor", "someindex"));
+
+        OrItem root = new OrItem();
+        root.addItem(labeledBranch);
+        root.addItem(unlabeledBranch);
+        query.getModel().getQueryTree().setRoot(root);
+
+        new Execution(searcher, Execution.Context.createContextStub()).search(query);
+
+        OrItem or = (OrItem) query.getModel().getQueryTree().getRoot();
+        CompositeItem first = (CompositeItem) or.getItem(0);
+        assertEquals(2, first.getItemCount(), "Labeled span should not be phrased: " + first);
+        assertEquals("t1", first.getItem(0).getLabel());
+        CompositeItem second = (CompositeItem) or.getItem(1);
+        assertTrue(second.getItem(0) instanceof PhraseItem, "Unlabeled span should be phrased: " + second);
+    }
+
+    @Test
     void testPartialPhrasing() {
         Searcher searcher =
                 new PhrasingSearcher("src/test/java/com/yahoo/prelude/querytransform/test/test-fsa.fsa");

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -312,6 +313,37 @@ public class StemmingSearcherTestCase {
         assertTrue(word != stemmedWord);
         assertNotEquals(word.get().getWord(), stemmedWord.get().getWord());
         assertEquals(Optional.of(new DocumentFrequency(13, 100)), stemmedWord.get().getDocumentFrequency());
+    }
+
+    @Test
+    void testLabelIsPropagated() {
+        var builder = new Query.Builder();
+        builder.setRequest(QueryTestCase.httpEncode("/search?query=trees"));
+        var query = builder.build();
+        var word = getFirstWord(query);
+        assertTrue(word.isPresent());
+        word.get().setLabel("myLabel");
+        executeStemming(query);
+        var stemmedWord = getFirstWord(query);
+        assertTrue(stemmedWord.isPresent());
+        assertTrue(word.get() != stemmedWord.get());
+        assertNotEquals(word.get().getWord(), stemmedWord.get().getWord());
+        assertEquals("myLabel", stemmedWord.get().getLabel());
+    }
+
+    @Test
+    void testNoLabelMeansNoLabelAndNoUniqueIdAfterStemming() {
+        var builder = new Query.Builder();
+        builder.setRequest(QueryTestCase.httpEncode("/search?query=trees"));
+        var query = builder.build();
+        var word = getFirstWord(query);
+        assertTrue(word.isPresent());
+        executeStemming(query);
+        var stemmedWord = getFirstWord(query);
+        assertTrue(stemmedWord.isPresent());
+        assertTrue(word.get() != stemmedWord.get());
+        assertNull(stemmedWord.get().getLabel());
+        assertFalse(stemmedWord.get().hasUniqueID(), "setLabel(null) must not be called: it force-assigns a unique id");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -17,6 +17,7 @@ import com.yahoo.prelude.query.FuzzyItem;
 import com.yahoo.prelude.query.IndexedItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.MarkerWordItem;
+import com.yahoo.prelude.query.NearItem;
 import com.yahoo.prelude.query.NearestNeighborItem;
 import com.yahoo.prelude.query.NumericInItem;
 import com.yahoo.prelude.query.PhraseItem;
@@ -406,6 +407,17 @@ public class YqlParserTestCase {
         assertEquals("abc", origin.string);
         assertEquals(1, origin.start);
         assertEquals(3, origin.end);
+    }
+
+    @Test
+    void testLabelOnCompositeIsInheritedByEachLeaf() {
+        QueryTree query = parse("select foo from bar where " +
+                "({label: \"t1\"}baz contains ({distance: 4}near(\"sports\", \"shoes\")))");
+        NearItem near = (NearItem) query.getRoot();
+        assertEquals(2, near.getItemCount());
+        for (Item leaf : near.items()) {
+            assertEquals("t1", leaf.getLabel());
+        }
     }
 
     @Test

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -13,6 +13,7 @@ import ai.vespa.schemals.index.Symbol.SymbolType;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.Argument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.KeywordArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.LabelArgument;
+import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.LabelFunctionArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.EnumArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.ExpressionArgument;
 import ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument.FieldArgument;
@@ -249,7 +250,7 @@ public class BuiltInFunctions {
         // ==== Rank score ====
         put("bm25", new GenericFunction("bm25", List.of(
             new FunctionSignature(new FieldArgument("field")),
-            new FunctionSignature(List.of(new FieldArgument("field"), new LabelArgument("label")))
+            new FunctionSignature(List.of(new FieldArgument("field"), new LabelFunctionArgument("name")))
         )));
         put("averageFieldLength", new GenericFunction("averageFieldLength",
             new FunctionSignature(new FieldArgument("field"), Set.of(

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -247,7 +247,10 @@ public class BuiltInFunctions {
         ));
 
         // ==== Rank score ====
-        put("bm25", new GenericFunction("bm25", new FunctionSignature(new FieldArgument("field"))));
+        put("bm25", new GenericFunction("bm25", List.of(
+            new FunctionSignature(new FieldArgument("field")),
+            new FunctionSignature(List.of(new FieldArgument("field"), new LabelArgument("label")))
+        )));
         put("averageFieldLength", new GenericFunction("averageFieldLength",
             new FunctionSignature(new FieldArgument("field"), Set.of(
                 "",

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/argument/LabelFunctionArgument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/argument/LabelFunctionArgument.java
@@ -1,0 +1,87 @@
+package ai.vespa.schemals.schemadocument.resolvers.RankExpression.argument;
+
+import java.util.Optional;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+import ai.vespa.schemals.common.SchemaDiagnostic;
+import ai.vespa.schemals.context.ParseContext;
+import ai.vespa.schemals.index.Symbol.SymbolStatus;
+import ai.vespa.schemals.index.Symbol.SymbolType;
+import ai.vespa.schemals.tree.rankingexpression.RankNode;
+import ai.vespa.schemals.tree.rankingexpression.RankNode.RankNodeType;
+
+/**
+ * An argument of the form label(&lt;name&gt;), naming the set of query items
+ * annotated with the given label. Exactly one name and no output suffix are
+ * accepted, mirroring the C++ side (util::parse_label_argument).
+ */
+public class LabelFunctionArgument implements Argument {
+
+    private String displayString;
+
+    public LabelFunctionArgument() {
+        this("name");
+    }
+
+    public LabelFunctionArgument(String nameDisplayString) {
+        this.displayString = "label(" + nameDisplayString + ")";
+    }
+
+    @Override
+    public int getStrictness() {
+        return 2;
+    }
+
+    @Override
+    public boolean validateArgument(RankNode node) {
+        Optional<RankNode> labelFunction = findLabelFunction(node);
+        return labelFunction.isPresent() && isValid(labelFunction.get());
+    }
+
+    @Override
+    public Optional<Diagnostic> parseArgument(ParseContext context, RankNode node) {
+        Optional<RankNode> labelFunction = findLabelFunction(node);
+        if (labelFunction.isPresent()) {
+            // the label() wrapper is not a rank feature itself; mark its symbols (even when the
+            // shape is rejected below) so later passes do not try to resolve them
+            ArgumentUtils.modifyNodeSymbol(context, node, SymbolType.FUNCTION, SymbolStatus.BUILTIN_REFERENCE);
+            for (RankNode name : labelFunction.get().getChildren()) {
+                ArgumentUtils.modifyNodeSymbol(context, name, SymbolType.LABEL, SymbolStatus.BUILTIN_REFERENCE);
+            }
+            if (isValid(labelFunction.get())) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(new SchemaDiagnostic.Builder()
+            .setRange(node.getRange())
+            .setMessage("The argument must be of the form " + displayString + ".")
+            .setSeverity(DiagnosticSeverity.Error)
+            .build());
+    }
+
+    private static Optional<RankNode> findLabelFunction(RankNode node) {
+        if (node.getType() != RankNodeType.EXPRESSION || node.getChildren().size() != 1) {
+            return Optional.empty();
+        }
+        RankNode function = node.getChildren().get(0);
+        if (function.getType() != RankNodeType.FEATURE
+                || !function.hasSymbol()
+                || !function.getSymbol().getShortIdentifier().equals("label")
+                || !function.getArgumentListExists()) {
+            return Optional.empty();
+        }
+        return Optional.of(function);
+    }
+
+    private static boolean isValid(RankNode labelFunction) {
+        return labelFunction.getChildren().size() == 1 && labelFunction.getProperty().isEmpty();
+    }
+
+    @Override
+    public String displayString() {
+        return displayString;
+    }
+
+}

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -239,6 +239,7 @@ public class SchemaParserTest {
              * CUSTOM TESTS
              * */
             "src/test/sdfiles/single/attributeposition.sd",
+            "src/test/sdfiles/single/bm25label.sd",
             "src/test/sdfiles/single/defaultdefault.sd",
             "src/test/sdfiles/single/elementwise.sd",
             "src/test/sdfiles/single/embed.sd",
@@ -315,7 +316,7 @@ public class SchemaParserTest {
             new BadFileTestCase("../../../config-model/src/test/examples/rankingexpressionfunction/rankingexpressionfunction.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/rankpropvars.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/stemmingresolver.sd", 1),
-            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 44),
+            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 41),
             new BadFileTestCase("../../../config-model/src/test/derived/renamedfeatures/foo.sd", 4),
 
             new BadFileTestCase("../../../config-model/src/test/derived/rankprofiles/rankprofiles.sd", 1), // only throws a warning during vespa deploy, but it is an unresolved reference case.

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -325,6 +325,7 @@ public class SchemaParserTest {
 
             new BadFileTestCase("../../../config-model/src/test/examples/simple.sd", 5), // TODO: unused rank-profile functions should throw errors? Also rank-type doesntexist: ... in field?
 
+            new BadFileTestCase("src/test/sdfiles/single/bm25labelbad.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/featuresinheritance.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/foreachbad.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/onnxmodel.sd", 1),

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/bm25label.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/bm25label.sd
@@ -1,0 +1,14 @@
+schema bm25label {
+    document bm25label {
+        field title type string {
+            indexing: index
+            index: enable-bm25
+        }
+    }
+
+    rank-profile myprofile {
+        first-phase {
+            expression: max(bm25(title), bm25(title, someLabel))
+        }
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/bm25labelbad.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/bm25labelbad.sd
@@ -1,5 +1,5 @@
-schema bm25label {
-    document bm25label {
+schema bm25labelbad {
+    document bm25labelbad {
         field title type string {
             indexing: index
             index: enable-bm25
@@ -8,7 +8,7 @@ schema bm25label {
 
     rank-profile myprofile {
         first-phase {
-            expression: max(bm25(title), bm25(title, label(someLabel)))
+            expression: bm25(title, label(someLabel).out)
         }
     }
 }

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -188,6 +188,15 @@ std::string make_same_element_stack_dump(const std::string& a1_term, const std::
     return StackDumpCreator::create(*builder.build());
 }
 
+std::string make_two_term_and_stack_dump(const std::string& field, const std::string& term1,
+                                         const std::string& term2) {
+    QueryBuilder<ProtonNodeTypes> builder;
+    builder.addAnd(2);
+    builder.addStringTerm(term1, field, 1, Weight(1));
+    builder.addStringTerm(term2, field, 2, Weight(1));
+    return StackDumpCreator::create(*builder.build());
+}
+
 std::string make_near_stack_dump(bool ordered, const std::string& term1, const std::string& term2) {
     QueryBuilder<ProtonNodeTypes> builder;
     constexpr int                 child_count = 2;
@@ -295,6 +304,12 @@ struct MyWorld {
         config.add(indexproperties::match::Feature::NAME,
                    "rankingExpression(\"reduce(merge(queryTermDocumentFrequency(f1),"
                    "queryTermDocumentFrequency(f2),f(a,b)(max(a,b))),sum,term)\")");
+    }
+
+    void setup_bm25_label_match_features() {
+        config.add(indexproperties::match::Feature::NAME, "bm25(f1)");
+        config.add(indexproperties::match::Feature::NAME, "bm25(f1,t1)");
+        config.add(indexproperties::match::Feature::NAME, "bm25(f1,t2)");
     }
 
     void setup_feature_renames() {
@@ -721,6 +736,46 @@ TEST_F(MatchingTest, require_that_query_term_document_frequency_match_feature_ha
     SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
     SearchReply::UP   reply = world.performSearch(*request, 1);
     MyWorld::verify_query_term_document_frequency_match_features(*reply);
+}
+
+TEST_F(MatchingTest, require_that_bm25_label_parameter_restricts_scoring_to_labeled_terms) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    // two terms matching the same documents in field f1
+    world.searchContext.idx(0).getFake().addResult("f1", "foo", FakeResult().doc(10).doc(20).doc(30));
+    world.searchContext.idx(0).getFake().addResult("f1", "bar", FakeResult().doc(10).doc(20).doc(30));
+    world.setup_bm25_label_match_features();
+    SearchRequest::SP request = MyWorld::createRequest(make_two_term_and_stack_dump("f1", "foo", "bar"));
+    auto&             rankProperties = request->propertiesMap.lookupCreate(MapNames::RANK);
+    rankProperties.add("vespa.label.t1.id", "1");
+    rankProperties.add("vespa.label.t2.id", "2");
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_GT(reply->hits.size(), 0u);
+    const auto& names = reply->match_features.names;
+    ASSERT_EQ(names.size(), 3u);
+    auto feature_index = [&names](const std::string& name) {
+        for (size_t i = 0; i < names.size(); ++i) {
+            if (names[i] == name) {
+                return i;
+            }
+        }
+        ADD_FAILURE() << "match feature '" << name << "' not found";
+        return names.size();
+    };
+    size_t full_idx = feature_index("bm25(f1)");
+    size_t t1_idx = feature_index("bm25(f1,t1)");
+    size_t t2_idx = feature_index("bm25(f1,t2)");
+    ASSERT_EQ(reply->match_features.values.size(), names.size() * reply->hits.size());
+    for (size_t i = 0; i < reply->hits.size(); ++i) {
+        const auto* values = &reply->match_features.values[i * names.size()];
+        double      full_score = values[full_idx].as_double();
+        double      t1_score = values[t1_idx].as_double();
+        double      t2_score = values[t2_idx].as_double();
+        // each labeled feature scores only its term, and together they cover the unlabeled score
+        EXPECT_GT(t1_score, 0.0);
+        EXPECT_GT(t2_score, 0.0);
+        EXPECT_DOUBLE_EQ(full_score, t1_score + t2_score);
+    }
 }
 
 TEST_F(MatchingTest, require_that_no_hits_gives_no_match_feature_names) {

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -308,8 +308,8 @@ struct MyWorld {
 
     void setup_bm25_label_match_features() {
         config.add(indexproperties::match::Feature::NAME, "bm25(f1)");
-        config.add(indexproperties::match::Feature::NAME, "bm25(f1,t1)");
-        config.add(indexproperties::match::Feature::NAME, "bm25(f1,t2)");
+        config.add(indexproperties::match::Feature::NAME, "bm25(f1,label(t1))");
+        config.add(indexproperties::match::Feature::NAME, "bm25(f1,label(t2))");
     }
 
     void setup_feature_renames() {
@@ -763,8 +763,8 @@ TEST_F(MatchingTest, require_that_bm25_label_parameter_restricts_scoring_to_labe
         return names.size();
     };
     size_t full_idx = feature_index("bm25(f1)");
-    size_t t1_idx = feature_index("bm25(f1,t1)");
-    size_t t2_idx = feature_index("bm25(f1,t2)");
+    size_t t1_idx = feature_index("bm25(f1,label(t1))");
+    size_t t2_idx = feature_index("bm25(f1,label(t2))");
     ASSERT_EQ(reply->match_features.values.size(), names.size() * reply->hits.size());
     for (size_t i = 0; i < reply->hits.size(); ++i) {
         const auto* values = &reply->match_features.values[i * names.size()];

--- a/searchlib/src/tests/features/bm25/bm25_test.cpp
+++ b/searchlib/src/tests/features/bm25/bm25_test.cpp
@@ -9,6 +9,7 @@
 #include <vespa/searchlib/fef/test/dummy_dependency_handler.h>
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/indexenvironmentbuilder.h>
+#include <vespa/searchlib/fef/test/labels.h>
 #include <vespa/searchlib/test/ft_test_app_base.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
@@ -138,9 +139,9 @@ TEST_P(Bm25BlueprintTest, blueprint_can_be_created_from_factory) {
 }
 
 TEST_P(Bm25BlueprintTest, blueprint_setup_fails_when_parameter_list_is_not_valid) {
-    expect_setup_fail({});           // wrong parameter number
-    expect_setup_fail({"as"});       // 'as' is an attribute
-    expect_setup_fail({"is", "ia"}); // wrong parameter number
+    expect_setup_fail({});                // wrong parameter number
+    expect_setup_fail({"as"});            // 'as' is an attribute
+    expect_setup_fail({"is", "ia", "x"}); // wrong parameter number
 }
 
 TEST_P(Bm25BlueprintTest, blueprint_setup_fails_when_k1_param_is_malformed) {
@@ -370,6 +371,169 @@ TEST_P(Bm25ExecutorTest, missing_interleaved_features_are_handled) {
     setup();
     prepare_term(0, 0, 0, 0);
     EXPECT_TRUE(execute(score(GetParam()._elementwise ? 0.0 : 1.0, 10, idf(25))));
+}
+
+// The label parameter is only supported by direct bm25 for now,
+// so the label tests below are not parameterized over the elementwise variants.
+
+struct Bm25LabelBlueprintTest : public ::testing::Test {
+    BlueprintFactory       factory;
+    test::IndexEnvironment index_env;
+
+    Bm25LabelBlueprintTest() : factory(), index_env() {
+        setup_search_features(factory);
+        test::IndexEnvironmentBuilder builder(index_env);
+        builder.addField(FieldType::INDEX, CollectionType::SINGLE, "is");
+    }
+    ~Bm25LabelBlueprintTest() override;
+
+    void expect_setup_fail(const std::string& base_name, const StringVector& params) {
+        auto                         blueprint = factory.createBlueprint(base_name);
+        test::DummyDependencyHandler deps(*blueprint);
+        EXPECT_FALSE(blueprint->setup(index_env, params));
+    }
+
+    void expect_setup_succeed(const StringVector& params) {
+        auto                         blueprint = factory.createBlueprint("bm25");
+        test::DummyDependencyHandler deps(*blueprint);
+        EXPECT_TRUE(blueprint->setup(index_env, params));
+        EXPECT_EQ(0, deps.input.size());
+        EXPECT_EQ(StringVector({"score"}), deps.output);
+    }
+};
+
+Bm25LabelBlueprintTest::~Bm25LabelBlueprintTest() = default;
+
+TEST_F(Bm25LabelBlueprintTest, blueprint_setup_succeeds_with_label_parameter) {
+    expect_setup_succeed({"is", "mylabel"});
+    // the label is an opaque string; one that happens to name a field is still just a label
+    expect_setup_succeed({"is", "ia"});
+}
+
+TEST_F(Bm25LabelBlueprintTest, blueprint_setup_fails_when_label_is_empty) {
+    expect_setup_fail("bm25", {"is", ""});
+}
+
+TEST_F(Bm25LabelBlueprintTest, label_parameter_is_not_supported_by_elementwise_bm25) {
+    expect_setup_fail("elementwise", {"bm25(is,someLabel)", "x", "double"});
+}
+
+struct Bm25LabelFixture {
+    BlueprintFactory           factory;
+    FtFeatureTest              test;
+    test::MatchDataBuilder::UP match_data;
+    Scorer                     scorer;
+    static constexpr uint32_t  total_doc_count = 100;
+
+    explicit Bm25LabelFixture(const std::vector<std::string>& features)
+        : factory(), test(factory, features), match_data() {
+        setup_search_features(factory);
+        test.getIndexEnv().getBuilder().addField(FieldType::INDEX, CollectionType::SINGLE, "foo");
+        test.getIndexEnv().getBuilder().addField(FieldType::INDEX, CollectionType::SINGLE, "bar");
+        add_query_term("foo", 25, 11);
+        add_query_term("foo", 35, 12);
+        add_query_term("bar", 45, 13);
+        test.getQueryEnv().getBuilder().set_avg_field_length("foo", 10);
+    }
+
+    void add_query_term(const std::string& field_name, uint32_t matching_doc_count, uint32_t unique_id) {
+        auto* term = test.getQueryEnv().getBuilder().addIndexNode({field_name});
+        term->field(0).setDocFreq(matching_doc_count, total_doc_count);
+        term->setUniqueId(unique_id);
+    }
+    void add_label(const std::string& label, const std::vector<uint32_t>& uids) {
+        search::fef::test::MultiLabel(label, uids).inject(test.getQueryEnv().getProperties());
+    }
+    void setup() {
+        EXPECT_TRUE(test.setup());
+        match_data = test.createMatchDataBuilder();
+        clear_term(0, 0);
+        clear_term(1, 0);
+        clear_term(2, 1);
+    }
+    void clear_term(uint32_t term_id, uint32_t field_id) {
+        auto* tfmd = match_data->getTermFieldMatchData(term_id, field_id);
+        ASSERT_TRUE(tfmd != nullptr);
+        tfmd->reset(123);
+    }
+    void prepare_term(uint32_t term_id, uint32_t field_id, uint16_t num_occs, uint16_t field_length,
+                      uint32_t doc_id = 1) {
+        auto* tfmd = match_data->getTermFieldMatchData(term_id, field_id);
+        ASSERT_TRUE(tfmd != nullptr);
+        tfmd->reset(doc_id);
+        tfmd->setNumOccs(num_occs);
+        tfmd->setFieldLength(field_length);
+    }
+    double idf(uint32_t matching_doc_count) const {
+        return Bm25Utils::calculate_inverse_document_frequency({matching_doc_count, total_doc_count});
+    }
+    feature_t score(feature_t num_occs, feature_t field_length, double inverse_doc_freq) const {
+        return scorer.score(num_occs, field_length, inverse_doc_freq);
+    }
+    bool execute(const test::RankResult& expected) { return test.execute(expected); }
+};
+
+TEST(Bm25LabelExecutorTest, only_labeled_terms_are_scored) {
+    Bm25LabelFixture f({"bm25(foo)", "bm25(foo,mylabel)"});
+    f.add_label("mylabel", {11});
+    f.setup();
+    f.prepare_term(0, 0, 3, 20);
+    f.prepare_term(1, 0, 7, 5);
+    // the labeled feature scores only the labeled term, while the unlabeled feature
+    // evaluated for the same query environment still scores all terms
+    test::RankResult expected;
+    expected.setEpsilon(0.000001);
+    expected.addScore("bm25(foo)", f.score(3.0, 20, f.idf(25)) + f.score(7.0, 5.0, f.idf(35)));
+    expected.addScore("bm25(foo,mylabel)", f.score(3.0, 20, f.idf(25)));
+    EXPECT_TRUE(f.execute(expected));
+}
+
+TEST(Bm25LabelExecutorTest, label_with_multiple_terms_scores_their_sum) {
+    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    f.add_label("mylabel", {11, 12});
+    f.setup();
+    f.prepare_term(0, 0, 3, 20);
+    f.prepare_term(1, 0, 7, 5);
+    test::RankResult expected;
+    expected.setEpsilon(0.000001);
+    expected.addScore("bm25(foo,mylabel)", f.score(3.0, 20, f.idf(25)) + f.score(7.0, 5.0, f.idf(35)));
+    EXPECT_TRUE(f.execute(expected));
+}
+
+TEST(Bm25LabelExecutorTest, label_not_present_in_query_gives_zero_score) {
+    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    f.setup();
+    f.prepare_term(0, 0, 3, 20);
+    test::RankResult expected;
+    expected.setEpsilon(0.000001);
+    expected.addScore("bm25(foo,mylabel)", 0.0);
+    EXPECT_TRUE(f.execute(expected));
+}
+
+TEST(Bm25LabelExecutorTest, labeled_term_searching_another_field_contributes_nothing) {
+    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    f.add_label("mylabel", {13}); // term searching field 'bar'
+    f.setup();
+    f.prepare_term(0, 0, 3, 20);
+    f.prepare_term(2, 1, 3, 20);
+    test::RankResult expected;
+    expected.setEpsilon(0.000001);
+    expected.addScore("bm25(foo,mylabel)", 0.0);
+    EXPECT_TRUE(f.execute(expected));
+}
+
+TEST(Bm25LabelExecutorTest, labeled_feature_uses_field_level_tuning) {
+    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    // tuning properties are keyed per field only, not per feature instance
+    f.test.getIndexEnv().getProperties().add("bm25(foo).k1", "2.5");
+    f.add_label("mylabel", {11});
+    f.setup();
+    f.prepare_term(0, 0, 3, 20);
+    f.scorer.k1_param = 2.5;
+    test::RankResult expected;
+    expected.setEpsilon(0.000001);
+    expected.addScore("bm25(foo,mylabel)", f.score(3.0, 20, f.idf(25)));
+    EXPECT_TRUE(f.execute(expected));
 }
 
 TEST_P(Bm25ExecutorTest, multiple_elements_and_terms) {

--- a/searchlib/src/tests/features/bm25/bm25_test.cpp
+++ b/searchlib/src/tests/features/bm25/bm25_test.cpp
@@ -405,17 +405,20 @@ struct Bm25LabelBlueprintTest : public ::testing::Test {
 Bm25LabelBlueprintTest::~Bm25LabelBlueprintTest() = default;
 
 TEST_F(Bm25LabelBlueprintTest, blueprint_setup_succeeds_with_label_parameter) {
-    expect_setup_succeed({"is", "mylabel"});
+    expect_setup_succeed({"is", "label(mylabel)"});
     // the label is an opaque string; one that happens to name a field is still just a label
-    expect_setup_succeed({"is", "ia"});
+    expect_setup_succeed({"is", "label(ia)"});
 }
 
-TEST_F(Bm25LabelBlueprintTest, blueprint_setup_fails_when_label_is_empty) {
+TEST_F(Bm25LabelBlueprintTest, blueprint_setup_fails_when_label_argument_is_malformed) {
     expect_setup_fail("bm25", {"is", ""});
+    expect_setup_fail("bm25", {"is", "mylabel"});   // missing label() wrapper
+    expect_setup_fail("bm25", {"is", "label()"});   // empty label name
+    expect_setup_fail("bm25", {"is", "label(a,b)"}); // more than one name
 }
 
 TEST_F(Bm25LabelBlueprintTest, label_parameter_is_not_supported_by_elementwise_bm25) {
-    expect_setup_fail("elementwise", {"bm25(is,someLabel)", "x", "double"});
+    expect_setup_fail("elementwise", {"bm25(is,label(someLabel))", "x", "double"});
 }
 
 struct Bm25LabelFixture {
@@ -474,7 +477,7 @@ struct Bm25LabelFixture {
 };
 
 TEST(Bm25LabelExecutorTest, only_labeled_terms_are_scored) {
-    Bm25LabelFixture f({"bm25(foo)", "bm25(foo,mylabel)"});
+    Bm25LabelFixture f({"bm25(foo)", "bm25(foo,label(mylabel))"});
     f.add_label("mylabel", {11});
     f.setup();
     f.prepare_term(0, 0, 3, 20);
@@ -484,46 +487,46 @@ TEST(Bm25LabelExecutorTest, only_labeled_terms_are_scored) {
     test::RankResult expected;
     expected.setEpsilon(0.000001);
     expected.addScore("bm25(foo)", f.score(3.0, 20, f.idf(25)) + f.score(7.0, 5.0, f.idf(35)));
-    expected.addScore("bm25(foo,mylabel)", f.score(3.0, 20, f.idf(25)));
+    expected.addScore("bm25(foo,label(mylabel))", f.score(3.0, 20, f.idf(25)));
     EXPECT_TRUE(f.execute(expected));
 }
 
 TEST(Bm25LabelExecutorTest, label_with_multiple_terms_scores_their_sum) {
-    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    Bm25LabelFixture f({"bm25(foo,label(mylabel))"});
     f.add_label("mylabel", {11, 12});
     f.setup();
     f.prepare_term(0, 0, 3, 20);
     f.prepare_term(1, 0, 7, 5);
     test::RankResult expected;
     expected.setEpsilon(0.000001);
-    expected.addScore("bm25(foo,mylabel)", f.score(3.0, 20, f.idf(25)) + f.score(7.0, 5.0, f.idf(35)));
+    expected.addScore("bm25(foo,label(mylabel))", f.score(3.0, 20, f.idf(25)) + f.score(7.0, 5.0, f.idf(35)));
     EXPECT_TRUE(f.execute(expected));
 }
 
 TEST(Bm25LabelExecutorTest, label_not_present_in_query_gives_zero_score) {
-    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    Bm25LabelFixture f({"bm25(foo,label(mylabel))"});
     f.setup();
     f.prepare_term(0, 0, 3, 20);
     test::RankResult expected;
     expected.setEpsilon(0.000001);
-    expected.addScore("bm25(foo,mylabel)", 0.0);
+    expected.addScore("bm25(foo,label(mylabel))", 0.0);
     EXPECT_TRUE(f.execute(expected));
 }
 
 TEST(Bm25LabelExecutorTest, labeled_term_searching_another_field_contributes_nothing) {
-    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    Bm25LabelFixture f({"bm25(foo,label(mylabel))"});
     f.add_label("mylabel", {13}); // term searching field 'bar'
     f.setup();
     f.prepare_term(0, 0, 3, 20);
     f.prepare_term(2, 1, 3, 20);
     test::RankResult expected;
     expected.setEpsilon(0.000001);
-    expected.addScore("bm25(foo,mylabel)", 0.0);
+    expected.addScore("bm25(foo,label(mylabel))", 0.0);
     EXPECT_TRUE(f.execute(expected));
 }
 
 TEST(Bm25LabelExecutorTest, labeled_feature_uses_field_level_tuning) {
-    Bm25LabelFixture f({"bm25(foo,mylabel)"});
+    Bm25LabelFixture f({"bm25(foo,label(mylabel))"});
     // tuning properties are keyed per field only, not per feature instance
     f.test.getIndexEnv().getProperties().add("bm25(foo).k1", "2.5");
     f.add_label("mylabel", {11});
@@ -532,7 +535,7 @@ TEST(Bm25LabelExecutorTest, labeled_feature_uses_field_level_tuning) {
     f.scorer.k1_param = 2.5;
     test::RankResult expected;
     expected.setEpsilon(0.000001);
-    expected.addScore("bm25(foo,mylabel)", f.score(3.0, 20, f.idf(25)));
+    expected.addScore("bm25(foo,label(mylabel))", f.score(3.0, 20, f.idf(25)));
     EXPECT_TRUE(f.execute(expected));
 }
 

--- a/searchlib/src/tests/features/util/util_test.cpp
+++ b/searchlib/src/tests/features/util/util_test.cpp
@@ -127,6 +127,25 @@ TEST(UtilsTest, require_that_duplicated_uid_values_are_deduped_by_term_set_looku
     EXPECT_EQ(0u, issues.list.size());
 }
 
+TEST(UtilsTest, require_that_label_argument_is_unwrapped) {
+    EXPECT_EQ("mylabel", parse_label_argument("label(mylabel)").value());
+    // whitespace is normalized by feature name parsing
+    EXPECT_EQ("mylabel", parse_label_argument("label( mylabel )").value());
+    // quoting allows label names that are not valid identifiers
+    EXPECT_EQ("my label", parse_label_argument("label(\"my label\")").value());
+}
+
+TEST(UtilsTest, require_that_malformed_label_argument_is_rejected) {
+    EXPECT_FALSE(parse_label_argument("").has_value());
+    EXPECT_FALSE(parse_label_argument("mylabel").has_value());      // missing label() wrapper
+    EXPECT_FALSE(parse_label_argument("label").has_value());        // no parameter list
+    EXPECT_FALSE(parse_label_argument("label()").has_value());      // empty label name
+    EXPECT_FALSE(parse_label_argument("label(a,b)").has_value());   // more than one name
+    EXPECT_FALSE(parse_label_argument("label(a).out").has_value()); // output suffix
+    EXPECT_FALSE(parse_label_argument("labels(a)").has_value());    // wrong wrapper name
+    EXPECT_FALSE(parse_label_argument("label(a").has_value());      // unbalanced parenthesis
+}
+
 template <typename T> void verifyStrToNum(const std::string& label) {
     SCOPED_TRACE(label);
     EXPECT_EQ(-17, static_cast<long>(strToNum<T>("-17")));

--- a/searchlib/src/tests/features/util/util_test.cpp
+++ b/searchlib/src/tests/features/util/util_test.cpp
@@ -3,7 +3,9 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/queryenvironment.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/issue.h>
 
+using vespalib::Issue;
 using namespace search;
 using namespace search::fef;
 using namespace search::fef::test;
@@ -35,8 +37,30 @@ struct TermLabelFixture {
         queryEnv.getProperties().add("vespa.label.bar.id", "0"); // undefined uid
         queryEnv.getProperties().add("vespa.label.baz.id", "10");
         queryEnv.getProperties().add("vespa.label.fox.id", "7"); // non-existing
+        queryEnv.getProperties().add("vespa.label.multi.id", "5");
+        queryEnv.getProperties().add("vespa.label.multi.id", "10");
+        queryEnv.getProperties().add("vespa.label.dup.id", "10"); // duplicated uid values
+        queryEnv.getProperties().add("vespa.label.dup.id", "10");
+        queryEnv.getProperties().add("vespa.label.zeroed.id", "0"); // undefined uid among valid ones
+        queryEnv.getProperties().add("vespa.label.zeroed.id", "10");
+        queryEnv.getProperties().add("vespa.label.partial.id", "5"); // non-existing uid among valid ones
+        queryEnv.getProperties().add("vespa.label.partial.id", "7");
+        queryEnv.getProperties().add("vespa.label.dupmissing.id", "5"); // duplicated non-existing uid
+        queryEnv.getProperties().add("vespa.label.dupmissing.id", "7");
+        queryEnv.getProperties().add("vespa.label.dupmissing.id", "7");
     }
+    const ITermData* term(size_t idx) { return &queryEnv.getTerms()[idx]; }
 };
+
+struct MyIssues : Issue::Handler {
+    std::vector<std::string> list;
+    Issue::Binding           capture;
+    MyIssues() : list(), capture(Issue::listen(*this)) {}
+    ~MyIssues() override;
+    void handle(const Issue& issue) override { list.push_back(issue.message()); }
+};
+
+MyIssues::~MyIssues() = default;
 
 TEST(UtilsTest, require_that_label_can_be_mapped_to_term) {
     TermLabelFixture f1;
@@ -45,6 +69,62 @@ TEST(UtilsTest, require_that_label_can_be_mapped_to_term) {
     EXPECT_EQ((ITermData*)&f1.queryEnv.getTerms()[2], getTermByLabel(f1.queryEnv, "baz"));
     EXPECT_EQ(nullptr, getTermByLabel(f1.queryEnv, "fox"));
     EXPECT_EQ(nullptr, getTermByLabel(f1.queryEnv, "unknown"));
+}
+
+TEST(UtilsTest, require_that_multi_valued_label_maps_to_the_first_value_term) {
+    TermLabelFixture f1;
+    EXPECT_EQ(f1.term(0), getTermByLabel(f1.queryEnv, "multi"));
+}
+
+TEST(UtilsTest, require_that_label_can_be_mapped_to_term_set) {
+    using TermVector = std::vector<const ITermData*>;
+    TermLabelFixture f1;
+    MyIssues         issues;
+    EXPECT_EQ(TermVector({f1.term(0)}), getTermsByLabel(f1.queryEnv, "foo"));
+    EXPECT_EQ(0u, issues.list.size());
+    EXPECT_EQ(TermVector({f1.term(2)}), getTermsByLabel(f1.queryEnv, "baz"));
+    EXPECT_EQ(0u, issues.list.size());
+    // terms are returned in query environment order
+    EXPECT_EQ(TermVector({f1.term(0), f1.term(2)}), getTermsByLabel(f1.queryEnv, "multi"));
+    EXPECT_EQ(0u, issues.list.size());
+    // unknown label -> empty result, no issue
+    EXPECT_EQ(TermVector(), getTermsByLabel(f1.queryEnv, "unknown"));
+    EXPECT_EQ(0u, issues.list.size());
+}
+
+TEST(UtilsTest, require_that_invalid_uid_values_are_skipped_by_term_set_lookup) {
+    using TermVector = std::vector<const ITermData*>;
+    TermLabelFixture f1;
+    MyIssues         issues;
+    // uid 0 is reported and skipped
+    EXPECT_EQ(TermVector(), getTermsByLabel(f1.queryEnv, "bar"));
+    EXPECT_EQ(1u, issues.list.size());
+    // uid 0 is reported and skipped, the valid uid is still resolved
+    EXPECT_EQ(TermVector({f1.term(2)}), getTermsByLabel(f1.queryEnv, "zeroed"));
+    EXPECT_EQ(2u, issues.list.size());
+}
+
+TEST(UtilsTest, require_that_non_existing_uids_are_reported_by_term_set_lookup) {
+    using TermVector = std::vector<const ITermData*>;
+    TermLabelFixture f1;
+    MyIssues         issues;
+    // non-existing uid is reported and contributes nothing
+    EXPECT_EQ(TermVector(), getTermsByLabel(f1.queryEnv, "fox"));
+    EXPECT_EQ(1u, issues.list.size());
+    // non-existing uid does not affect the valid one
+    EXPECT_EQ(TermVector({f1.term(0)}), getTermsByLabel(f1.queryEnv, "partial"));
+    EXPECT_EQ(2u, issues.list.size());
+    // duplicated non-existing uid is reported at most once
+    EXPECT_EQ(TermVector({f1.term(0)}), getTermsByLabel(f1.queryEnv, "dupmissing"));
+    EXPECT_EQ(3u, issues.list.size());
+}
+
+TEST(UtilsTest, require_that_duplicated_uid_values_are_deduped_by_term_set_lookup) {
+    using TermVector = std::vector<const ITermData*>;
+    TermLabelFixture f1;
+    MyIssues         issues;
+    EXPECT_EQ(TermVector({f1.term(2)}), getTermsByLabel(f1.queryEnv, "dup"));
+    EXPECT_EQ(0u, issues.list.size());
 }
 
 template <typename T> void verifyStrToNum(const std::string& label) {

--- a/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
@@ -3,6 +3,7 @@
 #include "bm25_feature.h"
 
 #include "bm25_utils.h"
+#include "utils.h"
 
 #include <vespa/searchlib/fef/featurenamebuilder.h>
 #include <vespa/searchlib/fef/itermdata.h>
@@ -25,6 +26,17 @@ using fef::MatchDataDetails;
 using fef::objectstore::as_value;
 using vespalib::Trinary;
 
+void Bm25Executor::add_term_fields(const fef::ITermData& term, uint32_t field_id, const fef::IQueryEnvironment& env,
+                                   double k1_param) {
+    for (size_t j = 0; j < term.numFields(); ++j) {
+        const ITermFieldData& term_field = term.field(j);
+        if (field_id == term_field.getFieldId()) {
+            _terms.emplace_back(term_field.getHandle(MatchDataDetails::Interleaved),
+                                Bm25Utils::get_inverse_document_frequency(term_field, env, term), k1_param);
+        }
+    }
+}
+
 Bm25Executor::Bm25Executor(const fef::FieldInfo& field, const fef::IQueryEnvironment& env, double avg_field_length,
                            double k1_param, double b_param)
     : FeatureExecutor(),
@@ -33,14 +45,20 @@ Bm25Executor::Bm25Executor(const fef::FieldInfo& field, const fef::IQueryEnviron
       _k1_mul_b(k1_param * b_param),
       _k1_mul_one_minus_b(k1_param * (1 - b_param)) {
     for (size_t i = 0; i < env.getNumTerms(); ++i) {
-        const ITermData* term = env.getTerm(i);
-        for (size_t j = 0; j < term->numFields(); ++j) {
-            const ITermFieldData& term_field = term->field(j);
-            if (field.id() == term_field.getFieldId()) {
-                _terms.emplace_back(term_field.getHandle(MatchDataDetails::Interleaved),
-                                    Bm25Utils::get_inverse_document_frequency(term_field, env, *term), k1_param);
-            }
-        }
+        add_term_fields(*env.getTerm(i), field.id(), env, k1_param);
+    }
+}
+
+Bm25Executor::Bm25Executor(const fef::FieldInfo& field, const fef::IQueryEnvironment& env,
+                           const std::vector<const fef::ITermData*>& terms, double avg_field_length, double k1_param,
+                           double b_param)
+    : FeatureExecutor(),
+      _terms(),
+      _avg_field_length(avg_field_length),
+      _k1_mul_b(k1_param * b_param),
+      _k1_mul_one_minus_b(k1_param * (1 - b_param)) {
+    for (const ITermData* term : terms) {
+        add_term_fields(*term, field.id(), env, k1_param);
     }
 }
 
@@ -79,7 +97,8 @@ Bm25Blueprint::Bm25Blueprint()
       _field(nullptr),
       _k1_param(default_k1_param),
       _b_param(default_b_param),
-      _avg_field_length() {
+      _avg_field_length(),
+      _label() {
 }
 
 void Bm25Blueprint::visitDumpFeatures(const fef::IIndexEnvironment& env, fef::IDumpFeatureVisitor& visitor) const {
@@ -98,7 +117,12 @@ fef::Blueprint::UP Bm25Blueprint::createInstance() const {
 }
 
 fef::ParameterDescriptions Bm25Blueprint::getDescriptions() const {
-    return fef::ParameterDescriptions().desc().indexField(fef::ParameterCollection::ANY);
+    return fef::ParameterDescriptions()
+        .desc()
+        .indexField(fef::ParameterCollection::ANY)
+        .desc()
+        .indexField(fef::ParameterCollection::ANY)
+        .string();
 }
 
 bool Bm25Blueprint::setup(const fef::IIndexEnvironment& env, const fef::ParameterList& params) {
@@ -118,8 +142,16 @@ bool Bm25Blueprint::setup(const fef::IIndexEnvironment& env, const fef::Paramete
     if (bm25_utils.lookup_param(Bm25Utils::average_field_length(), _avg_field_length) == Trinary::Undefined) {
         return fail(bm25_utils.last_error());
     }
-
-    describeOutput("score", "The bm25 score for all terms searching in the given index field");
+    if (params.size() == 2) {
+        _label = params[1].getValue();
+        if (_label.empty()) {
+            return fail("The label parameter cannot be empty");
+        }
+        describeOutput("score", "The bm25 score for the query terms with the given label searching in the given "
+                                "index field");
+    } else {
+        describeOutput("score", "The bm25 score for all terms searching in the given index field");
+    }
     return true;
 }
 
@@ -149,7 +181,11 @@ fef::FeatureExecutor& Bm25Blueprint::createExecutor(const fef::IQueryEnvironment
     double      avg_field_length = lookup_result != nullptr
                                        ? as_value<double>(*lookup_result)
                                        : _avg_field_length.value_or(get_average_field_length(env, _field->name()));
-    return stash.create<Bm25Executor>(*_field, env, avg_field_length, _k1_param, _b_param);
+    if (_label.empty()) {
+        return stash.create<Bm25Executor>(*_field, env, avg_field_length, _k1_param, _b_param);
+    }
+    return stash.create<Bm25Executor>(*_field, env, util::getTermsByLabel(env, _label), avg_field_length, _k1_param,
+                                      _b_param);
 }
 
 } // namespace search::features

--- a/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/bm25_feature.cpp
@@ -143,10 +143,12 @@ bool Bm25Blueprint::setup(const fef::IIndexEnvironment& env, const fef::Paramete
         return fail(bm25_utils.last_error());
     }
     if (params.size() == 2) {
-        _label = params[1].getValue();
-        if (_label.empty()) {
-            return fail("The label parameter cannot be empty");
+        auto label = util::parse_label_argument(params[1].getValue());
+        if (!label.has_value()) {
+            return fail("The second parameter must be of the form label(<query-item-label>), but was '%s'",
+                        params[1].getValue().c_str());
         }
+        _label = std::move(*label);
         describeOutput("score", "The bm25 score for the query terms with the given label searching in the given "
                                 "index field");
     } else {

--- a/searchlib/src/vespa/searchlib/features/bm25_feature.h
+++ b/searchlib/src/vespa/searchlib/features/bm25_feature.h
@@ -7,6 +7,8 @@
 #include <vespa/searchlib/fef/blueprint.h>
 #include <vespa/searchlib/fef/featureexecutor.h>
 
+#include <string>
+
 namespace search::features {
 
 /**
@@ -25,9 +27,16 @@ class Bm25Executor : public fef::FeatureExecutor {
     double _k1_mul_b;
     double _k1_mul_one_minus_b;
 
+    void add_term_fields(const fef::ITermData& term, uint32_t field_id, const fef::IQueryEnvironment& env,
+                         double k1_param);
+
 public:
     Bm25Executor(const fef::FieldInfo& field, const fef::IQueryEnvironment& env, double avg_field_length,
                  double k1_param, double b_param);
+    // Collects only from the given terms (the terms carrying a label).
+    Bm25Executor(const fef::FieldInfo& field, const fef::IQueryEnvironment& env,
+                 const std::vector<const fef::ITermData*>& terms, double avg_field_length, double k1_param,
+                 double b_param);
 
     void handle_bind_match_data(const fef::MatchData& match_data) override;
     void execute(uint32_t docId) override;
@@ -42,6 +51,7 @@ private:
     double                _k1_param;
     double                _b_param;
     std::optional<double> _avg_field_length;
+    std::string           _label; // empty = unlabeled, sum over all terms searching the field
 
 public:
     Bm25Blueprint();

--- a/searchlib/src/vespa/searchlib/features/utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/utils.cpp
@@ -6,6 +6,7 @@
 #include <vespa/searchlib/fef/itablemanager.h>
 #include <vespa/searchlib/fef/itermdata.h>
 #include <vespa/searchlib/fef/properties.h>
+#include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
@@ -180,6 +181,40 @@ const ITermData* getTermByLabel(const search::fef::IQueryEnvironment& env, const
     }
     Issue::report("Query label '%s' was attached to non-existing unique id: '%s'", label.c_str(), p.get().c_str());
     return nullptr;
+}
+
+std::vector<const ITermData*> getTermsByLabel(const search::fef::IQueryEnvironment& env, const std::string& label) {
+    // Labeling the query items with unique ids '5' and '7' with the label 'foo'
+    // is represented as: [vespa.label.foo.id: "5", vespa.label.foo.id: "7"]
+    vespalib::asciistream os;
+    os << "vespa.label." << label << ".id";
+    Property p = env.getProperties().lookup(os.view());
+    std::vector<const ITermData*> terms;
+    if (!p.found()) {
+        return terms;
+    }
+    vespalib::hash_set<uint32_t> uids;
+    for (uint32_t i(0), m(p.size()); i < m; ++i) {
+        uint32_t uid = strToNum<uint32_t>(p.getAt(i));
+        if (uid == 0) {
+            Issue::report("Query label '%s' was attached to invalid unique id: '%s'", label.c_str(),
+                          p.getAt(i).c_str());
+        } else {
+            uids.insert(uid);
+        }
+    }
+    vespalib::hash_set<uint32_t> missing_uids(uids);
+    for (uint32_t i(0), m(env.getNumTerms()); i < m; ++i) {
+        const ITermData* term = env.getTerm(i);
+        if (uids.contains(term->getUniqueId())) {
+            terms.push_back(term);
+            missing_uids.erase(term->getUniqueId());
+        }
+    }
+    for (uint32_t uid : missing_uids) {
+        Issue::report("Query label '%s' was attached to non-existing unique id: '%u'", label.c_str(), uid);
+    }
+    return terms;
 }
 
 std::optional<DocumentFrequency> lookup_document_frequency(const search::fef::IQueryEnvironment& env,

--- a/searchlib/src/vespa/searchlib/features/utils.cpp
+++ b/searchlib/src/vespa/searchlib/features/utils.cpp
@@ -3,6 +3,7 @@
 #include "utils.hpp"
 
 #include <vespa/searchlib/fef/featurenamebuilder.h>
+#include <vespa/searchlib/fef/featurenameparser.h>
 #include <vespa/searchlib/fef/itablemanager.h>
 #include <vespa/searchlib/fef/itermdata.h>
 #include <vespa/searchlib/fef/properties.h>
@@ -215,6 +216,15 @@ std::vector<const ITermData*> getTermsByLabel(const search::fef::IQueryEnvironme
         Issue::report("Query label '%s' was attached to non-existing unique id: '%u'", label.c_str(), uid);
     }
     return terms;
+}
+
+std::optional<std::string> parse_label_argument(const std::string& param) {
+    FeatureNameParser parser(param);
+    if (!parser.valid() || parser.baseName() != "label" || parser.parameters().size() != 1 ||
+        parser.parameters()[0].empty() || !parser.output().empty()) {
+        return std::nullopt;
+    }
+    return parser.parameters()[0];
 }
 
 std::optional<DocumentFrequency> lookup_document_frequency(const search::fef::IQueryEnvironment& env,

--- a/searchlib/src/vespa/searchlib/features/utils.h
+++ b/searchlib/src/vespa/searchlib/features/utils.h
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <limits>
 #include <optional>
+#include <vector>
 
 namespace search::features::util {
 
@@ -177,6 +178,21 @@ inline search::fef::TermFieldHandle getTermFieldHandle(const search::fef::IQuery
  * @param label query item label
  **/
 const search::fef::ITermData* getTermByLabel(const search::fef::IQueryEnvironment& env, const std::string& label);
+
+/**
+ * Obtain the set of terms annotated with the given label. A label
+ * names a set of query terms: the label property may hold multiple
+ * unique ids (e.g. when several query items share a label). This
+ * function reverse maps the label to its unique ids and collects the
+ * matching terms in query environment order. An unknown label yields
+ * an empty vector.
+ *
+ * @return terms with the given label, in query environment order
+ * @param env query environment
+ * @param label query item label
+ **/
+std::vector<const search::fef::ITermData*> getTermsByLabel(const search::fef::IQueryEnvironment& env,
+                                                           const std::string&                    label);
 
 std::optional<search::fef::DocumentFrequency> lookup_document_frequency(const search::fef::IQueryEnvironment& env,
                                                                         const search::fef::ITermData&         term);

--- a/searchlib/src/vespa/searchlib/features/utils.h
+++ b/searchlib/src/vespa/searchlib/features/utils.h
@@ -194,6 +194,18 @@ const search::fef::ITermData* getTermByLabel(const search::fef::IQueryEnvironmen
 std::vector<const search::fef::ITermData*> getTermsByLabel(const search::fef::IQueryEnvironment& env,
                                                            const std::string&                    label);
 
+/**
+ * Parse a feature parameter of the form 'label(<name>)' and extract
+ * the label name. The parameter is parsed as a feature name, so
+ * whitespace and quoting are handled ('label("my label")' yields 'my
+ * label'). Anything else (a bare name, 'label()', extra arguments or
+ * an output suffix) yields std::nullopt.
+ *
+ * @return the label name, or std::nullopt if the parameter is not of the required form
+ * @param param feature parameter expected to be of the form 'label(<name>)'
+ **/
+std::optional<std::string> parse_label_argument(const std::string& param);
+
 std::optional<search::fef::DocumentFrequency> lookup_document_frequency(const search::fef::IQueryEnvironment& env,
                                                                         const search::fef::ITermData&         term);
 

--- a/searchlib/src/vespa/searchlib/fef/test/labels.cpp
+++ b/searchlib/src/vespa/searchlib/fef/test/labels.cpp
@@ -6,4 +6,6 @@ namespace search::fef::test {
 
 NoLabel::~NoLabel() = default;
 
+MultiLabel::~MultiLabel() = default;
+
 }

--- a/searchlib/src/vespa/searchlib/fef/test/labels.h
+++ b/searchlib/src/vespa/searchlib/fef/test/labels.h
@@ -5,6 +5,8 @@
 #include <vespa/searchlib/fef/properties.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 
+#include <vector>
+
 namespace search::fef::test {
 
 struct Labels {
@@ -25,6 +27,21 @@ struct SingleLabel : public Labels {
         vespalib::asciistream value;
         value << uid;
         p.add(key.view(), value.view());
+    }
+};
+struct MultiLabel : public Labels {
+    std::string           label;
+    std::vector<uint32_t> uids;
+    MultiLabel(const std::string& l, std::vector<uint32_t> x) : label(l), uids(std::move(x)) {}
+    ~MultiLabel() override;
+    void inject(Properties& p) const override {
+        vespalib::asciistream key;
+        key << "vespa.label." << label << ".id";
+        for (uint32_t uid : uids) {
+            vespalib::asciistream value;
+            value << uid;
+            p.add(key.view(), value.view());
+        }
     }
 };
 


### PR DESCRIPTION
This initial implementation allows attaching labels to different text clauses, for example:

```
where ({label: "primary"}title contains "alpha") or ({label: "secondary"}title contains "beta")
```

Then, in the rank profile, you can consider only terms matching a specific label:
```
expression: bm25(title,primary)  # only takes the score of "alpha"
```

One could attach the same label to multiple clauses or to a composite operator like `near`, then BM25 will be computed on all children:
```
where ({label: "nearPair"}title contains ({distance: 4}near("alpha", "beta")))
```

Most of the label plumbing was already there (labels already work with geoLocation and nearestNeighbor), the main change has to do with handling multiple terms per label (and the required ones at that :D).

Currently, this only supports `bm25` (btw, `bm25(fieldName)` still works as before), it doesn't support elementwise(bm25...). That can be (and should be?) a separate PR, after/if we merge this one.

Built-in searcher support:
- Labels were silently dropped by StemmingSearcher, they are passed now, so that default queries work as expected.
- Same for CJKSearcher.
- PhraseMatcher skips making phrases where terms contain labels.
- I didn't go into NGramSearcher, because I don't think people want/need scoring for individual grams
- RangeQueryOptimizer didn't change, either. It will lose labels, but only on the actual range queries it touches - which won't matter for scoring.
- Other searchers are either safe or irrelevant for this topic, IIUC.