### PR TITLE
Skip padding counter metrics in DimensionCache

### DIFF
--- a/container-disc/src/main/java/com/yahoo/metrics/simple/DimensionCache.java
+++ b/container-disc/src/main/java/com/yahoo/metrics/simple/DimensionCache.java
@@ -86,7 +86,7 @@ class DimensionCache {
                 continue;
             }
             Identifier id = new Identifier(metric, leastOld.getKey());
-            if ( ! toPresent.hasIdentifier(id)) {
+            if ( ! toPresent.hasIdentifier(id) && ! leastOld.getValue().metric.isCounter()) {
                 toPresent.put(id, leastOld.getValue().metric.pruneData());
                 --toAdd;
             }

--- a/container-disc/src/test/java/com/yahoo/metrics/simple/DimensionsCacheTest.java
+++ b/container-disc/src/test/java/com/yahoo/metrics/simple/DimensionsCacheTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.metrics.simple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
@@ -80,6 +81,21 @@ public class DimensionsCacheTest {
     }
 
     @Test
+    final void doesNotPadCounters() {
+        Bucket first = new Bucket();
+        populateDimensionLessValue("gauge", first, 2);
+        populateDimensionLessCounter("counter", first, 3);
+        cache.updateDimensionPersistence(null, first);
+
+        Bucket second = new Bucket();
+        cache.updateDimensionPersistence(first, second);
+
+        Collection<String> names = second.getAllMetricNames();
+        assertTrue(names.contains("gauge"));
+        assertFalse(names.contains("counter"));
+    }
+
+    @Test
     final void requireThatOldDataIsForgotten() {
         Bucket first = new Bucket(); // "now" as timestamp
         populateDimensionLessValue("one", first, 2);
@@ -112,6 +128,12 @@ public class DimensionsCacheTest {
     private void populateDimensionLessValue(String metricName, Bucket bucket, double x) {
         Identifier id = new Identifier(metricName, null);
         Sample wrappedX = new Sample(new Measurement(Double.valueOf(x)), id, AssumedType.GAUGE);
+        bucket.put(wrappedX);
+    }
+
+    private void populateDimensionLessCounter(String metricName, Bucket bucket, double x) {
+        Identifier id = new Identifier(metricName, null);
+        Sample wrappedX = new Sample(new Measurement(Double.valueOf(x)), id, AssumedType.COUNTER);
         bucket.put(wrappedX);
     }
 


### PR DESCRIPTION
Fixes #35612

## Problem
Counter metrics with no new data in the current time window still showed up in
`state/v1/metrics` with `count=0`, instead of being dropped — contradicting the
documented behavior of `MetricSet.partialClone()`, which states aggregate
metrics are not carried over.

## Root cause
`DimensionCache.padMetric()` pads back *all* cached metrics regardless of type
to fill up to `pointsToKeep`, including counters, before
`MetricSet.partialClone()` gets a chance to filter them out.

## Fix
Skip counters when padding in `DimensionCache.padMetric()`, using the existing
`UntypedMetric.isCounter()` check. Gauges are unaffected and continue to be
padded as before.

## Testing
- Added `DimensionsCacheTest.doesNotPadCounters`, asserting a counter is
  dropped while a gauge is retained after padding.
- `mvn -pl container-disc test` — 542 tests, 0 failures, 0 errors (5 pre-existing skips).