### PR TITLE
feat: hour granularity to block window

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -745,7 +745,9 @@
     ],
     "methods" : [
       "public java.util.Optional start()",
+      "public java.util.Optional startTime()",
       "public java.util.Optional end()",
+      "public java.util.Optional endTime()",
       "public java.lang.String toString()"
     ],
     "fields" : [ ]

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
@@ -16,6 +16,7 @@ import com.yahoo.config.provision.zone.ZoneId;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
@@ -198,7 +199,10 @@ public final class DeploymentInstanceSpec extends DeploymentSpec.Steps {
                                                      .filter(DeploymentSpec.ChangeBlocker::blocksVersions)
                                                      .map(DeploymentSpec.ChangeBlocker::window)
                                                      .map(window -> window.dateRange().start()
-                                                                          .map(date -> date.atStartOfDay(window.zone())
+                                                                          .map(date -> date.atTime(window.dateRange()
+                                                                                                          .startTime()
+                                                                                                          .orElse(LocalTime.MIN))
+                                                                                           .atZone(window.zone())
                                                                                            .toInstant())
                                                                           .orElse(now))
                                                      .distinct();

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/TimeWindow.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/TimeWindow.java
@@ -7,6 +7,7 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
@@ -71,7 +72,7 @@ public class TimeWindow {
         LocalDateTime dt = LocalDateTime.ofInstant(instant, zone);
         return days.contains(dt.getDayOfWeek()) &&
                hours.contains(dt.getHour()) &&
-               dateRange.includes(dt.toLocalDate());
+               dateRange.includes(dt);
     }
 
     @Override
@@ -166,18 +167,23 @@ public class TimeWindow {
         }
     }
 
-    /** A range of local dates, which may be unbounded */
+    /** A range of local dates, which may be unbounded. The start and end may optionally carry a time of day */
     public static class LocalDateRange {
 
         private final Optional<LocalDate> start;
+        private final Optional<LocalTime> startTime;
         private final Optional<LocalDate> end;
+        private final Optional<LocalTime> endTime;
 
-        private LocalDateRange(Optional<LocalDate> start, Optional<LocalDate> end) {
+        private LocalDateRange(Optional<LocalDate> start, Optional<LocalTime> startTime,
+                                Optional<LocalDate> end, Optional<LocalTime> endTime) {
             this.start = Objects.requireNonNull(start);
+            this.startTime = Objects.requireNonNull(startTime);
             this.end = Objects.requireNonNull(end);
-            if (start.isPresent() && end.isPresent() && start.get().isAfter(end.get())) {
-                throw new IllegalArgumentException("Invalid date range: start date " + start.get() +
-                                                   " is after end date " + end.get());
+            this.endTime = Objects.requireNonNull(endTime);
+            if (start.isPresent() && end.isPresent() && startInclusive().isAfter(endInclusive())) {
+                throw new IllegalArgumentException("Invalid date range: start date " + boundString(start, startTime) +
+                                                   " is after end date " + boundString(end, endTime));
             }
         }
 
@@ -186,9 +192,19 @@ public class TimeWindow {
             return start;
         }
 
+        /** Returns the time of day the starting date of this begins at, if any. Defaults to the start of the day */
+        public Optional<LocalTime> startTime() {
+            return startTime;
+        }
+
         /** Returns the ending date of this (inclusive), if any */
         public Optional<LocalDate> end() {
             return end;
+        }
+
+        /** Returns the time of day the ending date of this ends at, if any. Defaults to the end of the day */
+        public Optional<LocalTime> endTime() {
+            return endTime;
         }
 
         /** Return days of week found in this range */
@@ -201,30 +217,55 @@ public class TimeWindow {
             return days;
         }
 
-        /** Returns whether includes the given date */
-        private boolean includes(LocalDate date) {
-            if (start.isPresent() && date.isBefore(start.get())) return false;
-            if (end.isPresent() && date.isAfter(end.get())) return false;
+        /** Returns whether this includes the given date and time */
+        private boolean includes(LocalDateTime dateTime) {
+            if (start.isPresent() && dateTime.isBefore(startInclusive())) return false;
+            if (end.isPresent() && dateTime.isAfter(endInclusive())) return false;
             return true;
+        }
+
+        /** Returns the earliest point in time included by this, or the minimum possible point in time if unbounded */
+        private LocalDateTime startInclusive() {
+            return start.map(date -> date.atTime(startTime.orElse(LocalTime.MIN))).orElse(LocalDateTime.MIN);
+        }
+
+        /** Returns the latest point in time included by this, or the maximum possible point in time if unbounded */
+        private LocalDateTime endInclusive() {
+            return end.map(date -> date.atTime(endTime.orElse(LocalTime.MAX))).orElse(LocalDateTime.MAX);
         }
 
         @Override
         public String toString() {
-            return "date range [" + start.map(LocalDate::toString).orElse("any date") +
-                   ", " + end.map(LocalDate::toString).orElse("any date") + "]";
+            return "date range [" + boundString(start, startTime) + ", " + boundString(end, endTime) + "]";
+        }
+
+        private static String boundString(Optional<LocalDate> date, Optional<LocalTime> time) {
+            return date.map(d -> time.<String>map(t -> d + "T" + t).orElseGet(d::toString))
+                       .orElse("any date");
         }
 
         private static LocalDateRange from(String start, String end) {
             try {
-                return new LocalDateRange(optionalDate(start), optionalDate(end));
+                Bound startBound = parseBound(start);
+                Bound endBound = parseBound(end);
+                return new LocalDateRange(startBound.date(), startBound.time(), endBound.date(), endBound.time());
             } catch (DateTimeParseException e) {
                 throw new IllegalArgumentException("Could not parse date range '" + start + "' and '" + end + "'", e);
             }
         }
 
-        private static Optional<LocalDate> optionalDate(String date) {
-            return Optional.of(date).filter(s -> !s.isEmpty()).map(LocalDate::parse);
+        /** Parse a date, optionally followed by a time of day, e.g. "2022-01-15" or "2022-01-15T08:00" */
+        private static Bound parseBound(String date) {
+            if (date.isEmpty()) return new Bound(Optional.empty(), Optional.empty());
+            String normalized = date.replace(' ', 'T');
+            if (normalized.indexOf('T') < 0) {
+                return new Bound(Optional.of(LocalDate.parse(normalized)), Optional.empty());
+            }
+            LocalDateTime dateTime = LocalDateTime.parse(normalized);
+            return new Bound(Optional.of(dateTime.toLocalDate()), Optional.of(dateTime.toLocalTime()));
         }
+
+        private record Bound(Optional<LocalDate> date, Optional<LocalTime> time) {}
 
     }
 

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/TimeWindow.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/TimeWindow.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.application.api;
 
+import com.yahoo.config.provision.LocalDateTimeRange;
 import com.yahoo.text.Text;
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
@@ -174,6 +175,7 @@ public class TimeWindow {
         private final Optional<LocalTime> startTime;
         private final Optional<LocalDate> end;
         private final Optional<LocalTime> endTime;
+        private final LocalDateTimeRange range;
 
         private LocalDateRange(Optional<LocalDate> start, Optional<LocalTime> startTime,
                                 Optional<LocalDate> end, Optional<LocalTime> endTime) {
@@ -181,10 +183,7 @@ public class TimeWindow {
             this.startTime = Objects.requireNonNull(startTime);
             this.end = Objects.requireNonNull(end);
             this.endTime = Objects.requireNonNull(endTime);
-            if (start.isPresent() && end.isPresent() && startInclusive().isAfter(endInclusive())) {
-                throw new IllegalArgumentException("Invalid date range: start date " + boundString(start, startTime) +
-                                                   " is after end date " + boundString(end, endTime));
-            }
+            this.range = new LocalDateTimeRange(start, startTime, end, endTime); // Validates that the range is non-inverted
         }
 
         /** Returns the starting date of this (inclusive), if any */
@@ -219,29 +218,23 @@ public class TimeWindow {
 
         /** Returns whether this includes the given date and time */
         private boolean includes(LocalDateTime dateTime) {
-            if (start.isPresent() && dateTime.isBefore(startInclusive())) return false;
-            if (end.isPresent() && dateTime.isAfter(endInclusive())) return false;
-            return true;
+            return range.includes(dateTime);
         }
 
         /** Returns the earliest point in time included by this, or the minimum possible point in time if unbounded */
         private LocalDateTime startInclusive() {
-            return start.map(date -> date.atTime(startTime.orElse(LocalTime.MIN))).orElse(LocalDateTime.MIN);
+            return range.startInclusive();
         }
 
         /** Returns the latest point in time included by this, or the maximum possible point in time if unbounded */
         private LocalDateTime endInclusive() {
-            return end.map(date -> date.atTime(endTime.orElse(LocalTime.MAX))).orElse(LocalDateTime.MAX);
+            return range.endInclusive();
         }
 
         @Override
         public String toString() {
-            return "date range [" + boundString(start, startTime) + ", " + boundString(end, endTime) + "]";
-        }
-
-        private static String boundString(Optional<LocalDate> date, Optional<LocalTime> time) {
-            return date.map(d -> time.<String>map(t -> d + "T" + t).orElseGet(d::toString))
-                       .orElse("any date");
+            return "date range [" + LocalDateTimeRange.boundString(start, startTime) + ", " +
+                   LocalDateTimeRange.boundString(end, endTime) + "]";
         }
 
         private static LocalDateRange from(String start, String end) {

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -940,6 +940,42 @@ public class DeploymentSpecTest {
     }
 
     @Test
+    public void deploymentSpecWithHourGranularChangeBlocker() {
+        // A one-off freeze from 2026-09-01 05:00 to 2026-09-04 08:00, Asia/Tokyo
+        StringReader r = new StringReader(
+                "<deployment>" +
+                "   <instance id='default'>" +
+                "      <block-change revision='false' version='true' maintenance='true'" +
+                "                    from-date='2026-09-01T05:00' to-date='2026-09-04T08:00' time-zone='Asia/Tokyo'/>" +
+                "      <prod>" +
+                "         <region>us-west-1</region>" +
+                "      </prod>" +
+                "   </instance>" +
+                "</deployment>"
+        );
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        var blocker = spec.requireInstance("default").changeBlocker().get(0);
+        assertFalse(blocker.blocksRevisions());
+        assertTrue(blocker.blocksVersions());
+        assertTrue(blocker.blocksMaintenance());
+
+        // Just before the block starts (04:59:59 JST)
+        assertTrue(spec.requireInstance("default").canUpgradeAt(Instant.parse("2026-08-31T19:59:59.00Z")));
+        // At the exact start of the block (05:00:00 JST)
+        assertFalse(spec.requireInstance("default").canUpgradeAt(Instant.parse("2026-08-31T20:00:00.00Z")));
+        // Well within the block
+        assertFalse(spec.requireInstance("default").canUpgradeAt(Instant.parse("2026-09-02T12:00:00.00Z")));
+        // At the exact end of the block (08:00:00 JST)
+        assertFalse(spec.requireInstance("default").canUpgradeAt(Instant.parse("2026-09-03T23:00:00.00Z")));
+        // Just after the block ends (08:00:01 JST)
+        assertTrue(spec.requireInstance("default").canUpgradeAt(Instant.parse("2026-09-03T23:00:01.00Z")));
+
+        // 75 hours blocked, not the 96 hours a day-granular block would cover
+        assertEquals(Duration.ofHours(75),
+                     Duration.between(Instant.parse("2026-08-31T20:00:00.00Z"), Instant.parse("2026-09-03T23:00:00.00Z")));
+    }
+
+    @Test
     public void changeBlockerInheritance() {
         StringReader r = new StringReader(
                 "<deployment version='1.0'>" +

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/TimeWindowTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/TimeWindowTest.java
@@ -87,6 +87,34 @@ public class TimeWindowTest {
             assertInside(tw3, i8);
             assertInside(tw3, i9);
         }
+        { // Date range with hour granularity at the boundaries
+            TimeWindow tw = TimeWindow.from("", "", "UTC", "2026-09-01T05:00", "2026-09-04T08:00");
+            assertOutside(tw, Instant.parse("2026-09-01T04:59:59.00Z")); // Before start hour
+            assertInside(tw, Instant.parse("2026-09-01T05:00:00.00Z")); // At start hour
+            assertInside(tw, Instant.parse("2026-09-02T12:00:00.00Z")); // Within window
+            assertInside(tw, Instant.parse("2026-09-04T08:00:00.00Z")); // At end hour
+            assertOutside(tw, Instant.parse("2026-09-04T08:00:01.00Z")); // After end hour
+
+            // A space is accepted as an alternative to 'T' as the date/time separator
+            TimeWindow tw2 = TimeWindow.from("", "", "UTC", "2026-09-01 05:00", "2026-09-04 08:00");
+            assertOutside(tw2, Instant.parse("2026-09-01T04:59:59.00Z"));
+            assertInside(tw2, Instant.parse("2026-09-01T05:00:00.00Z"));
+            assertInside(tw2, Instant.parse("2026-09-04T08:00:00.00Z"));
+            assertOutside(tw2, Instant.parse("2026-09-04T08:00:01.00Z"));
+
+            // Mixing a date-only bound with an hour-granular bound is allowed
+            TimeWindow tw3 = TimeWindow.from("", "", "UTC", "2026-09-01T05:00", "2026-09-04");
+            assertOutside(tw3, Instant.parse("2026-09-01T04:59:59.00Z"));
+            assertInside(tw3, Instant.parse("2026-09-04T23:59:59.00Z")); // Whole end day still included
+            assertOutside(tw3, Instant.parse("2026-09-05T00:00:00.00Z"));
+
+            // Time zone applies to the parsed date/time bounds
+            TimeWindow tw4 = TimeWindow.from("", "", "Asia/Tokyo", "2026-09-01T05:00", "2026-09-04T08:00");
+            assertOutside(tw4, Instant.parse("2026-08-31T19:59:59.00Z")); // 04:59:59 JST
+            assertInside(tw4, Instant.parse("2026-08-31T20:00:00.00Z")); // 05:00:00 JST
+            assertInside(tw4, Instant.parse("2026-09-03T23:00:00.00Z")); // 08:00:00 JST
+            assertOutside(tw4, Instant.parse("2026-09-03T23:00:01.00Z")); // 08:00:01 JST
+        }
     }
 
     @Test
@@ -135,6 +163,20 @@ public class TimeWindowTest {
             TimeWindow tw2 = TimeWindow.from("", "", "", "2022-01-01", "2100-01-01");
             assertEquals(List.of(DayOfWeek.values()), tw2.days());
         }
+        {   // Date range boundaries may carry an hour-of-day
+            TimeWindow tw = TimeWindow.from("", "", "Asia/Tokyo", "2026-09-01T05:00", "2026-09-04T08:00");
+            assertEquals(java.time.LocalDate.parse("2026-09-01"), tw.dateRange().start().get());
+            assertEquals(java.time.LocalTime.parse("05:00"), tw.dateRange().startTime().get());
+            assertEquals(java.time.LocalDate.parse("2026-09-04"), tw.dateRange().end().get());
+            assertEquals(java.time.LocalTime.parse("08:00"), tw.dateRange().endTime().get());
+            assertEquals("date range [2026-09-01T05:00, 2026-09-04T08:00]", tw.dateRange().toString());
+
+            // Without an hour-of-day, the range still prints as a bare date (unchanged, backward-compatible format)
+            TimeWindow tw2 = TimeWindow.from("", "", "", "2022-01-11", "2022-01-14");
+            assertTrue(tw2.dateRange().startTime().isEmpty());
+            assertTrue(tw2.dateRange().endTime().isEmpty());
+            assertEquals("date range [2022-01-11, 2022-01-14]", tw2.dateRange().toString());
+        }
     }
 
     @Test
@@ -160,6 +202,10 @@ public class TimeWindowTest {
         assertInvalidDateRange("", "2022-01-15", "2022-01-01", "Invalid date range: start date 2022-01-15 is after end date 2022-01-01");
         assertInvalidDateRange("wed", "2022-01-06", "2022-01-09", "Invalid day: date range [2022-01-06, 2022-01-09] does not contain WEDNESDAY");
         assertInvalidDateRange("mon-sun", "2022-01-03", "2022-01-07", "Invalid day: date range [2022-01-03, 2022-01-07] does not contain SATURDAY");
+
+        // Invalid date-time in date range
+        assertInvalidDateRange("", "2026-09-01T25:00", "2026-09-04T08:00", "Could not parse date range '2026-09-01T25:00' and '2026-09-04T08:00'");
+        assertInvalidDateRange("", "2026-09-01T10:00", "2026-09-01T09:00", "Invalid date range: start date 2026-09-01T10:00 is after end date 2026-09-01T09:00");
     }
 
     private static void assertOutside(TimeWindow window, Instant instant) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/BlockWindow.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/BlockWindow.java
@@ -4,6 +4,8 @@ package com.yahoo.config.provision;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
@@ -15,15 +17,23 @@ import java.util.Optional;
  */
 public record BlockWindow(boolean revision, boolean version, boolean maintenance,
                           List<DayOfWeek> days, List<Integer> hours, ZoneId zone,
-                          Optional<LocalDate> fromDate, Optional<LocalDate> toDate) {
+                          Optional<LocalDate> fromDate, Optional<LocalDate> toDate,
+                          Optional<LocalTime> fromTime, Optional<LocalTime> toTime) {
 
     public BlockWindow(boolean revision, boolean version, boolean maintenance, List<DayOfWeek> days, List<Integer> hours, ZoneId zone) {
-        this(revision, version, maintenance, days, hours, zone, Optional.empty(), Optional.empty());
+        this(revision, version, maintenance, days, hours, zone, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public BlockWindow(boolean revision, boolean version, boolean maintenance,
                        List<DayOfWeek> days, List<Integer> hours, ZoneId zone,
                        Optional<LocalDate> fromDate, Optional<LocalDate> toDate) {
+        this(revision, version, maintenance, days, hours, zone, fromDate, toDate, Optional.empty(), Optional.empty());
+    }
+
+    public BlockWindow(boolean revision, boolean version, boolean maintenance,
+                       List<DayOfWeek> days, List<Integer> hours, ZoneId zone,
+                       Optional<LocalDate> fromDate, Optional<LocalDate> toDate,
+                       Optional<LocalTime> fromTime, Optional<LocalTime> toTime) {
         this.revision    = revision;
         this.version     = version;
         this.maintenance = maintenance;
@@ -32,6 +42,8 @@ public record BlockWindow(boolean revision, boolean version, boolean maintenance
         this.zone        = zone;
         this.fromDate    = fromDate;
         this.toDate      = toDate;
+        this.fromTime    = fromTime;
+        this.toTime      = toTime;
     }
 
     /** Returns whether this window is currently blocking platform (Vespa version) upgrades */
@@ -50,12 +62,12 @@ public record BlockWindow(boolean revision, boolean version, boolean maintenance
     }
 
     private boolean isWithin(Instant instant) {
-        var localTime = instant.atZone(zone);
-        if (!days.contains(localTime.getDayOfWeek())) return false;
-        if (!hours.contains(localTime.getHour())) return false;
-        LocalDate date = localTime.toLocalDate();
-        if (fromDate.isPresent() && date.isBefore(fromDate.get())) return false;
-        if (toDate.isPresent() && date.isAfter(toDate.get())) return false;
+        var zonedDateTime = instant.atZone(zone);
+        if (!days.contains(zonedDateTime.getDayOfWeek())) return false;
+        if (!hours.contains(zonedDateTime.getHour())) return false;
+        LocalDateTime dateTime = zonedDateTime.toLocalDateTime();
+        if (fromDate.isPresent() && dateTime.isBefore(fromDate.get().atTime(fromTime.orElse(LocalTime.MIN)))) return false;
+        if (toDate.isPresent() && dateTime.isAfter(toDate.get().atTime(toTime.orElse(LocalTime.MAX)))) return false;
         return true;
     }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/BlockWindow.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/BlockWindow.java
@@ -4,7 +4,6 @@ package com.yahoo.config.provision;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -34,6 +33,7 @@ public record BlockWindow(boolean revision, boolean version, boolean maintenance
                        List<DayOfWeek> days, List<Integer> hours, ZoneId zone,
                        Optional<LocalDate> fromDate, Optional<LocalDate> toDate,
                        Optional<LocalTime> fromTime, Optional<LocalTime> toTime) {
+        new LocalDateTimeRange(fromDate, fromTime, toDate, toTime); // Validates that the range is non-inverted
         this.revision    = revision;
         this.version     = version;
         this.maintenance = maintenance;
@@ -65,10 +65,7 @@ public record BlockWindow(boolean revision, boolean version, boolean maintenance
         var zonedDateTime = instant.atZone(zone);
         if (!days.contains(zonedDateTime.getDayOfWeek())) return false;
         if (!hours.contains(zonedDateTime.getHour())) return false;
-        LocalDateTime dateTime = zonedDateTime.toLocalDateTime();
-        if (fromDate.isPresent() && dateTime.isBefore(fromDate.get().atTime(fromTime.orElse(LocalTime.MIN)))) return false;
-        if (toDate.isPresent() && dateTime.isAfter(toDate.get().atTime(toTime.orElse(LocalTime.MAX)))) return false;
-        return true;
+        return new LocalDateTimeRange(fromDate, fromTime, toDate, toTime).includes(zonedDateTime.toLocalDateTime());
     }
 
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/LocalDateTimeRange.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/LocalDateTimeRange.java
@@ -12,7 +12,7 @@ import java.util.Optional;
  * a time of day. A missing start or end date means the range is unbounded in that direction. A date
  * without a time defaults to the start (for the start date) or end (for the end date) of that day.
  *
- * @author olaa
+ * @author bragehk
  */
 public record LocalDateTimeRange(Optional<LocalDate> startDate, Optional<LocalTime> startTime,
                                   Optional<LocalDate> endDate, Optional<LocalTime> endTime) {

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/LocalDateTimeRange.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/LocalDateTimeRange.java
@@ -1,0 +1,57 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A range of local date-times, bounded by an optional start and end date, each optionally carrying
+ * a time of day. A missing start or end date means the range is unbounded in that direction. A date
+ * without a time defaults to the start (for the start date) or end (for the end date) of that day.
+ *
+ * @author olaa
+ */
+public record LocalDateTimeRange(Optional<LocalDate> startDate, Optional<LocalTime> startTime,
+                                  Optional<LocalDate> endDate, Optional<LocalTime> endTime) {
+
+    public LocalDateTimeRange {
+        Objects.requireNonNull(startDate);
+        Objects.requireNonNull(startTime);
+        Objects.requireNonNull(endDate);
+        Objects.requireNonNull(endTime);
+        if (startDate.isPresent() && endDate.isPresent()) {
+            LocalDateTime start = startDate.get().atTime(startTime.orElse(LocalTime.MIN));
+            LocalDateTime end = endDate.get().atTime(endTime.orElse(LocalTime.MAX));
+            if (start.isAfter(end)) {
+                throw new IllegalArgumentException("Invalid date range: start date " + boundString(startDate, startTime) +
+                                                    " is after end date " + boundString(endDate, endTime));
+            }
+        }
+    }
+
+    /** Returns whether this range includes the given date and time */
+    public boolean includes(LocalDateTime dateTime) {
+        if (startDate.isPresent() && dateTime.isBefore(startInclusive())) return false;
+        if (endDate.isPresent() && dateTime.isAfter(endInclusive())) return false;
+        return true;
+    }
+
+    /** Returns the earliest point in time included by this, or the minimum possible point in time if unbounded */
+    public LocalDateTime startInclusive() {
+        return startDate.map(date -> date.atTime(startTime.orElse(LocalTime.MIN))).orElse(LocalDateTime.MIN);
+    }
+
+    /** Returns the latest point in time included by this, or the maximum possible point in time if unbounded */
+    public LocalDateTime endInclusive() {
+        return endDate.map(date -> date.atTime(endTime.orElse(LocalTime.MAX))).orElse(LocalDateTime.MAX);
+    }
+
+    public static String boundString(Optional<LocalDate> date, Optional<LocalTime> time) {
+        return date.map(d -> time.<String>map(t -> d + "T" + t).orElseGet(d::toString))
+                   .orElse("any date");
+    }
+
+}

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/BlockWindowTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/BlockWindowTest.java
@@ -1,0 +1,90 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author bragehk
+ */
+class BlockWindowTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    @Test
+    void blocks_within_hour_granular_date_range() {
+        BlockWindow window = new BlockWindow(true, true, true,
+                                              List.of(DayOfWeek.MONDAY), List.of(9, 10, 11), UTC,
+                                              Optional.of(LocalDate.of(2026, 1, 5)), Optional.of(LocalDate.of(2026, 1, 5)),
+                                              Optional.of(LocalTime.of(9, 30)), Optional.of(LocalTime.of(10, 30)));
+
+        // Before the from-time on the from-date
+        assertFalse(window.blocksPlatformAt(Instant.parse("2026-01-05T09:00:00Z")));
+        // At the from-time boundary (inclusive)
+        assertTrue(window.blocksPlatformAt(Instant.parse("2026-01-05T09:30:00Z")));
+        // Between the bounds
+        assertTrue(window.blocksPlatformAt(Instant.parse("2026-01-05T10:00:00Z")));
+        // At the to-time boundary (inclusive)
+        assertTrue(window.blocksPlatformAt(Instant.parse("2026-01-05T10:30:00Z")));
+        // After the to-time on the to-date
+        assertFalse(window.blocksPlatformAt(Instant.parse("2026-01-05T10:31:00Z")));
+    }
+
+    @Test
+    void blocks_all_flags_only_when_enabled() {
+        BlockWindow window = new BlockWindow(true, false, false, List.of(DayOfWeek.MONDAY), List.of(9), UTC);
+        Instant withinWindow = Instant.parse("2026-01-05T09:30:00Z"); // A Monday
+
+        assertTrue(window.blocksRevisionAt(withinWindow));
+        assertFalse(window.blocksPlatformAt(withinWindow));
+        assertFalse(window.blocksMaintenanceAt(withinWindow));
+    }
+
+    @Test
+    void does_not_block_outside_days_or_hours() {
+        BlockWindow window = new BlockWindow(true, true, true, List.of(DayOfWeek.MONDAY), List.of(9), UTC);
+
+        assertFalse(window.blocksPlatformAt(Instant.parse("2026-01-06T09:30:00Z"))); // Tuesday
+        assertFalse(window.blocksPlatformAt(Instant.parse("2026-01-05T10:30:00Z"))); // Wrong hour
+    }
+
+    @Test
+    void rejects_inverted_date_range() {
+        assertThrows(IllegalArgumentException.class, () -> new BlockWindow(
+                true, true, true, List.of(DayOfWeek.MONDAY), List.of(9), UTC,
+                Optional.of(LocalDate.of(2026, 1, 5)), Optional.of(LocalDate.of(2026, 1, 1))));
+    }
+
+    @Test
+    void rejects_inverted_date_range_with_same_date_but_inverted_times() {
+        assertThrows(IllegalArgumentException.class, () -> new BlockWindow(
+                true, true, true, List.of(DayOfWeek.MONDAY), List.of(9), UTC,
+                Optional.of(LocalDate.of(2026, 1, 5)), Optional.of(LocalDate.of(2026, 1, 5)),
+                Optional.of(LocalTime.of(10, 0)), Optional.of(LocalTime.of(9, 0))));
+    }
+
+    @Test
+    void days_and_hours_are_immutable() {
+        List<DayOfWeek> days = new java.util.ArrayList<>(List.of(DayOfWeek.MONDAY));
+        List<Integer> hours = new java.util.ArrayList<>(List.of(9));
+        BlockWindow window = new BlockWindow(true, true, true, days, hours, UTC);
+        days.add(DayOfWeek.TUESDAY);
+        hours.add(10);
+
+        assertEquals(List.of(DayOfWeek.MONDAY), window.days());
+        assertEquals(List.of(9), window.hours());
+    }
+
+}

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/LocalDateTimeRangeTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/LocalDateTimeRangeTest.java
@@ -1,0 +1,64 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author bragehk
+ */
+class LocalDateTimeRangeTest {
+
+    @Test
+    void unbounded_range_includes_everything() {
+        LocalDateTimeRange range = new LocalDateTimeRange(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        assertTrue(range.includes(LocalDateTime.MIN));
+        assertTrue(range.includes(LocalDateTime.MAX));
+        assertTrue(range.includes(LocalDateTime.of(2000, 1, 1, 0, 0)));
+    }
+
+    @Test
+    void date_only_bounds_default_to_start_and_end_of_day() {
+        LocalDateTimeRange range = new LocalDateTimeRange(Optional.of(LocalDate.of(2026, 1, 1)), Optional.empty(),
+                                                            Optional.of(LocalDate.of(2026, 1, 3)), Optional.empty());
+        assertFalse(range.includes(LocalDateTime.of(2025, 12, 31, 23, 59)));
+        assertTrue(range.includes(LocalDateTime.of(2026, 1, 1, 0, 0)));
+        assertTrue(range.includes(LocalDateTime.of(2026, 1, 3, 23, 59, 59)));
+        assertFalse(range.includes(LocalDateTime.of(2026, 1, 4, 0, 0)));
+    }
+
+    @Test
+    void hour_granular_bounds_are_inclusive() {
+        LocalDateTimeRange range = new LocalDateTimeRange(Optional.of(LocalDate.of(2026, 1, 1)), Optional.of(LocalTime.of(9, 0)),
+                                                            Optional.of(LocalDate.of(2026, 1, 1)), Optional.of(LocalTime.of(17, 0)));
+        assertFalse(range.includes(LocalDateTime.of(2026, 1, 1, 8, 59)));
+        assertTrue(range.includes(LocalDateTime.of(2026, 1, 1, 9, 0)));
+        assertTrue(range.includes(LocalDateTime.of(2026, 1, 1, 17, 0)));
+        assertFalse(range.includes(LocalDateTime.of(2026, 1, 1, 17, 1)));
+    }
+
+    @Test
+    void rejects_inverted_range() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new LocalDateTimeRange(
+                Optional.of(LocalDate.of(2026, 1, 5)), Optional.empty(),
+                Optional.of(LocalDate.of(2026, 1, 1)), Optional.empty()));
+        assertEquals("Invalid date range: start date 2026-01-05 is after end date 2026-01-01", e.getMessage());
+    }
+
+    @Test
+    void rejects_inverted_range_on_same_date_with_times() {
+        assertThrows(IllegalArgumentException.class, () -> new LocalDateTimeRange(
+                Optional.of(LocalDate.of(2026, 1, 1)), Optional.of(LocalTime.of(17, 0)),
+                Optional.of(LocalDate.of(2026, 1, 1)), Optional.of(LocalTime.of(9, 0))));
+    }
+
+}

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -261,7 +261,9 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                         cb.window().hours(),
                         cb.window().zone(),
                         cb.window().dateRange().start(),
-                        cb.window().dateRange().end()))
+                        cb.window().dateRange().end(),
+                        cb.window().dateRange().startTime(),
+                        cb.window().dateRange().endTime()))
                 .toList();
 
         var telemetryExportConfig = session.telemetryExportConfig();

--- a/configserver/src/test/apps/hosted-with-backup/deployment.xml
+++ b/configserver/src/test/apps/hosted-with-backup/deployment.xml
@@ -1,7 +1,8 @@
 <!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <deployment version='1.0'>
   <backup frequency='24h' granularity='cluster' />
-  <block-change revision='true' version='false' days='mon,tue' hours='8-10' time-zone='UTC' />
+  <block-change revision='true' version='false' days='mon,tue' hours='8-10' time-zone='UTC'
+                from-date='2026-01-01T09:00' to-date='2026-12-31T17:30' />
   <memory-dump heap-dump-redaction='basic' />
   <prod>
     <region>us-north-1</region>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeploymentConfigStoreTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeploymentConfigStoreTest.java
@@ -18,6 +18,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +70,10 @@ public class DeploymentConfigStoreTest {
         assertEquals(List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY), window.days());
         assertEquals(List.of(8, 9, 10), window.hours());
         assertEquals(ZoneId.of("UTC"), window.zone());
+        assertEquals(Optional.of(LocalDate.of(2026, 1, 1)), window.fromDate());
+        assertEquals(Optional.of(LocalTime.of(9, 0)), window.fromTime());
+        assertEquals(Optional.of(LocalDate.of(2026, 12, 31)), window.toDate());
+        assertEquals(Optional.of(LocalTime.of(17, 30)), window.toTime());
 
         assertTrue(call.telemetryExporterConfiguration().isEmpty());
     }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Users can now optionally specify hour of day for the block windows.