### PR TITLE
fix: AndNot element ID filtering

### DIFF
--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/queryeval/andnotsearch.h>
 #include <vespa/searchlib/queryeval/andsearch.h>
 #include <vespa/searchlib/queryeval/booleanmatchiteratorwrapper.h>
+#include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/searchlib/queryeval/i_element_gap_inspector.h>
 #include <vespa/searchlib/queryeval/intermediate_blueprints.h>
 #include <vespa/searchlib/queryeval/isourceselector.h>
@@ -81,6 +82,19 @@ std::unique_ptr<sourceselector::Iterator> selector() {
 }
 
 MockElementGapInspector mock_element_gap_inspector(std::nullopt);
+
+//-----------------------------------------------------------------------------
+
+class ElementIdsSearch final : public EmptySearch {
+    std::vector<uint32_t> _element_ids;
+
+public:
+    explicit ElementIdsSearch(std::initializer_list<uint32_t> element_ids) : _element_ids(element_ids) {}
+
+    void get_element_ids(uint32_t, std::vector<uint32_t>& element_ids) override {
+        element_ids.insert(element_ids.end(), _element_ids.begin(), _element_ids.end());
+    }
+};
 
 //-----------------------------------------------------------------------------
 
@@ -197,6 +211,16 @@ TEST(QueryEvalTest, test_that_non_strict_andnot_search_does_not_forward_to_its_g
         AndNotSearch::create({AndSearch::create(search2("a", "b"), true), new TrueSearch(tfmd)}, false);
     auto filter = std::make_unique<TrueSearch>(tfmd);
     EXPECT_TRUE(nullptr != search->andWith(std::move(filter), 8).get());
+}
+
+TEST(QueryEvalTest, andnot_get_element_ids_handles_multiple_negative_children) {
+    for (bool strict : {false, true}) {
+        auto search = AndNotSearch::create(
+            {new ElementIdsSearch({1, 3, 5, 7}), new ElementIdsSearch({5, 7}), new ElementIdsSearch({1, 3})}, strict);
+        std::vector<uint32_t> element_ids;
+        search->get_element_ids(1, element_ids);
+        EXPECT_TRUE(element_ids.empty());
+    }
 }
 
 void expect_match(std::string input, std::string regexp) {

--- a/searchlib/src/vespa/searchlib/queryeval/andnotsearch.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/andnotsearch.cpp
@@ -145,6 +145,7 @@ void AndNotSearch::get_element_ids(uint32_t docid, std::vector<uint32_t>& elemen
     std::vector<uint32_t> temp_element_ids;
     std::vector<uint32_t> result;
     for (auto& child : others) {
+        temp_element_ids.clear();
         child->get_element_ids(docid, temp_element_ids);
         if (!temp_element_ids.empty()) {
             result.clear();


### PR DESCRIPTION
Clear the temporary element ID vector before collecting IDs from each negative child in `AndNotSearch::get_element_ids()`.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.