### PR TITLE
Add attribute-level quantization params and quantized distance function factory

### DIFF
--- a/searchlib/src/vespa/searchcommon/attribute/quantization_params.h
+++ b/searchlib/src/vespa/searchcommon/attribute/quantization_params.h
@@ -1,0 +1,37 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstdint>
+
+namespace search::attribute {
+
+/**
+ * Parameters for tensor attributes storing quantized dense subspaces.
+ *
+ * None of these parameters can be changed live on an existing tensor attribute;
+ * it must be rebuilt with updated parameters from the doc store source-of-truth.
+ * This also transitively applies to structures that depend on the attribute,
+ * such as HNSW indexes.
+ */
+class QuantizationParams {
+public:
+    enum class QuantizationMode { MSE, InnerProduct };
+
+private:
+    uint64_t         _seed;
+    QuantizationMode _quantization_mode;
+    uint8_t          _bits;
+
+public:
+    constexpr QuantizationParams(uint64_t seed_, QuantizationMode quantization_mode_, uint8_t bits_) noexcept
+        : _seed(seed_), _quantization_mode(quantization_mode_), _bits(bits_) {}
+
+    [[nodiscard]] constexpr uint64_t seed() const noexcept { return _seed; }
+    [[nodiscard]] constexpr QuantizationMode quantization_mode() const noexcept { return _quantization_mode; }
+    [[nodiscard]] constexpr uint8_t bits() const noexcept { return _bits; }
+
+    constexpr bool operator==(const QuantizationParams&) const noexcept = default;
+};
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
@@ -6,6 +6,7 @@
 #include "mips_distance_transform.h"
 
 using search::attribute::DistanceMetric;
+using search::attribute::QuantizationParams;
 using vespalib::eval::CellType;
 using vespalib::eval::Int8Float;
 
@@ -84,6 +85,45 @@ std::unique_ptr<DistanceFunctionFactory> make_distance_function_factory(Distance
     }
     // Not reached:
     return {};
+}
+
+namespace {
+
+DistanceFunctionFactory::UP make_quantized_distance_function_factory(DistanceMetric variant, size_t vector_dimensions,
+                                                                     const QuantizationParams& quant_params) {
+    // The cell type does not matter for quantized distance functions, as vectors are
+    // internally treated either as opaque quantized byte (well, Int8Float to be pedantic)
+    // vectors or float32 vectors.
+    switch (variant) {
+    case DistanceMetric::Angular:
+        return std::make_unique<QuantizedAngularDistanceFunctionFactory>(vector_dimensions, quant_params.bits(),
+                                                                         quant_params.seed());
+    case DistanceMetric::Euclidean:
+        return std::make_unique<QuantizedEuclideanDistanceFunctionFactory>(vector_dimensions, quant_params.bits(),
+                                                                           quant_params.seed());
+    case DistanceMetric::InnerProduct:
+    case DistanceMetric::PrenormalizedAngular:
+        return std::make_unique<QuantizedPrenormalizedAngularDistanceFunctionFactory>(
+            vector_dimensions, quant_params.bits(), quant_params.seed());
+    case DistanceMetric::Dotproduct:
+        return std::make_unique<QuantizedMipsDistanceFunctionFactory>(vector_dimensions, quant_params.bits(),
+                                                                      quant_params.seed());
+    default:
+        // Incompatible distance functions should not be allowed to be deployed.
+        abort();
+    }
+}
+
+} // namespace
+
+DistanceFunctionFactory::UP make_distance_function_factory(DistanceMetric variant, CellType cell_type,
+                                                           size_t                                   vector_dimensions,
+                                                           const std::optional<QuantizationParams>& quant_params) {
+    if (!quant_params) {
+        return make_distance_function_factory(variant, cell_type);
+    } else {
+        return make_quantized_distance_function_factory(variant, vector_dimensions, *quant_params);
+    }
 }
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_factory.h
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_factory.h
@@ -6,6 +6,9 @@
 #include "distance_function.h"
 
 #include <vespa/searchcommon/attribute/distance_metric.h>
+#include <vespa/searchcommon/attribute/quantization_params.h>
+
+#include <optional>
 
 namespace search::tensor {
 
@@ -18,8 +21,8 @@ struct DistanceFunctionFactory {
     using TypedCells = vespalib::eval::TypedCells;
     DistanceFunctionFactory() noexcept = default;
     virtual ~DistanceFunctionFactory() = default;
-    virtual BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const = 0;
-    virtual BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const = 0;
+    [[nodiscard]] virtual BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const = 0;
+    [[nodiscard]] virtual BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const = 0;
     using UP = std::unique_ptr<DistanceFunctionFactory>;
 };
 
@@ -27,7 +30,19 @@ struct DistanceFunctionFactory {
  * Create a distance function factory customized for the given metric
  * variant and (attribute) cell type.
  **/
-DistanceFunctionFactory::UP make_distance_function_factory(search::attribute::DistanceMetric variant,
-                                                           vespalib::eval::CellType          cell_type);
+[[nodiscard]] DistanceFunctionFactory::UP make_distance_function_factory(search::attribute::DistanceMetric variant,
+                                                                         vespalib::eval::CellType          cell_type);
+
+/**
+ * Create and return a distance function for the given metric variant and attribute
+ * cell type. Iff `quant_params` is set, returns a variant of the distance function
+ * specialized to operate on quantized tensor representations.
+ *
+ * Note that not all distance metrics are supported for quantized vectors.
+ */
+[[nodiscard]] DistanceFunctionFactory::UP
+make_distance_function_factory(search::attribute::DistanceMetric variant, vespalib::eval::CellType cell_type,
+                               size_t                                              vector_dimensions,
+                               const std::optional<attribute::QuantizationParams>& quant_params);
 
 } // namespace search::tensor


### PR DESCRIPTION
@arnej27959 please review. Keeping these parameters independent of the `vespalib::quant` types. Can refactor to pass quantization params around instead of explicit seed, bits etc. in a later round.

Quantization-aware distance function factory forwards to existing factory creation when no quantization params are present. Not yet wired from anwhere.
