### PR TITLE
Fail health check on document processing deadlock/CPU starvation

### DIFF
--- a/container-disc/abi-spec.json
+++ b/container-disc/abi-spec.json
@@ -404,6 +404,7 @@
       "public void setInRotation(java.lang.Boolean)",
       "public void addToRotation(java.lang.String)",
       "public void removeFromRotation(java.lang.String)",
+      "public void setLivenessOk(boolean)",
       "public boolean isInRotation()"
     ],
     "fields" : [ ]

--- a/container-disc/src/main/java/com/yahoo/container/handler/VipStatus.java
+++ b/container-disc/src/main/java/com/yahoo/container/handler/VipStatus.java
@@ -33,6 +33,13 @@ public class VipStatus {
 
     private final boolean initiallyInRotation;
 
+    /**
+     * Whether the container is considered live, e.g. not deadlocked or CPU starved.
+     * Unlike the cluster-derived state, this is not auto-recovered by unrelated
+     * addToRotation/removeFromRotation calls - only an explicit setLivenessOk() changes it.
+     */
+    private volatile boolean liveness = true;
+
     /** The current state of this */
     private boolean currentlyInRotation;
 
@@ -97,21 +104,35 @@ public class VipStatus {
         updateCurrentlyInRotation();
     }
 
+    /**
+     * Sets whether this container is considered live, e.g. not deadlocked or CPU starved.
+     * When set to false, this container is taken out of rotation regardless of cluster status,
+     * until liveness is reported ok again.
+     */
+    public void setLivenessOk(boolean ok) {
+        synchronized (mutex) {
+            liveness = ok;
+            updateCurrentlyInRotation();
+        }
+    }
+
     private void updateCurrentlyInRotation() {
         synchronized (mutex) {
             if (rotationOverride != null) {
                 currentlyInRotation = rotationOverride;
             } else {
+                boolean clustersOk;
                 if (healthState.status() == StateMonitor.Status.up) {
-                    currentlyInRotation = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ONE);
+                    clustersOk = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ONE);
                 }
                 else if (healthState.status() == StateMonitor.Status.initializing) {
-                    currentlyInRotation = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ALL)
-                                          && initiallyInRotation;
+                    clustersOk = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ALL)
+                                 && initiallyInRotation;
                 }
                 else {
-                    currentlyInRotation = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ALL);
+                    clustersOk = clustersStatus.containerShouldReceiveTraffic(ClustersStatus.Require.ALL);
                 }
+                currentlyInRotation = liveness && clustersOk;
             }
 
             // Change to/from 'up' when appropriate but don't change 'initializing' to 'down'

--- a/container-disc/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
+++ b/container-disc/src/test/java/com/yahoo/container/handler/VipStatusTestCase.java
@@ -81,6 +81,54 @@ public class VipStatusTestCase {
     }
 
     @Test
