### PR TITLE
Implicitly convert cell types during tensor (de-)quantization

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/tensor_quantization_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensor_quantization_test.cpp
@@ -5,17 +5,21 @@
 #include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/value.h>
 #include <vespa/eval/eval/value_codec.h>
+#include <vespa/eval/eval/value_type_spec.h>
 #include <vespa/searchlib/tensor/tensor_quantization.h>
 #include <vespa/vespalib/quant/eden.h>
 
 #include <gmock/gmock.h>
 
+#include <format>
 #include <iostream>
 
 using vespalib::eval::CellType;
 using vespalib::eval::FastValueBuilderFactory;
 using vespalib::eval::TensorSpec;
-using vespalib::eval::Value;
+using TensorValue = vespalib::eval::Value; // ambiguity with GTest testing::Value
+using vespalib::BFloat16;
+using vespalib::eval::Int8Float;
 using vespalib::eval::ValueType;
 using vespalib::quant::EdenQuantizer;
 using vespalib::quant::QuantMode;
@@ -26,7 +30,7 @@ namespace search::tensor {
 
 namespace {
 
-Value::UP create_tensor(const TensorSpec& spec) {
+TensorValue::UP create_tensor(const TensorSpec& spec) {
     return value_from_spec(spec, FastValueBuilderFactory::get());
 }
 
@@ -67,61 +71,146 @@ TEST(TensorQuantizationTest, quantized_type_conversion_flattens_indexed_dimensio
     EXPECT_EQ(to_quant_spec("tensor<float>(x{},y{},a[2],b[3],c[4])", 4), "tensor<int8>(c[16],x{},y{})");
 }
 
-TEST(TensorQuantizationTest, can_quantize_and_dequantize_indexed_tensors) {
-    constexpr uint8_t q_bits = 4;
+TEST(TensorQuantizationTest, quantized_tensor_shape_is_invariant_of_input_cell_type) {
+    EXPECT_EQ(to_quant_spec("tensor(x[16])", 1), "tensor<int8>(x[6])");
+    EXPECT_EQ(to_quant_spec("tensor<double>(x[16])", 1), "tensor<int8>(x[6])"); // alias of the above
+    EXPECT_EQ(to_quant_spec("tensor<float>(x[16])", 1), "tensor<int8>(x[6])");
+    EXPECT_EQ(to_quant_spec("tensor<bfloat16>(x[16])", 1), "tensor<int8>(x[6])");
+    EXPECT_EQ(to_quant_spec("tensor<int8>(x[16])", 1), "tensor<int8>(x[6])");
 
-    auto t = create_tensor(
-        TensorSpec("tensor<float>(x[2],y[3])").add({{"x", 0}, {"y", 1}}, 12).add({{"x", 1}, {"y", 2}}, 9));
-    auto q = make_quantizer_from_type(t->type(), q_bits);
-    auto q_type = to_quantized_tensor_type(t->type(), *q);
+    EXPECT_EQ(to_quant_spec("tensor(a{},b{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},b{},z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<double>(a{},b{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},b{},z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<float>(a{},b{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},b{},z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<bfloat16>(a{},b{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},b{},z[16])");
+    EXPECT_EQ(to_quant_spec("tensor<int8>(a{},b{},x[2],y[3],z[4])", 4), "tensor<int8>(a{},b{},z[16])");
+}
 
-    auto qt_mse = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::MSE);
-    auto dqt_mse = search::tensor::dequantize_tensor(*qt_mse, t->type(), *q);
-    auto qt_ip = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::InnerProduct);
-    auto dqt_ip = search::tensor::dequantize_tensor(*qt_ip, t->type(), *q);
+namespace {
+
+struct DequantizedTensors {
+    std::unique_ptr<TensorValue> mse_dequant; // MSE-optimized quantization mode
+    std::unique_ptr<TensorValue> ip_dequant;  // Inner-product-optimized quantization mode
+};
+
+DequantizedTensors quantize_tensor_roundtrip(const TensorValue& t, const uint8_t q_bits) {
+    auto q = make_quantizer_from_type(t.type(), q_bits);
+    auto q_type = to_quantized_tensor_type(t.type(), *q);
+
+    std::vector<float> scratch_space;
+
+    auto qt_mse = search::tensor::quantize_tensor(t, q_type, *q, QuantMode::MSE, scratch_space);
+    auto dqt_mse = search::tensor::dequantize_tensor(*qt_mse, t.type(), *q, scratch_space);
+
+    auto qt_ip = search::tensor::quantize_tensor(t, q_type, *q, QuantMode::InnerProduct, scratch_space);
+    auto dqt_ip = search::tensor::dequantize_tensor(*qt_ip, t.type(), *q, scratch_space);
 
     EXPECT_EQ(qt_mse->type(), q_type);
     EXPECT_EQ(qt_ip->type(), q_type);
 
-    // OG vector
-    EXPECT_THAT(t->cells().typify<float>(), ElementsAre(/*x=0*/ 0, 12, 0, /*x=1*/ 0, 0, 9));
-    // we have vector at home, MSE edition:
-    std::vector<float> mse_expected = {-0.364243, 11.9888, 1.24358, -0.301369, -0.404984, 8.79533};
-    EXPECT_THAT(dqt_mse->cells().typify<float>(), Pointwise(FloatNear(0.0001), mse_expected));
-    // Inner-product edition:
-    std::vector<float> ip_expected = {-0.36747, 12.0951, 1.2546, -0.304039, -0.408572, 8.87325};
-    EXPECT_THAT(dqt_ip->cells().typify<float>(), Pointwise(FloatNear(0.0001), ip_expected));
+    return {std::move(dqt_mse), std::move(dqt_ip)};
 }
 
-TEST(TensorQuantizationTest, can_quantize_and_dequantize_mixed_tensors) {
-    constexpr uint8_t q_bits = 4;
+DequantizedTensors quantize_indexed_tensor_roundtrip(const CellType cell_type, const uint8_t q_bits = 4) {
+    std::string cell_type_name = vespalib::eval::value_type::cell_type_to_name(cell_type);
+    std::string spec_str = std::format("tensor<{}>(x[2],y[3])", cell_type_name);
+    // Values are losslessly representable across all cell types, and will therefore
+    // result in the same float values used as input to the quantization algorithm.
+    auto t = create_tensor(TensorSpec(spec_str).add({{"x", 0}, {"y", 1}}, 12).add({{"x", 1}, {"y", 2}}, 9));
 
-    auto t = create_tensor(TensorSpec("tensor<float>(a{},x[2],y[3])")
+    return quantize_tensor_roundtrip(*t, q_bits);
+}
+
+template <typename CT>
+void do_test_4_bit_quantized_roundtrip_of_dense_indexed_floating_point_tensor() {
+    auto dq = quantize_indexed_tensor_roundtrip(vespalib::eval::get_cell_type<CT>(), 4);
+
+    // We can use the same expected floating point values for double/float/BFloat16, since doubles
+    // are implicitly converted to floats (and thus have no more actual precision) and BFloat16 is
+    // implicitly mantissa-truncated before comparison.
+    std::vector<CT> mse_expected = {-0.36424255, 11.988836, 1.243578, -0.30136871, -0.40498352, 8.7953281};
+    EXPECT_THAT(dq.mse_dequant->cells().template typify<CT>(), Pointwise(FloatNear(0.00001), mse_expected));
+
+    std::vector<CT> ip_expected = {-0.36747026, 12.095058, 1.2545962, -0.30403852, -0.40857196, 8.8732548};
+    EXPECT_THAT(dq.ip_dequant->cells().template typify<CT>(), Pointwise(FloatNear(0.00001), ip_expected));
+}
+
+DequantizedTensors quantize_mixed_tensor_roundtrip(const CellType cell_type, const uint8_t q_bits = 4) {
+    std::string cell_type_name = vespalib::eval::value_type::cell_type_to_name(cell_type);
+    std::string spec_str = std::format("tensor<{}>(a{{}},x[2],y[3])", cell_type_name);
+
+    // Will be normalized and arranged as bar=[0, 5, 0, 0, -3, 0], foo=[0, 12, 0, 0, 0, 9] in memory.
+    auto t = create_tensor(TensorSpec(spec_str)
                                .add({{"a", "foo"}, {"x", 0}, {"y", 1}}, 12)
                                .add({{"a", "foo"}, {"x", 1}, {"y", 2}}, 9)
                                .add({{"a", "bar"}, {"x", 0}, {"y", 1}}, 5)
-                               .add({{"a", "bar"}, {"x", 1}, {"y", 1}}, 3));
-    auto q = make_quantizer_from_type(t->type(), q_bits);
-    auto q_type = to_quantized_tensor_type(t->type(), *q);
+                               .add({{"a", "bar"}, {"x", 1}, {"y", 1}}, -3));
 
-    auto qt_mse = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::MSE);
-    auto dqt_mse = search::tensor::dequantize_tensor(*qt_mse, t->type(), *q);
-    auto qt_ip = search::tensor::quantize_f32_tensor(*t, q_type, *q, QuantMode::InnerProduct);
-    auto dqt_ip = search::tensor::dequantize_tensor(*qt_ip, t->type(), *q);
+    return quantize_tensor_roundtrip(*t, q_bits);
+}
 
-    EXPECT_EQ(qt_mse->type(), q_type);
-    EXPECT_EQ(qt_ip->type(), q_type);
+template <typename CT>
+void do_test_4_bit_quantized_roundtrip_of_mixed_floating_point_tensor() {
+    auto dq = quantize_mixed_tensor_roundtrip(vespalib::eval::get_cell_type<CT>(), 4);
 
-    // OG vector. Arranged as bar=[0, 5, 0, 0, 3, 0], foo=[0, 12, 0, 0, 0, 9]
-    EXPECT_THAT(t->cells().typify<float>(), ElementsAre(0, 5, 0, 0, 3, 0, 0, 12, 0, 0, 0, 9));
+    // As with indexed tensors, we can reuse the expected values across FP cell types.
+    std::vector<CT> mse_expected = {-0.4283701, 4.92065,  0.228362, -0.08518672, -3.048389,  -0.005629063,
+                                    -0.3642426, 11.98884, 1.243578, -0.3013687,  -0.4049835, 8.795328};
+    EXPECT_THAT(dq.mse_dequant->cells().template typify<CT>(), Pointwise(DoubleNear(0.00001), mse_expected));
 
-    std::vector<float> mse_expected = {-0.00648499, 4.85099, 0.384633, -0.0835068, 3.1499,    -0.309387,
-                                       -0.364243,   11.9888, 1.24358,  -0.301369,  -0.404984, 8.79533};
-    EXPECT_THAT(dqt_mse->cells().typify<float>(), Pointwise(FloatNear(0.0001), mse_expected));
+    std::vector<CT> ip_expected = {-0.4315633, 4.957332, 0.2300643, -0.08582163, -3.071113, -0.005670905,
+                                   -0.3674703, 12.09506, 1.254596,  -0.3040385,  -0.408572, 8.873255};
+    EXPECT_THAT(dq.ip_dequant->cells().template typify<CT>(), Pointwise(DoubleNear(0.00001), ip_expected));
+}
 
-    std::vector<float> ip_expected = {-0.00654173, 4.8935,  0.388003, -0.0842385, 3.1775,    -0.312098,
-                                      -0.36747,    12.0951, 1.2546,   -0.304039,  -0.408572, 8.87325};
-    EXPECT_THAT(dqt_ip->cells().typify<float>(), Pointwise(FloatNear(0.0001), ip_expected));
+} // namespace
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_double_dense_indexed_tensors) {
+    do_test_4_bit_quantized_roundtrip_of_dense_indexed_floating_point_tensor<double>();
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_float_dense_indexed_tensors) {
+    do_test_4_bit_quantized_roundtrip_of_dense_indexed_floating_point_tensor<float>();
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_bfloat16_dense_indexed_tensors) {
+    do_test_4_bit_quantized_roundtrip_of_dense_indexed_floating_point_tensor<BFloat16>();
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_int8_dense_indexed_tensors) {
+    auto dq = quantize_indexed_tensor_roundtrip(CellType::INT8);
+    // Original vector is {0, 12, 0, 0, 0, 9}
+    // As an interesting point of comparison, conversion using static_cast (flooring) rather
+    // than std::round (nearest) would yield {0, 11, 1, 0, 0, 8} instead, which has an absolute
+    // error of 3 rather than 1.
+    std::vector<Int8Float> mse_expected = {0, 12, 1, 0, 0, 9};
+    EXPECT_THAT(dq.mse_dequant->cells().typify<Int8Float>(), Pointwise(Eq(), mse_expected));
+
+    std::vector<Int8Float> ip_expected = {0, 12, 1, 0, 0, 9};
+    EXPECT_THAT(dq.ip_dequant->cells().typify<Int8Float>(), Pointwise(Eq(), ip_expected));
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_double_mixed_tensors) {
+    do_test_4_bit_quantized_roundtrip_of_mixed_floating_point_tensor<double>();
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_float_mixed_tensors) {
+    do_test_4_bit_quantized_roundtrip_of_mixed_floating_point_tensor<float>();
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_bfloat16_mixed_tensors) {
+    do_test_4_bit_quantized_roundtrip_of_mixed_floating_point_tensor<BFloat16>();
+}
+
+TEST(TensorQuantizationTest, can_quantize_and_dequantize_int8_mixed_tensors) {
+    auto dq = quantize_mixed_tensor_roundtrip(CellType::INT8, 4);
+    // Original vector is {0, 5, 0, 0, -3, 0, 0, 12, 0, 0, 0, 9}
+    // In this case, using static_cast (flooring) rather than std::round (nearest) would yield
+    // {0, 4, 0, 0, -3, 0, 0, 11, 1, 0, 0, 8} instead, with an absolute error of 4 rather than 1.
+    std::vector<Int8Float> mse_expected = {0, 5, 0, 0, -3, 0, 0, 12, 1, 0, 0, 9};
+    EXPECT_THAT(dq.mse_dequant->cells().typify<Int8Float>(), Pointwise(Eq(), mse_expected));
+
+    std::vector<Int8Float> ip_expected = {0, 5, 0, 0, -3, 0, 0, 12, 1, 0, 0, 9};
+    EXPECT_THAT(dq.ip_dequant->cells().typify<Int8Float>(), Pointwise(Eq(), ip_expected));
 }
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.cpp
@@ -4,14 +4,20 @@
 
 #include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/value.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/quant/eden.h>
+#include <vespa/vespalib/util/bfloat16.h>
 
+#include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <type_traits>
 
 using vespalib::eval::CellType;
 using vespalib::eval::FastValueBuilderFactory;
 using vespalib::eval::Int8Float;
+using vespalib::eval::TypedCells;
+using vespalib::eval::TypifyCellType;
 using vespalib::eval::ValueType;
 
 namespace search::tensor {
@@ -26,100 +32,207 @@ template <typename T, typename T2>
     return std::span<T>(reinterpret_cast<T*>(in.data()), in.size());
 }
 
+template <typename FromType, typename ToType>
+void copy_convert(std::span<const FromType> src, std::span<ToType> dst) noexcept __attribute__((noinline));
+
+template <typename FromType, typename ToType>
+void copy_convert(std::span<const FromType> src, std::span<ToType> dst) noexcept {
+    ToType* p = dst.data();
+    for (const FromType value : src) {
+        *p++ = static_cast<ToType>(value);
+    }
+}
+
+template <>
+void copy_convert<vespalib::BFloat16, float>(std::span<const vespalib::BFloat16> src, std::span<float> dst) noexcept {
+    vespalib::hwaccelerated::convert_bfloat16_to_float(reinterpret_cast<const uint16_t*>(src.data()), dst.data(),
+                                                       dst.size());
+}
+
+template <>
+void copy_convert<float, Int8Float>(std::span<const float> src, std::span<Int8Float> dst) noexcept {
+    Int8Float* p = dst.data();
+    // Since the dequantization process produces floating point numbers that are "approximately
+    // near" the original int8 values, it makes intuitive sense then to emit the int8 values that
+    // are closest to this approximation.
+    // Note: this gets auto-vectorized on AArch64 (GCC 15), but not at all on x64 (again GCC; Clang
+    // _does_ auto-vectorize this). Not sure why GCC doesn't use AVX2's _mm256_round_ps...
+    // TODO manually vectorize? Highway saturating DemoteTo(i8, ConvertTo(i32, Round(f32_vec)))?
+    for (const float value : src) {
+        // We saturate the rounded value since it's not obviously guaranteed that we'll never
+        // dequantize to floating point values outside the representable range of an int8.
+        // Not doing this runs the risk of over-/underflowing.
+        // Going via an i32 and clamping in the integer domain appears to generate better code
+        // on AArch64 (explicit vector smax/smin instructions rather than fp comparisons).
+        // TODO std::saturating_cast can be used on >= C++26
+        *p++ = std::clamp(static_cast<int32_t>(std::round(value)), -128, 127);
+    }
+}
+
+template <typename CT>
+void convert_to_f32(std::span<const CT> src, std::span<float> dst) {
+    static_assert(!std::is_same_v<CT, float>, "Trying to convert float to float; broken type conditions?");
+    assert(dst.size() == src.size());
+    copy_convert<CT, float>(src, dst);
+}
+
+template <typename CT>
+void convert_from_f32(std::span<const float> src, std::span<CT> dst) {
+    static_assert(!std::is_same_v<CT, float>, "Trying to convert float to float; broken type conditions?");
+    assert(dst.size() == src.size());
+    copy_convert<float, CT>(src, dst);
+}
+
 } // namespace
 
 // TODO consider if we should just pass the number of bits rather than a full quantizer...
 //  - could make size computation a static public function in EdenQuantizer
 
-ValueType to_quantized_tensor_type(const ValueType&                      f32_tensor_type,
-                                   const vespalib::quant::EdenQuantizer& quantizer) {
-    std::vector<ValueType::Dimension> q_dims = f32_tensor_type.mapped_dimensions();
-    assert(!f32_tensor_type.is_sparse()); // Must have at least 1 indexed dimension
-    assert(f32_tensor_type.dense_subspace_size() == quantizer.dimensions());
+ValueType to_quantized_tensor_type(const ValueType& in_tensor_type, const vespalib::quant::EdenQuantizer& quantizer) {
+    std::vector<ValueType::Dimension> q_dims = in_tensor_type.mapped_dimensions();
+    assert(!in_tensor_type.is_sparse()); // Must have at least 1 indexed dimension
+    assert(in_tensor_type.dense_subspace_size() == quantizer.dimensions());
     // Leave all sparse dimensions untouched and replace all indexed dimensions with a single
     // quantized "aggregate" dimension. We cheekily reuse the name of the last indexed dimension
     // to ensure we use a name that is unique within the tensor type.
-    q_dims.emplace_back(f32_tensor_type.indexed_dimensions().back().name, quantizer.quantized_size());
+    q_dims.emplace_back(in_tensor_type.indexed_dimensions().back().name, quantizer.quantized_size());
     return ValueType::make_type(CellType::INT8, std::move(q_dims));
 }
 
 // These functions have been cooked on firewood stol- uh, borrowed, from vespalib::eval::CopyValue. Yes. yes.
 
-std::unique_ptr<vespalib::eval::Value> quantize_f32_tensor(const vespalib::eval::Value&     f32_in_tensor,
-                                                           const vespalib::eval::ValueType& quantized_type,
-                                                           vespalib::quant::EdenQuantizer&  quantizer,
-                                                           const vespalib::quant::QuantMode quantization_mode) {
-    // We expect that the number of mapped dimensions is the same for both tensor types
-    const size_t num_mapped = quantized_type.count_mapped_dimensions();
-    const size_t input_dense_size = f32_in_tensor.type().dense_subspace_size();
-    const size_t quantized_dense_size = quantized_type.dense_subspace_size();
-    const auto&  idx = f32_in_tensor.index();
-    auto         input_cells = f32_in_tensor.cells().typify<float>();
-    assert(input_dense_size == quantizer.dimensions());
-    assert(quantized_dense_size == quantizer.quantized_size());
-    assert(num_mapped == quantized_type.dimensions().size() - 1); // Indexed must be reduced down to 1 dimension
-    auto builder = FastValueBuilderFactory::get().create_value_builder<Int8Float>(quantized_type, num_mapped,
-                                                                                  quantized_dense_size, idx.size());
-    std::vector<vespalib::string_id> addr(num_mapped);
-    if (num_mapped == 0) {
-        assert(idx.size() == 1);
-        auto i8f_array_ref = builder->add_subspace(addr);
-        auto u8_array_ref = span_cast<uint8_t>(i8f_array_ref);
-        quantizer.quantize(input_cells, u8_array_ref, quantization_mode);
-    } else {
-        auto view = idx.create_view({});
-        view->lookup({});
-        std::vector<vespalib::string_id*> addr_fetch;
-        addr_fetch.reserve(num_mapped);
-        for (auto& label : addr) {
-            addr_fetch.emplace_back(&label);
+namespace {
+
+struct QuantizeTensorWithImplicitInputConversion {
+    template <typename InputCT>
+    static std::unique_ptr<vespalib::eval::Value>
+    invoke(const vespalib::eval::Value& in_tensor, const vespalib::eval::ValueType& quantized_type,
+           vespalib::quant::EdenQuantizer& quantizer, const vespalib::quant::QuantMode quantization_mode,
+           std::vector<float>& scratch_space) {
+        // We expect that the number of mapped dimensions is the same for both tensor types
+        const size_t num_mapped = quantized_type.count_mapped_dimensions();
+        const size_t input_dense_size = in_tensor.type().dense_subspace_size();
+        const size_t quantized_dense_size = quantized_type.dense_subspace_size();
+        const auto&  idx = in_tensor.index();
+        auto         input_cells = in_tensor.cells().typify<InputCT>();
+
+        assert(input_dense_size == quantizer.dimensions());
+        assert(quantized_dense_size == quantizer.quantized_size());
+        assert(num_mapped == quantized_type.dimensions().size() - 1); // Indexed must be reduced down to 1 dimension
+
+        auto builder = FastValueBuilderFactory::get().create_value_builder<Int8Float>(
+            quantized_type, num_mapped, quantized_dense_size, idx.size());
+
+        if constexpr (!std::is_same_v<InputCT, float>) {
+            scratch_space.resize(input_dense_size);
         }
-        size_t subspace_idx;
-        while (view->next_result(addr_fetch, subspace_idx)) {
+        std::vector<vespalib::string_id> addr(num_mapped);
+        if (num_mapped == 0) {
+            assert(idx.size() == 1);
             auto i8f_array_ref = builder->add_subspace(addr);
             auto u8_array_ref = span_cast<uint8_t>(i8f_array_ref);
-            auto input = input_cells.subspan(input_dense_size * subspace_idx, input_dense_size);
-            quantizer.quantize(input, u8_array_ref, quantization_mode);
+            if constexpr (std::is_same_v<InputCT, float>) {
+                quantizer.quantize(input_cells, u8_array_ref, quantization_mode);
+            } else {
+                convert_to_f32(input_cells, scratch_space);
+                quantizer.quantize(scratch_space, u8_array_ref, quantization_mode);
+            }
+        } else {
+            auto view = idx.create_view({});
+            view->lookup({});
+            std::vector<vespalib::string_id*> addr_fetch;
+            addr_fetch.reserve(num_mapped);
+            for (auto& label : addr) {
+                addr_fetch.emplace_back(&label);
+            }
+            size_t subspace_idx;
+            while (view->next_result(addr_fetch, subspace_idx)) {
+                auto i8f_array_ref = builder->add_subspace(addr);
+                auto u8_array_ref = span_cast<uint8_t>(i8f_array_ref);
+                auto input = input_cells.subspan(input_dense_size * subspace_idx, input_dense_size);
+                if constexpr (std::is_same_v<InputCT, float>) {
+                    quantizer.quantize(input, u8_array_ref, quantization_mode);
+                } else {
+                    convert_to_f32(input, scratch_space);
+                    quantizer.quantize(scratch_space, u8_array_ref, quantization_mode);
+                }
+            }
         }
+        return builder->build(std::move(builder));
     }
-    return builder->build(std::move(builder));
+};
+
+struct DequantizeTensorWithImplicitOutputConversion {
+    template <typename OutputCT>
+    static std::unique_ptr<vespalib::eval::Value>
+    invoke(const vespalib::eval::Value& quantized_in_tensor, const vespalib::eval::ValueType& out_tensor_type,
+           vespalib::quant::EdenQuantizer& quantizer, std::vector<float>& scratch_space) {
+        // We expect that the number of mapped dimensions is the same for both tensor types
+        const size_t num_mapped = out_tensor_type.count_mapped_dimensions();
+        const size_t quantized_dense_size = quantizer.quantized_size();
+        const size_t dense_size = out_tensor_type.dense_subspace_size();
+        const auto&  idx = quantized_in_tensor.index();
+        auto         input_cells = quantized_in_tensor.cells().typify<Int8Float>();
+
+        assert(dense_size == quantizer.dimensions());
+        auto builder = FastValueBuilderFactory::get().create_value_builder<OutputCT>(out_tensor_type, num_mapped,
+                                                                                     dense_size, idx.size());
+        if constexpr (!std::is_same_v<OutputCT, float>) {
+            scratch_space.resize(dense_size);
+        }
+        std::vector<vespalib::string_id> addr(num_mapped);
+        if (num_mapped == 0) {
+            assert(idx.size() == 1);
+            auto array_ref = builder->add_subspace(addr);
+            auto input_as_u8 = span_cast<const uint8_t>(input_cells);
+            if constexpr (std::is_same_v<OutputCT, float>) {
+                quantizer.dequantize(input_as_u8, array_ref);
+            } else {
+                quantizer.dequantize(input_as_u8, scratch_space);
+                convert_from_f32(scratch_space, array_ref);
+            }
+        } else {
+            auto view = idx.create_view({});
+            view->lookup({});
+            std::vector<vespalib::string_id*> addr_fetch;
+            addr_fetch.reserve(num_mapped);
+            for (auto& label : addr) {
+                addr_fetch.emplace_back(&label);
+            }
+            size_t subspace_idx;
+            while (view->next_result(addr_fetch, subspace_idx)) {
+                auto array_ref = builder->add_subspace(addr);
+                auto input = input_cells.subspan(quantized_dense_size * subspace_idx, quantized_dense_size);
+                auto input_as_u8 = span_cast<const uint8_t>(input);
+                if constexpr (std::is_same_v<OutputCT, float>) {
+                    quantizer.dequantize(input_as_u8, array_ref);
+                } else {
+                    quantizer.dequantize(input_as_u8, scratch_space);
+                    convert_from_f32(scratch_space, array_ref);
+                }
+            }
+        }
+        return builder->build(std::move(builder));
+    }
+};
+
+} // namespace
+
+std::unique_ptr<vespalib::eval::Value> quantize_tensor(const vespalib::eval::Value&     in_tensor,
+                                                       const vespalib::eval::ValueType& quantized_type,
+                                                       vespalib::quant::EdenQuantizer&  quantizer,
+                                                       vespalib::quant::QuantMode       quantization_mode,
+                                                       std::vector<float>&              scratch_space) {
+    return vespalib::typify_invoke<1, TypifyCellType, QuantizeTensorWithImplicitInputConversion>(
+        in_tensor.type().cell_type(), in_tensor, quantized_type, quantizer, quantization_mode, scratch_space);
 }
 
 std::unique_ptr<vespalib::eval::Value> dequantize_tensor(const vespalib::eval::Value&     quantized_in_tensor,
-                                                         const vespalib::eval::ValueType& out_f32_tensor_type,
-                                                         vespalib::quant::EdenQuantizer&  quantizer) {
-    // We expect that the number of mapped dimensions is the same for both tensor types
-    const size_t num_mapped = out_f32_tensor_type.count_mapped_dimensions();
-    const size_t quantized_dense_size = quantizer.quantized_size();
-    const size_t dense_size = out_f32_tensor_type.dense_subspace_size();
-    const auto&  idx = quantized_in_tensor.index();
-    auto         input_cells = quantized_in_tensor.cells().typify<Int8Float>();
-    assert(dense_size == quantizer.dimensions());
-    auto builder = FastValueBuilderFactory::get().create_value_builder<float>(out_f32_tensor_type, num_mapped,
-                                                                              dense_size, idx.size());
-    std::vector<vespalib::string_id> addr(num_mapped);
-    if (num_mapped == 0) {
-        assert(idx.size() == 1);
-        auto f32_array_ref = builder->add_subspace(addr);
-        auto input_as_u8 = span_cast<const uint8_t>(input_cells);
-        quantizer.dequantize(input_as_u8, f32_array_ref);
-    } else {
-        auto view = idx.create_view({});
-        view->lookup({});
-        std::vector<vespalib::string_id*> addr_fetch;
-        addr_fetch.reserve(num_mapped);
-        for (auto& label : addr) {
-            addr_fetch.emplace_back(&label);
-        }
-        size_t subspace_idx;
-        while (view->next_result(addr_fetch, subspace_idx)) {
-            auto f32_array_ref = builder->add_subspace(addr);
-            auto input = input_cells.subspan(quantized_dense_size * subspace_idx, quantized_dense_size);
-            auto input_as_u8 = span_cast<const uint8_t>(input);
-            quantizer.dequantize(input_as_u8, f32_array_ref);
-        }
-    }
-    return builder->build(std::move(builder));
+                                                         const vespalib::eval::ValueType& out_tensor_type,
+                                                         vespalib::quant::EdenQuantizer&  quantizer,
+                                                         std::vector<float>&              scratch_space) {
+    return vespalib::typify_invoke<1, TypifyCellType, DequantizeTensorWithImplicitOutputConversion>(
+        out_tensor_type.cell_type(), quantized_in_tensor, out_tensor_type, quantizer, scratch_space);
 }
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.h
@@ -6,9 +6,10 @@
 #include <vespa/vespalib/quant/eden.h>
 
 #include <memory>
+#include <vector>
 
 /*
- * Generalized support for quantizing and dequantizing indexed and mixed float32 tensors.
+ * Generalized support for quantizing and dequantizing indexed and mixed tensors.
  *
  * We quantize each dense subspace individually, treating each such subspace as if it's logically
  * a single vector whose size is the product of all indexed dimension sizes. This allows for
@@ -16,7 +17,7 @@
  * and also allows for selectively dequantizing individual _mapped_ subspaces.
  *
  * This packing means that a quantized tensor has a differently shaped type than the original
- * float tensor. All mapped dimensions are preserved as-is, but all indexed dimensions are
+ * input tensor. All mapped dimensions are preserved as-is, but all indexed dimensions are
  * replaced with a single "aggregate" int8 indexed dimension whose size is equal to the number
  * of bytes required to store a single full, dense subspace. The number of bytes required
  * is proportional to the number of quantization bits used. To ensure dimension name uniqueness
@@ -38,32 +39,52 @@ namespace search::tensor {
  *
  * The tensor type must contain at least 1 indexed dimension.
  */
-[[nodiscard]] vespalib::eval::ValueType to_quantized_tensor_type(const vespalib::eval::ValueType& f32_tensor_type,
+[[nodiscard]] vespalib::eval::ValueType to_quantized_tensor_type(const vespalib::eval::ValueType&      in_tensor_type,
                                                                  const vespalib::quant::EdenQuantizer& quantizer);
 
 /*
- * Returns a quantized representation of the input `f32_in_tensor`, using the specified quantization mode.
+ * Returns a quantized representation of the input `in_tensor`, using the specified quantization mode.
+ *
+ * Quantization internally operates on float vectors, so if `in_tensor` has a cell type other than
+ * FLOAT the `scratch_space` vector will be resized to the combined dense input subspace size and
+ * used as a temporary conversion buffer. Cells of type DOUBLE will be narrowed (possible precision
+ * loss), all other types (BFLOAT16, INT8) will be widened (lossless).
+ *
+ * `scratch_space` is _not_ touched if the input cell type is FLOAT.
  *
  * Preconditions:
  *   - `quantizer` must be logically the same as that provided as input to `to_quantized_tensor_type()`
  *      (i.e. it must have the same construction parameters, but need not be the same actual instance).
- *   - `f32_in_tensor.type()` must be the same as that provided as input to `to_quantized_tensor_type()`.
+ *   - `in_tensor.type()` must be the same as that provided as input to `to_quantized_tensor_type()`.
  *   - `quantized_type` must be the same as the output of `to_quantized_tensor_type()`.
  */
-[[nodiscard]] std::unique_ptr<vespalib::eval::Value>
-quantize_f32_tensor(const vespalib::eval::Value& f32_in_tensor, const vespalib::eval::ValueType& quantized_type,
-                    vespalib::quant::EdenQuantizer& quantizer, vespalib::quant::QuantMode quantization_mode);
+[[nodiscard]] std::unique_ptr<vespalib::eval::Value> quantize_tensor(const vespalib::eval::Value&     in_tensor,
+                                                                     const vespalib::eval::ValueType& quantized_type,
+                                                                     vespalib::quant::EdenQuantizer&  quantizer,
+                                                                     vespalib::quant::QuantMode quantization_mode,
+                                                                     std::vector<float>&        scratch_space);
 
 /*
+ * Returns a dequantized representation of the input `quantized_in_tensor`, with an output tensor
+ * shape matching that of `out_tensor_type`.
+ *
+ * Dequantization internally operates on float vectors, so if `out_tensor_type` has a cell type
+ * other than FLOAT the `scratch_space` vector will be resized to the combined dense output
+ * subspace size and used as a temporary conversion buffer. Note that int8 output tensors are
+ * converted by floating point _rounding_ (not truncation) followed by saturation to [-128, 127].
+ *
+ * `scratch_space` is _not_ touched if the output cell type is FLOAT.
+ *
  * Preconditions:
  *   - `quantized_in_tensor` must contain tensor data that was produced by a prior call to
- *     `quantize_f32_tensor()`.
- *   - `out_f32_tensor_type` must match the type of the tensor that was originally provided
- *      as `f32_in_tensor` to the `quantize_f32_tensor` function.
- *   - `quantizer` must be logically the same as the one used in the prior `quantize_f32_tensor` call.
+ *     `quantize_tensor()`.
+ *   - `out_tensor_type` must match the type of the tensor that was originally provided
+ *      as `in_tensor` to the `quantize_tensor` function.
+ *   - `quantizer` must be logically the same as the one used in the prior `quantize_tensor` call.
  */
 [[nodiscard]] std::unique_ptr<vespalib::eval::Value>
-dequantize_tensor(const vespalib::eval::Value&     quantized_in_tensor,
-                  const vespalib::eval::ValueType& out_f32_tensor_type, vespalib::quant::EdenQuantizer& quantizer);
+dequantize_tensor(const vespalib::eval::Value& quantized_in_tensor, const vespalib::eval::ValueType& out_tensor_type,
+                  vespalib::quant::EdenQuantizer& quantizer, std::vector<float>& scratch_space);
+
 
 } // namespace search::tensor


### PR DESCRIPTION
@arnej27959 please review. The number of _functional_ code changes in this diff is actually pretty small; some `if constexpr` sprinkling that conditionally dispatches to (also newly added) partially specialized conversion functions. But the tests have been rewritten to cover all cell types, and the previous tensor conversion code has been moved into structs so that they can be dispatched via `typify_invoke`, so the diff appears more hefty.

This generalizes the tensor type support for `quantize_tensor` and `dequantize_tensor`, which previously explicitly only supported input/output tensors with `float` cell types. This was because the quantizer itself operates natively only on `float` vectors as the quantization input and dequantization output.

With this commit, both `quantize_tensor` and `dequantize_tensor` take in an auxiliary `scratch_space` vector that is used for intermediate float conversions iff needed.

Quantization _from_ non-`float` cells will convert distinct dense subspaces to `float` via the scratch space prior to quantization.

Dequantization _to_ non-`float` cells will dequantize to the `float` scratch space, then convert to the target cell type. This also happens per distinct dense subspace. Conversion to `int8` is done with round-to-nearest semantics (with saturation), as that empirically reduces vector reconstruction error (compared to rounding towards zero).

The scratch-space vector can be reused across calls and need not be sized prior to use.

