### PR TITLE
Add `map: fast-search` to schema definition

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/document/SDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/SDField.java
@@ -53,7 +53,7 @@ public class SDField extends Field implements ImmutableSDField {
     /** Use this field for modifying index-structure, even if it doesn't have any indexing code */
     private boolean indexStructureField = false;
 
-    /** Whether a fast search structure should be built the synthetic key value field */
+    /** Whether a synthetic key+value field should be built (with fast search structure) */
     private boolean fastMapSearch = false;
 
     /** The indexing statements to be applied to this value during indexing */

--- a/config-model/src/main/java/com/yahoo/schema/document/SDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/SDField.java
@@ -498,7 +498,7 @@ public class SDField extends Field implements ImmutableSDField {
     }
 
     /** Returns whether a fast search structure should be built for the synthetic key value field */
-    public boolean isFastMapSearch() {
+    public boolean hasFastMapSearch() {
         return fastMapSearch;
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/document/SDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/SDField.java
@@ -53,6 +53,9 @@ public class SDField extends Field implements ImmutableSDField {
     /** Use this field for modifying index-structure, even if it doesn't have any indexing code */
     private boolean indexStructureField = false;
 
+    /** Whether a fast search structure should be built the synthetic key value field */
+    private boolean fastMapSearch = false;
+
     /** The indexing statements to be applied to this value during indexing */
     private ScriptExpression indexingScript = new ScriptExpression();
 
@@ -492,6 +495,15 @@ public class SDField extends Field implements ImmutableSDField {
 
     public void setIndexStructureField(boolean indexStructureField) {
         this.indexStructureField = indexStructureField;
+    }
+
+    /** Returns whether a fast search structure should be built for the synthetic key value field */
+    public boolean isFastMapSearch() {
+        return fastMapSearch;
+    }
+
+    public void setFastMapSearch(boolean fastMapSearch) {
+        this.fastMapSearch = fastMapSearch;
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
@@ -253,7 +253,7 @@ public class ConvertParsedFields {
     }
 
     private void convertFastMapSearch(Schema schema, SDField field) {
-        if (!(field.getDataType() instanceof MapDataType)) {
+        if (!(field.getDataType() instanceof MapDataType mapType)) {
             throw new IllegalArgumentException(
                     String.format(
                             "For schema '%s', field '%s': 'map: fast-search' requires a map field, but the type is %s.",
@@ -261,6 +261,8 @@ public class ConvertParsedFields {
                             field.getName(),
                             field.getDataType().getName()));
         }
+        validateFastMapSubtype(schema, field, mapType.getKeyType(), "key");
+        validateFastMapSubtype(schema, field, mapType.getValueType(), "value");
         if (!properties.featureFlags().fastMapSearch()) {
             throw new IllegalArgumentException(
                     String.format("For schema '%s', field '%s': 'map: fast-search' is an unfinished feature that " +
@@ -269,6 +271,23 @@ public class ConvertParsedFields {
                                   field.getName()));
         }
         field.setFastMapSearch(true);
+    }
+
+    private void validateFastMapSubtype(Schema schema, SDField field, DataType type, String keyOrValue) {
+        if (!isSupportedFastMapKeyValueType(type)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "For schema '%s', field '%s': 'map: fast-search' requires %s to be of type string or int, but the type is %s.",
+                            schema.getName(),
+                            field.getName(),
+                            keyOrValue,
+                            type.getName()));
+        }
+    }
+
+    private boolean isSupportedFastMapKeyValueType(DataType dataType) {
+        return dataType.equals(DataType.STRING)
+                || dataType.equals(DataType.INT);
     }
 
     private void convertStructField(Schema schema, SDField field, ParsedField parsed) {

--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
@@ -1,7 +1,9 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.schema.parser;
 
+import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.document.DataType;
+import com.yahoo.document.MapDataType;
 import com.yahoo.schema.document.GeoPos;
 import com.yahoo.schema.parser.ConvertParsedTypes.TypeResolver;
 import com.yahoo.schema.Index;
@@ -33,10 +35,13 @@ public class ConvertParsedFields {
 
     private final TypeResolver context;
     private final Map<String, SDDocumentType> structProxies;
+    private final ModelContext.Properties properties;
 
-    ConvertParsedFields(TypeResolver context, Map<String, SDDocumentType> structProxies) {
+    ConvertParsedFields(TypeResolver context, Map<String, SDDocumentType> structProxies,
+                        ModelContext.Properties properties) {
         this.context = context;
         this.structProxies = structProxies;
+        this.properties = properties;
     }
 
     static void caseHandling(SDField field, Case casing) {
@@ -242,6 +247,28 @@ public class ConvertParsedFields {
         if (parsed.hasNormal()) {
             field.getRanking().setNormal(true);
         }
+        if (parsed.getFastMapSearch()) {
+            convertFastMapSearch(schema, field);
+        }
+    }
+
+    private void convertFastMapSearch(Schema schema, SDField field) {
+        if (!(field.getDataType() instanceof MapDataType)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "For schema '%s', field '%s': 'map: fast-search' requires a map field, but the type is %s.",
+                            schema.getName(),
+                            field.getName(),
+                            field.getDataType().getName()));
+        }
+        if (!properties.featureFlags().fastMapSearch()) {
+            throw new IllegalArgumentException(
+                    String.format("For schema '%s', field '%s': 'map: fast-search' is an unfinished feature that " +
+                                  "will not be enabled yet. Please remove this property from the field.",
+                                  schema.getName(),
+                                  field.getName()));
+        }
+        field.setFastMapSearch(true);
     }
 
     private void convertStructField(Schema schema, SDField field, ParsedField parsed) {

--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedSchemas.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedSchemas.java
@@ -284,7 +284,7 @@ public class ConvertParsedSchemas {
         parsed.getRawAsBase64().ifPresent(value -> schema.enableRawAsBase64(value));
         var typeContext = typeConverter.makeContext(parsed.getDocument());
         var sfResolver = new SummaryFieldTypeResolver(schema, parsed.getDocumentSummaries());
-        var fieldConverter = new ConvertParsedFields(typeContext, convertedStructs);
+        var fieldConverter = new ConvertParsedFields(typeContext, convertedStructs, properties);
         convertDocument(schema, parsed.getDocument(), fieldConverter);
         for (var field : parsed.getFields()) {
             fieldConverter.convertExtraField(schema, field);

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedField.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedField.java
@@ -25,6 +25,7 @@ public class ParsedField extends ParsedBlock {
     private int overrideId = 0;
     private boolean isLiteral = false;
     private boolean isNormal = false;
+    private boolean fastMapSearch = false;
     private Integer weight;
     private String normalizing = null;
     private String searchLinguisticsProfile;
@@ -52,6 +53,7 @@ public class ParsedField extends ParsedBlock {
     boolean hasFilter() { return this.isFilter; }
     boolean hasLiteral() { return this.isLiteral; }
     boolean hasNormal() { return this.isNormal; }
+    boolean getFastMapSearch() { return this.fastMapSearch; }
     boolean hasIdOverride() { return overrideId != 0; }
     int idOverride() { return overrideId; }
     List<DictionaryOption> getDictionaryOptions() { return List.copyOf(dictionaryOptions); }
@@ -121,6 +123,7 @@ public class ParsedField extends ParsedBlock {
     }
 
     public void setBolding(boolean value) { this.hasBolding = value; }
+    public void setFastMapSearch(boolean value) { this.fastMapSearch = value; }
     public void setFilter(boolean value) { this.isFilter = value; }
     public void setId(int id) { this.overrideId = id; }
     public void setLiteral(boolean value) { this.isLiteral = value; }

--- a/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
@@ -10,9 +10,9 @@ import com.yahoo.vespa.model.container.search.QueryProfiles;
 /**
  * Because of the way the parser works (allowing any token as identifier),
  * it is not practical to limit the syntax of field names there, do it here.
- * Important to disallow dash, has semantic in IL.
+ * Important to disallow dash, has semantic in indexing language.
  *
- * @author Vehard Havdal
+ * @author Vegard Havdal
  */
 public class IndexFieldNames extends Processor {
 

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -890,7 +890,8 @@ void fieldBody(ParsedField field) : { }
       summaryInField(field) |
       summaryTo(field) |
       weight(field) |
-      weightedset(field.getType()) )
+      weightedset(field.getType()) |
+      map(field) )
 }
 
 /**
@@ -1017,6 +1018,27 @@ void weightedsetBody(ParsedType type) : { }
 {
     ( <CREATE_IF_NONEXISTENT> { type.setCreateIfNonExistent(true); }
       | <REMOVE_IF_ZERO>      { type.setRemoveIfZero(true); } )
+}
+
+/**
+ * This rule consumes a map statement of a field element.
+ *
+ * @param field The field to modify.
+ */
+void map(ParsedField field) : { }
+{
+    <MAP> ( (<COLON> mapBody(field))
+                | (lbrace() (mapBody(field) (<NL>)*)* <RBRACE>) )
+}
+
+/**
+ * This rule consumes one body item of a map block.
+ *
+ * @param field The field to modify.
+ */
+void mapBody(ParsedField field) : { }
+{
+    ( <FAST_SEARCH> { field.setFastMapSearch(true); } )
 }
 
 /**

--- a/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
@@ -45,8 +45,8 @@ public class MapFastSearchTestCase {
         String fields = joinLines("field plain type map<string, string> { }",
                                   "field fast type map<string, string> { map: fast-search }");
         var schema = build(getSd(fields), true);
-        assertFalse(fieldIn(schema, "plain").isFastMapSearch());
-        assertTrue(fieldIn(schema, "fast").isFastMapSearch());
+        assertFalse(fieldIn(schema, "plain").hasFastMapSearch());
+        assertTrue(fieldIn(schema, "fast").hasFastMapSearch());
     }
 
     @Test
@@ -57,6 +57,20 @@ public class MapFastSearchTestCase {
                        "For schema 'test', field 'm': 'map: fast-search' requires a map field, but the type is Array<string>.");
         assertRejected("field m type weightedset<string> { map: fast-search }", true,
                        "For schema 'test', field 'm': 'map: fast-search' requires a map field, but the type is WeightedSet<string>.");
+    }
+
+    @Test
+    void requireFastMapRejectedForUnsupportedKeyAndValueTypes() throws ParseException {
+        assertRejected("field m type map<double, string> { map: fast-search }", true,
+                       "For schema 'test', field 'm': 'map: fast-search' requires key to be of type string or int, but the type is double.");
+        assertRejected("field m type map<string, bool> { map: fast-search }", true,
+                       "For schema 'test', field 'm': 'map: fast-search' requires value to be of type string or int, but the type is bool.");
+    }
+
+    @Test
+    void requireFastMapAcceptsIntAndStringKeyAndValue() throws ParseException {
+        assertTrue(fastMapSearchOf("field m type map<int, string> { map: fast-search }", true));
+        assertTrue(fastMapSearchOf("field m type map<string, int> { map: fast-search }", true));
     }
 
     private static void assertRejected(String field, boolean flagEnabled, String expectedMessage) throws ParseException {

--- a/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
@@ -1,0 +1,95 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema;
+
+import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.schema.document.SDField;
+import com.yahoo.schema.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import static com.yahoo.config.model.test.TestUtil.joinLines;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests the 'map: fast-search' setting on a field, which is gated by the fast-map-search feature flag.
+ *
+ * @author johsol
+ */
+public class MapFastSearchTestCase {
+
+    @Test
+    void requireFastSearchIsSetWhenFlagEnabled() throws ParseException {
+        assertTrue(fastMapSearchOf("field m type map<string, string> { map: fast-search }", true));
+    }
+
+    @Test
+    void requireFastSearchSpecifiedAsBlock() throws ParseException {
+        String field = joinLines("field m type map<string, string> {",
+                                 "  map {",
+                                 "    fast-search",
+                                 "  }",
+                                 "}");
+        assertTrue(fastMapSearchOf(field, true));
+    }
+
+    @Test
+    void requireFastSearchDisabledByDefault() throws ParseException {
+        assertFalse(fastMapSearchOf("field m type map<string, string> { }", true));
+        assertFalse(fastMapSearchOf("field m type map<string, string> { }", false));
+    }
+
+    @Test
+    void requireFastMapAndPlainMapCanCoexist() throws ParseException {
+        String fields = joinLines("field plain type map<string, string> { }",
+                                  "field fast type map<string, string> { map: fast-search }");
+        var schema = build(getSd(fields), true);
+        assertFalse(fieldIn(schema, "plain").isFastMapSearch());
+        assertTrue(fieldIn(schema, "fast").isFastMapSearch());
+    }
+
+    @Test
+    void requireFastMapRejectedForNonMaps() throws ParseException {
+        assertRejected("field m type int { map: fast-search }", true,
+                       "For schema 'test', field 'm': 'map: fast-search' requires a map field, but the type is int.");
+        assertRejected("field m type array<string> { map: fast-search }", true,
+                       "For schema 'test', field 'm': 'map: fast-search' requires a map field, but the type is Array<string>.");
+        assertRejected("field m type weightedset<string> { map: fast-search }", true,
+                       "For schema 'test', field 'm': 'map: fast-search' requires a map field, but the type is WeightedSet<string>.");
+    }
+
+    private static void assertRejected(String field, boolean flagEnabled, String expectedMessage) throws ParseException {
+        try {
+            build(getSd(field), flagEnabled);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        }
+    }
+
+    private static boolean fastMapSearchOf(String field, boolean flagEnabled) throws ParseException {
+        return fieldIn(build(getSd(field), flagEnabled), "m").isFastMapSearch();
+    }
+
+    private static SDField fieldIn(Schema schema, String fieldName) {
+        return (SDField) schema.getDocument().getField(fieldName);
+    }
+
+    private static Schema build(String sd, boolean flagEnabled) throws ParseException {
+        var builder = new ApplicationBuilder(new TestProperties().fastMapSearch(flagEnabled));
+        builder.addSchema(sd);
+        builder.build(true);
+        return builder.getSchema();
+    }
+
+    private static String getSd(String fields) {
+        return joinLines("schema test {",
+                         "  document test {",
+                         fields,
+                         "  }",
+                         "}");
+    }
+
+}

--- a/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
@@ -70,7 +70,7 @@ public class MapFastSearchTestCase {
     }
 
     private static boolean fastMapSearchOf(String field, boolean flagEnabled) throws ParseException {
-        return fieldIn(build(getSd(field), flagEnabled), "m").isFastMapSearch();
+        return fieldIn(build(getSd(field), flagEnabled), "m").hasFastMapSearch();
     }
 
     private static SDField fieldIn(Schema schema, String fieldName) {


### PR DESCRIPTION
Adds a property to the field model that declares whether we should use fast-search when the type is a map. It can be written like this:

```
field map1 type map<int, string> {
  map: fast-search
}
field map2 type map<string, int> {
  map {
    fast-search
  }
}
```

The feature is not finished, so it is gated behind a feature flag.

@arnej27959 please review
@boeker fyi

