### PR TITLE
Fall back to flat load balancing in partially az-assigned clusters

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/lb/BestOfRandom2Scheduler.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/lb/BestOfRandom2Scheduler.java
@@ -35,10 +35,9 @@ class BestOfRandom2Scheduler implements GroupScheduler {
     private TrackedGroup selectBestOf2(Set<Integer> rejectedGroups, boolean requireCoverage) {
         List<Integer> candidates = new ArrayList<>(scoreboard.size());
         for (TrackedGroup group : scoreboard.values()) {
-            if (rejectedGroups == null || !rejectedGroups.contains(group.id())) {
-                if (!requireCoverage || group.group().hasSufficientCoverage()) {
-                    candidates.add(group.id());
-                }
+            if (rejectedGroups.contains(group.id())) continue;
+            if (!requireCoverage || group.group().hasSufficientCoverage()) {
+                candidates.add(group.id());
             }
         }
         TrackedGroup candA = selectRandom(candidates);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/lb/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/lb/LoadBalancer.java
@@ -49,10 +49,19 @@ public class LoadBalancer {
             case LATENCY_AMORTIZED_OVER_TIME -> new AdaptiveScheduler(AdaptiveScheduler.Type.TIME, new Random(seed), scoreboard);
         };
 
-        this.remoteGroups = groups.stream()
-                                  .filter(group -> ! group.availabilityZone().equals(localAvailabilityZone))
-                                  .map(Group::id)
-                                  .collect(Collectors.toUnmodifiableSet());
+
+        // If any node don't have a proper AZ assigned, fall back to non-AZ-aware routing.
+        // TODO: Remove when there are no applications with a mixture of nodes having and not having an AZ
+        if (localAvailabilityZone.equals("default") ||
+            groups.stream().flatMap(group -> group.nodes().stream()).anyMatch(node -> node.availabilityZone().equals("default"))) {
+            this.remoteGroups = Set.of();
+        }
+        else {
+            this.remoteGroups = groups.stream()
+                                      .filter(group -> !group.availabilityZone().equals(localAvailabilityZone))
+                                      .map(Group::id)
+                                      .collect(Collectors.toUnmodifiableSet());
+        }
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/dispatch/lb/RoundRobinScheduler.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/lb/RoundRobinScheduler.java
@@ -26,7 +26,7 @@ class RoundRobinScheduler implements GroupScheduler {
         int groupId = needle;
         for (int i = 0; i < scoreboard.size(); i++) {
             TrackedGroup candidate = scoreboard.get(groupId);
-            if (rejectedGroups == null || !rejectedGroups.contains(candidate.id())) {
+            if (!rejectedGroups.contains(candidate.id())) {
                 TrackedGroup better = betterGroup(bestCandidate, candidate);
                 if (better == candidate)
                     bestCandidate = candidate;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTest.java
@@ -46,6 +46,87 @@ public class LoadBalancerTest {
         new LoadBalancerTester(LoadBalancer.Policy.LATENCY_AMORTIZED_OVER_TIME, 3.0).assertAzAwareLoadBalancing();
     }
 
+    // Clusters where *some* nodes are in "default" and others in an "az" should get flat balancing
+    @Test
+    void test_load_balancing_with_any_default_az_becomes_az_unaware() {
+        var tester = new LoadBalancerTester(LoadBalancer.Policy.ROUNDROBIN, 0.0);
+        Node n1 = new Node("test", 0, "test-node1", 0, true, "az1");
+        Node n2 = new Node("test", 0, "test-node2", 1, true, "az1");
+        Node n3 = new Node("test", 1, "test-node3", 2, true, "az2");
+        Node n4 = new Node("test", 1, "test-node4", 3, true, "default");
+        Group g0 = new Group(0, List.of(n1));
+        Group g1 = new Group(1, List.of(n2));
+        Group g2 = new Group(2, List.of(n3));
+        Group g3 = new Group(3, List.of(n4));
+
+        g0.setHasSufficientCoverage(true);
+        g1.setHasSufficientCoverage(true);
+        g2.setHasSufficientCoverage(true);
+        g3.setHasSufficientCoverage(true);
+        tester.assertLb(List.of(25, 25, 25, 25), tester.loadBalance(List.of(g0, g1, g2, g3), "az1"));
+        tester.assertLb(List.of(25, 25, 25, 25), tester.loadBalance(List.of(g0, g1, g2, g3), "az2"));
+        tester.assertLb(List.of(25, 25, 25, 25), tester.loadBalance(List.of(g0, g1, g2, g3), "default"));
+
+        g0.setHasSufficientCoverage(false);
+        g1.setHasSufficientCoverage(true);
+        g2.setHasSufficientCoverage(true);
+        g3.setHasSufficientCoverage(true);
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), "az1"));
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), "az2"));
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), "default"));
+
+        g0.setHasSufficientCoverage(false);
+        g1.setHasSufficientCoverage(false);
+        g2.setHasSufficientCoverage(true);
+        g3.setHasSufficientCoverage(true);
+        tester.assertLb(List.of(0, 0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), "az1"));
+        tester.assertLb(List.of(0, 0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), "az2"));
+
+        g0.setHasSufficientCoverage(false);
+        g1.setHasSufficientCoverage(false);
+        g2.setHasSufficientCoverage(false);
+        g3.setHasSufficientCoverage(true);
+        tester.assertLb(List.of(0, 0, 0, 100), tester.loadBalance(List.of(g0, g1, g2, g3), "az1"));
+        tester.assertLb(List.of(0, 0, 0, 100), tester.loadBalance(List.of(g0, g1, g2, g3), "az2"));
+
+        g0.setHasSufficientCoverage(false);
+        g1.setHasSufficientCoverage(false);
+        g2.setHasSufficientCoverage(false);
+        g3.setHasSufficientCoverage(false);
+        tester.assertLb(List.of(25, 25, 25, 25), tester.loadBalance(List.of(g0, g1, g2, g3), "az1"));
+        tester.assertLb(List.of(25, 25, 25, 25), tester.loadBalance(List.of(g0, g1, g2, g3), "az2"));
+        tester.assertLb(List.of(25, 25, 25, 25), tester.loadBalance(List.of(g0, g1, g2, g3), "default"));
+
+        // rejections
+
+        g0.setHasSufficientCoverage(true);
+        g1.setHasSufficientCoverage(true);
+        g2.setHasSufficientCoverage(true);
+        g3.setHasSufficientCoverage(true);
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0), "az1"));
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0), "default"));
+        tester.assertLb(List.of(0,  0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "az1"));
+        tester.assertLb(List.of(0,  0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "default"));
+        tester.assertLb(List.of(0,  0,  0,  0), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1, g2, g3), "az1"));
+        tester.assertLb(List.of(0,  0,  0,  0), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1, g2, g3), "default"));
+
+        g0.setHasSufficientCoverage(true);
+        g1.setHasSufficientCoverage(true);
+        g2.setHasSufficientCoverage(false);
+        g3.setHasSufficientCoverage(false);
+        tester.assertLb(List.of(0, 0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "az1"));
+        tester.assertLb(List.of(0, 0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "default"));
+
+        g0.setHasSufficientCoverage(false);
+        g1.setHasSufficientCoverage(false);
+        g2.setHasSufficientCoverage(false);
+        g3.setHasSufficientCoverage(false);
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0), "az1"));
+        tester.assertLb(List.of(0, 34, 33, 33), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0), "default"));
+        tester.assertLb(List.of(0,  0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "az1"));
+        tester.assertLb(List.of(0,  0, 50, 50), tester.loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "default"));
+    }
+
     @Test
     void test_search_time_decay() {
         AdaptiveScheduler.DecayByRequests decayer = new AdaptiveScheduler.DecayByRequests(0, Duration.ofSeconds(1));
@@ -92,23 +173,23 @@ public class LoadBalancerTest {
     @Test
     void test_adaptive_scheduler_weighted() {
         var scoreboard = createScoreBoard(5);
-        Random seq = sequence(0.0, 0.4379, 0.4380, 0.6569, 0.6570, 0.8029, 0.8030, 0.9124, 0.9125);
-        AdaptiveScheduler sched = new AdaptiveScheduler(AdaptiveScheduler.Type.REQUESTS, seq, scoreboard);
+        Random sequence = sequence(0.0, 0.4379, 0.4380, 0.6569, 0.6570, 0.8029, 0.8030, 0.9124, 0.9125);
+        var scheduler = new AdaptiveScheduler(AdaptiveScheduler.Type.REQUESTS, sequence, scoreboard);
         int i = 0;
         for (TrackedGroup gs : scoreboard.values()) {
             gs.setDecayer(new AdaptiveScheduler.DecayByRequests(1, Duration.ofMillis((long)(0.1 * (i + 1)*1000.0))));
             i++;
         }
 
-        assertEquals(0, sched.takeNextGroup(null).get().id());
-        assertEquals(0, sched.takeNextGroup(null).get().id());
-        assertEquals(1, sched.takeNextGroup(null).get().id());
-        assertEquals(1, sched.takeNextGroup(null).get().id());
-        assertEquals(2, sched.takeNextGroup(null).get().id());
-        assertEquals(2, sched.takeNextGroup(null).get().id());
-        assertEquals(3, sched.takeNextGroup(null).get().id());
-        assertEquals(3, sched.takeNextGroup(null).get().id());
-        assertEquals(4, sched.takeNextGroup(null).get().id());
+        assertEquals(0, scheduler.takeNextGroup(null).get().id());
+        assertEquals(0, scheduler.takeNextGroup(null).get().id());
+        assertEquals(1, scheduler.takeNextGroup(null).get().id());
+        assertEquals(1, scheduler.takeNextGroup(null).get().id());
+        assertEquals(2, scheduler.takeNextGroup(null).get().id());
+        assertEquals(2, scheduler.takeNextGroup(null).get().id());
+        assertEquals(3, scheduler.takeNextGroup(null).get().id());
+        assertEquals(3, scheduler.takeNextGroup(null).get().id());
+        assertEquals(4, scheduler.takeNextGroup(null).get().id());
     }
 
     @Test
@@ -125,15 +206,15 @@ public class LoadBalancerTest {
                 );
         BestOfRandom2Scheduler sched = new BestOfRandom2Scheduler(seq, createScoreBoard(5));
 
-        assertEquals(0, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(1, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(0, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(1, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(2, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(4, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(4, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(4, allocate(sched.takeNextGroup(null).get()).id());
-        assertEquals(0, allocate(sched.takeNextGroup(null).get()).id());
+        assertEquals(0, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(1, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(0, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(1, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(2, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(4, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(4, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(4, allocate(sched.takeNextGroup(Set.of()).get()).id());
+        assertEquals(0, allocate(sched.takeNextGroup(Set.of()).get()).id());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTester.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTester.java
@@ -98,7 +98,7 @@ public class LoadBalancerTester {
     }
 
     /** Asserts that the expected number of requests per group matches the actual. */
-    private void assertLb(List<Integer> expected, List<Integer> actual) {
+    public void assertLb(List<Integer> expected, List<Integer> actual) {
         if ( deviationPercentage == 0.0) { // Give better assert failure messages
             assertEquals(expected, actual);
         }
@@ -120,11 +120,11 @@ public class LoadBalancerTester {
                    message + ": Expected " + expected + " but was " + actual);
     }
 
-    private List<Integer> loadBalance(List<Group> groups, String localAZ) {
+    public List<Integer> loadBalance(List<Group> groups, String localAZ) {
         return loadBalance(groups, List.of(), localAZ);
     }
 
-    private List<Integer> loadBalance(List<Group> groups, List<Group> rejected, String localAZ) {
+    public List<Integer> loadBalance(List<Group> groups, List<Group> rejected, String localAZ) {
         LoadBalancer lb = new LoadBalancer(groups, policy, localAZ, 1);
         List<Integer> requestCounts = new ArrayList<>(groups.size());
         for (int i = 0; i < groups.size(); i++)


### PR DESCRIPTION
We currently have applications where some nodes have az assigned while others have "default". Disable az-aware load balancing in such clusters.
