### PR TITLE
Add label propagation for userInput

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -2386,6 +2386,7 @@ public class YqlParser implements Parser {
         private final Boolean normalizeCase;
         private final Boolean accentDrop;
         private final Boolean usePositionData;
+        private final String label;
 
         public AnnotationPropagator(OperatorNode<ExpressionOperator> ast) {
             isRanked = getAnnotation(ast, RANKED, Boolean.class, null, RANKED_DESCRIPTION);
@@ -2394,6 +2395,7 @@ public class YqlParser implements Parser {
             normalizeCase = getAnnotation(ast, NORMALIZE_CASE, Boolean.class, null, NORMALIZE_CASE_DESCRIPTION);
             accentDrop = getAnnotation(ast, ACCENT_DROP, Boolean.class, null, ACCENT_DROP_DESCRIPTION);
             usePositionData = getAnnotation(ast, USE_POSITION_DATA, Boolean.class, null, USE_POSITION_DATA_DESCRIPTION);
+            label = getAnnotation(ast, LABEL, String.class, null, "item label");
         }
 
         @Override
@@ -2413,6 +2415,9 @@ public class YqlParser implements Parser {
                 }
             }
             if (item instanceof TaggableItem) {
+                if (label != null && item.getLabel() == null) {
+                    item.setLabel(label);
+                }
                 if (isRanked != null) {
                     item.setRanked(isRanked);
                 }

--- a/container-search/src/test/java/com/yahoo/search/yql/TextInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/TextInputTestCase.java
@@ -67,6 +67,17 @@ public class TextInputTestCase {
     }
 
     @Test
+    void labelIsPropagatedToParsedTerms() {
+        Item root = parse("select foo from bar where title contains ({label:\"t1\"} text(\"new york\"))").getRoot();
+        assertInstanceOf(WeakAndItem.class, root);
+        WeakAndItem weakAnd = (WeakAndItem) root;
+        assertEquals(2, weakAnd.getItemCount());
+        for (Item term : weakAnd.items()) {
+            assertEquals("t1", term.getLabel());
+        }
+    }
+
+    @Test
     void allowEmptyReturnsNullItem() {
         Item root = parse("select foo from bar where title contains ([{allowEmpty:true}] text(@q))", "q", "").getRoot();
         assertInstanceOf(NullItem.class, root);

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -421,6 +421,26 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testLabelOnUserInputIsInheritedByEachParsedTerm() {
+        QueryTree query = parse("select foo from bar where " +
+                "({label: \"t1\"}userInput(\"new york\"))");
+        WeakAndItem weakAnd = (WeakAndItem) query.getRoot();
+        assertEquals(2, weakAnd.getItemCount());
+        for (Item term : weakAnd.items()) {
+            assertEquals("t1", term.getLabel());
+        }
+    }
+
+    @Test
+    void testLabelOnUserInputPhraseIsAppliedToParsedPhrase() {
+        QueryTree query = parse("select foo from bar where " +
+                "({label: \"t1\", grammar.syntax: \"none\", grammar.composite: \"phrase\"}" +
+                "userInput(\"new york\"))");
+        PhraseItem phrase = (PhraseItem) query.getRoot();
+        assertEquals("t1", phrase.getLabel());
+    }
+
+    @Test
     void testCompoundItemAnnotations() {
         assertEquals("and", parse("select foo from bar where ({annotations: {scope: \"and\"}}(a contains \"A\" and b contains \"B\"))")
             .getRoot().getAnnotation("scope"));


### PR DESCRIPTION
Propagate the `label` annotation on `userInput(...)` to the parsed query items, while preserving any labels already assigned by the parser.

This enables rank features such as `bm25(field, label)` to operate on labeled `userInput` subtrees.

Adds tests covering both `weakAnd` and `phrase` grammar.

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.