### PR TITLE
fix: persist refresh token from Auth0

### DIFF
--- a/client/go/internal/cli/auth/auth0/auth0.go
+++ b/client/go/internal/cli/auth/auth0/auth0.go
@@ -157,6 +157,12 @@ func (a *Client) AccessToken() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("auth0: failed to renew access token: %w: %s", err, reauthMessage)
 		} else {
+			if resp.RefreshToken != "" {
+				// the refresh token was rotated: persist the new one, or the next refresh will be rejected
+				if err := tr.Secrets.Set(auth.SecretsNamespace, a.options.SystemName, resp.RefreshToken); err != nil {
+					return "", fmt.Errorf("auth0: failed to persist rotated refresh token: %w", err)
+				}
+			}
 			// persist the updated system with renewed access token
 			creds.AccessToken = resp.AccessToken
 			creds.ExpiresAt = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)

--- a/client/go/internal/cli/auth/token.go
+++ b/client/go/internal/cli/auth/token.go
@@ -14,10 +14,11 @@ import (
 )
 
 type TokenResponse struct {
-	AccessToken string `json:"access_token"`
-	IDToken     string `json:"id_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
 }
 
 type TokenRetriever struct {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Previously when looking at the refresh token with `vespa status deploy && security find-generic-password -s vespa-cli -a publiccd -w`, then changing the .vespa/auth.json, the refresh token would not update. Doing the same 2 steps again would result in `Error: auth failed: auth0: failed to renew access token: unknown or invalid refresh token: re-authenticate with 'vespa auth login'`. 

After this change a new refresh token is set, and you can expire the token manually in .vespa/auth.json without any problems because new refresh tokens are fetched when the previous one is used.