### PR TITLE
Revert "Hoist query invariants in native rank features"

### DIFF
--- a/searchlib/src/tests/nativerank/nativerank_test.cpp
+++ b/searchlib/src/tests/nativerank/nativerank_test.cpp
@@ -574,11 +574,9 @@ TEST_F(NativeRankTest, test_native_proximity) {
             EXPECT_TRUE(pairs[0].first.termData() == &a);
             EXPECT_TRUE(pairs[0].second.termData() == &b);
             EXPECT_EQ(pairs[0].connectedness, 0.8);
-            EXPECT_EQ(pairs[0].term_pair_weight, 40);
             EXPECT_TRUE(pairs[1].first.termData() == &b);
             EXPECT_TRUE(pairs[1].second.termData() == &c);
             EXPECT_EQ(pairs[1].connectedness, 0.6);
-            EXPECT_EQ(pairs[1].term_pair_weight, 78);
             EXPECT_EQ(setup.divisor, 118); // (10 + 40)*0.8 + (40 + 90)*0.6
 
             pairs.clear();
@@ -589,15 +587,12 @@ TEST_F(NativeRankTest, test_native_proximity) {
             EXPECT_TRUE(pairs[0].first.termData() == &a);
             EXPECT_TRUE(pairs[0].second.termData() == &b);
             EXPECT_EQ(pairs[0].connectedness, 0.8);
-            EXPECT_EQ(pairs[0].term_pair_weight, 40);
             EXPECT_TRUE(pairs[1].first.termData() == &a);
             EXPECT_TRUE(pairs[1].second.termData() == &c);
             EXPECT_EQ(pairs[1].connectedness, 0.3);
-            EXPECT_EQ(pairs[1].term_pair_weight, 30);
             EXPECT_TRUE(pairs[2].first.termData() == &b);
             EXPECT_TRUE(pairs[2].second.termData() == &c);
             EXPECT_EQ(pairs[2].connectedness, 0.6);
-            EXPECT_EQ(pairs[2].term_pair_weight, 78);
             EXPECT_EQ(setup.divisor, 148); // (10 + 40)*0.8 + (10 + 90)*0.3 + (40 + 90)*0.6
 
             pairs.clear();
@@ -611,7 +606,6 @@ TEST_F(NativeRankTest, test_native_proximity) {
             EXPECT_TRUE(pairs[0].first.termData() == &b);
             EXPECT_TRUE(pairs[0].second.termData() == &c);
             EXPECT_EQ(pairs[0].connectedness, 0.6);
-            EXPECT_EQ(pairs[0].term_pair_weight, 54);
         }
     }
 

--- a/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.cpp
@@ -33,14 +33,13 @@ NativeFieldMatchExecutorSharedState::NativeFieldMatchExecutorSharedState(const I
                 const ITermFieldData& tfd = iter.get();
                 uint32_t              fieldId = tfd.getFieldId();
                 if (_params.considerField(fieldId)) { // only consider fields with contribution
-                    const auto& param = _params.vector[fieldId];
-                    totalFieldWeight += param.fieldWeight;
-                    qt.handles().push_back({tfd.getHandle(), &tfd, &param, param.fieldWeight / param.maxTableSum});
+                    totalFieldWeight += _params.vector[fieldId].fieldWeight;
+                    qt.handles().emplace_back(tfd.getHandle(), &tfd);
                 }
             }
             if (!qt.handles().empty()) {
                 _query_terms.push_back(qt);
-                _divisor += qt.query_weight() * totalFieldWeight;
+                _divisor += (qt.significance() * qt.termData()->getWeight().percent() * totalFieldWeight);
             }
         }
     }
