### PR TITLE
Support schema in linguistics profile in schema LSP

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -17,7 +17,9 @@ import ai.vespa.schemals.context.EventCompletionContext;
 import ai.vespa.schemals.lsp.common.completion.CompletionProvider;
 import ai.vespa.schemals.lsp.common.completion.CompletionUtils;
 import ai.vespa.schemals.lsp.schema.hover.SchemaHover;
+import ai.vespa.schemals.parser.ast.LBRACE;
 import ai.vespa.schemals.parser.ast.NL;
+import ai.vespa.schemals.parser.ast.RBRACE;
 import ai.vespa.schemals.parser.ast.RootRankProfile;
 import ai.vespa.schemals.parser.ast.annotationBody;
 import ai.vespa.schemals.parser.ast.attributeElm;
@@ -30,6 +32,7 @@ import ai.vespa.schemals.parser.ast.globalPhase;
 import ai.vespa.schemals.parser.ast.hnswIndex;
 import ai.vespa.schemals.parser.ast.indexInsideField;
 import ai.vespa.schemals.parser.ast.indexOutsideDoc;
+import ai.vespa.schemals.parser.ast.linguisticsElm;
 import ai.vespa.schemals.parser.ast.onnxModel;
 import ai.vespa.schemals.parser.ast.openLbrace;
 import ai.vespa.schemals.parser.ast.rankProfile;
@@ -82,6 +85,7 @@ public class BodyKeywordCompletion implements CompletionProvider {
             FixedKeywordBodies.INDEX.getBodySnippet(),
             CompletionUtils.constructSnippet("indexing", "indexing: ", "indexing:"),
             CompletionUtils.constructSnippet("indexing", "indexing {\n\t$0\n}", "indexing {}"),
+            CompletionUtils.constructSnippet("linguistics", "linguistics {\n\tprofile: $0\n}"),
             FixedKeywordBodies.MATCH.getColonSnippet(),
             FixedKeywordBodies.MATCH.getBodySnippet(),
             CompletionUtils.constructSnippet("normalizing", "normalizing: "),
@@ -244,6 +248,34 @@ public class BodyKeywordCompletion implements CompletionProvider {
         }
     }};
 
