### PR TITLE
Documentid indexing expression

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/DocumentIdExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/DocumentIdExpression.java
@@ -1,0 +1,81 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.DocumentId;
+import com.yahoo.document.datatypes.StringFieldValue;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Expression exposing the id of the document being processed as a string, or, given an optional
+ * argument, a single structural part of it (its namespace, document type, group, number or
+ * namespace-specific part).
+ *
+ * @author Dainius Jocas
+ */
+public final class DocumentIdExpression extends Expression {
+
+    private static final Set<String> PARTS = Set.of("namespace", "documenttype", "group", "number", "specific");
+
+    private final String part;
+
+    public DocumentIdExpression() { this(null); }
+
+    public DocumentIdExpression(String part) {
+        if (part != null && !PARTS.contains(part))
+            throw new IllegalArgumentException("documentid: unknown part '" + part + "', expected one of " + PARTS);
+        this.part = part;
+    }
+
+    public String getPart() { return part; }
+
+    @Override
+    public boolean requiresInput() { return false; }
+
+    @Override
+    public DataType setInputType(DataType inputType, TypeContext context) {
+        super.setInputType(inputType, context);
+        return DataType.STRING;
+    }
+
+    @Override
+    public DataType setOutputType(DataType outputType, TypeContext context) {
+        super.setOutputType(DataType.STRING, outputType, null, context);
+        return AnyDataType.instance;
+    }
+
+    @Override
+    protected void doExecute(ExecutionContext context) {
+        context.setCurrentValue(new StringFieldValue(extract(context.getDocumentId().orElse(null))));
+    }
+
+    private String extract(DocumentId id) {
+        if (id == null) return "";
+        if (part == null) return id.toString();
+        return switch (part) {
+            case "namespace" -> id.getScheme().getNamespace();
+            case "documenttype" -> id.hasDocType() ? id.getDocType() : "";
+            case "group" -> id.getScheme().hasGroup() ? id.getScheme().getGroup() : "";
+            case "number" -> id.getScheme().hasNumber() ? String.valueOf(id.getScheme().getNumber()) : "";
+            case "specific" -> id.getScheme().getNamespaceSpecific();
+            default -> throw new IllegalStateException("Unreachable, part is validated in the constructor");
+        };
+    }
+
+    @Override
+    public String toString() { return part == null ? "documentid" : "documentid " + part; }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof DocumentIdExpression rhs)) return false;
+        return Objects.equals(part, rhs.part);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode() + Objects.hashCode(part);
+    }
+
+}

--- a/indexinglanguage/src/main/javacc/IndexingParser.jj
+++ b/indexinglanguage/src/main/javacc/IndexingParser.jj
@@ -48,6 +48,7 @@ import com.yahoo.vespa.indexinglanguage.expressions.ChunkExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ClearStateExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Components;
 import com.yahoo.vespa.indexinglanguage.expressions.ConstantExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.DocumentIdExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EchoExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExactExpression;
@@ -253,6 +254,7 @@ TOKEN :
     <CHUNK: "chunk"> |
     <CLEAR_STATE: "clear_state"> |
     <CREATE_IF_NON_EXISTENT: "create_if_non_existent"> |
+    <DOCUMENT_ID: "documentid"> |
     <ECHO: "echo"> |
     <ELSE: "else"> |
     <EMBED: "embed"> |
@@ -409,6 +411,7 @@ Expression value() :
       val = busy_waitExp()          |
       val = chunkExp()              |
       val = clearStateExp()         |
+      val = documentIdExp()         |
       val = echoExp()               |
       val = embedExp()              |
       val = generateExp()           |
@@ -509,6 +512,15 @@ Expression clearStateExp() : { }
 {
     ( <CLEAR_STATE> )
     { return new ClearStateExpression(); }
+}
+
+Expression documentIdExp() :
+{
+    String val = null;
+}
+{
+    ( <DOCUMENT_ID> [ val = identifier() ] )
+    { return new DocumentIdExpression(val); }
 }
 
 Expression echoExp() : { }
@@ -1004,6 +1016,7 @@ String identifier() :
         <CHUNK>                  |
         <CLEAR_STATE>            |
         <CREATE_IF_NON_EXISTENT> |
