### PR TITLE
Mark NearestNeighborBlueprint as expensive (only) on early fallback to exact search

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -306,6 +306,21 @@ bool Query::handle_global_filter(Blueprint& blueprint, const vespalib::Doom& doo
         }
         trace_global_filter_decision(5, trace, "Skip", estimated_hit_ratio, effective_lower_limit,
                                      effective_upper_limit);
+
+        // We are skipping the global filter computation on the premise that this query matches only very few
+        // documents, i.e., the estimated hit ratio is very low, and using exact nearest neighbor search to compute
+        // the distances to these documents is cheap.
+        // A WhiteListBlueprint that only matches very few documents can be the reason for the low estimated
+        // hit ratio. Hence, we have to make sure that the WhiteListBlueprint comes before the
+        // NearestNeighborBlueprints to reap the benefits of the low estimated hit ratio. The WhiteListBlueprint is in
+        // the expensive cost tier, however, which means that we have to mark the NearestNeighborBlueprints also as
+        // expensive to allow them to come after the WhiteListBlueprint.
+        blueprint.each_node_post_order([](Blueprint& bp) {
+            if (auto nearest_neighbor = bp.asNearestNeighbor()) {
+                nearest_neighbor->set_cost_tier_to_expensive();
+            }
+        });
+
         return false;
     }
 

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -113,10 +113,6 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec&  
       _eval_stats() {
     _distance_heap.set_distance_threshold(_hnsw_params.distance_threshold);
     uint32_t est_hits = _attr_tensor.get_num_docs();
-    // Default to the expensive cost tier to allow the WhiteListBlueprint to come before this blueprint.
-    // If we decide to use HNSW (INDEX_TOP_K, INDEX_TOP_K_WITH_FILTER) or exact search with a global filter
-    // (EXACT_FALLBACK), we move the blueprint to the normal cost tier.
-    set_cost_tier(State::COST_TIER_EXPENSIVE);
     setEstimate(HitEstimate(est_hits, false));
 }
 
@@ -144,7 +140,6 @@ void NearestNeighborBlueprint::set_global_filter(const GlobalFilter& global_filt
             est_hits = std::min(est_hits, _global_filter_hits.value());
             if (_global_filter_hit_ratio.value() < _hnsw_params.global_filter_lower_limit) {
                 _algorithm = Algorithm::EXACT_FALLBACK;
-                set_cost_tier(State::COST_TIER_NORMAL);
                 setEstimate(HitEstimate(est_hits, false));
             }
         } else { // post-filtering case
@@ -160,7 +155,6 @@ void NearestNeighborBlueprint::set_global_filter(const GlobalFilter& global_filt
         }
         if (_algorithm != Algorithm::EXACT_FALLBACK) {
             est_hits = std::min(est_hits, _adjusted_target_hits);
-            set_cost_tier(State::COST_TIER_NORMAL);
             setEstimate(HitEstimate(est_hits, false));
             _pending_index_search = true;
         }
@@ -169,6 +163,11 @@ void NearestNeighborBlueprint::set_global_filter(const GlobalFilter& global_filt
 
 void NearestNeighborBlueprint::set_lazy_filter(const GlobalFilter& lazy_filter) {
     _lazy_filter = lazy_filter.shared_from_this();
+}
+
+void NearestNeighborBlueprint::set_cost_tier_to_expensive() {
+    // Move this blueprint to the expensive cost tier to allow the WhiteListBlueprint to come before this blueprint.
+    set_cost_tier(State::COST_TIER_EXPENSIVE);
 }
 
 bool NearestNeighborBlueprint::pending_index_search() const {

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -98,6 +98,8 @@ public:
     // decided on an index search and perform_index_search() has to be called to perform the search.
     void set_global_filter(const GlobalFilter& global_filter, double estimated_hit_ratio) override;
     void set_lazy_filter(const GlobalFilter& lazy_filter) override;
+    // Set the cost tier of this blueprint to State::COST_TIER_EXPENSIVE
+    void set_cost_tier_to_expensive();
     // Whether the last call to want_global_filter() resulted in the decision to search the index.
     bool pending_index_search() const;
     // Perform the index search scheduled by the last call to set_global_filter().


### PR DESCRIPTION
This is a revision of the fix from https://github.com/vespa-engine/vespa/pull/36230.

The problem there was that the early fallback to an exact search caused by a `WhiteListBlueprint` that filters out most documents led to still computing the distance to every document since the `NearestNeighborBlueprint` came before the `WhiteListBlueprint`. This was fixed by moving the `NearestNeighborBlueprint` to the expensive cost tier by default and moving it back to the normal tier if we use HNSW and/or we have a global filter.

The disadvantage of having the `NearestNeighborBlueprint` in the expensive cost tier by default is that if we are using exact search and have just a few inactive documents, the `WhiteListBlueprint` will come first and prevent the `NearestNeighborBlueprint` from being strict. In a local test with 100.000 int8 vectors with 128 dimensions using the Hamming distance, the QPS went down from roughly 6900 to 5600 when the `NearestNeighborBlueprint` was forced to came after the WhiteList.

This PR, instead of making the `NearestNeighborBlueprint` expensive by default, makes it expensive only if we fall back to exact search early, i.e., we have a very low estimated hit ratio. This handles the original problem while also avoiding the performance regression.