### PR TITLE
Include string_view to get declaration of std::string_view

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/isearchcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/isearchcontext.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string_view>
 
 namespace search::queryeval {
 class Searchable;


### PR DESCRIPTION
in search context interface.

@vekterli : please review
@boeker : FYI