+    void testLivenessOverridesClusterStatus() {
+        String[] clusters = {"cluster1", "cluster2", "cluster3"};
+
+        VipStatus v = createVipStatus(clusters, StateMonitor.Status.initializing, true, new ClustersStatus(), new MetricMock());
+        addToRotation(clusters, v);
+        assertTrue(v.isInRotation());
+
+        v.setLivenessOk(false);
+        assertFalse(v.isInRotation());  // stalled, even though all clusters are up
+
+        v.setLivenessOk(true);
+        assertTrue(v.isInRotation());   // liveness restored, cluster state still up
+    }
+
+    @Test
+    void testLivenessNotClearedByUnrelatedClusterChanges() {
+        String[] clusters = {"cluster1", "cluster2", "cluster3"};
+
+        VipStatus v = createVipStatus(clusters, StateMonitor.Status.initializing, true, new ClustersStatus(), new MetricMock());
+        addToRotation(clusters, v);
+        v.setLivenessOk(false);
+        assertFalse(v.isInRotation());
+
+        // Unrelated cluster status churn must not silently clear the liveness flag
+        v.removeFromRotation(clusters[0]);
+        v.addToRotation(clusters[0]);
+        assertFalse(v.isInRotation());
+
+        v.setLivenessOk(true);
+        assertTrue(v.isInRotation());
+    }
+
+    @Test
+    void testRotationOverrideWinsOverLiveness() {
+        String[] clusters = {"cluster1", "cluster2", "cluster3"};
+
+        VipStatus v = createVipStatus(clusters, StateMonitor.Status.initializing, true, new ClustersStatus(), new MetricMock());
+        v.setLivenessOk(false);
+        assertFalse(v.isInRotation());
+
+        v.setInRotation(true);
+        assertTrue(v.isInRotation());  // manual override wins regardless of liveness
+
+        v.setInRotation(null);
+        assertFalse(v.isInRotation()); // back to liveness-gated cluster-derived state
+    }
+
+    @Test
     void testClusterRemovalRemovedIsDown() {
         assertClusterRemoval(true, false);
     }

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocprocLivenessWatchdog.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocprocLivenessWatchdog.java
@@ -1,0 +1,95 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.docproc.jdisc;
+
+import java.util.function.LongSupplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Watches whether document processing is making progress, by periodically sampling how many
+ * requests have been submitted for processing versus how many have completed. If requests are
+ * outstanding but none complete for a sustained number of samples, this is the signature of a
+ * deadlock or CPU starvation among the container's request processing threads, and is reported
+ * to a {@link LivenessSink} so the container's health status reflects it. Progress resuming for
+ * a sustained number of samples clears the report again.
+ *
+ * Hysteresis (requiring several consecutive samples in a row) avoids reacting to a single slow
+ * tick, and avoids flapping once a stall has been reported.
+ *
+ * @author hmusum
+ */
+class DocprocLivenessWatchdog implements Runnable {
+
+    interface LivenessSink {
+        void setLivenessOk(boolean ok);
+    }
+
+    private static final Logger log = Logger.getLogger(DocprocLivenessWatchdog.class.getName());
+
+    private final LongSupplier submittedCount;
+    private final LongSupplier completedCount;
+    private final LivenessSink livenessSink;
+    private final int samplesToTrip;
+
+    private long lastCompleted = -1;
+    private int consecutiveStalledSamples = 0;
+    private int consecutiveHealthySamples = 0;
+    private boolean stalled = false;
+
+    DocprocLivenessWatchdog(LongSupplier submittedCount, LongSupplier completedCount, LivenessSink livenessSink,
+                            double sampleIntervalSeconds, double stalledThresholdSeconds) {
+        this(submittedCount, completedCount, livenessSink,
+             Math.max(1, (int) Math.round(stalledThresholdSeconds / sampleIntervalSeconds)));
+    }
+
+    /** For testing: trip/clear after exactly this many consecutive samples, rather than deriving it from seconds. */
+    DocprocLivenessWatchdog(LongSupplier submittedCount, LongSupplier completedCount, LivenessSink livenessSink,
+                            int samplesToTrip) {
+        this.submittedCount = submittedCount;
+        this.completedCount = completedCount;
+        this.livenessSink = livenessSink;
+        this.samplesToTrip = samplesToTrip;
+    }
+
+    @Override
+    public void run() {
+        try {
+            sample();
+        } catch (RuntimeException e) {
+            log.log(Level.WARNING, "Exception in docproc liveness watchdog", e);
+        }
+    }
+
+    /** Takes one sample and updates liveness state accordingly. Package-private for testing. */
+    void sample() {
+        long completed = completedCount.getAsLong();
+        long outstanding = submittedCount.getAsLong() - completed;
+        boolean progressed = lastCompleted == -1 || completed != lastCompleted;
+        lastCompleted = completed;
+
+        if (outstanding > 0 && !progressed) {
+            consecutiveStalledSamples++;
+            consecutiveHealthySamples = 0;
+        } else {
+            consecutiveHealthySamples++;
+            consecutiveStalledSamples = 0;
+        }
+
+        if ( ! stalled && consecutiveStalledSamples >= samplesToTrip) {
+            stalled = true;
+            long outstandingAtTrip = outstanding;
+            log.log(Level.WARNING, () -> "Document processing appears stalled: " + outstandingAtTrip +
+                                          " request(s) outstanding with no completions for " + consecutiveStalledSamples +
+                                          " consecutive samples. Reporting container as unhealthy.");
+            livenessSink.setLivenessOk(false);
+        } else if (stalled && consecutiveHealthySamples >= samplesToTrip) {
+            stalled = false;
+            log.log(Level.INFO, "Document processing has resumed making progress. Reporting container as healthy again.");
+            livenessSink.setLivenessOk(true);
+        }
+    }
+
+    /** For testing. */
+    boolean isStalled() { return stalled; }
+
+}

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
@@ -10,6 +10,7 @@ import com.yahoo.config.docproc.DocprocConfig;
 import com.yahoo.config.docproc.SchemamappingConfig;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.core.document.ContainerDocumentConfig;
