### PR TITLE
Use size_t for column width in interator benchmark test.

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/iterator_benchmark_test.cpp
@@ -677,7 +677,7 @@ void print_cell(const std::string& value, size_t width, bool left_align) {
 }
 
 struct Column {
-    uint64_t width = 4;
+    size_t width = 4;
 };
 
 /**


### PR DESCRIPTION
@vekterli : please review
