### PR TITLE
Sum itemRawScore over all query items with the label

### DIFF
--- a/searchlib/src/tests/features/item_raw_score/item_raw_score_test.cpp
+++ b/searchlib/src/tests/features/item_raw_score/item_raw_score_test.cpp
@@ -158,4 +158,38 @@ TEST(ItemRawScoreTest, require_that_stale_raw_score_is_ignored) {
     EXPECT_EQ(0.0, f2.getScore(10));
 }
 
+TEST(ItemRawScoreTest, require_that_raw_scores_of_all_items_with_the_label_are_summed) {
+    MultiLabel  f1("label", {1, 2});
+    RankFixture f2(2, 2, f1);
+    f2.setFooScore(0, 10, 1.0);
+    f2.setFooScore(1, 10, 2.0);
+    EXPECT_EQ(3.0, f2.getScore(10));
+}
+
+TEST(ItemRawScoreTest, require_that_labeled_items_in_different_fields_are_summed) {
+    MultiLabel  f1("label", {1, 3});
+    RankFixture f2(2, 2, f1);
+    f2.setFooScore(0, 10, 1.0);
+    f2.setFooScore(1, 10, 2.0);
+    f2.setBarScore(0, 10, 5.0);
+    f2.setBarScore(1, 10, 6.0);
+    EXPECT_EQ(6.0, f2.getScore(10));
+}
+
+TEST(ItemRawScoreTest, require_that_stale_raw_score_of_a_labeled_item_is_ignored) {
+    MultiLabel  f1("label", {1, 2});
+    RankFixture f2(2, 2, f1);
+    f2.setFooScore(0, 10, 1.0);
+    f2.setFooScore(1, 5, 2.0);
+    EXPECT_EQ(1.0, f2.getScore(10));
+}
+
+TEST(ItemRawScoreTest, require_that_non_existing_unique_ids_in_a_label_are_ignored) {
+    MultiLabel  f1("label", {1, 42});
+    RankFixture f2(2, 2, f1);
+    f2.setFooScore(0, 10, 1.0);
+    f2.setFooScore(1, 10, 2.0);
+    EXPECT_EQ(1.0, f2.getScore(10));
+}
+
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/features/item_raw_score_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/item_raw_score_feature.cpp
@@ -47,7 +47,7 @@ ItemRawScoreBlueprint::~ItemRawScoreBlueprint() = default;
 
 bool ItemRawScoreBlueprint::setup(const IIndexEnvironment&, const ParameterList& params) {
     _label = params[0].getValue();
-    describeOutput("out", "raw score for the given query item");
+    describeOutput("out", "summed raw score of the query items with the given label");
     return true;
 }
 
@@ -65,9 +65,10 @@ FeatureExecutor& ItemRawScoreBlueprint::createExecutor(const IQueryEnvironment& 
 
 ItemRawScoreBlueprint::HandleVector ItemRawScoreBlueprint::resolve(const IQueryEnvironment& env,
                                                                    const std::string&       label) {
-    HandleVector     handles;
-    const ITermData* term = util::getTermByLabel(env, label);
-    if (term != nullptr) {
+    HandleVector handles;
+    // A label may name several query items; the raw scores of all of them are summed, just like the raw scores
+    // of the fields of a single item are.
+    for (const ITermData* term : util::getTermsByLabel(env, label)) {
         uint32_t numFields(term->numFields());
         for (uint32_t i(0); i < numFields; ++i) {
             TermFieldHandle handle = term->field(i).getHandle();


### PR DESCRIPTION
A label may name several query items: Model.addLabels emits one vespa.label.<label>.id value per labeled item, and an annotation such as {label:"t1"}userInput("new york") labels every term the input parsed into.

Use getTermsByLabel and collect the field handles of every labeled item. The executor already summed the raw scores of the fields of one item, so this just applies that same rule to a larger set of handles, and a label naming a single item resolves exactly as before.