+import com.yahoo.container.handler.VipStatus;
 import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.docproc.AbstractConcreteDocumentFactory;
 import com.yahoo.docproc.CallStack;
@@ -27,8 +28,10 @@ import com.yahoo.messagebus.jdisc.MbusRequest;
 import com.yahoo.processing.execution.chain.ChainRegistry;
 
 import java.util.TimerTask;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -50,6 +53,9 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
             new ScheduledThreadPoolExecutor(2, new DaemonThreadFactory("docproc-later-"));
     private final ContainerDocumentConfig containerDocConfig;
     private final DocumentTypeManager documentTypeManager;
+    private final AtomicLong submittedCount = new AtomicLong();
+    private final AtomicLong completedCount = new AtomicLong();
+    private final ScheduledFuture<?> livenessWatchdogFuture;
 
     private DocumentProcessingHandler(ComponentRegistry<DocprocService> docprocServiceRegistry,
                                       ComponentRegistry<DocumentProcessor> documentProcessorComponentRegistry,
@@ -58,7 +64,11 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                                       ChainsModel chainsModel, SchemaMap schemaMap,
                                       Metric metric,
                                       ContainerDocumentConfig containerDocConfig,
-                                      ContainerThreadPool threadPool) {
+                                      ContainerThreadPool threadPool,
+                                      VipStatus vipStatus,
+                                      boolean livenessCheckEnabled,
+                                      double livenessSampleIntervalSeconds,
+                                      double livenessStalledThresholdSeconds) {
         this.docprocServiceRegistry = docprocServiceRegistry;
         this.docFactoryRegistry = docFactoryRegistry;
         this.containerDocConfig = containerDocConfig;
@@ -77,6 +87,16 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                 docprocServiceRegistry.register(service.getId(), service);
             }
         }
+
+        if (livenessCheckEnabled) {
+            DocprocLivenessWatchdog watchdog = new DocprocLivenessWatchdog(
+                    submittedCount::get, completedCount::get, vipStatus::setLivenessOk,
+                    livenessSampleIntervalSeconds, livenessStalledThresholdSeconds);
+            long intervalMillis = Math.max(1, Math.round(livenessSampleIntervalSeconds * 1000));
+            livenessWatchdogFuture = laterExecutor.scheduleAtFixedRate(watchdog, intervalMillis, intervalMillis, TimeUnit.MILLISECONDS);
+        } else {
+            livenessWatchdogFuture = null;
+        }
     }
 
     DocumentProcessingHandler(ComponentRegistry<DocprocService> docprocServiceRegistry,
@@ -87,7 +107,9 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
         this(docprocServiceRegistry, documentProcessorComponentRegistry, docFactoryRegistry,
              params.getDocumentTypeManager(), params.getChainsModel(), params.getSchemaMap(),
              params.getMetric(),
-             params.getContainerDocConfig(), threadPool);
+             params.getContainerDocConfig(), threadPool,
+             params.getVipStatus(), params.isLivenessCheckEnabled(),
+             params.getLivenessSampleIntervalSeconds(), params.getLivenessStalledThresholdSeconds());
     }
 
     @Inject
