### PR TITLE
chore: patch brace-expansion in vscode client (fixes CVE-2026-13149)

### DIFF
--- a/integration/schema-language-server/clients/vscode/package-lock.json
+++ b/integration/schema-language-server/clients/vscode/package-lock.json
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2012,9 +2012,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5795,9 +5795,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/integration/schema-language-server/clients/vscode/package.json
+++ b/integration/schema-language-server/clients/vscode/package.json
@@ -102,8 +102,8 @@
     "vscode-languageclient": "^9.0.1"
   },
   "overrides": {
-    "vscode-languageclient": {
-      "brace-expansion": "2.1.1"
-    }
+    "brace-expansion@1": "1.1.16",
+    "brace-expansion@2": "2.1.2",
+    "brace-expansion@5": "5.0.7"
   }
 }


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**
>
> **Once approved, please merge it** — this is an automated dependency-update PR and merging is the final step that closes out the linked Mend/Jira findings.

## Summary
Patches `brace-expansion` (HIGH ReDoS, CVE-2026-13149) in the schema-language-server VS Code extension client. Three vulnerable instances were resolving in that client's lockfile; this replaces the single nested override with version-keyed overrides that patch all three majors.

## Changed Files

**`integration/schema-language-server/clients/vscode/package.json`** — `overrides`:
- `brace-expansion@1`: → `1.1.16` (was 1.1.13 via `@vscode/vsce` → minimatch)
- `brace-expansion@2`: → `2.1.2` (was 2.1.1 via `vscode-languageclient`)
- `brace-expansion@5`: → `5.0.7` (was 5.0.5, top-level)

**`.../package-lock.json`** — regenerated via `npm install --package-lock-only`; all three `brace-expansion` instances now resolve to patched versions.

## CVEs Addressed

| Package | CVE(s) | Severity | Fix version reached |
|---|---|---|---|
| brace-expansion | CVE-2026-13149 | high | 1.1.16 / 2.1.2 / 5.0.7 |

Fix versions are the `maintenance-v1` (1.1.16), `maintenance-v2` (2.1.2) and `latest` (5.0.7) dist-tags. Verified via `npm view brace-expansion dist-tags`.

## ⚠️ Cannot fix in this PR

| Package | CVE | Reason |
|---|---|---|
| webrick @ 1.9.2 (Gemfile) | CVE-2026-38969 | 1.9.2 is the latest release on RubyGems and is itself vulnerable ("through 1.9.2"); the upstream fix (ruby/webrick#199) is still unmerged. No patched release exists. webrick here is the Ruby `jekyll serve` dev/preview webserver, not part of any shipped runtime. |

## Implementation Notes
The original override scoped `brace-expansion` only under `vscode-languageclient`; switching to version-keyed overrides catches the sibling instances pulled by `@vscode/vsce` and at the top level too (all dev/build tooling for the extension). Thorough fix to avoid re-flagging on the next scan.

## Verification
- `npm install --package-lock-only` resolves cleanly; all three `brace-expansion` instances patched.
- Re-run the Mend scan after merge to confirm CVE-2026-13149 clears (webrick will remain — see above).