### PR TITLE
Propagate file distribution permission-denied as a permanent error

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
@@ -13,6 +13,7 @@ import com.yahoo.net.HostName;
 import com.yahoo.security.tls.Capability;
 import com.yahoo.vespa.filedistribution.FileDownloader;
 import com.yahoo.vespa.filedistribution.FileReferenceDownload;
+import com.yahoo.vespa.filedistribution.FileReferenceDownloadPermissionDeniedException;
 
 import java.io.File;
 import java.util.Map;
@@ -78,6 +79,7 @@ class FileDistributionRpcServer {
     private static final int baseFileProviderErrorCode = baseErrorCode + 0x1000;
 
     private static final int fileReferenceNotFound = baseFileProviderErrorCode;
+    private static final int fileReferencePermissionDenied = baseFileProviderErrorCode + 1;
 
     private void getFile(Request req) {
         req.detach();
@@ -106,14 +108,19 @@ class FileDistributionRpcServer {
     private void downloadFile(Request req) {
         FileReference fileReference = new FileReference(req.parameters().get(0).asString());
         log.log(Level.FINE, () -> "getFile() called for file reference '" + fileReference.value() + "'");
-        Optional<File> file = downloader.getFile(new FileReferenceDownload(fileReference, HostName.getLocalhost()));
-        if (file.isPresent()) {
-            new RequestTracker().trackRequest(file.get().getParentFile());
-            req.returnValues().add(new StringValue(file.get().getAbsolutePath()));
-            log.log(Level.FINE, () -> "File reference '" + fileReference.value() + "' available at " + file.get());
-        } else {
-            log.log(Level.INFO, "File reference '" + fileReference.value() + "' not found");
-            req.setError(fileReferenceNotFound, "File reference '" + fileReference.value() + "' not found");
+        try {
+            Optional<File> file = downloader.getFile(new FileReferenceDownload(fileReference, HostName.getLocalhost()));
+            if (file.isPresent()) {
+                new RequestTracker().trackRequest(file.get().getParentFile());
+                req.returnValues().add(new StringValue(file.get().getAbsolutePath()));
+                log.log(Level.FINE, () -> "File reference '" + fileReference.value() + "' available at " + file.get());
+            } else {
+                log.log(Level.INFO, "File reference '" + fileReference.value() + "' not found");
+                req.setError(fileReferenceNotFound, "File reference '" + fileReference.value() + "' not found");
+            }
+        } catch (FileReferenceDownloadPermissionDeniedException e) {
+            log.log(Level.INFO, "File reference '" + fileReference.value() + "' download denied: " + e.getMessage());
+            req.setError(fileReferencePermissionDenied, "File reference '" + fileReference.value() + "' access denied: " + e.getMessage());
         }
 
         req.returnRequest();

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServerTest.java
@@ -1,0 +1,135 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.proxy.filedistribution;
+
+import com.yahoo.jrt.Acceptor;
+import com.yahoo.jrt.ListenFailedException;
+import com.yahoo.jrt.Request;
+import com.yahoo.jrt.RequestWaiter;
+import com.yahoo.jrt.Spec;
+import com.yahoo.jrt.StringValue;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.jrt.Target;
+import com.yahoo.jrt.Transport;
+import com.yahoo.vespa.config.Connection;
+import com.yahoo.vespa.config.ConnectionPool;
+import com.yahoo.vespa.filedistribution.FileDownloader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author hmusum
+ */
+public class FileDistributionRpcServerTest {
+
+    // Duplicated from FileDistributionRpcServer/FileAcquirerImpl.FileDistributionErrorCode
+    private static final int fileReferencePermissionDenied = 0x11001;
+
+    // Duplicated from MultiTenantRpcAuthorizer.JrtErrorCode / FileReferenceDownloader
+    private static final int jrtErrorUnauthorized = 0x20001;
+
+    @TempDir
+    public File downloadDirectory;
+
+    private Supervisor serverSupervisor;
+    private Supervisor clientSupervisor;
+    private Acceptor acceptor;
+    private FileDistributionRpcServer rpcServer;
+    private FakeConnection fakeConnection;
+    private Target target;
+
+    @BeforeEach
+    public void setup() throws ListenFailedException {
+        fakeConnection = new FakeConnection();
+        FileDownloader downloader = new FileDownloader(new FakeConnectionPool(fakeConnection),
+                                                        new Supervisor(new Transport()),
+                                                        downloadDirectory,
+                                                        Duration.ofSeconds(30), // Much longer than this test should ever take
+                                                        Duration.ofMillis(10));
+        serverSupervisor = new Supervisor(new Transport());
+        rpcServer = new FileDistributionRpcServer(serverSupervisor, downloader);
+        acceptor = serverSupervisor.listen(new Spec(0));
+
+        clientSupervisor = new Supervisor(new Transport());
+        target = clientSupervisor.connect(new Spec(acceptor.port()));
+    }
+
+    @AfterEach
+    public void teardown() {
+        target.close();
+        clientSupervisor.transport().shutdown().join();
+        acceptor.shutdown().join();
+        rpcServer.close();
+        serverSupervisor.transport().shutdown().join();
+    }
+
+    @Test
+    void permissionDeniedIsReturnedImmediatelyAsPermanentError() {
+        Request req = new Request("waitFor");
+        req.parameters().add(new StringValue("myFileReference"));
+        target.invokeSync(req, Duration.ofSeconds(10));
+
+        assertTrue(req.isError(), "Expected an error response, got: " + req.returnValues());
+        assertEquals(fileReferencePermissionDenied, req.errorCode());
+        assertTrue(req.errorMessage().contains("Peer is not allowed to access file reference"), req.errorMessage());
+
+        // Must fail fast - a single RPC round trip to the (fake) source, not retried for the full download timeout
+        assertEquals(1, fakeConnection.requestCount);
+    }
+
+    private static class FakeConnection implements Connection {
+
+        int requestCount = 0;
+
+        @Override
+        public void invokeAsync(Request request, Duration jrtTimeout, RequestWaiter requestWaiter) {
+            invokeSync(request, jrtTimeout);
+            requestWaiter.handleRequestDone(request);
+        }
+
+        @Override
+        public void invokeSync(Request request, Duration jrtTimeout) {
+            if (request.methodName().equals("filedistribution.serveFile")) {
+                requestCount++;
+                request.setError(jrtErrorUnauthorized,
+                                  "Peer is not allowed to access file reference " + request.parameters().get(0).asString());
+            }
+        }
+
+        @Override
+        public String getAddress() { return "localhost"; }
+
+    }
+
+    private static class FakeConnectionPool implements ConnectionPool {
+
+        private final Connection connection;
+
+        FakeConnectionPool(Connection connection) { this.connection = connection; }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public Connection getCurrent() { return connection; }
+
+        @Override
+        public Connection switchConnection(Connection failingConnection) { return connection; }
+
+        @Override
+        public int getSize() { return 1; }
+
+        @Override
+        public List<Connection> connections() { return List.of(connection); }
+
+    }
+
+}

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/security/MultiTenantRpcAuthorizerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/security/MultiTenantRpcAuthorizerTest.java
@@ -48,7 +48,10 @@ import java.util.concurrent.Executor;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -142,8 +145,14 @@ public class MultiTenantRpcAuthorizerTest {
         exceptionRule.expectMessage("Peer is not allowed to access file reference other-file-reference. Peer is owned by mytenant.myapplication. File references owned by this application: [file 'myfilereference']");
         exceptionRule.expectCause(instanceOf(AuthorizationException.class));
 
-        authorizer.authorizeFileRequest(fileRequest)
-                .get();
+        try {
+            authorizer.authorizeFileRequest(fileRequest).get();
+        } finally {
+            // Denial must be sent back to the client immediately, as a permanent (non-timeout) error -
+            // this is what allows FileReferenceDownloader/FileAcquirerImpl to fail fast instead of retrying.
+            verify(fileRequest).setError(eq(0x20001), anyString()); // JrtErrorCode.UNAUTHORIZED
+            verify(fileRequest).returnRequest();
+        }
     }
 
     @Test
@@ -162,8 +171,12 @@ public class MultiTenantRpcAuthorizerTest {
         exceptionRule.expectMessage("Peer is not allowed to access config owned by mytenant.myapplication. Peer is owned by malice.malice-app");
         exceptionRule.expectCause(instanceOf(AuthorizationException.class));
 
-        authorizer.authorizeConfigRequest(configRequest)
-                .get();
+        try {
+            authorizer.authorizeConfigRequest(configRequest).get();
+        } finally {
+            verify(configRequest).setError(eq(0x20001), anyString()); // JrtErrorCode.UNAUTHORIZED
+            verify(configRequest).returnRequest();
+        }
     }
 
     @Test

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
@@ -42,6 +42,7 @@ class FileAcquirerImpl implements FileAcquirer {
         public static final int baseErrorCode = 0x10000;
         public static final int baseFileProviderErrorCode = baseErrorCode + 0x1000;
         public static final int fileReferenceNotFound = baseFileProviderErrorCode;
+        public static final int fileReferencePermissionDenied = baseFileProviderErrorCode + 1;
 
     }
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -90,7 +90,12 @@ public class FileDownloader implements AutoCloseable {
     public Optional<File> getFile(FileReferenceDownload fileReferenceDownload) {
         try {
             return getFutureFile(fileReferenceDownload).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (ExecutionException e) {
+            fileReferenceDownloader.failedDownloading(fileReferenceDownload.fileReference());
+            if (e.getCause() instanceof FileReferenceDownloadPermissionDeniedException permissionDenied)
+                throw permissionDenied;
+            return Optional.empty();
+        } catch (InterruptedException | TimeoutException e) {
             fileReferenceDownloader.failedDownloading(fileReferenceDownload.fileReference());
             return Optional.empty();
         }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloadPermissionDeniedException.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloadPermissionDeniedException.java
@@ -1,0 +1,19 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.filedistribution;
+
+import com.yahoo.config.FileReference;
+
+/**
+ * Thrown when a peer (e.g. config server) has denied a request to download a file reference,
+ * typically because the requesting peer is unknown or not authorized to access that file reference.
+ * This is a permanent failure and should not be retried.
+ *
+ * @author hmusum
+ */
+public class FileReferenceDownloadPermissionDeniedException extends RuntimeException {
+
+    public FileReferenceDownloadPermissionDeniedException(FileReference fileReference, String reason) {
+        super("Download of " + fileReference + " denied: " + reason);
+    }
+
+}

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -40,7 +40,20 @@ public class FileReferenceDownloader {
     private static final Logger log = Logger.getLogger(FileReferenceDownloader.class.getName());
     private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(lz4, none, zstd);
 
-    private enum DownloadResult { SUCCESS, TIMEOUT, FAILURE }
+    private enum DownloadResult { SUCCESS, TIMEOUT, FAILURE, PERMISSION_DENIED }
+
+    private record RpcResult(DownloadResult result, String message) {
+        private static RpcResult of(DownloadResult result) { return new RpcResult(result, null); }
+    }
+
+    // Duplicated from MultiTenantRpcAuthorizer.JrtErrorCode (configserver module; this module can't depend on it)
+    // TODO: Consider moving this to a common module to avoid duplication
+    static final int jrtErrorUnauthorized = 0x20001;
+    static final int jrtErrorAuthorizationFailed = 0x20002;
+
+    private static boolean isAuthorizationError(int errorCode) {
+        return errorCode == jrtErrorUnauthorized || errorCode == jrtErrorAuthorizationFailed;
+    }
 
     private final ExecutorService downloadExecutor =
             Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
@@ -100,9 +113,15 @@ public class FileReferenceDownloader {
             log.log(Level.FINE, "Wait until download of " + fileReference + " has started, retryCount " + retryCount +
                     ", timeout " + timeout + " (request from " + fileReferenceDownload.client() + ")");
             if ( ! timeout.isNegative()) {
-                var result = startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout);
-                if (result == DownloadResult.SUCCESS) return;
-                if (result == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                var rpcResult = startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout);
+                if (rpcResult.result() == DownloadResult.SUCCESS) return;
+                if (rpcResult.result() == DownloadResult.PERMISSION_DENIED) {
+                    fileReferenceDownload.future().completeExceptionally(
+                            new FileReferenceDownloadPermissionDeniedException(fileReference, rpcResult.message()));
+                    downloads.remove(fileReference);
+                    return;
+                }
+                if (rpcResult.result() == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
                     timeoutCount++;
                     if (timeoutCount >= maxTimeoutsBeforeClose) {
                         log.log(Level.INFO, "RPC request for " + fileReference + " timed out " + timeoutCount +
@@ -160,13 +179,13 @@ public class FileReferenceDownloader {
 
                     log.log(Level.FINE, () -> "Will download " + fileReference + " with timeout " + downloadTimeout + " from " + spec.host());
                     downloads.add(fileReferenceDownload);
-                    var result = startDownloadRpc(fileReferenceDownload, 1, connection, downloadTimeout);
-                    if (result == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                    var rpcResult = startDownloadRpc(fileReferenceDownload, 1, connection, downloadTimeout);
+                    if (rpcResult.result() == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
                         connection.closeConnection();
                     }
                     // Need to explicitly remove from downloads if downloading has not started.
                     // If downloading *has* started FileReceiver will take care of that when download has completed or failed
-                    if (result != DownloadResult.SUCCESS)
+                    if (rpcResult.result() != DownloadResult.SUCCESS)
                         downloads.remove(fileReference);
                 });
         }
@@ -176,7 +195,7 @@ public class FileReferenceDownloader {
         downloads.remove(fileReference);
     }
 
-    private DownloadResult startDownloadRpc(FileReferenceDownload fileReferenceDownload, int retryCount, Connection connection, Duration timeout) {
+    private RpcResult startDownloadRpc(FileReferenceDownload fileReferenceDownload, int retryCount, Connection connection, Duration timeout) {
         Request request = createRequest(fileReferenceDownload);
         connection.invokeSync(request, timeout);
 
@@ -189,19 +208,24 @@ public class FileReferenceDownloader {
 
             if (errorCode == 0) {
                 log.log(Level.FINE, () -> "Found " + fileReference + " available at " + address);
-                return DownloadResult.SUCCESS;
+                return RpcResult.of(DownloadResult.SUCCESS);
             } else {
                 var error = FileApiErrorCodes.get(errorCode);
                 var errorDescription = error == null ? "Unknown error" : error.description();
                 log.log(logLevel, "Downloading " + fileReference + " from " + address + " failed (" + errorDescription + ")");
-                return DownloadResult.FAILURE;
+                return RpcResult.of(DownloadResult.FAILURE);
             }
+        } else if (isAuthorizationError(request.errorCode())) {
+            log.log(logLevel, "Downloading " + fileReference + " from " + address +
+                    " (client " + fileReferenceDownload.client() + ") denied:" +
+                    " error code " + request.errorCode() + " (" + request.errorMessage() + ")");
+            return new RpcResult(DownloadResult.PERMISSION_DENIED, request.errorMessage());
         } else {
             log.log(logLevel, "Downloading " + fileReference + " from " + address +
                     " (client " + fileReferenceDownload.client() + ") failed:" +
                     " error code " + request.errorCode() + " (" + request.errorMessage() + ")." +
                     " (retry " + retryCount + ", rpc timeout " + timeout + ")");
-            return request.errorCode() == ErrorCode.TIMEOUT ? DownloadResult.TIMEOUT : DownloadResult.FAILURE;
+            return RpcResult.of(request.errorCode() == ErrorCode.TIMEOUT ? DownloadResult.TIMEOUT : DownloadResult.FAILURE);
         }
     }
 

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -38,6 +38,7 @@ import static com.yahoo.vespa.filedistribution.FileReferenceData.Type;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type.compressed;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -196,6 +197,28 @@ public class FileDownloaderTest {
         assertDownloadStatus(fileReference, 1.0);
 
         assertEquals(timesToFail, responseHandler.failedTimes);
+    }
+
+    @Test
+    public void getFileWhenPermissionDenied() {
+        // Use a much longer timeout than the test should ever take: if the denial were treated as a
+        // retryable failure instead of failing fast, this test would time out waiting for getFile() instead
+        // of throwing promptly.
+        fileDownloader = createDownloader(connection, Duration.ofSeconds(30));
+
+        MockConnection.PermissionDeniedResponseHandler responseHandler = new MockConnection.PermissionDeniedResponseHandler();
+        connection.setResponseHandler(responseHandler);
+
+        FileReference fileReference = new FileReference("deniedFileReference");
+        FileReferenceDownloadPermissionDeniedException exception = assertThrows(
+                FileReferenceDownloadPermissionDeniedException.class,
+                () -> getFile(fileReference));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("Peer is not allowed to access file reference"));
+
+        // Denial must exit the retry loop on the very first RPC round trip, not after retrying for the
+        // full download timeout.
+        assertEquals(1, responseHandler.requestCount);
+        assertFalse(fileDownloader.isDownloading(fileReference));
     }
 
     @Test
@@ -494,6 +517,20 @@ public class FileDownloaderTest {
                         request.returnValues().add(new Int32Value(0));
                         request.returnValues().add(new StringValue("OK"));
                     }
+                }
+            }
+        }
+
+        private static class PermissionDeniedResponseHandler implements MockConnection.ResponseHandler {
+
+            int requestCount = 0;
+
+            @Override
+            public void request(Request request) {
+                if (request.methodName().equals("filedistribution.serveFile")) {
+                    requestCount++;
+                    request.setError(FileReferenceDownloader.jrtErrorUnauthorized,
+                                      "Peer is not allowed to access file reference " + request.parameters().get(0).asString());
                 }
             }
         }


### PR DESCRIPTION
## Summary

When `MultiTenantRpcAuthorizer` denies a file distribution request from an unknown/unauthorized peer, the denial was already sent back immediately at that hop, but every layer downstream of it discarded the signal:

- `FileReferenceDownloader` collapsed the authorization error into a generic `FAILURE` and retried with backoff for the full download timeout.
- `FileDownloader.getFile()` swallowed the failure into `Optional.empty()`.
- Config-proxy's `FileDistributionRpcServer` (the `waitFor` RPC handler `FileAcquirerImpl` calls) always reported the same generic `fileReferenceNotFound` code regardless of root cause.
- `FileAcquirerImpl` treats `fileReferenceNotFound` as retryable, so it kept retrying for its own full timeout and only ever surfaced a generic `TimeoutException` — never a fast, distinct "permission denied".

This change plumbs the denial through end-to-end so it's returned immediately and treated as a permanent (non-retryable) error.

- `FileReferenceDownloader` now detects the authorizer's JRT error codes and fails fast instead of retrying with backoff
- `FileDownloader.getFile()` propagates a new `FileReferenceDownloadPermissionDeniedException` instead of collapsing to `Optional.empty()`
- Config-proxy's `FileDistributionRpcServer` returns a distinct `fileReferencePermissionDenied` error code instead of the generic `fileReferenceNotFound`
- `FileAcquirerImpl` already treats any unrecognized error code as permanent by default, so it now exits its retry loop immediately with no logic changes needed there

## Benefits

- Permission-denied file distribution requests fail fast instead of hanging for the full retry/timeout window
- The real authorization failure reason now reaches `FileAcquirerImpl` instead of a generic timeout message

## Test plan

- [x] New test in `MultiTenantRpcAuthorizerTest` verifying the wire-level `setError`/`returnRequest` behavior on denial
- [x] New test in `FileDownloaderTest` proving the denial is detected on the first RPC round trip, not after retrying
- [x] New `FileDistributionRpcServerTest` proving the `waitFor` RPC returns the new permanent error code immediately
- [x] Full test suites pass for `filedistribution`, `config-proxy`, `fileacquirer`, and `configserver`

---
Generated with [Claude Code](https://claude.com/claude-code)