### PR TITLE
Only label the outermost taggable item of a parsed userInput

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -2404,6 +2404,9 @@ public class YqlParser implements Parser {
         private final Boolean usePositionData;
         private final String label;
 
+        /** The item which has been given the label on the branch currently being visited, if any. */
+        private Item labeledItem = null;
+
         public AnnotationPropagator(OperatorNode<ExpressionOperator> ast) {
             isRanked = getAnnotation(ast, RANKED, Boolean.class, null, RANKED_DESCRIPTION);
             filter = getAnnotation(ast, FILTER, Boolean.class, null, FILTER_DESCRIPTION);
@@ -2431,8 +2434,12 @@ public class YqlParser implements Parser {
                 }
             }
             if (item instanceof TaggableItem) {
-                if (label != null && item.getLabel() == null) {
+                // Label only the outermost taggable item on each branch: items below it (such as the words of a
+                // phrase) are not separate terms in the backend ranking framework, so a label there is never
+                // resolvable - it would only force a meaningless unique id onto the item.
+                if (label != null && labeledItem == null && item.getLabel() == null) {
                     item.setLabel(label);
+                    labeledItem = item;
                 }
                 if (isRanked != null) {
                     item.setRanked(isRanked);
@@ -2442,6 +2449,13 @@ public class YqlParser implements Parser {
                 }
             }
             return true;
+        }
+
+        @Override
+        public void onExit(Item item) {
+            if (item == labeledItem) {
+                labeledItem = null;
+            }
         }
 
     }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -31,6 +31,7 @@ import com.yahoo.prelude.query.StringInItem;
 import com.yahoo.prelude.query.Substring;
 import com.yahoo.prelude.query.SubstringItem;
 import com.yahoo.prelude.query.SuffixItem;
+import com.yahoo.prelude.query.TaggableItem;
 import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordAlternativesItem;
 import com.yahoo.prelude.query.WordItem;
@@ -438,6 +439,12 @@ public class YqlParserTestCase {
                 "userInput(\"new york\"))");
         PhraseItem phrase = (PhraseItem) query.getRoot();
         assertEquals("t1", phrase.getLabel());
+        // The words of a phrase are not separate terms in the backend, so labeling them would have no effect
+        // beyond forcing a unique id onto them
+        for (Item word : phrase.items()) {
+            assertNull(word.getLabel());
+            assertFalse(((TaggableItem) word).hasUniqueID());
+        }
     }
 
     @Test


### PR DESCRIPTION
The label annotation on userInput()/text() is applied to the parsed items by AnnotationPropagator, which visits the whole subtree. That also labeled the words inside a PhraseItem, which cannot work: Model.collectTaggableItems treats a phrase as a leaf, so a label below it never becomes a vespa.label.<label>.id rank property and can never be resolved in the backend.

What it did do is flip hasUniqueID (Item.setLabel does that), making the query serialization emit a unique id feature with the meaningless value 0 for every word of the phrase.

Stop labeling at the first taggable item on each branch instead. Terms directly below a non-taggable composite, such as the weakAnd userInput produces, are unaffected, and the per-term annotations (stem, accentDrop, ranked, ...) still propagate all the way down as before.
