### PR TITLE
Changes in threadpool require restart

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -20,6 +20,7 @@ import com.yahoo.vespa.model.application.validation.change.IndexedSearchClusterC
 import com.yahoo.vespa.model.application.validation.change.IndexingModeChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.NodeResourceChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.RestartOnDeployForLocalLLMValidator;
+import com.yahoo.vespa.model.application.validation.change.RestartOnDeployForContainerThreadpoolChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.RestartOnDeployForOnnxModelChangesValidator;
 import com.yahoo.vespa.model.application.validation.change.RestartOnDeployForSidecarValidator;
 import com.yahoo.vespa.model.application.validation.change.RestartOnDeployForTritonOnnxRuntimeValidator;
@@ -148,6 +149,7 @@ public class Validation {
         new DataplaneTokenRemovalValidator().validate(execution);
         new DataplaneProxyChangeValidator().validate(execution);
         new RestartOnDeployForSidecarValidator().validate(execution);
+        new RestartOnDeployForContainerThreadpoolChangeValidator().validate(execution);
     }
 
     public interface Context {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/DataplaneProxyChangeValidator.java
@@ -1,10 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
-import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.text.Text;
-import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
@@ -41,7 +39,7 @@ public class DataplaneProxyChangeValidator implements ChangeValidator {
                 var message = hasProxy
                         ? "Token endpoint was enabled for cluster '%s', services require restart"
                         : "Token endpoint was disabled for cluster '%s', services require restart";
-                var action = createRestartAction(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
+                var action = VespaRestartAction.ofCluster(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
                 context.require(action);
             }
         }
@@ -55,13 +53,5 @@ public class DataplaneProxyChangeValidator implements ChangeValidator {
     private static boolean hasDataplaneProxy(ApplicationContainerCluster cluster) {
         return cluster.getAllComponents().stream()
                 .anyMatch(component -> component.getClassId().getName().equals(DataplaneProxy.COMPONENT_CLASS));
-    }
-
-    private static VespaRestartAction createRestartAction(ApplicationContainerCluster cluster, String message,
-                                                         ConfigChangeRestartAction.ConfigChange configChange) {
-        var services = cluster.getContainers().stream()
-                .map(AbstractService::getServiceInfo)
-                .toList();
-        return new VespaRestartAction(cluster.id(), message, services, configChange);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForContainerThreadpoolChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForContainerThreadpoolChangeValidator.java
@@ -1,0 +1,60 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation.change;
+
+import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
+import com.yahoo.text.Text;
+import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
+import com.yahoo.vespa.model.utils.internal.ReflectionUtil;
+
+import java.util.Map;
+
+import static com.yahoo.config.model.api.ConfigChangeRestartAction.ConfigChange.DEFER_UNTIL_RESTART;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Sets restartOnDeploy for existing clusters when a container threadpool has changed,
+ * e.g. {@code <search><threadpool>}. Threadpools are sized when constructed and are
+ * not resized without restarting the container.
+ *
+ * @author glebashnik
+ */
+public class RestartOnDeployForContainerThreadpoolChangeValidator implements ChangeValidator {
+
+    @Override
+    public void validate(ChangeContext context) {
+        // Validate existing clusters only, new clusters do not need restartOnDeploy.
+        for (var previousCluster : context.previousModel().getContainerClusters().values()) {
+            var nextCluster = context.model().getContainerClusters().get(previousCluster.name());
+            if (nextCluster == null || nextCluster.getContainers().isEmpty()) continue;
+
+            var previousPools = findThreadpools(previousCluster);
+            var nextPools = findThreadpools(nextCluster);
+
+            for (var configId : nextPools.keySet()) {
+                // Threadpools that are new in the next model do not need restart.
+                if ( ! previousPools.containsKey(configId)) continue;
+
+                // Resolve configs through the models to include user <config> overrides.
+                var previousConfig = context.previousModel().getConfig(ContainerThreadpoolConfig.class, configId);
+                var nextConfig = context.model().getConfig(ContainerThreadpoolConfig.class, configId);
+
+                var changes = ReflectionUtil.getChangesRequiringRestart(previousConfig, nextConfig);
+                if (changes.needsRestart()) {
+                    var message = Text.format("Container threadpool '%s' has changed, need to restart services in %s:\n%s",
+                                              nextConfig.name(), nextCluster.id(), changes.toString(""));
+                    context.require(VespaRestartAction.ofCluster(nextCluster, message, DEFER_UNTIL_RESTART));
+                }
+            }
+        }
+    }
+
+    private static Map<String, ContainerThreadpool> findThreadpools(ApplicationContainerCluster cluster) {
+        return cluster.getAllComponents().stream()
+                      .filter(ContainerThreadpool.class::isInstance)
+                      .map(ContainerThreadpool.class::cast)
+                      .collect(toMap(ContainerThreadpool::getConfigId, threadpool -> threadpool));
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForContainerThreadpoolChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForContainerThreadpoolChangeValidator.java
@@ -24,6 +24,10 @@ public class RestartOnDeployForContainerThreadpoolChangeValidator implements Cha
 
     @Override
     public void validate(ChangeContext context) {
+        // Restart is only triggered automatically for hosted Vespa,
+        // for self-hosted a deferred restart would freeze all config changes until a manual restart.
+        if ( ! context.deployState().isHosted()) return;
+
         // Validate existing clusters only, new clusters do not need restartOnDeploy.
         for (var previousCluster : context.previousModel().getContainerClusters().values()) {
             var nextCluster = context.model().getContainerClusters().get(previousCluster.name());

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
@@ -6,7 +6,6 @@ import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.model.api.OnnxModelCost;
 import com.yahoo.text.Text;
-import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.Host;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.ApplicationContainer;
@@ -98,13 +97,7 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
 
     private static void setRestartOnDeployAndAddRestartAction(List<ConfigChangeAction> actions, ApplicationContainerCluster cluster, String message) {
         log.log(INFO, message);
-        actions.add(new VespaRestartAction(
-                cluster.id(),
-                message,
-                cluster.getContainers().stream()
-                        .map(AbstractService::getServiceInfo)
-                        .toList(),
-                DEFER_UNTIL_RESTART));
+        actions.add(VespaRestartAction.ofCluster(cluster, message, DEFER_UNTIL_RESTART));
     }
 
     private static boolean enoughMemoryToAvoidRestart(ApplicationContainerCluster clusterInCurrentModel,

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForSidecarValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForSidecarValidator.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.SidecarSpec;
 import com.yahoo.text.Text;
-import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
@@ -150,11 +149,6 @@ public class RestartOnDeployForSidecarValidator implements ChangeValidator {
     }
 
     private void addRestartAction(ChangeContext context, ApplicationContainerCluster cluster, String message) {
-        var services = cluster.getContainers().stream().map(AbstractService::getServiceInfo).toList();
-
-        context.require(new VespaRestartAction(
-                cluster.id(), message, services,
-                VespaRestartAction.ConfigChange.DEFER_UNTIL_RESTART
-        ));
+        context.require(VespaRestartAction.ofCluster(cluster, message, VespaRestartAction.ConfigChange.DEFER_UNTIL_RESTART));
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidator.java
@@ -1,10 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
-import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.text.Text;
-import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
@@ -43,7 +41,7 @@ public class RestartOnDeployForTritonOnnxRuntimeValidator implements ChangeValid
                 var message = hasTritonRuntime
                         ? "Triton ONNX runtime was enabled for cluster '%s', services require restart"
                         : "Triton ONNX runtime was disabled for cluster '%s', services require restart";
-                var action = createRestartAction(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
+                var action = VespaRestartAction.ofCluster(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
                 context.require(action);
             }
         }
@@ -58,13 +56,5 @@ public class RestartOnDeployForTritonOnnxRuntimeValidator implements ChangeValid
         return cluster.getAllComponents().stream()
                 .anyMatch(component ->
                         component.getClassId().getName().equals(ContainerModelEvaluation.TRITON_ONNX_RUNTIME_CLASS));
-    }
-
-    private static VespaRestartAction createRestartAction(
-            ApplicationContainerCluster cluster, String message, ConfigChangeRestartAction.ConfigChange configChange) {
-        var services = cluster.getContainers().stream()
-                .map(AbstractService::getServiceInfo)
-                .toList();
-        return new VespaRestartAction(cluster.id(), message, services, configChange);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/VespaRestartAction.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/VespaRestartAction.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.model.application.validation.change;
 import com.yahoo.config.model.api.ConfigChangeRestartAction;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.vespa.model.AbstractService;
+import com.yahoo.vespa.model.container.ContainerCluster;
 
 import java.util.List;
 
@@ -49,6 +51,13 @@ public class VespaRestartAction extends VespaConfigChangeAction implements Confi
         super(id, message, services);
         this.ignoreForInternalRedeploy = ignoreForInternalRedeploy;
         this.configChange = configChange;
+    }
+
+    /** Creates an action restarting all containers in the given cluster. */
+    public static VespaRestartAction ofCluster(ContainerCluster<?> cluster, String message, ConfigChange configChange) {
+        return new VespaRestartAction(cluster.id(), message,
+                                      cluster.getContainers().stream().map(AbstractService::getServiceInfo).toList(),
+                                      configChange);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerThreadpoolOptionsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerThreadpoolOptionsBuilder.java
@@ -81,11 +81,11 @@ public class ContainerThreadpoolOptionsBuilder {
             isRelative = false;
         }
 
-        if (min != null && min < 0)
+        if (min != null && (min.isNaN() || min.isInfinite() || min < 0))
             throw new IllegalArgumentException("For <threadpool>: <threads> must be positive.");
-        if (max != null && max <= 0)
+        if (max != null && (max.isNaN() || max.isInfinite() || max <= 0))
             throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be positive.");
-        if (queue != null && queue < 0)
+        if (queue != null && (queue.isNaN() || queue.isInfinite() || queue < 0))
             throw new IllegalArgumentException("For <threadpool>: <queue> must be positive.");
         if (min != null && max != null && min > max)
             throw new IllegalArgumentException("For <threadpool>: 'max' on <threads> must be greater than <threads>.");

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForContainerThreadpoolChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForContainerThreadpoolChangeValidatorTest.java
@@ -1,0 +1,241 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation.change;
+
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ConfigChangeAction;
+import com.yahoo.config.model.api.ContainerEndpoint;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.application.validation.ValidationTester;
+import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * @author glebashnik
+ */
+public class RestartOnDeployForContainerThreadpoolChangeValidatorTest {
+
+    @Test
+    void no_restart_when_not_hosted() {
+        var current = model(searchCluster("<threadpool><threads max='8'>4</threads></threadpool>"));
+        var next = model(searchCluster("<threadpool><threads max='16'>8</threads></threadpool>"));
+        var result = validate(current, next, false);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void no_restart_when_threadpool_unchanged() {
+        var current = model(searchCluster("<threadpool><threads max='8'>4</threads><queue>100</queue></threadpool>"));
+        var next = model(searchCluster("<threadpool><threads max='8'>4</threads><queue>100</queue></threadpool>"));
+        var result = validate(current, next, true);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void restart_when_search_threadpool_changed() {
+        var current = model(searchCluster("<threadpool><threads max='8'>4</threads></threadpool>"));
+        var next = model(searchCluster("<threadpool><threads max='16'>8</threads></threadpool>"));
+        var result = validate(current, next, true);
+
+        assertEquals(1, result.size());
+        assertRestartActionProperties(
+                result.get(0),
+                """
+                Container threadpool 'search-handler' has changed, need to restart services in cluster 'search':
+                # Minimum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMinThreads has changed from 4.0 to 8.0
+                # Maximum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMaxThreads has changed from 8.0 to 16.0""");
+    }
+
+    @Test
+    void restart_when_threadpool_element_added() {
+        // The threadpool component exists in both models (created by the search handler),
+        // adding the element changes its config from the defaults.
+        var current = model(searchCluster(""));
+        var next = model(searchCluster("<threadpool><threads max='8'>4</threads></threadpool>"));
+        var result = validate(current, next, true);
+
+        assertEquals(1, result.size());
+        assertRestartActionProperties(
+                result.get(0),
+                """
+                Container threadpool 'search-handler' has changed, need to restart services in cluster 'search':
+                # Minimum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMinThreads has changed from 10.0 to 4.0
+                # Maximum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMaxThreads has changed from 10.0 to 8.0""");
+    }
+
+    @Test
+    void restart_when_threadpool_element_removed() {
+        var current = model(searchCluster("<threadpool><threads max='8'>4</threads></threadpool>"));
+        var next = model(searchCluster(""));
+        var result = validate(current, next, true);
+
+        assertEquals(1, result.size());
+        assertRestartActionProperties(
+                result.get(0),
+                """
+                Container threadpool 'search-handler' has changed, need to restart services in cluster 'search':
+                # Minimum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMinThreads has changed from 4.0 to 10.0
+                # Maximum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMaxThreads has changed from 8.0 to 10.0""");
+    }
+
+    @Test
+    void restart_when_deprecated_absolute_threadpool_changed() {
+        var current = model(searchCluster("<threadpool><min-threads>4</min-threads><max-threads>8</max-threads>" +
+                                          "<queue-size>100</queue-size></threadpool>"));
+        var next = model(searchCluster("<threadpool><min-threads>8</min-threads><max-threads>16</max-threads>" +
+                                       "<queue-size>200</queue-size></threadpool>"));
+        var result = validate(current, next, true);
+
+        assertEquals(1, result.size());
+        assertRestartActionProperties(
+                result.get(0),
+                """
+                Container threadpool 'search-handler' has changed, need to restart services in cluster 'search':
+                # Maximum number of thread in the thread pool (absolute)
+                container-threadpool.maxThreads has changed from 8 to 16
+                # Minimum number of thread in the thread pool (absolute)
+                container-threadpool.minThreads has changed from 4 to 8
+                # Absolute queue capacity
+                container-threadpool.queueSize has changed from 100 to 200""");
+    }
+
+    @Test
+    void restart_when_user_config_override_changed() {
+        // A user <config> override on the cluster applies to all threadpools in it.
+        var current = model(searchClusterWithConfigOverride(200));
+        var next = model(searchClusterWithConfigOverride(400));
+        var result = validate(current, next, true);
+
+        assertFalse(result.isEmpty());
+        var messages = result.stream().map(ConfigChangeAction::getMessage).toList();
+        assertEquals(result.size(), messages.stream()
+                .filter(message -> message.contains("container-threadpool.maxThreads has changed from 200 to 400"))
+                .count());
+        assertEquals(1, messages.stream()
+                .filter(message -> message.startsWith("Container threadpool 'search-handler' has changed"))
+                .count());
+    }
+
+    @Test
+    void restart_when_docproc_threadpool_changed() {
+        var current = model(docprocCluster("<threadpool><threads>4</threads></threadpool>"));
+        var next = model(docprocCluster("<threadpool><threads>8</threads></threadpool>"));
+        var result = validate(current, next, true);
+
+        assertEquals(1, result.size());
+        assertRestartActionProperties(
+                result.get(0),
+                """
+                Container threadpool 'docproc-handler' has changed, need to restart services in cluster 'search':
+                # Minimum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMinThreads has changed from 4.0 to 8.0
+                # Maximum number of threads relative to number of cores (vcpu)
+                container-threadpool.relativeMaxThreads has changed from 4.0 to 8.0""");
+    }
+
+    @Test
+    void no_restart_for_new_cluster() {
+        var current = model(extraCluster("<threadpool><threads max='8'>4</threads></threadpool>"));
+        var next = model(searchCluster("<threadpool><threads max='16'>8</threads></threadpool>"));
+        var result = validate(current, next, true);
+        assertEquals(0, result.size());
+    }
+
+    private List<ConfigChangeAction> validate(VespaModel current, VespaModel next, boolean hosted) {
+        return ValidationTester.validateChanges(
+                new RestartOnDeployForContainerThreadpoolChangeValidator(),
+                next,
+                new DeployState.Builder()
+                        .properties(new TestProperties().setHostedVespa(hosted))
+                        .previousModel(current)
+                        .build());
+    }
+
+    private static void assertRestartActionProperties(ConfigChangeAction action, String expectedMessage) {
+        assertEquals(expectedMessage, action.getMessage());
+        assertFalse(action.ignoreForInternalRedeploy());
+        assertEquals(ConfigChangeAction.Type.RESTART, action.getType());
+        var restartAction = assertInstanceOf(VespaRestartAction.class, action);
+        assertEquals(VespaRestartAction.ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
+    }
+
+    private static String searchCluster(String threadpoolXml) {
+        return """
+            <container id='search' version='1.0'>
+              <nodes count='1'/>
+              <search>
+                %s
+              </search>
+            </container>
+            """.formatted(threadpoolXml);
+    }
+
+    private static String searchClusterWithConfigOverride(int maxThreads) {
+        return """
+            <container id='search' version='1.0'>
+              <nodes count='1'/>
+              <config name='container.handler.threadpool.container-threadpool'>
+                <maxThreads>%d</maxThreads>
+              </config>
+              <search/>
+            </container>
+            """.formatted(maxThreads);
+    }
+
+    private static String docprocCluster(String threadpoolXml) {
+        return """
+            <container id='search' version='1.0'>
+              <nodes count='1'/>
+              <document-processing>
+                %s
+              </document-processing>
+            </container>
+            """.formatted(threadpoolXml);
+    }
+
+    private static String extraCluster(String threadpoolXml) {
+        return """
+            <container id='extra' version='1.0'>
+              <nodes count='1'/>
+              <search>
+                %s
+              </search>
+            </container>
+            """.formatted(threadpoolXml);
+    }
+
+    private VespaModel model(String clustersXml) {
+        var servicesXml = """
+            <?xml version='1.0' encoding='utf-8' ?>
+            <services version='1.0'>
+              %s
+            </services>
+            """.formatted(clustersXml);
+        var properties = new TestProperties();
+        properties.setHostedVespa(true);
+        var deployState = new DeployState.Builder()
+                .properties(properties)
+                .endpoints(Set.of(endpoint("search"), endpoint("extra")));
+        return new VespaModelCreatorWithMockPkg(null, servicesXml).create(deployState);
+    }
+
+    private static ContainerEndpoint endpoint(String clusterId) {
+        return new ContainerEndpoint(clusterId, ApplicationClusterEndpoint.Scope.zone,
+                                     List.of(clusterId + ".example.com"));
+    }
+
+}

--- a/container-disc/src/main/resources/configdefinitions/container.handler.threadpool.container-threadpool.def
+++ b/container-disc/src/main/resources/configdefinitions/container.handler.threadpool.container-threadpool.def
@@ -1,32 +1,34 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+# All values are only applied when the thread pool is constructed, hence the restart flags.
+
 namespace=container.handler.threadpool
 
 ## Maximum number of thread in the thread pool (absolute)
-maxThreads int default=-1
+maxThreads int default=-1 restart
 
 ## Minimum number of thread in the thread pool (absolute)
-minThreads int default=-1
+minThreads int default=-1 restart
 
 ## Minimum number of threads relative to number of cores (vcpu)
-relativeMinThreads double default=-1.0
+relativeMinThreads double default=-1.0 restart
 
 ## Maximum number of threads relative to number of cores (vcpu)
-relativeMaxThreads double default=-1.0
+relativeMaxThreads double default=-1.0 restart
 
 ## The number of seconds that excess idle threads will wait for new tasks before terminating
-keepAliveTime double default=5.0
+keepAliveTime double default=5.0 restart
 
 ## Absolute queue capacity
-queueSize int default=-1
+queueSize int default=-1 restart
 
 ## Max queue capacity relative to number of cores
-relativeQueueSize double default=-1.0
+relativeQueueSize double default=-1.0 restart
 
 ## The max time the container tolerates having no threads available before it shuts down to
 ## get out of a bad state. This should be set a bit higher than the expected max execution
 ## time of each request when in a state of overload, i.e about "worst case execution time*2"
-maxThreadExecutionTimeSeconds int default=190
+maxThreadExecutionTimeSeconds int default=190 restart
 
 # Prefix for the name of the threads
-name string default="default-pool"
+name string default="default-pool" restart


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adds a new validator that require restarts when container search and docproc threadpools change.
Also changes are deferred until restart.
Did minor refactoring, moving out repeating code for creating restart action from validators.
