### PR TITLE
Add back zoneEndpointClusters()

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -276,6 +276,7 @@
       "public com.yahoo.config.application.api.Bcp bcp()",
       "public java.util.Optional backup()",
       "public boolean deploysTo(com.yahoo.config.provision.Environment, com.yahoo.config.provision.RegionName)",
+      "public java.util.Set zoneEndpointClusters()",
       "public java.util.Map zoneEndpoints(com.yahoo.config.provision.zone.ZoneId)",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
@@ -336,6 +336,11 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
         return zoneEndpoints;
     }
 
+    /** The container cluster ids targeted by zone and private endpoints. */
+    public Set<ClusterSpec.Id> zoneEndpointClusters() {
+        return zoneEndpoints.keySet();
+    }
+
     /** The zone endpoints in the given zone, possibly default values. */
     public Map<ClusterSpec.Id, ZoneEndpoint> zoneEndpoints(ZoneId zone) {
         return zoneEndpoints.keySet().stream()


### PR DESCRIPTION
Needed by older config models

Removed in https://github.com/vespa-engine/vespa/pull/37572, still needed by older models