### PR TITLE
Remove dead code

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedField.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedField.java
@@ -155,12 +155,4 @@ public class ParsedField extends ParsedBlock {
         structFields.put(fieldName, structField);
     }
 
-    void addSummaryField(ParsedSummaryField summaryField) {
-        String fieldName = summaryField.name();
-        verifyThat(! summaryFields.containsKey(fieldName), "already has summary field", fieldName);
-        if (summaryField.getType() == null) {
-            summaryField.setType(getType());
-        }
-        summaryFields.put(fieldName, summaryField);
-    }
 }

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedSummaryField.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedSummaryField.java
@@ -25,10 +25,6 @@ public class ParsedSummaryField extends ParsedBlock {
     private final List<String> destinations = new ArrayList<>();
     private String selectElementsBySummaryFeature = null;
 
-    public ParsedSummaryField(String name) {
-        this(name, null);
-    }
-
     public ParsedSummaryField(String name, ParsedType type) {
         super(name, "summary field");
         this.type = type;


### PR DESCRIPTION
Redundant — handled by summaryFieldFor in the same class. And would throw, which the one in use does not.