### PR TITLE
revive ReusableSet utility

### DIFF
--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -172,6 +172,7 @@ vespa_define_module(
     src/tests/util/hamming
     src/tests/util/md5
     src/tests/util/mimalloc
+    src/tests/util/reusable_set
     src/tests/valgrind
     src/tests/visit_ranges
     src/tests/wakeup

--- a/vespalib/src/tests/util/reusable_set/CMakeLists.txt
+++ b/vespalib/src/tests/util/reusable_set/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_reusable_set_test_app TEST
+    SOURCES
+    reusable_set_test.cpp
+    DEPENDS
+    vespalib
+    GTest::GTest
+)
+vespa_add_test(NAME vespalib_reusable_set_test_app COMMAND vespalib_reusable_set_test_app)

--- a/vespalib/src/tests/util/reusable_set/reusable_set_test.cpp
+++ b/vespalib/src/tests/util/reusable_set/reusable_set_test.cpp
@@ -1,0 +1,141 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/reusable_set_pool.h>
+
+using namespace vespalib;
+
+using Mark = ReusableSet::Mark;
+
+void verify_set(const ReusableSet& set, size_t sz, Mark val, size_t marked) {
+    EXPECT_EQ(sz, set.capacity());
+    EXPECT_EQ(val, set.generation());
+    size_t count = 0;
+    for (size_t i = 0; i < set.capacity(); ++i) {
+        if (set.is_marked(i))
+            ++count;
+    }
+    EXPECT_EQ(marked, count);
+}
+
+void verify_handle(const ReusableSetHandle& set, size_t sz, Mark val, size_t marked) {
+    EXPECT_EQ(sz, set.capacity());
+    EXPECT_EQ(val, set.generation());
+    size_t count = 0;
+    for (size_t i = 0; i < set.capacity(); ++i) {
+        if (set.is_marked(i))
+            ++count;
+    }
+    EXPECT_EQ(marked, count);
+}
+
+class Pool : public ::testing::Test {
+public:
+    ReusableSetPool pool;
+    Pool() : pool() {}
+    ~Pool() {}
+    void exercise(ReusableSetHandle& set) {
+        size_t sz = set.capacity();
+        size_t count = 0;
+        for (size_t i = 0; i < sz; ++i) {
+            if (set.is_marked(i))
+                ++count;
+        }
+        EXPECT_EQ(0, count);
+        for (int i = 0; i < 17; ++i) {
+            set.mark((i * 711) % sz);
+        }
+        count = 0;
+        for (size_t i = 0; i < sz; ++i) {
+            if (set.is_marked(i))
+                ++count;
+        }
+        EXPECT_EQ(17, count);
+        for (int i = 0; i < 17; ++i) {
+            set.mark((i * 711) % sz);
+        }
+        count = 0;
+        for (size_t i = 0; i < sz; ++i) {
+            if (set.is_marked(i))
+                ++count;
+        }
+        EXPECT_EQ(17, count);
+    }
+};
+
+TEST(ReusableSetTest, simple_usage) {
+    ReusableSet visited(7);
+    verify_set(visited, 7, 1, 0);
+    visited.mark(1);
+    visited.mark(2);
+    visited.mark(4);
+    EXPECT_EQ(false, visited.is_marked(0));
+    EXPECT_EQ(true, visited.is_marked(1));
+    EXPECT_EQ(true, visited.is_marked(2));
+    EXPECT_EQ(false, visited.is_marked(3));
+    verify_set(visited, 7, 1, 3);
+    visited.mark(4);
+    visited.mark(1);
+    visited.mark(2);
+    verify_set(visited, 7, 1, 3);
+    EXPECT_EQ(false, visited.is_marked(0));
+    EXPECT_EQ(true, visited.is_marked(1));
+    EXPECT_EQ(true, visited.is_marked(2));
+    EXPECT_EQ(false, visited.is_marked(3));
+    visited.clear();
+    verify_set(visited, 7, 2, 0);
+    visited.clear();
+    verify_set(visited, 7, 3, 0);
+}
+
+TEST_F(Pool, reuse_works) {
+    for (int i = 0; i < 65535; ++i) {
+        auto handle = pool.get(7);
+        EXPECT_EQ(i, pool.reuse_count());
+        EXPECT_EQ(1, pool.create_count());
+        verify_handle(handle, 248, i + 1, 0);
+        exercise(handle);
+    }
+    EXPECT_LT(500, pool.memory_usage().allocatedBytes());
+    EXPECT_GT(1000, pool.memory_usage().allocatedBytes());
+    for (int i = 0; i < 5; ++i) {
+        auto handle = pool.get(7);
+        EXPECT_EQ(65535 + i, pool.reuse_count());
+        EXPECT_EQ(1, pool.create_count());
+        verify_handle(handle, 248, i + 1, 0);
+        exercise(handle);
+    }
+    auto handle3 = pool.get(260);
+    EXPECT_EQ(2, pool.create_count());
+    verify_handle(handle3, 297, 1, 0);
+    exercise(handle3);
+    {
+        auto handle4 = pool.get(400);
+        EXPECT_EQ(3, pool.create_count());
+        verify_handle(handle4, 400, 1, 0);
+        exercise(handle4);
+        EXPECT_LT(1000, pool.memory_usage().usedBytes());
+        EXPECT_GT(2000, pool.memory_usage().usedBytes());
+    }
+    EXPECT_LT(500, pool.memory_usage().usedBytes());
+    EXPECT_GT(1000, pool.memory_usage().usedBytes());
+    auto handle7 = pool.get(401);
+    EXPECT_EQ(4, pool.create_count());
+    verify_handle(handle7, 480, 1, 0);
+    exercise(handle7);
+    EXPECT_LT(1000, pool.memory_usage().allocatedBytes());
+    EXPECT_GT(3000, pool.memory_usage().allocatedBytes());
+    {
+        auto handle8 = pool.get(2500);
+        auto handle9 = pool.get(2500);
+        EXPECT_LT(11000, pool.memory_usage().allocatedBytes());
+        EXPECT_GT(13000, pool.memory_usage().allocatedBytes());
+        auto handleA = pool.get(25000);
+        auto handleB = pool.get(25000);
+        EXPECT_LT(111000, pool.memory_usage().usedBytes());
+        EXPECT_GT(113000, pool.memory_usage().usedBytes());
+    }
+    EXPECT_GT(3000, pool.memory_usage().usedBytes());
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -79,6 +79,9 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     relative_frequency_sketch.cpp
     require.cpp
     resource_limits.cpp
+    reusable_set.cpp
+    reusable_set_handle.cpp
+    reusable_set_pool.cpp
     round_up_to_page_size.cpp
     runnable.cpp
     runnable_pair.cpp

--- a/vespalib/src/vespa/vespalib/util/reusable_set.cpp
+++ b/vespalib/src/vespa/vespalib/util/reusable_set.cpp
@@ -1,0 +1,3 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "reusable_set.h"

--- a/vespalib/src/vespa/vespalib/util/reusable_set.h
+++ b/vespalib/src/vespa/vespalib/util/reusable_set.h
@@ -1,0 +1,54 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "array.h"
+#include "array.hpp"
+
+#include <cstring>
+#include <memory>
+
+namespace vespalib {
+
+/**
+ * Generational marker implementation of a vector of boolean values.
+ * Limited API, used for marking "seen" nodes when exploring a graph.
+ **/
+class ReusableSet
+
+{
+public:
+    using Mark = unsigned short;
+
+    explicit ReusableSet(size_t size) : _array(size), _curval(-1), _sz(size) { clear(); }
+
+    ~ReusableSet() {}
+
+    /**
+     * Increments the generation value, only
+     * initializing the underlying memory when it wraps
+     **/
+    void clear() {
+        if (++_curval == 0) {
+            memset(bits(), 0, _sz * sizeof(Mark));
+            ++_curval;
+        }
+    }
+
+    void mark(size_t id) { _array[id] = _curval; }
+
+    bool is_marked(size_t id) const { return (_array[id] == _curval); }
+
+    Mark* bits() { return _array.begin(); }
+    Mark generation() const { return _curval; }
+    size_t capacity() const { return _sz; }
+
+    size_t memory_usage() const { return (_sz * sizeof(Mark)) + sizeof(ReusableSet); }
+
+private:
+    Array<Mark> _array;
+    Mark        _curval;
+    size_t      _sz;
+};
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/reusable_set_handle.cpp
+++ b/vespalib/src/vespa/vespalib/util/reusable_set_handle.cpp
@@ -1,0 +1,13 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "reusable_set_handle.h"
+
+#include "reusable_set_pool.h"
+
+namespace vespalib {
+
+ReusableSetHandle::~ReusableSetHandle() {
+    _pool.reuse(std::move(_owned));
+}
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/reusable_set_handle.h
+++ b/vespalib/src/vespa/vespalib/util/reusable_set_handle.h
@@ -1,0 +1,43 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "reusable_set.h"
+
+namespace vespalib {
+
+class ReusableSetPool;
+
+/**
+ * Wraps a ReusableSet allocated from a ReusableSetPool.
+ * Note that the handle returns the wrapped set to the pool
+ * on destruction.
+ **/
+class ReusableSetHandle {
+private:
+    using Mark = ReusableSet::Mark;
+    using RSUP = std::unique_ptr<ReusableSet>;
+
+    Mark*            _bits;
+    Mark             _curval;
+    RSUP             _owned;
+    ReusableSetPool& _pool;
+
+public:
+    ReusableSetHandle(RSUP backing, ReusableSetPool& owner)
+        : _bits(backing->bits()), _curval(backing->generation()), _owned(std::move(backing)), _pool(owner) {}
+
+    ~ReusableSetHandle();
+
+    /** mark an ID */
+    void mark(size_t id) { _bits[id] = _curval; }
+
+    /** check if an ID has been marked */
+    bool is_marked(size_t id) const { return (_bits[id] == _curval); }
+
+    // for unit tests and statistics
+    size_t capacity() const { return _owned->capacity(); }
+    Mark generation() const { return _curval; }
+};
+
+} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/util/reusable_set_pool.cpp
+++ b/vespalib/src/vespa/vespalib/util/reusable_set_pool.cpp
@@ -1,0 +1,3 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "reusable_set_pool.h"

--- a/vespalib/src/vespa/vespalib/util/reusable_set_pool.h
+++ b/vespalib/src/vespa/vespalib/util/reusable_set_pool.h
@@ -1,0 +1,87 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "memoryusage.h"
+#include "reusable_set.h"
+#include "reusable_set_handle.h"
+
+#include <mutex>
+#include <vector>
+
+namespace vespalib {
+
+/**
+ * A resource pool for ReusableSet instances.
+ * Note that the pool should have a guaranteed lifetime
+ * that is longer than any Handle retrieved from the pool.
+ **/
+class ReusableSetPool {
+    using RSUP = std::unique_ptr<ReusableSet>;
+    using Guard = std::lock_guard<std::mutex>;
+    std::vector<RSUP>  _lru_stack;
+    mutable std::mutex _lock;
+    size_t             _reuse_count;
+    size_t             _create_count;
+    MemoryUsage        _total_memory;
+    const size_t       _min_size;
+    const size_t       _grow_percent;
+
+    ReusableSetPool(const ReusableSetPool&) = delete;
+    ReusableSetPool& operator=(const ReusableSetPool&) = delete;
+
+public:
+    ReusableSetPool()
+        : _lru_stack(),
+          _lock(),
+          _reuse_count(0),
+          _create_count(0),
+          _total_memory(),
+          _min_size(248),
+          _grow_percent(20) {
+        _total_memory.incAllocatedBytes(sizeof(ReusableSetPool));
+    }
+
+    /** Create or re-use a set with (at least) the given size. */
+    ReusableSetHandle get(size_t size) {
+        Guard  guard(_lock);
+        size_t last_used_size = 0;
+        while (!_lru_stack.empty()) {
+            RSUP r = std::move(_lru_stack.back());
+            _lru_stack.pop_back();
+            if (r->capacity() >= size) {
+                r->clear();
+                ++_reuse_count;
+                _total_memory.incUsedBytes(r->memory_usage());
+                return ReusableSetHandle(std::move(r), *this);
+            }
+            _total_memory.decAllocatedBytes(r->memory_usage());
+            last_used_size = std::max(last_used_size, r->capacity());
+        }
+        double grow_factor = (1.0 + _grow_percent / 100.0);
+        last_used_size *= grow_factor;
+        size_t at_least_size = std::max(_min_size, last_used_size);
+        RSUP   r = std::make_unique<ReusableSet>(std::max(at_least_size, size));
+        _total_memory.incAllocatedBytes(r->memory_usage());
+        ++_create_count;
+        _total_memory.incUsedBytes(r->memory_usage());
+        return ReusableSetHandle(std::move(r), *this);
+    }
+
+    /** Return a ReusableSet to the pool. */
+    void reuse(RSUP used) {
+        Guard guard(_lock);
+        _total_memory.decUsedBytes(used->memory_usage());
+        _lru_stack.push_back(std::move(used));
+    }
+
+    // for unit testing and statistics
+    size_t reuse_count() const { return _reuse_count; }
+    size_t create_count() const { return _create_count; }
+    MemoryUsage memory_usage() const {
+        Guard guard(_lock);
+        return _total_memory;
+    }
+};
+
+} // namespace vespalib


### PR DESCRIPTION
Restore the ReusableSet family of classes (ReusableSet, ReusableSetHandle and ReusableSetPool) that were removed in a40e7f5b40c, along with their unit test.

ReusableSet is a generational "seen" marker used when exploring a graph: instead of clearing a bool vector on every traversal, it bumps a generation counter and only zeroes the backing memory when the counter wraps. This makes clear() effectively O(1). ReusableSetPool hands out appropriately sized sets via RAII handles that return the set to the pool on destruction, so repeated traversals reuse allocations rather than reallocating.

This utility may be useful again for graph search, hence the revival. The code is functionally identical to the removed version; only formatting (include ordering, brace/clang-format style) differs.
