### PR TITLE
The session ID that is active for an application may become stale

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -10,6 +10,7 @@ import com.yahoo.collections.Pair;
 import com.yahoo.component.Version;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.component.provider.ComponentRegistry;
+import com.yahoo.concurrent.UncheckedTimeoutException;
 import com.yahoo.config.FileReference;
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.application.api.ApplicationMetaData;
@@ -23,6 +24,7 @@ import com.yahoo.config.provision.ApplicationTransaction;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterHosts;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.DeploymentConfigStore;
 import com.yahoo.config.provision.EndpointsChecker;
 import com.yahoo.config.provision.EndpointsChecker.Availability;
 import com.yahoo.config.provision.EndpointsChecker.Endpoint;
@@ -31,13 +33,12 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.HostFilter;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.InfraDeployer;
+import com.yahoo.config.provision.NodeSuspensionProvider;
 import com.yahoo.config.provision.ParentHostUnavailableException;
-import com.yahoo.config.provision.DeploymentConfigStore;
 import com.yahoo.config.provision.Provisioner;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
-import com.yahoo.config.provision.NodeSuspensionProvider;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provision.exception.ActivationConflictException;
 import com.yahoo.container.jdisc.HttpResponse;
@@ -66,10 +67,6 @@ import com.yahoo.vespa.config.server.application.FileDistributionStatus;
 import com.yahoo.vespa.config.server.application.HttpProxy;
 import com.yahoo.vespa.config.server.application.PendingRestarts;
 import com.yahoo.vespa.config.server.application.TenantApplications;
-import com.yahoo.vespa.config.server.configchange.ConfigChangeActions;
-import com.yahoo.vespa.config.server.configchange.RefeedActions;
-import com.yahoo.vespa.config.server.configchange.ReindexActions;
-import com.yahoo.vespa.config.server.configchange.RestartActions;
 import com.yahoo.vespa.config.server.deploy.DeployHandlerLogger;
 import com.yahoo.vespa.config.server.deploy.Deployment;
 import com.yahoo.vespa.config.server.deploy.InfraDeployerProvider;
@@ -103,12 +100,12 @@ import com.yahoo.vespa.config.server.tenant.Tenant;
 import com.yahoo.vespa.config.server.tenant.TenantMetaData;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.curator.Curator;
+import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.curator.stats.LockStats;
 import com.yahoo.vespa.curator.stats.ThreadLockStats;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
-import com.yahoo.concurrent.UncheckedTimeoutException;
 import com.yahoo.yolean.Exceptions;
 
 import java.io.File;
@@ -562,9 +559,9 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return sessionRepository(tenant).read(session).applicationId();
     }
 
