### PR TITLE
Skip making ATTRIBUTION.md pr when only Last updated date has changed

### DIFF
--- a/.github/workflows/attribution.yml
+++ b/.github/workflows/attribution.yml
@@ -63,11 +63,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name  "github-actions[bot]"
 
-          git add ATTRIBUTIONS.md
-          if git diff --cached --quiet; then
+          # Ignore the "Last updated:" stamp so a date-only difference does
+          # not open a PR; the date still gets committed on real changes.
+          if git diff --exit-code -I '^Last updated: ' -- ATTRIBUTIONS.md > /dev/null; then
             echo "ATTRIBUTIONS.md is up to date — nothing to do."
             exit 0
           fi
+          git add ATTRIBUTIONS.md
 
           BRANCH="chore/update-attributions"
           git checkout -B "$BRANCH"


### PR DESCRIPTION
This GitHub Action job runs once a day and keeps the ATTRIBUTIONS.md document up to date, listing our third-party dependencies. Generated from a Mend repo.

This PR ignores the "Last updated:" stamp so a date-only difference does not open a PR. The date still gets committed on real changes.