### PR TITLE
Handling of request idle timeout when waiting for request content

### DIFF
--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyRequestContentReader.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyRequestContentReader.java
@@ -13,6 +13,7 @@ import org.eclipse.jetty.server.Request;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -124,7 +125,16 @@ class JettyRequestContentReader {
             }
             // Retry read if failure but not the last chunk
             if (Content.Chunk.isFailure(chunk, false)) {
-                log.log(Level.FINE, chunk.getFailure(), () -> "Failed to read non-last chunk");
+                var failure = chunk.getFailure();
+                // Jetty delivers connection/stream idle timeouts as transient failures while we wait for content.
+                // A client that stops sending mid-body without closing the connection never produces another chunk,
+                // so retrying would leave the request (and the handler thread reading the content) hanging forever.
+                if (failure instanceof TimeoutException) {
+                    jettyReadCompletion.completeExceptionally(new RequestException(
+                            HttpStatus.REQUEST_TIMEOUT_408, "Timed out waiting for request content", failure));
+                    return;
+                }
+                log.log(Level.FINE, failure, () -> "Failed to read non-last chunk");
                 jettyRequest.demand(this::processChunks);
                 return;
             }

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/BlockingContentReadRequestHandler.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/BlockingContentReadRequestHandler.java
@@ -1,0 +1,38 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.jdisc.http.server.jetty;
+
+import com.yahoo.jdisc.Request;
+import com.yahoo.jdisc.handler.AbstractRequestHandler;
+import com.yahoo.jdisc.handler.ContentChannel;
+import com.yahoo.jdisc.handler.ReadableContentChannel;
+import com.yahoo.jdisc.handler.ResponseHandler;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Blocks a dedicated thread reading the request content, mimicking handlers that consume content through a
+ * blocking input stream. The thread is only released when the content channel is closed or fails, so
+ * {@link #contentReadTerminated} verifies that a failed request read wakes up a blocked handler thread.
+ *
+ * @author glebashnik
+ */
+class BlockingContentReadRequestHandler extends AbstractRequestHandler {
+
+    final CountDownLatch contentReadTerminated = new CountDownLatch(1);
+
+    @Override
+    public ContentChannel handleRequest(Request request, ResponseHandler handler) {
+        var content = new ReadableContentChannel();
+        var reader = new Thread(() -> {
+            try (var in = content.toStream()) {
+                in.readAllBytes();
+            } catch (Throwable ignored) {
+            } finally {
+                contentReadTerminated.countDown();
+            }
+        });
+        reader.setDaemon(true);
+        reader.start();
+        return content;
+    }
+}

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/Http2IT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/Http2IT.java
@@ -9,22 +9,32 @@ import com.yahoo.jdisc.http.ServerConfig;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
 import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.yahoo.jdisc.Response.Status.OK;
 import static com.yahoo.jdisc.http.server.jetty.Utils.createHttp2Client;
 import static com.yahoo.jdisc.http.server.jetty.Utils.createSslTestDriver;
 import static com.yahoo.jdisc.http.server.jetty.Utils.generatePrivateKeyAndCertificate;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,5 +106,60 @@ class Http2IT {
             assertEquals(200, response.getCode());
         }
         assertTrue(driver.close());
+    }
+
+    @Test
+    void stalledRequestContentOnHttp2StreamFailsWith408() throws Exception {
+        var handler = new BlockingContentReadRequestHandler();
+        JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
+                handler,
+                new ServerConfig.Builder(),
+                // Connection-level idleTimeout is left at its default (180s), so the stalled stream
+                // must be failed by the stream idle timeout, as a multiplexed connection may be kept
+                // alive by other healthy streams.
+                new ConnectorConfig.Builder()
+                        .http2(new ConnectorConfig.Http2.Builder().streamIdleTimeout(0.5)));
+        try (CloseableHttpAsyncClient client = createHttp2Client(driver)) {
+            var request = new BasicHttpRequest(
+                    "POST", URI.create("http://localhost:" + driver.server().getListenPort() + "/"));
+            // Announce a body, send only part of it, then leave the stream stalled without closing it.
+            var response = client.execute(
+                            new BasicRequestProducer(request, new StallingEntityProducer("partial", 100)),
+                            SimpleResponseConsumer.create(), null)
+                    .get(30, TimeUnit.SECONDS);
+            assertEquals(408, response.getCode());
+        }
+        assertTrue(handler.contentReadTerminated.await(30, TimeUnit.SECONDS),
+                   "Handler thread was not released from blocking content read");
+        assertTrue(driver.close());
+    }
+
+    /** Produces part of the announced request content, then stalls without ever completing the stream. */
+    private static class StallingEntityProducer implements AsyncEntityProducer {
+
+        private final byte[] partialContent;
+        private final long contentLength;
+        private final AtomicBoolean produced = new AtomicBoolean();
+
+        StallingEntityProducer(String partialContent, long contentLength) {
+            this.partialContent = partialContent.getBytes(UTF_8);
+            this.contentLength = contentLength;
+        }
+
+        @Override public boolean isRepeatable() { return false; }
+        @Override public void failed(Exception cause) {}
+        @Override public long getContentLength() { return contentLength; }
+        @Override public String getContentType() { return "application/octet-stream"; }
+        @Override public String getContentEncoding() { return null; }
+        @Override public boolean isChunked() { return false; }
+        @Override public Set<String> getTrailerNames() { return Set.of(); }
+        @Override public int available() { return produced.get() ? 0 : partialContent.length; }
+        @Override public void releaseResources() {}
+
+        @Override
+        public void produce(DataStreamChannel channel) throws IOException {
+            if (produced.compareAndSet(false, true)) channel.write(ByteBuffer.wrap(partialContent));
+            // Never write the remaining content and never end the stream
+        }
     }
 }

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerIT.java
@@ -50,9 +50,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import javax.net.ssl.SSLContext;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.BindException;
+import java.net.Socket;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -98,6 +101,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -868,6 +872,55 @@ public class HttpServerIT {
                 new ConnectorConfig.Builder().maxContentSize(4));
         driver.client().newPost("/").setBinaryContent(new byte[4]).execute().expectStatusCode(is(OK));
         driver.client().newPost("/").setBinaryContent(new byte[5]).execute().expectStatusCode(is(REQUEST_TOO_LONG));