+    private static final List<CompletionItem> linguisticsBodySnippets = List.of(
+        CompletionUtils.constructSnippet("profile", "profile: $0", "profile:"),
+        CompletionUtils.constructSnippet("profile", "profile {\n\tindex: $1\n\tsearch: $0\n}", "profile {}")
+    );
+
+    private static final List<CompletionItem> linguisticsProfileBodySnippets = List.of(
+        CompletionUtils.constructSnippet("index", "index: $0"),
+        CompletionUtils.constructSnippet("search", "search: $0")
+    );
+
+    /**
+     * A linguistics element holds two nested bodies, <code>linguistics { profile { ... } }</code>,
+     * which the grammar represents as a single flat node. Which keywords are valid therefore depends on
+     * the brace depth at the cursor rather than on the enclosing AST class alone.
+     */
+    private static List<CompletionItem> linguisticsCompletionItems(Node linguisticsNode, Position position) {
+        int braceDepth = 0;
+        for (Node child : linguisticsNode) {
+            if (CSTUtils.positionLT(position, child.getRange().getStart())) break;
+            if (child.isASTInstance(openLbrace.class) || child.isASTInstance(LBRACE.class)) ++braceDepth;
+            else if (child.isASTInstance(RBRACE.class)) --braceDepth;
+        }
+
+        if (braceDepth == 1) return linguisticsBodySnippets;
+        if (braceDepth == 2) return linguisticsProfileBodySnippets;
+        return List.of();
+    }
+
     @Override
     public List<CompletionItem> getCompletionItems(EventCompletionContext context) {
         Position searchPos = context.startOfWord();
@@ -262,6 +294,8 @@ public class BodyKeywordCompletion implements CompletionProvider {
         if (searchNode == null) return List.of();
 
         if (searchNode.isASTInstance(openLbrace.class))searchNode = searchNode.getParent();
+
+        if (searchNode.isASTInstance(linguisticsElm.class)) return linguisticsCompletionItems(searchNode, searchPos);
 
         List<CompletionItem> result = bodyKeywordSnippets.get(searchNode.getASTClass());
         if (result == null) return List.of();

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokenConfig.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokenConfig.java
@@ -91,6 +91,7 @@ class SchemaSemanticTokenConfig {
         add(TokenType.INPUTS);
         add(TokenType.INTEROP_THREADS);
         add(TokenType.INTRAOP_THREADS);
+        add(TokenType.LINGUISTICS);
         add(TokenType.LOWER_BOUND);
         add(TokenType.MACRO);
         add(TokenType.MATCH);
@@ -105,6 +106,7 @@ class SchemaSemanticTokenConfig {
         add(TokenType.ONNX_MODEL);
         add(TokenType.OUTPUT);
         add(TokenType.POST_FILTER_THRESHOLD);
+        add(TokenType.PROFILE);
         add(TokenType.QUERY_COMMAND);
         add(TokenType.RANK);
         add(TokenType.RANK_FEATURES);

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/schema/IdentifyDeprecatedToken.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/parser/schema/IdentifyDeprecatedToken.java
@@ -13,6 +13,7 @@ import ai.vespa.schemals.parser.Token.TokenType;
 import ai.vespa.schemals.parser.ast.fieldElm;
 import ai.vespa.schemals.parser.ast.fieldOutsideDoc;
 import ai.vespa.schemals.parser.ast.identifierStr;
+import ai.vespa.schemals.parser.ast.rootSchema;
 import ai.vespa.schemals.parser.ast.structFieldElm;
 import ai.vespa.schemals.schemadocument.parser.Identifier;
 import ai.vespa.schemals.tree.Node;
@@ -34,10 +35,21 @@ public class IdentifyDeprecatedToken extends Identifier<SchemaNode> {
         put(TokenType.SEARCH,             new DeprecatedToken("Use schema instead.", DiagnosticCode.DEPRECATED_TOKEN_SEARCH));
     }};
 
+    /**
+     * A token in {@link #deprecatedTokens} is not necessarily deprecated wherever it occurs.
+     * The <code>search</code> keyword is only deprecated (in favour of <code>schema</code>) when used to open a schema.
+     * It is a regular, non-deprecated keyword elsewhere, e.g. in
+     * <code>linguistics { profile { search: myProfile } }</code>.
+     */
+    private static boolean isDeprecatedUsage(SchemaNode node) {
+        if (node.getSchemaType() != TokenType.SEARCH) return true;
+        return node.getParent() != null && node.getParent().isASTInstance(rootSchema.class);
+    }
+
     @Override
     public void identify(SchemaNode node, List<Diagnostic> diagnostics) {
         DeprecatedToken entry = deprecatedTokens.get(node.getSchemaType());
-        if (entry != null) {
+        if (entry != null && isDeprecatedUsage(node)) {
             diagnostics.add(
                 new SchemaDiagnostic.Builder()
                     .setRange(node.getRange())

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
@@ -3,13 +3,16 @@ package ai.vespa.schemals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -21,10 +24,13 @@ import com.yahoo.collections.Pair;
 import com.yahoo.io.IOUtils;
 
 import ai.vespa.schemals.common.ClientLogger;
+import ai.vespa.schemals.context.EventCompletionContext;
 import ai.vespa.schemals.context.EventPositionContext;
 import ai.vespa.schemals.context.InvalidContextException;
 import ai.vespa.schemals.context.ParseContext;
 import ai.vespa.schemals.index.SchemaIndex;
+import ai.vespa.schemals.lsp.schema.completion.SchemaCompletion;
+import ai.vespa.schemals.lsp.schema.completion.provider.BodyKeywordCompletion;
 import ai.vespa.schemals.lsp.schema.definition.SchemaDefinition;
 import ai.vespa.schemals.lsp.schema.hover.SchemaHover;
 import ai.vespa.schemals.schemadocument.DocumentManager;
@@ -98,4 +104,50 @@ public class LSPTest {
         }
     }
 
+    /**
+     * The linguistics element nests two bodies, linguistics { profile { ... } }, which the grammar
+     * flattens into a single node, so {@link BodyKeywordCompletion} has to tell them apart by brace depth.
+     */
+    @Test
+    void linguisticsCompletionTest() throws IOException, InvalidContextException {
+        String fileName = "src/test/sdfiles/single/linguistics.sd";
+        File file = new File(fileName);
+        String fileURI = file.toURI().toString();
+        String fileContent = IOUtils.readFile(file);
+
+        // The completion providers look up hover documentation relative to the server path when initialized.
+        SchemaLanguageServer.serverPath = Paths.get("target");
+
+        TestSchemaMessageHandler messageHandler = new TestSchemaMessageHandler();
+        TestSchemaProgressHandler progressHandler = new TestSchemaProgressHandler();
+        ClientLogger logger = new TestLogger(messageHandler);
+        SchemaIndex schemaIndex = new SchemaIndex(logger);
+        TestSchemaDiagnosticsHandler diagnosticsHandler = new TestSchemaDiagnosticsHandler(new ArrayList<>());
+        SchemaDocumentScheduler scheduler = new SchemaDocumentScheduler(logger, diagnosticsHandler, schemaIndex, messageHandler, progressHandler);
+
+        scheduler.openDocument(new TextDocumentItem(fileURI, "vespaSchema", 0, fileContent));
+        DocumentManager document = scheduler.getDocument(fileURI);
+
+        // Positions are 0-indexed and point at the start of a line inside the given body.
+        assertEquals(List.of("profile", "profile"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(8, 16)),
+                     "Inside a linguistics body only profile should be suggested.");
+        assertEquals(List.of("index", "search"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(10, 20)),
+                     "Inside a linguistics profile body index and search should be suggested.");
+        assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(16, 12)).contains("linguistics"),
+                   "linguistics should be suggested in a field body.");
+    }
+
+    private List<String> completionLabelsAt(SchemaDocumentScheduler scheduler,
+                                            SchemaIndex schemaIndex,
+                                            TestSchemaMessageHandler messageHandler,
+                                            DocumentManager document,
+                                            Position position) throws InvalidContextException {
+        EventCompletionContext context = new EventCompletionContext(
+            scheduler, schemaIndex, messageHandler, document.getVersionedTextDocumentIdentifier(), position, null);
+        return SchemaCompletion.getCompletionItems(context, System.err)
+                               .stream()
+                               .map(CompletionItem::getLabel)
+                               .sorted()
+                               .toList();
+    }
 }

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -1,6 +1,7 @@
 package ai.vespa.schemals;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URI;
@@ -11,11 +12,13 @@ import java.util.stream.Stream;
 
 import org.eclipse.lsp4j.Diagnostic;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 import com.yahoo.io.IOUtils;
 
 import ai.vespa.schemals.common.FileUtils;
+import ai.vespa.schemals.common.SchemaDiagnostic.DiagnosticCode;
 import ai.vespa.schemals.context.ParseContext;
 import ai.vespa.schemals.index.SchemaIndex;
 import ai.vespa.schemals.schemadocument.SchemaDocument;
@@ -244,6 +247,7 @@ public class SchemaParserTest {
             "src/test/sdfiles/single/elementwise.sd",
             "src/test/sdfiles/single/embed.sd",
             "src/test/sdfiles/single/foreach.sd",
+            "src/test/sdfiles/single/linguistics.sd",
             "src/test/sdfiles/single/rankprofilebuiltin.sd",
             "src/test/sdfiles/single/structinfieldset.sd",
             "src/test/sdfiles/single/subqueries.sd",
@@ -352,4 +356,31 @@ public class SchemaParserTest {
                      .map(testCase -> DynamicTest.dynamicTest(testCase.filePath(), () -> checkFileFails(testCase.filePath(), testCase.expectedErrors())));
     }
 
+    private List<Diagnostic> deprecatedSearchDiagnostics(List<Diagnostic> diagnostics) {
+        return diagnostics.stream()
+                          .filter(diag -> diag.getCode() != null && diag.getCode().isRight())
+                          .filter(diag -> diag.getCode().getRight().equals(DiagnosticCode.DEPRECATED_TOKEN_SEARCH.ordinal()))
+                          .toList();
+    }
+
+    /**
+     * "search" is only deprecated as the keyword opening a schema. Inside a linguistics profile it is a
+     * regular keyword, and warning about it there would also offer a quick fix that corrupts the schema.
+     */
+    @Test
+    void searchInLinguisticsProfileIsNotDeprecated() throws Exception {
+        var parseResult = parseFile("src/test/sdfiles/single/linguistics.sd");
+        List<Diagnostic> deprecated = deprecatedSearchDiagnostics(parseResult.diagnostics());
+        assertTrue(deprecated.isEmpty(),
+                   "Expected no deprecation warning for search inside linguistics, got: "
+                 + Utils.constructDiagnosticMessage(deprecated, 1));
+    }
+
+    @Test
+    void searchAsSchemaKeywordIsDeprecated() throws Exception {
+        var parseResult = parseFile("src/test/sdfiles/single/deprecatedsearch.sd");
+        assertEquals(1, deprecatedSearchDiagnostics(parseResult.diagnostics()).size(),
+                     "Expected search used as the schema keyword to be reported as deprecated"
+                   + Utils.constructDiagnosticMessage(parseResult.diagnostics(), 1));
+    }
 }

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/deprecatedsearch.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/deprecatedsearch.sd
@@ -1,0 +1,8 @@
+# Uses the deprecated "search" keyword to open the schema instead of "schema".
+search deprecatedsearch {
+    document deprecatedsearch {
+        field title type string {
+            indexing: index | summary
+        }
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/linguistics.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/linguistics.sd
@@ -1,0 +1,22 @@
+schema linguistics {
+    document linguistics {
+        field combined_keywords_suggestions type string {
+            indexing {
+                "de" | set_language;
+                input combined_keywords_suggestions | index | summary;
+            }
+            linguistics {
+                profile {
+                    index: de_index_unstemmed
+                    search: de_search_stemmed
+                }
+            }
+        }
+        field title type string {
+            indexing: index | summary
+            linguistics {
+                profile: de_index_and_search
+            }
+        }
+    }
+}


### PR DESCRIPTION
Context:

Before this PR: 

<img width="809" height="439" alt="image" src="https://github.com/user-attachments/assets/663e92a1-ce5f-4b73-8d35-1f68c6047a23" />

`lingustics` element is not included for completion, and the deprecated `search` should only be deprecated in top level of schema. 

Code written by Claude, manually tested and verified by me. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
