### PR TITLE
Harden logstash-output-vespa YAML loading with SafeConstructor

### DIFF
--- a/integration/logstash-plugins/logstash-output-vespa/src/main/java/org/logstashplugins/VespaAppPackageWriter.java
+++ b/integration/logstash-plugins/logstash-output-vespa/src/main/java/org/logstashplugins/VespaAppPackageWriter.java
@@ -18,7 +18,9 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.LockException;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public class VespaAppPackageWriter {
     private final QuickStartConfig config;
@@ -401,7 +403,7 @@ public class VespaAppPackageWriter {
 
         logger.info("Loading type conflict resolution from {}", source);
         try (InputStream is = resolutionStream) {
-            Yaml yaml = new Yaml();
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
             return yaml.load(is);
         } catch (IOException e) {
             logger.error("Error loading type conflict resolution: {}", e.getMessage());

--- a/integration/logstash-plugins/logstash-output-vespa/src/main/java/org/logstashplugins/VespaQuickStarter.java
+++ b/integration/logstash-plugins/logstash-output-vespa/src/main/java/org/logstashplugins/VespaQuickStarter.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 
 import org.logstash.ObjectMappers;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public class VespaQuickStarter {
     private static final Logger logger = LogManager.getLogger(VespaQuickStarter.class);
@@ -207,7 +209,7 @@ public class VespaQuickStarter {
 
         logger.info("Loading type mappings from {}", source);
         try (InputStream is = mappingStream) {
-            Yaml yaml = new Yaml();
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
             Map<String, List<String>> typeConfigs = yaml.load(is);
             
             Map<String, List<String>> mappings = new HashMap<>();


### PR DESCRIPTION
# PR title
Harden logstash-output-vespa YAML loading with SafeConstructor

# PR body

## What

Restrict the SnakeYAML parsers in `logstash-output-vespa` to standard YAML
types by passing a `SafeConstructor`:

```java
Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
```

Changed in the two places the plugin parses a YAML file:

- `VespaAppPackageWriter.loadTypeConflictResolution()` (`type_conflict_resolution.yml`)
- `VespaQuickStarter.loadTypeMappings()` (`type_mappings.yml`)

## Why

Both sinks currently use the default `new Yaml()`, whose `Constructor`
resolves arbitrary `!!java.*` global tags and can instantiate arbitrary
classes on the classpath during `load()`. These loaders read from a
classpath resource by default, but can be pointed at an operator-supplied
file via the `type_conflict_resolution_file` / `type_mappings_file` settings.

This is **not a remotely exploitable vulnerability** — the file paths are
static `PluginConfigSpec.stringSetting`s read from `logstash.conf`, no event
data reaches the parser, and an actor who can supply the file already has
local code-execution equivalence via Logstash's `ruby{}` filter. So this is
defense-in-depth / hygiene, not a security fix.

`SafeConstructor` restricts parsing to the standard YAML types (maps, lists,
strings, numbers, booleans, null), which is exactly what both files contain,
so parsing of all legitimate mapping/resolution files is unchanged.

## Compatibility

- SnakeYAML 2.6 is already the pinned version (`snakeYamlVersion = '2.6'`),
  which provides `SafeConstructor(LoaderOptions)`.
- Return types are unchanged (`Map<String, Map<String, String>>` and
  `Map<String, List<String>>`).
- No API or config surface changes.
