### PR TITLE
GH-37198: fix type inference in the config-model for tensorFromLabelsWithOffset ranking expression

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -393,17 +393,6 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             }
         }
 
-        if (reference.name().equals("tensorFromLabelsWithOffset")) {
-            int numArgs = reference.arguments().size();
-            if (numArgs != 3) {
-                throw new IllegalArgumentException(reference + " must have 3 arguments, not " + numArgs + ": (attribute(myarray), label-dimension, offset-dimension)");
-            }
-            var builder = new TensorType.Builder(TensorType.Value.FLOAT);
-            builder.mapped(String.valueOf(arg1));
-            builder.mapped(String.valueOf(arg2));
-            return Optional.of(builder.build());
-        }
-
         // fill dimension from second argument if present:
         if (arg1 != null) {
             if ((arg1 instanceof NameNode) ||
@@ -414,6 +403,29 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
                 throw new IllegalArgumentException("The second argument of " + reference.name() +
                                                    " must be a dimension name, not " + arg1);
             }
+        }
+
+        if (reference.name().equals("tensorFromLabelsWithOffset")) {
+            int numArgs = reference.arguments().size();
+            if (numArgs != 3) {
+                throw new IllegalArgumentException(reference + " must have 3 arguments, not " + numArgs + ": (attribute(myarray), label-dimension, offset-dimension)");
+            }
+
+            var builder = new TensorType.Builder(TensorType.Value.FLOAT);
+            // the first dimension is already checked
+            builder.mapped(dimension);
+            if (arg2 != null) {
+                if ((arg2 instanceof NameNode) ||
+                        (arg2 instanceof ReferenceNode ref2 && ref2.reference().isIdentifier()))
+                {
+                    // it is safe to add a second dimension
+                    builder.mapped(arg2.toString());
+                } else  {
+                    throw new IllegalArgumentException("The third argument of " + reference.name() +
+                            " must be a dimension name, not " + arg2);
+                }
+            }
+            return Optional.of(builder.build());
         }
 
         if (dimension == null) {

--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -414,16 +414,12 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             var builder = new TensorType.Builder(TensorType.Value.FLOAT);
             // the first dimension is already checked
             builder.mapped(dimension);
-            if (arg2 != null) {
-                if ((arg2 instanceof NameNode) ||
-                        (arg2 instanceof ReferenceNode ref2 && ref2.reference().isIdentifier()))
-                {
-                    // it is safe to add a second dimension
-                    builder.mapped(arg2.toString());
-                } else  {
-                    throw new IllegalArgumentException("The third argument of " + reference.name() +
-                            " must be a dimension name, not " + arg2);
-                }
+            if ((arg2 instanceof NameNode) || (arg2 instanceof ReferenceNode ref2 && ref2.reference().isIdentifier())) {
+                  // it is safe to add a second dimension
+                  builder.mapped(arg2.toString());
+            } else  {
+                  throw new IllegalArgumentException("The third argument of " + reference.name() +
+                          " must be a dimension name, not " + arg2);
             }
             return Optional.of(builder.build());
         }

--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -297,8 +297,9 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
     }
 
     /**
-     * There are 6 features which may return (non-empty) tensor type:
+     * There are 7 features which may return (non-empty) tensor type:
      * - tensorFromLabels
+     * - tensorFromLabelsWithOffset
      * - tensorFromWeightedSet
      * - tensorFromStructs
      * - closest
@@ -313,6 +314,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             return Optional.of(new TensorType.Builder(TensorType.Value.DOUBLE).mapped("term").build());
         }
         if ( ! reference.name().equals("tensorFromLabels") &&
+             ! reference.name().equals("tensorFromLabelsWithOffset") &&
              ! reference.name().equals("tensorFromWeightedSet") &&
              ! reference.name().equals("tensorFromStructs") &&
              ! reference.name().equals("elementwise") &&
@@ -377,7 +379,8 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             return Optional.of(builder.build());
         }
         if (reference.name().equals("tensorFromLabels") ||
-            reference.name().equals("tensorFromWeightedSet"))
+            reference.name().equals("tensorFromWeightedSet") ||
+            reference.name().equals("tensorFromLabelsWithOffset"))
         {
             if (arg0 instanceof ReferenceNode arg0ref && FeatureNames.isSimpleFeature(arg0ref.reference())) {
                 if (arg1 == null) {
@@ -388,6 +391,17 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
                 throw new IllegalArgumentException("The first argument of " + reference.name() +
                                                    " must be a simple feature, not " + arg0);
             }
+        }
+
+        if (reference.name().equals("tensorFromLabelsWithOffset")) {
+            int numArgs = reference.arguments().size();
+            if (numArgs != 3) {
+                throw new IllegalArgumentException(reference + " must have 3 arguments, not " + numArgs + ": (attribute(myarray), label-dimension, offset-dimension)");
+            }
+            var builder = new TensorType.Builder(cellType);
+            builder.mapped(String.valueOf(arg1));
+            builder.mapped(String.valueOf(arg2));
+            return Optional.of(builder.build());
         }
 
         // fill dimension from second argument if present:

--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -398,7 +398,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             if (numArgs != 3) {
                 throw new IllegalArgumentException(reference + " must have 3 arguments, not " + numArgs + ": (attribute(myarray), label-dimension, offset-dimension)");
             }
-            var builder = new TensorType.Builder(cellType);
+            var builder = new TensorType.Builder(TensorType.Value.FLOAT);
             builder.mapped(String.valueOf(arg1));
             builder.mapped(String.valueOf(arg2));
             return Optional.of(builder.build());

--- a/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
@@ -110,7 +110,7 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
 
     @Test
     void testTensorFromLabelsWithOffsetTypeConstruction() throws ParseException {
-        var expression = "tensorFromLabelsWithOffset(attribute(int_array_field), mylabel, myoffset)";
+        var expression = "merge(tensorFromLabelsWithOffset(attribute(int_array_field), mylabel, myoffset), tensor<float>(mylabel{}, myoffset{}):{{mylabel:'0',myoffset:'0'}:1.0}, f(a,b)(a+b))";
         var expected = "tensor<float>(mylabel{},myoffset{})";
         for (var rankPropertyExpression : buildSearch(expression)) {
             if (rankPropertyExpression.getFirst().equals("rankingExpression(testexpression).type")) {
@@ -172,6 +172,9 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
                 "            indexing: summary | attribute \n" +
                 "        }\n" +
                 "        field double_array_field type array<double> { \n" +
+                "            indexing: summary | attribute \n" +
+                "        }\n" +
+                "        field int_array_field type array<int> { \n" +
                 "            indexing: summary | attribute \n" +
                 "        }\n" +
                 "        field weightedset_field type weightedset<int> { \n" +

--- a/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
@@ -110,7 +110,7 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
     @Test
     void testTensorFromLabelsWithOffsetTypeConstruction() throws ParseException {
         var expression = "tensorFromLabelsWithOffset(attribute(int_array_field), mylabel, myoffset)";
-        var expected = "tensor(mylabel{},myoffset{})";
+        var expected = "tensor<float>(mylabel{},myoffset{})";
         for (var rankPropertyExpression : buildSearch(expression)) {
             if (rankPropertyExpression.getFirst().equals("rankingExpression(testexpression).type")) {
                 String rankExpression = censorBindingHash(rankPropertyExpression.getSecond().replace(" ",""));

--- a/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
@@ -108,6 +108,20 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
+    void testTensorFromLabelsWithOffsetTypeConstruction() throws ParseException {
+        var expression = "tensorFromLabelsWithOffset(attribute(int_array_field), mylabel, myoffset)";
+        var expected = "tensor(mylabel{},myoffset{})";
+        for (var rankPropertyExpression : buildSearch(expression)) {
+            if (rankPropertyExpression.getFirst().equals("rankingExpression(testexpression).type")) {
+                String rankExpression = censorBindingHash(rankPropertyExpression.getSecond().replace(" ",""));
+                assertEquals(expected, rankExpression);
+                return;
+            }
+        }
+        fail("No 'rankingExpression(testexpression).type' property produced");
+    }
+
+    @Test
     void requireThatMaxAndMinWithTensorInQueryIsReplaced() throws ParseException {
         assertTransformedExpression("reduce(query(q),max,x)", "max(query(q),x)");
         assertTransformedExpression("max(query(n),x)", "max(query(n),x)");

--- a/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TensorTransformTestCase extends AbstractSchemaTestCase {
 
@@ -119,6 +120,15 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
             }
         }
         fail("No 'rankingExpression(testexpression).type' property produced");
+    }
+
+    @Test
+    void testNumArgsInTensorFromLabelsWithOffsetTypeConstruction() throws ParseException {
+        var expressionWithTooFewArgsNum = "tensorFromLabelsWithOffset(attribute(int_array_field), mylabel)";
+        assertThrows(IllegalArgumentException.class, () -> buildSearch(expressionWithTooFewArgsNum));
+
+        var expressionWithTooManyArgsNum = "tensorFromLabelsWithOffset(attribute(int_array_field), mylabel, myoffset, toomany)";
+        assertThrows(IllegalArgumentException.class, () -> buildSearch(expressionWithTooManyArgsNum));
     }
 
     @Test


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Solves the issue with type inference in `merge` function as described [here](https://github.com/vespa-engine/vespa/issues/37198#issuecomment-5129232084).

The problem this PR solves is that during the deployment the configuration model validation was missing the logic for the new ranking expression.
In the original [PR](https://github.com/vespa-engine/vespa/pull/37256) the addition of the new expression to the config-model was somehow forgotten.

Types are correctly declared in the content node code as shown in the workaround.