@@ -99,7 +121,8 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                                      DocprocConfig docprocConfig,
                                      ContainerDocumentConfig containerDocConfig,
                                      Metric metric,
-                                     ContainerThreadPool threadPool) {
+                                     ContainerThreadPool threadPool,
+                                     VipStatus vipStatus) {
         this(new ComponentRegistry<>(),
              documentProcessorComponentRegistry, docFactoryRegistry,
                 new DocumentProcessingHandlerParameters()
@@ -107,7 +130,11 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                      .setDocumentTypeManager(documentTypeManager)
                      .setChainsModel(buildFromConfig(chainsConfig)).setSchemaMap(configureMapping(mappingConfig))
                      .setMetric(metric)
-                     .setContainerDocumentConfig(containerDocConfig),
+                     .setContainerDocumentConfig(containerDocConfig)
+                     .setVipStatus(vipStatus)
+                     .setLivenessCheckEnabled(docprocConfig.livenessCheckEnabled())
+                     .setLivenessSampleIntervalSeconds(docprocConfig.livenessSampleIntervalSeconds())
+                     .setLivenessStalledThresholdSeconds(docprocConfig.livenessStalledThresholdSeconds()),
                 threadPool);
 
         // Set simple annotations flag
@@ -118,6 +145,9 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
 
     @Override
     protected void destroy() {
+        if (livenessWatchdogFuture != null) {
+            livenessWatchdogFuture.cancel(false);
+        }
         laterExecutor.shutdown();
         if ( ! laterExecutor.getQueue().isEmpty()) {
             // This should not happen, as container should keep this alive until all requests are served.
@@ -181,6 +211,7 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
         }
 
         DocumentProcessingTask task = new DocumentProcessingTask(requestContext, this, service, service.getThreadPoolExecutor());
+        submittedCount.incrementAndGet();
         task.submit();
         return null;
     }
@@ -188,6 +219,11 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
     void submit(DocumentProcessingTask task, long delay) {
         LaterTimerTask timerTask = new LaterTimerTask(task, delay);
         laterExecutor.schedule(timerTask, delay, TimeUnit.MILLISECONDS);
+    }
+
+    /** Records that a document processing request has run to completion (successfully or not). */
+    void recordCompleted() {
+        completedCount.incrementAndGet();
     }
 
     private static class LaterTimerTask extends TimerTask {

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerParameters.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerParameters.java
@@ -3,6 +3,7 @@ package com.yahoo.docproc.jdisc;
 
 import com.yahoo.component.chain.model.ChainsModel;
 import com.yahoo.container.core.document.ContainerDocumentConfig;
+import com.yahoo.container.handler.VipStatus;
 import com.yahoo.docproc.jdisc.metric.NullMetric;
 import com.yahoo.docproc.proxy.SchemaMap;
 import com.yahoo.document.DocumentTypeManager;
@@ -22,6 +23,10 @@ public class DocumentProcessingHandlerParameters {
     private SchemaMap schemaMap = null;
     private Metric metric = new NullMetric();
     private ContainerDocumentConfig containerDocConfig;
+    private VipStatus vipStatus = new VipStatus();
+    private boolean livenessCheckEnabled = false;
+    private double livenessSampleIntervalSeconds = 5.0;
+    private double livenessStalledThresholdSeconds = 180.0;
 
 
 
@@ -91,6 +96,42 @@ public class DocumentProcessingHandlerParameters {
 
     public ContainerDocumentConfig getContainerDocConfig() {
         return containerDocConfig;
+    }
+
+    public VipStatus getVipStatus() {
+        return vipStatus;
+    }
+
+    public DocumentProcessingHandlerParameters setVipStatus(VipStatus vipStatus) {
+        this.vipStatus = vipStatus;
+        return this;
+    }
+
+    public boolean isLivenessCheckEnabled() {
+        return livenessCheckEnabled;
+    }
+
+    public DocumentProcessingHandlerParameters setLivenessCheckEnabled(boolean livenessCheckEnabled) {
+        this.livenessCheckEnabled = livenessCheckEnabled;
+        return this;
+    }
+
+    public double getLivenessSampleIntervalSeconds() {
+        return livenessSampleIntervalSeconds;
+    }
+
+    public DocumentProcessingHandlerParameters setLivenessSampleIntervalSeconds(double livenessSampleIntervalSeconds) {
+        this.livenessSampleIntervalSeconds = livenessSampleIntervalSeconds;
+        return this;
+    }
+
+    public double getLivenessStalledThresholdSeconds() {
+        return livenessStalledThresholdSeconds;
+    }
+
+    public DocumentProcessingHandlerParameters setLivenessStalledThresholdSeconds(double livenessStalledThresholdSeconds) {
+        this.livenessStalledThresholdSeconds = livenessStalledThresholdSeconds;
+        return this;
     }
 
 }

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingTask.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingTask.java
@@ -69,6 +69,8 @@ public class DocumentProcessingTask implements Runnable {
             if (DocumentProcessor.Progress.LATER.equals(progress) && !processings.isEmpty()) {
                 DocumentProcessor.LaterProgress laterProgress = (DocumentProcessor.LaterProgress) progress;
                 docprocHandler.submit(this, laterProgress.getDelay());
+            } else {
+                docprocHandler.recordCompleted();
             }
         } catch (Error error) {
             try {

--- a/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
+++ b/docproc/src/main/resources/configdefinitions/config.docproc.docproc.def
@@ -12,3 +12,14 @@ numthreads int default=-1
 # Not used - always enabled.
 # When enabled, uses SimpleIndexingAnnotations (flat arrays) instead of full SpanTree objects.
 simpleAnnotations bool default=true
+
+# Whether to watch for stalled document processing (e.g. due to deadlock or CPU starvation)
+# and report the container as unhealthy if detected.
+livenessCheckEnabled bool default=true
+
+# How often to sample document processing progress, in seconds.
+livenessSampleIntervalSeconds double default=5.0
+
+# How long document processing must show no progress, while requests are outstanding,
+# before the container is reported as unhealthy.
+livenessStalledThresholdSeconds double default=180.0

--- a/docproc/src/test/java/com/yahoo/docproc/jdisc/DocprocLivenessWatchdogTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/jdisc/DocprocLivenessWatchdogTestCase.java
@@ -1,0 +1,109 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.docproc.jdisc;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author hmusum
+ */
+public class DocprocLivenessWatchdogTestCase {
+
+    private static final int SAMPLES_TO_TRIP = 3;
+
+    @Test
+    public void testIdleContainerIsNeverStalled() {
+        AtomicLong submitted = new AtomicLong(0);
+        AtomicLong completed = new AtomicLong(0);
+        AtomicBoolean livenessOk = new AtomicBoolean(true);
+        DocprocLivenessWatchdog watchdog = watchdog(submitted, completed, livenessOk);
+
+        for (int i = 0; i < 10; i++)
+            watchdog.sample();
+
+        assertFalse(watchdog.isStalled());
+        assertTrue(livenessOk.get());
+    }
+
+    @Test
+    public void testProgressingBacklogIsNotStalled() {
+        AtomicLong submitted = new AtomicLong(0);
+        AtomicLong completed = new AtomicLong(0);
+        AtomicBoolean livenessOk = new AtomicBoolean(true);
+        DocprocLivenessWatchdog watchdog = watchdog(submitted, completed, livenessOk);
+
+        for (int i = 0; i < 10; i++) {
+            submitted.incrementAndGet();
+            watchdog.sample();
+            completed.incrementAndGet();
+        }
+
+        assertFalse(watchdog.isStalled());
+        assertTrue(livenessOk.get());
+    }
+
+    @Test
+    public void testBacklogWithNoProgressUnderThresholdIsNotYetStalled() {
+        AtomicLong submitted = new AtomicLong(0);
+        AtomicLong completed = new AtomicLong(0);
+        AtomicBoolean livenessOk = new AtomicBoolean(true);
+        DocprocLivenessWatchdog watchdog = watchdog(submitted, completed, livenessOk);
+        watchdog.sample(); // establish baseline while idle, as would happen in production before any stall begins
+
+        submitted.incrementAndGet(); // one outstanding request, never completes
+        for (int i = 0; i < SAMPLES_TO_TRIP - 1; i++)
+            watchdog.sample();
+
+        assertFalse(watchdog.isStalled());
+        assertTrue(livenessOk.get());
+    }
+
+    @Test
+    public void testBacklogWithNoProgressOverThresholdIsStalled() {
+        AtomicLong submitted = new AtomicLong(0);
+        AtomicLong completed = new AtomicLong(0);
+        AtomicBoolean livenessOk = new AtomicBoolean(true);
+        DocprocLivenessWatchdog watchdog = watchdog(submitted, completed, livenessOk);
+        watchdog.sample(); // establish baseline while idle
+
+        submitted.incrementAndGet(); // one outstanding request, never completes
+        for (int i = 0; i < SAMPLES_TO_TRIP; i++)
+            watchdog.sample();
+
+        assertTrue(watchdog.isStalled());
+        assertFalse(livenessOk.get());
+    }
+
+    @Test
+    public void testRecoveryAfterProgressResumes() {
+        AtomicLong submitted = new AtomicLong(0);
+        AtomicLong completed = new AtomicLong(0);
+        AtomicBoolean livenessOk = new AtomicBoolean(true);
+        DocprocLivenessWatchdog watchdog = watchdog(submitted, completed, livenessOk);
+        watchdog.sample(); // establish baseline while idle
+
+        submitted.incrementAndGet();
+        for (int i = 0; i < SAMPLES_TO_TRIP; i++)
+            watchdog.sample();
+        assertTrue(watchdog.isStalled());
+        assertFalse(livenessOk.get());
+
+        // Progress resumes and the outstanding request completes
+        completed.incrementAndGet();
+        for (int i = 0; i < SAMPLES_TO_TRIP; i++)
+            watchdog.sample();
+
+        assertFalse(watchdog.isStalled());
+        assertTrue(livenessOk.get());
+    }
+
+    private static DocprocLivenessWatchdog watchdog(AtomicLong submitted, AtomicLong completed, AtomicBoolean livenessOk) {
+        return new DocprocLivenessWatchdog(submitted::get, completed::get, livenessOk::set, SAMPLES_TO_TRIP);
+    }
+
+}


### PR DESCRIPTION
## Summary
- Health checks (`/state/v1/health`, `status.html`) previously only reflected backend cluster availability, with no signal for a deadlocked or CPU-starved container.
- Adds a liveness gate to `VipStatus`, independent of cluster status, driven by a new `DocprocLivenessWatchdog` that watches whether document processing requests are actually completing.
- The watchdog samples submitted-vs-completed request counters on the live docproc request path and flags a stall (outstanding requests, zero completions for a sustained period), with hysteresis to trip/clear without flapping.
- New config in `config.docproc.docproc.def`: `livenessCheckEnabled` (default `true`), `livenessSampleIntervalSeconds`, `livenessStalledThresholdSeconds`.

## Test plan
- New unit tests for the watchdog's stall-detection logic (idle, progressing, stalled-under/over-threshold, recovery)
- Extended `VipStatusTestCase` for the new liveness gate interactions
- `mvn test` passes for `docproc` and `container-disc` modules

Generated with Claude Code.