-    public Transaction deactivateCurrentActivateNew(Optional<Session> active, Session prepared, boolean force) {
+    public Transaction deactivateCurrentActivateNew(Lock applicationLock, Optional<Session> active, Session prepared, boolean force) {
         Tenant tenant = tenantRepository.getTenant(prepared.getTenantName());
-        Transaction transaction = tenant.getSessionRepository().createActivateTransaction(prepared);
+        Transaction transaction = tenant.getSessionRepository().createActivateTransaction(applicationLock, prepared);
         if (active.isPresent()) {
             checkIfActiveHasChanged(prepared, active.get(), force);
             checkIfActiveIsNewerThanSessionToBeActivated(prepared.getSessionId(), active.get().getSessionId());
@@ -631,7 +628,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         NestedTransaction transaction = new NestedTransaction();
         Optional<ApplicationTransaction> applicationTransaction = hostProvisioner.map(provisioner -> provisioner.lock(applicationId))
                                                                                  .map(lock -> new ApplicationTransaction(lock, transaction));
-        try (@SuppressWarnings("unused") var applicationLock = tenantApplications.lock(applicationId)) {
+        try (var applicationLock = tenantApplications.lock(applicationId)) {
             Optional<Long> activeSession = tenantApplications.activeSessionOf(applicationId);
             CompletionWaiter waiter;
             if (activeSession.isPresent()) {
@@ -655,7 +652,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             transaction.add(new EndpointCertificateMetadataStore(curator, tenant.getPath()).delete(applicationId));
             // This call will remove application in zookeeper. Watches in TenantApplications will remove the application
             // and allocated hosts in model and handlers in RPC server
-            transaction.add(tenantApplications.createDeleteTransaction(applicationId));
+            transaction.add(tenantApplications.createDeleteTransaction(applicationLock, applicationId));
             transaction.onCommitted(() -> log.log(Level.INFO, "Deleted " + applicationId));
 
             if (applicationTransaction.isPresent()) {
@@ -1032,12 +1029,12 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                                                                                  .map(lock -> new ApplicationTransaction(lock, transaction));
 
         Tenant tenant = tenantRepository().getTenant(applicationId.tenant());
-        try (@SuppressWarnings("unused") var sessionLock = tenant.getApplicationRepo().lock(applicationId)) {
+        try (var applicationLock = tenant.getApplicationRepo().lock(applicationId)) {
             Optional<Session> activeSession = getActiveSession(applicationId);
             var sessionZooKeeperClient = tenant.getSessionRepository().createSessionZooKeeperClient(session.getSessionId());
             CompletionWaiter waiter = sessionZooKeeperClient.createActiveWaiter();
 
-            transaction.add(deactivateCurrentActivateNew(activeSession, session, force));
+            transaction.add(deactivateCurrentActivateNew(applicationLock, activeSession, session, force));
             if (applicationTransaction.isPresent()) {
                 var hostsByCluster = session.getAllocatedHosts().getHostsByCluster();
                 validate(hostsByCluster, clusters);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabase.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabase.java
@@ -99,35 +99,22 @@ public class ApplicationCuratorDatabase {
     }
 
     /**
-     * Returns a transaction which writes the given session id as the currently active for the given application.
-     *
-     * @param applicationId An {@link ApplicationId} that represents an active application.
-     * @param sessionId     session id belonging to the application package for this application id.
+     * Append transaction operations that updates the last "deployed" (prepare or activate) session, and the active session,
+     * assuming the /config/v2/lock application lock is held.
      */
-    public Transaction createWriteActiveTransaction(Transaction transaction, ApplicationId applicationId, long sessionId) {
+    public Transaction appendDeployOperations(@SuppressWarnings("unused") Lock applicationLock,
+                                              ApplicationId applicationId,
+                                              long deployedSessionId,
+                                              OptionalLong activeSessionId,
+                                              Transaction transaction) {
         String path = applicationPath(applicationId).getAbsolute();
-        return transaction.add(setData(path, new ApplicationData(applicationId, OptionalLong.of(sessionId), OptionalLong.of(sessionId)).toJson()));
-    }
-
-    /**
-     * Returns a transaction which writes the given session id as the currently active for the given application.
-     *
-     * @param applicationId An {@link ApplicationId} that represents an active application.
-     * @param sessionId session id belonging to the application package for this application id.
-     */
-    public Transaction createWritePrepareTransaction(Transaction transaction,
-                                                     ApplicationId applicationId,
-                                                     long sessionId,
-                                                     OptionalLong activeSessionId) {
-        // Needs to read or be supplied current active session id, to avoid overwriting a newer session id.
-        String path = applicationPath(applicationId).getAbsolute();
-        return transaction.add(setData(path, new ApplicationData(applicationId, activeSessionId, OptionalLong.of(sessionId)).toJson()));
+        return transaction.add(setData(path, new ApplicationData(applicationId, activeSessionId, OptionalLong.of(deployedSessionId)).toJson()));
     }
 
     /**
      * Returns a transaction which deletes this application.
      */
-    public CuratorTransaction createDeleteTransaction(ApplicationId applicationId) {
+    public CuratorTransaction createDeleteTransaction(@SuppressWarnings("unused") Lock applicationLock, ApplicationId applicationId) {
         return CuratorTransaction.from(CuratorOperations.deleteAll(applicationPath(applicationId).getAbsolute(), curator), curator);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationData.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationData.java
@@ -62,6 +62,7 @@ public class ApplicationData {
             .map(OptionalLong::getAsLong);
     }
 
+    /** The session ID that was last prepared or activated. */
     public Optional<Long> lastDeployedSession() {
         return Optional.of(lastDeployedSession)
                 .filter(OptionalLong::isPresent)

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -9,6 +9,7 @@ import com.yahoo.config.FileReference;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
+import com.yahoo.text.Text;
 import com.yahoo.transaction.Transaction;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.GetConfigRequest;
@@ -31,7 +32,6 @@ import com.yahoo.vespa.flags.ListFlag;
 import com.yahoo.vespa.flags.PermanentFlags;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
-import com.yahoo.text.Text;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -139,29 +139,28 @@ public class TenantApplications implements RequestHandler, HostValidator {
     }
 
     /**
-     * Returns a transaction which writes the given session id as the currently active for the given application.
-     *
-     * @param applicationId An {@link ApplicationId} that represents an active application.
-     * @param sessionId session id belonging to the application package for this application id.
+     * Append transaction operations for activation of session: update the "last deployed" session of the application,
+     * and set which session is active for the application.
      */
-    public Transaction createWriteActiveTransaction(Transaction transaction, ApplicationId applicationId, long sessionId) {
-        return database().createWriteActiveTransaction(transaction, applicationId, sessionId);
+    public Transaction appendActivateOperations(Lock applicationLock,
+                                                ApplicationId applicationId,
+                                                long sessionId,
+                                                Transaction transaction) {
+        return database().appendDeployOperations(applicationLock, applicationId, sessionId, OptionalLong.of(sessionId), transaction);
     }
 
-    /**
-     * Returns a transaction which writes the given session id as the last deployed for the given application.
-     *
-     * @param applicationId An {@link ApplicationId} that represents an active application.
-     * @param sessionId session id belonging to the application package for this application id.
-     */
-    public Transaction createWritePrepareTransaction(Transaction transaction,
-                                                     ApplicationId applicationId,
-                                                     long sessionId,
-                                                     Optional<Long> activeSessionId) {
-        return database().createWritePrepareTransaction(transaction,
-                                                        applicationId,
-                                                        sessionId,
-                                                        activeSessionId.map(OptionalLong::of).orElseGet(OptionalLong::empty));
+    /** Application session is being prepared: Update the "last deployed" session of the application. */
+    public void prepare(ApplicationId applicationId, long sessionId) {
+        try (var applicationLock = lock(applicationId);
+             var transaction = new CuratorTransaction(curator)) {
+            OptionalLong activeSessionId = database().activeSessionOf(applicationId).map(OptionalLong::of).orElseGet(OptionalLong::empty);
+            database().appendDeployOperations(applicationLock,
+                                              applicationId,
+                                              sessionId,
+                                              activeSessionId,
+                                              transaction)
+                      .commit();
+        }
     }
 
     /**
@@ -186,8 +185,8 @@ public class TenantApplications implements RequestHandler, HostValidator {
     /**
      * Returns a transaction which deletes this application.
      */
-    public CuratorTransaction createDeleteTransaction(ApplicationId applicationId) {
-        return database().createDeleteTransaction(applicationId);
+    public CuratorTransaction createDeleteTransaction(Lock applicationLock, ApplicationId applicationId) {
+        return database().createDeleteTransaction(applicationLock, applicationId);
     }
 
     /**

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -20,18 +20,18 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.io.IOUtils;
 import com.yahoo.path.Path;
+import com.yahoo.text.Text;
 import com.yahoo.transaction.AbstractTransaction;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.transaction.Transaction;
 import com.yahoo.vespa.config.server.ConfigServerDB;
 import com.yahoo.vespa.config.server.TimeoutBudget;
-import com.yahoo.vespa.config.server.application.InheritableApplications;
 import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.vespa.config.server.application.ApplicationVersions;
+import com.yahoo.vespa.config.server.application.InheritableApplications;
 import com.yahoo.vespa.config.server.application.TenantApplications;
 import com.yahoo.vespa.config.server.configchange.ConfigChangeActions;
 import com.yahoo.vespa.config.server.deploy.TenantFileSystemDirs;
-import com.yahoo.text.Text;
 import com.yahoo.vespa.config.server.filedistribution.FileDistributionFactory;
 import com.yahoo.vespa.config.server.http.InvalidApplicationException;
 import com.yahoo.vespa.config.server.http.UnknownVespaVersionException;
@@ -46,7 +46,6 @@ import com.yahoo.vespa.config.server.zookeeper.SessionCounter;
 import com.yahoo.vespa.config.server.zookeeper.ZKApplication;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.Lock;
-import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
@@ -80,7 +79,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -90,6 +88,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static com.yahoo.vespa.config.server.session.ActivationTriggers.DeferredReconfiguration;
 import static com.yahoo.vespa.config.server.session.Session.Status.ACTIVATE;
@@ -276,13 +275,7 @@ public class SessionRepository {
                 ? Optional.empty()
                 : Optional.of(sessionZooKeeperClient.createPrepareWaiter());
         Optional<ApplicationVersions> activeApplicationVersions = activeApplicationVersions(applicationId);
-        try (var transaction = new CuratorTransaction(curator)) {
-            tenantApplications.createWritePrepareTransaction(transaction,
-                                                             applicationId,
-                                                             sessionId,
-                                                             getActiveSessionId(applicationId))
-                    .commit();
-        }
+        tenantApplications.prepare(applicationId, sessionId);
         ConfigChangeActions actions = sessionPreparer.prepare(tenantApplications, logger, params,
                                                               activeApplicationVersions, now, getSessionAppDir(sessionId),
                                                               session.getApplicationPackage(), sessionZooKeeperClient)
@@ -1124,10 +1117,9 @@ public class SessionRepository {
                 sessionAdded(sessionId);
     }
 
-    public Transaction createActivateTransaction(Session session) {
+    public Transaction createActivateTransaction(Lock applicationLock, Session session) {
         Transaction transaction = createSetStatusTransaction(session, ACTIVATE);
-        transaction.add(tenantApplications.createWriteActiveTransaction(transaction, session.getApplicationId(), session.getSessionId()).operations());
-        return transaction;
+        return tenantApplications.appendActivateOperations(applicationLock, session.getApplicationId(), session.getSessionId(), transaction);
     }
 
     public Transaction createSetStatusTransaction(Session session, Session.Status status) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabaseTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabaseTest.java
@@ -144,22 +144,22 @@ public class ApplicationCuratorDatabaseTest {
 
 
     private void deleteApplication(ApplicationCuratorDatabase db, ApplicationId applicationId) {
-        try (var t = db.createDeleteTransaction(applicationId)) {
+        try (var applicationLock = db.lock(applicationId);
+             var t = db.createDeleteTransaction(applicationLock, applicationId)) {
             t.commit();
         }
     }
 
     private void prepareSession(ApplicationCuratorDatabase db, ApplicationId applicationId, long sessionId, OptionalLong activesSessionId) {
-        try (var t = db.createWritePrepareTransaction(new CuratorTransaction(curator),
-                                                      applicationId,
-                                                      sessionId,
-                                                      activesSessionId)) {
+        try (var applicationLock = db.lock(applicationId);
+             var t = db.appendDeployOperations(applicationLock, applicationId, sessionId, activesSessionId, new CuratorTransaction(curator))) {
             t.commit();
         }
     }
 
     private void activateSession(ApplicationCuratorDatabase db, ApplicationId applicationId, long sessionId) {
-        try (var t = db.createWriteActiveTransaction(new CuratorTransaction(curator), applicationId, sessionId)) {
+        try (var applicationLock = db.lock(applicationId);
+             var t = db.appendDeployOperations(applicationLock, applicationId, sessionId, OptionalLong.of(sessionId), new CuratorTransaction(curator))) {
             t.commit();
         }
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/TenantApplicationsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/TenantApplicationsTest.java
@@ -336,14 +336,16 @@ public class TenantApplicationsTest {
     }
 
     private static void deleteApplication(TenantApplications repo, ApplicationId id1) {
-        try (var transaction = repo.createDeleteTransaction(id1)) {
+        try (var applicationLock = repo.lock(id1);
+             var transaction = repo.createDeleteTransaction(applicationLock, id1)) {
             transaction.commit();
         }
     }
 
     private void writeActiveTransaction(TenantApplications repo, ApplicationId id1, int x) {
-        try (var transaction = new CuratorTransaction(curator)) {
-            repo.createWriteActiveTransaction(transaction, id1, x).commit();
+        try (var applicationLock = repo.lock(id1);
+             var transaction = new CuratorTransaction(curator)) {
+            repo.appendActivateOperations(applicationLock, id1, x, transaction).commit();
         }
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandlerTest.java
@@ -128,8 +128,9 @@ public class ListApplicationsHandlerTest {
     }
 
     private void writeActiveTransaction(TenantApplications repo, ApplicationId id1, int x) {
-        try (var transaction = new CuratorTransaction(tenantRepository.getCurator())) {
-            repo.createWriteActiveTransaction(transaction, id1, x).commit();
+        try (var applicationLock = repo.lock(id1);
+             var transaction = new CuratorTransaction(tenantRepository.getCurator())) {
+            repo.appendActivateOperations(applicationLock, id1, x, transaction).commit();
         }
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/tenant/TenantRepositoryTest.java
@@ -110,8 +110,9 @@ public class TenantRepositoryTest {
         TenantApplications applicationRepo = tenantRepository.getTenant(tenant1).getApplicationRepo();
         ApplicationId id = ApplicationId.from(tenant1, ApplicationName.defaultName(), InstanceName.defaultName());
         applicationRepo.createApplication(id);
-        try (var transaction = new CuratorTransaction(curator)) {
-            applicationRepo.createWriteActiveTransaction(transaction, id, 4).commit();
+        try (var applicationLock = applicationRepo.lock(id);
+             var transaction = new CuratorTransaction(curator)) {
+            applicationRepo.appendActivateOperations(applicationLock, id, 4, transaction).commit();
         }
         applicationRepo.activateApplication(ApplicationVersions.fromList(List.of(new Application(new VespaModel(MockApplicationPackage.createEmpty()),
                                                                                                  new ServerCache(),


### PR DESCRIPTION
The old/current preparation code

 1. reads the active session ID from ZK in [SessionRepository.java:283](https://github.com/vespa-engine/vespa/blob/6e510bbcdfc780a161dbbc8fcf84a2cd41f3c44b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java#L283), and
 2. writes it back to ZK along with an updated "last deploy session ID" in [SessionRepository.java:280](https://github.com/vespa-engine/vespa/blob/6e510bbcdfc780a161dbbc8fcf84a2cd41f3c44b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java#L280).

These are done without a lock.  A concurrent activation may update which session is active, only for it to be overwritten by the above stale read. This is the classic ABA problem.

This PR ensures the prepare takes the `/config/v2/lock` application lock while updating the last deployed time.  The activation code already has the same lock.