### PR TITLE
Optimize hex encoding of dense tensor values in JsonFormat

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -149,67 +149,108 @@ public class JsonFormat {
             addressObject.setString(type.dimensions().get(i).name(), address.label(i));
     }
 
-    private static final char[] hexDigits = {
-        '0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
-    };
+    private static final byte[] hexDigits = "0123456789ABCDEF".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
 
-
-    private static String asHexString(IndexedTensor tensor) {
-        return asHexString(tensor.sizeAsInt(),
-                           tensor.type().valueType(),
-                           i -> tensor.get(i),
-                           i -> tensor.getFloat(i));
+    /** Two hex chars (as UTF-8 bytes) per byte value: hexPairs[b*2], hexPairs[b*2+1] */
+    private static final byte[] hexPairs = new byte[512];
+    static {
+        for (int b = 0; b < 256; b++) {
+            hexPairs[b * 2] = hexDigits[b >>> 4];
+            hexPairs[b * 2 + 1] = hexDigits[b & 0xF];
+        }
     }
 
-    private static String asHexString(int denseSize,
-                                      TensorType.Value cellType,
-                                      Function<Integer, Double> dblSrc,
-                                      Function<Integer, Float> fltSrc)
-    {
-        StringBuilder buf = new StringBuilder();
+
+    private static byte[] asHexString(IndexedTensor tensor) {
+        int denseSize = tensor.sizeAsInt();
+        TensorType.Value cellType = tensor.type().valueType();
+        byte[] buf = new byte[denseSize * hexCharsPerCell(cellType)];
+        int pos = 0;
         switch (cellType) {
             case DOUBLE:
-                for (int i = 0; i < denseSize; i++) {
-                    double d = dblSrc.apply(i);
-                    long bits = Double.doubleToRawLongBits(d);
-                    for (int nibble = 16; nibble-- > 0; ) {
-                        int digit = (int) (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexDouble(buf, pos, tensor.get(i));
                 break;
             case FLOAT:
-                for (int i = 0; i < denseSize; i++) {
-                    float f = fltSrc.apply(i);
-                    int bits = Float.floatToRawIntBits(f);
-                    for (int nibble = 8; nibble-- > 0; ) {
-                        int digit = (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexFloat(buf, pos, tensor.getFloat(i));
                 break;
             case BFLOAT16:
-                for (int i = 0; i < denseSize; i++) {
-                    float f = fltSrc.apply(i);
-                    int bits = Float.floatToRawIntBits(f);
-                    for (int nibble = 8; nibble-- > 4; ) {
-                        int digit = (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexBFloat16(buf, pos, tensor.getFloat(i));
                 break;
             case INT8:
-                for (int i = 0; i < denseSize; i++) {
-                    byte bits = fltSrc.apply(i).byteValue();
-                    for (int nibble = 2; nibble-- > 0; ) {
-                        int digit = (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexByte(buf, pos, (byte) tensor.getFloat(i));
                 break;
         }
-        return buf.toString();
+        return buf;
+    }
+
+    private static byte[] asHexString(double[] cells, TensorType.Value cellType) {
+        byte[] buf = new byte[cells.length * hexCharsPerCell(cellType)];
+        int pos = 0;
+        switch (cellType) {
+            case DOUBLE:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexDouble(buf, pos, cells[i]);
+                break;
+            case FLOAT:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexFloat(buf, pos, (float) cells[i]);
+                break;
+            case BFLOAT16:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexBFloat16(buf, pos, (float) cells[i]);
+                break;
+            case INT8:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexByte(buf, pos, (byte) (float) cells[i]);
+                break;
+        }
+        return buf;
+    }
+
+    private static int hexCharsPerCell(TensorType.Value cellType) {
+        return switch (cellType) {
+            case DOUBLE -> 16;
+            case FLOAT -> 8;
+            case BFLOAT16 -> 4;
+            case INT8 -> 2;
+        };
+    }
+
+    private static int putHexDouble(byte[] buf, int pos, double value) {
+        long bits = Double.doubleToRawLongBits(value);
+        pos = putHexByte(buf, pos, (int) (bits >>> 56));
+        pos = putHexByte(buf, pos, (int) (bits >>> 48));
+        pos = putHexByte(buf, pos, (int) (bits >>> 40));
+        pos = putHexByte(buf, pos, (int) (bits >>> 32));
+        pos = putHexByte(buf, pos, (int) (bits >>> 24));
+        pos = putHexByte(buf, pos, (int) (bits >>> 16));
+        pos = putHexByte(buf, pos, (int) (bits >>> 8));
+        return putHexByte(buf, pos, (int) bits);
+    }
+
+    private static int putHexFloat(byte[] buf, int pos, float value) {
+        int bits = Float.floatToRawIntBits(value);
+        pos = putHexByte(buf, pos, bits >>> 24);
+        pos = putHexByte(buf, pos, bits >>> 16);
+        pos = putHexByte(buf, pos, bits >>> 8);
+        return putHexByte(buf, pos, bits);
+    }
+
+    private static int putHexBFloat16(byte[] buf, int pos, float value) {
+        int bits = Float.floatToRawIntBits(value);
+        pos = putHexByte(buf, pos, bits >>> 24);
+        return putHexByte(buf, pos, bits >>> 16);
+    }
+
+    private static int putHexByte(byte[] buf, int pos, int byteValue) {
+        int b = (byteValue & 0xFF) * 2;
+        buf[pos] = hexPairs[b];
+        buf[pos + 1] = hexPairs[b + 1];
+        return pos + 2;
     }
 
     private static void encodeDenseValues(IndexedTensor tensor, Cursor target) {
@@ -233,10 +274,7 @@ public class JsonFormat {
 
     private static void encodeLabeledSubspace(String label, MixedTensor.DenseSubspace subspace, TensorType denseSubType, Cursor cursor, boolean hexForDensePart) {
         if (hexForDensePart) {
-            cursor.setString(label, asHexString(subspace.cells.length,
-                                                denseSubType.valueType(),
-                                                i -> subspace.cells[i],
-                                                i -> (float)subspace.cells[i]));
+            cursor.setString(label, asHexString(subspace.cells, denseSubType.valueType()));
         } else {
             IndexedTensor denseSubspace = IndexedTensor.Builder.of(denseSubType, subspace.cells).build();
             var target = cursor.setArray(label);

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -149,67 +149,108 @@ public class JsonFormat {
             addressObject.setString(type.dimensions().get(i).name(), address.label(i));
     }
 
-    private static final char[] hexDigits = {
-        '0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
-    };
+    private static final byte[] hexDigits = "0123456789ABCDEF".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
 
-
-    private static String asHexString(IndexedTensor tensor) {
-        return asHexString(tensor.sizeAsInt(),
-                           tensor.type().valueType(),
-                           i -> tensor.get(i),
-                           i -> tensor.getFloat(i));
+    /** Two hex chars (as UTF-8 bytes) per byte value: hexPairs[b*2], hexPairs[b*2+1] */
+    private static final byte[] hexPairs = new byte[512];
+    static {
+        for (int b = 0; b < 256; b++) {
+            hexPairs[b * 2] = hexDigits[b >>> 4];
+            hexPairs[b * 2 + 1] = hexDigits[b & 0xF];
+        }
     }
 
-    private static String asHexString(int denseSize,
-                                      TensorType.Value cellType,
-                                      Function<Integer, Double> dblSrc,
-                                      Function<Integer, Float> fltSrc)
-    {
-        StringBuilder buf = new StringBuilder();
+
+    private static byte[] asHexString(IndexedTensor tensor) {
+        int denseSize = tensor.sizeAsInt();
+        TensorType.Value cellType = tensor.type().valueType();
+        byte[] buf = new byte[denseSize * hexCharsPerCell(cellType)];
+        int pos = 0;
         switch (cellType) {
             case DOUBLE:
-                for (int i = 0; i < denseSize; i++) {
-                    double d = dblSrc.apply(i);
-                    long bits = Double.doubleToRawLongBits(d);
-                    for (int nibble = 16; nibble-- > 0; ) {
-                        int digit = (int) (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexDouble(buf, pos, tensor.get(i));
                 break;
             case FLOAT:
-                for (int i = 0; i < denseSize; i++) {
-                    float f = fltSrc.apply(i);
-                    int bits = Float.floatToRawIntBits(f);
-                    for (int nibble = 8; nibble-- > 0; ) {
-                        int digit = (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexFloat(buf, pos, tensor.getFloat(i));
                 break;
             case BFLOAT16:
-                for (int i = 0; i < denseSize; i++) {
-                    float f = fltSrc.apply(i);
-                    int bits = Float.floatToRawIntBits(f);
-                    for (int nibble = 8; nibble-- > 4; ) {
-                        int digit = (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexBFloat16(buf, pos, tensor.getFloat(i));
                 break;
             case INT8:
-                for (int i = 0; i < denseSize; i++) {
-                    byte bits = fltSrc.apply(i).byteValue();
-                    for (int nibble = 2; nibble-- > 0; ) {
-                        int digit = (bits >> (4 * nibble)) & 0xF;
-                        buf.append(hexDigits[digit]);
-                    }
-                }
+                for (int i = 0; i < denseSize; i++)
+                    pos = putHexByte(buf, pos, (byte) tensor.getFloat(i));
                 break;
         }
-        return buf.toString();
+        return buf;
+    }
+
+    private static byte[] asHexString(double[] cells, TensorType.Value cellType) {
+        byte[] buf = new byte[cells.length * hexCharsPerCell(cellType)];
+        int pos = 0;
+        switch (cellType) {
+            case DOUBLE:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexDouble(buf, pos, cells[i]);
+                break;
+            case FLOAT:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexFloat(buf, pos, (float) cells[i]);
+                break;
+            case BFLOAT16:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexBFloat16(buf, pos, (float) cells[i]);
+                break;
+            case INT8:
+                for (int i = 0; i < cells.length; i++)
+                    pos = putHexByte(buf, pos, (byte) (float) cells[i]);
+                break;
+        }
+        return buf;
+    }
+
+    private static int hexCharsPerCell(TensorType.Value cellType) {
+        return switch (cellType) {
+            case DOUBLE -> 16;
+            case FLOAT -> 8;
+            case BFLOAT16 -> 4;
+            case INT8 -> 2;
+        };
+    }
+
+    private static int putHexDouble(byte[] buf, int pos, double value) {
+        long bits = Double.doubleToLongBits(value);
+        pos = putHexByte(buf, pos, (int) (bits >>> 56));
+        pos = putHexByte(buf, pos, (int) (bits >>> 48));
+        pos = putHexByte(buf, pos, (int) (bits >>> 40));
+        pos = putHexByte(buf, pos, (int) (bits >>> 32));
+        pos = putHexByte(buf, pos, (int) (bits >>> 24));
+        pos = putHexByte(buf, pos, (int) (bits >>> 16));
+        pos = putHexByte(buf, pos, (int) (bits >>> 8));
+        return putHexByte(buf, pos, (int) bits);
+    }
+
+    private static int putHexFloat(byte[] buf, int pos, float value) {
+        int bits = Float.floatToIntBits(value);
+        pos = putHexByte(buf, pos, bits >>> 24);
+        pos = putHexByte(buf, pos, bits >>> 16);
+        pos = putHexByte(buf, pos, bits >>> 8);
+        return putHexByte(buf, pos, bits);
+    }
+
+    private static int putHexBFloat16(byte[] buf, int pos, float value) {
+        int bits = Float.floatToIntBits(value);
+        pos = putHexByte(buf, pos, bits >>> 24);
+        return putHexByte(buf, pos, bits >>> 16);
+    }
+
+    private static int putHexByte(byte[] buf, int pos, int byteValue) {
+        int b = (byteValue & 0xFF) * 2;
+        buf[pos] = hexPairs[b];
+        buf[pos + 1] = hexPairs[b + 1];
+        return pos + 2;
     }
 
     private static void encodeDenseValues(IndexedTensor tensor, Cursor target) {
@@ -233,10 +274,7 @@ public class JsonFormat {
 
     private static void encodeLabeledSubspace(String label, MixedTensor.DenseSubspace subspace, TensorType denseSubType, Cursor cursor, boolean hexForDensePart) {
         if (hexForDensePart) {
-            cursor.setString(label, asHexString(subspace.cells.length,
-                                                denseSubType.valueType(),
-                                                i -> subspace.cells[i],
-                                                i -> (float)subspace.cells[i]));
+            cursor.setString(label, asHexString(subspace.cells, denseSubType.valueType()));
         } else {
             IndexedTensor denseSubspace = IndexedTensor.Builder.of(denseSubType, subspace.cells).build();
             var target = cursor.setArray(label);


### PR DESCRIPTION
### Human side

The problem we ran into was that we have a dedicated vespa content cluster for internal embeddings (to send them to triton inference server for processing) but we store them as `raw` type to get the fastest query fetch times, but this requires us converting tensor types to raw bytes during ingestion which costs cpu and makes tensor lose type safety. We would like to use the native tensor type and to preserve the fetch times.

We tried using `hex` and `hex-value` types to render native tensors as HEX but this added ~5ms mean and ~15ms p99 latency when rendering tensor as HEX instead of just `raw` bytes.

**This change is mostly written by LLM and assisted by me** to reduce the number of allocations when rendering tensors as HEX and to reduce the rendering times.

### Summary

Optimizes `JsonFormat.asHexString`, the hex encoding of dense tensor values used when rendering tensors in JSON short form (`hex-value` / `hex`):

- **Preallocate an exact-size buffer** — cell count and cell type determine the output length up front, so a right-sized `byte[]` replaces a growing `StringBuilder` (no growth copies, no `toString()` copy).
- **512-entry hex pair table** — each byte is emitted as two chars via one table lookup instead of two shift/mask/nibble lookups; the per-value byte loops are unrolled.
- **Return UTF-8 `byte[]` instead of `String`** — hex output is pure ASCII, so the result is fed straight to Slime's `Inserter.insertSTRING(byte[] utf8)` / `Cursor.setString(String, byte[] utf8)` overloads. This skips both the `String` allocation and Slime's internal UTF-8 re-encoding of that String (same approach `TensorDataSource.asHexString` already uses).
- **Remove boxed value sources** — the `Function<Integer, Double>` / `Function<Integer, Float>` parameters boxed an `Integer` and a `Double`/`Float` per cell. The method only ever had two callers, so they are replaced by direct overloads: `asHexString(IndexedTensor)` and `asHexString(double[], TensorType.Value)`.

Output is byte-identical to the previous implementation (verified for all four cell types), with one intentional nuance: `floatToIntBits`/`doubleToLongBits` are used instead of the `Raw` variants, so non-canonical NaN bit patterns are canonicalized. JSON hex round-trips preserve NaN-ness either way.

### Benchmark

Rendering 1000 results, each a 1024-cell dense tensor. Allocations measured per thread via `ThreadMXBean.getThreadAllocatedBytes`; the "before" numbers include the UTF-8 re-encode Slime performed on the returned `String`. JDK 17 (Temurin 17.0.18), aarch64.

| cell type | alloc before | alloc after | alloc reduction | time before | time after | speedup |
|---|---|---|---|---|---|---|
| double   | 69.9 MB | 16.4 MB | **4.3x** | 24.0 ms | 3.7 ms | **6.5x** |
| float    | 35.0 MB | 8.2 MB  | **4.3x** | 12.4 ms | 2.4 ms | **5.2x** |
| bfloat16 | 48.3 MB | 4.1 MB  | **11.8x** | 14.2 ms | 1.4 ms | **10.0x** |
| int8     | 39.6 MB | 2.1 MB  | **19.2x** | 9.2 ms | 1.5 ms | **6.1x** |

After the change, rendering a tensor performs exactly one allocation: the right-sized output `byte[]` itself (e.g. int8: 2,064 bytes measured = `byte[2048]` + object header).
