### PR TITLE
Re-apply BouncyCastle 1.85, and allow long common names in CSR subjects

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -69,7 +69,7 @@
         <asm.vespa.version>9.10.1</asm.vespa.version>
         <assertj.vespa.version>3.27.7</assertj.vespa.version>
 
-        <bouncycastle.vespa.version>1.84</bouncycastle.vespa.version>
+        <bouncycastle.vespa.version>1.85</bouncycastle.vespa.version>
         <byte-buddy.vespa.version>1.18.11</byte-buddy.vespa.version>
         <checker-qual.vespa.version>3.38.0</checker-qual.vespa.version>
         <classworlds-classworlds.vespa.version>1.1</classworlds-classworlds.vespa.version>

--- a/security-utils/src/main/java/com/yahoo/security/Pkcs10CsrBuilder.java
+++ b/security-utils/src/main/java/com/yahoo/security/Pkcs10CsrBuilder.java
@@ -34,9 +34,13 @@ import static com.yahoo.security.SubjectAlternativeName.Type.DNS;
 public class Pkcs10CsrBuilder {
 
     /**
-     * BouncyCastle 1.85 and later enforce the RFC 5280 ub-common-name upper bound (64) when parsing a DN string.
-     * Athenz role certificates legitimately carry longer common names ('{@code <domain>:role.<role>}'), so encode
-     * the common name without that check. Produces the same encoding as {@link BCStyle} for names within the bound.
+     * BouncyCastle 1.85 and later enforce the RFC 5280 ub-common-name upper bound (64) when encoding a DN string.
+     * That enforcement is deliberate (https://github.com/bcgit/bc-java/issues/750): a longer common name is not
+     * RFC compliant. Athenz role certificate subjects are '{@code <domain>:role.<role>}', which exceeds the bound,
+     * is not ours to shorten, and is already in use, so opt out of the check for the common name rather than fail
+     * to request the certificate. Common names within the bound are encoded exactly as {@link BCStyle} does.
+     * Handing the {@link X500Principal} to the request builder would also avoid the check, but reverses the RDN
+     * order of the subject.
      */
     private static final X500NameStyle LENIENT_COMMON_NAME_STYLE = new BCStyle() {
         @Override

--- a/security-utils/src/main/java/com/yahoo/security/Pkcs10CsrBuilder.java
+++ b/security-utils/src/main/java/com/yahoo/security/Pkcs10CsrBuilder.java
@@ -1,8 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.security;
 
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameStyle;
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
@@ -27,6 +32,18 @@ import static com.yahoo.security.SubjectAlternativeName.Type.DNS;
  * @author bjorncs
  */
 public class Pkcs10CsrBuilder {
+
+    /**
+     * BouncyCastle 1.85 and later enforce the RFC 5280 ub-common-name upper bound (64) when parsing a DN string.
+     * Athenz role certificates legitimately carry longer common names ('{@code <domain>:role.<role>}'), so encode
+     * the common name without that check. Produces the same encoding as {@link BCStyle} for names within the bound.
+     */
+    private static final X500NameStyle LENIENT_COMMON_NAME_STYLE = new BCStyle() {
+        @Override
+        protected ASN1Encodable encodeStringValue(ASN1ObjectIdentifier oid, String value) {
+            return CN.equals(oid) ? new DERUTF8String(value) : super.encodeStringValue(oid, value);
+        }
+    };
 
     private final X500Principal subject;
     private final KeyPair keyPair;
@@ -75,7 +92,8 @@ public class Pkcs10CsrBuilder {
     public Pkcs10Csr build() {
         try {
             PKCS10CertificationRequestBuilder requestBuilder =
-                    new JcaPKCS10CertificationRequestBuilder(new X500Name(subject.getName()), keyPair.getPublic());
+                    new JcaPKCS10CertificationRequestBuilder(
+                            new X500Name(LENIENT_COMMON_NAME_STYLE, subject.getName()), keyPair.getPublic());
             ExtensionsGenerator extGen = new ExtensionsGenerator();
             if (basicConstraintsExtension != null) {
                 extGen.addExtension(

--- a/security-utils/src/test/java/com/yahoo/security/Pkcs10CsrBuilderTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/Pkcs10CsrBuilderTest.java
@@ -1,11 +1,14 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.security;
 
+import org.bouncycastle.asn1.x500.X500Name;
 import org.junit.jupiter.api.Test;
 
 import javax.security.auth.x500.X500Principal;
+import java.io.IOException;
 import java.security.KeyPair;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -22,6 +25,25 @@ public class Pkcs10CsrBuilderTest {
                 .addSubjectAlternativeName("san2.com")
                 .build();
         assertEquals(subject, csr.getSubject());
+    }
+
+    @Test
+    void can_build_csr_with_common_name_exceeding_rfc5280_upper_bound() {
+        // Athenz role certificates use '<domain>:role.<role>' as common name, which regularly exceeds 64 characters
+        String commonName = "vespa.vespa:role.hosting.tenant.my-tenant.my-application.res_group.my-instance.reader";
+        X500Principal subject = new X500Principal("CN=" + commonName);
+        KeyPair keypair = KeyUtils.generateKeypair(KeyAlgorithm.EC, 256);
+        Pkcs10Csr csr = Pkcs10CsrBuilder.fromKeypair(subject, keypair, SignatureAlgorithm.SHA512_WITH_ECDSA).build();
+        assertEquals(subject, csr.getSubject());
+    }
+
+    @Test
+    void encodes_subject_within_upper_bound_as_default_style_does() throws IOException {
+        X500Principal subject = new X500Principal("OU=organizational-unit, CN=subject");
+        KeyPair keypair = KeyUtils.generateKeypair(KeyAlgorithm.EC, 256);
+        Pkcs10Csr csr = Pkcs10CsrBuilder.fromKeypair(subject, keypair, SignatureAlgorithm.SHA512_WITH_ECDSA).build();
+        assertArrayEquals(new X500Name(subject.getName()).getEncoded("DER"),
+                          csr.getBcCsr().getSubject().getEncoded("DER"));
     }
 
 }


### PR DESCRIPTION
Re-applies the BouncyCastle 1.85 bump that was reverted in #37414, with a fix for `Pkcs10CsrBuilder` which it breaks.

## Why it was reverted

BouncyCastle 1.85 started enforcing the RFC 5280 `ub-common-name` upper bound (64) when converting a DN **string** into an `X500Name`. Parsing an already encoded DN is unaffected. Athenz role certificates use `<domain>:role.<role>` as the common name, which routinely exceeds 64 characters, and Athenz's `Crypto.extractX500DnField` re-parses `cert.getSubjectX500Principal().getName()`, so role certificate authorization started failing.

The check is deliberate on BouncyCastle's part, added from bcgit/bc-java#750: a common name longer than 64 characters is not RFC compliant. There is no system property to disable it, and 1.85.2 still has it.

That is fixed upstream in AthenZ/athenz#3424, released in Athenz 1.12.45, which parses subject DNs with a lenient X500 name style. Builds that combine this repo with Athenz need to be on 1.12.45 or later before merging this.

## This fix

`Pkcs10CsrBuilder.build` had the same construct, `new X500Name(subject.getName())`, so generating a role certificate CSR with a common name over 64 characters threw `IllegalArgumentException` rather than producing a CSR. 

Fixed by parsing the subject with a BCStyle subclass that encodes the common name without the length check. This is a deliberate opt-out from a compliance check, scoped to the common name and to this builder; BouncyCastle still enforces the bound elsewhere, including X500NameBuilder. It restores the 1.84 behaviour under which these CSRs were already produced and the resulting certificates are in use.

Two alternatives were measured and rejected:

- Handing the X500Principal to `JcaPKCS10CertificationRequestBuilder` rather than round-tripping through a string. This is what Athenz's own Crypto.generateX509CSR does, and it avoids the check because BouncyCastle deliberately left the DER parse path permissive. But it reverses the subject's RDN order, so Pkcs10Csr.getSubject() would stop equalling the subject that was passed in. Most subjects we build have several RDNs (OU=…, CN=… for instance and role certificates, CN=…, OU=Vespa, C=NO in the controller), so this would have changed production CSRs. No existing test covered it; the new encoding test does.
- Leaving it alone is not viable, because the common names are not ours to shorten.

The lenient style is the only option that leaves compliant CSRs byte-identical, which the second new test asserts.

## Risks

The builder now accepts long common names for every caller, not only the Athenz ones. That permits non-RFC-compliant CSRs, but does not grant privileges and does not bypass CA validation: a CSR is only a request, and ZTS still derives the role from the common name and checks membership before issuing. Nothing in the chain truncates, so two names cannot collide on a shared 64-character prefix. 

This is not only about role certificates: service identity common names can exceed the bound too, which is why athenz#3424's own regression fixture is a 65-character identity. The builder therefore has to accept long names for both kinds of subject it produces. The remaining cost is losing BouncyCastle's build-time check for subjects that should have stayed within the bound, which would now surface later, at whatever validator sees the certificate, rather than at build time.

## Tested

- `mvn test -pl security-utils` passes, 135 tests.
- New test `can_build_csr_with_common_name_exceeding_rfc5280_upper_bound` fails with `commonName length 85 exceeds RFC 5280 ub-common-name (64)` when the lenient style is removed, and passes with it.
- New test `encodes_subject_within_upper_bound_as_default_style_does` asserts the subject DER for a compliant name is identical to what the default style produces, so the lenient style cannot silently drift.
- Verified against a real 114-character role common name with BouncyCastle 1.85 on the classpath: both the CSR generation and the Athenz-side common name extraction succeed.
- Signed a long-common-name CSR through X509CertificateBuilder.fromCsr and read it back: getSubjectCommonNames returns the name exactly, LdapName parses the subject DN, and the DER round-trip preserves it. The signing path was already permissive, so this does not move the failure downstream.

Note on the version: BouncyCastle 1.85.2 exists, but only for `bcprov-jdk18on`. `bcpkix-jdk18on` and `bcutil-jdk18on` are still at 1.85, and all three are driven from the single `bouncycastle.vespa.version` property, so this stays at 1.85.

---

*AI-assisted PR (Opus 5, reviewed by GPT-5.6 Sol) - all changes verified by the author before submission*
