### PR TITLE
Add utility code for force-unrolling a functor invocation N times

### DIFF
--- a/vespalib/src/tests/hwaccelerated/CMakeLists.txt
+++ b/vespalib/src/tests/hwaccelerated/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_executable(vespalib_hwaccelerated_test_app TEST
     SOURCES
+    unroller_test.cpp
     hwaccelerated_test.cpp
     DEPENDS
     vespalib

--- a/vespalib/src/tests/hwaccelerated/unroller_test.cpp
+++ b/vespalib/src/tests/hwaccelerated/unroller_test.cpp
@@ -1,0 +1,61 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/hwaccelerated/unroller.h>
+
+#include <gmock/gmock.h>
+
+#include <format>
+
+using namespace ::testing;
+
+namespace vespalib::hwaccelerated {
+
+namespace {
+
+template <size_t UnrollCount>
+std::string unroll_simple() {
+    std::string out;
+
+    auto fn = [&out](auto idx) { std::format_to(std::back_inserter(out), "{} ", decltype(idx)::value); };
+    Unroller::unroll<UnrollCount>(fn);
+    return out;
+}
+
+template <size_t UnrollCount>
+std::string unroll_with_args() {
+    std::string out;
+    const char  c = ':';
+    int         mut_v = 1;
+
+    auto fn = [&out](auto idx, char my_c, int& my_mut_v) {
+        std::format_to(std::back_inserter(out), "{}{}{} ", decltype(idx)::value, my_c, my_mut_v);
+        my_mut_v += 2;
+    };
+    Unroller::unroll<UnrollCount>(fn, c, mut_v);
+    return out;
+}
+
+} // namespace
+
+TEST(ForceUnrollTest, unrolled_fn_invocations_have_well_defined_index_order) {
+    EXPECT_EQ(unroll_simple<1>(), "0 ");
+    EXPECT_EQ(unroll_simple<2>(), "0 1 ");
+    EXPECT_EQ(unroll_simple<3>(), "0 1 2 ");
+    EXPECT_EQ(unroll_simple<4>(), "0 1 2 3 ");
+    EXPECT_EQ(unroll_simple<5>(), "0 1 2 3 4 ");
+    EXPECT_EQ(unroll_simple<6>(), "0 1 2 3 4 5 ");
+    EXPECT_EQ(unroll_simple<7>(), "0 1 2 3 4 5 6 ");
+    EXPECT_EQ(unroll_simple<8>(), "0 1 2 3 4 5 6 7 ");
+    EXPECT_EQ(unroll_simple<9>(), "0 1 2 3 4 5 6 7 8 ");
+    EXPECT_EQ(unroll_simple<10>(), "0 1 2 3 4 5 6 7 8 9 ");
+}
+
+TEST(ForceUnrollTest, can_pass_mutable_and_immutable_fn_args) {
+    EXPECT_EQ(unroll_with_args<1>(), "0:1 ");
+    EXPECT_EQ(unroll_with_args<2>(), "0:1 1:3 ");
+    EXPECT_EQ(unroll_with_args<3>(), "0:1 1:3 2:5 ");
+    EXPECT_EQ(unroll_with_args<4>(), "0:1 1:3 2:5 3:7 ");
+    EXPECT_EQ(unroll_with_args<5>(), "0:1 1:3 2:5 3:7 4:9 ");
+}
+
+} // namespace vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/unroller.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/unroller.h
@@ -1,0 +1,78 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstddef>
+#include <iostream>
+#include <utility>
+
+namespace vespalib::hwaccelerated {
+
+// Typed unrolling index wrapper to allow callee to easily do constexpr stuff on it
+template <size_t Idx> struct UnrollIdx {
+    static constexpr size_t value = Idx;
+};
+
+/**
+ * Unroller utility which lets a functor invocation be explicitly N-way duplicated in
+ * a sequence. All called functors will receive (and must therefore accept) as their
+ * first argument an `UnrollIdx<I>` value, where `I` is the unrolling "index" of that
+ * invocation, starting at 0.
+ *
+ * E.g.
+ *
+ *   auto foo = [](auto idx) {};
+ *   Unroller::unroll<4>(foo);
+ *
+ * will result in the following sequence of invocations:
+ *
+ *   foo(UnrollIdx<0>{})
+ *   foo(UnrollIdx<1>{})
+ *   foo(UnrollIdx<2>{})
+ *   foo(UnrollIdx<3>{})
+ *
+ * Since the `UnrollIdx` is a fully constexpr value, it can be used for clever things
+ * such as striping usage of accumulator registers based on the index value etc. This
+ * differs from regular compiler-unrolled loops (which should be preferred in most
+ * situations), where the value of loop induction variables is not something you can
+ * _explicitly_ use for meta-programming.
+ *
+ * Additional functor arguments can be passed to unroll(); these will be passed to
+ * each invocation _after_ the first `UnrollIdx<I>` argument.
+ *
+ * Function arguments are std::forward()'ed to each unrolled invocation of the functor
+ * to allow for reference type arguments, so be careful to not pass (and consume) any
+ * _rvalue_ references.
+ */
+class Unroller {
+    // We make the simplifying, yet hopefully reasonable, assumption that noexcept-ness
+    // does not depend on the unroll index passed to the unrolled function.
+    // All unrolling indirections are force-inlined and should therefore never result in
+    // any recursion. We do not use the `flatten` attribute, as that decision should be
+    // left up to the callee.
+    template <size_t UnrollLbound, size_t UnrollUbound, typename Fn, typename... FnArgs>
+    static inline __attribute__((always_inline)) void
+    do_unroll(Fn&& fn, FnArgs&&... fn_args) noexcept(noexcept(fn(UnrollIdx<0>{}, std::forward<FnArgs>(fn_args)...))) {
+        if constexpr (UnrollLbound == UnrollUbound - 1) { // Leaf recursion case
+            constexpr size_t unroll_idx = UnrollLbound;
+            fn(UnrollIdx<unroll_idx>{}, std::forward<FnArgs>(fn_args)...);
+        } else {
+            static_assert(UnrollLbound < UnrollUbound);
+            constexpr size_t half = (UnrollUbound - UnrollLbound) / 2;
+            do_unroll<UnrollLbound, UnrollLbound + half>(std::forward<Fn>(fn), std::forward<FnArgs>(fn_args)...);
+            if constexpr (half > 0) {
+                do_unroll<UnrollLbound + half, UnrollUbound>(std::forward<Fn>(fn), std::forward<FnArgs>(fn_args)...);
+            }
+        }
+    }
+
+public:
+    template <size_t UnrollCount, typename Fn, typename... FnArgs>
+    static inline __attribute__((always_inline)) void
+    unroll(Fn&& fn, FnArgs&&... fn_args) noexcept(noexcept(fn(UnrollIdx<0>{}, std::forward<FnArgs>(fn_args)...))) {
+        static_assert(UnrollCount > 0, "must have at least one invocation");
+        do_unroll<0, UnrollCount>(std::forward<Fn>(fn), std::forward<FnArgs>(fn_args)...);
+    }
+};
+
+} // namespace vespalib::hwaccelerated

--- a/vespalib/src/vespa/vespalib/hwaccelerated/unroller.h
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/unroller.h
@@ -53,16 +53,10 @@ class Unroller {
     template <size_t UnrollLbound, size_t UnrollUbound, typename Fn, typename... FnArgs>
     static inline __attribute__((always_inline)) void
     do_unroll(Fn&& fn, FnArgs&&... fn_args) noexcept(noexcept(fn(UnrollIdx<0>{}, std::forward<FnArgs>(fn_args)...))) {
-        if constexpr (UnrollLbound == UnrollUbound - 1) { // Leaf recursion case
-            constexpr size_t unroll_idx = UnrollLbound;
-            fn(UnrollIdx<unroll_idx>{}, std::forward<FnArgs>(fn_args)...);
-        } else {
-            static_assert(UnrollLbound < UnrollUbound);
-            constexpr size_t half = (UnrollUbound - UnrollLbound) / 2;
-            do_unroll<UnrollLbound, UnrollLbound + half>(std::forward<Fn>(fn), std::forward<FnArgs>(fn_args)...);
-            if constexpr (half > 0) {
-                do_unroll<UnrollLbound + half, UnrollUbound>(std::forward<Fn>(fn), std::forward<FnArgs>(fn_args)...);
-            }
+        constexpr size_t unroll_idx = UnrollLbound;
+        fn(UnrollIdx<unroll_idx>{}, std::forward<FnArgs>(fn_args)...);
+        if constexpr (UnrollLbound + 1 < UnrollUbound) {
+            do_unroll<UnrollLbound + 1, UnrollUbound>(std::forward<Fn>(fn), std::forward<FnArgs>(fn_args)...);
         }
     }
 


### PR DESCRIPTION
@boeker please review this bundle of template fun 👹 Not wired into anything yet, but I have some future work that should benefit from this.

This is a fairly specialized piece of code that is not meant for "generalized" unrolling (the compiler does that well enough already), but for when the callee wants to explicitly know `constexpr`-time what its unrolling invocation "index" is. We use this information today (via manual unrolling) to stripe accumulator vector register usage across vector kernel invocations. This utility is intended to remove that need for partial code duplication.

Unrolling is done via a pretty standard template recursion with invocations happening in the leaf recursion cases. All intermediate steps are force-inlined to avoid any _actual_ run-time recursion.

