### PR TITLE
Call shutdown on reindexers before waiting for execeutor to shut down

### DIFF
--- a/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/ReindexingMaintainer.java
+++ b/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/ReindexingMaintainer.java
@@ -98,11 +98,13 @@ public class ReindexingMaintainer extends AbstractComponent {
             // Shutdown the executor before reindexers, so that no new reindexing tasks are submitted when
             // reindexers have shutdown
             executor.shutdown();
-            if ( ! executor.awaitTermination(5, TimeUnit.SECONDS))
-                log.log(WARNING, "Failed to shut down reindexing within timeout");
 
+            // Abort current reindexing visitor sessions.
             for (Reindexer reindexer : reindexers)
                 reindexer.shutdown();
+
+            if ( ! executor.awaitTermination(5, TimeUnit.SECONDS))
+                log.log(WARNING, "Failed to shut down reindexing within timeout");
 
             curator.close(); // Close the underlying curator independently to force shutdown.
         }


### PR DESCRIPTION
#### Context

When ReindexingMaintainer gets a new config, it reconstructs its components, and during destruction, we get:

```
Failed to shut down reindexing within timeout.
2026-08-03 08:21:33.309 Completed deconstruction in 5.013 seconds
2026-08-03 08:21:36.955 Exception when reindexing exception=
java.lang.RuntimeException: Could not check existence of /reindexing/v1/content-chunks/status
	at com.yahoo.vespa.curator.Curator.exists(Curator.java:213)
	at com.yahoo.vespa.curator.Curator.set(Curator.java:231)
	at com.yahoo.vespa.curator.Curator.set(Curator.java:223)
	at ai.vespa.reindexing.ReindexingCurator.writeReindexing(ReindexingCurator.java:81)
	at ai.vespa.reindexing.Reindexer.progress(Reindexer.java:202)
	at ai.vespa.reindexing.Reindexer.reindex(Reindexer.java:118)
	at ai.vespa.reindexing.ReindexingMaintainer.lambda$maintain$2(ReindexingMaintainer.java:84)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	Suppressed: java.lang.RuntimeException: Exception releasing lock '/reindexing/v1/content-chunks/lock'
		at com.yahoo.vespa.curator.Lock.close(Lock.java:72)
		at ai.vespa.reindexing.Reindexer.reindex(Reindexer.java:107)
		... 7 more
	Caused by: org.apache.curator.framework.api.CuratorClosedException: Expected state [STARTED] was [STOPPED]
		at org.apache.curator.framework.imps.CuratorFrameworkBase.checkState(CuratorFrameworkBase.java:108)
		at org.apache.curator.framework.imps.CuratorFrameworkBase.delete(CuratorFrameworkBase.java:144)
		at org.apache.curator.framework.recipes.locks.LockInternals.deleteOurPath(LockInternals.java:283)
		at org.apache.curator.framework.recipes.locks.LockInternals.releaseLock(LockInternals.java:109)
		at org.apache.curator.framework.recipes.locks.InterProcessMutex.release(InterProcessMutex.java:140)
		at com.yahoo.vespa.curator.Lock.close(Lock.java:67)
		... 8 more
Caused by: org.apache.curator.framework.api.CuratorClosedException: Expected state [STARTED] was [STOPPED]
	at org.apache.curator.framework.imps.CuratorFrameworkBase.checkState(CuratorFrameworkBase.java:108)
	at org.apache.curator.framework.imps.CuratorFrameworkBase.checkExists(CuratorFrameworkBase.java:150)
	at com.yahoo.vespa.curator.Curator.exists(Curator.java:210)
```

The Reindexer tries to clean up after the curator has closed.

#### Fix

Change the order:

1. Calling shutdown on the executor stops it from submitting new tasks.
2. Calling shutdown on the reindexers sets their state to aborted, which should make them start terminating their visitor threads.
3. Then, we can wait for the executor to finish termination.
4. Finally, close the curator.


@hmusum fyi
