### PR TITLE
Make _fieldName_keyvalue field

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -5,19 +5,36 @@ import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.document.DataType;
 import com.yahoo.document.MapDataType;
+import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.schema.RankProfileRegistry;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.Attribute;
 import com.yahoo.schema.document.SDDocumentType;
 import com.yahoo.schema.document.SDField;
+import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.CatExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ConstantExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.Expression;
+import com.yahoo.vespa.indexinglanguage.expressions.ForEachExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.GetFieldExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.InputExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ScriptExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.StatementExpression;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 
+
 /**
- * Adds a "fieldName.$keyvalue" attribute to maps with fast-search enabled.
+ * Adds a "_fieldName_keyvalue" attribute to maps with fast-search enabled.
+ *
+ * The attribute holds one string per map entry, on the form key + separator + value,
+ * so that a key-value pair can be matched with a single lexical lookup.
  *
  * @author johsol
  */
 public class CreateFastMapSearch extends Processor {
+
+    /** DEL cannot occur in a map key and is accepted by Text.isTextCharacter. */
+    static final String KEY_VALUE_SEPARATOR = String.valueOf((char) 0x7F);
 
     private final SDDocumentType repo;
 
@@ -33,26 +50,23 @@ public class CreateFastMapSearch extends Processor {
 
     @Override
     public void process(boolean validate, boolean documentsOnly) {
+        if (documentsOnly) {
+            return;
+        }
+
         for (SDField field : schema.allConcreteFields()) {
             if (!shouldCreateFastMapAttribute(field)) {
                 continue;
             }
-
-            String fieldName = field.getName();
-
-            SDField fastMapField = createFastMapField(field, fieldName + ".$keyvalue", validate);
-            schema.addExtraField(fastMapField);
+            SDField keyValueField = createFastMapField(field, keyValueFieldName(field.getName()), validate);
+            schema.addExtraField(keyValueField);
+            schema.fieldSets().addBuiltInFieldSetItem(BuiltInFieldSets.INTERNAL_FIELDSET_NAME, keyValueField.getName());
         }
     }
 
-    /**
-     * Returns whether a fast map attribute should be created for the given field.
-     */
+    /** Returns whether a fast map attribute should be created for the given field. */
     private boolean shouldCreateFastMapAttribute(SDField field) {
-        DataType dataType = field.getDataType();
-        return (dataType instanceof MapDataType)
-                && field.doesAttributing()
-                && field.hasFastMapSearch();
+        return (field.getDataType() instanceof MapDataType) && field.hasFastMapSearch();
     }
 
     /**
@@ -60,7 +74,7 @@ public class CreateFastMapSearch extends Processor {
      * type array of strings since we will do lexical search on the key-value pairs of the map.
      */
     private SDField createFastMapField(SDField inputField, String fieldName, boolean validate) {
-        if (validate && schema.getConcreteField(fieldName) != null || schema.getAttribute(fieldName) != null) {
+        if (validate && (schema.getConcreteField(fieldName) != null || schema.getAttribute(fieldName) != null)) {
             throw newProcessException(schema, null, "Incompatible map attribute '" + fieldName + "' already created.");
         }
 
@@ -68,8 +82,32 @@ public class CreateFastMapSearch extends Processor {
         Attribute attribute = new Attribute(fieldName, Attribute.Type.STRING, Attribute.CollectionType.ARRAY);
         attribute.setFastSearch(true);
         field.addAttribute(attribute);
-
+        field.setIndexingScript(schema.getName(), keyValueScript(inputField, fieldName));
         return field;
+    }
+
+    /**
+     * The synthetic attribute is named _&lt;field&gt;_keyvalue. The leading underscore makes the name
+     * impossible to declare in a schema while still being a legal identifier in the indexing language.
+     */
+    static String keyValueFieldName(String fieldName) {
+        return "_" + fieldName + "_keyvalue";
+    }
+
+    /** Builds "input mapField | for_each { get_field $key . separator . get_field $value } | attribute". */
+    private static ScriptExpression keyValueScript(SDField inputField, String fieldName) {
+        return new ScriptExpression(
+                new StatementExpression(
+                        new InputExpression(inputField.getName()),
+                        new ForEachExpression(
+                                // Note: the array cast picks the varargs constructor. CatExpression is an
+                                // Iterable<Expression>, so passing it directly would flatten it into a pipeline.
+                                new StatementExpression(new Expression[] {
+                                        new CatExpression(
+                                                new GetFieldExpression("$key"),
+                                                new ConstantExpression(new StringFieldValue(KEY_VALUE_SEPARATOR)),
+                                                new GetFieldExpression("$value")) })),
+                        new AttributeExpression(fieldName)));
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -1,0 +1,75 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.ModelContext;
+import com.yahoo.document.DataType;
+import com.yahoo.document.MapDataType;
+import com.yahoo.schema.RankProfileRegistry;
+import com.yahoo.schema.Schema;
+import com.yahoo.schema.document.Attribute;
+import com.yahoo.schema.document.SDDocumentType;
+import com.yahoo.schema.document.SDField;
+import com.yahoo.vespa.model.container.search.QueryProfiles;
+
+/**
+ * Adds a "fieldName.$keyvalue" attribute to maps with fast-search enabled.
+ *
+ * @author johsol
+ */
+public class CreateFastMapSearch extends Processor {
+
+    private final SDDocumentType repo;
+
+    public CreateFastMapSearch(Schema schema, DeployLogger deployLogger, RankProfileRegistry rankProfileRegistry, QueryProfiles queryProfiles) {
+        super(schema, deployLogger, rankProfileRegistry, queryProfiles);
+        repo = schema.getDocument();
+    }
+
+    @Override
+    public void process(boolean validate, boolean documentsOnly, ModelContext.Properties properties) {
+        process(validate, documentsOnly);
+    }
+
+    @Override
+    public void process(boolean validate, boolean documentsOnly) {
+        for (SDField field : schema.allConcreteFields()) {
+            if (!shouldCreateFastMapAttribute(field)) {
+                continue;
+            }
+
+            String fieldName = field.getName();
+
+            SDField fastMapField = createFastMapField(field, fieldName + ".$keyvalue", validate);
+            schema.addExtraField(fastMapField);
+        }
+    }
+
+    /**
+     * Returns whether a fast map attribute should be created for the given field.
+     */
+    private boolean shouldCreateFastMapAttribute(SDField field) {
+        DataType dataType = field.getDataType();
+        return (dataType instanceof MapDataType)
+                && field.doesAttributing()
+                && field.hasFastMapSearch();
+    }
+
+    /**
+     * Creates a synthetic attribute for a map with fast search. The attribute has data
+     * type array of strings since we will do lexical search on the key-value pairs of the map.
+     */
+    private SDField createFastMapField(SDField inputField, String fieldName, boolean validate) {
+        if (validate && schema.getConcreteField(fieldName) != null || schema.getAttribute(fieldName) != null) {
+            throw newProcessException(schema, null, "Incompatible map attribute '" + fieldName + "' already created.");
+        }
+
+        SDField field = new SDField(repo, fieldName, DataType.getArray(DataType.STRING));
+        Attribute attribute = new Attribute(fieldName, Attribute.Type.STRING, Attribute.CollectionType.ARRAY);
+        attribute.setFastSearch(true);
+        field.addAttribute(attribute);
+
+        return field;
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
@@ -38,6 +38,7 @@ public class Processing {
                 LiteralBoost::new,
                 TagType::new,
                 ValidateFieldTypesDocumentsOnly::new,
+                CreateFastMapSearch::new,
                 IndexingInputs::new,
                 OptimizeIlscript::new,
                 ValidateFieldWithIndexSettingsCreatesIndex::new,

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -1,0 +1,137 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.document.DataType;
+import com.yahoo.schema.ApplicationBuilder;
+import com.yahoo.schema.Schema;
+import com.yahoo.schema.document.Attribute;
+import com.yahoo.schema.document.SDField;
+import com.yahoo.schema.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import static com.yahoo.config.model.test.TestUtil.joinLines;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the synthetic key-value attribute created for map fields with 'map: fast-search'.
+ *
+ * @author johsol
+ */
+public class CreateFastMapSearchTest {
+
+    @Test
+    void requireKeyValueFieldIsCreatedForFastSearchMap() throws ParseException {
+        var schema = build(fastSearchMap("map<string, string>"));
+
+        SDField field = schema.getConcreteField("_foo_keyvalue");
+        assertNotNull(field, "Expected a synthetic key-value field");
+        assertEquals(DataType.getArray(DataType.STRING), field.getDataType());
+    }
+
+    @Test
+    void requireKeyValueAttributeIsAFastSearchStringArray() throws ParseException {
+        var schema = build(fastSearchMap("map<string, string>"));
+
+        Attribute attribute = schema.getConcreteField("_foo_keyvalue").getAttributes().get("_foo_keyvalue");
+        assertNotNull(attribute);
+        assertEquals(Attribute.Type.STRING, attribute.getType());
+        assertEquals(Attribute.CollectionType.ARRAY, attribute.getCollectionType());
+        assertTrue(attribute.isFastSearch());
+    }
+
+    @Test
+    void requireKeyValueFieldIsCreatedForIntKeysAndValues() throws ParseException {
+        for (String type : new String[] { "map<int, string>", "map<string, int>", "map<int, int>" }) {
+            var schema = build(fastSearchMap(type));
+            assertNotNull(schema.getConcreteField("_foo_keyvalue"), "Expected key-value field for " + type);
+        }
+    }
+
+    @Test
+    void requireKeyValueFieldIsAddedToTheInternalFieldSet() throws ParseException {
+        var schema = build(fastSearchMap("map<string, string>"));
+
+        var internal = schema.fieldSets().builtInFieldSets().get(BuiltInFieldSets.INTERNAL_FIELDSET_NAME);
+        assertNotNull(internal);
+        assertTrue(internal.getFieldNames().contains("_foo_keyvalue"),
+                   "Expected _foo_keyvalue in " + internal.getFieldNames());
+    }
+
+    @Test
+    void requireNoKeyValueFieldWithoutFastSearch() throws ParseException {
+        var schema = build(joinLines("field foo type map<string, string> {",
+                                     "  indexing: summary",
+                                     "}"));
+
+        assertNull(schema.getConcreteField("_foo_keyvalue"));
+    }
+
+    @Test
+    void requireNoKeyValueFieldForNonMapFields() throws ParseException {
+        var schema = build(joinLines("field foo type array<string> {",
+                                     "  indexing: summary",
+                                     "}"));
+
+        assertNull(schema.getConcreteField("_foo_keyvalue"));
+    }
+
+    @Test
+    void requireOneKeyValueFieldPerFastSearchMap() throws ParseException {
+        var schema = build(joinLines("field foo type map<string, string> {",
+                                     "  indexing: summary",
+                                     "  map: fast-search",
+                                     "}",
+                                     "field bar type map<string, string> {",
+                                     "  indexing: summary",
+                                     "  map: fast-search",
+                                     "}",
+                                     "field baz type map<string, string> {",
+                                     "  indexing: summary",
+                                     "}"));
+
+        assertNotNull(schema.getConcreteField("_foo_keyvalue"));
+        assertNotNull(schema.getConcreteField("_bar_keyvalue"));
+        assertNull(schema.getConcreteField("_baz_keyvalue"));
+    }
+
+    /**
+     * The leading underscore is what keeps the synthetic name out of reach of schema authors,
+     * so that a user cannot declare a field colliding with it.
+     */
+    @Test
+    void requireUsersCannotDeclareTheKeyValueFieldName() {
+        try {
+            build(joinLines("field _foo_keyvalue type array<string> {",
+                            "  indexing: attribute",
+                            "}"));
+            throw new AssertionError("Expected exception");
+        }
+        catch (IllegalArgumentException | ParseException e) {
+            assertTrue(e.getMessage().contains("Not a legal field name"),
+                       "Unexpected message: " + e.getMessage());
+        }
+    }
+
+    private static String fastSearchMap(String type) {
+        return joinLines("field foo type " + type + " {",
+                         "  indexing: summary",
+                         "  map: fast-search",
+                         "}");
+    }
+
+    private static Schema build(String fields) throws ParseException {
+        var builder = new ApplicationBuilder(new TestProperties().fastMapSearch(true));
+        builder.addSchema(joinLines("schema test {",
+                                    "  document test {",
+                                    fields,
+                                    "  }",
+                                    "}"));
+        builder.build(true);
+        return builder.getSchema();
+    }
+
+}

--- a/document/src/main/java/com/yahoo/document/datatypes/MapFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/MapFieldValue.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 /**
  * Vespa map. Backed by and parametrized by FieldValue
  *
- * @author vegardh
+ * @author Vegard Havdal
  */
 public class MapFieldValue<K extends FieldValue, V extends FieldValue> extends CompositeFieldValue implements java.util.Map<K,V> {
 

--- a/document/src/main/java/com/yahoo/document/datatypes/TensorFieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/TensorFieldValue.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 /**
  * Field value class that wraps a tensor.
  *
- * @author geirst
+ * @author Geir Storli
  */
 public class TensorFieldValue extends FieldValue {
 


### PR DESCRIPTION
#### This PR

- **Feature:** Adds a new processor that creates a synthetic field called _fieldName_keyvalue.
- **_ instead of $:** Field names starting with an underscore aren't legal in the schema, but they are legal in the indexing language. Dollar was not legal, so the design changed, but the semantics are the same.
- **DEL instead of 0x1**: 0x1 was not accepted by StringFieldValue, so it was changed to DEL (0x7F). This is non-printable but legal to store in StringFieldValue.

We planned to call it `fieldName.$keyvalue` and use 0x1 as the separator, but changed it to `_fieldName_keyvalue` and used DEL as the separator.

#### Additional info
- The processor builds an indexing statement that concatenates the key and the value with DEL as a separator.
- Not handling int-to-hex string yet.
- Gated by a feature flag through `field.hasFastMapSearch()`.

#### Manual testing
- Created a map with fast search and fed some data.
- Using `vespa-attribute-inspect`, I dumped the data, and it looked correct.
- Using `vespa-get-config` I saw that the _foo_key_value attribute was made.
- Using `yql=select * from music where _foo_keyvalue contains "bar\x7fbaz"` to verify, I could use the attribute to retrieve the document where map{"bar"} contains "baz".

@arnej27959 please review
@boeker fyi