+        <DOCUMENT_ID>            |
         <ECHO>                   |
         <EXACT>                  |
         <ELSE>                   |

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/DocumentIdTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/DocumentIdTestCase.java
@@ -1,0 +1,112 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.DocumentId;
+import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
+import org.junit.Test;
+
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Dainius Jocas
+ */
+public class DocumentIdTestCase {
+
+    @Test
+    public void requireThatHashCodeAndEqualsAreImplemented() {
+        Expression exp = new DocumentIdExpression();
+        assertFalse(exp.equals(new Object()));
+        assertEquals(exp, new DocumentIdExpression());
+        assertEquals(exp.hashCode(), new DocumentIdExpression().hashCode());
+
+        Expression withPart = new DocumentIdExpression("namespace");
+        assertEquals(withPart, new DocumentIdExpression("namespace"));
+        assertEquals(withPart.hashCode(), new DocumentIdExpression("namespace").hashCode());
+        assertFalse(exp.equals(withPart));
+        assertFalse(withPart.equals(new DocumentIdExpression("group")));
+    }
+
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        assertVerify(AnyDataType.instance, new DocumentIdExpression(), DataType.STRING);
+        assertVerify(AnyDataType.instance, new DocumentIdExpression("namespace"), DataType.STRING);
+    }
+
+    @Test
+    public void requireThatUnknownPartFailsFast() {
+        assertThrows(IllegalArgumentException.class, () -> new DocumentIdExpression("bogus"));
+    }
+
+    @Test
+    public void requireThatDocumentIdIsSet() {
+        ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter());
+        ctx.setDocumentId(new DocumentId("id:myns:mytype:n=123:foo"));
+        new DocumentIdExpression().execute(ctx);
+
+        FieldValue val = ctx.getCurrentValue();
+        assertTrue(val instanceof StringFieldValue);
+        assertEquals("id:myns:mytype:n=123:foo", ((StringFieldValue)val).getString());
+    }
+
+    @Test
+    public void requireThatMissingDocumentIdYieldsEmptyString() {
+        ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter());
+        new DocumentIdExpression().execute(ctx);
+
+        FieldValue val = ctx.getCurrentValue();
+        assertTrue(val instanceof StringFieldValue);
+        assertEquals("", ((StringFieldValue)val).getString());
+    }
+
+    @Test
+    public void requireThatNamespaceIsExtracted() {
+        assertEquals("myns", extract("namespace", "id:myns:mytype::foo"));
+    }
+
+    @Test
+    public void requireThatDocumentTypeIsExtracted() {
+        assertEquals("mytype", extract("documenttype", "id:myns:mytype::foo"));
+    }
+
+    @Test
+    public void requireThatSpecificIsExtracted() {
+        assertEquals("foo", extract("specific", "id:myns:mytype::foo"));
+    }
+
+    @Test
+    public void requireThatGroupIsExtracted() {
+        assertEquals("mygroup", extract("group", "id:myns:mytype:g=mygroup:foo"));
+    }
+
+    @Test
+    public void requireThatNumberIsExtracted() {
+        assertEquals("123", extract("number", "id:myns:mytype:n=123:foo"));
+    }
+
+    @Test
+    public void requireThatMissingGroupOrNumberYieldsEmptyString() {
+        assertEquals("", extract("group", "id:myns:mytype::foo"));
+        assertEquals("", extract("number", "id:myns:mytype::foo"));
+    }
+
+    @Test
+    public void requireThatExpressionParsesFromScript() throws com.yahoo.vespa.indexinglanguage.parser.ParseException {
+        assertEquals(new DocumentIdExpression(), Expression.fromString("documentid"));
+        assertEquals(new DocumentIdExpression("namespace"), Expression.fromString("documentid namespace"));
+    }
+
+    private static String extract(String part, String documentId) {
+        ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter());
+        ctx.setDocumentId(new DocumentId(documentId));
+        new DocumentIdExpression(part).execute(ctx);
+        return ((StringFieldValue)ctx.getCurrentValue()).getString();
+    }
+
+}

--- a/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
@@ -183,6 +183,7 @@ TOKEN :
     <BUSY_WAIT: "busy_wait"> |
     <CASE: "case"> |
     <CASE_DEFAULT: "default"> |
+    <DOCUMENTID: "documentid"> |
     <CHUNK: "chunk"> |
     <CLEAR_STATE: "clear_state"> |
     <CREATE_IF_NON_EXISTENT: "create_if_non_existent"> |
@@ -348,6 +349,7 @@ Expression value() :
       val = busy_waitExp()          |
       val = chunkExp()              |
       val = clearStateExp()         |
+      val = documentIdExp()         |
       val = echoExp()               |
       val = embedExp()              |
       val = exactExp()              |
@@ -454,6 +456,15 @@ Expression chunkExp() :
     {
         return new ChunkExpression(chunkers, chunkerId, arguments);
     }
+;
+
+Expression documentIdExp() :
+{
+    String part = null;
+}
+
+    ( <DOCUMENTID> [ SCAN(identifierStr) => (part = identifierStr()) ] )
+    { return new DocumentIdExpression(part); }
 ;
 
 Expression clearStateExp() : { }
@@ -953,6 +964,7 @@ String identifierStr() :
         <CHUNK>                  |
         <CLEAR_STATE>            |
         <CREATE_IF_NON_EXISTENT> |
+        <DOCUMENTID>             |
         <ECHO>                   |
         <EXACT>                  |
         <ELSE>                   |

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/IndexingParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/IndexingParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.yahoo.vespa.indexinglanguage.ExpressionVisitor;
 import com.yahoo.vespa.indexinglanguage.expressions.ArithmeticExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.DocumentIdExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ChunkExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ConstantExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
@@ -68,6 +69,15 @@ public class IndexingParserTest {
             PackBitsExpression.class,
             AttributeExpression.class,
             IndexExpression.class}, "input text | chunk fixed-length 1024 | embed | pack_bits | attribute | index");
+
+        assertEqualsParsedFlattened(new Class<?>[] {
+                StatementExpression.class,
+                DocumentIdExpression.class,
+                AttributeExpression.class}, "documentid namespace | attribute");
+        assertEqualsParsedFlattened(new Class<?>[] {
+                StatementExpression.class,
+                DocumentIdExpression.class,
+                AttributeExpression.class}, "documentid | attribute");
     }
 
     private static void assertEqualsParsedFlattened(Class<?>[] expectedFlattened, String input) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Allows using the `documentid` in the indexing language.

Potential uses are:
1. Enabling searching over parts of the document ID, e.g. namespace. Removes the need to send the value explicitly, or writing a custom document processor.
2. Creating a stable and properly randomized `hash` value to be used as a tie-breaker for iterating over many documents.

When no argument version is used, then the entire document id is taken. Optional argument specifies which part to take.
