### PR TITLE
Do not reprocess removed quantized attributes to the doc store 

### DIFF
--- a/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/attribute_reprocessing_initializer_test.cpp
+++ b/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/attribute_reprocessing_initializer_test.cpp
@@ -70,6 +70,9 @@ struct MyConfig {
             if (attr == "tensor") {
                 _mgr->addAttribute({attr, AttributeUtils::getTensorConfig()}, 1);
                 _schema.addAttributeField(Schema::AttributeField(attr, DataType::TENSOR));
+            } else if (attr == "quantized_tensor") {
+                _mgr->addAttribute({attr, AttributeUtils::get_quantized_tensor_config()}, 1);
+                _schema.addAttributeField(Schema::AttributeField(attr, DataType::TENSOR));
             } else if (attr == "predicate") {
                 _mgr->addAttribute({attr, AttributeUtils::getPredicateConfig()}, 1);
                 _schema.addAttributeField(Schema::AttributeField(attr, DataType::BOOLEANTREE));
@@ -260,6 +263,13 @@ TEST_F(InitializerTest, require_that_removing_attribute_aspect_from_tensor_field
 TEST_F(InitializerTest, require_that_predicate_fields_are_not_populated_from_attribute) {
     addOldConfig({"a", "b", "c", "d", "predicate"}, {"a", "b", "c", "d", "predicate"})
         .addNewConfig({"a", "b", "c", "d", "predicate"}, {"a", "b"})
+        .init();
+    assertFields({"c", "d"});
+}
+
+TEST_F(InitializerTest, quantized_tensor_fields_are_not_populated_from_attribute) {
+    addOldConfig({"a", "b", "c", "d", "quantized_tensor"}, {"a", "b", "c", "d", "quantized_tensor"})
+        .addNewConfig({"a", "b", "c", "d", "quantized_tensor"}, {"a", "b"})
         .init();
     assertFields({"c", "d"});
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/document_field_retriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/document_field_retriever.cpp
@@ -140,7 +140,8 @@ void set_raw_value(DocumentIdT lid, Document& doc, const document::Field& field,
 
 void setTensorValue(DocumentIdT lid, Document& doc, const document::Field& field, const IAttributeVector& attr) {
     const auto& tensorAttribute = static_cast<const TensorAttribute&>(attr);
-    auto        tensor = tensorAttribute.getTensor(lid);
+    assert(!tensorAttribute.is_quantized()); // Should never populate document fields from lossy, quantized attribute
+    auto tensor = tensorAttribute.getTensor(lid);
     if (tensor) {
         auto tensorField = field.createValue();
         dynamic_cast<TensorFieldValue&>(*tensorField) = std::move(tensor);

--- a/searchcore/src/vespa/searchcore/proton/test/attribute_utils.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/attribute_utils.cpp
@@ -10,6 +10,7 @@ using search::CommitParam;
 using search::attribute::BasicType;
 using search::attribute::CollectionType;
 using search::attribute::Config;
+using search::attribute::QuantizationParams;
 
 namespace proton::test {
 
@@ -64,10 +65,22 @@ Config tensorConfig() {
     return Config(BasicType::TENSOR).setTensorType(vespalib::eval::ValueType::from_spec("tensor(x{},y{})"));
 }
 
+Config quantized_tensor_config() {
+    constexpr uint64_t seed = 0x1234567890;
+    QuantizationParams qp(seed, QuantizationParams::QuantizationMode::MSE, 4);
+    return Config(BasicType::TENSOR)
+        .set_tensor_type_with_quantization(vespalib::eval::ValueType::from_spec("tensor(x{},y[128])"), qp);
+}
+
 } // namespace
 
 const Config& AttributeUtils::getTensorConfig() {
     static Config cfg = tensorConfig();
+    return cfg;
+}
+
+const Config& AttributeUtils::get_quantized_tensor_config() {
+    static Config cfg = quantized_tensor_config();
     return cfg;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/test/attribute_utils.h
+++ b/searchcore/src/vespa/searchcore/proton/test/attribute_utils.h
@@ -22,6 +22,7 @@ struct AttributeUtils {
     static const Config& getStringConfig();
     static const Config& getPredicateConfig();
     static const Config& getTensorConfig();
+    static const Config& get_quantized_tensor_config();
     static const Config& get_bool_config();
 };
 

--- a/searchlib/src/vespa/searchcommon/attribute/attribute_utils.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/attribute_utils.cpp
@@ -7,9 +7,10 @@
 namespace search::attribute {
 
 bool isUpdateableInMemoryOnly(const std::string& attrName, const Config& cfg) {
-    auto basicType = cfg.basicType().type();
+    const auto basicType = cfg.basicType().type();
+    const bool is_quantized_tensor = (basicType == BasicType::Type::TENSOR && cfg.quantization_params().has_value());
     return ((basicType != BasicType::Type::PREDICATE) && (basicType != BasicType::Type::REFERENCE)) &&
-           !isStructFieldAttribute(attrName);
+           !is_quantized_tensor && !isStructFieldAttribute(attrName);
 }
 
 bool isStructFieldAttribute(const std::string& attrName) {


### PR DESCRIPTION
@toregge please review. Followup of #37419.
@arnej27959 FYI.

The source of truth for quantized attributes is already in the doc store, so trying to write-back the attribute state to disk upon attribute removal will only end in sadness.

Also assert that `DocumentFieldRetriever` doesn't populate from quantized attributes.