### PR TITLE
Add feature flag to select metrics consumer for cluster deployment metrics

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -209,7 +209,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
              new ActiveTokenFingerprintsClient(),
              flagSource,
              new DeploymentMetricsRetriever(new ClusterDeploymentMetricsRetriever(),
-                     nodeSuspensionProvider(nodeSuspensionProviders)));
+                     nodeSuspensionProvider(nodeSuspensionProviders), flagSource));
     }
 
     private static NodeSuspensionProvider nodeSuspensionProvider(ComponentRegistry<NodeSuspensionProvider> registry) {
@@ -366,7 +366,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                                              ClusterReindexingStatusClient.DUMMY_INSTANCE,
                                              __ -> activeTokens,
                                              flagSource,
-                                             new DeploymentMetricsRetriever());
+                                             new DeploymentMetricsRetriever(new ClusterDeploymentMetricsRetriever(),
+                                                     NodeSuspensionProvider.EMPTY, flagSource));
         }
 
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsRetriever.java
@@ -6,6 +6,8 @@ import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.provision.NodeSuspensionProvider;
 import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.vespa.config.server.http.v2.response.DeploymentMetricsResponse;
+import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.Flags;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Set;
@@ -21,34 +23,32 @@ public class DeploymentMetricsRetriever {
 
     private final ClusterDeploymentMetricsRetriever metricsRetriever;
     private final NodeSuspensionProvider nodeSuspensionProvider;
-
-    public DeploymentMetricsRetriever() {
-        this(new ClusterDeploymentMetricsRetriever(), NodeSuspensionProvider.EMPTY);
-    }
-
-    public DeploymentMetricsRetriever(ClusterDeploymentMetricsRetriever metricsRetriever) {
-        this(metricsRetriever, NodeSuspensionProvider.EMPTY);
-    }
+    private final FlagSource flagSource;
 
     public DeploymentMetricsRetriever(ClusterDeploymentMetricsRetriever metricsRetriever,
-                                      NodeSuspensionProvider nodeSuspensionProvider) {
+                                      NodeSuspensionProvider nodeSuspensionProvider,
+                                      FlagSource flagSource) {
         this.metricsRetriever = metricsRetriever;
         this.nodeSuspensionProvider = nodeSuspensionProvider;
+        this.flagSource = flagSource;
     }
 
     public DeploymentMetricsResponse getMetrics(Application application) {
         var suspendedHostnames = nodeSuspensionProvider.suspendedHosts(application.getId());
-        var hosts = getHostsOfApplication(application, suspendedHostnames);
+        String consumer = Flags.DEPLOYMENT_METRICS_CONSUMER.bindTo(flagSource)
+                .with(application.getId())
+                .value();
+        var hosts = getHostsOfApplication(application, suspendedHostnames, consumer);
         var clusterMetrics = metricsRetriever.requestMetricsGroupedByCluster(hosts);
         return new DeploymentMetricsResponse(application.getId(), clusterMetrics);
     }
 
-    private static Collection<URI> getHostsOfApplication(Application application, Set<String> suspendedHostnames) {
+    private static Collection<URI> getHostsOfApplication(Application application, Set<String> suspendedHostnames, String consumer) {
         return application.getModel().getHosts().stream()
                 .filter(host -> host.getServices().stream().noneMatch(isLogserver()))
                 .filter(host -> !suspendedHostnames.contains(host.getHostname()))
                 .map(HostInfo::getHostname)
-                .map(DeploymentMetricsRetriever::createMetricsProxyURI)
+                .map(hostname -> createMetricsProxyURI(hostname, consumer))
                 .toList();
     }
 
@@ -56,8 +56,8 @@ public class DeploymentMetricsRetriever {
         return serviceInfo -> serviceInfo.getServiceType().equalsIgnoreCase("logserver");
     }
 
-    private static URI createMetricsProxyURI(String hostname) {
-        return URI.create("http://" + hostname + ":19092/metrics/v1/values?consumer=Vespa");
+    private static URI createMetricsProxyURI(String hostname, String consumer) {
+        return URI.create("http://" + hostname + ":19092/metrics/v1/values?consumer=" + consumer);
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsRetrieverTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsRetrieverTest.java
@@ -12,6 +12,8 @@ import com.yahoo.config.provision.NodeSuspensionProvider;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.buildergen.ConfigDefinition;
 import com.yahoo.vespa.config.server.application.Application;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import org.junit.Test;
 
 import java.net.URI;
@@ -37,10 +39,41 @@ public class DeploymentMetricsRetrieverTest {
         Application application = new Application(mockModel, null, 0,
                                                   null, null, ApplicationId.fromSerializedForm("tenant:app:instance"));
 
-        DeploymentMetricsRetriever clusterMetricsRetriever = new DeploymentMetricsRetriever(mockMetricsRetriever);
+        DeploymentMetricsRetriever clusterMetricsRetriever =
+                new DeploymentMetricsRetriever(mockMetricsRetriever, NodeSuspensionProvider.EMPTY, new InMemoryFlagSource());
         clusterMetricsRetriever.getMetrics(application);
 
         assertEquals(2, mockMetricsRetriever.hosts.size()); // Verify that logserver was ignored
+    }
+
+    @Test
+    public void defaultConsumerIsVespa() {
+        MockModel mockModel = new MockModel(mockHosts());
+        MockDeploymentMetricsRetriever mockMetricsRetriever = new MockDeploymentMetricsRetriever();
+        Application application = new Application(mockModel, null, 0,
+                                                  null, null, ApplicationId.fromSerializedForm("tenant:app:instance"));
+
+        DeploymentMetricsRetriever clusterMetricsRetriever =
+                new DeploymentMetricsRetriever(mockMetricsRetriever, NodeSuspensionProvider.EMPTY, new InMemoryFlagSource());
+        clusterMetricsRetriever.getMetrics(application);
+
+        assertTrue(mockMetricsRetriever.hosts.stream().allMatch(uri -> uri.getQuery().equals("consumer=Vespa")));
+    }
+
+    @Test
+    public void consumerCanBeOverriddenByFlag() {
+        MockModel mockModel = new MockModel(mockHosts());
+        MockDeploymentMetricsRetriever mockMetricsRetriever = new MockDeploymentMetricsRetriever();
+        Application application = new Application(mockModel, null, 0,
+                                                  null, null, ApplicationId.fromSerializedForm("tenant:app:instance"));
+
+        InMemoryFlagSource flagSource = new InMemoryFlagSource()
+                .withStringFlag(Flags.DEPLOYMENT_METRICS_CONSUMER.id(), "cluster-deployment-metrics");
+        DeploymentMetricsRetriever clusterMetricsRetriever =
+                new DeploymentMetricsRetriever(mockMetricsRetriever, NodeSuspensionProvider.EMPTY, flagSource);
+        clusterMetricsRetriever.getMetrics(application);
+
+        assertTrue(mockMetricsRetriever.hosts.stream().allMatch(uri -> uri.getQuery().equals("consumer=cluster-deployment-metrics")));
     }
 
     @Test
@@ -52,7 +85,8 @@ public class DeploymentMetricsRetrieverTest {
                                                   null, null, applicationId);
 
         NodeSuspensionProvider suspensionProvider = id -> Set.of("host1");
-        DeploymentMetricsRetriever retriever = new DeploymentMetricsRetriever(mockMetricsRetriever, suspensionProvider);
+        DeploymentMetricsRetriever retriever =
+                new DeploymentMetricsRetriever(mockMetricsRetriever, suspensionProvider, new InMemoryFlagSource());
         retriever.getMetrics(application);
 
         assertEquals(1, mockMetricsRetriever.hosts.size()); // logserver (host3) and suspended host1 are ignored
@@ -69,7 +103,8 @@ public class DeploymentMetricsRetrieverTest {
                 null, null, applicationId);
 
         NodeSuspensionProvider suspensionProvider = id -> Set.of();
-        DeploymentMetricsRetriever retriever = new DeploymentMetricsRetriever(mockMetricsRetriever, suspensionProvider);
+        DeploymentMetricsRetriever retriever =
+                new DeploymentMetricsRetriever(mockMetricsRetriever, suspensionProvider, new InMemoryFlagSource());
         retriever.getMetrics(application);
         // With an empty suspension set, behavior should be the same as without a provider: only logserver is ignored
         assertEquals(2, mockMetricsRetriever.hosts.size());

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -12,6 +12,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
 
@@ -62,6 +63,15 @@ public class Flags {
             List.of("hmusum"), "2020-12-02", "2026-12-01",
             "Selects type of sequenced executor used for mbus responses, valid values are LATENCY, ADAPTIVE, THROUGHPUT",
             "Takes effect at redeployment",
+            INSTANCE_ID);
+
+    public static final UnboundStringFlag DEPLOYMENT_METRICS_CONSUMER = defineStringFlag(
+            "deployment-metrics-consumer", "Vespa",
+            List.of("hmusum"), "2026-07-10", "2026-12-01",
+            "Selects which metrics-proxy consumer the config server uses when fetching " +
+            "metrics for cluster deployment metrics aggregation. Valid values: Vespa, cluster-deployment-metrics",
+            "Takes effect on next metrics retrieval",
+            value -> Set.of("Vespa", "cluster-deployment-metrics").contains(value),
             INSTANCE_ID);
 
     public static final UnboundIntFlag RESPONSE_NUM_THREADS = defineIntFlag(


### PR DESCRIPTION
## Summary
- Add `Flags.DEPLOYMENT_METRICS_CONSUMER` (default `Vespa`, also allows `cluster-deployment-metrics`), selectable per `ApplicationId`
- `DeploymentMetricsRetriever` binds the flag and uses it when building metrics-proxy URIs, instead of hardcoding `consumer=Vespa`
- Wire `FlagSource` through `ApplicationRepository`'s `DeploymentMetricsRetriever` construction

Generated with Claude Code.