### PR TITLE
Make error messages in ParsedType nice

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedType.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedType.java
@@ -170,7 +170,7 @@ public class ParsedType {
     public static ParsedType wsetOf(ParsedType vt) {
         assert(vt != null);
         if (vt.getVariant() != Variant.BUILTIN) {
-            throw new IllegalArgumentException("weightedset of complex type '" + vt + "' is not supported");
+            throw new IllegalArgumentException("weightedset of complex type '" + vt.toNiceName() + "' is not supported");
         }
         switch (vt.name()) {
             // allowed types:
@@ -181,17 +181,17 @@ public class ParsedType {
         case "uri":
             break;
         case "bool":
-            throw new IllegalArgumentException("weightedset of trivial type '" + vt + "' is not supported");
+            throw new IllegalArgumentException("weightedset of trivial type '" + vt.toNiceName() + "' is not supported");
         case "predicate":
         case "raw":
         case "tag":
-            throw new IllegalArgumentException("weightedset of complex type '" + vt + "' is not supported");
+            throw new IllegalArgumentException("weightedset of complex type '" + vt.toNiceName() + "' is not supported");
         case "float16":
         case "float":
         case "double":
-            throw new IllegalArgumentException("weightedset of inexact type '" + vt + "' is not supported");
+            throw new IllegalArgumentException("weightedset of inexact type '" + vt.toNiceName() + "' is not supported");
         default:
-            throw new IllegalArgumentException("weightedset of unknown type '" + vt + "' is not supported");
+            throw new IllegalArgumentException("weightedset of unknown type '" + vt.toNiceName() + "' is not supported");
         }
         return new ParsedType("weightedset<" + vt.name() + ">", Variant.WSET, vt);
     }
@@ -222,14 +222,14 @@ public class ParsedType {
 
     public void setCreateIfNonExistent(boolean value) {
         if (variant != Variant.WSET) {
-            throw new IllegalArgumentException("CreateIfNonExistent only valid for weightedset, not " + variant);
+            throw new IllegalArgumentException("CreateIfNonExistent only valid for weightedset, not " + toNiceName());
         }
         this.createIfNonExistent = value;
     }
 
     public void setRemoveIfZero(boolean value) {
         if (variant != Variant.WSET) {
-            throw new IllegalArgumentException("RemoveIfZero only valid for weightedset, not " + variant);
+            throw new IllegalArgumentException("RemoveIfZero only valid for weightedset, not " + toNiceName());
         }
         this.removeIfZero = value;
     }

--- a/config-model/src/test/java/com/yahoo/schema/processing/SingleValueOnlyAttributeValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/SingleValueOnlyAttributeValidatorTestCase.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author geirst
+ * @author Geir Storli
  */
 public class SingleValueOnlyAttributeValidatorTestCase {
 
@@ -33,12 +33,18 @@ public class SingleValueOnlyAttributeValidatorTestCase {
         }
         catch (IllegalArgumentException e) {
             if (type.equals("bool")) {
-                assertEquals("weightedset of trivial type '[type BUILTIN] {bool}' is not supported",
+                assertEquals("weightedset of trivial type 'bool' is not supported",
                         e.getMessage());
             } else if (type.equals("raw")) {
-                assertEquals("weightedset of complex type '[type BUILTIN] {raw}' is not supported",
+                assertEquals("weightedset of complex type 'raw' is not supported",
                         e.getMessage());
-            } else {
+            } else if (type.equals("double")) {
+                assertEquals("weightedset of inexact type 'double' is not supported",
+                        e.getMessage());
+            } else if (type.equals("map<int, string>")) {
+                assertEquals("weightedset of complex type 'map<int, string>' is not supported",
+                        e.getMessage());
+            }else {
                 assertEquals("For schema 'test', field 'b': Only single value " + type + " attribute fields are supported",
                         e.getMessage());
             }
@@ -53,6 +59,16 @@ public class SingleValueOnlyAttributeValidatorTestCase {
     @Test
     void weightedset_of_bool_attribute_is_not_supported() throws ParseException {
         weightedset_attribute_is_not_supported("bool");
+    }
+
+    @Test
+    void weightedset_of_double_attribute_is_not_supported() throws ParseException {
+        weightedset_attribute_is_not_supported("double");
+    }
+
+    @Test
+    void weightedset_of_map_attribute_is_not_supported() throws ParseException {
+        weightedset_attribute_is_not_supported("map<int, string>");
     }
 
     @Test


### PR DESCRIPTION
Using nice types #37524 

Some examples of error messages produced by ParsedType before this change:
```
weightedset of complex type '[type MAP] { map<[type BUILTIN] {int},[type BUILTIN] {bool}> }' is not supported
weightedset of inexact type '[type BUILTIN] {double}' is not supported
RemoveIfZero only valid for weightedset, not MAP
```

Some examples of error messages produced by ParsedType after this change:
```
weightedset of complex type 'map<int, bool>' is not supported
weightedset of inexact type 'double' is not supported
RemoveIfZero only valid for weightedset, not map<string, int>
```