+        assertTrue(driver.close());
+    }
+
+    @Test
+    void stalledRequestContentFailsWith408() throws Exception {
+        var handler = new BlockingContentReadRequestHandler();
+        JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
+                handler,
+                new ServerConfig.Builder(),
+                new ConnectorConfig.Builder().idleTimeout(0.5));
+        try (var socket = new Socket("localhost", driver.server().getListenPort())) {
+            socket.setSoTimeout(30_000);
+            // Announce a body, send only part of it, then go silent while keeping the connection open.
+            // Jetty's idle timeout is then delivered as a transient read failure which must fail the
+            // request; if it is swallowed instead, the handler thread blocks reading content forever.
+            socket.getOutputStream().write(
+                    ("POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n\r\npartial").getBytes(UTF_8));
+            socket.getOutputStream().flush();
+            var statusLine = new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8)).readLine();
+            assertNotNull(statusLine, "Connection closed without a response");
+            assertTrue(statusLine.contains("408"), "Expected '408 Request Timeout', got: " + statusLine);
+        }
+        assertTrue(handler.contentReadTerminated.await(30, TimeUnit.SECONDS),
+                   "Handler thread was not released from blocking content read");
+        assertTrue(driver.close());
+    }
+
+    @Test
+    void slowlyProgressingRequestContentDoesNotTimeOut() throws Exception {
+        JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
+                new ReadBeforeWriteRequestHandler(),
+                new ServerConfig.Builder(),
+                new ConnectorConfig.Builder().idleTimeout(1.5));
+        try (var socket = new Socket("localhost", driver.server().getListenPort())) {
+            socket.setSoTimeout(30_000);
+            var out = socket.getOutputStream();
+            out.write("POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 20\r\n\r\n".getBytes(UTF_8));
+            out.flush();
+            // Each gap between chunks is well below the idle timeout, but the gaps sum to above it.
+            // The timeout must reset on every chunk - only a full stall should fail the request.
+            for (int i = 0; i < 4; i++) {
+                Thread.sleep(500);
+                out.write("chunk".getBytes(UTF_8));
+                out.flush();
+            }
+            var statusLine = new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8)).readLine();
+            assertNotNull(statusLine, "Connection closed without a response");
+            assertTrue(statusLine.contains("200"), "Expected '200 OK', got: " + statusLine);
+        }
         assertTrue(driver.close());
     }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Request idle timeout when waiting for post data was not handled leading to search-handler thread stalling indefinitely.