### PR TITLE
Add tensorFromLabelsWithOffset to the schema language server

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -112,6 +112,18 @@ public class BuiltInFunctions {
         )));
 
         // TODO: requires you to write attribute(name)
+        // Only array attributes are supported, and both dimension names are required.
+        // Note: the argument names make up the signature string used to look up the hover documentation,
+        // so they have to match the documented parameter names.
+        put("tensorFromLabelsWithOffset", new GenericFunction("tensorFromLabelsWithOffset",
+            new FunctionSignature(List.of(
+                new FieldArgument(FieldArgument.ArrayType, FieldArgument.IndexAttributeType, "attribute"),
+                new StringArgument("label-dimension"),
+                new StringArgument("offset-dimension")
+            ))
+        ));
+
+        // TODO: requires you to write attribute(name)
         put("tensorFromStructs", new GenericFunction("tensorFromStructs", BuiltInFunctions.tensorFromStructsSignatures()));
 
         // ==== Field match features - normalized ====

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/argument/FieldArgument.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/argument/FieldArgument.java
@@ -44,6 +44,11 @@ public class FieldArgument extends SymbolArgument {
         FieldType.STRING_ARRAY
     );
 
+    public static final EnumSet<FieldType> ArrayType = EnumSet.of(
+        FieldType.NUMERIC_ARRAY,
+        FieldType.STRING_ARRAY
+    );
+
     public static final EnumSet<IndexingType> IndexAttributeType = EnumSet.of(
         IndexingType.ATTRIBUTE,
         IndexingType.INDEX

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/SymbolReferenceResolver.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/SymbolReferenceResolver.java
@@ -442,6 +442,11 @@ public class SymbolReferenceResolver {
             return myArgIndex == 1;
         }
 
+        if (functionIdentifier.equals("tensorFromLabelsWithOffset")) {
+            // both the label dimension and the offset dimension are names, not symbols
+            return myArgIndex == 1 || myArgIndex == 2;
+        }
+
         if (functionIdentifier.equals("query")) {
             // TODO: query gotodefinition could be nice to refer to inputs {} where possible
             return myArgIndex == 0;

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -247,6 +247,7 @@ public class SchemaParserTest {
             "src/test/sdfiles/single/rankprofilebuiltin.sd",
             "src/test/sdfiles/single/structinfieldset.sd",
             "src/test/sdfiles/single/subqueries.sd",
+            "src/test/sdfiles/single/tensorfromlabels.sd",
         };
 
         return Arrays.stream(filePaths)
@@ -333,6 +334,7 @@ public class SchemaParserTest {
             new BadFileTestCase("src/test/sdfiles/single/rankprofilefuncs.sd", 2),
             new BadFileTestCase("src/test/sdfiles/single/rankproperties.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/tensorGenerate.sd", 2),
+            new BadFileTestCase("src/test/sdfiles/single/tensorfromlabelsbad.sd", 1),
         };
 
         return Arrays.stream(tests)

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/tensorfromlabels.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/tensorfromlabels.sd
@@ -1,0 +1,33 @@
+schema tensorfromlabels {
+    document tensorfromlabels {
+        field tags type array<string> {
+            indexing: attribute
+        }
+
+        field ids type array<int> {
+            indexing: attribute
+        }
+
+        field category type string {
+            indexing: attribute
+        }
+    }
+
+    rank-profile myprofile {
+        function labels_default() {
+            expression: sum(tensorFromLabels(attribute(tags)))
+        }
+
+        function labels_dim() {
+            expression: sum(tensorFromLabels(attribute(category), tag))
+        }
+
+        function labels_with_offset() {
+            expression: sum(tensorFromLabelsWithOffset(attribute(tags), tag, offset))
+        }
+
+        function labels_with_offset_int() {
+            expression: sum(tensorFromLabelsWithOffset(attribute(ids), id, pos))
+        }
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/tensorfromlabelsbad.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/tensorfromlabelsbad.sd
@@ -1,0 +1,14 @@
+schema tensorfromlabelsbad {
+    document tensorfromlabelsbad {
+        field tags type array<string> {
+            indexing: attribute
+        }
+    }
+
+    rank-profile myprofile {
+        # the offset dimension is required
+        function missing_offset_dimension() {
+            expression: sum(tensorFromLabelsWithOffset(attribute(tags), tag))
+        }
+    }
+}


### PR DESCRIPTION
⚠️  Code written by Claude, verified and manually tested with locally built extension by me.

The `tensorFromLabelsWithOffset` rank feature added in #37256 was never registered in the schema language server, so the VSCode and IntelliJ schema validation flags every use of it as an error.

## Changes

Two places needed it, the same two that `tensorFromLabels` touches:

- **`BuiltInFunctions`** — registers the feature with its single three argument signature. Taken from the blueprint in `tensor_from_labels_with_offset_feature.h` (`.desc().string().string().string()`, `setup()` rejecting non-`attribute()` sources, `createExecutor()` rejecting single-valued, wset and floating point attributes).
- **`SymbolReferenceResolver.didExpectLabel()`** — the two dimension names are bare identifiers, not symbols. Without an entry here every dimension name resolves as an undefined symbol.
- **`FieldArgument`** — new `ArrayType` enum set, since this feature requires an array attribute, unlike `tensorFromLabels`.

Note that `FieldArgument.fieldTypes` is declarative only today — no resolver reads it — so the array-only restriction does not produce a diagnostic yet. This matches how `tensorFromLabels` declares `SingleValueOrArrayType`.

The argument names are `label-dimension` and `offset-dimension` rather than something more natural, because `SpecificFunction.getSignatureString()` joins the argument display names into the filename used to look up the hover documentation. They have to match `tensorFromLabelsWithOffset(attribute,label-dimension,offset-dimension).md`, otherwise hover silently falls back to the generic "builtin" string. There is a comment in the code to that effect.

## Tests

- `tensorfromlabels.sd` — good file, covers both `tensorFromLabels` forms plus `tensorFromLabelsWithOffset` on a string array and an int array
- `tensorfromlabelsbad.sd` — bad file, one error for the missing offset dimension

Full language server suite is green (325 tests) built with JDK 17, the same JDK `lspDeploy.yml` uses.

FYI @dainiusjocas 