### PR TITLE
Annotate field paths updates for element assign

### DIFF
--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
@@ -548,17 +548,55 @@ public class IndexingProcessorTestCase {
         assertEquals(new StringFieldValue("HELLO"), assign.getNewValue());
     }
 
+    /**
+     * The script for a field includes every statement taking only that field as input, including
+     * ones writing derived fields. Nothing guarantees a derived field is element-wise aligned with
+     * the target field, so only the element of the target field is reconstructed.
+     */
+    @Test
+    public void requireThatElementAssignEmitsOnlyTheTargetField() {
+        var tester = elementAssignTester("input a | for_each { lowercase } | index a",
+                                         "input a | for_each { lowercase } | index c");
+        DocumentType type = tester.getDocumentType("test");
+        DocumentUpdate input = new DocumentUpdate(type, "id:ns:test::1");
+        input.addFieldPathUpdate(new AssignFieldPathUpdate(type, "a[2]", "", new StringFieldValue("HELLO")));
+
+        DocumentUpdate output = (DocumentUpdate)tester.process(input);
+        assertEquals(1, output.fieldPathUpdates().size());
+        AssignFieldPathUpdate assign = (AssignFieldPathUpdate)output.fieldPathUpdates().iterator().next();
+        assertEquals("a[2]", assign.getOriginalFieldPath());
+        assertEquals(new StringFieldValue("hello"), assign.getNewValue());
+        assertTrue(output.fieldUpdates().isEmpty());
+    }
+
+    /** When the script routes the target field elsewhere only, there is no processed element to emit. */
+    @Test
+    public void requireThatElementAssignIsPassedOnWhenScriptDoesNotOutputTargetField() {
+        var tester = elementAssignTester("input a | for_each { lowercase } | index c");
+        DocumentType type = tester.getDocumentType("test");
+        DocumentUpdate input = new DocumentUpdate(type, "id:ns:test::1");
+        input.addFieldPathUpdate(new AssignFieldPathUpdate(type, "a[2]", "", new StringFieldValue("HELLO")));
+
+        DocumentUpdate output = (DocumentUpdate)tester.process(input);
+        assertEquals(1, output.fieldPathUpdates().size());
+        AssignFieldPathUpdate assign = (AssignFieldPathUpdate)output.fieldPathUpdates().iterator().next();
+        assertEquals("a[2]", assign.getOriginalFieldPath());
+        assertEquals(new StringFieldValue("HELLO"), assign.getNewValue());
+    }
+
     private static IndexingProcessorTester elementAssignTester(String... ilscriptContents) {
         var documentTypes = new DocumentTypeManager();
         var test = new DocumentType("test");
         test.addField("a", DataType.getArray(DataType.STRING));
         test.addField("b", DataType.STRING);
+        test.addField("c", DataType.getArray(DataType.STRING));
         documentTypes.register(test);
 
         var ilscript = new IlscriptsConfig.Ilscript.Builder()
                                                    .doctype("test")
                                                    .docfield("a")
-                                                   .docfield("b");
+                                                   .docfield("b")
+                                                   .docfield("c");
 
         for (String content : ilscriptContents) {
             ilscript.content(content);

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
@@ -13,6 +13,7 @@ import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.PositionDataType;
 import com.yahoo.document.TensorDataType;
 import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 import com.yahoo.document.update.AssignValueUpdate;
 import com.yahoo.document.update.FieldUpdate;
 import com.yahoo.language.process.Chunker;
@@ -20,6 +21,7 @@ import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
 import com.yahoo.language.process.InvocationContext;
 import com.yahoo.language.process.TimeoutException;
+import com.yahoo.language.simple.SimpleLinguistics;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
@@ -512,6 +514,66 @@ public class IndexingProcessorTestCase {
         String reason = progress.getReason().get();
         assertTrue("Expected reason to contain 'timed out', got: " + reason, reason.contains("timed out"));
         assertTrue("Expected reason to contain '5000ms', got: " + reason, reason.contains("5000ms"));
+    }
+
+    @Test
+    public void requireThatElementAssignIsProcessedByIndexingScript() {
+        var tester = elementAssignTester("input a | for_each { lowercase } | index a");
+        DocumentType type = tester.getDocumentType("test");
+        DocumentUpdate input = new DocumentUpdate(type, "id:ns:test::1");
+        input.addFieldPathUpdate(new AssignFieldPathUpdate(type, "a[2]", "", new StringFieldValue("HELLO")));
+
+        DocumentUpdate output = (DocumentUpdate)tester.process(input);
+        assertEquals(1, output.fieldPathUpdates().size());
+        AssignFieldPathUpdate assign = (AssignFieldPathUpdate)output.fieldPathUpdates().iterator().next();
+        assertEquals("a[2]", assign.getOriginalFieldPath());
+        assertEquals(new StringFieldValue("hello"), assign.getNewValue());
+    }
+
+    /**
+     * A field which no indexing statement takes as its only input has no script to run the assigned
+     * element through. The update must then be passed on as fed rather than failing the whole update.
+     */
+    @Test
+    public void requireThatElementAssignOfFieldWithoutIndexingStatementIsPassedOn() {
+        var tester = elementAssignTester("input b | index b");
+        DocumentType type = tester.getDocumentType("test");
+        DocumentUpdate input = new DocumentUpdate(type, "id:ns:test::1");
+        input.addFieldPathUpdate(new AssignFieldPathUpdate(type, "a[2]", "", new StringFieldValue("HELLO")));
+
+        DocumentUpdate output = (DocumentUpdate)tester.process(input);
+        assertEquals(1, output.fieldPathUpdates().size());
+        AssignFieldPathUpdate assign = (AssignFieldPathUpdate)output.fieldPathUpdates().iterator().next();
+        assertEquals("a[2]", assign.getOriginalFieldPath());
+        assertEquals(new StringFieldValue("HELLO"), assign.getNewValue());
+    }
+
+    private static IndexingProcessorTester elementAssignTester(String... ilscriptContents) {
+        var documentTypes = new DocumentTypeManager();
+        var test = new DocumentType("test");
+        test.addField("a", DataType.getArray(DataType.STRING));
+        test.addField("b", DataType.STRING);
+        documentTypes.register(test);
+
+        var ilscript = new IlscriptsConfig.Ilscript.Builder()
+                                                   .doctype("test")
+                                                   .docfield("a")
+                                                   .docfield("b");
+
+        for (String content : ilscriptContents) {
+            ilscript.content(content);
+        }
+
+        IlscriptsConfig.Builder config = new IlscriptsConfig.Builder();
+        config.ilscript(ilscript);
+        var scripts = new ScriptManager(documentTypes,
+                                        new IlscriptsConfig(config),
+                                        new SimpleLinguistics(),
+                                        Chunker.throwsOnUse.asMap(),
+                                        Embedder.throwsOnUse.asMap(),
+                                        FieldGenerator.throwsOnUse.asMap(),
+                                        MetricReceiver.nullImplementation);
+        return new IndexingProcessorTester(documentTypes, scripts);
     }
 
     static class PartialUpdateTester {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ElementAssignFieldPathUpdateFieldValues.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ElementAssignFieldPathUpdateFieldValues.java
@@ -1,0 +1,110 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentId;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.Field;
+import com.yahoo.document.FieldPath;
+import com.yahoo.document.datatypes.Array;
+import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.expressions.FieldValues;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Adapter for running an element assign, e.g. <code>"my_array[3]": {"assign": "foo"}</code>,
+ * through the indexing script, so that the assigned value gets the same processing (e.g.
+ * linguistics annotations) as it would get in a put. Without this the raw value reaches the
+ * backend unprocessed, and e.g. an assigned element of an indexed string array produces no
+ * index tokens.
+ *
+ * <p>The element cannot be applied to an empty document, since assigning to an array index
+ * beyond the array size is a no-op. Instead the element is wrapped as a single-element array
+ * in the target field of a partial document, the script processes that document, and the
+ * processed element is unwrapped into a new assign to the original element index.</p>
+ *
+ * @author johsol
+ */
+public class ElementAssignFieldPathUpdateFieldValues implements UpdateFieldValues {
+
+    private final DocumentFieldValues adapter;
+    private final Expression optimizedExpression;
+    private final AssignFieldPathUpdate update;
+
+    public ElementAssignFieldPathUpdateFieldValues(Expression optimizedExpression,
+                                                   DocumentFieldValues adapter,
+                                                   AssignFieldPathUpdate update) {
+        this.adapter = adapter;
+        this.optimizedExpression = optimizedExpression;
+        this.update = update;
+    }
+
+    /** Creates a partial document holding the assigned element as a single-element array in the target field. */
+    @SuppressWarnings("unchecked")
+    public static Document newPartialDocument(DocumentType docType, DocumentId docId, AssignFieldPathUpdate update) {
+        Document doc = new Document(docType, docId);
+        Field field = update.getFieldPath().get(0).getFieldRef();
+        Array<FieldValue> array = (Array<FieldValue>)field.getDataType().createFieldValue();
+        array.add(update.getNewValue().clone());
+        doc.setFieldValue(field, array);
+        return doc;
+    }
+
+    @Override
+    public DocumentUpdate getOutput() {
+        Document doc = adapter.getFullOutput();
+        DocumentUpdate out = new DocumentUpdate(doc.getDataType(), doc.getId());
+        for (Iterator<Map.Entry<Field, FieldValue>> it = doc.iterator(); it.hasNext();) {
+            Map.Entry<Field, FieldValue> entry = it.next();
+            if (!(entry.getValue() instanceof Array<?> array) || array.size() != 1) {
+                // An element assign can only be reconstructed from a single processed element.
+                continue;
+            }
+            String path = entry.getKey().getName() + "[" + elementIndex() + "]";
+            out.addFieldPathUpdate(new AssignFieldPathUpdate(update.getDocumentType(), path,
+                                                             update.getOriginalWhereClause(),
+                                                             array.getFieldValue(0)));
+        }
+        if (out.fieldPathUpdates().isEmpty()) {
+            // The script produced no usable output for this field; keep the update as fed.
+            out.addFieldPathUpdate(update);
+        }
+        return out;
+    }
+
+    private int elementIndex() {
+        return update.getFieldPath().get(1).getLookupIndex();
+    }
+
+    @Override
+    public Expression getExpression(Expression expression) {
+        return optimizedExpression != null ? optimizedExpression : expression;
+    }
+
+    @Override
+    public DataType getFieldType(String fieldName, Expression exp) {
+        return adapter.getFieldType(fieldName, exp);
+    }
+
+    @Override
+    public FieldValue getInputValue(String fieldName) {
+        return adapter.getInputValue(fieldName);
+    }
+
+    @Override
+    public FieldValue getInputValue(FieldPath fieldPath) {
+        return adapter.getInputValue(fieldPath);
+    }
+
+    @Override
+    public FieldValues setOutputValue(String fieldName, FieldValue fieldValue, Expression exp) {
+        return adapter.setOutputValue(fieldName, fieldValue, exp);
+    }
+
+}

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ElementAssignFieldPathUpdateFieldValues.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ElementAssignFieldPathUpdateFieldValues.java
@@ -1,0 +1,115 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentId;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.Field;
+import com.yahoo.document.FieldPath;
+import com.yahoo.document.datatypes.Array;
+import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.expressions.FieldValues;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Adapter for running an element assign, e.g. <code>"my_array[3]": {"assign": "foo"}</code>,
+ * through the indexing script, so that the assigned value gets the same processing (e.g.
+ * linguistics annotations) as it would get in a put. Without this the raw value reaches the
+ * backend unprocessed, and e.g. an assigned element of an indexed string array produces no
+ * index tokens.
+ *
+ * <p>The element cannot be applied to an empty document, since assigning to an array index
+ * beyond the array size is a no-op. Instead the element is wrapped as a single-element array
+ * in the target field of a partial document, the script processes that document, and the
+ * processed element is unwrapped into a new assign to the original element index.</p>
+ *
+ * @author johsol
+ */
+public class ElementAssignFieldPathUpdateFieldValues implements UpdateFieldValues {
+
+    private final DocumentFieldValues adapter;
+    private final Expression optimizedExpression;
+    private final AssignFieldPathUpdate update;
+
+    public ElementAssignFieldPathUpdateFieldValues(Expression optimizedExpression,
+                                                   DocumentFieldValues adapter,
+                                                   AssignFieldPathUpdate update) {
+        this.adapter = adapter;
+        this.optimizedExpression = optimizedExpression;
+        this.update = update;
+    }
+
+    /** Creates a partial document holding the assigned element as a single-element array in the target field. */
+    @SuppressWarnings("unchecked")
+    public static Document newPartialDocument(DocumentType docType, DocumentId docId, AssignFieldPathUpdate update) {
+        Document doc = new Document(docType, docId);
+        Field field = update.getFieldPath().get(0).getFieldRef();
+        Array<FieldValue> array = (Array<FieldValue>)field.getDataType().createFieldValue();
+        array.add(update.getNewValue().clone());
+        doc.setFieldValue(field, array);
+        return doc;
+    }
+
+    @Override
+    public DocumentUpdate getOutput() {
+        Document doc = adapter.getFullOutput();
+        DocumentUpdate out = new DocumentUpdate(doc.getDataType(), doc.getId());
+        for (Iterator<Map.Entry<Field, FieldValue>> it = doc.iterator(); it.hasNext();) {
+            Map.Entry<Field, FieldValue> entry = it.next();
+            if (!(entry.getValue() instanceof Array<?> array) || array.size() != 1) {
+                // An element assign can only be reconstructed from a single processed element.
+                continue;
+            }
+            String path = entry.getKey().getName() + "[" + elementIndex() + "]";
+            AssignFieldPathUpdate processed = new AssignFieldPathUpdate(update.getDocumentType(), path,
+                                                                        update.getOriginalWhereClause(),
+                                                                        array.getFieldValue(0));
+            // Carry over the flags of the update as fed: the script processes the value only, and
+            // e.g. removeIfZero decides whether an assigned zero removes the element instead.
+            processed.setCreateMissingPath(update.getCreateMissingPath());
+            processed.setRemoveIfZero(update.getRemoveIfZero());
+            out.addFieldPathUpdate(processed);
+        }
+        if (out.fieldPathUpdates().isEmpty()) {
+            // The script produced no usable output for this field; keep the update as fed.
+            out.addFieldPathUpdate(update);
+        }
+        return out;
+    }
+
+    private int elementIndex() {
+        return update.getFieldPath().get(1).getLookupIndex();
+    }
+
+    @Override
+    public Expression getExpression(Expression expression) {
+        return optimizedExpression != null ? optimizedExpression : expression;
+    }
+
+    @Override
+    public DataType getFieldType(String fieldName, Expression exp) {
+        return adapter.getFieldType(fieldName, exp);
+    }
+
+    @Override
+    public FieldValue getInputValue(String fieldName) {
+        return adapter.getInputValue(fieldName);
+    }
+
+    @Override
+    public FieldValue getInputValue(FieldPath fieldPath) {
+        return adapter.getInputValue(fieldPath);
+    }
+
+    @Override
+    public FieldValues setOutputValue(String fieldName, FieldValue fieldValue, Expression exp) {
+        return adapter.setOutputValue(fieldName, fieldValue, exp);
+    }
+
+}

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ElementAssignFieldPathUpdateFieldValues.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/ElementAssignFieldPathUpdateFieldValues.java
@@ -3,8 +3,6 @@ package com.yahoo.vespa.indexinglanguage;
 
 import com.yahoo.document.DataType;
 import com.yahoo.document.Document;
-import com.yahoo.document.DocumentId;
-import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.Field;
 import com.yahoo.document.FieldPath;
@@ -14,8 +12,8 @@ import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.FieldValues;
 
-import java.util.Iterator;
-import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Adapter for running an element assign, e.g. <code>"my_array[3]": {"assign": "foo"}</code>,
@@ -26,12 +24,19 @@ import java.util.Map;
  *
  * <p>The element cannot be applied to an empty document, since assigning to an array index
  * beyond the array size is a no-op. Instead the element is wrapped as a single-element array
- * in the target field of a partial document, the script processes that document, and the
- * processed element is unwrapped into a new assign to the original element index.</p>
+ * in the target field of a partial document (see {@link FieldPathUpdateHelper#newElementAssignPartialDocument}),
+ * the script processes that document, and the processed element is unwrapped into a new assign
+ * to the original element index.</p>
+ *
+ * <p>Only the field targeted by the update is reconstructed. The script may also write derived
+ * fields from the same input, but nothing guarantees those are element-wise aligned with the
+ * target field, so no element assign is emitted for them.</p>
  *
  * @author johsol
  */
 public class ElementAssignFieldPathUpdateFieldValues implements UpdateFieldValues {
+
+    private static final Logger log = Logger.getLogger(ElementAssignFieldPathUpdateFieldValues.class.getName());
 
     private final DocumentFieldValues adapter;
     private final Expression optimizedExpression;
@@ -45,42 +50,35 @@ public class ElementAssignFieldPathUpdateFieldValues implements UpdateFieldValue
         this.update = update;
     }
 
-    /** Creates a partial document holding the assigned element as a single-element array in the target field. */
-    @SuppressWarnings("unchecked")
-    public static Document newPartialDocument(DocumentType docType, DocumentId docId, AssignFieldPathUpdate update) {
-        Document doc = new Document(docType, docId);
-        Field field = update.getFieldPath().get(0).getFieldRef();
-        Array<FieldValue> array = (Array<FieldValue>)field.getDataType().createFieldValue();
-        array.add(update.getNewValue().clone());
-        doc.setFieldValue(field, array);
-        return doc;
-    }
-
     @Override
     public DocumentUpdate getOutput() {
         Document doc = adapter.getFullOutput();
         DocumentUpdate out = new DocumentUpdate(doc.getDataType(), doc.getId());
-        for (Iterator<Map.Entry<Field, FieldValue>> it = doc.iterator(); it.hasNext();) {
-            Map.Entry<Field, FieldValue> entry = it.next();
-            if (!(entry.getValue() instanceof Array<?> array) || array.size() != 1) {
-                // An element assign can only be reconstructed from a single processed element.
-                continue;
-            }
-            String path = entry.getKey().getName() + "[" + elementIndex() + "]";
-            AssignFieldPathUpdate processed = new AssignFieldPathUpdate(update.getDocumentType(), path,
-                                                                        update.getOriginalWhereClause(),
-                                                                        array.getFieldValue(0));
+        FieldValue processed = doc.getFieldValue(targetField());
+        if (processed instanceof Array<?> array && array.size() == 1) {
+            String path = targetField().getName() + "[" + elementIndex() + "]";
+            AssignFieldPathUpdate assign = new AssignFieldPathUpdate(update.getDocumentType(), path,
+                                                                     array.getFieldValue(0));
             // Carry over the flags of the update as fed: the script processes the value only, and
             // e.g. removeIfZero decides whether an assigned zero removes the element instead.
-            processed.setCreateMissingPath(update.getCreateMissingPath());
-            processed.setRemoveIfZero(update.getRemoveIfZero());
-            out.addFieldPathUpdate(processed);
-        }
-        if (out.fieldPathUpdates().isEmpty()) {
-            // The script produced no usable output for this field; keep the update as fed.
+            assign.setCreateMissingPath(update.getCreateMissingPath());
+            assign.setRemoveIfZero(update.getRemoveIfZero());
+            out.addFieldPathUpdate(assign);
+        } else {
+            // The script did not output a single processed element for the target field, e.g. because
+            // it writes the input to other fields only. Pass the update on as fed, but be loud about
+            // it: this is the unprocessed value reaching the backend which this class exists to prevent.
+            log.log(Level.WARNING, () -> "Indexing script for field '" + targetField().getName() + "' of " +
+                                         doc.getId() + " did not produce a processed element for '" +
+                                         update.getOriginalFieldPath() + "', got " + processed +
+                                         ". Passing the element assign on unprocessed.");
             out.addFieldPathUpdate(update);
         }
         return out;
+    }
+
+    private Field targetField() {
+        return update.getFieldPath().get(0).getFieldRef();
     }
 
     private int elementIndex() {
@@ -110,6 +108,11 @@ public class ElementAssignFieldPathUpdateFieldValues implements UpdateFieldValue
     @Override
     public FieldValues setOutputValue(String fieldName, FieldValue fieldValue, Expression exp) {
         return adapter.setOutputValue(fieldName, fieldValue, exp);
+    }
+
+    @Override
+    public String toString() {
+        return "element assign field values for '" + update.getOriginalFieldPath() + "': " + adapter;
     }
 
 }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldPathUpdateHelper.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldPathUpdateHelper.java
@@ -25,6 +25,27 @@ public abstract class FieldPathUpdateHelper {
                 && update.getFieldPath().get(0).getType() == FieldPathEntry.Type.STRUCT_FIELD);
     }
 
+    /**
+     * Returns true if this update assigns a value to one element of a top-level array field,
+     * e.g. <code>my_array[3]</code>.
+     */
+    public static boolean isElementAssign(FieldPathUpdate update) {
+        if (!(update instanceof AssignFieldPathUpdate assign)) {
+            return false;
+        }
+        // If getNewValue() returns null, assign is applying a mathematical expression to the field.
+        // Currently, we only support assigning a value to top level array field.
+        if (assign.getNewValue() == null) {
+            return false;
+        }
+        if (update.getOriginalWhereClause() != null && !update.getOriginalWhereClause().isEmpty()) {
+            return false;
+        }
+        return ((update.getFieldPath().size() == 2)
+                && update.getFieldPath().get(0).getType() == FieldPathEntry.Type.STRUCT_FIELD
+                && update.getFieldPath().get(1).getType() == FieldPathEntry.Type.ARRAY_INDEX);
+    }
+
     public static void applyUpdate(FieldPathUpdate update, Document doc) {
         if (update instanceof AddFieldPathUpdate) {
             update.applyTo(doc);

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldPathUpdateHelper.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldPathUpdateHelper.java
@@ -1,9 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.indexinglanguage;
 
+import com.yahoo.document.ArrayDataType;
 import com.yahoo.document.Document;
 import com.yahoo.document.DocumentId;
+import com.yahoo.document.Field;
+import com.yahoo.document.FieldPath;
 import com.yahoo.document.FieldPathEntry;
+import com.yahoo.document.datatypes.Array;
 import com.yahoo.document.datatypes.FieldPathIteratorHandler;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.fieldpathupdate.AddFieldPathUpdate;
@@ -27,23 +31,24 @@ public abstract class FieldPathUpdateHelper {
 
     /**
      * Returns true if this update assigns a value to one element of a top-level array field,
-     * e.g. <code>my_array[3]</code>.
+     * e.g. <code>my_array[3]</code>. Arithmetic and conditional assigns are not element assigns,
+     * as they are computed from the stored document and cannot be processed up front.
      */
     public static boolean isElementAssign(FieldPathUpdate update) {
         if (!(update instanceof AssignFieldPathUpdate assign)) {
             return false;
         }
-        // If getNewValue() returns null, assign is applying a mathematical expression to the field.
-        // Currently, we only support assigning a value to top level array field.
-        if (assign.getNewValue() == null) {
+        if (assign.isArithmetic()) {
             return false;
         }
         if (update.getOriginalWhereClause() != null && !update.getOriginalWhereClause().isEmpty()) {
             return false;
         }
-        return ((update.getFieldPath().size() == 2)
-                && update.getFieldPath().get(0).getType() == FieldPathEntry.Type.STRUCT_FIELD
-                && update.getFieldPath().get(1).getType() == FieldPathEntry.Type.ARRAY_INDEX);
+        FieldPath path = update.getFieldPath();
+        return path.size() == 2
+               && path.get(0).getType() == FieldPathEntry.Type.STRUCT_FIELD
+               && path.get(0).getFieldRef().getDataType() instanceof ArrayDataType
+               && path.get(1).getType() == FieldPathEntry.Type.ARRAY_INDEX;
     }
 
     public static void applyUpdate(FieldPathUpdate update, Document doc) {
@@ -67,6 +72,23 @@ public abstract class FieldPathUpdateHelper {
     public static Document newPartialDocument(DocumentId docId, FieldPathUpdate update) {
         Document doc = new Document(update.getDocumentType(), docId);
         applyUpdate(update, doc);
+        return doc;
+    }
+
+    /**
+     * Creates a partial document holding the element assigned by the given element assign as a
+     * single-element array in the target field. The update itself cannot be applied to an empty
+     * document, as assigning to an index beyond the array size is a no-op.
+     */
+    @SuppressWarnings("unchecked")
+    public static Document newElementAssignPartialDocument(DocumentId docId, AssignFieldPathUpdate update) {
+        Document doc = new Document(update.getDocumentType(), docId);
+        Field field = update.getFieldPath().get(0).getFieldRef();
+        // isElementAssign guarantees the field is an array, and an ARRAY_INDEX path entry is only
+        // ever built by ArrayDataType, so the field value created for the field is an Array.
+        Array<FieldValue> array = (Array<FieldValue>)field.getDataType().createFieldValue();
+        array.add(update.getNewValue().clone());
+        doc.setFieldValue(field, array);
         return doc;
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldValuesFactory.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldValuesFactory.java
@@ -6,6 +6,7 @@ import com.yahoo.document.DocumentId;
 import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.Field;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
 import com.yahoo.document.update.FieldUpdate;
 import com.yahoo.document.update.ValueUpdate;
@@ -56,6 +57,18 @@ public class FieldValuesFactory {
                     // in wolf's clothing. Convert it to a regular field update to be friendlier
                     // towards the search core backend.
                     FieldPathUpdateHelper.applyUpdate(fieldUpdate, complete);
+                } else if (FieldPathUpdateHelper.isElementAssign(fieldUpdate)) {
+                    // The assigned element must be processed by the indexing script like any put
+                    // value, or e.g. an element of an indexed string array reaches the backend
+                    // without linguistics annotations and produces no index tokens.
+                    AssignFieldPathUpdate elementAssign = (AssignFieldPathUpdate)fieldUpdate;
+                    String fieldName = fieldUpdate.getFieldPath().get(0).getFieldRef().getName();
+                    Document partial = ElementAssignFieldPathUpdateFieldValues.newPartialDocument(docType, docId,
+                                                                                                  elementAssign);
+                    ret.add(new ElementAssignFieldPathUpdateFieldValues(
+                            expressionSelector.selectExpression(docType, fieldName),
+                            newDocumentAdapter(partial, true),
+                            elementAssign));
                 } else {
                     ret.add(new IdentityFieldPathUpdateFieldValues(fieldUpdate, newDocumentAdapter(complete, true)));
                 }

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldValuesFactory.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldValuesFactory.java
@@ -107,7 +107,7 @@ public class FieldValuesFactory {
             // than failing the entire update.
             return new IdentityFieldPathUpdateFieldValues(elementAssign, newDocumentAdapter(complete, true));
         }
-        Document partial = ElementAssignFieldPathUpdateFieldValues.newPartialDocument(docType, docId, elementAssign);
+        Document partial = FieldPathUpdateHelper.newElementAssignPartialDocument(docId, elementAssign);
         return new ElementAssignFieldPathUpdateFieldValues(expression, newDocumentAdapter(partial, true), elementAssign);
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldValuesFactory.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/FieldValuesFactory.java
@@ -6,6 +6,7 @@ import com.yahoo.document.DocumentId;
 import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.Field;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
 import com.yahoo.document.update.FieldUpdate;
 import com.yahoo.document.update.ValueUpdate;
@@ -56,6 +57,12 @@ public class FieldValuesFactory {
                     // in wolf's clothing. Convert it to a regular field update to be friendlier
                     // towards the search core backend.
                     FieldPathUpdateHelper.applyUpdate(fieldUpdate, complete);
+                } else if (FieldPathUpdateHelper.isElementAssign(fieldUpdate)) {
+                    // The assigned element must be processed by the indexing script like any put
+                    // value, or e.g. an element of an indexed string array reaches the backend
+                    // without linguistics annotations and produces no index tokens.
+                    ret.add(newElementAssignFieldValues(docType, docId, complete,
+                                                        (AssignFieldPathUpdate)fieldUpdate));
                 } else {
                     ret.add(new IdentityFieldPathUpdateFieldValues(fieldUpdate, newDocumentAdapter(complete, true)));
                 }
@@ -83,6 +90,25 @@ public class FieldValuesFactory {
         }
         ret.add(FieldUpdateFieldValues.fromCompleteUpdate(newDocumentAdapter(complete, true)));
         return ret;
+    }
+
+    /**
+     * Returns values which run the assigned element through the indexing script, or - if this field has
+     * no indexing statement taking only it as input - values which pass the update on unchanged.
+     */
+    private UpdateFieldValues newElementAssignFieldValues(DocumentType docType, DocumentId docId, Document complete,
+                                                          AssignFieldPathUpdate elementAssign) {
+        String fieldName = elementAssign.getFieldPath().get(0).getFieldRef().getName();
+        Expression expression;
+        try {
+            expression = expressionSelector.selectExpression(docType, fieldName);
+        } catch (IllegalArgumentException e) {
+            // There is no script to run the element through, so pass the update on as fed rather
+            // than failing the entire update.
+            return new IdentityFieldPathUpdateFieldValues(elementAssign, newDocumentAdapter(complete, true));
+        }
+        Document partial = ElementAssignFieldPathUpdateFieldValues.newPartialDocument(docType, docId, elementAssign);
+        return new ElementAssignFieldPathUpdateFieldValues(expression, newDocumentAdapter(partial, true), elementAssign);
     }
 
 }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ElementAssignUpdateTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ElementAssignUpdateTestCase.java
@@ -1,0 +1,106 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.Field;
+import com.yahoo.document.MapDataType;
+import com.yahoo.document.datatypes.Array;
+import com.yahoo.document.datatypes.IntegerFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
+import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
+import com.yahoo.document.fieldpathupdate.RemoveFieldPathUpdate;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.parser.ParseException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that an element assign, e.g. <code>"my_str[0]": {"assign": "HELLO"}</code>, is run
+ * through the indexing script like any put value, instead of being passed through untouched.
+ *
+ * @author johsol
+ */
+public class ElementAssignUpdateTestCase {
+
+    private static DocumentType newDocumentType() {
+        DocumentType docType = new DocumentType("my_type");
+        docType.addField(new Field("my_str", DataType.getArray(DataType.STRING)));
+        docType.addField(new Field("my_map", new MapDataType(DataType.STRING, DataType.INT)));
+        return docType;
+    }
+
+    @Test
+    public void requireThatElementAssignIsRecognized() {
+        DocumentType docType = newDocumentType();
+        assertTrue(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str[0]", "", new StringFieldValue("foo"))));
+    }
+
+    @Test
+    public void requireThatOtherFieldPathUpdatesAreNotRecognizedAsElementAssign() {
+        DocumentType docType = newDocumentType();
+
+        // Whole-field assign is handled by isFieldValues, not as an element assign.
+        Array<StringFieldValue> array = new Array<>(docType.getField("my_str").getDataType());
+        array.add(new StringFieldValue("foo"));
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str", "", array)));
+
+        // Expression assigns compute from the stored document and cannot be pre-processed.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str[0]", "", "5")));
+
+        // Conditional assigns depend on the stored document.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str[0]", "my_type.my_str == \"foo\"",
+                                          new StringFieldValue("foo"))));
+
+        // Map key paths are not element assigns.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_map{a}", "", new IntegerFieldValue(1))));
+
+        // Removes carry no value to process.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new RemoveFieldPathUpdate(docType, "my_str[0]", "")));
+    }
+
+    @Test
+    public void requireThatElementAssignIsProcessedByIndexingScript() throws ParseException {
+        DocumentType docType = newDocumentType();
+        DocumentUpdate upd = new DocumentUpdate(docType, "id:scheme:my_type::");
+        upd.addFieldPathUpdate(new AssignFieldPathUpdate(docType, "my_str[0]", "",
+                                                         new StringFieldValue("HELLO")));
+
+        upd = Expression.execute(Expression.fromString("input my_str | for_each { lowercase } | index my_str"), upd);
+
+        assertNotNull(upd);
+        assertEquals(1, upd.fieldPathUpdates().size());
+        FieldPathUpdate out = upd.fieldPathUpdates().iterator().next();
+        assertTrue(out instanceof AssignFieldPathUpdate);
+        assertEquals("my_str[0]", out.getOriginalFieldPath());
+        assertEquals(new StringFieldValue("hello"), ((AssignFieldPathUpdate)out).getNewValue());
+    }
+
+    @Test
+    public void requireThatExpressionAssignToElementIsPassedThrough() throws ParseException {
+        DocumentType docType = newDocumentType();
+        DocumentUpdate upd = new DocumentUpdate(docType, "id:scheme:my_type::");
+        upd.addFieldPathUpdate(new AssignFieldPathUpdate(docType, "my_str[0]", "", "5"));
+
+        upd = Expression.execute(Expression.fromString("input my_str | for_each { lowercase } | index my_str"), upd);
+
+        assertNotNull(upd);
+        assertEquals(1, upd.fieldPathUpdates().size());
+        FieldPathUpdate out = upd.fieldPathUpdates().iterator().next();
+        assertTrue(out instanceof AssignFieldPathUpdate);
+        assertEquals("5", ((AssignFieldPathUpdate)out).getExpression());
+    }
+
+}

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ElementAssignUpdateTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ElementAssignUpdateTestCase.java
@@ -1,0 +1,149 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.Field;
+import com.yahoo.document.MapDataType;
+import com.yahoo.document.StructDataType;
+import com.yahoo.document.datatypes.Array;
+import com.yahoo.document.datatypes.IntegerFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.document.datatypes.Struct;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
+import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
+import com.yahoo.document.fieldpathupdate.RemoveFieldPathUpdate;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.parser.ParseException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that an element assign, e.g. <code>"my_str[0]": {"assign": "HELLO"}</code>, is run
+ * through the indexing script like any put value, instead of being passed through untouched.
+ *
+ * @author johsol
+ */
+public class ElementAssignUpdateTestCase {
+
+    private static DocumentType newDocumentType() {
+        DocumentType docType = new DocumentType("my_type");
+        docType.addField(new Field("my_str", DataType.getArray(DataType.STRING)));
+        docType.addField(new Field("my_int", DataType.getArray(DataType.INT)));
+        docType.addField(new Field("my_structs", DataType.getArray(newStructType())));
+        docType.addField(new Field("my_map", new MapDataType(DataType.STRING, DataType.INT)));
+        return docType;
+    }
+
+    private static StructDataType newStructType() {
+        StructDataType structType = new StructDataType("my_struct");
+        structType.addField(new Field("s", DataType.STRING));
+        return structType;
+    }
+
+    @Test
+    public void requireThatElementAssignIsRecognized() {
+        DocumentType docType = newDocumentType();
+        assertTrue(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str[0]", "", new StringFieldValue("foo"))));
+    }
+
+    @Test
+    public void requireThatOtherFieldPathUpdatesAreNotRecognizedAsElementAssign() {
+        DocumentType docType = newDocumentType();
+
+        // Whole-field assign is handled by isFieldValues, not as an element assign.
+        Array<StringFieldValue> array = new Array<>(docType.getField("my_str").getDataType());
+        array.add(new StringFieldValue("foo"));
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str", "", array)));
+
+        // Expression assigns compute from the stored document and cannot be pre-processed.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str[0]", "", "5")));
+
+        // Conditional assigns depend on the stored document.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_str[0]", "my_type.my_str == \"foo\"",
+                                          new StringFieldValue("foo"))));
+
+        // Map key paths are not element assigns.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_map{a}", "", new IntegerFieldValue(1))));
+
+        // Removes carry no value to process.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new RemoveFieldPathUpdate(docType, "my_str[0]", "")));
+
+        // Only top level array fields are handled: a path into an element is not an element assign.
+        assertFalse(FieldPathUpdateHelper.isElementAssign(
+                new AssignFieldPathUpdate(docType, "my_structs[0].s", "", new StringFieldValue("foo"))));
+    }
+
+    @Test
+    public void requireThatElementAssignIsProcessedByIndexingScript() throws ParseException {
+        DocumentType docType = newDocumentType();
+        DocumentUpdate upd = new DocumentUpdate(docType, "id:scheme:my_type::");
+        upd.addFieldPathUpdate(new AssignFieldPathUpdate(docType, "my_str[0]", "",
+                                                         new StringFieldValue("HELLO")));
+
+        upd = Expression.execute(Expression.fromString("input my_str | for_each { lowercase } | index my_str"), upd);
+
+        assertNotNull(upd);
+        assertEquals(1, upd.fieldPathUpdates().size());
+        FieldPathUpdate out = upd.fieldPathUpdates().iterator().next();
+        assertTrue(out instanceof AssignFieldPathUpdate);
+        assertEquals("my_str[0]", out.getOriginalFieldPath());
+        assertEquals(new StringFieldValue("hello"), ((AssignFieldPathUpdate)out).getNewValue());
+    }
+
+    /**
+     * The script processes the assigned value only, so the flags deciding how the assign is applied
+     * must survive it. An assigned zero with removeIfZero set removes the element instead of setting it.
+     */
+    @Test
+    public void requireThatElementAssignKeepsFlagsOfTheUpdateAsFed() throws ParseException {
+        DocumentType docType = newDocumentType();
+        DocumentUpdate upd = new DocumentUpdate(docType, "id:scheme:my_type::");
+        AssignFieldPathUpdate assign = new AssignFieldPathUpdate(docType, "my_int[1]", "",
+                                                                 new IntegerFieldValue(0));
+        assign.setRemoveIfZero(true);
+        assign.setCreateMissingPath(false);
+        upd.addFieldPathUpdate(assign);
+
+        upd = Expression.execute(Expression.fromString("input my_int | attribute my_int"), upd);
+
+        assertNotNull(upd);
+        assertEquals(1, upd.fieldPathUpdates().size());
+        AssignFieldPathUpdate out = (AssignFieldPathUpdate)upd.fieldPathUpdates().iterator().next();
+        assertEquals("my_int[1]", out.getOriginalFieldPath());
+        assertEquals(new IntegerFieldValue(0), out.getNewValue());
+        assertTrue(out.getRemoveIfZero());
+        assertFalse(out.getCreateMissingPath());
+    }
+
+    /** The element of an array of struct must survive being wrapped and unwrapped. */
+    @Test
+    public void requireThatElementAssignOfArrayOfStructIsProcessed() throws ParseException {
+        DocumentType docType = newDocumentType();
+        Struct element = new Struct(newStructType());
+        element.setFieldValue("s", new StringFieldValue("foo"));
+
+        DocumentUpdate upd = new DocumentUpdate(docType, "id:scheme:my_type::");
+        upd.addFieldPathUpdate(new AssignFieldPathUpdate(docType, "my_structs[1]", "", element));
+
+        upd = Expression.execute(Expression.fromString("input my_structs | passthrough my_structs"), upd);
+
+        assertNotNull(upd);
+        assertEquals(1, upd.fieldPathUpdates().size());
+        AssignFieldPathUpdate out = (AssignFieldPathUpdate)upd.fieldPathUpdates().iterator().next();
+        assertEquals("my_structs[1]", out.getOriginalFieldPath());
+        assertEquals(element, out.getNewValue());
+    }
+
+}

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ElementAssignUpdateTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/ElementAssignUpdateTestCase.java
@@ -103,6 +103,28 @@ public class ElementAssignUpdateTestCase {
     }
 
     /**
+     * The element is processed in a single-element array regardless of its index, so an index beyond
+     * any plausible array size must still be processed and come back out at the same index. The backend
+     * decides whether the assign is a no-op against the stored document.
+     */
+    @Test
+    public void requireThatElementIndexIsPreserved() throws ParseException {
+        DocumentType docType = newDocumentType();
+        DocumentUpdate upd = new DocumentUpdate(docType, "id:scheme:my_type::");
+        upd.addFieldPathUpdate(new AssignFieldPathUpdate(docType, "my_str[1000]", "",
+                                                         new StringFieldValue("HELLO")));
+
+        upd = Expression.execute(Expression.fromString("input my_str | for_each { lowercase } | index my_str"), upd);
+
+        assertNotNull(upd);
+        assertEquals(1, upd.fieldPathUpdates().size());
+        AssignFieldPathUpdate out = (AssignFieldPathUpdate)upd.fieldPathUpdates().iterator().next();
+        assertEquals("my_str[1000]", out.getOriginalFieldPath());
+        assertEquals(1000, out.getFieldPath().get(1).getLookupIndex());
+        assertEquals(new StringFieldValue("hello"), out.getNewValue());
+    }
+
+    /**
      * The script processes the assigned value only, so the flags deciding how the assign is applied
      * must survive it. An assigned zero with removeIfZero set removes the element instead of setting it.
      */


### PR DESCRIPTION
**Problem it fixes**: an element assign like `"my_array[3]": {"assign": "foo"}` bypassed the indexing script, so the raw value reached the backend unprocessed — e.g., an assigned element of an indexed string array got no linguistic annotations and produced no index tokens.

#### Element assign operation
An `element assign` assigns a new value to an index in a multi-value field. For instance, if the field `foo` has type `array<int>`, then `foo[3] = 5` is an element assign. This feature is not fully supported for attribute vectors yet; work in progress.

#### Indexing script

The indexing script transforms document fields before storing or indexing them. To process an update, `FieldValuesFactory` represents each operation as a small partial document (containing only the updated field). It places the updated value in the document, runs the field’s indexing statement, and converts the resulting value back into an update operation through `UpdateFieldValues.getOutput()`. Regular value updates already followed this path, while IdentityFieldPathUpdateFieldValues forwarded field path updates unchanged.

That pass-through meant an element assign like `"my_str[0]": {"assign": "d"}` never ran through linguistics, so the assigned element of an indexed string array reached the backend without annotations and produced no index tokens. This means it was stored and visible in summary, but unsearchable.

#### This change

This change gives element assigns the same treatment as regular partial updates: `isElementAssign` recognizes a value-carrying assign to `field[N]` on a top-level array, the element is wrapped as a one-element array in a partial document (applying the update to an empty document would be an out-of-bounds no-op), the per-field script processes it, and the update is reconstructed at the original index with the processed value. If the script produces no usable output, it forwards the update as-is.

#### Example with lowercase of text

<img width="1669" height="1385" alt="image" src="https://github.com/user-attachments/assets/dc35a007-570d-43fc-9ece-6e18f6af8ee0" />

 In a partial update, index assignment out of bounds is a no-op, so use an array of length 1.