### PR TITLE
Shurdown maintainer executor before reindexer

### DIFF
--- a/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/ReindexingMaintainer.java
+++ b/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/ReindexingMaintainer.java
@@ -95,17 +95,16 @@ public class ReindexingMaintainer extends AbstractComponent {
     @Override
     public void deconstruct() {
         try {
+            // Shutdown the executor before reindexers, so that no new reindexing tasks are submitted when
+            // reindexers have shutdown
+            executor.shutdown();
+            if ( ! executor.awaitTermination(5, TimeUnit.SECONDS))
+                log.log(WARNING, "Failed to shut down reindexing within timeout");
+
             for (Reindexer reindexer : reindexers)
                 reindexer.shutdown();
 
-            executor.shutdown();
-
-            executor.awaitTermination(5, TimeUnit.SECONDS); // Give it 5s to complete gracefully.
-
             curator.close(); // Close the underlying curator independently to force shutdown.
-
-            if ( ! executor.isShutdown() && ! executor.awaitTermination(5, TimeUnit.SECONDS))
-                log.log(WARNING, "Failed to shut down reindexing within timeout");
         }
         catch (InterruptedException e) {
             log.log(WARNING, "Interrupted while waiting for reindexing to shut down");


### PR DESCRIPTION
Otherwise we might try to start reindexing when reindexer is shut down (seen in system tests)