### PR TITLE
Fix tensor modify update: support 'addresses' key and any field order

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/readers/TensorModifyUpdateReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorModifyUpdateReader.java
@@ -31,6 +31,7 @@ public class TensorModifyUpdateReader {
     private static final String MODIFY_ADD = "add";
     private static final String MODIFY_MULTIPLY = "multiply";
     private static final String MODIFY_CREATE = "create";
+    private static final String MODIFY_ADDRESSES = "addresses";
 
     public static TensorModifyUpdate createModifyUpdate(TokenBuffer buffer, Field field) {
         expectFieldIsOfTypeTensor(field);
@@ -81,9 +82,8 @@ public class TensorModifyUpdateReader {
 
     private static ModifyUpdateResult createModifyUpdateResult(TokenBuffer buffer, Field field) {
         ModifyUpdateResult result = new ModifyUpdateResult();
-        buffer.next();
         int localNesting = buffer.nesting();
-        while (localNesting <= buffer.nesting()) {
+        for (buffer.next(); localNesting <= buffer.nesting(); buffer.next()) {
             switch (buffer.currentName()) {
                 case MODIFY_OPERATION:
                     result.operation = createOperation(buffer, field.getName());
@@ -92,6 +92,7 @@ public class TensorModifyUpdateReader {
                     result.createNonExistingCells = createNonExistingCells(buffer, field.getName());
                     break;
                 case TENSOR_CELLS:
+                case MODIFY_ADDRESSES:
                     result.tensor = createTensorFromCells(buffer, field);
                     break;
                 case TENSOR_BLOCKS:
@@ -100,7 +101,6 @@ public class TensorModifyUpdateReader {
                 default:
                     throw new IllegalArgumentException("Unknown JSON string '" + buffer.currentName() + "' in modify update for field '" + field.getName() + "'");
             }
-            buffer.next();
         }
         return result;
     }

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -2355,6 +2355,57 @@ public class JsonReaderTestCase {
     }
 
     @Test
+    public void tensor_modify_update_with_addresses() {
+        // 'addresses' is an alias for the fully-specified 'cells' array form, as documented at
+        // https://docs.vespa.ai/en/reference/schemas/document-json-format.html#tensor-modify
+        assertTensorModifyUpdate("{{x:a,y:b}:7.0, {x:c,y:d}:8.0}", TensorModifyUpdate.Operation.REPLACE, "sparse_tensor",
+                                 """
+                                 {
+                                   "operation": "replace",
+                                   "addresses": [
+                                     { "address": { "x": "a", "y": "b" }, "value": 7.0 },
+                                     { "address": { "x": "c", "y": "d" }, "value": 8.0 }
+                                   ]
+                                 }""");
+    }
+
+    @Test
+    public void tensor_modify_update_with_cells_before_operation() {
+        assertTensorModifyUpdate("{{x:a,y:b}:2.0}", TensorModifyUpdate.Operation.REPLACE, "sparse_tensor",
+                                 """
+                                 {
+                                   "cells": [
+                                     { "address": { "x": "a", "y": "b" }, "value": 2.0 }
+                                   ],
+                                   "operation": "replace"
+                                 }""");
+    }
+
+    @Test
+    public void tensor_modify_update_with_addresses_before_operation() {
+        assertTensorModifyUpdate("{{x:a,y:b}:2.0}", TensorModifyUpdate.Operation.REPLACE, "sparse_tensor",
+                                 """
+                                 {
+                                   "addresses": [
+                                     { "address": { "x": "a", "y": "b" }, "value": 2.0 }
+                                   ],
+                                   "operation": "replace"
+                                 }""");
+    }
+
+    @Test
+    public void tensor_modify_update_with_blocks_before_operation() {
+        assertTensorModifyUpdate("{{x:a,y:0}:1,{x:a,y:1}:2,{x:a,y:2}:3}", TensorModifyUpdate.Operation.REPLACE, "mixed_tensor",
+                                 """
+                                 {
+                                   "blocks": {
+                                     "a": [1,2,3]
+                                   },
+                                   "operation": "replace"
+                                 }""");
+    }
+
+    @Test
     public void tensor_modify_update_on_non_tensor_field_throws() {
         try {
             JsonReader reader = createReader("""


### PR DESCRIPTION
Fixes #37431

## Problem
Two bugs in `TensorModifyUpdateReader` when parsing a tensor `modify` update:
1. The `addresses` key from the docs (document-json-format.html#tensor-modify) wasn't accepted — only `cells`/`blocks` were, giving `Unknown JSON string 'addresses' in modify update for field '...'`.
2. If `cells`/`blocks`/`addresses` appeared before `operation` in the payload, `operation` was silently never read, giving `... does not contain an operation`.

## Root cause
1. `addresses` was never wired up as an alias for the `cells` array form (`{"address": {...}, "value": ...}`), which is the same shape.
2. The field-scanning loop in `createModifyUpdateResult` captured its nesting-depth marker *after* advancing onto the first field's value, instead of *before* — the pattern used everywhere else in this file (`readTensorCells`, `readTensorCell`, etc.). When the first field read was itself a JSON struct (`cells`/`addresses` array, `blocks` object) rather than a scalar, the marker ended up one nesting level too deep, so the loop exited right after that field, dropping anything after it — including `operation`.

## Fix
- Added `addresses` as an alias for `cells`, reusing the existing cell-array reader.
- Moved the nesting marker capture to before the first `buffer.next()` so field order no longer matters.

## Verified
- Added 4 regression tests covering both scenarios (`addresses` key; `cells`/`addresses`/`blocks` before `operation`).
- Confirmed each new test fails against the pre-fix code with the exact error messages from the issue.
- With the fix: `JsonReaderTestCase` 131/131, `DocumentUpdateJsonSerializerTest` 30/30, full `document` module 821/821 passing.

cc @kkraune @johansolbakken