### PR TITLE
Fix join source remap feed race

### DIFF
--- a/storage/src/vespa/storage/persistence/splitjoinhandler.cpp
+++ b/storage/src/vespa/storage/persistence/splitjoinhandler.cpp
@@ -205,10 +205,17 @@ MessageTracker::UP SplitJoinHandler::handleJoinBuckets(api::JoinBucketsCommand& 
     for (uint32_t i = 0; i < cmd.getSourceBuckets().size(); i++) {
         document::Bucket           srcBucket(destBucket.getBucketSpace(), cmd.getSourceBuckets()[i]);
         FileStorHandler::RemapInfo target(cmd.getBucket());
-        _env._fileStorHandler.remapQueueAfterJoin(FileStorHandler::RemapInfo(srcBucket), target);
-        // Remove source from bucket db.
+        // Feed operations hold the source bucket's DB entry lock from bucket lookup
+        // through queue insertion. Holding the same lock across queue remapping and
+        // source removal ensures a concurrent feed op is either included in the
+        // remap, or observes the removed source and is remapped or rejected at
+        // ingress. Otherwise it may execute against the source after the provider
+        // join and leave the provider and service layer bucket DB out of sync.
+        // This mirrors the lock ordering used by the split path.
         StorBucketDatabase::WrappedEntry entry =
             _env.getBucketDatabase(srcBucket.getBucketSpace()).get(srcBucket.getBucketId(), "join-remove-source");
+        _env._fileStorHandler.remapQueueAfterJoin(FileStorHandler::RemapInfo(srcBucket), target);
+        // Remove source from bucket db.
         if (entry.exists()) {
             lastModified = std::max(lastModified, entry->info.getLastModified());
             entry.remove();


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

A feed operation checks that its source bucket exists and schedules the operation while holding the bucket DB entry lock. Previously, join remapped queued operations before acquiring this lock to remove the source bucket.

This left a window where a feed operation could be scheduled after the queue remap but before the source bucket was removed. The operation would then be stranded in the queue for a bucket that no longer existed in the bucket DB.

The join path now acquires the source bucket DB entry lock before remapping queued operations and holds it until the source entry has been removed. This ensures that a concurrent feed operation either:

- is scheduled before the remap and gets remapped to the target bucket, or
- observes the removed source bucket and is remapped or rejected.

This also makes the join path consistent with the existing split lock ordering.