### PR TITLE
Restore SidecarImages for config-model versions that import it

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SidecarImages.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SidecarImages.java
@@ -1,0 +1,74 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision;
+
+import com.yahoo.text.Text;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/**
+ * Provides access to sidecar images configured in sidecar-images.properties.
+ *
+ * The properties file is expected to have entries of the form
+ * <pre>
+ *     key=registry/repository:tag
+ * </pre>
+ * where the key is an arbitrary identifier for the image, and the value is a container image reference.
+ *
+ * @author glebashnik
+ * @deprecated Sidecar images are configured outside this repository, through implementations of
+ *             com.yahoo.config.model.api.SidecarProvider. This class is unused here, but released
+ *             config-model versions that predate the SidecarProvider hook import it from this bundle
+ *             at runtime, so removing it fails deployments for applications on those versions with
+ *             NoClassDefFoundError. Remove this class and sidecar-images.properties once no
+ *             config-model version importing it is in use.
+ */
+@Deprecated(forRemoval = true)
+public class SidecarImages {
+    private final Map<String, DockerImage> images;
+
+    private SidecarImages(Map<String, DockerImage> images) {
+        this.images = images;
+    }
+
+    public static SidecarImages readFromPropertiesFile() {
+        var props = new Properties();
+
+        try (InputStream inputStream = SidecarImages.class.getResourceAsStream("/sidecar-images.properties")) {
+            if (inputStream == null) {
+                throw new IllegalStateException("sidecar-images.properties not found");
+            }
+
+            props.load(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read sidecar-images.properties", e);
+        }
+
+        return new SidecarImages(props.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey().toString(),
+                        e -> DockerImage.fromString(e.getValue().toString()))));
+    }
+
+    public DockerImage getOrThrow(String key) {
+        var image = images.get(key);
+
+        if (image == null) {
+            throw new IllegalStateException(
+                    Text.format("Sidecar image '%s' is not configured in sidecar-images.properties", key));
+        }
+
+        return image;
+    }
+
+    public DockerImage getByRepositoryOrThrow(String repository) {
+        return images.values().stream()
+                .filter(image -> image.repository().equals(repository))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(Text.format(
+                        "No sidecar image with repository '%s' configured in sidecar-images.properties", repository)));
+    }
+}

--- a/config-provisioning/src/main/resources/sidecar-images.properties
+++ b/config-provisioning/src/main/resources/sidecar-images.properties
@@ -1,0 +1,1 @@
+triton=nvcr.io/nvidia/tritonserver:25.12-py3


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Removing SidecarImages in https://github.com/vespa-engine/vespa/pull/37594 makes deployment preparation fail with NoClassDefFoundError for applications on those versions when the use-triton flag is enabled.

Restores  and sidecar-images.properties unchanged, deprecated for removal once no config-model version importing them is in use.
