### PR TITLE
Add internal quantization support to TensorAttribute

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/simple_value.h>
 #include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/test/reference_operations.h>
 #include <vespa/eval/eval/test/value_compare.h>
 #include <vespa/eval/eval/value.h>
 #include <vespa/eval/eval/value_codec.h>
@@ -50,6 +51,7 @@ using search::AttributeVector;
 using search::CommitParam;
 using search::attribute::DistanceMetric;
 using search::attribute::HnswIndexParams;
+using search::attribute::QuantizationParams;
 using search::queryeval::Blueprint;
 using search::queryeval::GlobalFilter;
 using search::queryeval::NearestNeighborBlueprint;
@@ -72,6 +74,8 @@ using search::tensor::TensorAttribute;
 using search::tensor::TensorAttributeFlags;
 using search::tensor::VectorBundle;
 using testing::AllOf;
+using testing::Eq;
+using testing::ExplainMatchResult;
 using testing::Ge;
 using testing::Le;
 using vespalib::Generation;
@@ -82,6 +86,7 @@ using vespalib::datastore::CompactionStrategy;
 using vespalib::datastore::EntryRef;
 using vespalib::eval::CellType;
 using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::Int8Float;
 using vespalib::eval::SimpleValue;
 using vespalib::eval::TensorSpec;
 using vespalib::eval::Value;
@@ -91,6 +96,7 @@ using DoubleVector = std::vector<double>;
 
 std::string              sparseSpec("tensor(x{},y{})");
 std::string              denseSpec("tensor(x[2],y[3])");
+std::string              quantized_dense_spec("tensor<int8>(y[7])"); // sizeof(float) + 4bits*2*3 => 7 bytes
 std::string              a_dimension("a");
 std::string              b_dimension("b");
 std::string              x_dimension("x");
