### PR TITLE
Add quantized Maximum Inner Product Search distance function

### DIFF
--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_test.cpp
@@ -632,6 +632,10 @@ double computeTransformedMipsChecked(TypedCells a, TypedCells b, bool check_inse
         auto d_i = dbl_dff.for_insertion_vector(a);
         EXPECT_DOUBLE_EQ(d_i->calc(b), result);
     }
+
+    QuantizedMipsDistanceFunctionFactory q_dff(a.size, quant_bits, quant_seed);
+    check_quantized_distance_function(q_dff, a, b, result, 1.8, vespalib::quant::QuantMode::InnerProduct);
+
     return result;
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.cpp
@@ -2,33 +2,30 @@
 
 #include "mips_distance_transform.h"
 
+#include "distance_function_vector_access.h"
 #include "temporary_vector_store.h"
-
-#include <vespa/vespalib/hwaccelerated/functions.h>
 
 #include <cmath>
 #include <variant>
 
 using vespalib::eval::Int8Float;
-namespace hwaccelerated = vespalib::hwaccelerated;
 
 namespace search::tensor {
 
-template <typename VectorStoreType, bool extra_dim>
+template <typename VectorAccessType, bool extra_dim>
 class BoundMipsDistanceFunction final : public BoundDistanceFunction {
-    using FloatType = VectorStoreType::FloatType;
-    mutable VectorStoreType          _tmpSpace;
-    const std::span<const FloatType> _lhs_vector;
-    double                           _max_sq_norm;
+    mutable VectorAccessType _access;
+    double                   _max_sq_norm;
     using ExtraDimT = std::conditional_t<extra_dim, double, std::monostate>;
     [[no_unique_address]] ExtraDimT _lhs_extra_dim;
 
 public:
-    BoundMipsDistanceFunction(TypedCells lhs, MaximumSquaredNormStore& sq_norm_store)
-        : BoundDistanceFunction(), _tmpSpace(lhs.size), _lhs_vector(_tmpSpace.storeLhs(lhs)) {
-        const FloatType* a = _lhs_vector.data();
+    template <typename... AccessArgs>
+    BoundMipsDistanceFunction(TypedCells lhs, MaximumSquaredNormStore& sq_norm_store, AccessArgs&&... access_args)
+        : BoundDistanceFunction(), _access(lhs, std::forward<AccessArgs>(access_args)...) {
+        const auto* a = _access.lhs().data();
         if constexpr (extra_dim) {
-            double lhs_sq_norm = hwaccelerated::dot_product(cast(a), cast(a), lhs.size);
+            double lhs_sq_norm = _access.dot_product(cast(a), cast(a));
             _max_sq_norm = sq_norm_store.get_max(lhs_sq_norm);
             _lhs_extra_dim = std::sqrt(_max_sq_norm - lhs_sq_norm);
         } else {
@@ -43,12 +40,12 @@ public:
     }
 
     double calc(TypedCells rhs) const noexcept override {
-        std::span<const FloatType> rhs_vector = _tmpSpace.convertRhs(rhs);
-        const FloatType*           a = _lhs_vector.data();
-        const FloatType*           b = rhs_vector.data();
-        double                     dp = hwaccelerated::dot_product(cast(a), cast(b), rhs.size);
+        auto        rhs_vector = _access.convert_rhs(rhs);
+        const auto* a = _access.lhs().data();
+        const auto* b = rhs_vector.data();
+        double      dp = _access.dot_product(cast(a), cast(b));
         if constexpr (extra_dim) {
-            double rhs_sq_norm = hwaccelerated::dot_product(cast(b), cast(b), rhs.size);
+            double rhs_sq_norm = _access.dot_product(cast(b), cast(b));
             // avoid sqrt(negative) for robustness:
             double diff = std::max(0.0, _max_sq_norm - rhs_sq_norm);
             double rhs_extra_dim = std::sqrt(diff);
@@ -65,17 +62,17 @@ public:
 
 template <typename FloatType>
 BoundDistanceFunction::UP MipsDistanceFunctionFactory<FloatType>::for_query_vector(TypedCells lhs) const {
-    return std::make_unique<BoundMipsDistanceFunction<TemporaryVectorStore<FloatType>, false>>(lhs, *_sq_norm_store);
+    return std::make_unique<BoundMipsDistanceFunction<TemporaryVectorAccess<FloatType>, false>>(lhs, *_sq_norm_store);
 }
 
 template <typename FloatType>
 BoundDistanceFunction::UP MipsDistanceFunctionFactory<FloatType>::for_insertion_vector(TypedCells lhs) const {
     if (_reference_insertion_vector) {
-        return std::make_unique<BoundMipsDistanceFunction<ReferenceVectorStore<FloatType>, true>>(lhs,
-                                                                                                  *_sq_norm_store);
+        return std::make_unique<BoundMipsDistanceFunction<ReferenceVectorAccess<FloatType>, true>>(lhs,
+                                                                                                   *_sq_norm_store);
     } else {
-        return std::make_unique<BoundMipsDistanceFunction<TemporaryVectorStore<FloatType>, true>>(lhs,
-                                                                                                  *_sq_norm_store);
+        return std::make_unique<BoundMipsDistanceFunction<TemporaryVectorAccess<FloatType>, true>>(lhs,
+                                                                                                   *_sq_norm_store);
     }
 };
 
@@ -83,5 +80,15 @@ template class MipsDistanceFunctionFactory<Int8Float>;
 template class MipsDistanceFunctionFactory<vespalib::BFloat16>;
 template class MipsDistanceFunctionFactory<float>;
 template class MipsDistanceFunctionFactory<double>;
+
+BoundDistanceFunction::UP QuantizedMipsDistanceFunctionFactory::for_query_vector(TypedCells lhs) const {
+    return std::make_unique<BoundMipsDistanceFunction<Float32LhsQuantizedRhsVectorAccess, false>>(
+        lhs, *_sq_norm_store, _dimensions, _bits, _seed);
+}
+
+BoundDistanceFunction::UP QuantizedMipsDistanceFunctionFactory::for_insertion_vector(TypedCells lhs) const {
+    return std::make_unique<BoundMipsDistanceFunction<QuantizedLhsAndRhsVectorAccess, true>>(
+        lhs, *_sq_norm_store, _dimensions, _bits, _seed);
+};
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
@@ -77,4 +77,32 @@ public:
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };
 
+/**
+ * Factory for distance functions which can apply a transformation mapping Maximum
+ * Inner Product Search to a nearest neighbor problem.  When inserting vectors, an
+ * extra dimension is added ensuring behavior "as if" all vectors had length equal
+ * to the longest vector inserted so far, or at least length 1.
+ *
+ * The left hand side may be either a float32 (full precision) vector or a quantized
+ * vector in int8 format, and the right hand side is always a quantized vector in
+ * int8 format.
+ *
+ * Query vectors are always converted to float32 form. That means a _query_ vector
+ * of int8 values will be elementwise promoted to float and will _not_ be treated
+ * as the quantized representation of a query vector.
+ *
+ * Insertion vectors are expected to be in pre-quantized int8 format.
+ */
+class QuantizedMipsDistanceFunctionFactory : public MipsDistanceFunctionFactoryBase {
+    const size_t   _dimensions;
+    const uint64_t _seed;
+    const uint8_t  _bits;
+
+public:
+    QuantizedMipsDistanceFunctionFactory(size_t dimensions, uint8_t bits, uint64_t seed) noexcept
+        : _dimensions(dimensions), _seed(seed), _bits(bits) {}
+    BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
+    BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
+};
+
 } // namespace search::tensor


### PR DESCRIPTION
@arnej27959 please review. A small one this time 👀 

Exact same procedure as the other quantized distance functions.

This should be the last remaining distance function that it makes sense to add quantization support for:

 - Hamming is not really amendable to quantization since either it's bitwise (and you don't need quantization) or it depends on element value equality (which will be casually mangled by quantization approximations in unspecified and exciting ways).
 - GeoDegrees is not amendable to quantization due to its low dimensionality (2D).
