### PR TITLE
Bump brace-expansion override pins in schema-language-server vscode client (Mend HIGH CVE-2026-14257)

### DIFF
--- a/integration/schema-language-server/clients/vscode/package-lock.json
+++ b/integration/schema-language-server/clients/vscode/package-lock.json
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2012,16 +2012,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5795,9 +5795,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/integration/schema-language-server/clients/vscode/package.json
+++ b/integration/schema-language-server/clients/vscode/package.json
@@ -102,8 +102,8 @@
     "vscode-languageclient": "^9.0.1"
   },
   "overrides": {
-    "brace-expansion@1": "1.1.16",
-    "brace-expansion@2": "2.1.2",
-    "brace-expansion@5": "5.0.7"
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@2": "2.1.4",
+    "brace-expansion@5": "5.0.9"
   }
 }


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**
>
> **Once approved, please merge it** — this is an automated dependency-update PR and merging is the final step that closes out the linked Mend/Jira findings.

## Summary
The `overrides` block in the schema-language-server VS Code client pins all three `brace-expansion` majors to versions that predate the upstream backports for CVE-2026-14257 (HIGH 8.7). The backports have since landed (GHSA-mh99-v99m-4gvg), so a plain lock regeneration cannot move off the vulnerable 2.1.2 — the pins themselves must be bumped. The runtime-relevant vulnerable chain is `vscode-languageclient@^9.0.1` → `minimatch 5.1.9` → `brace-expansion ^2.0.1`.

## Changed Files
**`integration/schema-language-server/clients/vscode/package.json`** — three override pin bumps, nothing else:
- `brace-expansion@1`: 1.1.16 → 1.1.18
- `brace-expansion@2`: 2.1.2 → 2.1.4
- `brace-expansion@5`: 5.0.7 → 5.0.9

**`integration/schema-language-server/clients/vscode/package-lock.json`** — regenerated via `npm install --package-lock-only`; only the three `brace-expansion` entries changed (no other packages, no downgrades).

## CVEs Addressed
| Package | CVE | Severity | Fixed version |
|---|---|---|---|
| brace-expansion | CVE-2026-14257, CVE-2026-69152 | high | 2.1.4 (also 1.1.18 / 5.0.9 same-CVE pins) |

## Implementation Notes

- 2026-08-04: CVE-2026-69152 (incomplete-fix follow-up to CVE-2026-14257, published after this PR opened) is fixed in exactly 1.1.18 / 2.1.4 / 5.0.9 — the versions this PR already pins. Added to the table; no code change needed.

- **Scoped to the flagged subtree only** — this is the core product repo (released 4×/week), so the usual whole-manifest dependency sweep is deliberately not applied; the change is limited to the flagged subtree's security pins. No other dependencies or manifests in the repo are touched.
- The `@1` and `@5` pins are bumped proactively: the same CVE also affects brace-expansion < 1.1.17 and < 5.0.8. The runtime-relevant path is the `@2` one via `vscode-languageclient`; the 1.x/5.x occurrences are dev-only.
- Fixed versions per OSV (GHSA-mh99-v99m-4gvg): 1.x ≥ 1.1.17, 2.x ≥ 2.1.3, 5.x ≥ 5.0.8; pins set to the latest npm release of each line (1.1.18 / 2.1.4 / 5.0.9).

## Verification
- Lock greps: every `brace-expansion` entry now resolves to 1.1.18 (1.x, under `@vscode/vsce`), 2.1.4 (2.x, under `vscode-languageclient`), 5.0.9 (5.x, top-level).
- `npm ci --ignore-scripts` in a clean `node:22-slim` container against the updated manifest+lock: exit 0 — proves manifest/lock consistency, the gate `lspDeploy.yml` enforces via `npm ci`.

Jira: VESPANG-3662