@@ -48,58 +47,53 @@ NativeFieldMatchExecutorSharedState::NativeFieldMatchExecutorSharedState(const I
 
 NativeFieldMatchExecutorSharedState::~NativeFieldMatchExecutorSharedState() = default;
 
-feature_t NativeFieldMatchExecutor::calculateScore(const MyQueryTerm& qt, uint32_t docId, size_t& tfmd_idx) {
+feature_t NativeFieldMatchExecutor::calculateScore(const MyQueryTerm& qt, uint32_t docId) {
     feature_t termScore = 0;
     for (size_t i = 0; i < qt.handles().size(); ++i) {
-        const auto&                  handle = qt.handles()[i];
-        const TermFieldMatchData*    tfmd = _tfmds[tfmd_idx++];
-        const NativeFieldMatchParam& param = *handle.param;
+        TermFieldHandle              tfh = qt.handles()[i].first;
+        const TermFieldMatchData*    tfmd = _md->resolveTermField(tfh);
+        const NativeFieldMatchParam& param = _params.vector[tfmd->getFieldId()];
         if (tfmd->has_ranking_data(docId)) { // do we have a hit
             FieldPositionsIterator pos = tfmd->getIterator();
             if (pos.valid()) {
                 uint32_t fieldLength = getFieldLength(param, pos.getFieldLength());
                 termScore += ((getFirstOccBoost(param, pos.getPosition(), fieldLength) * param.firstOccImportance) +
                               (getNumOccBoost(param, pos.size(), fieldLength) * (1 - param.firstOccImportance))) *
-                             handle.field_scale;
+                             param.fieldWeight / param.maxTableSum;
             }
         }
     }
-    return termScore * qt.query_weight();
+    termScore *= (qt.significance() * qt.termData()->getWeight().percent());
+    return termScore;
 }
 
 NativeFieldMatchExecutor::NativeFieldMatchExecutor(const NativeFieldMatchExecutorSharedState& shared_state)
     : FeatureExecutor(),
       _params(shared_state.get_params()),
       _queryTerms(shared_state.get_query_terms()),
-      _score_scale(shared_state.get_divisor() > 0 ? 1.0 / shared_state.get_divisor() : 1.0),
-      _tfmds() {
-    size_t num_handles = 0;
+      _divisor(shared_state.get_divisor()),
+      _md(nullptr) {
     for (const auto& qt : _queryTerms) {
         for (const auto& handle : qt.handles()) {
             // Record that we need normal term field match data
-            (void)handle.term_field->getHandle(MatchDataDetails::Normal);
-            ++num_handles;
+            (void)handle.second->getHandle(MatchDataDetails::Normal);
         }
     }
-    _tfmds.reserve(num_handles);
 }
 
 void NativeFieldMatchExecutor::execute(uint32_t docId) {
     feature_t score = 0;
-    size_t    tfmd_idx = 0;
     for (size_t i = 0; i < _queryTerms.size(); ++i) {
-        score += calculateScore(_queryTerms[i], docId, tfmd_idx);
+        score += calculateScore(_queryTerms[i], docId);
     }
-    outputs().set_number(0, score * _score_scale);
+    if (_divisor > 0) {
+        score /= _divisor;
+    }
+    outputs().set_number(0, score);
 }
 
 void NativeFieldMatchExecutor::handle_bind_match_data(const fef::MatchData& md) {
-    _tfmds.clear();
-    for (const auto& qt : _queryTerms) {
-        for (const auto& handle : qt.handles()) {
-            _tfmds.push_back(md.resolveTermField(handle.tfh));
-        }
-    }
+    _md = &md;
 }
 
 NativeFieldMatchBlueprint::NativeFieldMatchBlueprint()

--- a/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.h
+++ b/searchlib/src/vespa/searchlib/features/nativefieldmatchfeature.h
@@ -35,24 +35,15 @@ public:
  */
 class NativeFieldMatchExecutorSharedState : public fef::Anything {
 public:
-    struct WrappedHandle {
-        fef::TermFieldHandle         tfh;
-        const fef::ITermFieldData*   term_field;
-        const NativeFieldMatchParam* param;
-        feature_t                    field_scale;
-    };
+    using WrappedHandle = std::pair<fef::TermFieldHandle, const fef::ITermFieldData*>;
     using HandleVector = std::vector<WrappedHandle>;
     class MyQueryTerm : public QueryTerm {
     private:
         HandleVector _handles; // field match handles
-        feature_t    _query_weight;
-
     public:
-        MyQueryTerm(const QueryTerm& qt)
-            : QueryTerm(qt), _handles(), _query_weight(qt.significance() * qt.termData()->getWeight().percent()) {}
+        MyQueryTerm(const QueryTerm& qt) : QueryTerm(qt), _handles() {}
         HandleVector& handles() { return _handles; }
         const HandleVector& handles() const { return _handles; }
-        feature_t query_weight() const { return _query_weight; }
     };
 
 private:
@@ -75,12 +66,12 @@ public:
 class NativeFieldMatchExecutor : public fef::FeatureExecutor {
 private:
     using MyQueryTerm = NativeFieldMatchExecutorSharedState::MyQueryTerm;
-    const NativeFieldMatchParams&               _params;
-    std::span<const MyQueryTerm>                _queryTerms;
-    feature_t                                   _score_scale;
-    std::vector<const fef::TermFieldMatchData*> _tfmds;
+    const NativeFieldMatchParams& _params;
+    std::span<const MyQueryTerm>  _queryTerms;
+    feature_t                     _divisor;
+    const fef::MatchData*         _md;
 
-    VESPA_DLL_LOCAL feature_t calculateScore(const MyQueryTerm& qt, uint32_t docId, size_t& tfmd_idx);
+    VESPA_DLL_LOCAL feature_t calculateScore(const MyQueryTerm& qt, uint32_t docId);
 
     uint32_t getFieldLength(const NativeFieldMatchParam& param, uint32_t fieldLength) const {
         if (param.averageFieldLength != NativeFieldMatchParam::NOT_DEF_FIELD_LENGTH) {

--- a/searchlib/src/vespa/searchlib/features/nativeproximityfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/nativeproximityfeature.cpp
@@ -57,13 +57,6 @@ NativeProximityExecutorSharedState::NativeProximityExecutorSharedState(const IQu
             FieldSetup setup(entry.first);
             generateTermPairs(env, entry.second, _params.slidingWindow, setup);
             if (!setup.pairs.empty()) {
-                const auto& param = params.vector[entry.first];
-                for (auto& pair : setup.pairs) {
-                    pair.forward_scale = pair.term_pair_weight * param.proximityImportance / param.maxTableSum;
-                    pair.reverse_scale = pair.term_pair_weight * (1 - param.proximityImportance) / param.maxTableSum;
-                }
-                setup.field_scale = (setup.divisor > 0) ? static_cast<feature_t>(param.fieldWeight) / setup.divisor
-                                                        : static_cast<feature_t>(param.fieldWeight);
                 _setups.push_back(std::move(setup));
                 _total_field_weight += params.vector[entry.first].fieldWeight;
             }
@@ -87,43 +80,48 @@ void NativeProximityExecutorSharedState::generateTermPairs(const IQueryEnvironme
             connectedness /= (j - i);
             if (terms[i].termData()->getWeight().percent() != 0 ||
                 terms[j].termData()->getWeight().percent() != 0) { // only consider term pairs with contribution
-                feature_t term_pair_weight = (terms[i].significance() * terms[i].termData()->getWeight().percent() +
-                                              terms[j].significance() * terms[j].termData()->getWeight().percent()) *
-                                             connectedness;
-                pairs.emplace_back(terms[i], terms[j], connectedness, term_pair_weight);
-                setup.divisor += term_pair_weight;
+                pairs.push_back(TermPair(terms[i], terms[j], connectedness));
+                setup.divisor += (terms[i].significance() * terms[i].termData()->getWeight().percent() +
+                                  terms[j].significance() * terms[j].termData()->getWeight().percent()) *
+                                 connectedness;
             }
         }
     }
 }
 
 feature_t NativeProximityExecutor::calculateScoreForField(const FieldSetup& fs, uint32_t docId) {
-    feature_t   score = 0;
-    const auto& param = _params.vector[fs.fieldId];
+    feature_t score = 0;
     for (size_t i = 0; i < fs.pairs.size(); ++i) {
-        score += calculateScoreForPair(fs.pairs[i], param, docId);
+        score += calculateScoreForPair(fs.pairs[i], fs.fieldId, docId);
     }
-    return score * fs.field_scale;
+    score *= _params.vector[fs.fieldId].fieldWeight;
+    if (fs.divisor > 0) {
+        score /= fs.divisor;
+    }
+    return score;
 }
 
-feature_t NativeProximityExecutor::calculateScoreForPair(const TermPair& pair, const NativeProximityParam& param,
-                                                         uint32_t docId) {
+feature_t NativeProximityExecutor::calculateScoreForPair(const TermPair& pair, uint32_t fieldId, uint32_t docId) {
+    const NativeProximityParam&    param = _params.vector[fieldId];
     TermDistanceCalculator::Result result;
     const QueryTerm&               a = pair.first;
     const QueryTerm&               b = pair.second;
     TermDistanceCalculator::run(a, b, param._element_gap, *_md, docId, result);
-    uint32_t forwardIdx = result.forwardDist > 0 ? result.forwardDist - 1 : 0;
-    uint32_t reverseIdx = result.reverseDist > 0 ? result.reverseDist - 1 : 0;
-    return param.proximityTable->get(forwardIdx) * pair.forward_scale +
-           param.revProximityTable->get(reverseIdx) * pair.reverse_scale;
+    uint32_t  forwardIdx = result.forwardDist > 0 ? result.forwardDist - 1 : 0;
+    uint32_t  reverseIdx = result.reverseDist > 0 ? result.reverseDist - 1 : 0;
+    feature_t forwardScore = param.proximityTable->get(forwardIdx) * param.proximityImportance;
+    feature_t reverseScore = param.revProximityTable->get(reverseIdx) * (1 - param.proximityImportance);
+    feature_t termPairWeight = pair.connectedness * (a.significance() * a.termData()->getWeight().percent() +
+                                                     b.significance() * b.termData()->getWeight().percent());
+    feature_t score = (forwardScore + reverseScore) * termPairWeight / param.maxTableSum;
+    return score;
 }
 
 NativeProximityExecutor::NativeProximityExecutor(const NativeProximityExecutorSharedState& shared_state)
     : FeatureExecutor(),
       _params(shared_state.get_params()),
       _setups(shared_state.get_setups()),
-      _total_field_scale(shared_state.get_total_field_weight() > 0 ? 1.0 / shared_state.get_total_field_weight()
-                                                                   : 1.0),
+      _totalFieldWeight(shared_state.get_total_field_weight()),
       _md(nullptr) {
     auto& fields = shared_state.get_fields();
     for (const auto& entry : fields) {
@@ -139,7 +137,10 @@ void NativeProximityExecutor::execute(uint32_t docId) {
     for (size_t i = 0; i < _setups.size(); ++i) {
         score += calculateScoreForField(_setups[i], docId);
     }
-    outputs().set_number(0, score * _total_field_scale);
+    if (_totalFieldWeight > 0) {
+        score /= _totalFieldWeight;
+    }
+    outputs().set_number(0, score);
 }
 
 void NativeProximityExecutor::handle_bind_match_data(const fef::MatchData& md) {

--- a/searchlib/src/vespa/searchlib/features/nativeproximityfeature.h
+++ b/searchlib/src/vespa/searchlib/features/nativeproximityfeature.h
@@ -46,11 +46,7 @@ public:
         QueryTerm first;
         QueryTerm second;
         feature_t connectedness;
-        feature_t term_pair_weight;
-        feature_t forward_scale;
-        feature_t reverse_scale;
-        TermPair(QueryTerm f, QueryTerm s, feature_t c, feature_t weight) noexcept
-            : first(f), second(s), connectedness(c), term_pair_weight(weight), forward_scale(0), reverse_scale(0) {}
+        TermPair(QueryTerm f, QueryTerm s, feature_t c) : first(f), second(s), connectedness(c) {}
     };
     using TermPairVector = std::vector<TermPair>;
     /**
@@ -60,8 +56,7 @@ public:
         uint32_t       fieldId;
         TermPairVector pairs;
         feature_t      divisor;
-        feature_t      field_scale;
-        FieldSetup(uint32_t fid) : fieldId(fid), pairs(), divisor(0), field_scale(0) {}
+        FieldSetup(uint32_t fid) : fieldId(fid), pairs(), divisor(0) {}
     };
 
 private:
@@ -93,11 +88,11 @@ public:
 private:
     const NativeProximityParams& _params;
     std::span<const FieldSetup>  _setups;
-    feature_t                    _total_field_scale;
+    uint32_t                     _totalFieldWeight;
     const fef::MatchData*        _md;
 
     feature_t calculateScoreForField(const FieldSetup& fs, uint32_t docId);
-    feature_t calculateScoreForPair(const TermPair& pair, const NativeProximityParam& param, uint32_t docId);
+    feature_t calculateScoreForPair(const TermPair& pair, uint32_t fieldId, uint32_t docId);
 
     void handle_bind_match_data(const fef::MatchData& md) override;
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#37481

Broke some system tests: Bug4917478::test_bug4917478__INDEXED and Bug4917478::test_bug4917478__STREAMING, likely due to different order of operations causing different rounding errors and the tests being too strict.

@arnej27959 : please review
