### PR TITLE
Allow tagged argument identifiers in ranking expressions

### DIFF
--- a/integration/schema-language-server/language-server/src/main/ccc/rankingexpression/RankingExpressionParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/rankingexpression/RankingExpressionParser.ccc
@@ -408,13 +408,28 @@ String out() :
     { /* Unreachable: return null; */ }
 ;
 
+ExpressionNode argExpression() :
+{
+    String argName, argValue;
+    ExpressionNode node;
+}
+
+    ( SCAN 2 (
+        argName = identifierStr() <COLON> argValue = identifierStr() {
+            node = new ConstantNode(Value.parse("\"" + argName + ":" + argValue + "\""));
+            thisProduction.expressionNode = node;
+            return node;
+        }
+      ) | ( node = expression() { thisProduction.expressionNode = node; return node; } ) )
+;
+
 List<ExpressionNode> args() :
 {
     List<ExpressionNode> arguments = new ArrayList<ExpressionNode>();
     ExpressionNode argument;
 }
 
-    ( ( argument = expression() { arguments.add(argument); } ( <COMMA> argument = expression() { arguments.add(argument); } )* )? )
+    ( ( argument = argExpression() { arguments.add(argument); } ( <COMMA> argument = argExpression() { arguments.add(argument); } )* )? )
     { return arguments; }
 ;
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/tree/rankingexpression/RankNode.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/tree/rankingexpression/RankNode.java
@@ -12,6 +12,7 @@ import org.eclipse.lsp4j.Range;
 import ai.vespa.schemals.index.Symbol;
 import ai.vespa.schemals.index.Symbol.SymbolStatus;
 import ai.vespa.schemals.index.Symbol.SymbolType;
+import ai.vespa.schemals.parser.rankingexpression.ast.argExpression;
 import ai.vespa.schemals.parser.rankingexpression.ast.args;
 import ai.vespa.schemals.parser.rankingexpression.ast.expression;
 import ai.vespa.schemals.parser.rankingexpression.ast.feature;
@@ -119,6 +120,11 @@ public class RankNode implements Iterable<RankNode>  {
         for (Node child : parameterNode) {
             if (child.getASTClass() == expression.class) {
                 ret.add(new RankNode(child.getSchemaNode()));
+            } else if (child.getASTClass() == argExpression.class) {
+                // An argExpression wraps either a normal expression or a "name:value" tag.
+                // Flatten it so the parameter structure matches a plain expression argument;
+                // the tag form has no expression child and thus contributes no parameter.
+                ret.addAll(findChildren(child.getSchemaNode()));
             }
         }
 

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -315,7 +315,7 @@ public class SchemaParserTest {
             new BadFileTestCase("../../../config-model/src/test/examples/rankingexpressionfunction/rankingexpressionfunction.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/rankpropvars.sd", 2),
             new BadFileTestCase("../../../config-model/src/test/examples/stemmingresolver.sd", 1),
-            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 44),
+            new BadFileTestCase("../../../config-model/src/test/derived/rankingexpression/rankexpression.sd", 41),
             new BadFileTestCase("../../../config-model/src/test/derived/renamedfeatures/foo.sd", 4),
 
             new BadFileTestCase("../../../config-model/src/test/derived/rankprofiles/rankprofiles.sd", 1), // only throws a warning during vespa deploy, but it is an unresolved reference case.

--- a/searchlib/src/main/javacc/RankingExpressionParser.jj
+++ b/searchlib/src/main/javacc/RankingExpressionParser.jj
@@ -358,13 +358,27 @@ String out() :
     { return null; }
 }
 
+private ExpressionNode argExpression() :
+{
+    String argName, argValue;
+    ExpressionNode node;
+}
+{
+    LOOKAHEAD(2) (
+        argName = identifier() <COLON> argValue = identifier() {
+            node = new ConstantNode(Value.parse("\"" + argName + ":" + argValue + "\""));
+              return node;
+        }
+    ) | ( node = expression() { return node; } )
+}
+
 List<ExpressionNode> args() :
 {
     List<ExpressionNode> arguments = new ArrayList<ExpressionNode>();
     ExpressionNode argument;
 }
 {
-    ( ( argument = expression() { arguments.add(argument); } ( <COMMA> argument = expression() { arguments.add(argument); } )* )? )
+    ( ( argument = argExpression() { arguments.add(argument); } ( <COMMA> argument = argExpression() { arguments.add(argument); } )* )? )
     { return arguments; }
 }
 


### PR DESCRIPTION
Extend the ranking expression grammar so a function argument may be written as an `identifierA: identifierB` tag in addition to a normal expression. The new argExpression() production uses LOOKAHEAD(2) to recognize the `name:value` form and turns it into a string ConstantNode holding "name:value", falling back to the existing expression() rule otherwise so all current expressions parse unchanged.

Why: this allows us to require some extensions to use tagged labels, like `bm25(someField, label: myLabel)` instead of relying solely on number of arguments.
