### PR TITLE
Optimize chunked Hamming MaxSim

### DIFF
--- a/eval/src/tests/instruction/sum_max_inv_hamming_function/sum_max_inv_hamming_function_test.cpp
+++ b/eval/src/tests/instruction/sum_max_inv_hamming_function/sum_max_inv_hamming_function_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/eval/eval/test/eval_fixture.h>
 #include <vespa/eval/eval/test/gen_spec.h>
 #include <vespa/eval/instruction/sum_max_inv_hamming_function.h>
+#include <vespa/eval/streamed/streamed_value_builder_factory.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace vespalib;
@@ -15,6 +16,7 @@ const ValueBuilderFactory& prod_factory = FastValueBuilderFactory::get();
 
 std::string main_expr = "reduce(reduce(1/(1+reduce(hamming(a,b),sum,z)),max,y),sum,x)";
 std::string alt_expr = "reduce(reduce(1/(reduce(hamming(a,b),sum,z)+1),max,y),sum,x)";
+std::string chunked_expr = "reduce(reduce(reduce(1/(1+reduce(hamming(a,b),sum,z)),max,y),sum,x),max,c)";
 
 //-----------------------------------------------------------------------------
 
@@ -47,6 +49,35 @@ void assert_not_optimized(const TensorSpec& a, const TensorSpec& b, const std::s
     EXPECT_EQ(info.size(), 0);
 }
 