@@ -355,12 +361,14 @@ public:
 
 class MockNearestNeighborIndexFactory : public NearestNeighborIndexFactory {
 
-    std::unique_ptr<NearestNeighborIndex> make(const DocVectorAccess& vectors, size_t vector_size,
-                                               bool multi_vector_index, CellType cell_type,
-                                               const search::attribute::HnswIndexParams& params) const override {
+    std::unique_ptr<NearestNeighborIndex>
+    make(const DocVectorAccess& vectors, size_t vector_size, bool multi_vector_index, CellType cell_type,
+         const search::attribute::HnswIndexParams&                   params,
+         const std::optional<search::attribute::QuantizationParams>& quant_params) const override {
         (void)vector_size;
         (void)params;
         (void)multi_vector_index;
+        (void)quant_params;
         assert(cell_type == CellType::DOUBLE);
         return std::make_unique<MockNearestNeighborIndex>(vectors);
     }
@@ -378,6 +386,7 @@ struct FixtureTraits {
     bool use_mock_index = false;
     bool use_mmap_file_allocator = false;
     bool use_mips_distance = false;
+    bool use_quantization = false;
 
     FixtureTraits dense() && {
         use_dense_tensor_attribute = true;
@@ -424,6 +433,11 @@ struct FixtureTraits {
         use_direct_tensor_attribute = true;
         return *this;
     }
+
+    FixtureTraits quantized() && {
+        use_quantization = true;
+        return *this;
+    }
 };
 
 struct WrapValue {
@@ -448,6 +462,57 @@ void PrintTo(const WrapValue& value, std::ostream* os) {
     }
 }
 
+/*
+ * Checks if two tensors are approximately equal to each other, where the max divergence is
+ * given by the `max_nrmse` (maximum normalized root mean squared error) argument.
+ * NRMSE isn't necessarily the most intuitive error metric, but unlike other metrics (MAPE,
+ * SMAPE etc.) it is well-defined for values of (or close to) zero, and it compensates for
+ * different vector norms. The latter is very useful since vector dequantization precision
+ * is directly affected by the norm due to the scaling factor used during reconstruction.
+ *
+ * If `max_nrmse` is zero, this will fall back to eval::Value operator== for equality testing,
+ * as it transparently handles floating point precision issues.
+ *
+ * `arg` is expected to be a WrapValue instance.
+ *
+ * TODO move this out since it's useful for other quantization tests.
+ */
+MATCHER_P2(TensorApproxEquals, exp_spec, max_nrmse, "") {
+    using vespalib::eval::Aggr;
+    using vespalib::eval::ReferenceOperations;
+    if (max_nrmse == 0) {
+        return ExplainMatchResult(Eq(exp_spec), arg, result_listener);
+    }
+    auto arg_spec = TensorSpec::from_value(*arg._value); // WrapValue arg
+    if (exp_spec.type() != arg_spec.type()) {
+        *result_listener << "tensors have mismatching types";
+        return false;
+    }
+    // Root mean squared error (RMSE)
+    // For simplicity, compute across all subspaces. Quantization works on a per
+    // dense subspace basis, so we may want to change this to be subspace-aware.
+    // We also casually assume tensors have at least 1 dimension.
+    const double n = ReferenceOperations::reduce(exp_spec, Aggr::COUNT, {}).as_double();
+    auto         err_sq = ReferenceOperations::merge(exp_spec, arg_spec, [](double a, double b) noexcept {
+        const double diff = a - b;
+        return diff * diff;
+    });
+    const double sum_err_sq = ReferenceOperations::reduce(err_sq, Aggr::SUM, {}).as_double();
+    const double mse = sum_err_sq / n;
+    const double rmse = std::sqrt(mse);
+    // Normalized root mean squared error (NRSME)
+    // We choose to normalize based on the max observed cell value in the expected tensor
+    // Ref: https://en.wikipedia.org/wiki/Root_mean_square_deviation#Normalization
+    const double exp_max = ReferenceOperations::reduce(exp_spec, Aggr::MAX, {}).as_double();
+    const double nrmse = (exp_max != 0) ? (rmse / exp_max) : rmse;
+
+    if (nrmse > max_nrmse) {
+        *result_listener << "expected NRMSE between tensors to be <= " << max_nrmse << ", was " << nrmse;
+        return false;
+    }
+    return true;
+}
+
 struct Fixture {
     using BasicType = search::attribute::BasicType;
     using CollectionType = search::attribute::CollectionType;
@@ -456,8 +521,10 @@ struct Fixture {
     search::test::DirectoryHandler               _dir_handler;
     Config                                       _cfg;
     std::string                                  _name;
-    std::string                                  _typeSpec;
-    ValueType                                    _tensor_type;
+    std::string                                  _configured_type_spec;
+    std::string                                  _stored_type_spec; // possibly quantized spec
+    ValueType                                    _configured_tensor_type;
+    ValueType                                    _stored_tensor_type; // possibly quantized type
     bool                                         _use_mock_index;
     std::unique_ptr<NearestNeighborIndexFactory> _index_factory;
     std::shared_ptr<TensorAttribute>             _tensorAttr;
@@ -472,7 +539,16 @@ struct Fixture {
     ~Fixture();
 
     void setup() {
-        _cfg.setTensorType(ValueType::from_spec(_typeSpec));
+        if (!_traits.use_quantization) {
+            _cfg.setTensorType(ValueType::from_spec(_configured_type_spec));
+        } else {
+            constexpr uint64_t seed = 0x12345678;
+            constexpr auto     mode = QuantizationParams::QuantizationMode::MSE;
+            _cfg.set_tensor_type_with_quantization(ValueType::from_spec(_configured_type_spec),
+                                                   QuantizationParams(seed, mode, 4));
+            _stored_type_spec = _cfg.tensorType().to_spec();
+            _stored_tensor_type = ValueType::from_spec(_stored_type_spec);
+        }
         if (_cfg.tensorType().is_dense()) {
             _denseTensors = true;
         }
@@ -546,15 +622,26 @@ struct Fixture {
         _attr->commit();
     }
 
-    void set_tensor(uint32_t docid, const TensorSpec& spec) { set_tensor_internal(docid, *createTensor(spec)); }
+    // Expected max normalized root mean squared error (NRMSE) between expected and actual
+    // tensor cell values. Always zero for non-quantized tensor attributes.
+    [[nodiscard]] double max_nrmse() const noexcept { return _traits.use_quantization ? 0.042 : 0.0; }
+
+    [[nodiscard]] std::unique_ptr<Value> create_tensor_auto_quantized(const TensorSpec& spec) const {
+        auto t = createTensor(spec);
+        return _traits.use_quantization ? _tensorAttr->make_quantizer()->quantize(*t) : std::move(t);
+    }
+
+    void set_tensor(uint32_t docid, const TensorSpec& spec) {
+        set_tensor_internal(docid, *create_tensor_auto_quantized(spec));
+    }
 
     std::unique_ptr<PrepareResult> prepare_set_tensor(uint32_t docid, const TensorSpec& spec) const {
-        return _tensorAttr->prepare_set_tensor(docid, *createTensor(spec));
+        return _tensorAttr->prepare_set_tensor(docid, *create_tensor_auto_quantized(spec));
     }
 
     void complete_set_tensor(uint32_t docid, const TensorSpec& spec, std::unique_ptr<PrepareResult> prepare_result) {
         ensureSpace(docid);
-        _tensorAttr->complete_set_tensor(docid, *createTensor(spec), std::move(prepare_result));
+        _tensorAttr->complete_set_tensor(docid, *create_tensor_auto_quantized(spec), std::move(prepare_result));
         _attr->commit();
     }
 
@@ -581,7 +668,12 @@ struct Fixture {
 
     WrapValue get_tensor(uint32_t docId) {
         AttributeGuard guard(_attr);
-        return {_tensorAttr->getTensor(docId)};
+        auto           t = _tensorAttr->getTensor(docId);
+        if (!t || !_traits.use_quantization) {
+            return {std::move(t)};
+        } else {
+            return {_tensorAttr->make_dequantizer()->dequantize(*t)};
+        }
     }
 
     bool save() {
@@ -619,14 +711,17 @@ struct Fixture {
 
     TensorSpec expEmptyDenseTensor() const { return {denseSpec}; }
 
-    std::string expEmptyDenseTensorSpec() const { return denseSpec; }
+    std::string expEmptyDenseTensorSpec() const {
+        return _traits.use_quantization ? quantized_dense_spec : denseSpec;
+    }
 
-    uint32_t count_mapped_dimensions() { return _tensor_type.count_mapped_dimensions(); }
+    uint32_t count_mapped_dimensions() { return _configured_tensor_type.count_mapped_dimensions(); }
 
     vespalib::FileHeader get_file_header();
     void set_example_tensors();
     void assert_example_tensors();
     void save_example_tensors_with_mock_index();
+    void test_tensor_quantization_config();
     void testEmptyAttribute();
     void testSetTensorValue();
     void testSaveLoad();
@@ -643,8 +738,10 @@ Fixture::Fixture(const std::string& typeSpec, FixtureTraits traits)
     : _dir_handler(test_dir),
       _cfg(BasicType::TENSOR, CollectionType::SINGLE),
       _name(attr_name),
-      _typeSpec(typeSpec),
-      _tensor_type(ValueType::from_spec(typeSpec)),
+      _configured_type_spec(typeSpec),
+      _stored_type_spec(typeSpec),
+      _configured_tensor_type(ValueType::from_spec(typeSpec)),
+      _stored_tensor_type(_configured_tensor_type),
       _index_factory(),
       _tensorAttr(),
       _attr(),
@@ -683,6 +780,19 @@ void Fixture::save_example_tensors_with_mock_index() {
     EXPECT_TRUE(std::filesystem::exists(std::filesystem::path(_name + ".nnidx")));
 }
 
+void Fixture::test_tensor_quantization_config() {
+    SCOPED_TRACE("test_tensor_quantization_config");
+    EXPECT_EQ(_tensorAttr->is_quantized(), _traits.use_quantization);
+    EXPECT_EQ(_tensorAttr->unquantized_tensor_type(), _configured_tensor_type);
+    if (_traits.use_quantization) {
+        EXPECT_NE(_stored_tensor_type, _configured_tensor_type);
+        EXPECT_EQ(_tensorAttr->getTensorType(), _stored_tensor_type);
+    } else {
+        EXPECT_EQ(_stored_tensor_type, _configured_tensor_type);
+        EXPECT_EQ(_tensorAttr->getTensorType(), _configured_tensor_type);
+    }
+}
+
 void Fixture::testEmptyAttribute() {
     SCOPED_TRACE("testEmptyAttribute");
     EXPECT_EQ(1u, _attr->getNumDocs());
@@ -701,7 +811,7 @@ void Fixture::testSetTensorValue() {
     if (_denseTensors) {
         EXPECT_EQ(WrapValue(expEmptyDenseTensor()), get_tensor(4));
         set_tensor(3, expDenseTensor3());
-        EXPECT_EQ(WrapValue(expDenseTensor3()), get_tensor(3));
+        EXPECT_THAT(get_tensor(3), TensorApproxEquals(expDenseTensor3(), max_nrmse()));
     } else {
         EXPECT_EQ(WrapValue(TensorSpec(sparseSpec)), get_tensor(4));
         set_tensor(3, TensorSpec(sparseSpec).add({{"x", ""}, {"y", ""}}, 11));
@@ -726,7 +836,7 @@ void Fixture::testSaveLoad() {
     EXPECT_EQ(5u, _attr->getNumDocs());
     EXPECT_EQ(5u, _attr->getCommittedDocIdLimit());
     if (_denseTensors) {
-        EXPECT_EQ(WrapValue(expDenseTensor3()), get_tensor(3));
+        EXPECT_THAT(get_tensor(3), TensorApproxEquals(expDenseTensor3(), max_nrmse()));
         EXPECT_EQ(WrapValue(expEmptyDenseTensor()), get_tensor(4));
     } else {
         EXPECT_EQ(WrapValue(TensorSpec(sparseSpec).add({{"x", ""}, {"y", "1"}}, 11)), get_tensor(3));
@@ -776,8 +886,8 @@ void Fixture::testCompaction() {
     LOG(info, "iter = %" PRIu64 ", memory usage %" PRIu64 " -> %" PRIu64, iter, oldStatus.getUsed(),
         newStatus.getUsed());
     EXPECT_EQ(WrapValue(), get_tensor(1));
-    EXPECT_EQ(WrapValue(fill_tensor), get_tensor(2));
-    EXPECT_EQ(WrapValue(simple_tensor), get_tensor(3));
+    EXPECT_THAT(get_tensor(2), TensorApproxEquals(fill_tensor, max_nrmse()));
+    EXPECT_THAT(get_tensor(3), TensorApproxEquals(simple_tensor, max_nrmse()));
     EXPECT_EQ(WrapValue(empty_xy_tensor), get_tensor(4));
 }
 
@@ -797,7 +907,7 @@ void Fixture::testTensorTypeFileHeaderTag() {
 
     auto header = get_file_header();
     EXPECT_TRUE(header.hasTag("tensortype"));
-    EXPECT_EQ(_typeSpec, header.getTag("tensortype").asString());
+    EXPECT_EQ(_stored_type_spec, header.getTag("tensortype").asString());
     if (_traits.use_dense_tensor_attribute) {
         EXPECT_EQ(1u, header.getTag("version").asInteger());
     } else {
@@ -814,7 +924,7 @@ void Fixture::testEmptyTensor() {
         EXPECT_EQ(emptyTensor->type(), ValueType::from_spec(expSpec));
     } else {
         EXPECT_EQ(emptyTensor->type(), tensorAttr.getConfig().tensorType());
-        EXPECT_EQ(emptyTensor->type(), ValueType::from_spec(_typeSpec));
+        EXPECT_EQ(emptyTensor->type(), ValueType::from_spec(_configured_type_spec));
     }
 }
 
@@ -834,7 +944,13 @@ void Fixture::testSerializedTensorRef() {
     }
     auto ref = tensorAttr.get_serialized_tensor_ref(3);
     auto vectors = ref.get_vectors();
-    if (_denseTensors) {
+    if (_traits.use_quantization) {
+        // Quantized serialized tensor refs only lets us see the opaque quantization bytes.
+        ASSERT_EQ(1u, vectors.subspaces());
+        auto labels = ref.get_labels(0);
+        EXPECT_EQ(0u, labels.size());
+        EXPECT_EQ(vectors.cells(0).size, 7);
+    } else if (_denseTensors) {
         EXPECT_EQ(1u, vectors.subspaces());
         auto cells = vectors.cells(0).typify<double>();
         auto labels = ref.get_labels(0);
@@ -898,6 +1014,7 @@ void Fixture::test_mmap_file_allocator() {
 }
 
 template <class MakeFixture> void testAll(MakeFixture&& f) {
+    f()->test_tensor_quantization_config();
     f()->testEmptyAttribute();
     f()->testSetTensorValue();
     f()->testSaveLoad();
@@ -926,12 +1043,20 @@ TEST(TensorAttributeTest, Test_dense_tensors_with_generic_tensor_attribute) {
     testAll([]() { return std::make_shared<Fixture>(denseSpec); });
 }
 
+TEST(TensorAttributeTest, quantized_dense_tensors_with_generic_tensor_attribute) {
+    testAll([]() { return std::make_shared<Fixture>(denseSpec, FixtureTraits().quantized()); });
+}
+
 TEST(TensorAttributeTest, Test_dense_tensors_with_generic_tensor_attribute_with_paged_setting) {
     testAll([]() { return std::make_shared<Fixture>(denseSpec, FixtureTraits().mmap_file_allocator()); });
 }
 
 TEST(TensorAttributeTest, Test_dense_tensors_with_dense_tensor_attribute) {
     testAll([]() { return std::make_shared<Fixture>(denseSpec, FixtureTraits().dense()); });
+}
+
+TEST(TensorAttributeTest, quantized_dense_tensors_with_dense_tensor_attribute) {
+    testAll([]() { return std::make_shared<Fixture>(denseSpec, FixtureTraits().dense().quantized()); });
 }
 
 TEST(TensorAttributeTest, Test_dense_tensors_with_dense_tensor_attribute_with_paged_setting) {
@@ -1029,6 +1154,19 @@ MixedTensorAttributeTest::MixedTensorAttributeTest() : ::testing::TestWithParam<
 
 MixedTensorAttributeTest::~MixedTensorAttributeTest() = default;
 
+class QuantizedDenseTensorAttributeHnswIndex : public TensorAttributeHnswIndex<HnswIndexType::SINGLE> {
+public:
+    QuantizedDenseTensorAttributeHnswIndex()
+        : TensorAttributeHnswIndex<HnswIndexType::SINGLE>(vec_2d_spec, FixtureTraits().hnsw().quantized()) {}
+};
+
+class QuantizedMixedTensorAttributeHnswIndex : public TensorAttributeHnswIndex<HnswIndexType::MULTI> {
+public:
+    QuantizedMixedTensorAttributeHnswIndex(uint32_t mapped_dimensions)
+        : TensorAttributeHnswIndex<HnswIndexType::MULTI>(vec_specs[mapped_dimensions],
+                                                         FixtureTraits().mixed_hnsw().quantized()) {}
+};
+
 TEST(TensorAttributeTest, Hnsw_index_is_instantiated_in_dense_tensor_attribute_when_specified_in_config) {
     DenseTensorAttributeHnswIndex f;
     f.test_setup();
@@ -1049,11 +1187,29 @@ TEST_P(MixedTensorAttributeTest, Hnsw_index_is_integrated_in_mixed_tensor_attrib
     f.test_save_load(false);
 }
 
+TEST(TensorAttributeTest, hnsw_index_is_instantiated_in_quantized_dense_tensor_attribute_when_specified_in_config) {
+    QuantizedDenseTensorAttributeHnswIndex f;
+    f.test_setup();
+}
+
+TEST(TensorAttributeTest, hnsw_index_is_integrated_in_quantized_dense_tensor_attribute_and_can_be_saved_and_loaded) {
+    QuantizedDenseTensorAttributeHnswIndex f;
+    f.test_save_load(false);
+}
+
 TEST_P(
     MixedTensorAttributeTest,
     Hnsw_index_is_integrated_in_mixed_tensor_attribute_and_can_be_saved_and_loaded_with_multiple_points_per_document) {
-    MixedTensorAttributeHnswIndex f(GetParam());
-    f.test_save_load(true);
+    {
+        SCOPED_TRACE("unquantized mixed");
+        MixedTensorAttributeHnswIndex f(GetParam());
+        f.test_save_load(true);
+    }
+    {
+        SCOPED_TRACE("quantized mixed");
+        QuantizedMixedTensorAttributeHnswIndex f(GetParam());
+        f.test_save_load(true);
+    }
 }
 
 TEST(TensorAttributeTest, Populates_address_space_usage_in_dense_tensor_attribute_with_hnsw_index) {

--- a/searchlib/src/vespa/searchcommon/attribute/config.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/config.cpp
@@ -2,13 +2,22 @@
 
 #include "config.h"
 
+#include <vespa/searchlib/tensor/tensor_quantization.h>
+
 namespace search::attribute {
 
 namespace {
 
 static constexpr uint64_t MAX_UNCOMMITTED_MEMORY = 8000;
 
+vespalib::eval::ValueType to_quantized_type(const vespalib::eval::ValueType& original_tensor_type,
+                                            const QuantizationParams&        qp) {
+    // TODO don't require going via a quantizer instance to compute the type
+    vespalib::quant::EdenQuantizer quantizer(original_tensor_type.dense_subspace_size(), qp.bits(), qp.seed());
+    return tensor::to_quantized_tensor_type(original_tensor_type, quantizer);
 }
+
+} // namespace
 
 Config::Config() noexcept : Config(BasicType::NONE, CollectionType::SINGLE, false) {
 }
@@ -29,6 +38,7 @@ Config::Config(BasicType bt, CollectionType ct, bool fastSearch_) noexcept
       _compactionStrategy(),
       _predicateParams(),
       _tensorType(vespalib::eval::ValueType::error_type()),
+      _unquantized_tensor_type(vespalib::eval::ValueType::error_type()),
       _hnsw_index_params() {
 }
 
@@ -44,8 +54,25 @@ bool Config::operator==(const Config& b) const noexcept {
            _maxUnCommittedMemory == b._maxUnCommittedMemory && _match == b._match && _dictionary == b._dictionary &&
            _growStrategy == b._growStrategy && _compactionStrategy == b._compactionStrategy &&
            _predicateParams == b._predicateParams &&
-           (_basicType.type() != BasicType::Type::TENSOR || _tensorType == b._tensorType) &&
-           _distance_metric == b._distance_metric && _hnsw_index_params == b._hnsw_index_params;
+           (_basicType.type() != BasicType::Type::TENSOR ||
+            (_tensorType == b._tensorType && _unquantized_tensor_type == b._unquantized_tensor_type)) &&
+           _distance_metric == b._distance_metric && _hnsw_index_params == b._hnsw_index_params &&
+           _quantization_params == b._quantization_params;
+}
+
+Config& Config::setTensorType(const vespalib::eval::ValueType& tensorType_in) {
+    _tensorType = tensorType_in;
+    _unquantized_tensor_type = tensorType_in;
+    _quantization_params.reset();
+    return *this;
+}
+
+Config& Config::set_tensor_type_with_quantization(const vespalib::eval::ValueType& original_tensor_type,
+                                                  const QuantizationParams&        quantization_params) {
+    _tensorType = to_quantized_type(original_tensor_type, quantization_params);
+    _unquantized_tensor_type = original_tensor_type;
+    _quantization_params = quantization_params;
+    return *this;
 }
 
 Config& Config::set_hnsw_index_params(const HnswIndexParams& params) {

--- a/searchlib/src/vespa/searchcommon/attribute/config.h
+++ b/searchlib/src/vespa/searchcommon/attribute/config.h
@@ -6,6 +6,7 @@
 #include "collectiontype.h"
 #include "hnsw_index_params.h"
 #include "predicate_params.h"
+#include "quantization_params.h"
 
 #include <vespa/eval/eval/value_type.h>
 #include <vespa/searchcommon/common/dictionary_config.h>
@@ -35,14 +36,23 @@ public:
     Config& operator=(Config&&) noexcept;
     ~Config();
 
-    BasicType basicType() const noexcept { return _basicType; }
-    CollectionType collectionType() const noexcept { return _type; }
-    bool fastSearch() const noexcept { return _fastSearch; }
-    bool paged() const noexcept { return _paged; }
-    const PredicateParams& predicateParams() const noexcept { return _predicateParams; }
-    const vespalib::eval::ValueType& tensorType() const noexcept { return _tensorType; }
-    DistanceMetric distance_metric() const noexcept { return _distance_metric; }
-    const std::optional<HnswIndexParams>& hnsw_index_params() const { return _hnsw_index_params; }
+    [[nodiscard]] BasicType basicType() const noexcept { return _basicType; }
+    [[nodiscard]] CollectionType collectionType() const noexcept { return _type; }
+    [[nodiscard]] bool fastSearch() const noexcept { return _fastSearch; }
+    [[nodiscard]] bool paged() const noexcept { return _paged; }
+    [[nodiscard]] const PredicateParams& predicateParams() const noexcept { return _predicateParams; }
+    [[nodiscard]] const vespalib::eval::ValueType& tensorType() const noexcept { return _tensorType; }
+    // If quantization_params() is empty, the returned type is equal to tensorType()
+    [[nodiscard]] const vespalib::eval::ValueType& unquantized_tensor_type() const noexcept {
+        return _unquantized_tensor_type;
+    }
+    [[nodiscard]] DistanceMetric distance_metric() const noexcept { return _distance_metric; }
+    [[nodiscard]] const std::optional<HnswIndexParams>& hnsw_index_params() const noexcept {
+        return _hnsw_index_params;
+    }
+    [[nodiscard]] const std::optional<QuantizationParams>& quantization_params() const noexcept {
+        return _quantization_params;
+    }
 
     /**
      * Check if attribute posting list can consist of only a bitvector with
@@ -69,10 +79,10 @@ public:
         _predicateParams = v;
         return *this;
     }
-    Config& setTensorType(const vespalib::eval::ValueType& tensorType_in) {
-        _tensorType = tensorType_in;
-        return *this;
-    }
+    Config& setTensorType(const vespalib::eval::ValueType& tensorType_in);
+    Config& set_tensor_type_with_quantization(const vespalib::eval::ValueType& original_tensor_type,
+                                              const QuantizationParams&        quantization_params);
+
     Config& set_distance_metric(DistanceMetric value) {
         _distance_metric = value;
         return *this;
@@ -132,22 +142,24 @@ public:
     std::string type_to_string() const;
 
 private:
-    BasicType                      _basicType;
-    CollectionType                 _type;
-    bool                           _fastSearch : 1;
-    bool                           _isFilter : 1;
-    bool                           _fastAccess : 1;
-    bool                           _mutable : 1;
-    bool                           _paged : 1;
-    DistanceMetric                 _distance_metric;
-    Match                          _match;
-    DictionaryConfig               _dictionary;
-    uint64_t                       _maxUnCommittedMemory;
-    GrowStrategy                   _growStrategy;
-    CompactionStrategy             _compactionStrategy;
-    PredicateParams                _predicateParams;
-    vespalib::eval::ValueType      _tensorType;
-    std::optional<HnswIndexParams> _hnsw_index_params;
+    BasicType                          _basicType;
+    CollectionType                     _type;
+    bool                               _fastSearch : 1;
+    bool                               _isFilter : 1;
+    bool                               _fastAccess : 1;
+    bool                               _mutable : 1;
+    bool                               _paged : 1;
+    DistanceMetric                     _distance_metric;
+    Match                              _match;
+    DictionaryConfig                   _dictionary;
+    uint64_t                           _maxUnCommittedMemory;
+    GrowStrategy                       _growStrategy;
+    CompactionStrategy                 _compactionStrategy;
+    PredicateParams                    _predicateParams;
+    vespalib::eval::ValueType          _tensorType;
+    vespalib::eval::ValueType          _unquantized_tensor_type;
+    std::optional<HnswIndexParams>     _hnsw_index_params;
+    std::optional<QuantizationParams>  _quantization_params;
 };
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/tensor/default_nearest_neighbor_index_factory.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/default_nearest_neighbor_index_factory.cpp
@@ -27,19 +27,18 @@ RandomLevelGenerator::UP make_random_level_generator(uint32_t m) {
 
 std::unique_ptr<NearestNeighborIndex>
 DefaultNearestNeighborIndexFactory::make(const DocVectorAccess& vectors, size_t vector_size, bool multi_vector_index,
-                                         vespalib::eval::CellType                  cell_type,
-                                         const search::attribute::HnswIndexParams& params) const {
-    (void)vector_size;
+                                         vespalib::eval::CellType                            cell_type,
+                                         const search::attribute::HnswIndexParams&           params,
+                                         const std::optional<attribute::QuantizationParams>& quant_params) const {
     uint32_t        m = params.max_links_per_node();
     HnswIndexConfig cfg(m * 2, m, params.neighbors_to_explore_at_insert(), 10000, true);
+    auto dist_ff = make_distance_function_factory(params.distance_metric(), cell_type, vector_size, quant_params);
     if (multi_vector_index) {
-        return std::make_unique<HnswIndex<HnswIndexType::MULTI>>(
-            vectors, make_distance_function_factory(params.distance_metric(), cell_type),
-            make_random_level_generator(m), cfg);
+        return std::make_unique<HnswIndex<HnswIndexType::MULTI>>(vectors, std::move(dist_ff),
+                                                                 make_random_level_generator(m), cfg);
     } else {
-        return std::make_unique<HnswIndex<HnswIndexType::SINGLE>>(
-            vectors, make_distance_function_factory(params.distance_metric(), cell_type),
-            make_random_level_generator(m), cfg);
+        return std::make_unique<HnswIndex<HnswIndexType::SINGLE>>(vectors, std::move(dist_ff),
+                                                                  make_random_level_generator(m), cfg);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/default_nearest_neighbor_index_factory.h
+++ b/searchlib/src/vespa/searchlib/tensor/default_nearest_neighbor_index_factory.h
@@ -13,7 +13,8 @@ class DefaultNearestNeighborIndexFactory : public NearestNeighborIndexFactory {
 public:
     std::unique_ptr<NearestNeighborIndex> make(const DocVectorAccess& vectors, size_t vector_size,
                                                bool multi_vector_index, vespalib::eval::CellType cell_type,
-                                               const search::attribute::HnswIndexParams& params) const override;
+                                               const search::attribute::HnswIndexParams& params,
+                                               const std::optional<attribute::QuantizationParams>& quant_params) const override;
 };
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/direct_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/direct_tensor_attribute.cpp
@@ -33,6 +33,7 @@ void DirectTensorAttribute::setTensor(DocId lid, const vespalib::eval::Value& te
 
 void DirectTensorAttribute::update_tensor(DocId docId, const document::TensorUpdate& update,
                                           bool create_if_non_existing) {
+    assert(!is_quantized()); // See `TensorAttribute::update_tensor()` for rationale
     EntryRef ref;
     if (docId < getCommittedDocIdLimit()) {
         ref = _refVector[docId].load_relaxed();

--- a/searchlib/src/vespa/searchlib/tensor/i_tensor_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/i_tensor_attribute.h
@@ -25,34 +25,66 @@ namespace search::tensor {
 struct DistanceFunctionFactory;
 class NearestNeighborIndex;
 class SerializedTensorRef;
+class TensorDequantizer;
 
 /**
  * Interface for tensor attribute used by feature executors to get information.
  */
 class ITensorAttribute : public DocVectorAccess {
 public:
-    virtual ~ITensorAttribute() = default;
-    virtual std::unique_ptr<vespalib::eval::Value> getTensor(uint32_t docId) const = 0;
-    virtual std::unique_ptr<vespalib::eval::Value> getEmptyTensor() const = 0;
-    virtual vespalib::eval::TypedCells extract_cells_ref(uint32_t docid) const = 0;
-    virtual const vespalib::eval::Value& get_tensor_ref(uint32_t docid) const = 0;
-    virtual SerializedTensorRef get_serialized_tensor_ref(uint32_t docid) const = 0;
-    virtual bool supports_extract_cells_ref() const = 0;
-    virtual bool supports_get_tensor_ref() const = 0;
-    virtual bool supports_get_serialized_tensor_ref() const = 0;
+    ~ITensorAttribute() override = default;
 
-    virtual const vespalib::eval::ValueType& getTensorType() const = 0;
+    /*
+     * Returns whether the tensor data stored in this attribute is a quantized representation
+     * of full precision tensor data kept in the document store. If so, the tensor type of the
+     * attribute will be a transformed version of the original full precision type that is
+     * suitable for storing quantized dense subspaces. The original type can be retrieved from
+     * `unquantized_tensor_type()`.
+     *
+     * Tensor attribute users must _explicitly_ check for, and handle, the presence of
+     * quantized tensors when setting or getting tensors, as the input and output tensors must
+     * be quantized and dequantized, respectively.
+     */
+    [[nodiscard]] virtual bool is_quantized() const noexcept = 0;
+    /*
+     * Iff `is_quantized() == true`, this returns the original, unquantized tensor type as
+     * defined in the document type schema. Otherwise, returns the same type as getTensorType().
+     */
+    [[nodiscard]] virtual const vespalib::eval::ValueType& unquantized_tensor_type() const noexcept = 0;
+    /*
+     * Returns a new TensorDequantizer instance that can be used to transform stored, quantized
+     * tensors to a shape and type matching `unquantized_tensor_type()`.
+     *
+     * A TensorDequantizer constructed from one TensorAttribute must never be attempted used
+     * on the tensor data retrieved from another, unrelated TensorAttribute.
+     *
+     * Important: individual TensorDequantizer instances are _not_ thread safe.
+     *
+     * Precondition: `is_quantized() == true`
+     */
+    [[nodiscard]] virtual std::unique_ptr<TensorDequantizer> make_dequantizer() const = 0;
 
-    virtual DistanceFunctionFactory& distance_function_factory() const = 0;
-    virtual const NearestNeighborIndex* nearest_neighbor_index() const { return nullptr; }
+    [[nodiscard]] virtual std::unique_ptr<vespalib::eval::Value> getTensor(uint32_t docId) const = 0;
+    [[nodiscard]] virtual std::unique_ptr<vespalib::eval::Value> getEmptyTensor() const = 0;
+    [[nodiscard]] virtual vespalib::eval::TypedCells extract_cells_ref(uint32_t docid) const = 0;
+    [[nodiscard]] virtual const vespalib::eval::Value& get_tensor_ref(uint32_t docid) const = 0;
+    [[nodiscard]] virtual SerializedTensorRef get_serialized_tensor_ref(uint32_t docid) const = 0;
+    [[nodiscard]] virtual bool supports_extract_cells_ref() const = 0;
+    [[nodiscard]] virtual bool supports_get_tensor_ref() const = 0;
+    [[nodiscard]] virtual bool supports_get_serialized_tensor_ref() const = 0;
+
+    [[nodiscard]] virtual const vespalib::eval::ValueType& getTensorType() const = 0;
+
+    [[nodiscard]] virtual DistanceFunctionFactory& distance_function_factory() const = 0;
+    [[nodiscard]] virtual const NearestNeighborIndex* nearest_neighbor_index() const { return nullptr; }
     using DistanceMetric = search::attribute::DistanceMetric;
-    virtual DistanceMetric distance_metric() const = 0;
-    virtual uint32_t get_num_docs() const = 0;
+    [[nodiscard]] virtual DistanceMetric distance_metric() const = 0;
+    [[nodiscard]] virtual uint32_t get_num_docs() const = 0;
 
     /**
      * Creates a state explorer for this tensor attribute.
      */
-    virtual std::unique_ptr<vespalib::StateExplorer> make_state_explorer() const = 0;
+    [[nodiscard]] virtual std::unique_ptr<vespalib::StateExplorer> make_state_explorer() const = 0;
 };
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.cpp
@@ -3,6 +3,7 @@
 #include "imported_tensor_attribute_vector_read_guard.h"
 
 #include "serialized_tensor_ref.h"
+#include "tensor_quantization.h"
 #include "vector_bundle.h"
 
 #include <vespa/eval/eval/value.h>
@@ -32,6 +33,18 @@ ImportedTensorAttributeVectorReadGuard::~ImportedTensorAttributeVectorReadGuard(
 
 const ITensorAttribute* ImportedTensorAttributeVectorReadGuard::asTensorAttribute() const {
     return this;
+}
+
+bool ImportedTensorAttributeVectorReadGuard::is_quantized() const noexcept {
+    return _target_tensor_attribute.is_quantized();
+}
+
+const vespalib::eval::ValueType& ImportedTensorAttributeVectorReadGuard::unquantized_tensor_type() const noexcept {
+    return _target_tensor_attribute.unquantized_tensor_type();
+}
+
+std::unique_ptr<TensorDequantizer> ImportedTensorAttributeVectorReadGuard::make_dequantizer() const {
+    return _target_tensor_attribute.make_dequantizer();
 }
 
 std::unique_ptr<vespalib::eval::Value> ImportedTensorAttributeVectorReadGuard::getTensor(uint32_t docId) const {

--- a/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/tensor/imported_tensor_attribute_vector_read_guard.h
@@ -32,6 +32,9 @@ public:
 
     const ITensorAttribute* asTensorAttribute() const override;
 
+    bool is_quantized() const noexcept override;
+    const vespalib::eval::ValueType& unquantized_tensor_type() const noexcept override;
+    std::unique_ptr<TensorDequantizer> make_dequantizer() const override;
     std::unique_ptr<vespalib::eval::Value> getTensor(uint32_t docId) const override;
     std::unique_ptr<vespalib::eval::Value> getEmptyTensor() const override;
     vespalib::eval::TypedCells extract_cells_ref(uint32_t docid) const override;

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_factory.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_factory.h
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <vespa/eval/eval/value_type.h>
+#include <vespa/searchcommon/attribute/quantization_params.h>
 
 #include <memory>
+#include <optional>
 
 namespace search::attribute {
 class HnswIndexParams;
@@ -21,9 +23,11 @@ class NearestNeighborIndex;
 class NearestNeighborIndexFactory {
 public:
     virtual ~NearestNeighborIndexFactory() = default;
-    virtual std::unique_ptr<NearestNeighborIndex> make(const DocVectorAccess& vectors, size_t vector_size,
-                                                       bool multi_vector_index, vespalib::eval::CellType cell_type,
-                                                       const search::attribute::HnswIndexParams& params) const = 0;
+
+    [[nodiscard]] virtual std::unique_ptr<NearestNeighborIndex>
+    make(const DocVectorAccess& vectors, size_t vector_size, bool multi_vector_index,
+         vespalib::eval::CellType cell_type, const search::attribute::HnswIndexParams& params,
+         const std::optional<attribute::QuantizationParams>& quant_params) const = 0;
 };
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
@@ -19,9 +19,11 @@
 #include <vespa/eval/eval/value.h>
 #include <vespa/eval/eval/value_codec.h>
 #include <vespa/searchcommon/attribute/config.h>
+#include <vespa/searchcommon/attribute/quantization_params.h>
 #include <vespa/searchlib/attribute/address_space_components.h>
 #include <vespa/searchlib/util/file_settings.h>
 #include <vespa/vespalib/datastore/i_compaction_context.h>
+#include <vespa/vespalib/quant/eden.h>
 #include <vespa/vespalib/util/shared_string_repo.h>
 #include <vespa/vespalib/util/size_literals.h>
 
@@ -53,16 +55,65 @@ std::string makeWrongTensorTypeMsg(const ValueType& fieldTensorType, const Value
                                  fieldTensorType.to_spec().c_str(), tensorType.to_spec().c_str());
 }
 
+vespalib::quant::QuantMode to_vespalib_quant_mode(attribute::QuantizationParams::QuantizationMode mode) noexcept {
+    switch (mode) {
+    case attribute::QuantizationParams::QuantizationMode::MSE:
+        return vespalib::quant::QuantMode::MSE;
+    case attribute::QuantizationParams::QuantizationMode::InnerProduct:
+        return vespalib::quant::QuantMode::InnerProduct;
+    }
+    abort();
+}
+
+class TensorQuantizerImpl final : public TensorQuantizer, public TensorDequantizer {
+    const vespalib::eval::ValueType& _full_precision_type;
+    const vespalib::eval::ValueType& _quantized_type;
+    vespalib::quant::EdenQuantizer   _quantizer;
+    std::vector<float>               _quant_scratch_buf;
+    vespalib::quant::QuantMode       _quant_mode;
+
+public:
+    TensorQuantizerImpl(const vespalib::eval::ValueType&     full_precision_type,
+                        const vespalib::eval::ValueType&     quantized_type,
+                        const attribute::QuantizationParams& quant_params)
+        : _full_precision_type(full_precision_type),
+          _quantized_type(quantized_type),
+          _quantizer(_full_precision_type.dense_subspace_size(), quant_params.bits(), quant_params.seed()),
+          _quant_scratch_buf(), // lazily allocated, iff needed
+          _quant_mode(to_vespalib_quant_mode(quant_params.quantization_mode())) {}
+
+    ~TensorQuantizerImpl() override;
+
+    std::unique_ptr<vespalib::eval::Value> quantize(const vespalib::eval::Value& full_precision_tensor) override {
+        if (!TensorDataType::isAssignableType(_full_precision_type, full_precision_tensor.type())) [[unlikely]] {
+            throw WrongTensorTypeException(makeWrongTensorTypeMsg(_full_precision_type, full_precision_tensor.type()),
+                                           VESPA_STRLOC);
+        }
+        return quantize_tensor(full_precision_tensor, _quantized_type, _quantizer, _quant_mode, _quant_scratch_buf);
+    }
+
+    // This works transparently for the output of getTensor and get_tensor_ref
+    // TODO also make one that works for get_serialized_tensor_ref?
+    std::unique_ptr<vespalib::eval::Value> dequantize(const vespalib::eval::Value& quantized_tensor) override {
+        return dequantize_tensor(quantized_tensor, _full_precision_type, _quantizer, _quant_scratch_buf);
+    }
+};
+
+TensorQuantizerImpl::~TensorQuantizerImpl() = default;
+
 } // namespace
 
-TensorAttribute::TensorAttribute(std::string_view name, const Config& cfg, TensorStore& tensorStore,
+TensorAttribute::TensorAttribute(std::string_view name, const Config& cfg, TensorStore& tensor_store,
                                  const NearestNeighborIndexFactory& index_factory)
     : NotImplementedAttribute(name, cfg),
       _refVector(cfg.getGrowStrategy(), getGenerationHolder()),
-      _tensorStore(tensorStore),
-      _distance_function_factory(make_distance_function_factory(cfg.distance_metric(), cfg.tensorType().cell_type())),
+      _tensorStore(tensor_store),
+      _distance_function_factory(make_distance_function_factory(cfg.distance_metric(), cfg.tensorType().cell_type(),
+                                                                cfg.unquantized_tensor_type().dense_subspace_size(),
+                                                                cfg.quantization_params())),
       _index(),
       _is_dense(cfg.tensorType().is_dense()),
+      _is_quantized(cfg.quantization_params().has_value()),
       _emptyTensor(createEmptyTensor(cfg.tensorType())),
       _compactGeneration(0),
       _subspace_type(cfg.tensorType()),
@@ -71,10 +122,10 @@ TensorAttribute::TensorAttribute(std::string_view name, const Config& cfg, Tenso
       _memory_usage_at_save_start(0),
       _size_on_disk_factor(1.0) {
     if (cfg.hnsw_index_params().has_value()) {
-        auto   tensor_type = cfg.tensorType();
-        size_t vector_size = tensor_type.dense_subspace_size();
-        _index = index_factory.make(*this, vector_size, !_is_dense, tensor_type.cell_type(),
-                                    cfg.hnsw_index_params().value());
+        // Note that we always pass the dimensionality of the unquantized (original) tensor type
+        size_t vector_size = cfg.unquantized_tensor_type().dense_subspace_size();
+        _index = index_factory.make(*this, vector_size, !_is_dense, cfg.tensorType().cell_type(),
+                                    cfg.hnsw_index_params().value(), cfg.quantization_params());
     }
 }
 
@@ -231,6 +282,10 @@ const vespalib::eval::ValueType& TensorAttribute::getTensorType() const {
     return getConfig().tensorType();
 }
 
+const vespalib::eval::ValueType& TensorAttribute::unquantized_tensor_type() const noexcept {
+    return getConfig().unquantized_tensor_type();
+}
+
 DistanceFunctionFactory& TensorAttribute::distance_function_factory() const {
     return *_distance_function_factory;
 }
@@ -307,6 +362,11 @@ void TensorAttribute::setTensor(DocId docId, const Value& tensor) {
 
 void TensorAttribute::update_tensor(DocId docId, const document::TensorUpdate& update,
                                     bool create_empty_if_non_existing) {
+    // It never makes sense to do a low-level read-modify-write update with an arbitrary
+    // higher-level TensorUpdate when the tensor is quantized. This is because we'll end
+    // up applying the update on the implementation-specific raw quantized int8 representation
+    // rather than the (expected) full precision representation, with "exciting" results.
+    assert(!_is_quantized);
     const vespalib::eval::Value* old_v = nullptr;
     auto                         old_tensor = getTensor(docId);
     if (old_tensor) {
@@ -453,6 +513,18 @@ void TensorAttribute::reclaim_unused_memory() {
             _index->reclaim_memory(oldest_used_gen);
         }
     }
+}
+
+std::unique_ptr<TensorQuantizer> TensorAttribute::make_quantizer() const {
+    assert(_is_quantized);
+    return std::make_unique<TensorQuantizerImpl>(unquantized_tensor_type(), getTensorType(),
+                                                 *getConfig().quantization_params());
+}
+
+std::unique_ptr<TensorDequantizer> TensorAttribute::make_dequantizer() const {
+    assert(_is_quantized);
+    return std::make_unique<TensorQuantizerImpl>(unquantized_tensor_type(), getTensorType(),
+                                                 *getConfig().quantization_params());
 }
 
 } // namespace search::tensor

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.h
@@ -5,6 +5,7 @@
 #include "i_tensor_attribute.h"
 #include "prepare_result.h"
 #include "subspace_type.h"
+#include "tensor_quantization.h"
 #include "tensor_store.h"
 #include "typed_cells_comparator.h"
 
@@ -37,6 +38,7 @@ protected:
     std::unique_ptr<DistanceFunctionFactory> _distance_function_factory;
     std::unique_ptr<NearestNeighborIndex>    _index;
     bool                                     _is_dense;
+    bool                                     _is_quantized;
     std::unique_ptr<vespalib::eval::Value>   _emptyTensor;
     vespalib::Generation                     _compactGeneration; // Generation when last compact occurred
     SubspaceType                             _subspace_type;
@@ -62,10 +64,27 @@ protected:
     void setup_memory_usage_empty();
 
 public:
-    TensorAttribute(std::string_view name, const Config& cfg, TensorStore& tensorStore,
+    TensorAttribute(std::string_view name, const Config& cfg, TensorStore& tensor_store,
                     const NearestNeighborIndexFactory& index_factory);
     ~TensorAttribute() override;
     const ITensorAttribute* asTensorAttribute() const override;
+
+    [[nodiscard]] bool is_quantized() const noexcept final { return _is_quantized; }
+    [[nodiscard]] const vespalib::eval::ValueType& unquantized_tensor_type() const noexcept final;
+    /*
+     * Returns a new TensorQuantizer instance that can be used to transform full-precision
+     * input tensors of the schema-configured tensor type to a quantized shape and type
+     * matching `unquantized_tensor_type()`.
+     *
+     * A TensorQuantizer constructed from one TensorAttribute must never be attempted used
+     * on the tensor data inserted into another, unrelated TensorAttribute.
+     *
+     * Important: individual TensorQuantizer instances are _not_ thread safe.
+     *
+     * Precondition: is_quantized() == true
+     */
+    [[nodiscard]] std::unique_ptr<TensorQuantizer> make_quantizer() const;
+    [[nodiscard]] std::unique_ptr<TensorDequantizer> make_dequantizer() const override;
 
     uint32_t clearDoc(DocId docId) override;
     void onCommit() override;

--- a/searchlib/src/vespa/searchlib/tensor/tensor_ext_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_ext_attribute.cpp
@@ -41,6 +41,9 @@ TensorExtAttribute::TensorExtAttribute(const std::string& name, const Config& cf
       _subspace_type(cfg.tensorType()),
       _empty(_subspace_type),
       _empty_tensor(create_empty_tensor(cfg.tensorType())) {
+    // Streaming search pseudo-attributes operate on the raw, full-precision document data
+    // and should therefore never be quantized.
+    assert(!cfg.quantization_params().has_value());
 }
 
 TensorExtAttribute::~TensorExtAttribute() = default;
@@ -84,6 +87,18 @@ VectorBundle TensorExtAttribute::get_vectors(uint32_t docid) const noexcept {
         return {};
     }
     return {tensor->cells().data, static_cast<uint32_t>(tensor->index().size()), _subspace_type};
+}
+
+bool TensorExtAttribute::is_quantized() const noexcept {
+    return false;
+}
+
+const vespalib::eval::ValueType& TensorExtAttribute::unquantized_tensor_type() const noexcept {
+    return getConfig().tensorType();
+}
+
+std::unique_ptr<TensorDequantizer> TensorExtAttribute::make_dequantizer() const {
+    notImplemented();
 }
 
 std::unique_ptr<Value> TensorExtAttribute::getTensor(uint32_t docid) const {

--- a/searchlib/src/vespa/searchlib/tensor/tensor_ext_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_ext_attribute.h
@@ -39,6 +39,9 @@ public:
     VectorBundle get_vectors(uint32_t docid) const noexcept override;
 
     // ITensorAttribute API
+    bool is_quantized() const noexcept override;
+    const vespalib::eval::ValueType& unquantized_tensor_type() const noexcept override;
+    std::unique_ptr<TensorDequantizer> make_dequantizer() const override;
     std::unique_ptr<vespalib::eval::Value> getTensor(uint32_t docid) const override;
     std::unique_ptr<vespalib::eval::Value> getEmptyTensor() const override;
     vespalib::eval::TypedCells extract_cells_ref(uint32_t docid) const override;

--- a/searchlib/src/vespa/searchlib/tensor/tensor_quantization.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_quantization.h
@@ -86,5 +86,44 @@ namespace search::tensor {
 dequantize_tensor(const vespalib::eval::Value& quantized_in_tensor, const vespalib::eval::ValueType& out_tensor_type,
                   vespalib::quant::EdenQuantizer& quantizer, std::vector<float>& scratch_space);
 
+/*
+ * Transforms input tensors from full precision to an opaque, quantized representation. The
+ * input and output types depend on the TensorAttribute the TensorQuantizer was created from,
+ * and the quantizer must never be used with another unrelated TensorAttribute instance.
+ *
+ * Lifetime must not exceed that of the tensor attribute the quantizer was created from.
+ */
+class TensorQuantizer {
+public:
+    virtual ~TensorQuantizer() = default;
+
+    // Returns a new tensor value that is a quantized representation of `full_precision_tensor`
+    // that is suitable for inserting into the quantized tensor attribute this TensorQuantizer
+    // was created by.
+    // Note: _not_ thread safe.
+    [[nodiscard]] virtual std::unique_ptr<vespalib::eval::Value>
+    quantize(const vespalib::eval::Value& full_precision_tensor) = 0;
+};
+
+/*
+ * Transforms input tensors from a quantized representation to an _approximation_ of the original
+ * input full precision tensor, which was previously created by a TensorQuantizer for the same
+ * TensorAttribute. The input and output types depend on the TensorAttribute the TensorDequantizer
+ * was created from, and the dequantizer must never be used with another unrelated TensorAttribute
+ * instance.
+ *
+ * Lifetime must not exceed that of the tensor attribute the dequantizer was created from.
+ */
+class TensorDequantizer {
+public:
+    virtual ~TensorDequantizer() = default;
+
+    // Returns a new tensor value that is a dequantized version of `quantized_tensor`. The
+    // returned tensor has the same type as the configured (unquantized) tensor type of the
+    // attribute this TensorDequantizer was created by.
+    // Note: _not_ thread safe.
+    [[nodiscard]] virtual std::unique_ptr<vespalib::eval::Value>
+    dequantize(const vespalib::eval::Value& quantized_tensor) = 0;
+};
 
 } // namespace search::tensor


### PR DESCRIPTION
@arnej27959 please review. Many of the added lines are comments.

The search core-internal attribute `Config` can now be set up with an explicitly quantized tensor type. This internally transforms the input tensor type to the corresponding quantized tensor type, and uses the quantized type as the stored tensor type. The original (unquantized) tensor type is also made available. For non-quantized tensors, these types are always identical.

Doing the tensor type transformation as early as possible is done to minimize the amount of places we can get out of sync between what the schema says the tensor type should be, and what the actual underlying tensor attribute type ends up being.

`TensorAttribute` now picks up the added quantization config. When quantized, the attribute supports creating `TensorQuantizer` and `TensorDequantizer` instances that can be used for transforming input and output tensors to the correct representations.

Quantization config is now also used when selecting the appropriate distance function factory, both for the attribute and the related HNSW index (if any).

Note that it is the responsibility of `TensorAttribute` users to ensure that they transform tensors both on the input and output paths, if needed. Distance function calculations now transparently handle quantized tensors, so they do not need to do any transforms.

Wiring in quantization-awareness for the rest of the search core is out of scope for this commit.

