### PR TITLE
Fix deprecated Gradle constructs in logstash-output-vespa for Gradle 10

### DIFF
--- a/integration/logstash-plugins/logstash-output-vespa/build.gradle
+++ b/integration/logstash-plugins/logstash-output-vespa/build.gradle
@@ -1,5 +1,6 @@
 import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import groovy.ant.FileNameFinder
 
 buildscript {
     repositories {
@@ -24,8 +25,8 @@ apply from: LOGSTASH_CORE_PATH + "/../rubyUtils.gradle"
 // ===========================================================================
 // plugin info
 // ===========================================================================
-group                      'org.logstashplugins' // must match the package of the main plugin class
-version                    "${file("VERSION").text.trim()}" // read from required VERSION file
+group                      = 'org.logstashplugins' // must match the package of the main plugin class
+version                    = "${file("VERSION").text.trim()}" // read from required VERSION file
 description                = "Output plugin for Vespa"
 pluginInfo.licenses        = ['Apache-2.0'] // list of SPDX license IDs
 pluginInfo.longDescription = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using \$LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -91,19 +92,24 @@ tasks.withType(JavaCompile) {
 
 tasks.register("vendor"){
     dependsOn shadowJar
+    def projectGroup = project.group
+    def projectVersion = project.version
+    def projectName = project.name
     doLast {
         String vendorPathPrefix = "vendor/jar-dependencies"
-        String projectGroupPath = project.group.replaceAll('\\.', '/')
-        File projectJarFile = file("${vendorPathPrefix}/${projectGroupPath}/${pluginInfo.pluginFullName()}/${project.version}/${pluginInfo.pluginFullName()}-${project.version}.jar")
+        String projectGroupPath = projectGroup.replaceAll('\\.', '/')
+        File projectJarFile = file("${vendorPathPrefix}/${projectGroupPath}/${pluginInfo.pluginFullName()}/${projectVersion}/${pluginInfo.pluginFullName()}-${projectVersion}.jar")
         projectJarFile.mkdirs()
-        Files.copy(file("$buildDir/libs/${project.name}-${project.version}.jar").toPath(), projectJarFile.toPath(), REPLACE_EXISTING)
-        validatePluginJar(projectJarFile, project.group)
+        Files.copy(layout.buildDirectory.file("libs/${projectName}-${projectVersion}.jar").get().asFile.toPath(), projectJarFile.toPath(), REPLACE_EXISTING)
+        validatePluginJar(projectJarFile, projectGroup)
     }
 }
 
 tasks.register("generateRubySupportFiles") {
+    def pluginDescription = project.description
+    def pluginGroup = project.group
     doLast {
-        generateRubySupportFilesForPlugin(project.description, project.group, version)
+        generateRubySupportFilesForPlugin(pluginDescription, pluginGroup, version)
     }
 }
 
@@ -121,11 +127,11 @@ tasks.register("removeObsoleteJars") {
 tasks.register("gem"){
     dependsOn = [downloadAndInstallJRuby, removeObsoleteJars, vendor, generateRubySupportFiles]
     doLast {
-        buildGem(projectDir, buildDir, pluginInfo.pluginFullName() + ".gemspec")
+        buildGem(projectDir, layout.buildDirectory.get().asFile, pluginInfo.pluginFullName() + ".gemspec")
     }
 }
 
 task integrationTest(type: Exec) {
-    workingDir 'integration-test'
+    workingDir = file('integration-test')
     commandLine './run_tests.sh'
 }


### PR DESCRIPTION
## Summary
- Fix Groovy DSL property-setter syntax (`group`/`version`) that Gradle's own upgrade guide documents as scheduled for removal in Gradle 10
- Replace deprecated `$buildDir` usage with the `layout.buildDirectory` API
- Capture project properties (`group`, `version`, `name`, `description`) at configuration time instead of accessing `project.*` inside `doLast` blocks, which triggers a "Task.project at execution time... will fail with an error in Gradle 10" deprecation warning
- Add a missing `import groovy.ant.FileNameFinder` — this class is no longer implicitly imported under the newer Groovy version bundled with Gradle 9+

*Generated with the help of Claude Code.*