### PR TITLE
ci: verify opensource RPM install on AlmaLinux 9 in addition to 8

### DIFF
--- a/.github/workflows/verify-opensource-rpm-installable.yml
+++ b/.github/workflows/verify-opensource-rpm-installable.yml
@@ -16,8 +16,17 @@ jobs:
   verify-opensource-rpm-installable:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - almalinux-version: 8
+            crb-repo: powertools
+          - almalinux-version: 9
+            crb-repo: crb
+
     container:
-      image: almalinux:8
+      image: almalinux:${{ matrix.almalinux-version }}
 
     steps:
       - name: Install Vespa
@@ -25,6 +34,6 @@ jobs:
           dnf list llvm-libs --showduplicates
           dnf install -y dnf-plugins-core
           dnf -y config-manager --add-repo https://raw.githubusercontent.com/vespa-engine/vespa/master/dist/vespa-engine.repo
-          dnf config-manager --enable powertools
+          dnf config-manager --enable ${{ matrix.crb-repo }}
           dnf install -y epel-release
           dnf install -y vespa


### PR DESCRIPTION
## What

- Run the RPM install check on both AlmaLinux 8 and 9 (matrix; `powertools` repo on el8, `crb` on el9).

## Why

- EL9 RPMs are being added to the open-source Cloudsmith repository and should be install-verified like el8.

## Additional info

- Keep as draft until the first EL9 RPMs are published — the el9 job fails until then
- Check name changes to `verify-opensource-rpm-installable (8, powertools)` / `(9, crb)`; update any branch-protection rule keyed on the old name

## How to test

- Re-run the workflow once EL9 RPMs exist; both legs must pass.