+void assert_chunked_optimized(const TensorSpec& a, const TensorSpec& b, size_t vec_size, size_t chunk_dim,
+                              const std::string&         expr = chunked_expr,
+                              const ValueBuilderFactory& factory = prod_factory) {
+    EvalFixture::ParamRepo param_repo;
+    param_repo.add("a", a);
+    param_repo.add("b", b);
+    EvalFixture slow_fixture(factory, expr, param_repo, false);
+    EvalFixture fast_fixture(factory, expr, param_repo, true);
+    EXPECT_EQ(slow_fixture.result(), EvalFixture::ref(expr, param_repo));
+    EXPECT_EQ(fast_fixture.result(), slow_fixture.result());
+    auto info = fast_fixture.find_all<MaxSumMaxInvHammingFunction>();
+    if (info.size() == 1) {
+        EXPECT_TRUE(info[0]->result_is_mutable());
+        EXPECT_EQ(info[0]->vec_size(), vec_size);
+        EXPECT_EQ(info[0]->chunk_dim(), chunk_dim);
+    }
+    EXPECT_EQ(info.size(), 1);
+}
+
+void assert_chunked_not_optimized(const TensorSpec& a, const TensorSpec& b, const std::string& expr = chunked_expr) {
+    EvalFixture::ParamRepo param_repo;
+    param_repo.add("a", a);
+    param_repo.add("b", b);
+    EvalFixture fast_fixture(prod_factory, expr, param_repo, true);
+    EXPECT_EQ(fast_fixture.result(), EvalFixture::ref(expr, param_repo));
+    auto info = fast_fixture.find_all<MaxSumMaxInvHammingFunction>();
+    EXPECT_EQ(info.size(), 0);
+}
+
 //-----------------------------------------------------------------------------
 
 GenSpec make_spec(const std::string& desc, CellType cell_type) {
@@ -56,6 +87,7 @@ GenSpec make_spec(const std::string& desc, CellType cell_type) {
 
 GenSpec query = make_spec("x3_1z7", CellType::INT8);
 GenSpec document = make_spec("y5_1z7", CellType::INT8);
+GenSpec chunked_document = make_spec("c2_1y5_1z7", CellType::INT8);
 
 TEST(SumMaxInvHamming, expression_can_be_optimized) {
     assert_optimized(query, document, 7);
@@ -121,6 +153,49 @@ TEST(SumMaxInvHamming, extra_dimensions_are_not_allowed) {
     assert_not_optimized(query_es, document_es);
     assert_not_optimized(query_ed, document_ed);
 }
+
+//-----------------------------------------------------------------------------
+
+TEST(SumMaxInvHamming, chunked_expression_can_be_optimized) {
+    assert_chunked_optimized(query, chunked_document, 7, 0);
+    assert_chunked_optimized(chunked_document, query, 7, 0);
+    assert_chunked_optimized(query, chunked_document, 7, 0, chunked_expr, StreamedValueBuilderFactory::get());
+}
+
+TEST(SumMaxInvHamming, the_chunk_dimension_may_come_after_the_document_token_dimension) {
+    std::string expr = "reduce(reduce(reduce(1/(1+reduce(hamming(a,b),sum,z)),max,c),sum,x),max,y)";
+    assert_chunked_optimized(query, make_spec("c5_1y2_1z7", CellType::INT8), 7, 1, expr);
+}
+
+TEST(SumMaxInvHamming, chunked_optimization_works_with_empty_tensors) {
+    auto empty_query = make_spec("x0_0z7", CellType::INT8);
+    auto empty_document = make_spec("c0_0y0_0z7", CellType::INT8);
+    assert_chunked_optimized(empty_query, chunked_document, 7, 0);
+    assert_chunked_optimized(query, empty_document, 7, 0);
+    assert_chunked_optimized(empty_query, empty_document, 7, 0);
+}
+
+TEST(SumMaxInvHamming, chunk_scores_are_accumulated_in_float) {
+    // generic evaluation sums the inverted distances into float cells; summing them in double would differ
+    EvalFixture::ParamRepo param_repo;
+    param_repo.add("a", GenSpec::from_desc("x32_1z16").cells(CellType::INT8).seq(Seq({0})));
+    param_repo.add("b", GenSpec::from_desc("c1_1y1_1z16")
+                            .cells(CellType::INT8)
+                            .seq(Seq({3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})));
+    EvalFixture slow_fixture(prod_factory, chunked_expr, param_repo, false);
+    EvalFixture fast_fixture(prod_factory, chunked_expr, param_repo, true);
+    EXPECT_EQ(fast_fixture.result(), slow_fixture.result());
+    EXPECT_EQ(fast_fixture.find_all<MaxSumMaxInvHammingFunction>().size(), 1);
+}
+
+TEST(SumMaxInvHamming, chunked_optimization_needs_two_mapped_document_dimensions) {
+    assert_chunked_not_optimized(query, make_spec("c2y5_1z7", CellType::INT8));
+    assert_chunked_not_optimized(query, make_spec("c2_1y5z7", CellType::INT8));
+    assert_chunked_not_optimized(query, make_spec("c2_1d3_1y5_1z7", CellType::INT8));
+    assert_chunked_not_optimized(query.cpy().cells(CellType::DOUBLE), chunked_document.cpy().cells(CellType::DOUBLE));
+}
+
+//-----------------------------------------------------------------------------
 
 TEST(SumMaxInvHamming, similar_expressions_are_not_optimized) {
     assert_not_optimized(query, document, "reduce(reduce(1*(1+reduce(hamming(a,b),sum,z)),max,y),sum,x)");

--- a/eval/src/vespa/eval/eval/optimize_tensor_function.cpp
+++ b/eval/src/vespa/eval/eval/optimize_tensor_function.cpp
@@ -73,6 +73,7 @@ const TensorFunction& optimize_for_factory(const ValueBuilderFactory&, const Ten
                       [&stash](const Child& child) { child.set(PowAsMapOptimizer::optimize(child.get(), stash)); });
     run_optimize_pass(root, [&stash](const Child& child) {
         child.set(SumMaxInvHammingFunction::optimize(child.get(), stash));
+        child.set(MaxSumMaxInvHammingFunction::optimize(child.get(), stash));
         child.set(SumMaxDotProductFunction::optimize(child.get(), stash));
     });
     run_optimize_pass(root, [&stash](const Child& child) {

--- a/eval/src/vespa/eval/instruction/sum_max_inv_hamming_function.cpp
+++ b/eval/src/vespa/eval/instruction/sum_max_inv_hamming_function.cpp
@@ -3,7 +3,14 @@
 #include "sum_max_inv_hamming_function.h"
 
 #include <vespa/eval/eval/value.h>
+#include <vespa/eval/eval/wrap_param.h>
+#include <vespa/vespalib/hwaccelerated/functions.h>
 #include <vespa/vespalib/util/binary_hamming_distance.h>
+
+#include <algorithm>
+#include <array>
+#include <unordered_map>
+#include <vector>
 
 namespace vespalib::eval {
 
@@ -29,6 +36,60 @@ void my_sum_max_inv_hamming_op(InterpretedFunction::State& state, uint64_t vec_s
             }
             result += max_inv_hamming;
         }
+    }
+    state.pop_pop_push(state.stash.create<DoubleValue>(result));
+}
+
+struct ChunkedParam {
+    size_t vec_size;
+    size_t chunk_dim;
+    ChunkedParam(size_t vec_size_in, size_t chunk_dim_in) : vec_size(vec_size_in), chunk_dim(chunk_dim_in) {}
+};
+
+void my_max_sum_max_inv_hamming_op(InterpretedFunction::State& state, uint64_t param_in) {
+    const auto&  param = unwrap_param<ChunkedParam>(param_in);
+    double       result = 0.0;
+    auto         query_cells = state.peek(1).cells().unsafe_typify<int8_t>();
+    const Value& document = state.peek(0);
+    auto         document_cells = document.cells().unsafe_typify<int8_t>();
+    if ((query_cells.size() > 0) && (document_cells.size() > 0)) {
+        size_t                               num_query_vectors = query_cells.size() / param.vec_size;
+        size_t                               max_distance = param.vec_size * 8;
+        size_t                               num_chunks = 0;
+        std::unordered_map<uint32_t, size_t> chunk_index;
+        std::vector<size_t>                  min_distances;
+        std::array<string_id, 2>             address;
+        std::array<string_id*, 2>            address_ref = {&address[0], &address[1]};
+        size_t                               subspace = 0;
+        auto                                 view = document.index().create_view({});
+        view->lookup({});
+        while (view->next_result(address_ref, subspace)) {
+            auto [pos, inserted] = chunk_index.try_emplace(address[param.chunk_dim].value(), num_chunks);
+            if (inserted) {
+                min_distances.resize(++num_chunks * num_query_vectors, max_distance);
+            }
+            size_t*       chunk_distances = min_distances.data() + (pos->second * num_query_vectors);
+            const int8_t* document_vector = document_cells.data() + (subspace * param.vec_size);
+            for (size_t i = 0; i < num_query_vectors; ++i) {
+                if (chunk_distances[i] != 0) {
+                    const int8_t* query_vector = query_cells.data() + (i * param.vec_size);
+                    chunk_distances[i] = std::min(
+                        chunk_distances[i],
+                        hwaccelerated::binary_hamming_distance(query_vector, document_vector, param.vec_size));
+                }
+            }
+        }
+        // sum in float to match the cell type of the per-chunk tensor produced by generic evaluation
+        float max_chunk_score = aggr::Max<float>::null_value();
+        for (size_t chunk = 0; chunk < num_chunks; ++chunk) {
+            const size_t* chunk_distances = min_distances.data() + (chunk * num_query_vectors);
+            float         chunk_score = 0.0f;
+            for (size_t i = 0; i < num_query_vectors; ++i) {
+                chunk_score += 1.0f / (1.0f + chunk_distances[i]);
+            }
+            max_chunk_score = aggr::Max<float>::combine(max_chunk_score, chunk_score);
+        }
+        result = max_chunk_score;
     }
     state.pop_pop_push(state.stash.create<DoubleValue>(result));
 }
@@ -86,11 +147,26 @@ bool check_params(const ValueType& res_type, const ValueType& query, const Value
             (document.stride_of(ham_dim) == 1));
 }
 
+bool check_chunked_params(const ValueType& res_type, const ValueType& query, const ValueType& document,
+                          const std::string& sum_dim, const std::string& max_dim, const std::string& chunk_dim,
+                          const std::string& ham_dim) {
+    return (res_type.is_double() && (query.dimensions().size() == 2) && (query.cell_type() == CellType::INT8) &&
+            (document.dimensions().size() == 3) && (document.count_mapped_dimensions() == 2) &&
+            (document.cell_type() == CellType::INT8) && query.has_dimension(sum_dim) &&
+            (query.stride_of(ham_dim) == 1) && document.has_dimension(max_dim) && document.has_dimension(chunk_dim) &&
+            (document.stride_of(ham_dim) == 1));
+}
+
 size_t get_dim_size(const ValueType& type, const std::string& dim) {
     size_t npos = ValueType::Dimension::npos;
     size_t idx = type.dimension_index(dim);
     assert(idx != npos);
     return type.dimensions()[idx].size;
+}
+
+// the document has exactly two mapped dimensions; the chunk dimension is either the first or the second
+size_t get_chunk_dim(const ValueType& document, const std::string& chunk_dim) {
+    return (document.mapped_dimensions()[0].name == chunk_dim) ? 0 : 1;
 }
 
 } // namespace
@@ -126,6 +202,54 @@ const TensorFunction& SumMaxInvHammingFunction::optimize(const TensorFunction& e
                             size_t vec_size = get_dim_size(ham->rhs().result_type(), ham_dim);
                             return stash.create<SumMaxInvHammingFunction>(expr.result_type(), ham->rhs(), ham->lhs(),
                                                                           vec_size);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return expr;
+}
+
+MaxSumMaxInvHammingFunction::MaxSumMaxInvHammingFunction(const ValueType& res_type_in, const TensorFunction& query,
+                                                         const TensorFunction& document, size_t vec_size,
+                                                         size_t chunk_dim)
+    : tensor_function::Op2(res_type_in, query, document), _vec_size(vec_size), _chunk_dim(chunk_dim) {
+}
+
+InterpretedFunction::Instruction MaxSumMaxInvHammingFunction::compile_self(const ValueBuilderFactory&,
+                                                                           Stash& stash) const {
+    const auto& param = stash.create<ChunkedParam>(_vec_size, _chunk_dim);
+    return InterpretedFunction::Instruction(my_max_sum_max_inv_hamming_op, wrap_param<ChunkedParam>(param));
+}
+
+const TensorFunction& MaxSumMaxInvHammingFunction::optimize(const TensorFunction& expr, Stash& stash) {
+    if (auto chunk_reduce = check_reduce(expr, Aggr::MAX)) {
+        if (auto sum_reduce = check_reduce(chunk_reduce->child(), Aggr::SUM)) {
+            if (auto max_reduce = check_reduce(sum_reduce->child(), Aggr::MAX)) {
+                if (auto inverted = check_inv(max_reduce->child())) {
+                    if (auto ham_reduce = check_reduce(*inverted, Aggr::SUM)) {
+                        if (auto ham = check_join(ham_reduce->child(), Hamming::f)) {
+                            const auto& sum_dim = sum_reduce->dimensions()[0];
+                            const auto& max_dim = max_reduce->dimensions()[0];
+                            const auto& chunk_dim = chunk_reduce->dimensions()[0];
+                            const auto& ham_dim = ham_reduce->dimensions()[0];
+                            if (check_chunked_params(expr.result_type(), ham->lhs().result_type(),
+                                                     ham->rhs().result_type(), sum_dim, max_dim, chunk_dim, ham_dim))
+                            {
+                                size_t vec_size = get_dim_size(ham->lhs().result_type(), ham_dim);
+                                return stash.create<MaxSumMaxInvHammingFunction>(
+                                    expr.result_type(), ham->lhs(), ham->rhs(), vec_size,
+                                    get_chunk_dim(ham->rhs().result_type(), chunk_dim));
+                            }
+                            if (check_chunked_params(expr.result_type(), ham->rhs().result_type(),
+                                                     ham->lhs().result_type(), sum_dim, max_dim, chunk_dim, ham_dim))
+                            {
+                                size_t vec_size = get_dim_size(ham->rhs().result_type(), ham_dim);
+                                return stash.create<MaxSumMaxInvHammingFunction>(
+                                    expr.result_type(), ham->rhs(), ham->lhs(), vec_size,
+                                    get_chunk_dim(ham->lhs().result_type(), chunk_dim));
+                            }
                         }
                     }
                 }

--- a/eval/src/vespa/eval/instruction/sum_max_inv_hamming_function.h
+++ b/eval/src/vespa/eval/instruction/sum_max_inv_hamming_function.h
@@ -42,4 +42,44 @@ public:
     static const TensorFunction& optimize(const TensorFunction& expr, Stash& stash);
 };
 
+/**
+ * Tensor function scoring each document chunk like
+ * SumMaxInvHammingFunction scores a whole document, keeping the best
+ * chunk score as the result.
+ *
+ * inputs:
+ *   query:    tensor<int8>(qt{},x[32])
+ *   document: tensor<int8>(chunk{},dt{},x[32])
+ *
+ * expression:
+ *   reduce(
+ *     reduce(
+ *       reduce(
+ *         1/(1+reduce(hamming(query, document), sum, x)),
+ *         max, dt
+ *       ),
+ *       sum, qt
+ *     ),
+ *     max, chunk
+ *   )
+ *
+ * The document has one extra mapped dimension grouping its vectors
+ * into chunks; both the chunk dimension and the document token
+ * dimension must be mapped.
+ **/
+class MaxSumMaxInvHammingFunction : public tensor_function::Op2 {
+private:
+    size_t _vec_size;
+    size_t _chunk_dim; // index of the chunk dimension in the document address
+
+public:
+    MaxSumMaxInvHammingFunction(const ValueType& res_type_in, const TensorFunction& query,
+                                const TensorFunction& document, size_t vec_size, size_t chunk_dim);
+    InterpretedFunction::Instruction compile_self(const ValueBuilderFactory& factory, Stash& stash) const override;
+    size_t vec_size() const { return _vec_size; }
+    size_t chunk_dim() const { return _chunk_dim; }
+    bool result_is_mutable() const override { return true; }
+    static const TensorFunction& optimize(const TensorFunction& expr, Stash& stash);
+};
+
 } // namespace vespalib::eval


### PR DESCRIPTION
The existing `SumMaxInvHammingFunction` optimizer introduced in #32320 recognizes Hamming MaxSim over a 2D document tensor. This change adds the corresponding 3D optimizer:

```text
query:    tensor<int8>(qt{},x[N])
document: tensor<int8>(chunk{},t{},x[N])
max(chunk, sum(qt, max(t, 1 / (1 + sum(x, hamming(query, document))))))
```

---

I measured a small dataset of 16-byte binary vectors, 32 query vectors, and 301 chunks of 138 document vectors:

| Measurement | Result |
|:--|--:|
| Before | 91.8 ms |
| After | 2.8 ms |
| Speedup | **32.8×** |

The 32.8× speedup is roughly in line with that [observed for the two-dimensional optimization](https://github.com/vespa-engine/vespa/issues/32232#issuecomment-2367477852).

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
